### PR TITLE
Preload all resources to increase performance, decrease jitter

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -59,6 +59,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/world/customer-3d.gd"
 }, {
+"base": "Reference",
+"class": "CustomerLoader",
+"language": "GDScript",
+"path": "res://src/main/world/restaurant/customer-loader.gd"
+}, {
 "base": "Sprite",
 "class": "MultiOutlineSprite",
 "language": "GDScript",
@@ -180,6 +185,7 @@ _global_script_class_icons={
 "CheatCodeDetector": "",
 "Customer": "",
 "Customer3D": "",
+"CustomerLoader": "",
 "MultiOutlineSprite": "",
 "NextPieceDisplay": "",
 "NextPieceDisplays": "",
@@ -207,7 +213,7 @@ _global_script_class_icons={
 [application]
 
 config/name="Turbo Fat"
-run/main_scene="res://src/main/ui/ScenarioMenu.tscn"
+run/main_scene="res://src/main/ui/LoadingScreen.tscn"
 config/icon="res://assets/ui/icon.png"
 config/version="0.0419"
 
@@ -217,11 +223,11 @@ default_bus_layout="res://assets/ui/default_bus_layout.tres"
 
 [autoload]
 
-CustomerLoader="*res://src/main/world/restaurant/customer-loader.gd"
+Global="*res://src/main/global.gd"
 InteractableManager="*res://src/main/world/interactable-manager.gd"
 PieceSpeeds="*res://src/main/puzzle/piece/piece-speeds.gd"
 PieceTypes="*res://src/main/puzzle/piece/piece-types.gd"
-Global="*res://src/main/global.gd"
+ResourceCache="*res://src/main/ResourceCache.tscn"
 ScenarioHistory="*res://src/main/puzzle/scenario-history.gd"
 ScenarioLibrary="*res://src/main/puzzle/scenario-library.gd"
 
@@ -233,11 +239,6 @@ window/stretch/aspect="keep"
 [editor_plugins]
 
 enabled=PoolStringArray( "gut" )
-
-[global]
-
-nvidia=false
-env=false
 
 [gui]
 
@@ -320,13 +321,10 @@ rewind_text={
  ]
 }
 
-[oversampling]
-
-stretch/mode=false
-
 [rendering]
 
 quality/2d/gles2_use_nvidia_rect_flicker_workaround=true
+threads/thread_model=2
 quality/filters/msaa=2
 quality/depth/hdr=false
 environment/default_environment="res://src/main/default_env.tres"

--- a/src/delint.sh
+++ b/src/delint.sh
@@ -5,12 +5,12 @@
 grep -R -n "^func.*):$" --include="*.gd" .
 
 # long lines
-grep -R -n "^.\{120,\}$" --include="*.gd" .
-grep -R -n "^	.\{116,\}$" --include="*.gd" .
-grep -R -n "^		.\{112,\}$" --include="*.gd" .
-grep -R -n "^			.\{108,\}$" --include="*.gd" .
-grep -R -n "^				.\{104,\}$" --include="*.gd" .
-grep -R -n "^					.\{100,\}$" --include="*.gd" .
+#grep -R -n "^.\{120,\}$" --include="*.gd" .
+#grep -R -n "^	.\{116,\}$" --include="*.gd" .
+#grep -R -n "^		.\{112,\}$" --include="*.gd" .
+#grep -R -n "^			.\{108,\}$" --include="*.gd" .
+#grep -R -n "^				.\{104,\}$" --include="*.gd" .
+#grep -R -n "^					.\{100,\}$" --include="*.gd" .
 
 # fields/variables missing type hint. includes a list of whitelisted type hint omissions
 grep -R -n "var [^:]* = " --include="*.gd" . \

--- a/src/main/ResourceCache.tscn
+++ b/src/main/ResourceCache.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/main/resource-cache.gd" type="Script" id=1]
+
+[node name="ResourceCache" type="Node"]
+script = ExtResource( 1 )

--- a/src/main/puzzle/scenario-settings.gd
+++ b/src/main/puzzle/scenario-settings.gd
@@ -95,7 +95,6 @@ func add_level_up(type: int, value: int, level: String) -> void:
 	level_up.type = type
 	level_up.value = value
 	level_up.level = level
-	print("116: %s %s" % [level_up.level, typeof(level_up.level)])
 	level_ups.append(level_up)
 
 

--- a/src/main/resource-cache.gd
+++ b/src/main/resource-cache.gd
@@ -1,0 +1,123 @@
+extends Node
+"""
+Preloads resources to speed up scene transitions.
+
+By default, Godot loads the resources it needs for each scene and caches them until they're not needed anymore. This
+allows the game to start up quickly, but results in long wait times when transitioning from one scene to another.
+
+By preloading resources used throughout the game, we have a slower startup time in exchange for faster load times
+during the game.
+"""
+
+signal finished_loading
+
+# enables logging paths and durations for loaded resources
+export (bool) var _verbose := false
+
+# maintains references to all resources to prevent them from being cleaned up
+var _cache := {}
+
+# setting this to 'true' causes the background thread to terminate gracefully
+var _exiting := false
+
+# background thread for loading resources
+var _load_thread: Thread
+
+# these two properties are used for the get_progress calculation
+var _work_done := 0.0
+var _work_remaining := 3.0
+
+func _ready() -> void:
+	_load_thread = Thread.new()
+	_load_thread.start(self, "_preload_pngs")
+
+
+func _exit_tree() -> void:
+	_exiting = true
+	_load_thread.wait_to_finish()
+
+
+func get_progress() -> float:
+	return clamp(_work_done / _work_remaining, 0.0, 1.0)
+
+
+"""
+Loads all pngs in the /assets directory and stores the resulting resources in our cache
+
+Parameters:
+	'userdata': Unused; needed for threads
+"""
+func _preload_pngs(userdata: Object) -> void:
+	var png_paths := _find_png_paths()
+	
+	# all pngs have been located. increment the progress bar and calculate its new maximum
+	_work_remaining += png_paths.size()
+	_work_done += 3.0
+	
+	# We shuffle the pngs to prevent clumps of similar files. We use a known seed to keep the timing predictable.
+	seed(253686)
+	png_paths.shuffle()
+	
+	for png_path in png_paths:
+		_load_resource(png_path)
+		_work_done += 1.0
+		if _exiting:
+			break
+	
+	emit_signal("finished_loading")
+
+
+"""
+Returns a list of all png files in the /assets directory.
+
+Recursively traverses the assets directory searching for pngs. Any additional directories it discovers are appended to
+a queue for later traversal.
+
+Note: We search for '.png.import' files instead of searching for png files directly. This is because png files
+	disappear when the project is exported.
+"""
+func _find_png_paths() -> Array:
+	var png_paths := []
+	
+	# directories remaining to be traversed
+	var dir_queue := ["res://assets"]
+	
+	var dir: Directory
+	var file: String
+	while true:
+		if file:
+			if dir.current_is_dir():
+				dir_queue.append("%s/%s" % [dir.get_current_dir(), file])
+			elif file.ends_with(".png.import"):
+				png_paths.append("%s/%s" % [dir.get_current_dir(), file.get_basename()])
+		else:
+			if dir:
+				dir.list_dir_end()
+			if dir_queue.empty():
+				break
+			# there are more directories. open the next directory
+			dir = Directory.new()
+			dir.open(dir_queue.pop_front())
+			dir.list_dir_begin(true, true)
+		file = dir.get_next()
+	
+	return png_paths
+
+
+"""
+Loads and caches the resource at the specified path.
+
+If the resource is not found, we cache that fact and do not attempt to load it again.
+"""
+func _load_resource(resource_path: String) -> void:
+	if _cache.has(resource_path):
+		# resource already cached
+		pass
+	elif !ResourceLoader.exists(resource_path):
+		# resource doesn't exist; cache so we don't try again
+		_cache[resource_path] = "_"
+	else:
+		var start := OS.get_ticks_msec()
+		_cache[resource_path] = load(resource_path)
+		var duration := OS.get_ticks_msec() - start
+		if _verbose: print("resource loaded: %4d, %s" % [duration, resource_path])

--- a/src/main/ui/LoadingScreen.tscn
+++ b/src/main/ui/LoadingScreen.tscn
@@ -1,0 +1,37 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://assets/ui/xolonium-48.tres" type="DynamicFont" id=1]
+[ext_resource path="res://src/main/ui/loading-screen.gd" type="Script" id=2]
+[ext_resource path="res://assets/puzzle/wood-backdrop.png" type="Texture" id=3]
+
+[node name="LoadingScreen" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="TextureRect" type="TextureRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+texture = ExtResource( 3 )
+expand = true
+stretch_mode = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ProgressBar" type="ProgressBar" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -332.0
+margin_top = -29.0
+margin_right = 332.0
+margin_bottom = 29.0
+custom_fonts/font = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/src/main/ui/loading-screen.gd
+++ b/src/main/ui/loading-screen.gd
@@ -1,0 +1,15 @@
+extends Control
+"""
+Shows a progress bar while resources are loading.
+"""
+
+func _ready() -> void:
+	ResourceCache.connect("finished_loading", self, "change_scene")
+
+
+func _process(delta: float) -> void:
+	$ProgressBar.value = 100.0 * ResourceCache.get_progress()
+
+
+func change_scene() -> void:
+	get_tree().change_scene("res://src/main/ui/ScenarioMenu.tscn")

--- a/src/main/world/restaurant/Seat.tscn
+++ b/src/main/world/restaurant/Seat.tscn
@@ -37,7 +37,6 @@ z_index = -10
 texture = ExtResource( 3 )
 
 [node name="Customer" parent="." instance=ExtResource( 1 )]
-visible = false
 position = Vector2( 1.228, -149.237 )
 
 [node name="WoodTable0" type="Sprite" parent="."]


### PR DESCRIPTION
Resources were previously being loaded as needed, particularly for
customers. This had a few clunky results, such as having characters be
temporarily invisible on the 3D screen, and it was also still quite slow
(about 5 seconds of delay during transitions.)

My first idea was to load these resources in a background thread on the
main menu or maybe a title screen. However it was still too jerky -- even
when just navigating menus it looked bad. It's better just to preload things
and work on improving loading times.

Changed to multi-threading rendering model; this weirdly makes resources load
12% faster.

Increased chime delays in customer.gd to compensate for customers being
preloaded.

Removed 'long line' delint detection, as there's way too many currently.
it's interfering with my usual delinting