### PR TITLE
Camera predicts movement. Minor jump physics fix

### DIFF
--- a/src/main/world/turbo.gd
+++ b/src/main/world/turbo.gd
@@ -27,6 +27,15 @@ const GRAVITY := 400.0
 # Vertical force applied to Turbo when she jumps
 const JUMP_SPEED := 160
 
+# Default position of camera relative to Turbo. The camera is above and in front.
+const DEFAULT_CAMERA_TRANSLATION := Vector3(300, 250, 300)
+
+# How far the camera should lead Turbo's movement when Turbo is walking/jumping
+const CAMERA_LEAD_DISTANCE := 60
+
+# Number from [0.0, 1.0] for how tight the camera should snap to Turbo's movement
+const CAMERA_JERKINESS := 0.04
+
 # Turbo's (X, Y, Z) velocity
 var _velocity := Vector3(0, 0, 0)
 
@@ -40,12 +49,17 @@ var _jumping := false
 # 'true' if Turbo is either slipping, or mid-air after having slipped
 var _slipping := false
 
+# The direction Turbo is walking in (X, Y) coordinates, where 'Y' is forward.
+var _walk_direction := Vector2(0, 0)
+
 func _physics_process(delta):
 	var was_on_floor = is_on_floor()
 	
 	_apply_friction()
 	_apply_gravity(delta)
 	_apply_player_input(delta)
+	_update_animation()
+	_update_camera_target()
 
 	move_and_slide(_velocity, Vector3.UP)
 	
@@ -61,8 +75,32 @@ func _physics_process(delta):
 		$CoyoteTimer.start()
 
 
+func _update_animation():
+	if _slipping:
+		if $AnimationPlayer.current_animation != "":
+			$AnimationPlayer.stop()
+			$Sprite3D.frame = 0
+	elif _jumping:
+		if $AnimationPlayer.current_animation != "":
+			$AnimationPlayer.stop()
+			$Sprite3D.frame = 0
+	elif _walk_direction.length() > 0:
+		if $AnimationPlayer.current_animation != "walk-sw":
+			$AnimationPlayer.play("walk-sw")
+	else:
+		if $AnimationPlayer.current_animation != "":
+			$AnimationPlayer.stop()
+			$Sprite3D.frame = 0
+
+
+func _update_camera_target():
+	var new_translation := DEFAULT_CAMERA_TRANSLATION \
+			+ Vector3(_walk_direction.x, 0, _walk_direction.y) * CAMERA_LEAD_DISTANCE
+	$CameraTarget.translation = lerp($CameraTarget.translation, new_translation, CAMERA_JERKINESS)
+
+
 func _apply_gravity(delta: float) -> void:
-	if is_on_floor():
+	if is_on_floor() and not _jumping:
 		_velocity.y = 0
 	_velocity += Vector3.DOWN * GRAVITY * delta
 
@@ -110,28 +148,27 @@ function.
 func _apply_player_input(delta: float) -> void:
 	if _slipping:
 		# Turbo is slipping; all input is ignored
+		_walk_direction = Vector2(0, 0)
 		return
 
 	if $CoyoteTimer.is_stopped() and not is_on_floor():
 		# Turbo is in mid-air; no movement allowed in mid-air
 		pass
 	else:
+		_walk_direction = Vector2(0, 0)
 		# calculate the direction the player wants to move
-		var player_input := Vector2(0, 0)
 		if Input.is_action_pressed("ui_left"):
-			player_input += Vector2.LEFT
+			_walk_direction += Vector2.LEFT
 		if Input.is_action_pressed("ui_right"):
-			player_input += Vector2.RIGHT
+			_walk_direction += Vector2.RIGHT
 		if Input.is_action_pressed("ui_up"):
-			player_input += Vector2.UP
+			_walk_direction += Vector2.UP
 		if Input.is_action_pressed("ui_down"):
-			player_input += Vector2.DOWN
+			_walk_direction += Vector2.DOWN
 		if _rotate_controls:
-			player_input = player_input.rotated(-PI / 4)
-		
+			_walk_direction = _walk_direction.rotated(-PI / 4)
 		# move Turbo towards the direction the player wants to move
-		accelerate_player_xy(delta, player_input, MAX_RUN_ACCELERATION, MAX_RUN_SPEED)
-	
+		accelerate_player_xy(delta, _walk_direction, MAX_RUN_ACCELERATION, MAX_RUN_SPEED)
 	
 	if Input.is_action_just_pressed("jump"):
 		if is_on_floor() or not $CoyoteTimer.is_stopped():
@@ -173,7 +210,6 @@ func jump() -> void:
 When Turbo attempts to jump onto a narrow surface, she slides off unless she lands very squarely in the middle of it.
 """
 func _slide_from_narrow_surfaces(delta: float) -> void:
-	var was_slipping := _slipping
 	if is_on_floor():
 		var just_slipped = false
 		if get_slide_count() > 0:


### PR DESCRIPTION
The camera now predicts Turbo's movement, so the player can see ahead of where
they're walking.

Fixed an issue where holding the button didn't trigger a jump. This was
already coded, but a bug in the gravity code caused the player's jump to
be nullified.