### PR TITLE
Turbo physics tweak: preserve velocity, improved velocity cap

### DIFF
--- a/src/main/world/turbo-trace.gd
+++ b/src/main/world/turbo-trace.gd
@@ -12,3 +12,4 @@ func _process(delta: float) -> void:
 		text += "-" if turbo.get_node("JumpBuffer").is_stopped() else "b"
 		text += "j" if turbo._jumping else "-"
 		text += "s" if turbo._slipping else "-"
+		text += "f" if turbo._friction else "-"


### PR DESCRIPTION
Turbo's velocity is now updated as she collides with the floor and other
obstacles. This made her feel overly slippery, so I also added some logic
which applies friction when you steer her in a new direction. Friction is
now visible when using the 'COYOTE' cheat.

I also fixed a bug in the velocity capping logic in _accelerate_player_xy.
While Turbo's max run speed was allegedly 60 units/sec, she was typically
running at about 85 units/sec because of how the old capping logic worked.

This has one questionable side effect, which is that it's no longer
possible to hold the jump button and jump around in different directions,
since Turbo maintains her previous velocity.