### PR TITLE
Fixed piece physics glitches introduced in 56e0cb2.

### DIFF
--- a/src/main/puzzle/piece/piece-manager.gd
+++ b/src/main/puzzle/piece/piece-manager.gd
@@ -38,7 +38,7 @@ func _ready() -> void:
 	piece_speed = PieceSpeeds.beginner_level_0
 	$States.set_state($States/Prespawn)
 	# Set the state frames so that the piece spawns immediately
-	$States._state.frames = 3600
+	$States/Prespawn.frames = 3600
 
 
 func get_state() -> State:
@@ -80,7 +80,8 @@ func _physics_process(_delta: float) -> void:
 
 
 func clear_piece() -> void:
-	$States.set_state($States/None)
+	if $States.get_state() != $States/None:
+		$States.set_state($States/None)
 	active_piece = ActivePiece.new(PieceTypes.piece_null)
 	tile_map_dirty = true
 
@@ -273,7 +274,8 @@ func _smush_to_target() -> void:
 	
 	_move_piece_to_target()
 	$SmushSound.play()
-	$States.set_state($States/MovePiece)
+	if $States.get_state() != $States/MovePiece:
+		$States.set_state($States/MovePiece)
 	active_piece.gravity = 0
 	_gravity_delay_frames = PieceSpeeds.SMUSH_FRAMES
 

--- a/src/main/puzzle/piece/states/prelock.gd
+++ b/src/main/puzzle/piece/states/prelock.gd
@@ -9,13 +9,12 @@ func update(piece_manager: PieceManager) -> String:
 	
 	if frames >= piece_manager.piece_speed.post_lock_delay:
 		var active_piece = piece_manager.active_piece
-		if piece_manager.playfield:
-			if piece_manager.playfield.write_piece(active_piece.pos, active_piece.orientation, active_piece.type,
-					piece_manager.piece_speed.line_clear_delay):
-				# line was cleared; different appearance delay
-				active_piece.spawn_delay = piece_manager.piece_speed.line_appearance_delay
-			else:
-				active_piece.spawn_delay = piece_manager.piece_speed.appearance_delay
+		if piece_manager.playfield.write_piece(active_piece.pos, active_piece.orientation, active_piece.type,
+				piece_manager.piece_speed.line_clear_delay):
+			# line was cleared; different appearance delay
+			active_piece.spawn_delay = piece_manager.piece_speed.line_appearance_delay
+		else:
+			active_piece.spawn_delay = piece_manager.piece_speed.appearance_delay
 		active_piece.setType(PieceTypes.piece_null)
 		piece_manager.tile_map_dirty = true
 		new_state_name = "WaitForPlayfield"

--- a/src/main/puzzle/piece/states/wait-for-playfield.gd
+++ b/src/main/puzzle/piece/states/wait-for-playfield.gd
@@ -6,6 +6,6 @@ a new piece.
 
 func update(piece_manager: PieceManager) -> String:
 	var new_state := ""
-	if piece_manager.playfield == null or piece_manager.playfield.ready_for_new_piece():
+	if piece_manager.playfield.ready_for_new_piece():
 		new_state = "Prespawn"
 	return new_state

--- a/src/main/state-machine.gd
+++ b/src/main/state-machine.gd
@@ -11,7 +11,7 @@ invoking their methods, and emitting signals.
 signal entered_state
 
 # the currently active state
-var _state: State setget set_state, get_state
+var _state: State
 
 # the host object which is passed into each state
 onready var _host := get_parent()

--- a/src/main/world/restaurant/CustomerView.tscn
+++ b/src/main/world/restaurant/CustomerView.tscn
@@ -6,14 +6,6 @@
 [ext_resource path="res://src/main/world/restaurant/customer-view.gd" type="Script" id=4]
 [ext_resource path="res://src/main/world/restaurant/fat-player.gd" type="Script" id=5]
 
-
-
-
-
-
-
-
-
 [sub_resource type="Animation" id=1]
 resource_name = "Fat"
 length = 10.0


### PR DESCRIPTION
There are some glitches with gdscript's 'setget' keyword. A statement
like $States._state.frames = 3600 gets incorrectly interpreted as a
'set_state' call. I've removed the 'setget' keyword to avoid these
issues.

Removed some unnecessary playfield null checks.