### PR TITLE
Added HTML5 export (2D parts only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ data_turbo Fat
 Turbo Fat.exe
 Turbo Fat.pck
 Turbo Fat.x86_64
+/export/html5/*
 
 !.gitkeep

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -99,3 +99,26 @@ privacy/microphone_usage_description=""
 texture_format/s3tc=true
 texture_format/etc=false
 texture_format/etc2=false
+
+[preset.3]
+
+name="HTML5"
+platform="HTML5"
+runnable=true
+custom_features=""
+export_filter="all_resources"
+include_filter="*.json"
+exclude_filter=""
+export_path="export/html5/Turbo Fat.html"
+patch_list=PoolStringArray(  )
+script_export_mode=1
+script_encryption_key=""
+
+[preset.3.options]
+
+vram_texture_compression/for_desktop=true
+vram_texture_compression/for_mobile=false
+html/custom_html_shell=""
+html/head_include=""
+custom_template/release=""
+custom_template/debug=""

--- a/src/main/ui/loading-screen.gd
+++ b/src/main/ui/loading-screen.gd
@@ -4,8 +4,8 @@ Shows a progress bar while resources are loading.
 """
 
 func _ready() -> void:
-	ResourceCache.start_load()
 	ResourceCache.connect("finished_loading", self, "change_scene")
+	ResourceCache.start_load()
 
 
 func _process(delta: float) -> void:

--- a/src/main/ui/scenario-menu.gd
+++ b/src/main/ui/scenario-menu.gd
@@ -20,6 +20,8 @@ func _ready() -> void:
 		$VBoxContainer/Marathon/Expert.disable(unlock_message)
 	if ScenarioHistory.get_best_rank("marathon-expert") > RANK_TO_UNLOCK:
 		$VBoxContainer/Marathon/Master.disable(unlock_message)
+	if OS.has_feature("web"):
+		$OverworldButton.visible = false
 	
 	# grab focus so the player can navigate with the keyboard
 	$VBoxContainer/Marathon/Normal/Button.grab_focus()


### PR DESCRIPTION
HTML5 does not support threads, so I modified ResourceCache to support a
non-threading loading mechanism for HTML5.

The 3D stuff causes my browser to lock up. I'll have to investigate this
further, but it may just be infeasible for HTML5 to do the 3D parts of the
game. For now I've removed the '3D world' button from the scenario menu.