### PR TITLE
Moved MilestoneHud into Puzzle. Added u-kicks.

### DIFF
--- a/src/main/global.gd
+++ b/src/main/global.gd
@@ -20,6 +20,12 @@ var scenario_settings := ScenarioSettings.new()
 # The customers who will show up during the next puzzle. The first customer in the queue will show up first.
 var customer_queue := []
 
+# 'true' if the customer should change when breaking combo. Disabled for tutorials.
+var customer_switch := true
+
+# 'true' if the customer should get fatter. Disabled for tutorials.
+var customer_fatten := true
+
 # 'true' if launching a puzzle from the overworld. This changes the menus and disallows restarting.
 var overworld_puzzle := false
 

--- a/src/main/puzzle/Puzzle.tscn
+++ b/src/main/puzzle/Puzzle.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=47 format=2]
+[gd_scene load_steps=50 format=2]
 
 [ext_resource path="res://src/main/puzzle/puzzle.gd" type="Script" id=1]
 [ext_resource path="res://src/main/puzzle/Playfield.tscn" type="PackedScene" id=2]
@@ -17,6 +17,7 @@
 [ext_resource path="res://assets/world/chef/go-voice2.wav" type="AudioStream" id=15]
 [ext_resource path="res://src/main/puzzle/frosting-globs.gd" type="Script" id=16]
 [ext_resource path="res://src/main/puzzle/metaball.shader" type="Shader" id=17]
+[ext_resource path="res://assets/ui/xolonium-24.tres" type="DynamicFont" id=18]
 [ext_resource path="res://src/main/puzzle/stretch-map.gd" type="Script" id=19]
 [ext_resource path="res://src/main/puzzle/piece/states/prelock.gd" type="Script" id=20]
 [ext_resource path="res://src/main/puzzle/piece/states/move-piece.gd" type="Script" id=21]
@@ -86,6 +87,17 @@ shader_param/noise = SubResource( 5 )
 [sub_resource type="ViewportTexture" id=7]
 flags = 5
 viewport_path = NodePath("FrostingGlobs/RainbowViewport")
+
+[sub_resource type="StyleBoxFlat" id=8]
+bg_color = Color( 1, 1, 1, 0.333333 )
+
+[sub_resource type="StyleBoxFlat" id=9]
+bg_color = Color( 0, 0, 0, 1 )
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color( 1, 1, 1, 1 )
 
 [node name="Puzzle" type="Control"]
 margin_right = 1024.0
@@ -341,6 +353,45 @@ margin_left = 58.0
 margin_top = 25.0
 margin_right = 308.0
 margin_bottom = 85.0
+
+[node name="MilestoneHud" type="Control" parent="Chalkboard"]
+margin_left = 58.0
+margin_top = 153.0
+margin_right = 308.0
+margin_bottom = 233.0
+rect_min_size = Vector2( 250, 40 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ProgressBar" type="ProgressBar" parent="Chalkboard/MilestoneHud"]
+margin_left = 150.0
+margin_top = 30.0
+margin_right = 250.0
+margin_bottom = 75.0
+custom_styles/fg = SubResource( 8 )
+custom_styles/bg = SubResource( 9 )
+percent_visible = false
+
+[node name="Desc" type="Label" parent="Chalkboard/MilestoneHud"]
+anchor_right = 1.0
+margin_bottom = 30.0
+custom_fonts/font = ExtResource( 18 )
+text = "Goal"
+align = 2
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Value" type="Label" parent="Chalkboard/MilestoneHud"]
+margin_left = 150.0
+margin_top = 30.0
+margin_right = 250.0
+margin_bottom = 75.0
+custom_fonts/font = ExtResource( 18 )
+text = "¥2000"
+align = 1
+valign = 1
 
 [node name="HudHolder" type="Node2D" parent="."]
 position = Vector2( 364, 28 )

--- a/src/main/puzzle/ResultsHud.tscn
+++ b/src/main/puzzle/ResultsHud.tscn
@@ -12,6 +12,7 @@
 [node name="ResultsHud" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 2
 script = ExtResource( 3 )
 __meta__ = {
 "_edit_use_anchors_": false

--- a/src/main/puzzle/Scenario.tscn
+++ b/src/main/puzzle/Scenario.tscn
@@ -7,28 +7,25 @@
 [ext_resource path="res://assets/ui/matchend.wav" type="AudioStream" id=5]
 [ext_resource path="res://assets/ui/applause.wav" type="AudioStream" id=6]
 [ext_resource path="res://assets/puzzle/levelup.wav" type="AudioStream" id=7]
+[ext_resource path="res://assets/ui/blogger-sans-medium-30.tres" type="DynamicFont" id=8]
+[ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=9]
 [ext_resource path="res://src/main/puzzle/puzzle-trace.gd" type="Script" id=10]
 [ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=11]
 [ext_resource path="res://src/main/puzzle/ResultsHud.tscn" type="PackedScene" id=12]
 
-[sub_resource type="StyleBoxFlat" id=1]
-bg_color = Color( 1, 1, 1, 0.333333 )
-
-[sub_resource type="StyleBoxFlat" id=2]
-bg_color = Color( 0, 0, 0, 1 )
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color( 1, 1, 1, 1 )
-
-[node name="PuzzleScenario" type="Control"]
+[node name="Scenario" type="Control"]
+margin_right = 1024.0
+margin_bottom = 600.0
 script = ExtResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Puzzle" parent="." instance=ExtResource( 3 )]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_right = 0.0
+margin_bottom = 0.0
 
 [node name="PuzzleTrace" type="Label" parent="Puzzle"]
 visible = false
@@ -43,52 +40,25 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Hud" type="Control" parent="."]
-margin_top = 180.0
-margin_right = 250.0
-margin_bottom = 220.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="ProgressBar" type="ProgressBar" parent="Hud"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -100.0
-margin_top = 30.0
-margin_bottom = 75.0
-custom_styles/fg = SubResource( 1 )
-custom_styles/bg = SubResource( 2 )
-percent_visible = false
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Label" type="Label" parent="Hud"]
-anchor_right = 1.0
-margin_bottom = 30.0
-custom_fonts/font = ExtResource( 2 )
-text = "Goal"
-align = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Value" type="Label" parent="Hud"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -100.0
-margin_top = 30.0
-margin_bottom = 75.0
-custom_fonts/font = ExtResource( 2 )
-text = "¥2000"
-align = 1
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
 [node name="ResultsHud" parent="." instance=ExtResource( 12 )]
+
+[node name="TutorialHud" type="Control" parent="."]
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="RichTextLabel" type="RichTextLabel" parent="TutorialHud"]
+margin_left = 10.0
+margin_top = 10.0
+margin_right = 345.0
+margin_bottom = 305.0
+custom_styles/normal = ExtResource( 9 )
+custom_fonts/normal_font = ExtResource( 8 )
+text = "Oh my, you're not supposed to know how to do that! ...But yes, snack boxes get you $15 when you clear them. Maybe more if you're clever."
 
 [node name="ApplauseSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 6 )

--- a/src/main/puzzle/piece/piece-types.gd
+++ b/src/main/puzzle/piece/piece-types.gd
@@ -34,10 +34,10 @@ const KICKS_T := [
 
 
 const KICKS_U := [
-		[Vector2( 1, -1), Vector2( 1, -2), Vector2( 0,  1), Vector2( 1,  1)],
-		[Vector2(-1,  1), Vector2(-1,  2), Vector2( 0, -1), Vector2(-1, -1)],
-		[Vector2(-1, -1), Vector2(-1, -2), Vector2( 0,  1), Vector2(-1,  1)],
-		[Vector2( 1,  1), Vector2( 1,  2), Vector2( 0, -1), Vector2( 1, -1)]
+		[Vector2( 1, -1), Vector2( 1, -2), Vector2( 0,  1), Vector2( 1,  1), Vector2( 1,  0)],
+		[Vector2(-1,  1), Vector2(-1,  2), Vector2( 0, -1), Vector2(-1, -1), Vector2(-1,  0)],
+		[Vector2(-1, -1), Vector2(-1, -2), Vector2( 0,  1), Vector2(-1,  1), Vector2(-1,  0)],
+		[Vector2( 1,  1), Vector2( 1,  2), Vector2( 0, -1), Vector2( 1, -1), Vector2( 1,  0)]
 	]
 
 const KICKS_P := [

--- a/src/main/puzzle/puzzle.gd
+++ b/src/main/puzzle/puzzle.gd
@@ -34,16 +34,6 @@ func show_message(text: String) -> void:
 	$HudHolder/Hud.show_message(text)
 
 
-"""
-Ends the game. This occurs when the player loses, wins, or runs out of time.
-"""
-func end_game(delay: float, message: String) -> void:
-	PuzzleScore.end_game()
-	show_message(message)
-	yield(get_tree().create_timer(delay), "timeout")
-	emit_signal("after_game_ended")
-
-
 func start_game() -> void:
 	PuzzleScore.prepare_game()
 	show_message("3")
@@ -61,6 +51,41 @@ func start_game() -> void:
 
 
 """
+Ends the game. This occurs when the player loses, wins, or runs out of time.
+"""
+func end_game(delay: float, message: String) -> void:
+	PuzzleScore.end_game()
+	show_message(message)
+	yield(get_tree().create_timer(delay), "timeout")
+	emit_signal("after_game_ended")
+
+
+func hide_chalkboard() -> void:
+	$Chalkboard.visible = false
+
+
+"""
+Returns the milestone hud's description label.
+"""
+func miledesc() -> Label:
+	return $Chalkboard/MilestoneHud/Desc as Label
+
+
+"""
+Returns the milestone hud's progress bar.
+"""
+func milebar() -> ProgressBar:
+	return $Chalkboard/MilestoneHud/ProgressBar as ProgressBar
+
+
+"""
+Returns the milestone hud's value label.
+"""
+func milevalue() -> Label:
+	return $Chalkboard/MilestoneHud/Value as Label
+
+
+"""
 Triggers the eating animation and makes the customer fatter. Accepts a 'fatness_pct' parameter which defines how
 much fatter the customer should get. We can calculate how fat they should be, and a value of 0.4 means the customer
 should increase by 40% of the amount needed to reach that target.
@@ -74,7 +99,7 @@ Parameters:
 func _feed_customer(fatness_pct: float) -> void:
 	$CustomerView/SceneClip/CustomerSwitcher/Scene.feed()
 	
-	if PuzzleScore.game_active:
+	if PuzzleScore.game_active and Global.customer_fatten:
 		var old_fatness: float = $CustomerView.get_fatness()
 		var target_fatness := sqrt(1 + PuzzleScore.get_customer_score() / 50.0)
 		$CustomerView.set_fatness(lerp(old_fatness, target_fatness, fatness_pct))
@@ -115,6 +140,6 @@ func _on_Playfield_line_cleared(y: int, total_lines: int, remaining_lines: int, 
 
 
 func _on_PuzzleScore_combo_ended() -> void:
-	if PuzzleScore.game_active:
+	if PuzzleScore.game_active and Global.customer_switch:
 		$CustomerView.play_goodbye_voice()
 		$CustomerView.scroll_to_new_customer()

--- a/src/main/puzzle/scenario-settings.gd
+++ b/src/main/puzzle/scenario-settings.gd
@@ -18,9 +18,13 @@ class ComboBreakConditions:
 	Populates this object from a string array. Used for loading json data.
 	"""
 	func from_string_array(string_array: Array) -> void:
-		for string in string_array:
+		for string_obj in string_array:
+			var string: String = string_obj
 			if string == "veg-row":
 				veg_row = true
+			if string.begins_with("pieces-"):
+				pieces = int(StringUtils.substring_after(string, "pieces-"))
+
 
 # The requirements to level up and make the game harder. This mostly applies to 'Marathon Mode' where clearing lines
 # makes you level up.
@@ -73,7 +77,8 @@ func set_win_condition(type: int, value: int, lenient_value: int = -1) -> void:
 	win_condition = Milestone.new()
 	win_condition.type = type
 	win_condition.value = value
-	win_condition.lenient_value = lenient_value
+	if lenient_value > -1:
+		win_condition.set_meta("lenient_value", lenient_value)
 
 
 """

--- a/src/main/world/restaurant/Customer.tscn
+++ b/src/main/world/restaurant/Customer.tscn
@@ -63,7 +63,6 @@
 [ext_resource path="res://assets/ui/chat/emote-sweat1.wav" type="AudioStream" id=74]
 [ext_resource path="res://assets/ui/chat/emote-laugh1.wav" type="AudioStream" id=75]
 
-
 [sub_resource type="ShaderMaterial" id=1]
 resource_local_to_scene = true
 shader = ExtResource( 46 )

--- a/src/main/world/restaurant/customer-view.gd
+++ b/src/main/world/restaurant/customer-view.gd
@@ -87,5 +87,5 @@ func scroll_to_new_customer() -> void:
 If they ended the previous game while serving a customer, we scroll to a new one
 """
 func _on_PuzzleScore_game_prepared() -> void:
-	if get_fatness() > 1:
+	if get_fatness() > 1 and Global.customer_switch:
 		scroll_to_new_customer()

--- a/src/main/world/restaurant/customer.gd
+++ b/src/main/world/restaurant/customer.gd
@@ -51,7 +51,7 @@ enum HeadBobMode {
 }
 
 # delays between when customer arrives and when door chime is played (in seconds)
-const CHIME_DELAYS: Array = [0.5, 1.0, 1.5, 2.0, 3.0]
+const CHIME_DELAYS: Array = [0.2, 0.3, 0.5, 1.0, 1.5]
 
 # maps customer orientations to appropriate (x, y) direction vectors
 const ORIENTATION_VECTORS := {
@@ -599,7 +599,9 @@ func _update_customer_properties() -> void:
 		if _suppress_one_chime:
 			_suppress_one_chime = false
 		else:
-			play_door_chime()
+			if Global.customer_switch:
+				# don't play chime for scenarios with only one customer (tutorials)
+				play_door_chime()
 
 
 """

--- a/src/test/test-piece-kicks-u.gd
+++ b/src/test/test-piece-kicks-u.gd
@@ -177,3 +177,142 @@ func test_u_spire_kick_ccw2() -> void:
 	]
 	_assert_kick()
 
+
+"""
+'loutish kicks' and 'moutish kicks' demonstrate what happens when the U piece is boxed in by two corners
+"""
+func test_u_loutish_kick_cw0() -> void:
+	from_grid = [
+		"::   ",
+		":u u ",
+		" uuu:",
+		"   ::",
+	]
+	to_grid = [
+		"::   ",
+		":uu  ",
+		" u  :",
+		" uu::",
+	]
+	_assert_kick()
+
+
+func test_u_moutish_kick_ccw0() -> void:
+	from_grid = [
+		"   ::",
+		" u u:",
+		":uuu ",
+		"::   ",
+	]
+	to_grid = [
+		"   ::",
+		"  uu:",
+		":  u ",
+		"::uu ",
+	]
+	_assert_kick()
+
+
+func test_u_loutish_kick_cw1() -> void:
+	from_grid = [
+		"::  ",
+		":uu ",
+		" u  ",
+		" uu:",
+		"  ::",
+	]
+	to_grid = [
+		"::  ",
+		":uuu",
+		" u u",
+		"   :",
+		"  ::",
+	]
+	_assert_kick()
+
+
+func test_u_moutish_kick_ccw1() -> void:
+	from_grid = [
+		"  ::",
+		" uu:",
+		" u  ",
+		":uu ",
+		"::  ",
+	]
+	to_grid = [
+		"  ::",
+		"u u:",
+		"uuu ",
+		":   ",
+		"::  ",
+	]
+	_assert_kick()
+
+
+func test_u_loutish_kick_cw2() -> void:
+	from_grid = [
+		"::   ",
+		":uuu ",
+		" u u:",
+		"   ::",
+	]
+	to_grid = [
+		"::   ",
+		":uu  ",
+		"  u :",
+		" uu::",
+	]
+	_assert_kick()
+
+
+func test_u_moutish_kick_ccw2() -> void:
+	from_grid = [
+		"   ::",
+		" uuu:",
+		":u u ",
+		"::   ",
+	]
+	to_grid = [
+		"   ::",
+		"  uu:",
+		": u  ",
+		"::uu ",
+	]
+	_assert_kick()
+
+
+func test_u_loutish_kick_cw3() -> void:
+	from_grid = [
+		"::  ",
+		":uu ",
+		"  u ",
+		" uu:",
+		"  ::",
+	]
+	to_grid = [
+		"::  ",
+		":u u",
+		" uuu",
+		"   :",
+		"  ::",
+	]
+	_assert_kick()
+
+
+func test_u_moutish_kick_cw3() -> void:
+	from_grid = [
+		"  ::",
+		" uu:",
+		" u  ",
+		":uu ",
+		"::  ",
+	]
+	to_grid = [
+		"  ::",
+		"u u:",
+		"uuu ",
+		":   ",
+		"::  ",
+	]
+	_assert_kick()
+


### PR DESCRIPTION
Started introducing tutorial UI element customization. Launching the
tutorial scenario hides the chalkboard, summons master fat.

Simplified milestone hud logic. Instead of granular methods like 'update
colors', 'update content', 'update goal', 'prepare', there's just two methods
now: 'prepare hud' and 'update hud'

Added some missing u-kick tests. The piece was stuck even though there were
clear places it could rotate.