### PR TITLE
Enlarged 3D objects to reduce physics glitches.

### DIFF
--- a/assets/world/overworld-material-outline.tres
+++ b/assets/world/overworld-material-outline.tres
@@ -4,7 +4,7 @@
 flags_unshaded = true
 params_cull_mode = 1
 params_grow = true
-params_grow_amount = 0.08
+params_grow_amount = 0.8
 albedo_color = Color( 0.423529, 0.262745, 0.192157, 1 )
 
 [resource]

--- a/assets/world/purple-box-library.tres
+++ b/assets/world/purple-box-library.tres
@@ -6,7 +6,7 @@
 
 [sub_resource type="CubeMesh" id=1]
 material = ExtResource( 1 )
-size = Vector3( 2, 1.2, 2 )
+size = Vector3( 20, 12, 20 )
 
 [sub_resource type="Image" id=2]
 data = {
@@ -22,10 +22,11 @@ image = SubResource( 2 )
 size = Vector2( 64, 64 )
 
 [sub_resource type="BoxShape" id=4]
+extents = Vector3( 10, 6, 10 )
 
 [sub_resource type="CubeMesh" id=5]
 material = ExtResource( 2 )
-size = Vector3( 2, 1.2, 2 )
+size = Vector3( 20, 12, 20 )
 
 [sub_resource type="Image" id=6]
 data = {
@@ -42,7 +43,7 @@ size = Vector2( 64, 64 )
 
 [sub_resource type="CubeMesh" id=8]
 material = ExtResource( 3 )
-size = Vector3( 2, 1.2, 2 )
+size = Vector3( 20, 12, 20 )
 
 [sub_resource type="Image" id=9]
 data = {

--- a/src/main/world/Overworld.tscn
+++ b/src/main/world/Overworld.tscn
@@ -18,7 +18,7 @@
 [ext_resource path="res://FpsLabel.tscn" type="PackedScene" id=18]
 
 [sub_resource type="CubeMesh" id=1]
-size = Vector3( 36, 2, 36 )
+size = Vector3( 360, 20, 360 )
 
 [sub_resource type="SpatialMaterial" id=2]
 params_diffuse_mode = 4
@@ -30,12 +30,14 @@ roughness = 0.15
 uv1_scale = Vector3( 27, 18, 1 )
 
 [sub_resource type="BoxShape" id=3]
-extents = Vector3( 18, 1, 18 )
+extents = Vector3( 180, 10, 180 )
 
 [sub_resource type="SphereMesh" id=4]
+radius = 10.0
+height = 20.0
 
 [sub_resource type="BoxShape" id=5]
-extents = Vector3( 0.65, 0.85, 0.5 )
+extents = Vector3( 6.5, 8.5, 5 )
 
 [sub_resource type="Animation" id=6]
 resource_name = "walk-sw"
@@ -55,12 +57,15 @@ tracks/0/keys = {
 }
 
 [sub_resource type="CylinderMesh" id=7]
+top_radius = 10.0
+bottom_radius = 10.0
+height = 20.0
 
 [sub_resource type="SpatialMaterial" id=8]
 flags_unshaded = true
 params_cull_mode = 1
 params_grow = true
-params_grow_amount = 0.08
+params_grow_amount = 0.8
 albedo_color = Color( 0.423529, 0.262745, 0.192157, 1 )
 
 [sub_resource type="SpatialMaterial" id=9]
@@ -72,8 +77,12 @@ metallic_specular = 0.2
 roughness = 0.15
 
 [sub_resource type="CylinderShape" id=10]
+radius = 10.0
+height = 20.0
 
 [sub_resource type="SphereMesh" id=11]
+radius = 10.0
+height = 20.0
 
 [sub_resource type="SpatialMaterial" id=12]
 next_pass = SubResource( 8 )
@@ -98,24 +107,23 @@ __meta__ = {
 }
 
 [node name="FpsLabel" parent="." instance=ExtResource( 18 )]
-visible = false
 
 [node name="VersionLabel" parent="." instance=ExtResource( 3 )]
 
 [node name="Floor" type="StaticBody" parent="."]
 
 [node name="MeshInstance" type="MeshInstance" parent="Floor"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -10, 0 )
 mesh = SubResource( 1 )
 material/0 = SubResource( 2 )
 
 [node name="CollisionShape" type="CollisionShape" parent="Floor"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -10, 0 )
 shape = SubResource( 3 )
 
 [node name="GridMap" type="GridMap" parent="."]
 mesh_library = ExtResource( 12 )
-cell_size = Vector3( 2, 1.2, 2 )
+cell_size = Vector3( 20, 12, 20 )
 data = {
 "cells": PoolIntArray( 2, 0, 2, 3, 0, 2, 2, 1, 2, 3, 1, 2, 2, 2, 2, 3, 2, 2, 2, 3, 2, 3, 3, 2, 65529, 3, 2, 65530, 3, 2, 2, 4, 2, 3, 4, 2, 4, 4, 2, 5, 4, 2, 65528, 4, 2, 65529, 4, 2, 65530, 4, 2, 65531, 4, 2, 131065, 4, 1, 131066, 4, 1, 2, 5, 2, 3, 5, 2, 4, 5, 2, 5, 5, 2, 65528, 5, 2, 65529, 5, 2, 65530, 5, 2, 65531, 5, 2, 131065, 5, 1, 131066, 5, 1, 0, 6, 2, 1, 6, 2, 2, 6, 2, 3, 6, 2, 4, 6, 2, 5, 6, 2, 6, 6, 2, 7, 6, 2, 65528, 6, 2, 65529, 6, 2, 65530, 6, 2, 65531, 6, 2, 65534, 6, 2, 65535, 6, 2, 65536, 6, 1, 65537, 6, 1, 65538, 6, 1, 65539, 6, 1, 131065, 6, 1, 131066, 6, 1, 131070, 6, 1, 131071, 6, 1, 131072, 6, 0, 131073, 6, 0, 196606, 6, 0, 196607, 6, 0, 0, 7, 2, 1, 7, 2, 2, 7, 2, 3, 7, 2, 4, 7, 2, 5, 7, 2, 6, 7, 2, 7, 7, 2, 65529, 7, 2, 65530, 7, 2, 65534, 7, 2, 65535, 7, 2, 65536, 7, 1, 65537, 7, 1, 65538, 7, 1, 65539, 7, 1, 131070, 7, 1, 131071, 7, 1, 131072, 7, 0, 131073, 7, 0, 196606, 7, 0, 196607, 7, 0, 0, 65528, 2, 1, 65528, 2, 2, 65528, 2, 3, 65528, 2, 4, 65528, 2, 5, 65528, 2, 6, 65528, 2, 65528, 65528, 2, 65529, 65528, 2, 65530, 65528, 2, 65531, 65528, 2, 65532, 65528, 2, 65533, 65528, 2, 65534, 65528, 2, 65535, 65528, 2, 131066, 65528, 1, 131067, 65528, 1, 131068, 65528, 1, 131069, 65528, 1, 196602, 65528, 0, 196603, 65528, 0, 0, 65529, 2, 1, 65529, 2, 2, 65529, 2, 3, 65529, 2, 4, 65529, 2, 5, 65529, 2, 6, 65529, 2, 65528, 65529, 2, 65529, 65529, 2, 65530, 65529, 2, 65531, 65529, 2, 65532, 65529, 2, 65533, 65529, 2, 65534, 65529, 2, 65535, 65529, 2, 131066, 65529, 1, 131067, 65529, 1, 131068, 65529, 1, 131069, 65529, 1, 196602, 65529, 0, 196603, 65529, 0, 4, 65530, 2, 5, 65530, 2, 65528, 65530, 2, 65529, 65530, 2, 65530, 65530, 2, 65531, 65530, 2, 65532, 65530, 2, 65533, 65530, 2, 131066, 65530, 1, 131067, 65530, 1, 196602, 65530, 0, 196603, 65530, 0, 4, 65531, 2, 5, 65531, 2, 65528, 65531, 2, 65529, 65531, 2, 65530, 65531, 2, 65531, 65531, 2, 65532, 65531, 2, 65533, 65531, 2, 131066, 65531, 1, 131067, 65531, 1, 196602, 65531, 0, 196603, 65531, 0, 4, 65532, 2, 5, 65532, 2, 65528, 65532, 2, 65529, 65532, 2, 65530, 65532, 2, 65531, 65532, 2, 131066, 65532, 1, 131067, 65532, 1, 4, 65533, 2, 5, 65533, 2, 65528, 65533, 2, 65529, 65533, 2, 65530, 65533, 2, 65531, 65533, 2, 131066, 65533, 1, 131067, 65533, 1, 2, 65534, 2, 3, 65534, 2, 4, 65534, 2, 5, 65534, 2, 65530, 65534, 2, 65531, 65534, 2, 131066, 65534, 1, 131067, 65534, 1, 2, 65535, 2, 3, 65535, 2, 4, 65535, 2, 5, 65535, 2, 65530, 65535, 2, 65531, 65535, 2, 131066, 65535, 1, 131067, 65535, 1 )
 }
@@ -125,29 +133,29 @@ __meta__ = {
 }
 
 [node name="Turbo" type="KinematicBody" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 10, 0 )
 script = ExtResource( 4 )
 
 [node name="Sprite3D" type="Sprite3D" parent="Turbo"]
-transform = Transform( 0.707107, -0.353553, 0.612372, 0, 0.866025, 0.5, -0.707107, -0.353553, 0.612372, 0, 0.73, 0 )
+transform = Transform( 0.707107, -0.353553, 0.612372, 0, 0.866025, 0.5, -0.707107, -0.353553, 0.612372, 0, 7.3, 0 )
 offset = Vector2( 0, -160 )
-pixel_size = 0.004
+pixel_size = 0.04
 texture = ExtResource( 7 )
 vframes = 2
 hframes = 8
 
 [node name="ShadowMesh" type="MeshInstance" parent="Turbo"]
-transform = Transform( 0.459619, 0, 0.353553, 0, 0.85, 0, -0.459619, 0, 0.353553, 0.35, -0.15, 0.35 )
+transform = Transform( 0.459619, 0, 0.353553, 0, 0.85, 0, -0.459619, 0, 0.353553, 3.5, -1.5, 3.5 )
 cast_shadow = 3
 mesh = SubResource( 4 )
 material/0 = null
 
 [node name="CollisionShape" type="CollisionShape" parent="Turbo"]
-transform = Transform( 0.707107, 0, 0.707107, 0, 1, 0, -0.707107, 0, 0.707107, 0.35, -0.15, 0.35 )
+transform = Transform( 0.707107, 0, 0.707107, 0, 1, 0, -0.707107, 0, 0.707107, 3.5, -1.5, 3.5 )
 shape = SubResource( 5 )
 
 [node name="CameraTarget" type="Spatial" parent="Turbo"]
-transform = Transform( 0.707107, -0.353553, 0.612372, 0, 0.866025, 0.5, -0.707107, -0.353553, 0.612372, 30, 25, 30 )
+transform = Transform( 0.707107, -0.353553, 0.612372, 0, 0.866025, 0.5, -0.707107, -0.353553, 0.612372, 300, 250, 300 )
 
 [node name="CoyoteTimer" type="Timer" parent="Turbo"]
 wait_time = 0.13
@@ -172,9 +180,9 @@ __meta__ = {
 anims/walk-sw = SubResource( 6 )
 
 [node name="Red" type="KinematicBody" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 6, 2.2, 2 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 60, 22, 20 )
 script = ExtResource( 6 )
-foothold_radius = 0.4
+foothold_radius = 4.0
 
 [node name="MeshInstance" type="MeshInstance" parent="Red"]
 mesh = SubResource( 7 )
@@ -184,7 +192,7 @@ material/0 = SubResource( 9 )
 shape = SubResource( 10 )
 
 [node name="Blue" type="KinematicBody" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 8 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 10, 80 )
 
 [node name="MeshInstance" type="MeshInstance" parent="Blue"]
 mesh = SubResource( 7 )
@@ -194,24 +202,25 @@ material/0 = ExtResource( 13 )
 shape = SubResource( 10 )
 
 [node name="InterpolatedCamera" type="InterpolatedCamera" parent="."]
-transform = Transform( 0.707107, -0.353553, 0.612373, 0, 0.866026, 0.5, -0.707107, -0.353553, 0.612373, 30, 25, 30 )
+transform = Transform( 0.707107, -0.353553, 0.612373, 0, 0.866026, 0.5, -0.707107, -0.353553, 0.612373, 300, 250, 300 )
 environment = ExtResource( 11 )
 projection = 1
 current = true
-size = 14.0
+size = 140.0
+near = 0.5
+far = 1000.0
 target = NodePath("../Turbo/CameraTarget")
-speed = 6.0
+speed = 4.0
 enabled = true
 
 [node name="DirectionalLight2" type="DirectionalLight" parent="."]
-transform = Transform( -0.5, -0.709407, 0.496732, 0, 0.573576, 0.819152, -0.866025, 0.409576, -0.286788, 0, 20, 0 )
+transform = Transform( -0.5, -0.709407, 0.496731, 0, 0.573576, 0.819152, -0.866025, 0.409576, -0.286788, 0, 200, 0 )
 light_energy = 0.33
 shadow_enabled = true
-directional_shadow_mode = 0
-directional_shadow_normal_bias = 0.0
+directional_shadow_max_distance = 1000.0
 
 [node name="Sphere" type="MeshInstance" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 1, -4 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -40, 10, -40 )
 mesh = SubResource( 11 )
 material/0 = SubResource( 12 )
 

--- a/src/main/world/PurpleBoxTexture.tscn
+++ b/src/main/world/PurpleBoxTexture.tscn
@@ -4,15 +4,16 @@
 [ext_resource path="res://assets/world/purple-box-texture-2.tres" type="Material" id=2]
 [ext_resource path="res://assets/world/purple-box-texture-1.tres" type="Material" id=3]
 
-[sub_resource type="CubeMesh" id=1]
-size = Vector3( 2, 1.2, 2 )
+[sub_resource type="CubeMesh" id=3]
+size = Vector3( 20, 12, 20 )
 
 [sub_resource type="BoxShape" id=2]
+extents = Vector3( 10, 6, 10 )
 
 [node name="PurpleBoxTexture" type="Spatial"]
 
 [node name="Box0" type="MeshInstance" parent="."]
-mesh = SubResource( 1 )
+mesh = SubResource( 3 )
 material/0 = ExtResource( 1 )
 
 [node name="StaticBody" type="StaticBody" parent="Box0"]
@@ -21,8 +22,8 @@ material/0 = ExtResource( 1 )
 shape = SubResource( 2 )
 
 [node name="Box1" type="MeshInstance" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2.90753, 0.133638, -0.417253 )
-mesh = SubResource( 1 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 30, 0, 0 )
+mesh = SubResource( 3 )
 material/0 = ExtResource( 3 )
 
 [node name="StaticBody" type="StaticBody" parent="Box1"]
@@ -31,8 +32,8 @@ material/0 = ExtResource( 3 )
 shape = SubResource( 2 )
 
 [node name="Box2" type="MeshInstance" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 6.62268, 0.11759, -0.417253 )
-mesh = SubResource( 1 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 60, 0, 0 )
+mesh = SubResource( 3 )
 material/0 = ExtResource( 2 )
 
 [node name="StaticBody" type="StaticBody" parent="Box2"]

--- a/src/main/world/turbo.gd
+++ b/src/main/world/turbo.gd
@@ -7,25 +7,25 @@ The 3D object representing 'Turbo', the player-controlled character who moves ar
 const FRICTION := 0.15
 
 # How fast can Turbo move
-const MAX_RUN_SPEED := 6
+const MAX_RUN_SPEED := 60
 
 # How fast can Turbo slip
-const MAX_SLIP_SPEED := 9
+const MAX_SLIP_SPEED := 90
 
 # How fast Turbo slips off of slippery platforms
-const MAX_SLIP_ACCELERATION := 220
+const MAX_SLIP_ACCELERATION := 2200
 
 # How fast can Turbo accelerate
-const MAX_RUN_ACCELERATION := 150
+const MAX_RUN_ACCELERATION := 1500
 
 # How slow can Turbo move before she stops
-const MIN_RUN_SPEED := 4
+const MIN_RUN_SPEED := 40
 
 # How fast does gravity accelerate Turbo
-const GRAVITY := 40.0
+const GRAVITY := 400.0
 
 # Vertical force applied to Turbo when she jumps
-const JUMP_SPEED := 16
+const JUMP_SPEED := 160
 
 # Turbo's (X, Y, Z) velocity
 var _velocity := Vector3(0, 0, 0)
@@ -57,10 +57,6 @@ func _physics_process(delta):
 		else:
 			_jumping = false
 	
-	if is_on_floor() and not _jumping:
-		# the character visibly jitters between y values of [1.06, 1.10] if we do not smooth the value
-		translation.y = stepify(translation.y, 0.2)
-		
 	if not is_on_floor() and was_on_floor and not _jumping and not _slipping:
 		$CoyoteTimer.start()
 


### PR DESCRIPTION
There was some unusual code in turbo.gd to reduce jitter. Controlling a box which is 2 units high causes 0.2 units of jitter in Godot, which is very noticable as it is 10% of the object's height. I attempted to reduce this jitter by snapping the character's Y coordinate to the nearest 0.2, but this was not a perfect fix. Some bouncing was still visible occasionally. It also didn't work if Turbo ever landed on a surface that wasn't a perfect multiple of 0.2.

I've made all 3D objects 900% bigger to reduce these physics glitches. Controlling a box which is 20 units high makes the jitter less visible. I also removed the snapping behavior for Turbo's movement.

Fixed lighting artifacts; orthogonal lights were introducing weird stripes on textures in editor