### PR TITLE
Fixed puzzle freezing when prelock was interrupted.

### DIFF
--- a/src/main/puzzle/piece/next-pieces.gd
+++ b/src/main/puzzle/piece/next-pieces.gd
@@ -1,3 +1,4 @@
+class_name NextPieces
 extends Control
 """
 Contains logic for displaying upcoming pieces to the player, organizing and maintaining all of the 'next piece

--- a/src/main/puzzle/piece/states/move-piece.gd
+++ b/src/main/puzzle/piece/states/move-piece.gd
@@ -3,10 +3,11 @@ extends State
 State: The player is moving the piece around the playfield.
 """
 
-func enter(piece_manager: PieceManager) -> void:
-	# apply an immediate frame of player movement and gravity to prevent the piece from flickering at the top of the
-	# screen at 20G or when hard drop is held
-	update(piece_manager)
+func enter(piece_manager: PieceManager, prev_state_name: String) -> void:
+	if prev_state_name == "Prespawn":
+		# apply an immediate frame of player movement and gravity to prevent the piece from flickering at the top of the
+		# screen at 20G or when hard drop is held
+		update(piece_manager)
 
 
 func update(piece_manager: PieceManager) -> String:

--- a/src/main/puzzle/piece/states/prelock.gd
+++ b/src/main/puzzle/piece/states/prelock.gd
@@ -5,18 +5,16 @@ The piece has locked into position. The player can still press 'down' to unlock 
 
 func update(piece_manager: PieceManager) -> String:
 	var new_state_name := ""
-	piece_manager.apply_player_input()
-	
-	if frames >= piece_manager.piece_speed.post_lock_delay:
-		var active_piece = piece_manager.active_piece
-		if piece_manager.playfield.write_piece(active_piece.pos, active_piece.orientation, active_piece.type,
-				piece_manager.piece_speed.line_clear_delay):
+	if piece_manager.apply_player_input():
+		new_state_name = "MovePiece"
+	elif frames >= piece_manager.piece_speed.post_lock_delay:
+		var spawn_delay: float
+		if piece_manager.write_piece_to_playfield():
 			# line was cleared; different appearance delay
-			active_piece.spawn_delay = piece_manager.piece_speed.line_appearance_delay
+			spawn_delay = piece_manager.piece_speed.line_appearance_delay
 		else:
-			active_piece.spawn_delay = piece_manager.piece_speed.appearance_delay
-		active_piece.setType(PieceTypes.piece_null)
-		piece_manager.tile_map_dirty = true
+			spawn_delay = piece_manager.piece_speed.appearance_delay
+		piece_manager.active_piece.spawn_delay = spawn_delay
 		new_state_name = "WaitForPlayfield"
 	
 	return new_state_name

--- a/src/main/state-machine.gd
+++ b/src/main/state-machine.gd
@@ -38,9 +38,10 @@ Transitions to a new state.
 Resets the state's internal variables and notifies any listeners.
 """
 func set_state(state: State) -> void:
+	var prev_state_name := "" if _state == null else _state.name
 	_state = state
 	_state.frames = 0
-	_state.enter(_host)
+	_state.enter(_host, prev_state_name)
 	emit_signal("entered_state", state)
 
 

--- a/src/main/state.gd
+++ b/src/main/state.gd
@@ -12,8 +12,10 @@ Called once when the state is first entered.
 
 Parameters:
 	'_host': The state machine's parent object.
+	
+	'_prev_state': The previous state the state machine was in.
 """
-func enter(_host) -> void:
+func enter(_host, _prev_state_name: String) -> void:
 	pass
 
 """


### PR DESCRIPTION
The prelock state can result in two states; writing the piece to the
playfield or going back to the move state if the player smushes or
performs a lock reset. If these two state changes overlapped, bugs
resulted such as infinite loops or freezes.

I've refactored the surrounding code to minimize the number of places
where we manage the piece state using 'set_state'. The states themselves
now monitor 'apply_player_input' and change the state themselves.