### PR TITLE
Changed piece timings; faster but more lenient

### DIFF
--- a/src/main/puzzle/Playfield.tscn
+++ b/src/main/puzzle/Playfield.tscn
@@ -77,6 +77,10 @@
 0/autotile/z_index_map = [  ]
 0/occluder_offset = Vector2( 0, 0 )
 0/navigation_offset = Vector2( 0, 0 )
+0/shape_offset = Vector2( 0, 0 )
+0/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+0/shape_one_way = false
+0/shape_one_way_margin = 0.0
 0/shapes = [  ]
 0/z_index = 0
 1/name = "blocks-boxes.png"
@@ -94,6 +98,10 @@
 1/autotile/z_index_map = [  ]
 1/occluder_offset = Vector2( 0, 0 )
 1/navigation_offset = Vector2( 0, 0 )
+1/shape_offset = Vector2( 0, 0 )
+1/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+1/shape_one_way = false
+1/shape_one_way_margin = 0.0
 1/shapes = [  ]
 1/z_index = 0
 2/name = "blocks-vegetable.png"
@@ -111,6 +119,10 @@
 2/autotile/z_index_map = [  ]
 2/occluder_offset = Vector2( 0, 0 )
 2/navigation_offset = Vector2( 0, 0 )
+2/shape_offset = Vector2( 0, 0 )
+2/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+2/shape_one_way = false
+2/shape_one_way_margin = 0.0
 2/shapes = [  ]
 2/z_index = 0
 
@@ -130,6 +142,10 @@
 0/autotile/z_index_map = [  ]
 0/occluder_offset = Vector2( 0, 0 )
 0/navigation_offset = Vector2( 0, 0 )
+0/shape_offset = Vector2( 0, 0 )
+0/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+0/shape_one_way = false
+0/shape_one_way_margin = 0.0
 0/shapes = [  ]
 0/z_index = 0
 1/name = "blocks-boxes-shadows.png 1"
@@ -147,6 +163,10 @@
 1/autotile/z_index_map = [  ]
 1/occluder_offset = Vector2( 0, 0 )
 1/navigation_offset = Vector2( 0, 0 )
+1/shape_offset = Vector2( 0, 0 )
+1/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+1/shape_one_way = false
+1/shape_one_way_margin = 0.0
 1/shapes = [  ]
 1/z_index = 0
 2/name = "blocks-vegetable-shadows.png 2"
@@ -164,6 +184,10 @@
 2/autotile/z_index_map = [  ]
 2/occluder_offset = Vector2( 0, 0 )
 2/navigation_offset = Vector2( 0, 0 )
+2/shape_offset = Vector2( 0, 0 )
+2/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+2/shape_one_way = false
+2/shape_one_way_margin = 0.0
 2/shapes = [  ]
 2/z_index = 0
 
@@ -259,10 +283,12 @@ bus = "Reverb Bus"
 
 [node name="ClearSnackPieceSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 12 )
+volume_db = -4.0
 bus = "Reverb Bus"
 
 [node name="ClearCakePieceSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 13 )
+volume_db = -4.0
 bus = "Reverb Bus"
 
 [node name="Combo1Sound" type="AudioStreamPlayer" parent="."]

--- a/src/main/puzzle/piece/piece-manager.gd
+++ b/src/main/puzzle/piece/piece-manager.gd
@@ -26,7 +26,7 @@ onready var _game_over_voices := [$GameOverVoice0, $GameOverVoice1, $GameOverVoi
 
 # information about the current 'speed level', such as how fast pieces drop, how long it takes them to lock into the
 # playfield, and how long to pause when clearing lines.
-var piece_speed
+var piece_speed: PieceSpeed
 
 # settings and state for the currently active piece.
 var active_piece := ActivePiece.new(PieceTypes.piece_null)

--- a/src/main/puzzle/piece/piece-speeds.gd
+++ b/src/main/puzzle/piece/piece-speeds.gd
@@ -13,7 +13,7 @@ const G := 256
 
 # The maximum number of 'lock resets' the player is allotted for a single piece. A lock reset occurs when a piece is at
 # the bottom of the screen but the player moves or rotates it to prevent from locking.
-const MAX_LOCK_RESETS := 12
+const MAX_LOCK_RESETS := 15
 
 # The gravity constant used when the player soft-drops a piece.
 const DROP_G := 128
@@ -21,43 +21,45 @@ const DROP_G := 128
 # When the player does a 'smush move' the piece is unaffected by gravity for this many frames.
 const SMUSH_FRAMES := 4
 
+
+
 # used when the game isn't running
-var null_level := PieceSpeed.new("-",   4, 20, 36, 7, 16, 43, 40, 40)
+var null_level := PieceSpeed.new("-",   4, 20, 36, 7, 16, 40, 24, 12)
 
-var beginner_level_0 := PieceSpeed.new("0",   4, 20, 36, 7, 16, 43, 40, 40)
-var beginner_level_1 := PieceSpeed.new("1",   5, 20, 36, 7, 16, 43, 40, 40)
-var beginner_level_2 := PieceSpeed.new("2",   6, 20, 36, 7, 16, 43, 40, 40)
-var beginner_level_3 := PieceSpeed.new("3",   8, 20, 36, 7, 16, 43, 40, 40)
-var beginner_level_4 := PieceSpeed.new("4",  10, 20, 36, 7, 16, 43, 40, 40)
-var beginner_level_5 := PieceSpeed.new("5",  12, 20, 36, 7, 16, 43, 40, 40)
-var beginner_level_6 := PieceSpeed.new("6",  16, 20, 36, 7, 16, 43, 40, 40)
-var beginner_level_7 := PieceSpeed.new("7",  24, 20, 36, 7, 16, 43, 40, 40)
-var beginner_level_8 := PieceSpeed.new("8",  32, 20, 36, 7, 16, 43, 40, 40)
-var beginner_level_9 := PieceSpeed.new("9",  48, 20, 36, 7, 16, 43, 40, 40)
+var beginner_level_0 := PieceSpeed.new("0",   4, 20, 36, 7, 16, 40, 24, 12)
+var beginner_level_1 := PieceSpeed.new("1",   5, 20, 36, 7, 16, 40, 24, 12)
+var beginner_level_2 := PieceSpeed.new("2",   6, 20, 36, 7, 16, 40, 24, 12)
+var beginner_level_3 := PieceSpeed.new("3",   8, 20, 36, 7, 16, 40, 24, 12)
+var beginner_level_4 := PieceSpeed.new("4",  10, 20, 36, 7, 16, 40, 24, 12)
+var beginner_level_5 := PieceSpeed.new("5",  12, 20, 36, 7, 16, 40, 24, 12)
+var beginner_level_6 := PieceSpeed.new("6",  16, 20, 36, 7, 16, 40, 24, 12)
+var beginner_level_7 := PieceSpeed.new("7",  24, 20, 36, 7, 16, 40, 24, 12)
+var beginner_level_8 := PieceSpeed.new("8",  32, 20, 36, 7, 16, 40, 24, 12)
+var beginner_level_9 := PieceSpeed.new("9",  48, 20, 36, 7, 16, 40, 24, 12)
 
-var hard_level_0  := PieceSpeed.new("A0",    4, 20, 20, 7, 16, 30, 40, 20)
-var hard_level_1  := PieceSpeed.new("A1",   32, 20, 20, 7, 16, 30, 40, 20)
-var hard_level_2  := PieceSpeed.new("A2",   48, 20, 20, 7, 16, 30, 40, 20)
-var hard_level_3  := PieceSpeed.new("A3",   64, 20, 20, 7, 16, 30, 40, 20)
-var hard_level_4  := PieceSpeed.new("A4",   96, 20, 20, 7, 16, 30, 40, 20)
-var hard_level_5  := PieceSpeed.new("A5",  128, 20, 20, 7, 16, 30, 40, 20)
-var hard_level_6  := PieceSpeed.new("A6",  152, 20, 20, 7, 16, 30, 40, 20)
-var hard_level_7  := PieceSpeed.new("A7",  176, 20, 20, 7, 16, 30, 40, 20)
-var hard_level_8  := PieceSpeed.new("A8",  200, 20, 20, 7, 16, 30, 40, 20)
-var hard_level_9  := PieceSpeed.new("A9",  224, 20, 20, 7, 16, 30, 40, 20)
-var hard_level_10 := PieceSpeed.new("AA",  1*G, 20, 20, 7, 16, 30, 40, 20)
-var hard_level_11 := PieceSpeed.new("AB",  2*G, 20, 20, 7, 16, 30, 40, 20)
-var hard_level_12 := PieceSpeed.new("AC",  3*G, 20, 20, 7, 16, 30, 40, 20)
-var hard_level_13 := PieceSpeed.new("AD",  5*G, 20, 20, 7, 16, 30, 40, 20)
-var hard_level_14 := PieceSpeed.new("AE", 20*G, 20, 20, 7, 10, 30, 25, 12)
-var hard_level_15 := PieceSpeed.new("AF", 20*G, 20, 12, 7, 10, 30, 12,  6)
+var hard_level_0  := PieceSpeed.new("A0",    4, 20, 20, 7, 16, 40, 24, 12)
+var hard_level_1  := PieceSpeed.new("A1",   32, 20, 20, 7, 16, 40, 24, 12)
+var hard_level_2  := PieceSpeed.new("A2",   48, 20, 20, 7, 16, 40, 24, 12)
+var hard_level_3  := PieceSpeed.new("A3",   64, 20, 20, 7, 16, 40, 24, 12)
+var hard_level_4  := PieceSpeed.new("A4",   96, 20, 20, 7, 16, 40, 24, 12)
+var hard_level_5  := PieceSpeed.new("A5",  128, 20, 20, 7, 16, 40, 24, 12)
+var hard_level_6  := PieceSpeed.new("A6",  152, 20, 20, 7, 16, 40, 24, 12)
+var hard_level_7  := PieceSpeed.new("A7",  176, 20, 20, 7, 16, 40, 24, 12)
+var hard_level_8  := PieceSpeed.new("A8",  200, 20, 20, 7, 16, 40, 24, 12)
+var hard_level_9  := PieceSpeed.new("A9",  224, 20, 20, 7, 16, 40, 24, 12)
+var hard_level_10 := PieceSpeed.new("AA",  1*G, 20, 20, 7, 16, 40, 24, 12)
+var hard_level_11 := PieceSpeed.new("AB",  2*G, 20, 20, 7, 16, 40, 24, 12)
+var hard_level_12 := PieceSpeed.new("AC",  3*G, 20, 20, 7, 16, 40, 24, 12)
+var hard_level_13 := PieceSpeed.new("AD",  5*G, 20, 20, 7, 16, 40, 24, 12)
+var hard_level_14 := PieceSpeed.new("AE", 20*G, 20, 16, 7, 10, 30, 18,  9)
+var hard_level_15 := PieceSpeed.new("AF", 20*G, 16, 12, 7, 10, 30, 12,  6)
 
-var crazy_level_0 := PieceSpeed.new( "F0",    4, 12, 8, 7, 10, 20, 6, 3)
-var crazy_level_1 := PieceSpeed.new( "F1",  1*G, 12, 8, 7, 10, 20, 6, 3)
-var crazy_level_2 := PieceSpeed.new( "FA", 20*G, 12, 8, 7, 10, 20, 6, 3)
-var crazy_level_3 := PieceSpeed.new( "FB", 20*G,  8, 4, 5,  8, 18, 5, 3)
-var crazy_level_4 := PieceSpeed.new( "FC", 20*G,  8, 4, 5,  8, 16, 5, 3)
-var crazy_level_5 := PieceSpeed.new( "FD", 20*G,  2, 2, 5,  8, 14, 4, 3)
-var crazy_level_6 := PieceSpeed.new( "FE", 20*G,  2, 2, 5,  8, 12, 4, 3)
-var crazy_level_7 := PieceSpeed.new( "FF", 20*G,  1, 1, 5,  8, 10, 3, 3)
-var crazy_level_8 := PieceSpeed.new("FFF", 20*G,  1, 1, 5,  8,  8, 3, 3)
+var crazy_level_0 := PieceSpeed.new( "F0",    4, 12, 8, 7, 10, 24, 6, 3)
+var crazy_level_1 := PieceSpeed.new( "F1",  1*G, 12, 8, 7, 10, 24, 6, 3)
+var crazy_level_2 := PieceSpeed.new( "FA", 20*G, 12, 8, 7, 10, 24, 6, 3)
+var crazy_level_3 := PieceSpeed.new( "FB", 20*G,  8, 6, 5,  6, 22, 5, 3)
+var crazy_level_4 := PieceSpeed.new( "FC", 20*G,  6, 4, 5,  6, 20, 4, 3)
+var crazy_level_5 := PieceSpeed.new( "FD", 20*G,  4, 2, 5,  6, 18, 3, 3)
+var crazy_level_6 := PieceSpeed.new( "FE", 20*G,  4, 2, 5,  6, 16, 3, 3)
+var crazy_level_7 := PieceSpeed.new( "FF", 20*G,  4, 2, 5,  6, 14, 3, 3)
+var crazy_level_8 := PieceSpeed.new("FFF", 20*G,  4, 2, 5,  6, 12, 3, 3)

--- a/src/main/puzzle/piece/piece-type.gd
+++ b/src/main/puzzle/piece/piece-type.gd
@@ -30,7 +30,7 @@ var ccw_kicks: Array
 var max_floor_kicks: int
 
 func _init(init_string: String, init_pos_arr: Array, init_color_arr: Array, init_kicks: Array,
-		init_max_floor_kicks := 2) -> void:
+		init_max_floor_kicks := 3) -> void:
 	string = init_string
 	pos_arr = init_pos_arr
 	color_arr = init_color_arr

--- a/src/main/puzzle/piece/piece-types.gd
+++ b/src/main/puzzle/piece/piece-types.gd
@@ -148,7 +148,7 @@ var piece_u := PieceType.new("u",
 		[Vector2(2, 2), Vector2(2, 2), Vector2(9, 2), Vector2(12, 2), Vector2(5, 2)],
 		[Vector2(10, 2), Vector2(4, 2), Vector2(3, 2), Vector2(9, 2), Vector2(4, 2)]],
 		KICKS_U,
-		3 # u-piece allows additional floor kicks because it kicks the floor twice if you rotate it four times
+		5 # u-piece allows additional floor kicks because it kicks the floor twice if you rotate it four times
 	)
 
 var piece_v := PieceType.new("v",

--- a/src/main/puzzle/puzzle-trace.gd
+++ b/src/main/puzzle/puzzle-trace.gd
@@ -13,6 +13,9 @@ func _process(delta: float) -> void:
 		new_text += "l" if _playfield._remaining_line_clear_frames > 0 else "-"
 		new_text += "b" if _playfield._remaining_box_build_frames > 0 else "-"
 		new_text += "r" if _playfield.ready_for_new_piece() else "-"
-		new_text += "%1d" % _playfield._combo_break
+		var das: bool = _pieceManager._input_left_frames > _pieceManager.piece_speed.delayed_auto_shift_delay \
+				or _pieceManager._input_right_frames > _pieceManager.piece_speed.delayed_auto_shift_delay
+		new_text += "D" if das else "-"
+		new_text += "%1d%1d" % [min(9, _pieceManager._input_left_frames), min(9, _pieceManager._input_right_frames)]
 		new_text += " %s(%02d)" % [_pieceManager.get_state().name.left(4), min(99, _pieceManager.get_state().frames)]
 		text = new_text


### PR DESCRIPTION
The overall goal of these timing changes was:

1. Bring the overall max/min blocks per minute in line with other similar games
2. Allow faster players to play faster on easier difficulties
3. Allow slower players more leniency on easier difficulties
4. Have a smooth difficulty curve (except for the sudden 1G/20G increases)

The frame delay when creating a box or clearing a line has been decreased, especially on easier levels. This allows fast players to play faster.

The number of lock resets and floor kicks has been increased. This makes piece movement more lenient. I've also increased the lock delay from 30 frames to 40 frames for the middle difficulties.

The top speed of the crazy difficulties now remains unchanged for the last few levels. THis allows expert players to find and stick to a rhythm.