### PR TITLE
Added FPS tracker; tweaked gravity physics

### DIFF
--- a/FpsLabel.tscn
+++ b/FpsLabel.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://assets/ui/xolonium-16.tres" type="DynamicFont" id=1]
+[ext_resource path="res://fps-label.gd" type="Script" id=2]
+
+[node name="FpsLabel" type="Label"]
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -110.0
+margin_top = -50.0
+margin_right = -9.99982
+margin_bottom = -20.0
+custom_fonts/font = ExtResource( 1 )
+text = "60.00 fps"
+align = 2
+script = ExtResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/fps-label.gd
+++ b/fps-label.gd
@@ -1,0 +1,7 @@
+extends Label
+"""
+Renders the current frames-per-second to the screen, '60.00 fps'
+"""
+
+func _process(delta: float):
+	text = "%.2f fps" % Engine.get_frames_per_second()

--- a/src/main/world/Overworld.tscn
+++ b/src/main/world/Overworld.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=30 format=2]
+[gd_scene load_steps=31 format=2]
 
 [ext_resource path="res://assets/ui/xolonium-36.tres" type="DynamicFont" id=1]
 [ext_resource path="res://src/main/world/overworld.gd" type="Script" id=2]
@@ -16,6 +16,7 @@
 [ext_resource path="res://src/main/ui/cheat-code-detector.gd" type="Script" id=14]
 [ext_resource path="res://assets/ui/cheat-enable.wav" type="AudioStream" id=15]
 [ext_resource path="res://assets/ui/cheat-disable.wav" type="AudioStream" id=16]
+[ext_resource path="res://FpsLabel.tscn" type="PackedScene" id=18]
 
 [sub_resource type="CubeMesh" id=1]
 size = Vector3( 36, 2, 36 )
@@ -30,7 +31,7 @@ roughness = 0.15
 uv1_scale = Vector3( 27, 18, 1 )
 
 [sub_resource type="BoxShape" id=3]
-extents = Vector3( 16, 1, 16 )
+extents = Vector3( 18, 1, 18 )
 
 [sub_resource type="PlaneMesh" id=4]
 size = Vector2( 4, 4 )
@@ -89,6 +90,9 @@ text = "P"
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
+[node name="FpsLabel" parent="." instance=ExtResource( 18 )]
+visible = false
 
 [node name="VersionLabel" parent="." instance=ExtResource( 3 )]
 
@@ -201,7 +205,7 @@ material/0 = SubResource( 13 )
 
 [node name="CheatCodeDetector" type="Node" parent="."]
 script = ExtResource( 14 )
-codes = [ "coyote" ]
+codes = [ "coyote", "bigfps" ]
 
 [node name="CheatEnabledSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 15 )

--- a/src/main/world/overworld.gd
+++ b/src/main/world/overworld.gd
@@ -15,3 +15,10 @@ func _on_CheatCodeDetector_cheat_detected(cheat: String):
 		else:
 			$Turbo/Label.visible = false
 			$CheatDisabledSound.play()
+	if cheat == "bigfps":
+		if not $FpsLabel.visible:
+			$FpsLabel.visible = true
+			$CheatEnabledSound.play()
+		else:
+			$FpsLabel.visible = false
+			$CheatDisabledSound.play()

--- a/src/main/world/turbo.gd
+++ b/src/main/world/turbo.gd
@@ -67,7 +67,7 @@ func _physics_process(delta):
 
 func _apply_gravity(delta: float) -> void:
 	if is_on_floor():
-		_velocity.y = max(_velocity.y, 0)
+		_velocity.y = 0
 	_velocity += Vector3.DOWN * GRAVITY * delta
 
 


### PR DESCRIPTION
The FPS tracker can be enabled by typing 'BIGFPS' in the overworld. It
will most likely be capped at 60, although you can temporarily uncap the FPS by
disabling VSYNC in the project settings.

I encountered a transient error where landing on a platform caused the
player to constantly bounce up and down, with their Y value oscillating between
-4 and 0. I'm changing the gravity code to reset their Y velocity as a
countermeasure, although this bug is difficult to reproduce.