### PR TITLE
PuzzleScore state, win/finish conditions.

### DIFF
--- a/assets/puzzle/scenario/sprint-expert.json
+++ b/assets/puzzle/scenario/sprint-expert.json
@@ -1,6 +1,6 @@
 {
   "start-level": "F0",
-  "win-condition": {
+  "finish-condition": {
     "type": "time",
     "value": "180"
   }

--- a/assets/puzzle/scenario/sprint-normal.json
+++ b/assets/puzzle/scenario/sprint-normal.json
@@ -1,6 +1,6 @@
 {
   "start-level": "A0",
-  "win-condition": {
+  "finish-condition": {
     "type": "time",
     "value": "150"
   }

--- a/assets/puzzle/scenario/ultra-expert.json
+++ b/assets/puzzle/scenario/ultra-expert.json
@@ -1,6 +1,6 @@
 {
   "start-level": "F0",
-  "win-condition": {
+  "finish-condition": {
     "type": "score",
     "value": "3000"
   }

--- a/assets/puzzle/scenario/ultra-hard.json
+++ b/assets/puzzle/scenario/ultra-hard.json
@@ -1,6 +1,6 @@
 {
   "start-level": "A0",
-  "win-condition": {
+  "finish-condition": {
     "type": "score",
     "value": "1000"
   }

--- a/assets/puzzle/scenario/ultra-normal.json
+++ b/assets/puzzle/scenario/ultra-normal.json
@@ -1,6 +1,6 @@
 {
   "start-level": "0",
-  "win-condition": {
+  "finish-condition": {
     "type": "score",
     "value": "200"
   }

--- a/src/demo/customer-view-demo.gd
+++ b/src/demo/customer-view-demo.gd
@@ -37,13 +37,15 @@ func _input(event: InputEvent) -> void:
 			else:
 				_current_color_index += CustomerLoader.DEFINITIONS.size()
 				_current_color_index = (_current_color_index - 1) % CustomerLoader.DEFINITIONS.size()
-			$CustomerView.summon_customer(CustomerLoader.DEFINITIONS[_current_color_index])
+			Global.customer_queue.push_front(CustomerLoader.DEFINITIONS[_current_color_index])
+			$CustomerView.summon_customer()
 		KEY_BRACERIGHT:
 			if _current_color_index == -1:
 				_current_color_index = 0
 			else:
 				_current_color_index = (_current_color_index + 1) % CustomerLoader.DEFINITIONS.size()
-			$CustomerView.summon_customer(CustomerLoader.DEFINITIONS[_current_color_index])
+			Global.customer_queue.push_front(CustomerLoader.DEFINITIONS[_current_color_index])
+			$CustomerView.summon_customer()
 		KEY_P:
 			print($CustomerView/SceneClip/CustomerSwitcher/Scene/Customer/AnimationPlayer.current_animation)
 			print($CustomerView/SceneClip/CustomerSwitcher/Scene/Customer/AnimationPlayer.is_playing())

--- a/src/demo/restaurant-scene-demo.gd
+++ b/src/demo/restaurant-scene-demo.gd
@@ -29,13 +29,15 @@ func _input(event: InputEvent) -> void:
 			else:
 				_current_color_index += CustomerLoader.DEFINITIONS.size()
 				_current_color_index = (_current_color_index - 1) % CustomerLoader.DEFINITIONS.size()
-			$RestaurantScene.summon_customer(CustomerLoader.DEFINITIONS[_current_color_index], 1)
+			Global.customer_queue.push_front(CustomerLoader.DEFINITIONS[_current_color_index])
+			$RestaurantScene.summon_customer(1)
 		KEY_BRACERIGHT:
 			if _current_color_index == -1:
 				_current_color_index = 0
 			else:
 				_current_color_index = (_current_color_index + 1) % CustomerLoader.DEFINITIONS.size()
-			$RestaurantScene.summon_customer(CustomerLoader.DEFINITIONS[_current_color_index], 1)
+			Global.customer_queue.push_front(CustomerLoader.DEFINITIONS[_current_color_index])
+			$RestaurantScene.summon_customer(1)
 		KEY_P:
 			print($RestaurantScene/Customer/AnimationPlayer.current_animation)
 			print($RestaurantScene/Customer/AnimationPlayer.is_playing())

--- a/src/demo/results-hud-demo.gd
+++ b/src/demo/results-hud-demo.gd
@@ -13,7 +13,7 @@ var _customer_scores := [
 	89, 853, 986, 713, 294, 468, 207, 63, 59, 570, 98, 341, 461, 39, 56, 51, 6, 3, 16, 94, 72, 739, 459, 552, 968,
 	648, 688, 594, 9, 23, 669, 784, 496, 2, 258, 79, 679, 377, 41, 53, 522, 636, 77, 706, 981, 86, 438, 151, 74, 665,
 	754, 378, 937, 419, 840, 62, 289, 584, 640, 20, 28, 652, 25, 708, 12, 11, 727, 52, 466, 60, 306, 48, 45, 339]
-var _win_condition_type := ScenarioSettings.SCORE
+var _finish_condition_type := ScenarioSettings.SCORE
 
 func _ready() -> void:
 	_rank_result.seconds = 600.0
@@ -25,5 +25,5 @@ func _ready() -> void:
 
 func _input(event: InputEvent) -> void:
 	match(Global.key_scancode(event)):
-		KEY_S: $ResultsHud.show_results_message(_rank_result, _customer_scores, _win_condition_type)
+		KEY_S: $ResultsHud.show_results_message(_rank_result, _customer_scores, _finish_condition_type)
 		KEY_H: $ResultsHud.hide_results_message()

--- a/src/main/puzzle/Puzzle.tscn
+++ b/src/main/puzzle/Puzzle.tscn
@@ -377,7 +377,7 @@ bus = "Voice Bus"
 [connection signal="box_made" from="Playfield" to="FrostingGlobs" method="_on_Playfield_box_made"]
 [connection signal="customer_left" from="Playfield" to="." method="_on_Playfield_customer_left"]
 [connection signal="line_cleared" from="Playfield" to="." method="_on_Playfield_line_cleared"]
-[connection signal="game_ended" from="PieceManager" to="." method="_on_Piece_game_ended"]
+[connection signal="piece_spawn_blocked" from="PieceManager" to="." method="_on_PieceManager_piece_spawn_blocked"]
 [connection signal="entered_state" from="PieceManager/States" to="PieceManager" method="_on_States_entered_state"]
 [connection signal="back_button_pressed" from="HudHolder/Hud" to="." method="_on_Hud_back_button_pressed"]
 [connection signal="start_button_pressed" from="HudHolder/Hud" to="." method="_on_Hud_start_button_pressed"]

--- a/src/main/puzzle/Scenario.tscn
+++ b/src/main/puzzle/Scenario.tscn
@@ -228,8 +228,5 @@ bus = "Main Bus"
 [node name="CheatCodeDetector" parent="." instance=ExtResource( 11 )]
 codes = [ "delays" ]
 [connection signal="after_game_ended" from="Puzzle" to="ResultsHud" method="_on_Puzzle_after_game_ended"]
-[connection signal="before_game_started" from="Puzzle" to="." method="_on_Puzzle_before_game_started"]
-[connection signal="before_game_started" from="Puzzle" to="ResultsHud" method="_on_Puzzle_before_game_started"]
-[connection signal="game_ended" from="Puzzle" to="." method="_on_Puzzle_game_ended"]
 [connection signal="line_cleared" from="Puzzle" to="." method="_on_Puzzle_line_cleared"]
 [connection signal="cheat_detected" from="CheatCodeDetector" to="Puzzle/PuzzleTrace" method="_on_CheatCodeDetector_cheat_detected"]

--- a/src/main/puzzle/piece/next-piece-displays.gd
+++ b/src/main/puzzle/piece/next-piece-displays.gd
@@ -14,25 +14,9 @@ export (PackedScene) var NextPieceDisplay
 var _next_piece_displays := []
 
 func _ready() -> void:
+	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
 	for i in range(DISPLAY_COUNT):
 		_add_display(i, 5, 5 + i * (486 / (DISPLAY_COUNT - 1)), 0.5)
-
-
-"""
-Hides all next piece displays. We can't let the player see the upcoming pieces before the game starts.
-"""
-func hide_pieces() -> void:
-	for next_piece_display in _next_piece_displays:
-		next_piece_display.hide()
-
-
-"""
-Starts a new game, randomizing the pieces and filling the piece queues.
-"""
-func start_game() -> void:
-	_piece_queue.clear()
-	for next_piece_display in _next_piece_displays:
-		next_piece_display.show()
 
 
 """
@@ -50,5 +34,15 @@ func _add_display(piece_index: int, x: float, y: float, scale: float) -> void:
 	new_display.initialize(_piece_queue, piece_index)
 	new_display.scale = Vector2(scale, scale)
 	new_display.position = Vector2(x, y)
+	new_display.hide()
 	add_child(new_display)
 	_next_piece_displays.append(new_display)
+
+
+"""
+Gets ready for a new game, randomizing the pieces and filling the piece queues.
+"""
+func _on_PuzzleScore_game_prepared() -> void:
+	_piece_queue.clear()
+	for next_piece_display in _next_piece_displays:
+		next_piece_display.show()

--- a/src/main/puzzle/puzzle-hud.gd
+++ b/src/main/puzzle/puzzle-hud.gd
@@ -10,6 +10,8 @@ signal start_button_pressed
 signal back_button_pressed
 
 func _ready() -> void:
+	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
+	PuzzleScore.connect("game_started", self, "_on_PuzzleScore_game_started")
 	$MessageLabel.hide()
 	# grab focus so the player can start a new game or navigate with the keyboard
 	$StartGameButton.grab_focus()
@@ -34,13 +36,6 @@ func show_message(text: String) -> void:
 	$MessageLabel.text = text
 
 
-func hide_buttons_and_messages() -> void:
-	$StartGameButton.hide()
-	$BackButton.hide()
-	$MessageLabel.hide()
-	$DetailMessageLabel.hide()
-
-
 """
 Restores the HUD elements after the player wins or loses.
 """
@@ -57,9 +52,24 @@ func after_game_ended() -> void:
 		$StartGameButton.grab_focus()
 
 
+func _hide_buttons_and_messages() -> void:
+	$StartGameButton.hide()
+	$BackButton.hide()
+	$MessageLabel.hide()
+	$DetailMessageLabel.hide()
+
+
 func _on_StartGameButton_pressed() -> void:
 	emit_signal("start_button_pressed")
 
 
 func _on_BackButton_pressed() -> void:
 	emit_signal("back_button_pressed")
+
+
+func _on_PuzzleScore_game_started() -> void:
+	_hide_buttons_and_messages()
+
+
+func _on_PuzzleScore_game_prepared() -> void:
+	_hide_buttons_and_messages()

--- a/src/main/puzzle/puzzle.gd
+++ b/src/main/puzzle/puzzle.gd
@@ -5,33 +5,22 @@ Represents a minimal puzzle game with a piece, playfield of pieces, and next pie
 class to add goals, win conditions, challenges or time limits.
 """
 
-# signal emitted when the 'new game' countdown begins for piece randomization, clearing the playfield
-signal before_game_started
-
-# signal emitted when the 'new game' countdown finishes, giving the player control
-signal game_started
-
 # signal emitted when a line is cleared
 signal line_cleared(y, total_lines, remaining_lines)
-
-# signal emitted when the player's pieces reach the top of the playfield
-signal game_ended
 
 # signal emitted a few seconds after the game ends, for displaying messages
 signal after_game_ended
 
+# signal emitted after a customer leaves (usually when a combo ends)
+signal customer_left
+
 onready var _go_voices := [$GoVoice0, $GoVoice1, $GoVoice2]
 
-# 'true' if the player has started a game which is still running.
-var game_active: bool = true
-
 func _ready() -> void:
-	$NextPieceDisplays.hide_pieces()
-	$PieceManager.clear_piece()
 	$Playfield/TileMapClip/TileMap/Viewport/ShadowMap.piece_tile_map = $PieceManager/TileMap
 	
 	for i in range(3):
-		_summon_customer(i)
+		$CustomerView.summon_customer(i)
 
 
 """
@@ -52,10 +41,8 @@ func show_message(text: String) -> void:
 Ends the game. This occurs when the player loses, wins, or runs out of time.
 """
 func end_game(delay: float, message: String) -> void:
-	game_active = false
 	emit_signal("game_ended")
-	$Playfield.end_game()
-	$PieceManager.end_game()
+	PuzzleScore.end_game()
 	show_message(message)
 	yield(get_tree().create_timer(delay), "timeout")
 	$HudHolder/Hud.after_game_ended()
@@ -63,17 +50,7 @@ func end_game(delay: float, message: String) -> void:
 
 
 func start_game() -> void:
-	emit_signal("before_game_started")
-	$HudHolder/Hud.hide_buttons_and_messages()
-	
-	$NextPieceDisplays.start_game()
-	$Playfield.start_game()
-	PuzzleScore.reset()
-	$PieceManager.clear_piece()
-	if $CustomerView.get_fatness() > 1:
-		# if they ended a game on a fattened customer, scroll to a new one
-		_scroll_to_new_customer()
-	
+	PuzzleScore.prepare_game()
 	show_message("3")
 	$ReadySound.play()
 	yield(get_tree().create_timer(0.8), "timeout")
@@ -83,14 +60,9 @@ func start_game() -> void:
 	show_message("1")
 	$ReadySound.play()
 	yield(get_tree().create_timer(0.8), "timeout")
-	$HudHolder/Hud.hide_buttons_and_messages()
 	$GoSound.play()
 	_go_voices[randi() % _go_voices.size()].play()
-	
-	$PieceManager.start_game()
-	
-	game_active = true
-	emit_signal("game_started")
+	PuzzleScore.start_game()
 
 
 """
@@ -107,32 +79,10 @@ Parameters:
 func _feed_customer(fatness_pct: float) -> void:
 	$CustomerView/SceneClip/CustomerSwitcher/Scene.feed()
 	
-	if $Playfield.clock_running:
+	if PuzzleScore.game_active:
 		var old_fatness: float = $CustomerView.get_fatness()
 		var target_fatness := sqrt(1 + PuzzleScore.get_customer_score() / 50.0)
 		$CustomerView.set_fatness(lerp(old_fatness, target_fatness, fatness_pct))
-
-
-"""
-Scroll to a new customer and replace the old customer.
-"""
-func _scroll_to_new_customer() -> void:
-	var customer_index: int = $CustomerView.get_current_customer_index()
-	var new_customer_index: int = (customer_index + randi() % 2 + 1) % 3
-	$CustomerView.set_current_customer_index(new_customer_index)
-	yield(get_tree().create_timer(0.5), "timeout")
-	$CustomerView.set_fatness(1, customer_index)
-	
-	_summon_customer(customer_index)
-
-
-func _summon_customer(customer_index: int) -> void:
-	var customer_def: Dictionary
-	if Global.customer_queue.empty():
-		customer_def = CustomerLoader.DEFINITIONS[randi() % CustomerLoader.DEFINITIONS.size()]
-	else:
-		customer_def = Global.customer_queue.pop_front()
-	$CustomerView.summon_customer(customer_def, customer_index)
 
 
 func _on_Hud_back_button_pressed() -> void:
@@ -149,7 +99,7 @@ func _on_Hud_start_button_pressed() -> void:
 """
 When the current piece can't be placed, we end the game and emit the appropriate signals.
 """
-func _on_Piece_game_ended() -> void:
+func _on_PieceManager_piece_spawn_blocked() -> void:
 	end_game(2.4, "Game over")
 
 
@@ -170,6 +120,7 @@ func _on_Playfield_line_cleared(y: int, total_lines: int, remaining_lines: int) 
 
 
 func _on_Playfield_customer_left() -> void:
-	if $Playfield.clock_running:
+	if PuzzleScore.game_active:
 		$CustomerView.play_goodbye_voice()
-		_scroll_to_new_customer()
+		$CustomerView.scroll_to_new_customer()
+	emit_signal("customer_left")

--- a/src/main/puzzle/results-hud.gd
+++ b/src/main/puzzle/results-hud.gd
@@ -19,6 +19,9 @@ const HINTS = [
 	"Sometimes, pressing 'down' can cheat pieces through other pieces!"
 ]
 
+func _ready() -> void:
+	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
+
 
 func hide_results_message() -> void:
 	$ResultsLabel.hide_text()
@@ -31,7 +34,7 @@ Prepares a game over message to show to the player.
 The message is littered with lull characters, '/', which are hidden from the player but result in a brief pause when
 displayed.
 """
-func show_results_message(rank_result: RankResult, customer_scores: Array, win_condition_type: int) -> void:
+func show_results_message(rank_result: RankResult, customer_scores: Array, finish_condition_type: int) -> void:
 	# Generate post-game message with stats, grades, and a gameplay hint
 	var text := "//////////"
 	
@@ -52,7 +55,7 @@ func show_results_message(rank_result: RankResult, customer_scores: Array, win_c
 	
 	# Append grade information
 	text += "/////\n"
-	if win_condition_type == ScenarioSettings.SCORE:
+	if finish_condition_type == ScenarioSettings.SCORE:
 		text += "Speed: %d (%s)\n" % [round(rank_result.speed * 200 / 60), Global.grade(rank_result.speed_rank)]
 	else:
 		text += "Lines: %d (%s)\n" % [rank_result.lines, Global.grade(rank_result.lines_rank)]
@@ -65,7 +68,7 @@ func show_results_message(rank_result: RankResult, customer_scores: Array, win_c
 	
 	text += "/////\nOverall: "
 	text += "//////////"
-	if win_condition_type == ScenarioSettings.SCORE:
+	if finish_condition_type == ScenarioSettings.SCORE:
 		var seconds := ceil(rank_result.seconds)
 		text += "%01d:%02d (%s)\n" % [int(seconds) / 60, int(seconds) % 60,
 				Global.grade(rank_result.seconds_rank)]
@@ -96,16 +99,16 @@ func _period_count(s: String) -> int:
 	return result
 
 
-func _on_Puzzle_before_game_started() -> void:
+func _on_PuzzleScore_game_prepared() -> void:
 	hide_results_message()
 
 
 func _on_Puzzle_after_game_ended() -> void:
 	var rank_result: RankResult = PlayerData.get_last_scenario_result(Global.scenario_settings.name)
 	var customer_scores: Array = PuzzleScore.customer_scores
-	var win_condition_type := Global.scenario_settings.win_condition.type
+	var finish_condition_type := Global.scenario_settings.get_winish_condition().type
 	
-	show_results_message(rank_result, customer_scores, win_condition_type)
+	show_results_message(rank_result, customer_scores, finish_condition_type)
 
 
 func _on_ResultsLabel_text_shown(new_text: String) -> void:

--- a/src/main/puzzle/scenario-settings.gd
+++ b/src/main/puzzle/scenario-settings.gd
@@ -23,7 +23,7 @@ class LevelUp:
 		level = json["level"]
 
 
-class WinCondition:
+class FinishCondition:
 	"""
 	Defines the criteria for finishing the scenario, such as a time, score, or line goal.
 	"""
@@ -39,7 +39,7 @@ class WinCondition:
 	scenario because they didn't survive 1,000 lines, when the marathon scenario is intended as a 'for fun' mode where
 	getting 1,000 lines is not really the true goal.
 	"""
-	var lenient_value: int
+	var lenient_value: int = -1
 	
 	"""
 	Populates this object from a dictionary. Used for loading json data.
@@ -75,11 +75,23 @@ const JSON_MILESTONE_TYPES := {
 # makes you level up.
 var level_ups := []
 
-# The requirements to finish the scenario. This can be a line, score, or time requirement.
-var win_condition: WinCondition
+# How the player wins. When the player wins, there's a big fanfare and celebration, it should be used for
+# accomplishments such as surviving 10 minutes or getting 1,000 points. 
+var win_condition := FinishCondition.new()
+
+# How the player finishes. When the player finishes, they can't play anymore, and the level just ends. It should be
+# used for limits such as serving 5 customers or clearing 10 lines. 
+var finish_condition := FinishCondition.new()
 
 # The scenario name, used internally for saving/loading data.
 var name := ""
+
+func reset() -> void:
+	level_ups.clear()
+	win_condition = FinishCondition.new()
+	finish_condition = FinishCondition.new()
+	name = ""
+
 
 func set_start_level(level: String) -> void:
 	level_ups.clear()
@@ -90,7 +102,6 @@ func set_start_level(level: String) -> void:
 Adds criteria for leveling up, such as a time, score, or line limit.
 """
 func add_level_up(type: int, value: int, level: String) -> void:
-	var win_condition := WinCondition.new()
 	var level_up := LevelUp.new()
 	level_up.type = type
 	level_up.value = value
@@ -99,13 +110,31 @@ func add_level_up(type: int, value: int, level: String) -> void:
 
 
 """
-Sets the criteria for finishing the scenario, such as a time, score, or line goal.
+Sets the criteria for winning the scenario, such as a time, score, or line goal.
 """
 func set_win_condition(type: int, value: int, lenient_value: int = -1) -> void:
-	win_condition = WinCondition.new()
+	win_condition = FinishCondition.new()
 	win_condition.type = type
 	win_condition.value = value
 	win_condition.lenient_value = lenient_value
+
+
+"""
+Sets the criteria for finishing the scenario, such as a time, score, or line goal.
+"""
+func set_finish_condition(type: int, value: int) -> void:
+	finish_condition = FinishCondition.new()
+	finish_condition.type = type
+	finish_condition.value = value
+
+
+"""
+Returns either the win or finish condition, whichever is defined.
+
+If both are defined, the win condition takes precedence.
+"""
+func get_winish_condition() -> FinishCondition:
+	return win_condition if win_condition.type != NONE else finish_condition
 
 
 """
@@ -127,5 +156,10 @@ func from_dict(new_name: String, json: Dictionary) -> void:
 			level_up.from_dict(json_level_up)
 			level_ups.append(level_up)
 
-	win_condition = WinCondition.new()
-	win_condition.from_dict(json["win-condition"])
+	win_condition = FinishCondition.new()
+	if json.has("win-condition"):
+		win_condition.from_dict(json["win-condition"])
+	
+	finish_condition = FinishCondition.new()
+	if json.has("finish-condition"):
+		finish_condition.from_dict(json["finish-condition"])

--- a/src/main/puzzle/scenario.gd
+++ b/src/main/puzzle/scenario.gd
@@ -18,39 +18,50 @@ var _rank_calculator := RankCalculator.new()
 var _level := 0
 
 func _ready() -> void:
-	PuzzleScore.reset()
-	$TimeHud.hide()
+	PuzzleScore.connect("game_ended", self, "_on_PuzzleScore_game_ended")
+	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
 	$LinesHud.hide()
 	$ScoreHud.hide()
-	match Global.scenario_settings.win_condition.type:
-		ScenarioSettings.TIME:
-			$TimeHud.show()
-			var seconds := ceil(Global.scenario_settings.win_condition.value)
-			$TimeHud/TimeValue.text = "%01d:%02d" % [int(seconds) / 60, int(seconds) % 60]
+	$TimeHud.hide()
+	
+	var winish_condition: ScenarioSettings.FinishCondition = Global.scenario_settings.get_winish_condition()
+	match winish_condition.type:
 		ScenarioSettings.LINES:
 			$LinesHud.show()
 			_set_level(0)
 		ScenarioSettings.SCORE:
 			$ScoreHud.show()
-			$ScoreHud/ScoreValue.text = "¥%s" % Global.scenario_settings.win_condition.value
+			$ScoreHud/ScoreValue.text = "¥%s" % winish_condition.value
 			$ScoreHud/TimeLabel.hide()
 			$ScoreHud/TimeValue.hide()
+		ScenarioSettings.TIME:
+			$TimeHud.show()
+			var seconds := ceil(winish_condition.value)
+			$TimeHud/TimeValue.text = "%01d:%02d" % [int(seconds) / 60, int(seconds) % 60]
 
 
 func _physics_process(_delta: float) -> void:
-	if Global.scenario_settings.win_condition.type == ScenarioSettings.TIME and $Puzzle/Playfield.clock_running:
-		if PuzzleScore.scenario_performance.seconds >= Global.scenario_settings.win_condition.value:
-			$MatchEndSound.play()
-			$Puzzle.end_game(2.2, "Finish!")
+	if not PuzzleScore.game_active:
+		return
+	
+	var winish_condition: ScenarioSettings.FinishCondition = Global.scenario_settings.get_winish_condition()
+	match winish_condition.type:
+		ScenarioSettings.TIME:
+			var seconds := PuzzleScore.scenario_performance.seconds
+			if seconds >= winish_condition.value:
+				$MatchEndSound.play()
+				$Puzzle.end_game(2.2, "Finish!")
 
 
 func _process(_delta: float) -> void:
-	if Global.scenario_settings.win_condition.type == ScenarioSettings.TIME:
-		var seconds := ceil(Global.scenario_settings.win_condition.value - PuzzleScore.scenario_performance.seconds)
-		$TimeHud/TimeValue.text = "%01d:%02d" % [int(seconds) / 60, int(seconds) % 60]
-	elif Global.scenario_settings.win_condition.type == ScenarioSettings.SCORE:
-		var seconds := ceil(PuzzleScore.scenario_performance.seconds)
-		$ScoreHud/TimeValue.text = "%01d:%02d" % [int(seconds) / 60, int(seconds) % 60]
+	var winish_condition: ScenarioSettings.FinishCondition = Global.scenario_settings.get_winish_condition()
+	match winish_condition.type:
+		ScenarioSettings.SCORE:
+			var seconds := ceil(PuzzleScore.scenario_performance.seconds)
+			$ScoreHud/TimeValue.text = "%01d:%02d" % [int(seconds) / 60, int(seconds) % 60]
+		ScenarioSettings.TIME:
+			var seconds := ceil(winish_condition.value - PuzzleScore.scenario_performance.seconds)
+			$TimeHud/TimeValue.text = "%01d:%02d" % [int(seconds) / 60, int(seconds) % 60]
 
 
 """
@@ -77,21 +88,23 @@ func _set_level(new_level:int) -> void:
 	
 	$LinesHud/ProgressBar.get("custom_styles/fg").set_bg_color(
 			Color(level_color.r, level_color.g, level_color.g, 0.33))
-	if new_level + 1 < Global.scenario_settings.level_ups.size():
-		$LinesHud/ProgressBar.min_value = Global.scenario_settings.level_ups[new_level].value
-		$LinesHud/ProgressBar.max_value = Global.scenario_settings.level_ups[new_level + 1].value
-	elif Global.scenario_settings.win_condition.type == ScenarioSettings.LINES:
-		$LinesHud/ProgressBar.min_value = Global.scenario_settings.level_ups[new_level].value
-		$LinesHud/ProgressBar.max_value = Global.scenario_settings.win_condition.value
-	else:
-		$LinesHud/ProgressBar.min_value = 0
-		$LinesHud/ProgressBar.max_value = 100
+	var winish_condition: ScenarioSettings.FinishCondition = Global.scenario_settings.get_winish_condition()
+	match winish_condition.type:
+		ScenarioSettings.LINES:
+			if new_level + 1 < Global.scenario_settings.level_ups.size():
+				# marathon mode; fill up the bar as they approach the next level
+				$LinesHud/ProgressBar.min_value = Global.scenario_settings.level_ups[new_level].value
+				$LinesHud/ProgressBar.max_value = Global.scenario_settings.level_ups[new_level + 1].value
+			else:
+				# final level of marathon mode; fill up the bar as they near their goal
+				$LinesHud/ProgressBar.min_value = Global.scenario_settings.level_ups[new_level].value
+				$LinesHud/ProgressBar.max_value = winish_condition.value
 
 
 """
 Method invoked when the game ends. Stores the rank result for later.
 """
-func _on_Puzzle_game_ended() -> void:
+func _on_PuzzleScore_game_ended() -> void:
 	# ensure score is up to date before calculating rank
 	PuzzleScore.end_combo()
 	var rank_result := _rank_calculator.calculate_rank()
@@ -99,19 +112,19 @@ func _on_Puzzle_game_ended() -> void:
 	PlayerData.money += rank_result.score
 	PlayerSave.save_player_data()
 	
-	if Global.scenario_settings.win_condition.type == ScenarioSettings.SCORE:
-		if not PuzzleScore.scenario_performance.died and rank_result.seconds_rank < 24:
-			$ApplauseSound.play()
-	else:
-		if not PuzzleScore.scenario_performance.died and rank_result.score_rank < 24:
-			$ApplauseSound.play()
+	var winish_condition: ScenarioSettings.FinishCondition = Global.scenario_settings.get_winish_condition()
+	match winish_condition.type:
+		ScenarioSettings.SCORE:
+			if not PuzzleScore.scenario_performance.died and rank_result.seconds_rank < 24: $ApplauseSound.play()
+		_:
+			if not PuzzleScore.scenario_performance.died and rank_result.score_rank < 24: $ApplauseSound.play()
 
 
 """
 Method invoked when a line is cleared. Updates the level.
 """
 func _on_Puzzle_line_cleared(y: int, total_lines: int, remaining_lines: int) -> void:
-	if not $Puzzle.game_active:
+	if not PuzzleScore.game_active:
 		return
 	
 	var lines: int = PuzzleScore.scenario_performance.lines
@@ -125,34 +138,76 @@ func _on_Puzzle_line_cleared(y: int, total_lines: int, remaining_lines: int) -> 
 		$LevelUpSound.play()
 		_set_level(new_level)
 	
-	if Global.scenario_settings.win_condition.type == ScenarioSettings.LINES:
-		if new_level + 1 < Global.scenario_settings.level_ups.size():
-			if Global.scenario_settings.level_ups[new_level + 1].type == ScenarioSettings.LINES:
+	_update_goal_hud()
+	_check_for_match_end()
+
+
+func _check_for_match_end() -> void:
+	if not PuzzleScore.game_active:
+		return
+	
+	# toggled if the player reaches a score/time goal
+	var finish := false
+	
+	# toggled if the player reaches the end of a long survival/marathon level
+	var win := false
+	
+	match Global.scenario_settings.win_condition.type:
+		ScenarioSettings.LINES:
+			var lines := PuzzleScore.scenario_performance.lines
+			win = lines >= Global.scenario_settings.win_condition.value
+		ScenarioSettings.SCORE:
+			var total_score: int = PuzzleScore.get_score() + PuzzleScore.get_bonus_score()
+			win = total_score >= Global.scenario_settings.win_condition.value
+	
+	match Global.scenario_settings.finish_condition.type:
+		ScenarioSettings.LINES:
+			var lines := PuzzleScore.scenario_performance.lines
+			finish = lines >= Global.scenario_settings.finish_condition.value
+		ScenarioSettings.SCORE:
+			var total_score: int = PuzzleScore.get_score() + PuzzleScore.get_bonus_score()
+			finish = total_score >= Global.scenario_settings.finish_condition.value
+	
+	if win:
+		$ExcellentSound.play()
+		$Puzzle.end_game(4.2, "You win!")
+	elif finish:
+		$MatchEndSound.play()
+		$Puzzle.end_game(2.2, "Finish!")
+
+
+func _update_goal_hud() -> void:
+	var winish_condition: ScenarioSettings.FinishCondition = Global.scenario_settings.get_winish_condition()
+	match winish_condition.type:
+		ScenarioSettings.LINES:
+			var lines: int = PuzzleScore.scenario_performance.lines
+			if _level + 1 < Global.scenario_settings.level_ups.size():
+				if Global.scenario_settings.level_ups[_level + 1].type == ScenarioSettings.LINES:
+					$LinesHud/ProgressBar.value = lines
+			elif winish_condition.type == ScenarioSettings.LINES:
 				$LinesHud/ProgressBar.value = lines
-		elif Global.scenario_settings.win_condition.type == ScenarioSettings.LINES:
-			$LinesHud/ProgressBar.value = lines
-		if lines >= Global.scenario_settings.win_condition.value:
-			$ExcellentSound.play()
-			$Puzzle.end_game(4.2, "You win!")
-	
-	if Global.scenario_settings.win_condition.type == ScenarioSettings.SCORE:
-		var total_score: int = PuzzleScore.get_score() + PuzzleScore.get_bonus_score()
-		$ScoreHud/ProgressBar.value = total_score
-		if total_score >= Global.scenario_settings.win_condition.value:
-			$MatchEndSound.play()
-			$Puzzle.end_game(2.2, "Finish!")
+		ScenarioSettings.SCORE:
+			var total_score: int = PuzzleScore.get_score() + PuzzleScore.get_bonus_score()
+			$ScoreHud/ProgressBar.value = total_score
 
 
-func _on_Puzzle_before_game_started() -> void:
+func _on_PuzzleScore_game_prepared() -> void:
 	_set_level(0)
-
-	if Global.scenario_settings.win_condition.type == ScenarioSettings.SCORE:
-		$ScoreHud/TimeLabel.show()
-		$ScoreHud/TimeValue.show()
-		$ScoreHud/ScoreLabel.hide()
-		$ScoreHud/ScoreValue.hide()
-		$ScoreHud/ProgressBar.max_value = Global.scenario_settings.win_condition.value
-		$ScoreHud/ProgressBar.value = 0
 	
-	if Global.scenario_settings.win_condition.type == ScenarioSettings.LINES:
-		$LinesHud/ProgressBar.value = 0
+	var winish_condition: ScenarioSettings.FinishCondition = Global.scenario_settings.get_winish_condition()
+	match winish_condition.type:
+		ScenarioSettings.LINES:
+			$LinesHud/ProgressBar.value = 0
+		ScenarioSettings.SCORE:
+			$ScoreHud/TimeLabel.show()
+			$ScoreHud/TimeValue.show()
+			$ScoreHud/ScoreLabel.hide()
+			$ScoreHud/ScoreValue.hide()
+			$ScoreHud/ProgressBar.max_value = winish_condition.value
+			$ScoreHud/ProgressBar.value = 0
+
+
+func _on_Puzzle_customer_left() -> void:
+	_update_goal_hud()
+	_check_for_match_end()
+

--- a/src/main/resource-cache.gd
+++ b/src/main/resource-cache.gd
@@ -14,6 +14,9 @@ signal finished_loading
 # enables logging paths and durations for loaded resources
 export (bool) var _verbose := false
 
+# reduces the number of textures loaded throughout the game
+export (bool) var minimal_resources := false
+
 # maintains references to all resources to prevent them from being cleaned up
 var _cache := {}
 

--- a/src/main/world/restaurant/customer.gd
+++ b/src/main/world/restaurant/customer.gd
@@ -21,7 +21,7 @@ signal food_eaten
 # signal emitted when a customer arrives and sits down
 signal customer_arrived
 
-# signal emitted when a stands up and customer leaves
+# signal emitted when a customer stands up and leaves
 signal customer_left
 
 # signal emitted when a movement animation starts (e.g Spira starts running in a direction)
@@ -337,10 +337,14 @@ func summon(customer_def: Dictionary, use_defaults: bool = true) -> void:
 		put_if_absent(_customer_def, "eye_rgb", "282828 dedede")
 		put_if_absent(_customer_def, "horn_rgb", "f1e398")
 		
-		put_if_absent(_customer_def, "eye", ["0", "0", "0", "1", "2"][randi() % 5])
-		put_if_absent(_customer_def, "ear", ["0", "0", "0", "1", "2"][randi() % 5])
-		put_if_absent(_customer_def, "horn", ["0", "0", "0", "1", "2"][randi() % 5])
-		put_if_absent(_customer_def, "mouth", ["0", "0", "1"][randi() % 3])
+		if ResourceCache.minimal_resources:
+			# avoid loading unnecessary resources for things like the scenario editor
+			pass
+		else:
+			put_if_absent(_customer_def, "eye", ["0", "0", "0", "1", "2"][randi() % 5])
+			put_if_absent(_customer_def, "ear", ["0", "0", "0", "1", "2"][randi() % 5])
+			put_if_absent(_customer_def, "horn", ["0", "0", "0", "1", "2"][randi() % 5])
+			put_if_absent(_customer_def, "mouth", ["0", "0", "1"][randi() % 3])
 		put_if_absent(_customer_def, "body", "0")
 	
 	_customer_loader.load_details(_customer_def)

--- a/src/test/test-rank-calculator.gd
+++ b/src/test/test-rank-calculator.gd
@@ -12,24 +12,24 @@ particularly important for this code.
 var _rank_calculator := RankCalculator.new()
 
 func before_each() -> void:
+	Global.scenario_settings.reset()
 	Global.scenario_settings.set_start_level("0")
-	Global.scenario_settings.set_win_condition(ScenarioSettings.LINES, 100)
 	PuzzleScore.scenario_performance = ScenarioPerformance.new()
 
 
 func test_max_lpm_slow_marathon() -> void:
 	Global.scenario_settings.set_start_level("0")
-	assert_almost_eq(_rank_calculator._max_lpm(), 34.29, 0.1)
+	assert_almost_eq(_rank_calculator._max_lpm(), 30.77, 0.1)
 
 
 func test_max_lpm_medium_marathon() -> void:
 	Global.scenario_settings.set_start_level("A0")
-	assert_almost_eq(_rank_calculator._max_lpm(), 40.44, 0.1)
+	assert_almost_eq(_rank_calculator._max_lpm(), 35.64, 0.1)
 
 
 func test_max_lpm_fast_marathon() -> void:
 	Global.scenario_settings.set_start_level("F0")
-	assert_almost_eq(_rank_calculator._max_lpm(), 81.36, 0.1)
+	assert_almost_eq(_rank_calculator._max_lpm(), 64.00, 0.1)
 
 
 func test_max_lpm_mixed_marathon() -> void:
@@ -37,15 +37,15 @@ func test_max_lpm_mixed_marathon() -> void:
 	Global.scenario_settings.add_level_up(ScenarioSettings.LINES, 30, "A0")
 	Global.scenario_settings.add_level_up(ScenarioSettings.LINES, 60, "F0")
 	Global.scenario_settings.set_win_condition(ScenarioSettings.LINES, 100)
-	assert_almost_eq(_rank_calculator._max_lpm(), 52.96, 0.1)
+	assert_almost_eq(_rank_calculator._max_lpm(), 45.01, 0.1)
 
 
 func test_max_lpm_mixed_sprint() -> void:
 	Global.scenario_settings.set_start_level("0")
 	Global.scenario_settings.add_level_up(ScenarioSettings.TIME, 30, "A0")
 	Global.scenario_settings.add_level_up(ScenarioSettings.TIME, 60, "F0")
-	Global.scenario_settings.set_win_condition(ScenarioSettings.TIME, 90)
-	assert_almost_eq(_rank_calculator._max_lpm(), 57.85, 0.1)
+	Global.scenario_settings.set_finish_condition(ScenarioSettings.TIME, 90)
+	assert_almost_eq(_rank_calculator._max_lpm(), 49.47, 0.1)
 
 
 func test_calculate_rank_marathon_300_master() -> void:
@@ -64,7 +64,6 @@ func test_calculate_rank_marathon_300_master() -> void:
 
 
 func test_calculate_rank_marathon_300_mixed() -> void:
-	Global.scenario_settings.set_start_level("0")
 	Global.scenario_settings.set_win_condition(ScenarioSettings.LINES, 300)
 	PuzzleScore.scenario_performance.seconds = 240
 	PuzzleScore.scenario_performance.lines = 60
@@ -80,7 +79,6 @@ func test_calculate_rank_marathon_300_mixed() -> void:
 
 
 func test_calculate_rank_marathon_lenient() -> void:
-	Global.scenario_settings.set_start_level("0")
 	Global.scenario_settings.set_win_condition(ScenarioSettings.LINES, 300, 200)
 	PuzzleScore.scenario_performance.seconds = 240
 	PuzzleScore.scenario_performance.lines = 60
@@ -96,7 +94,6 @@ func test_calculate_rank_marathon_lenient() -> void:
 
 
 func test_calculate_rank_marathon_300_fail() -> void:
-	Global.scenario_settings.set_start_level("0")
 	Global.scenario_settings.set_win_condition(ScenarioSettings.LINES, 300)
 	PuzzleScore.scenario_performance.seconds = 0
 	PuzzleScore.scenario_performance.lines = 0
@@ -113,7 +110,7 @@ func test_calculate_rank_marathon_300_fail() -> void:
 
 func test_calculate_rank_sprint_120() -> void:
 	Global.scenario_settings.set_start_level("A0")
-	Global.scenario_settings.set_win_condition(ScenarioSettings.TIME, 120)
+	Global.scenario_settings.set_finish_condition(ScenarioSettings.TIME, 120)
 	PuzzleScore.scenario_performance.seconds = 120
 	PuzzleScore.scenario_performance.lines = 47
 	PuzzleScore.scenario_performance.box_score = 395
@@ -128,8 +125,7 @@ func test_calculate_rank_sprint_120() -> void:
 
 
 func test_calculate_rank_ultra_200() -> void:
-	Global.scenario_settings.set_start_level("0")
-	Global.scenario_settings.set_win_condition(ScenarioSettings.SCORE, 200)
+	Global.scenario_settings.set_finish_condition(ScenarioSettings.SCORE, 200)
 	PuzzleScore.scenario_performance.seconds = 20.233
 	PuzzleScore.scenario_performance.lines = 8
 	PuzzleScore.scenario_performance.box_score = 135
@@ -144,8 +140,7 @@ func test_calculate_rank_ultra_200() -> void:
 
 
 func test_calculate_rank_ultra_200_died() -> void:
-	Global.scenario_settings.set_start_level("0")
-	Global.scenario_settings.set_win_condition(ScenarioSettings.SCORE, 200)
+	Global.scenario_settings.set_finish_condition(ScenarioSettings.SCORE, 200)
 	PuzzleScore.scenario_performance.seconds = 60
 	PuzzleScore.scenario_performance.lines = 10
 	PuzzleScore.scenario_performance.box_score = 80
@@ -163,8 +158,7 @@ func test_calculate_rank_ultra_200_died() -> void:
 This is an edge case where, if the player gets too many points for ultra, they can sort of be robbed of a master rank.
 """
 func test_calculate_rank_ultra_200_overshot() -> void:
-	Global.scenario_settings.set_start_level("0")
-	Global.scenario_settings.set_win_condition(ScenarioSettings.SCORE, 200)
+	Global.scenario_settings.set_finish_condition(ScenarioSettings.SCORE, 200)
 	PuzzleScore.scenario_performance.seconds = 19
 	PuzzleScore.scenario_performance.lines = 10
 	PuzzleScore.scenario_performance.box_score = 150
@@ -182,12 +176,12 @@ These two times are pretty far apart; they shouldn't yield the same rank
 """
 func test_two_rank_s() -> void:
 	Global.scenario_settings.set_start_level("A0")
-	Global.scenario_settings.set_win_condition(ScenarioSettings.SCORE, 1000)
+	Global.scenario_settings.set_finish_condition(ScenarioSettings.SCORE, 1000)
 	PuzzleScore.scenario_performance.seconds = 88.55
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(Global.grade(rank.seconds_rank), "SS+")
 
-	Global.scenario_settings.set_win_condition(ScenarioSettings.SCORE, 1000)
+	Global.scenario_settings.set_finish_condition(ScenarioSettings.SCORE, 1000)
 	PuzzleScore.scenario_performance.seconds = 128.616
 	var rank2 := _rank_calculator.calculate_rank()
 	assert_eq(Global.grade(rank2.seconds_rank), "S+")
@@ -197,7 +191,7 @@ func test_two_rank_s() -> void:
 This edge case used to result in a combo_score_per_line of 22.5
 """
 func test_combo_score_per_line_ultra_overshot() -> void:
-	Global.scenario_settings.set_win_condition(ScenarioSettings.SCORE, 200)
+	Global.scenario_settings.set_finish_condition(ScenarioSettings.SCORE, 200)
 	PuzzleScore.scenario_performance.combo_score = 45
 	PuzzleScore.scenario_performance.lines = 7
 	var rank := _rank_calculator.calculate_rank()


### PR DESCRIPTION
There were some bugs with lines being cleared after the player had
completed Ultra mode. I've pushed the 'game is running' concept out of
playfield.gd and puzzle.gd, and moved it into puzzle-score.gd. This
greatly simplifies a lot of signals, eliminates several bugs, and lets us
push some code from puzzle.gd into its collaborators.

Split out win/finish conditions. Scenarios can now have a condition where
you win by doing something impressive (clearing 1,000 lines), or a condition
where you finish by doing something ordinary (waiting 2 minutes.) This
distinction was already embedded in scenario.gd, but now it's an aspect of
the scenario json definition.

Fixed lpm tests broken in b1345ec. These tests were originally written
assuming a perfect player would move the piece for 0/1 frames. I've fixed
them so they assume 6 frames of leeway.

Added ResourceCache.minimal_resources flag for testing scenarios quickly.