### PR TITLE
Fixed repetitive sfx for wall kicks, DAS

### DIFF
--- a/assets/ui/default_bus_layout.tres
+++ b/assets/ui/default_bus_layout.tres
@@ -1,7 +1,8 @@
 [gd_resource type="AudioBusLayout" load_steps=2 format=2]
 
-[sub_resource type="AudioEffectReverb" id=1]
+[sub_resource type="AudioEffectReverb" id=2]
 resource_name = "Reverb"
+predelay_feedback = 0.2
 room_size = 0.0
 damping = 0.05
 spread = 0.2
@@ -9,13 +10,13 @@ hipass = 0.5
 wet = 0.15
 
 [resource]
-bus/1/name = "Reverb Bus"
+bus/1/name = "Main Bus"
 bus/1/solo = false
 bus/1/mute = false
 bus/1/bypass_fx = false
 bus/1/volume_db = 0.0
 bus/1/send = "Master"
-bus/1/effect/0/effect = SubResource( 1 )
+bus/1/effect/0/effect = SubResource( 2 )
 bus/1/effect/0/enabled = true
 bus/2/name = "Voice Bus"
 bus/2/solo = false
@@ -23,5 +24,3 @@ bus/2/mute = false
 bus/2/bypass_fx = false
 bus/2/volume_db = 0.0
 bus/2/send = "Master"
-bus/2/effect/0/effect = SubResource( 1 )
-bus/2/effect/0/enabled = false

--- a/src/delint.sh
+++ b/src/delint.sh
@@ -15,4 +15,5 @@ grep -R -n "^					.\{100,\}$" --include="*.gd" .
 # fields/variables missing type hint. includes a list of whitelisted type hint omissions
 grep -R -n "var [^:]* = " --include="*.gd" . \
   | grep -v "chat-library.gd:48" \
-  | grep -v "chat-event.gd:76"
+  | grep -v "chat-event.gd:76" \
+  | grep -v "scenario-history.gd:119" \

--- a/src/main/puzzle/Playfield.tscn
+++ b/src/main/puzzle/Playfield.tscn
@@ -247,205 +247,205 @@ script = ExtResource( 41 )
 
 [node name="Erase1Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 6 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Erase2Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 7 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Erase3Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 8 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="LineFallSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 9 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="MakeCakeBoxSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 10 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="MakeSnackBoxSound0" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 59 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="MakeSnackBoxSound1" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 11 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="MakeSnackBoxSound2" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 60 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="MakeSnackBoxSound3" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 58 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ClearSnackPieceSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 12 )
 volume_db = -4.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ClearCakePieceSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 13 )
 volume_db = -4.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Fanfare1" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 15 )
 volume_db = -4.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Fanfare2" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 16 )
 volume_db = -4.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Fanfare3" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 17 )
 volume_db = -4.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo01Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 14 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo02Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 18 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo03Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 19 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo04Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 20 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo05Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 21 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo06Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 22 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo07Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 23 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo08Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 24 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo09Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 25 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo10Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 26 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo11Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 27 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo12Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 28 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo13Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 29 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo14Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 30 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo15Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 31 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo16Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 32 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo17Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 33 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo18Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 34 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo19Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 35 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo20Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 36 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo21Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 42 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo22Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 44 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo23Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 45 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Combo24Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 43 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ComboEndless00Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 48 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ComboEndless01Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 49 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ComboEndless02Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 47 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ComboEndless03Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 52 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ComboEndless04Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 46 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ComboEndless05Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 50 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ComboEndless06Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 51 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ComboEndless07Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 53 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ComboEndless08Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 54 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ComboEndless09Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 56 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ComboEndless10Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 57 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ComboEndless11Sound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 55 )
-bus = "Reverb Bus"
+bus = "Main Bus"

--- a/src/main/puzzle/Puzzle.tscn
+++ b/src/main/puzzle/Puzzle.tscn
@@ -162,23 +162,23 @@ script = ExtResource( 38 )
 
 [node name="Rotate0Sound" type="AudioStreamPlayer" parent="PieceManager"]
 stream = ExtResource( 29 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="Rotate1Sound" type="AudioStreamPlayer" parent="PieceManager"]
 stream = ExtResource( 30 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="MoveSound" type="AudioStreamPlayer" parent="PieceManager"]
 stream = ExtResource( 31 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="LockSound" type="AudioStreamPlayer" parent="PieceManager"]
 stream = ExtResource( 28 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="GameOverSound" type="AudioStreamPlayer" parent="PieceManager"]
 stream = ExtResource( 32 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="GameOverVoice0" type="AudioStreamPlayer" parent="PieceManager"]
 stream = ExtResource( 36 )
@@ -202,7 +202,7 @@ bus = "Voice Bus"
 
 [node name="SmushSound" type="AudioStreamPlayer" parent="PieceManager"]
 stream = ExtResource( 26 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="NextPieceDisplays" parent="." instance=ExtResource( 4 )]
 margin_left = 688.0
@@ -234,12 +234,12 @@ margin_bottom = 150.0
 [node name="ReadySound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 7 )
 volume_db = -4.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="GoSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 8 )
 volume_db = -4.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="GoVoice0" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 13 )

--- a/src/main/puzzle/Scenario.tscn
+++ b/src/main/puzzle/Scenario.tscn
@@ -208,19 +208,19 @@ __meta__ = {
 
 [node name="LevelUpSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 7 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ExcellentSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 4 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ApplauseSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 6 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="MatchEndSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 5 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="CheatCodeDetector" parent="." instance=ExtResource( 11 )]
 codes = [ "delays" ]

--- a/src/main/puzzle/piece/piece-manager.gd
+++ b/src/main/puzzle/piece/piece-manager.gd
@@ -423,7 +423,14 @@ func _move_piece_to_target(play_sfx := false) -> bool:
 					$Rotate0Sound.play()
 				else:
 					$Rotate1Sound.play()
-			if active_piece.pos != _target_piece_pos:
+			elif active_piece.pos != _target_piece_pos:
+				if $MoveSound.playing:
+					# Adjust the pitch/volume of DAS moves so they don't sound as grating and samey
+					$MoveSound.pitch_scale = clamp($MoveSound.pitch_scale + 0.08, 0.94, 2.00)
+					$MoveSound.volume_db = clamp($MoveSound.volume_db * 0.92, 0.50, 1.00)
+				else:
+					$MoveSound.pitch_scale = 0.94
+					$MoveSound.volume_db = 1.00
 				$MoveSound.play()
 		active_piece.pos = _target_piece_pos
 		active_piece.orientation = _target_piece_orientation

--- a/src/main/puzzle/scenario-history.gd
+++ b/src/main/puzzle/scenario-history.gd
@@ -116,7 +116,10 @@ func load_scenario_history() -> void:
 			var line_string := save_game.get_line()
 			if not line_string:
 				continue
-			var line_json: Dictionary = parse_json(line_string)
+			var line_json = parse_json(line_string)
+			if not line_json:
+				continue
+			var line_dict: Dictionary = line_json
 			for rank_result_json in line_json["scenario_history"]:
 				var rank_result := RankResult.new()
 				rank_result.from_dict(rank_result_json)

--- a/src/main/resource-cache.gd
+++ b/src/main/resource-cache.gd
@@ -26,7 +26,7 @@ var _load_thread: Thread
 # these two properties are used for the get_progress calculation
 var _work_done := 0.0
 var _work_remaining := 3.0
-var _remaining_png_paths = []
+var _remaining_png_paths := []
 
 """
 Initializes the resource load.

--- a/src/main/ui/CheatCodeDetector.tscn
+++ b/src/main/ui/CheatCodeDetector.tscn
@@ -10,9 +10,9 @@ script = ExtResource( 3 )
 [node name="CheatDisableSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 1 )
 volume_db = -4.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="CheatEnableSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 2 )
 volume_db = -4.0
-bus = "Reverb Bus"
+bus = "Main Bus"

--- a/src/main/ui/chat/ChatChoices.tscn
+++ b/src/main/ui/chat/ChatChoices.tscn
@@ -41,9 +41,9 @@ _choice_text = "I wouldn't choose this one!"
 [node name="PopSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 4 )
 volume_db = -6.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ChooseSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 5 )
 volume_db = -6.0
-bus = "Reverb Bus"
+bus = "Main Bus"

--- a/src/main/ui/chat/ChatFrame.tscn
+++ b/src/main/ui/chat/ChatFrame.tscn
@@ -274,12 +274,12 @@ bus = "Voice Bus"
 [node name="PopInSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 12 )
 volume_db = -14.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="PopOutSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 14 )
 volume_db = -14.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 [connection signal="pop_out_completed" from="Tween" to="." method="_on_Tween_pop_out_completed"]
 [connection signal="tween_completed" from="Tween" to="Tween" method="_on_tween_completed"]
 [connection signal="all_text_shown" from="SentenceManager" to="." method="_on_SentenceManager_all_text_shown"]

--- a/src/main/world/Customer3D.tscn
+++ b/src/main/world/Customer3D.tscn
@@ -105,19 +105,19 @@ shape = SubResource( 7 )
 stream = ExtResource( 2 )
 attenuation_model = 3
 unit_db = -12.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="JumpSound" type="AudioStreamPlayer3D" parent="."]
 stream = ExtResource( 4 )
 attenuation_model = 3
 unit_db = -6.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="BonkSound" type="AudioStreamPlayer3D" parent="."]
 stream = ExtResource( 5 )
 attenuation_model = 3
 unit_db = -6.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 [connection signal="customer_arrived" from="Viewport/Customer" to="." method="_on_Customer_customer_arrived"]
 [connection signal="jumped" from="Viewport/Customer" to="." method="_on_Customer_jumped"]
 [connection signal="landed" from="Viewport/Customer" to="." method="_on_Customer_landed"]

--- a/src/main/world/restaurant/Customer.tscn
+++ b/src/main/world/restaurant/Customer.tscn
@@ -2709,7 +2709,7 @@ script = ExtResource( 58 )
 
 [node name="EmoteSfx" type="AudioStreamPlayer" parent="EmoteAnims"]
 stream = ExtResource( 72 )
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="FatPlayer" type="AnimationPlayer" parent="."]
 anims/fat = SubResource( 52 )
@@ -2753,31 +2753,31 @@ bus = "Voice Bus"
 stream = ExtResource( 15 )
 volume_db = -4.0
 max_distance = 4000.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="DoorChime1" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource( 11 )
 volume_db = -4.0
 max_distance = 4000.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="DoorChime2" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource( 24 )
 volume_db = -4.0
 max_distance = 4000.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="DoorChime3" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource( 16 )
 volume_db = -4.0
 max_distance = 4000.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="DoorChime4" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource( 18 )
 volume_db = -4.0
 max_distance = 4000.0
-bus = "Reverb Bus"
+bus = "Main Bus"
 
 [node name="ComboVoice00" type="AudioStreamPlayer2D" parent="."]
 position = Vector2( 160, 0 )


### PR DESCRIPTION
Wall kicks were playing a rotate and move sound effect simultaneously.
They now only play the rotate sound.

DAS move sfx now vary in pitch/volume. They had sort of a grating
machinegun-like quality to them before.

Fixed NPE when save file not found.