### PR TITLE
Removed some P/Q climb kicks. Prevent initial DAS from killing you.

### DIFF
--- a/src/main/puzzle/piece/piece-manager.gd
+++ b/src/main/puzzle/piece/piece-manager.gd
@@ -153,7 +153,8 @@ func _spawn_piece() -> void:
 		var old_pos := active_piece.pos
 		_reset_piece_target()
 		_kick_piece([Vector2(-4, 0), Vector2(-4, -1), Vector2(-3, 0), Vector2(-3, -1),
-				Vector2(-2, 0), Vector2(-2, -1), Vector2(-1, 0), Vector2(-1, -1)])
+				Vector2(-2, 0), Vector2(-2, -1), Vector2(-1, 0), Vector2(-1, -1),
+				Vector2(0, 0), Vector2(0, -1), Vector2(1, 0), Vector2(1, -1)])
 		_move_piece_to_target()
 		if old_pos != active_piece.pos:
 			$MoveSound.play()
@@ -167,7 +168,8 @@ func _spawn_piece() -> void:
 		var old_pos := active_piece.pos
 		_reset_piece_target()
 		_kick_piece([Vector2(4, 0), Vector2(4, -1), Vector2(3, 0), Vector2(3, -1),
-				Vector2(2, 0), Vector2(2, -1), Vector2(1, 0), Vector2(1, -1)])
+				Vector2(2, 0), Vector2(2, -1), Vector2(1, 0), Vector2(1, -1),
+				Vector2(0, 0), Vector2(0, -1), Vector2(-1, 0), Vector2(-1, -1)])
 		_move_piece_to_target()
 		if old_pos != active_piece.pos:
 			$MoveSound.play()

--- a/src/main/puzzle/piece/piece-types.gd
+++ b/src/main/puzzle/piece/piece-types.gd
@@ -6,10 +6,14 @@ how they 'kick' when they're blocked from rotating.
 
 
 const KICKS_JLT := [
-		[Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1), Vector2( 0,  2), Vector2(-1,  1), Vector2(-1,  2), Vector2(0, -1)],
-		[Vector2( 1,  0), Vector2( 1,  1), Vector2( 0, -1), Vector2( 0, -2), Vector2( 1, -1), Vector2( 1, -2), Vector2(0,  1)],
-		[Vector2( 1,  0), Vector2( 1, -1), Vector2( 0,  1), Vector2( 0,  2), Vector2( 1,  1), Vector2( 1,  2), Vector2(0, -1)],
-		[Vector2(-1,  0), Vector2(-1,  1), Vector2( 0, -1), Vector2( 0, -2), Vector2(-1, -1), Vector2(-1, -2), Vector2(0,  1)]
+		[Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1), Vector2( 0,  2),
+				Vector2(-1,  1), Vector2(-1,  2), Vector2(0, -1)],
+		[Vector2( 1,  0), Vector2( 1,  1), Vector2( 0, -1), Vector2( 0, -2),
+				Vector2( 1, -1), Vector2( 1, -2), Vector2(0,  1)],
+		[Vector2( 1,  0), Vector2( 1, -1), Vector2( 0,  1), Vector2( 0,  2),
+				Vector2( 1,  1), Vector2( 1,  2), Vector2(0, -1)],
+		[Vector2(-1,  0), Vector2(-1,  1), Vector2( 0, -1), Vector2( 0, -2),
+				Vector2(-1, -1), Vector2(-1, -2), Vector2(0,  1)]
 	]
 
 const KICKS_U := [
@@ -19,11 +23,18 @@ const KICKS_U := [
 		[Vector2( 1,  1), Vector2( 1,  2), Vector2( 0, -1), Vector2( 1, -1)]
 	]
 
-const KICKS_PQ := [
-		[Vector2( 0,  1), Vector2( 0, -1), Vector2( 0, -2), Vector2(-1, -1)],
-		[Vector2( 1,  0), Vector2( 0,  1), Vector2( 0,  2), Vector2( 1, -1)],
-		[Vector2( 1,  0), Vector2( 0,  1), Vector2( 0, -2), Vector2( 1,  1)],
-		[Vector2( 0,  1), Vector2( 0, -1), Vector2( 0,  2), Vector2(-1,  1)]
+const KICKS_P := [
+		[Vector2( 0, -1), Vector2(-1, -1), Vector2( 0,  1), Vector2(-1,  0)],
+		[Vector2( 1,  0), Vector2( 1, -1), Vector2( 0, -1), Vector2( 0,  1)],
+		[Vector2( 0,  1), Vector2( 1,  1), Vector2( 0, -1), Vector2(-1,  0)],
+		[Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1)]
+	]
+
+const KICKS_Q := [
+		[Vector2(-1,  0), Vector2(-1, -1), Vector2( 0, -1), Vector2( 0,  1)],
+		[Vector2( 0, -1), Vector2( 1, -1), Vector2( 0,  1), Vector2( 1,  0)],
+		[Vector2( 1,  0), Vector2( 1,  1), Vector2( 0,  1), Vector2( 0, -1)],
+		[Vector2( 0,  1), Vector2(-1,  1), Vector2( 0, -1), Vector2( 1,  0)]
 	]
 
 const KICKS_V := [
@@ -104,7 +115,7 @@ var piece_p := PieceType.new("p",
 		[Vector2(2, 0), Vector2(10, 0), Vector2(7, 0), Vector2(9, 0), Vector2(5, 0)],
 		[Vector2(10, 0), Vector2(6, 0), Vector2(9, 0), Vector2(13, 0), Vector2(4, 0)],
 		[Vector2(10, 0), Vector2(6, 0), Vector2(11, 0), Vector2(5, 0), Vector2(1, 0)]],
-		KICKS_PQ
+		KICKS_P
 	)
 
 var piece_q := PieceType.new("q",
@@ -118,7 +129,7 @@ var piece_q := PieceType.new("q",
 		[Vector2(10, 1), Vector2(6, 1), Vector2(9, 1), Vector2(7, 1), Vector2(1, 1)],
 		[Vector2(10, 1), Vector2(6, 1), Vector2(8, 1), Vector2(13, 1), Vector2(5, 1)],
 		[Vector2(2, 1), Vector2(11, 1), Vector2(6, 1), Vector2(9, 1), Vector2(5, 1)]],
-		KICKS_PQ
+		KICKS_Q
 	)
 
 var piece_t := PieceType.new("t",

--- a/src/test/test-piece-kicks-jl.gd
+++ b/src/test/test-piece-kicks-jl.gd
@@ -1,0 +1,939 @@
+extends "res://src/test/test-piece-kicks.gd"
+"""
+Tests the j/l piece's kick behavior.
+"""
+
+func test_j_lwallkick_cw() -> void:
+	from_grid = [
+		"    ",
+		"jj  ",
+		"j   ",
+		"j   ",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		"    ",
+		"jjj ",
+		"  j ",
+		"    ",
+	]
+	_assert_kick()
+
+
+func test_j_lwallkick_ccw() -> void:
+	from_grid = [
+		"    ",
+		"jj  ",
+		"j   ",
+		"j   ",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		"j   ",
+		"jjj ",
+		"    ",
+		"    ",
+	]
+	_assert_kick()
+
+
+func test_l_lwallkick_cw() -> void:
+	from_grid = [
+		"    ",
+		"l   ",
+		"l   ",
+		"ll  ",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		"    ",
+		"lll ",
+		"l   ",
+		"    ",
+	]
+	_assert_kick()
+
+
+func test_l_lwallkick_ccw() -> void:
+	from_grid = [
+		"    ",
+		"l   ",
+		"l   ",
+		"ll  ",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		"  l ",
+		"lll ",
+		"    ",
+		"    ",
+	]
+	_assert_kick()
+
+
+
+func test_j_rwallkick_cw() -> void:
+	from_grid = [
+		"    ",
+		"   j",
+		"   j",
+		"  jj",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		" j  ",
+		" jjj",
+		"    ",
+		"    ",
+	]
+	_assert_kick()
+
+
+func test_j_rwallkick_ccw() -> void:
+	from_grid = [
+		"    ",
+		"   j",
+		"   j",
+		"  jj",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		"    ",
+		" jjj",
+		"   j",
+		"    ",
+	]
+	_assert_kick()
+
+
+func test_l_rwallkick_cw() -> void:
+	from_grid = [
+		"    ",
+		"  ll",
+		"   l",
+		"   l",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		"   l",
+		" lll",
+		"    ",
+		"    ",
+	]
+	_assert_kick()
+
+
+func test_l_rwallkick_ccw() -> void:
+	from_grid = [
+		"    ",
+		"  ll",
+		"   l",
+		"   l",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		"    ",
+		" lll",
+		" l  ",
+		"    ",
+	]
+	_assert_kick()
+
+
+func test_j_floorkick_cw() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		" j   ",
+		" jjj ",
+	]
+	to_grid = [
+		"     ",
+		" jj  ",
+		" j   ",
+		" j   ",
+	]
+	_assert_kick()
+
+
+func test_j_floorkick_ccw() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		" j   ",
+		" jjj ",
+	]
+	to_grid = [
+		"     ",
+		"   j ",
+		"   j ",
+		"  jj ",
+	]
+	_assert_kick()
+
+
+func test_l_floorkick_cw() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"   l ",
+		" lll ",
+	]
+	to_grid = [
+		"     ",
+		" l   ",
+		" l   ",
+		" ll  ",
+	]
+	_assert_kick()
+
+
+func test_l_floorkick_ccw() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"   l ",
+		" lll ",
+	]
+	to_grid = [
+		"     ",
+		"  ll ",
+		"   l ",
+		"   l ",
+	]
+	_assert_kick()
+
+
+"""
+A 'vee kick' is when a J/L piece pivots like a V piece to hook its long end into a gap
+"""
+func test_j_vee_kick0() -> void:
+	from_grid = [
+		"   ::",
+		"   : ",
+		"  j: ",
+		"  jjj",
+	]
+	to_grid = [
+		"   ::",
+		"   :j",
+		"   :j",
+		"   jj",
+	]
+	_assert_kick()
+
+
+func test_j_vee_kick1() -> void:
+	from_grid = [
+		"     ",
+		"  j::",
+		"::j  ",
+		" jj  ",
+	]
+	to_grid = [
+		"     ",
+		"jjj::",
+		"::j  ",
+		"     ",
+	]
+	_assert_kick()
+
+
+func test_j_vee_kick2() -> void:
+	from_grid = [
+		":    ",
+		"jjj  ",
+		" :j  ",
+		" :   ",
+	]
+	to_grid = [
+		":    ",
+		"jj   ",
+		"j:   ",
+		"j:   ",
+	]
+	_assert_kick()
+
+
+func test_j_vee_kick3() -> void:
+	from_grid = [
+		"     ",
+		"  jj ",
+		"  j::",
+		"  j  ",
+	]
+	to_grid = [
+		"     ",
+		"     ",
+		"  j::",
+		"  jjj",
+	]
+	_assert_kick()
+
+
+func test_l_vee_kick_cw0() -> void:
+	from_grid = [
+		"::   ",
+		" :   ",
+		" :l  ",
+		"lll  ",
+	]
+	to_grid = [
+		"::   ",
+		"l:   ",
+		"l:   ",
+		"ll   ",
+	]
+	_assert_kick()
+
+
+func test_l_vee_kick1() -> void:
+	from_grid = [
+		"     ",
+		"::l  ",
+		"  l::",
+		"  ll ",
+	]
+	to_grid = [
+		"     ",
+		"::lll",
+		"  l::",
+		"     ",
+	]
+	_assert_kick()
+
+
+func test_l_vee_kick2() -> void:
+	from_grid = [
+		"    :",
+		"  lll",
+		"  l: ",
+		"   : ",
+	]
+	to_grid = [
+		"    :",
+		"   ll",
+		"   :l",
+		"   :l",
+	]
+	_assert_kick()
+
+
+func test_l_vee_kick3() -> void:
+	from_grid = [
+		"     ",
+		" ll  ",
+		"::l  ",
+		"  l  ",
+	]
+	to_grid = [
+		"     ",
+		"     ",
+		"::l  ",
+		"lll  ",
+	]
+	_assert_kick()
+
+
+func test_j_triple0() -> void:
+	from_grid = [
+		"     ",
+		" j:: ",
+		" jjj ",
+		":: ::",
+		":: ::",
+		":  ::",
+	]
+	to_grid = [
+		"     ",
+		"  :: ",
+		"     ",
+		"::j::",
+		"::j::",
+		":jj::",
+	]
+	_assert_kick()
+
+
+func test_j_triple1() -> void:
+	from_grid = [
+		"     ",
+		"j :: ",
+		"jjj  ",
+		":: ::",
+		":: ::",
+		":  ::",
+	]
+	to_grid = [
+		"     ",
+		" ::  ",
+		"     ",
+		"::j::",
+		"::j::",
+		":jj::",
+	]
+	_assert_kick()
+
+
+func test_j_triple2() -> void:
+	from_grid = [
+		"   ::",
+		"     ",
+		"  jjj",
+		"::::j",
+		":::: ",
+		":::  ",
+	]
+	to_grid = [
+		"   ::",
+		"     ",
+		"     ",
+		"::::j",
+		"::::j",
+		":::jj",
+	]
+	_assert_kick()
+
+
+func test_l_triple0() -> void:
+	from_grid = [
+		"     ",
+		" ::l ",
+		" lll ",
+		":: ::",
+		":: ::",
+		"::  :",
+	]
+	to_grid = [
+		"     ",
+		" ::  ",
+		"     ",
+		"::l::",
+		"::l::",
+		"::ll:",
+	]
+	_assert_kick()
+
+
+func test_l_triple1() -> void:
+	from_grid = [
+		"     ",
+		" :: l",
+		"  lll",
+		":: ::",
+		":: ::",
+		"::  :",
+	]
+	to_grid = [
+		"     ",
+		" ::  ",
+		"     ",
+		"::l::",
+		"::l::",
+		"::ll:",
+	]
+	_assert_kick()
+
+
+func test_l_triple2() -> void:
+	from_grid = [
+		"::   ",
+		"     ",
+		"lll  ",
+		"l::::",
+		" ::::",
+		"  :::",
+	]
+	to_grid = [
+		"::   ",
+		"     ",
+		"     ",
+		"l::::",
+		"l::::",
+		"ll:::",
+	]
+	_assert_kick()
+
+
+"""
+A 'gold kick' is when a J/L piece hooks its short end into a small gap
+"""
+func test_j_gold_kick0() -> void:
+	from_grid = [
+		"  :  ",
+		"     ",
+		"jjj  ",
+		"::j::",
+		":  ::",
+	]
+	to_grid = [
+		"  :  ",
+		"     ",
+		"  j  ",
+		"::j::",
+		":jj::",
+	]
+	_assert_kick()
+
+
+func test_j_gold_kick1() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"::j  ",
+		" :j  ",
+		" jj  ",
+	]
+	to_grid = [
+		"     ",
+		"     ",
+		"::   ",
+		"j:   ",
+		"jjj  ",
+	]
+	_assert_kick()
+
+
+func test_j_gold_kick2() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"     ",
+		"  j::",
+		"  jjj",
+	]
+	to_grid = [
+		"     ",
+		"     ",
+		"  jj ",
+		"  j::",
+		"  j  ",
+	]
+	_assert_kick()
+
+
+func test_j_gold_kick3() -> void:
+	from_grid = [
+		"     ",
+		"   ::",
+		"  jj ",
+		"  j: ",
+		"  j::",
+	]
+	to_grid = [
+		"     ",
+		"     ",
+		"  jjj",
+		"   :j",
+		"   ::",
+	]
+	_assert_kick()
+
+
+func test_l_gold_kick0() -> void:
+	from_grid = [
+		"  :  ",
+		"     ",
+		"  lll",
+		"::l::",
+		"::  :",
+	]
+	to_grid = [
+		"  :  ",
+		"     ",
+		"  l  ",
+		"::l::",
+		"::ll:",
+	]
+	_assert_kick()
+
+
+func test_l_gold_kick1() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"  l::",
+		"  l: ",
+		"  ll ",
+	]
+	to_grid = [
+		"     ",
+		"     ",
+		"   ::",
+		"   :l",
+		"  lll",
+	]
+	_assert_kick()
+
+
+func test_l_gold_kick2() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"     ",
+		"::l  ",
+		"lll  ",
+	]
+	to_grid = [
+		"     ",
+		"     ",
+		" ll  ",
+		"::l  ",
+		"  l  ",
+	]
+	_assert_kick()
+
+
+func test_l_gold_kick3() -> void:
+	from_grid = [
+		"     ",
+		"::   ",
+		" ll  ",
+		" :l  ",
+		"::l  ",
+	]
+	to_grid = [
+		"     ",
+		"     ",
+		"lll  ",
+		"l:   ",
+		"::   ",
+	]
+	_assert_kick()
+
+
+"""
+A 'gold kick' is when a J/L piece hooks its short end into a small gap from far away.
+"""
+func test_j_golder_kick() -> void:
+	from_grid = [
+		"     ",
+		"   ::",
+		"  jjj",
+		" :  j",
+		"::: :",
+		"::  :",
+	]
+	to_grid = [
+		"     ",
+		"   ::",
+		"     ",
+		" : j ",
+		":::j:",
+		"::jj:",
+	]
+	_assert_kick()
+
+
+func test_l_golder_kick() -> void:
+	from_grid = [
+		"     ",
+		"::   ",
+		"lll  ",
+		"l  : ",
+		": :::",
+		":  ::",
+	]
+	to_grid = [
+		"     ",
+		"::   ",
+		"     ",
+		" l : ",
+		":l:::",
+		":ll::",
+	]
+	_assert_kick()
+
+
+func test_j_climb_kick0() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"  jj ",
+		"  j: ",
+		"  j::",
+	]
+	to_grid = [
+		"     ",
+		" jjj ",
+		"   j ",
+		"   : ",
+		"   ::",
+	]
+	_assert_kick()
+
+
+func test_j_climb_kick1() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"  j  ",
+		": j::",
+		":jj::",
+	]
+	to_grid = [
+		"     ",
+		" j   ",
+		" jjj ",
+		":  ::",
+		":  ::",
+	]
+	_assert_kick()
+
+
+func test_j_climb_kick2() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"  j: ",
+		": j::",
+		":jj::",
+	]
+	to_grid = [
+		" j   ",
+		" jjj ",
+		"   : ",
+		":  ::",
+		":  ::",
+	]
+	_assert_kick()
+
+
+func test_j_climb_kick3() -> void:
+	from_grid = [
+		"     ",
+		"::   ",
+		":jjj ",
+		":::j ",
+	]
+	to_grid = [
+		"  jj ",
+		"::j  ",
+		": j  ",
+		":::  ",
+	]
+	_assert_kick()
+
+
+func test_j_climb_kick4() -> void:
+	from_grid = [
+		"     ",
+		"  j  ",
+		"::j  ",
+		":jj  ",
+	]
+	to_grid = [
+		"     ",
+		" jjj ",
+		":: j ",
+		":    ",
+	]
+	_assert_kick()
+
+
+func test_l_climb_kick0() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		" ll  ",
+		" :l  ",
+		"::l  ",
+	]
+	to_grid = [
+		"     ",
+		" lll ",
+		" l   ",
+		" :   ",
+		"::   ",
+	]
+	_assert_kick()
+
+
+func test_l_climb_kick1() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"  l  ",
+		"::l :",
+		"::ll:",
+	]
+	to_grid = [
+		"     ",
+		"   l ",
+		" lll ",
+		"::  :",
+		"::  :",
+	]
+	_assert_kick()
+
+
+func test_l_climb_kick2() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		" :l  ",
+		"::l :",
+		"::ll:",
+	]
+	to_grid = [
+		"   l ",
+		" lll ",
+		" :   ",
+		"::  :",
+		"::  :",
+	]
+	_assert_kick()
+
+
+func test_l_climb_kick3() -> void:
+	from_grid = [
+		"     ",
+		"   ::",
+		" lll:",
+		" l:::",
+	]
+	to_grid = [
+		" ll  ",
+		"  l::",
+		"  l :",
+		"  :::",
+	]
+	_assert_kick()
+
+
+func test_l_climb_kick4() -> void:
+	from_grid = [
+		"     ",
+		"  l  ",
+		"  l::",
+		"  ll:",
+	]
+	to_grid = [
+		"     ",
+		" lll ",
+		" l ::",
+		"    :",
+	]
+	_assert_kick()
+
+
+"""
+A 'hammer kick' is where the J piece pivots around its tip, like swinging a hammer.
+"""
+func test_j_hammer_kick0() -> void:
+	from_grid = [
+		"    ",
+		"jj::",
+		"j:::",
+		"j  :",
+		":: :",
+	]
+	to_grid = [
+		"    ",
+		"  ::",
+		" :::",
+		"jjj:",
+		"::j:",
+	]
+	_assert_kick()
+
+
+func test_l_hammer_kick() -> void:
+	from_grid = [
+		"    ",
+		"::ll",
+		":::l",
+		":  l",
+		": ::",
+	]
+	to_grid = [
+		"    ",
+		"::  ",
+		"::: ",
+		":lll",
+		":l::",
+	]
+	_assert_kick()
+
+
+"""
+A plant kick is when the j/l piece pivots around its hinge like a t block.
+"""
+func test_j_plant_kick0() -> void:
+	from_grid = [
+		":: ::",
+		"  j::",
+		"  jjj",
+		":: ::",
+		":: ::",
+	]
+	to_grid = [
+		":: ::",
+		"   ::",
+		"  jj ",
+		"::j::",
+		"::j::",
+	]
+	_assert_kick()
+
+
+func test_j_plant_kick1() -> void:
+	from_grid = [
+		":: ::",
+		"   ::",
+		"jjj  ",
+		"::j::",
+		":: ::",
+	]
+	to_grid = [
+		"::j::",
+		"  j::",
+		" jj  ",
+		":: ::",
+		":: ::",
+	]
+	_assert_kick()
+
+
+func test_l_plant_kick0() -> void:
+	from_grid = [
+		":: ::",
+		"::l  ",
+		"lll  ",
+		":: ::",
+		":: ::",
+	]
+	to_grid = [
+		":: ::",
+		"::   ",
+		" ll  ",
+		"::l::",
+		"::l::",
+	]
+	_assert_kick()
+
+
+func test_l_plant_kick1() -> void:
+	from_grid = [
+		":: ::",
+		"::   ",
+		"  lll",
+		"::l::",
+		":: ::",
+	]
+	to_grid = [
+		"::l::",
+		"::l  ",
+		"  ll ",
+		":: ::",
+		":: ::",
+	]
+	_assert_kick()

--- a/src/test/test-piece-kicks-qp.gd
+++ b/src/test/test-piece-kicks-qp.gd
@@ -3,7 +3,7 @@ extends "res://src/test/test-piece-kicks.gd"
 Tests the p/q piece's kick behavior.
 """
 
-func test_p_floor_kick_cw() -> void:
+func test_p_floorkick_cw() -> void:
 	from_grid = [
 		"     ",
 		" ppp ",
@@ -17,35 +17,35 @@ func test_p_floor_kick_cw() -> void:
 	_assert_kick()
 
 
-func test_p_floor_kick_ccw() -> void:
+func test_p_floorkick_ccw() -> void:
 	from_grid = [
 		"     ",
 		" ppp ",
 		"  pp ",
 	]
 	to_grid = [
-		" pp  ",
-		" pp  ",
-		" p   ",
+		"  pp ",
+		"  pp ",
+		"  p  ",
 	]
 	_assert_kick()
 
 
-func test_q_floor_kick_cw() -> void:
+func test_q_floorkick_cw() -> void:
 	from_grid = [
 		"     ",
 		" qqq ",
 		" qq  ",
 	]
 	to_grid = [
-		"  qq ",
-		"  qq ",
-		"   q ",
+		" qq  ",
+		" qq  ",
+		"  q  ",
 	]
 	_assert_kick()
 
 
-func test_q_floor_kick_ccw() -> void:
+func test_q_floorkick_ccw() -> void:
 	from_grid = [
 		"     ",
 		" qqq ",
@@ -59,7 +59,7 @@ func test_q_floor_kick_ccw() -> void:
 	_assert_kick()
 
 
-func test_p_wall_kick_cw() -> void:
+func test_p_rwallkick_cw() -> void:
 	from_grid = [
 		"    ",
 		"  pp",
@@ -69,15 +69,15 @@ func test_p_wall_kick_cw() -> void:
 	]
 	to_grid = [
 		"    ",
-		"    ",
 		" ppp",
 		"  pp",
+		"    ",
 		"    ",
 	]
 	_assert_kick()
 
 
-func test_p_wall_kick_ccw() -> void:
+func test_p_lwallkick_ccw() -> void:
 	from_grid = [
 		"    ",
 		" p  ",
@@ -95,7 +95,7 @@ func test_p_wall_kick_ccw() -> void:
 	_assert_kick()
 
 
-func test_q_wall_kick_cw() -> void:
+func test_q_rwallkick_cw() -> void:
 	from_grid = [
 		"    ",
 		"  q ",
@@ -113,7 +113,7 @@ func test_q_wall_kick_cw() -> void:
 	_assert_kick()
 
 
-func test_q_wall_kick_ccw() -> void:
+func test_q_lwallkick_ccw() -> void:
 	from_grid = [
 		"    ",
 		"qq  ",
@@ -123,9 +123,9 @@ func test_q_wall_kick_ccw() -> void:
 	]
 	to_grid = [
 		"    ",
-		"    ",
 		"qqq ",
 		"qq  ",
+		"    ",
 		"    ",
 	]
 	_assert_kick()
@@ -134,35 +134,71 @@ func test_q_wall_kick_ccw() -> void:
 """
 A 'pump kick' is when the nub of a p/q piece swings into a gap, while the other 4 blocks remain in place
 """
-func test_p_pump_kick_0() -> void:
-	from_grid = [
-		" : :",
-		" pp ",
-		" ppp",
-		"  ::"]
-	to_grid = [
-		" :p:",
-		" pp ",
-		" pp ",
-		"  ::"]
-	_assert_kick()
-
-
-func test_p_pump_kick_1() -> void:
+func test_p_pump_kick0() -> void:
 	from_grid = [
 		"    ",
 		"  p ",
 		" pp:",
-		":pp "]
+		":pp ",
+	]
 	to_grid = [
 		"    ",
 		"    ",
 		" pp:",
-		":ppp"]
+		":ppp",
+	]
 	_assert_kick()
 
 
-func test_q_pump_kick_0() -> void:
+func test_p_pump_kick1() -> void:
+	from_grid = [
+		"    ",
+		": p ",
+		" pp ",
+		":pp "]
+	to_grid = [
+		"    ",
+		":   ",
+		"ppp ",
+		":pp "]
+	_assert_kick()
+
+
+func test_p_pump_kick2() -> void:
+	from_grid = [
+		"    ",
+		" pp:",
+		" pp ",
+		" p::",
+	]
+	to_grid = [
+		"    ",
+		" pp:",
+		" ppp",
+		"  ::",
+	]
+	_assert_kick()
+
+
+func test_p_pump_kick3() -> void:
+	from_grid = [
+		"    ",
+		":   ",
+		" pp ",
+		":pp:",
+		":p::",
+	]
+	to_grid = [
+		"    ",
+		":   ",
+		"ppp ",
+		":pp:",
+		": ::",
+	]
+	_assert_kick()
+
+
+func test_q_pump_kick0() -> void:
 	from_grid = [
 		"    ",
 		" q  ",
@@ -176,38 +212,77 @@ func test_q_pump_kick_0() -> void:
 	_assert_kick()
 
 
-func test_q_pump_kick_1() -> void:
+func test_q_pump_kick1() -> void:
 	from_grid = [
-		": : ",
+		"    ",
+		" q :",
 		" qq ",
-		"qqq ",
-		"::  "]
+		" qq:"]
 	to_grid = [
-		":q: ",
+		"    ",
+		"   :",
+		" qqq",
+		" qq:"]
+	_assert_kick()
+
+
+func test_q_pump_kick2() -> void:
+	from_grid = [
+		"    ",
+		":qq ",
 		" qq ",
+		"::q ",
+	]
+	to_grid = [
+		"    ",
+		":qq ",
+		"qqq ",
+		"::  ",
+	]
+	_assert_kick()
+
+
+func test_q_pump_kick3() -> void:
+	from_grid = [
+		"    ",
+		":   ",
 		" qq ",
-		"::  "]
+		":qq:",
+		"::q:",
+	]
+	to_grid = [
+		"    ",
+		"   :",
+		" qqq",
+		":qq:",
+		":: :",
+	]
 	_assert_kick()
 
 
 """
 A 'murky kick' is when the nub of a p/q piece swings into a faraway gap, pulling the piece with it
 """
-func test_p_murky_kick_0() -> void:
+func test_p_murky_kick0() -> void:
+	# there's enough space above the piece to do a (0, -2) kick, which would be bad
 	from_grid = [
-		" :::",
+		"    ",
+		"    ",
+		"  ::",
 		" pp ",
 		" ppp",
 		" : :"]
 	to_grid = [
-		" :::",
+		"    ",
+		"    ",
+		"  ::",
 		"  pp",
 		"  pp",
 		" :p:"]
 	_assert_kick()
 
 
-func test_p_murky_kick_1() -> void:
+func test_p_murky_kick1() -> void:
 	from_grid = [
 		": : ",
 		"ppp ",
@@ -221,7 +296,7 @@ func test_p_murky_kick_1() -> void:
 	_assert_kick()
 
 
-func test_p_murky_kick_2() -> void:
+func test_p_murky_kick2() -> void:
 	from_grid = [
 		" : :",
 		" ppp",
@@ -235,21 +310,26 @@ func test_p_murky_kick_2() -> void:
 	_assert_kick()
 
 
-func test_q_murky_kick_0() -> void:
+func test_q_murky_kick0() -> void:
+	# there's enough space above the piece to do a (0, -2) kick, which would be bad
 	from_grid = [
-		"::: ",
+		"    ",
+		"    ",
+		"::  ",
 		" qq ",
 		"qqq ",
 		": : "]
 	to_grid = [
-		"::: ",
+		"    ",
+		"    ",
+		"::  ",
 		"qq  ",
 		"qq  ",
 		":q: "]
 	_assert_kick()
 
 
-func test_q_murky_kick_1() -> void:
+func test_q_murky_kick1() -> void:
 	from_grid = [
 		" : :",
 		" qqq",
@@ -263,7 +343,7 @@ func test_q_murky_kick_1() -> void:
 	_assert_kick()
 
 
-func test_q_murky_kick_2() -> void:
+func test_q_murky_kick2() -> void:
 	from_grid = [
 		": : ",
 		"qqq ",
@@ -277,25 +357,25 @@ func test_q_murky_kick_2() -> void:
 	_assert_kick()
 
 
-func test_p_climb_kick_0() -> void:
+func test_p_climb_kick0() -> void:
 	from_grid = [
 		"     ",
 		"     ",
 		"     ",
 		":: p ",
 		"::pp ",
-		"::pp "]
+		"::pp:"]
 	to_grid = [
 		"     ",
 		"     ",
 		" ppp ",
 		"::pp ",
 		"::   ",
-		"::   "]
+		"::  :"]
 	_assert_kick()
 
 
-func test_p_climb_kick_1() -> void:
+func test_p_failed_climb_kick1() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -304,34 +384,34 @@ func test_p_climb_kick_1() -> void:
 		"::   ",
 		"::   "]
 	to_grid = [
-		" pp  ",
-		" pp  ",
-		" p   ",
-		"::   ",
-		"::   ",
+		"     ",
+		"     ",
+		"  pp ",
+		"::pp ",
+		"::p  ",
 		"::   "]
 	_assert_kick()
 
 
-func test_q_climb_kick_0() -> void:
+func test_q_climb_kick0() -> void:
 	from_grid = [
 		"     ",
 		"     ",
 		"     ",
 		" q ::",
 		" qq::",
-		" qq::"]
+		":qq::"]
 	to_grid = [
 		"     ",
 		"     ",
 		" qqq ",
 		" qq::",
 		"   ::",
-		"   ::"]
+		":  ::"]
 	_assert_kick()
 
 
-func test_q_climb_kick_1() -> void:
+func test_q_failed_climb_kick1() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -340,10 +420,10 @@ func test_q_climb_kick_1() -> void:
 		"   ::",
 		"   ::"]
 	to_grid = [
-		"  qq ",
-		"  qq ",
-		"   q ",
-		"   ::",
-		"   ::",
+		"     ",
+		"     ",
+		" qq  ",
+		" qq::",
+		"  q::",
 		"   ::"]
 	_assert_kick()

--- a/src/test/test-piece-kicks-t.gd
+++ b/src/test/test-piece-kicks-t.gd
@@ -247,7 +247,7 @@ func test_duck_kick_up1() -> void:
 	_assert_kick()
 
 
-func test_floor_kick0() -> void:
+func test_floorkick_cw() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -263,7 +263,7 @@ func test_floor_kick0() -> void:
 	_assert_kick()
 
 
-func test_floor_kick1() -> void:
+func test_floorkick_ccw() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -279,7 +279,7 @@ func test_floor_kick1() -> void:
 	_assert_kick()
 
 
-func test_wall_kick_right0() -> void:
+func test_lwallkick0() -> void:
 	from_grid = [
 		"     ",
 		"t    ",
@@ -297,7 +297,7 @@ func test_wall_kick_right0() -> void:
 	_assert_kick()
 
 
-func test_wall_kick_right1() -> void:
+func test_lwallkick1() -> void:
 	from_grid = [
 		"     ",
 		"t    ",
@@ -315,7 +315,7 @@ func test_wall_kick_right1() -> void:
 	_assert_kick()
 
 
-func test_wall_kick_left0() -> void:
+func test_rwallkick0() -> void:
 	from_grid = [
 		"     ",
 		"    t",
@@ -333,7 +333,7 @@ func test_wall_kick_left0() -> void:
 	_assert_kick()
 
 
-func test_wall_kick_left1() -> void:
+func test_rwallkick1() -> void:
 	from_grid = [
 		"     ",
 		"    t",

--- a/src/test/test-piece-kicks-u.gd
+++ b/src/test/test-piece-kicks-u.gd
@@ -3,7 +3,7 @@ extends "res://src/test/test-piece-kicks.gd"
 Tests the u piece's kick behavior.
 """
 
-func test_u_floor_kick_cw() -> void:
+func test_u_floorkick_cw() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -19,7 +19,7 @@ func test_u_floor_kick_cw() -> void:
 	_assert_kick()
 
 
-func test_u_floor_kick_ccw() -> void:
+func test_u_floorkick_ccw() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -35,7 +35,7 @@ func test_u_floor_kick_ccw() -> void:
 	_assert_kick()
 
 
-func test_u_wall_kick_cw() -> void:
+func test_u_rwallkick_cw() -> void:
 	from_grid = [
 		"    ",
 		"  uu",
@@ -53,7 +53,7 @@ func test_u_wall_kick_cw() -> void:
 	_assert_kick()
 
 
-func test_u_wall_kick_ccw() -> void:
+func test_u_lwallkick_ccw() -> void:
 	from_grid = [
 		"    ",
 		"uu  ",
@@ -74,7 +74,7 @@ func test_u_wall_kick_ccw() -> void:
 """
 A spire kick is when a u piece rotates while a block is in its gap.
 """
-func test_u_spire_kick_cw_0() -> void:
+func test_u_spire_kick_cw0() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -90,7 +90,7 @@ func test_u_spire_kick_cw_0() -> void:
 	_assert_kick()
 
 
-func test_u_spire_kick_cw_1() -> void:
+func test_u_spire_kick_cw1() -> void:
 	from_grid = [
 		"     ",
 		"uu   ",
@@ -108,7 +108,7 @@ func test_u_spire_kick_cw_1() -> void:
 	_assert_kick()
 
 
-func test_u_spire_kick_cw_2() -> void:
+func test_u_spire_kick_cw2() -> void:
 	from_grid = [
 		"     ",
 		"   uu",
@@ -126,7 +126,7 @@ func test_u_spire_kick_cw_2() -> void:
 	_assert_kick()
 
 
-func test_u_spire_kick_ccw_0() -> void:
+func test_u_spire_kick_ccw0() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -142,7 +142,7 @@ func test_u_spire_kick_ccw_0() -> void:
 	_assert_kick()
 
 
-func test_u_spire_kick_ccw_1() -> void:
+func test_u_spire_kick_ccw1() -> void:
 	from_grid = [
 		"     ",
 		"   uu",
@@ -160,7 +160,7 @@ func test_u_spire_kick_ccw_1() -> void:
 	_assert_kick()
 
 
-func test_u_spire_kick_ccw_2() -> void:
+func test_u_spire_kick_ccw2() -> void:
 	from_grid = [
 		"     ",
 		"uu   ",
@@ -176,3 +176,4 @@ func test_u_spire_kick_ccw_2() -> void:
 		"     ",
 	]
 	_assert_kick()
+

--- a/src/test/test-piece-kicks-v.gd
+++ b/src/test/test-piece-kicks-v.gd
@@ -3,7 +3,7 @@ extends "res://src/test/test-piece-kicks.gd"
 Tests the v piece's kick behavior.
 """
 
-func test_v_climb_kick_cw_0() -> void:
+func test_v_climb_kick_cw0() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -21,7 +21,7 @@ func test_v_climb_kick_cw_0() -> void:
 	_assert_kick()
 
 
-func test_v_climb_kick_cw_1() -> void:
+func test_v_climb_kick_cw1() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -39,7 +39,7 @@ func test_v_climb_kick_cw_1() -> void:
 	_assert_kick()
 
 
-func test_v_climb_kick_cw_2() -> void:
+func test_v_climb_kick_cw2() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -57,7 +57,7 @@ func test_v_climb_kick_cw_2() -> void:
 	_assert_kick()
 
 
-func test_v_climb_kick_cw_3() -> void:
+func test_v_climb_kick_cw3() -> void:
 	from_grid = [
 		"    ",
 		"vvv ",
@@ -73,7 +73,7 @@ func test_v_climb_kick_cw_3() -> void:
 	_assert_kick()
 
 
-func test_v_climb_kick_cw_4() -> void:
+func test_v_climb_kick_cw4() -> void:
 	from_grid = [
 		"    ",
 		"vvv:",
@@ -89,7 +89,7 @@ func test_v_climb_kick_cw_4() -> void:
 	_assert_kick()
 
 
-func test_v_climb_kick_ccw_0() -> void:
+func test_v_climb_kick_ccw0() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -107,7 +107,7 @@ func test_v_climb_kick_ccw_0() -> void:
 	_assert_kick()
 
 
-func test_v_climb_kick_ccw_1() -> void:
+func test_v_climb_kick_ccw1() -> void:
 	from_grid = [
 		"      ",
 		"      ",
@@ -125,7 +125,7 @@ func test_v_climb_kick_ccw_1() -> void:
 	_assert_kick()
 
 
-func test_v_climb_kick_ccw_2() -> void:
+func test_v_climb_kick_ccw2() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -143,7 +143,7 @@ func test_v_climb_kick_ccw_2() -> void:
 	_assert_kick()
 
 
-func test_v_climb_kick_ccw_3() -> void:
+func test_v_climb_kick_ccw3() -> void:
 	from_grid = [
 		"    ",
 		" vvv",
@@ -159,7 +159,7 @@ func test_v_climb_kick_ccw_3() -> void:
 	_assert_kick()
 
 
-func test_v_climb_kick_ccw_4() -> void:
+func test_v_climb_kick_ccw4() -> void:
 	from_grid = [
 		"    ",
 		":vvv",
@@ -217,7 +217,7 @@ func test_v_snack_kick_ccw() -> void:
 """
 The v piece can't technically wall kick, but it can kick against other blocks similar to a wall kick
 """
-func test_v_wall_kick_cw_0() -> void:
+func test_v_rwallkick_cw0() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -235,7 +235,7 @@ func test_v_wall_kick_cw_0() -> void:
 	_assert_kick()
 
 
-func test_v_wall_kick_cw_1() -> void:
+func test_v_rwallkick_cw1() -> void:
 	from_grid = [
 		"    :",
 		"    :",
@@ -253,7 +253,7 @@ func test_v_wall_kick_cw_1() -> void:
 	_assert_kick()
 
 
-func test_v_wall_kick_cw_2() -> void:
+func test_v_rwallkick_cw2() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -271,7 +271,7 @@ func test_v_wall_kick_cw_2() -> void:
 	_assert_kick()
 
 
-func test_v_wall_kick_cw_3() -> void:
+func test_v_lwallkick_cw3() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -289,7 +289,7 @@ func test_v_wall_kick_cw_3() -> void:
 	_assert_kick()
 
 
-func test_v_wall_kick_cw_4() -> void:
+func test_v_lwallkick_cw4() -> void:
 	from_grid = [
 		":    ",
 		":    ",
@@ -307,7 +307,7 @@ func test_v_wall_kick_cw_4() -> void:
 	_assert_kick()
 
 
-func test_v_wall_kick_ccw_0() -> void:
+func test_v_lwallkick_ccw0() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -325,7 +325,7 @@ func test_v_wall_kick_ccw_0() -> void:
 	_assert_kick()
 
 
-func test_v_wall_kick_ccw_1() -> void:
+func test_v_lwallkick_ccw1() -> void:
 	from_grid = [
 		":    ",
 		":    ",
@@ -343,7 +343,7 @@ func test_v_wall_kick_ccw_1() -> void:
 	_assert_kick()
 
 
-func test_v_wall_kick_ccw_2() -> void:
+func test_v_lwallkick_ccw2() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -362,7 +362,7 @@ func test_v_wall_kick_ccw_2() -> void:
 
 
 
-func test_v_wall_kick_ccw_3() -> void:
+func test_v_rwallkick_ccw3() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -380,7 +380,7 @@ func test_v_wall_kick_ccw_3() -> void:
 	_assert_kick()
 
 
-func test_v_wall_kick_ccw_4() -> void:
+func test_v_rwallkick_ccw4() -> void:
 	from_grid = [
 		"    :",
 		"    :",
@@ -401,7 +401,7 @@ func test_v_wall_kick_ccw_4() -> void:
 """
 A ritzy kick is when the hinge of the v piece pivots one square diagonally.
 """
-func test_ritzy_kick_cw_0() -> void:
+func test_ritzy_kick_cw0() -> void:
 	from_grid = [
 		"    ",
 		"  v ",
@@ -417,7 +417,7 @@ func test_ritzy_kick_cw_0() -> void:
 	_assert_kick()
 
 
-func test_ritzy_kick_cw_1() -> void:
+func test_ritzy_kick_cw1() -> void:
 	from_grid = [
 		"v ::",
 		"v   ",
@@ -433,7 +433,7 @@ func test_ritzy_kick_cw_1() -> void:
 	_assert_kick()
 
 
-func test_ritzy_kick_cw_2() -> void:
+func test_ritzy_kick_cw2() -> void:
 	from_grid = [
 		":vvv",
 		" v :",
@@ -449,7 +449,7 @@ func test_ritzy_kick_cw_2() -> void:
 	_assert_kick()
 
 
-func test_ritzy_kick_cw_3() -> void:
+func test_ritzy_kick_cw3() -> void:
 	from_grid = [
 		"   :",
 		" vvv",
@@ -465,7 +465,7 @@ func test_ritzy_kick_cw_3() -> void:
 	_assert_kick()
 
 
-func test_ritzy_kick_ccw_0() -> void:
+func test_ritzy_kick_ccw0() -> void:
 	from_grid = [
 		"    ",
 		" v  ",
@@ -481,7 +481,7 @@ func test_ritzy_kick_ccw_0() -> void:
 	_assert_kick()
 
 
-func test_ritzy_kick_ccw_1() -> void:
+func test_ritzy_kick_ccw1() -> void:
 	from_grid = [
 		":: v",
 		"   v",
@@ -497,7 +497,7 @@ func test_ritzy_kick_ccw_1() -> void:
 	_assert_kick()
 
 
-func test_ritzy_kick_ccw_2() -> void:
+func test_ritzy_kick_ccw2() -> void:
 	from_grid = [
 		"vvv:",
 		": v ",
@@ -513,7 +513,7 @@ func test_ritzy_kick_ccw_2() -> void:
 	_assert_kick()
 
 
-func test_ritzy_kick_ccw_3() -> void:
+func test_ritzy_kick_ccw3() -> void:
 	from_grid = [
 		":   ",
 		"vvv ",
@@ -533,7 +533,7 @@ func test_ritzy_kick_ccw_3() -> void:
 A plant kick is when the v piece pivots around its hinge like a t block. This is disorienting and should be a last
 resort.
 """
-func test_plant_kick_cw_0() -> void:
+func test_plant_kick_cw0() -> void:
 	from_grid = [
 		"::   ",
 		"     ",
@@ -551,7 +551,7 @@ func test_plant_kick_cw_0() -> void:
 	_assert_kick()
 
 
-func test_plant_kick_cw_1() -> void:
+func test_plant_kick_cw1() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -569,7 +569,7 @@ func test_plant_kick_cw_1() -> void:
 	_assert_kick()
 
 
-func test_plant_kick_cw_2() -> void:
+func test_plant_kick_cw2() -> void:
 	from_grid = [
 		"::v::",
 		"::v::",
@@ -583,7 +583,7 @@ func test_plant_kick_cw_2() -> void:
 	_assert_kick()
 
 
-func test_plant_kick_cw_3() -> void:
+func test_plant_kick_cw3() -> void:
 	from_grid = [
 		"  v::",
 		"::v::",
@@ -601,7 +601,7 @@ func test_plant_kick_cw_3() -> void:
 	_assert_kick()
 
 
-func test_plant_kick_ccw_0() -> void:
+func test_plant_kick_ccw0() -> void:
 	from_grid = [
 		"   ::",
 		"     ",
@@ -619,7 +619,7 @@ func test_plant_kick_ccw_0() -> void:
 	_assert_kick()
 
 
-func test_plant_kick_ccw_1() -> void:
+func test_plant_kick_ccw1() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -637,7 +637,7 @@ func test_plant_kick_ccw_1() -> void:
 	_assert_kick()
 
 
-func test_plant_kick_ccw_2() -> void:
+func test_plant_kick_ccw2() -> void:
 	from_grid = [
 		"::v::",
 		"::v::",
@@ -651,7 +651,7 @@ func test_plant_kick_ccw_2() -> void:
 	_assert_kick()
 
 
-func test_plant_kick_ccw_3() -> void:
+func test_plant_kick_ccw3() -> void:
 	from_grid = [
 		"::v  ",
 		"::v::",
@@ -667,3 +667,4 @@ func test_plant_kick_ccw_3() -> void:
 		"::v::",
 	]
 	_assert_kick()
+

--- a/src/test/test-piece-kicks.gd
+++ b/src/test/test-piece-kicks.gd
@@ -58,9 +58,12 @@ func _assert_kick() -> void:
 
 
 func _kick_piece() -> Vector2:
+	var result := Vector2.ZERO
 	_from_piece = _create_active_piece(from_grid)
 	_to_piece = _create_active_piece(to_grid)
-	return _from_piece.kick_piece(funcref(self, "_is_cell_blocked"), _from_piece.pos, _to_piece.orientation)
+	if not _from_piece.can_move_piece_to(funcref(self, "_is_cell_blocked"), _from_piece.pos, _to_piece.orientation):
+		result = _from_piece.kick_piece(funcref(self, "_is_cell_blocked"), _from_piece.pos, _to_piece.orientation)
+	return result
 
 
 func _is_cell_blocked(pos: Vector2) -> bool:


### PR DESCRIPTION
Some P/Q climb kicks were causing the piece to jump up unexpectedly instead of
squeezing into a gap.

Added the initial spawn locations to the initial DAS kicks. It felt bad
dying as a result of applying initial DAS, so now if you die, you would
have died anyways even without initial DAS.