### PR TITLE
Pieces stretch around when smushing through other blocks.

### DIFF
--- a/scenes/Piece.tscn
+++ b/scenes/Piece.tscn
@@ -1,14 +1,15 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://scenes/Piece.gd" type="Script" id=1]
 [ext_resource path="res://art/blocks.png" type="Texture" id=2]
 [ext_resource path="res://scenes/CornerMap.tscn" type="PackedScene" id=3]
-[ext_resource path="res://sound/rotate.wav" type="AudioStream" id=4]
-[ext_resource path="res://sound/move.wav" type="AudioStream" id=5]
-[ext_resource path="res://sound/harddrop.wav" type="AudioStream" id=6]
-[ext_resource path="res://sound/lock.wav" type="AudioStream" id=7]
-[ext_resource path="res://sound/gameover.wav" type="AudioStream" id=8]
-[ext_resource path="res://sound/smash.wav" type="AudioStream" id=9]
+[ext_resource path="res://scenes/StretchMap.gd" type="Script" id=4]
+[ext_resource path="res://sound/rotate.wav" type="AudioStream" id=5]
+[ext_resource path="res://sound/move.wav" type="AudioStream" id=6]
+[ext_resource path="res://sound/harddrop.wav" type="AudioStream" id=7]
+[ext_resource path="res://sound/lock.wav" type="AudioStream" id=8]
+[ext_resource path="res://sound/gameover.wav" type="AudioStream" id=9]
+[ext_resource path="res://sound/smash.wav" type="AudioStream" id=10]
 
 [sub_resource type="TileSet" id=1]
 0/name = "blocks.png 0"
@@ -43,20 +44,32 @@ tile_data = PoolIntArray( 196613, 0, 196608, 262147, 0, 196608, 262148, 0, 19660
 
 [node name="CornerMap" parent="TileMap" instance=ExtResource( 3 )]
 
-[node name="RotateSound" type="AudioStreamPlayer" parent="."]
-stream = ExtResource( 4 )
+[node name="StretchMap" type="TileMap" parent="."]
+visible = false
+position = Vector2( 0, -96 )
+scale = Vector2( 0.5, 0.5 )
+tile_set = SubResource( 1 )
+cell_size = Vector2( 72, 64 )
+format = 1
+tile_data = PoolIntArray( 196613, 0, 196608, 262147, 0, 196608, 262148, 0, 196608, 262149, 0, 196608 )
+script = ExtResource( 4 )
 
-[node name="MoveSound" type="AudioStreamPlayer" parent="."]
+[node name="CornerMap" parent="StretchMap" instance=ExtResource( 3 )]
+
+[node name="RotateSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 5 )
 
-[node name="DropSound" type="AudioStreamPlayer" parent="."]
+[node name="MoveSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 6 )
 
-[node name="LockSound" type="AudioStreamPlayer" parent="."]
+[node name="DropSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 7 )
 
-[node name="GameOverSound" type="AudioStreamPlayer" parent="."]
+[node name="LockSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 8 )
 
-[node name="SmashSound" type="AudioStreamPlayer" parent="."]
+[node name="GameOverSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 9 )
+
+[node name="SmushSound" type="AudioStreamPlayer" parent="."]
+stream = ExtResource( 10 )

--- a/scenes/Playfield.gd
+++ b/scenes/Playfield.gd
@@ -191,35 +191,35 @@ func _check_for_boxes() -> bool:
 	for y in range(0, ROW_COUNT):
 		for x in range(0, COL_COUNT):
 			# check for 5x3s (vertical)
-			if dt5[y][x] >= 3 and _check_for_box(x - 2, y - 4, 3, 5, true):
+			if dt5[y][x] >= 3 && _check_for_box(x - 2, y - 4, 3, 5, true):
 				$CakeBoxSound.play()
 				# exit box check; a dropped piece can only make one box, and making a box invalidates the db cache
 				_remaining_box_build_frames = _line_clear_delay
 				return true
 			
 			# check for 4x3s (vertical)
-			if dt4[y][x] >= 3 and _check_for_box(x - 2, y - 3, 3, 4, true):
+			if dt4[y][x] >= 3 && _check_for_box(x - 2, y - 3, 3, 4, true):
 				$CakeBoxSound.play()
 				# exit box check; a dropped piece can only make one box, and making a box invalidates the db cache
 				_remaining_box_build_frames = _line_clear_delay
 				return true
 			
 			# check for 5x3s (horizontal)
-			if dt3[y][x] >= 5 and _check_for_box(x - 4, y - 2, 5, 3, true):
+			if dt3[y][x] >= 5 && _check_for_box(x - 4, y - 2, 5, 3, true):
 				$CakeBoxSound.play()
 				# exit box check; a dropped piece can only make one box, and making a box invalidates the db cache
 				_remaining_box_build_frames = _line_clear_delay
 				return true
 			
 			# check for 4x3s (horizontal)
-			if dt3[y][x] >= 4 and _check_for_box(x - 3, y - 2, 4, 3, true):
+			if dt3[y][x] >= 4 && _check_for_box(x - 3, y - 2, 4, 3, true):
 				$CakeBoxSound.play()
 				# exit box check; a dropped piece can only make one box, and making a box invalidates the db cache
 				_remaining_box_build_frames = _line_clear_delay
 				return true
 			
 			# check for 3x3s
-			if dt3[y][x] >= 3 and _check_for_box(x - 2, y - 2, 3, 3):
+			if dt3[y][x] >= 3 && _check_for_box(x - 2, y - 2, 3, 3):
 				$SnackBoxSound.play()
 				# exit box check; a dropped piece can only make one box, and making a box invalidates the db cache
 				_remaining_box_build_frames = _line_clear_delay

--- a/scenes/PracticeMenu.gd
+++ b/scenes/PracticeMenu.gd
@@ -46,7 +46,7 @@ func get_fastest_time_text(scenario_name: String) -> String:
 	var best_grade
 	var rank_results: Array = ScenarioHistory.scenario_history[scenario_name]
 	for rank_result in rank_results:
-		if rank_result.seconds < best_seconds and !rank_result.died:
+		if rank_result.seconds < best_seconds && !rank_result.died:
 			best_seconds = rank_result.seconds
 			best_grade = Global.grade(rank_result.seconds_rank)
 	if best_seconds == 9999.0:

--- a/scenes/StretchMap.gd
+++ b/scenes/StretchMap.gd
@@ -1,0 +1,100 @@
+"""
+This TileMap handles drawing the active piece when it's stretched around other pieces.
+"""
+extends TileMap
+
+onready var Playfield = get_node("../../Playfield")
+
+# constants used when drawing blocks which are connected to other blocks
+const CONNECTED_UP = 1
+const CONNECTED_DOWN = 2
+const CONNECTED_LEFT = 4
+const CONNECTED_RIGHT = 8
+
+var _row_count: int
+var _col_count: int
+
+var _stretch_pos := []
+var _stretch_seconds_total := 0.0
+var _stretch_seconds_remaining := 0.0
+var _max_distance := 0
+var _color_y: int
+
+func _ready():
+	if Playfield != null:
+		_col_count = Playfield.COL_COUNT
+		_row_count = Playfield.ROW_COUNT
+	else:
+		_col_count = 9
+		_row_count = 18
+	for row in range(0, _row_count):
+		_stretch_pos.append([])
+		for col in range (0, _col_count):
+			_stretch_pos[row].append(0)
+
+func _process(delta: float) -> void:
+	if _stretch_seconds_remaining > 0:
+		for row in range(0, _row_count):
+			for col in range (0, _col_count):
+				if _stretch_pos[row][col] > _max_distance * (_stretch_seconds_total -_stretch_seconds_remaining) / _stretch_seconds_total:
+					set_cell(col, row, 0, false, false, false, Vector2(0, _color_y))
+				else:
+					set_cell(col, row, -1)
+		
+		for row in range(0, _row_count):
+			for col in range (0, _col_count):
+				if get_cell(col, row) != 0:
+					continue
+				var color_x = 0
+				if row > 0 && get_cell(col, row - 1) == 0:
+					color_x |= CONNECTED_UP
+				if row < _row_count - 1 && get_cell(col, row + 1) == 0:
+					color_x |= CONNECTED_DOWN
+				if col > 0 && get_cell(col - 1, row) == 0:
+					color_x |= CONNECTED_LEFT
+				if col < _col_count - 1 && get_cell(col + 1, row) == 0:
+					color_x |= CONNECTED_RIGHT
+				set_cell(col, row, 0, false, false, false, Vector2(color_x, _color_y))
+		
+		_stretch_seconds_remaining -= delta
+		$CornerMap.dirty = true
+
+"""
+Adds the specified cells to the current stretch operation.
+"""
+func stretch_to(piece_pos_arr: Array, offset: Vector2) -> void:
+	if !_is_stretched_to(piece_pos_arr, offset):
+		return
+	
+	_max_distance += 1
+	
+	for piece_pos in piece_pos_arr:
+		_stretch_pos[piece_pos.y + offset.y][piece_pos.x + offset.x] = _max_distance
+
+"""
+Returns 'true' if the piece is already stretched to the specified position.
+"""
+func _is_stretched_to(piece_pos_arr: Array, offset: Vector2) -> bool:
+	if _max_distance == 0:
+		return true
+	
+	for piece_pos in piece_pos_arr:
+		if _stretch_pos[piece_pos.y + offset.y][piece_pos.x + offset.x] < _max_distance:
+			return true
+	
+	return false
+
+"""
+Starts a new stretch operation, which will make the piece appear stretched out for a few frames.
+"""
+func start_stretch(stretch_frames: int, new_color_y: int) -> void:
+	_stretch_seconds_total = stretch_frames / 60.0
+	_stretch_seconds_remaining = _stretch_seconds_total
+	_max_distance = 0
+	_color_y = new_color_y
+	
+	clear()
+	$CornerMap.dirty = true
+	for row in range(0, _row_count):
+		for col in range (0, _col_count):
+			_stretch_pos[row][col] = 0

--- a/todo.txt
+++ b/todo.txt
@@ -1,3 +1,4 @@
+-refactor 'connected_up" constants into one place
 -joystick support
 -upgrade to godot 3.2
 -customize controls


### PR DESCRIPTION
I originally planned to have this 'stretch' logic apply to hard drops
and 20G, but it was too distracting and made the game feel slower. Now
it only applies to long-distance block smushes.

The original approach where pieces stretch in more circumstances is
branched at 'pieces-stretch'.