### PR TITLE
Customer3D mesh no longer tilts. Tweaked collisions, slipping

### DIFF
--- a/src/main/world/Customer3D.tscn
+++ b/src/main/world/Customer3D.tscn
@@ -63,8 +63,9 @@ tracks/0/keys = {
 "values": [ 1.0, 1.0, 0.9, 0.9, 0.95, 1.0 ]
 }
 
-[sub_resource type="BoxShape" id=7]
-extents = Vector3( 8.5, 7.5, 7 )
+[sub_resource type="CylinderShape" id=7]
+radius = 8.0
+height = 20.4
 
 [node name="Customer3D" type="KinematicBody"]
 transform = Transform( 1, 0, 0, 0, 0.999999, 0, 0, 0, 0.999999, 0, 10, -40 )
@@ -81,12 +82,12 @@ position = Vector2( 512, 932 )
 scale = Vector2( 2.5, 2.5 )
 
 [node name="Sprite" type="MeshInstance" parent="."]
-transform = Transform( 0.707107, -0.353553, 0.612373, 0, 0.866025, 0.5, -0.707107, -0.353553, 0.612372, 0, 7.5, 0 )
+transform = Transform( 0.707107, 0, 0.707107, 0, 1.2, 0, -0.707107, 0, 0.707107, 2.5, 14, 2.5 )
 mesh = SubResource( 3 )
 material/0 = null
 
 [node name="ShadowMesh" type="MeshInstance" parent="."]
-transform = Transform( 0.459619, 0, 0.353553, 0, 0.850001, 0, -0.459619, 0, 0.353553, 3.5, -1.5, 3.5 )
+transform = Transform( 0.459619, 0, 0.353553, 0, 0.850001, 0, -0.459619, 0, 0.353553, 0, 0, 0 )
 cast_shadow = 3
 mesh = SubResource( 4 )
 material/0 = null
@@ -97,11 +98,10 @@ anims/jump = SubResource( 5 )
 anims/run = SubResource( 6 )
 
 [node name="CollisionShape" type="CollisionShape" parent="."]
-transform = Transform( 0.707107, 0, 0.707108, 0, 1, 0, -0.707107, 0, 0.707108, 2.5, -2.5, 2.5 )
+transform = Transform( 0.707107, 0, 0.707108, 0, 1, 0, -0.707107, 0, 0.707108, 0, 0, 0 )
 shape = SubResource( 7 )
 
 [node name="HopSound" type="AudioStreamPlayer3D" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )
 stream = ExtResource( 2 )
 attenuation_model = 3
 unit_db = -12.0
@@ -121,5 +121,5 @@ bus = "Reverb Bus"
 [connection signal="customer_arrived" from="Viewport/Customer" to="." method="_on_Customer_customer_arrived"]
 [connection signal="jumped" from="Viewport/Customer" to="." method="_on_Customer_jumped"]
 [connection signal="landed" from="Viewport/Customer" to="." method="_on_Customer_landed"]
-[connection signal="movement_animation_started" from="Viewport/Customer" to="Viewport" method="_on_Customer_movement_animation_started"]
 [connection signal="movement_animation_started" from="Viewport/Customer" to="." method="_on_Customer_movement_animation_started"]
+[connection signal="movement_animation_started" from="Viewport/Customer" to="Viewport" method="_on_Customer_movement_animation_started"]

--- a/src/main/world/customer-3d.gd
+++ b/src/main/world/customer-3d.gd
@@ -29,7 +29,7 @@ Plays a movement animation with the specified prefix and direction, such as a 'r
 Parameters:
 	'animation_prefix': A partial name of an animation on $Customer/MovementAnims, omitting the directional suffix
 	
-	'movement_direction': A unit vector in the (X, Y) direction the customer is moving.
+	'movement_direction': A vector in the (X, Y) direction the customer is moving.
 """
 func play_movement_animation(animation_prefix: String, movement_direction: Vector2 = Vector2.ZERO) -> void:
 	$Viewport/Customer.play_movement_animation(animation_prefix, movement_direction)

--- a/src/main/world/restaurant/Customer.tscn
+++ b/src/main/world/restaurant/Customer.tscn
@@ -2420,8 +2420,14 @@ light_mask = 2
 rotation = 0.00355033
 curve = SubResource( 7 )
 script = ExtResource( 3 )
+spline_length = 25.0
+_smooth = false
+_straighten = false
+closed = true
+line_color = Color( 0, 0, 0, 1 )
 fill_color = Color( 0, 0, 0, 1 )
 line_width = 2.0
+_fatness = 1.0
 editing = false
 
 [node name="Outline" type="Path2D" parent="Sprites/Body"]

--- a/src/main/world/restaurant/customer.gd
+++ b/src/main/world/restaurant/customer.gd
@@ -429,7 +429,9 @@ func play_movement_animation(animation_prefix: String, movement_direction: Vecto
 		if _movement_mode != false:
 			set_movement_mode(false)
 	else:
-		if movement_direction.length() > 0:
+		if movement_direction.length() > 1:
+			# tiny movement vectors are often the result of a collision. we ignore these to avoid constantly flipping
+			# their orientation if they're mashing themselves into a wall
 			var new_orientation := _compute_orientation(movement_direction)
 			if new_orientation != _orientation:
 				set_orientation(new_orientation)


### PR DESCRIPTION
Tilted meshes could potentially be problematic because tall sprites near a wall
would tilt towards the wall and clip. This would have been a problem for
background sprites such as trees or street lights. Customer3D mesh is now
vertically stretched instead of being tilted.

Vertically stretched meshes also take up less horizontal space, so I could
shrink the hit boxes into compact cylinders.

Modified the slip logic to avoid a bug where Turbo could slip if she bumped
into a customer horizontally.

Modified the movement animation logic to ignore infinitesmally small
movement vectors. This was resulting in a glitchy flickering look when the
character pressed into a wall.