### PR TITLE
Data load now handles missing fields. Renamed save file.

### DIFF
--- a/src/delint.sh
+++ b/src/delint.sh
@@ -15,7 +15,7 @@ grep -R -n "^					.\{100,\}$" --include="*.gd" .
 # fields/variables missing type hint. includes a list of whitelisted type hint omissions
 grep -R -n "var [^:]* = " --include="*.gd" . \
   | grep -v " = parse_json(" \
-  | grep -v "chat-event.gd:76"
+  | grep -v "chat-event.gd:73"
 
 find -name *.TMP
 find -name *.gd~

--- a/src/main/puzzle/editor/editor-json.gd
+++ b/src/main/puzzle/editor/editor-json.gd
@@ -26,8 +26,8 @@ func can_parse_json() -> bool:
 	var parsed = parse_json(text)
 	_json_tree = parsed if typeof(parsed) == TYPE_DICTIONARY else {}
 	if _json_tree:
-		_json_blocks_start = _json_tree[BLOCKS_START] if _json_tree.has(BLOCKS_START) else {}
-		_json_tiles = _json_blocks_start[TILES] if _json_blocks_start.has(TILES) else []
+		_json_blocks_start = _json_tree.get(BLOCKS_START, {})
+		_json_tiles = _json_blocks_start.get(TILES, [])
 	return not _json_tree.empty()
 
 
@@ -38,8 +38,10 @@ func refresh_tilemap() -> void:
 	if can_parse_json():
 		_tile_map.clear()
 		for json_tile in _json_tiles:
-			var json_pos_arr: PoolStringArray = json_tile["pos"].split(" ")
-			var json_tile_arr: PoolStringArray = json_tile["tile"].split(" ")
+			var json_pos_arr: PoolStringArray = json_tile.get("pos", "").split(" ")
+			var json_tile_arr: PoolStringArray = json_tile.get("tile", "").split(" ")
+			if json_pos_arr.size() < 2 or json_tile_arr.size() < 3:
+				continue
 			var pos := Vector2(int(json_pos_arr[0]), int(json_pos_arr[1]))
 			var tile := int(json_tile_arr[0])
 			var autotile_coord := Vector2(int(json_tile_arr[1]), int(json_tile_arr[2]))

--- a/src/main/puzzle/milestone.gd
+++ b/src/main/puzzle/milestone.gd
@@ -34,12 +34,9 @@ const JSON_MILESTONE_TYPES := {
 var type: int
 var value: int
 
-"""
-Populates this object with json data.
-"""
-func from_dict(json: Dictionary) -> void:
-	type = JSON_MILESTONE_TYPES[json["type"]]
-	value = int(json["value"])
+func from_json_dict(json: Dictionary) -> void:
+	type = JSON_MILESTONE_TYPES.get(json.get("type"), MilestoneType.NONE)
+	value = int(json.get("value", "0"))
 	for key in json.keys():
 		if not key in ["type", "value"]:
 			set_meta(key, json.get(key))

--- a/src/main/puzzle/rank-result.gd
+++ b/src/main/puzzle/rank-result.gd
@@ -13,12 +13,12 @@ var lines := 0
 var lines_rank := 0.0
 
 # bonus points awarded for clearing boxes
-var box_score := 0.0
+var box_score := 0
 var box_score_per_line := 0.0
 var box_score_per_line_rank := 0.0
 
 # bonus points awarded for combos
-var combo_score := 0.0
+var combo_score := 0
 var combo_score_per_line := 0.0
 var combo_score_per_line_rank := 0.0
 
@@ -36,10 +36,7 @@ var top_out_count := 0
 # did the player lose?
 var lost := false
 
-"""
-Returns this object's data in a json-friendly format.
-"""
-func to_dict() -> Dictionary:
+func to_json_dict() -> Dictionary:
 	return {
 		"box_score": box_score,
 		"box_score_per_line": box_score_per_line,
@@ -59,26 +56,23 @@ func to_dict() -> Dictionary:
 		"top_out_count": top_out_count }
 
 
-"""
-Populates this object with json data.
-"""
-func from_dict(json: Dictionary) -> void:
-	box_score = json["box_score"]
-	box_score_per_line = json["box_score_per_line"]
-	box_score_per_line_rank = json["box_score_per_line_rank"]
-	combo_score = json["combo_score"]
-	combo_score_per_line = json["combo_score_per_line"]
-	combo_score_per_line_rank = json["combo_score_per_line_rank"]
-	lines = int(json["lines"])
-	lines_rank = json["lines_rank"]
-	lost = json["lost"]
-	score = int(json["score"])
-	score_rank = json["score_rank"]
-	seconds = json["seconds"]
-	seconds_rank = json["seconds_rank"]
-	speed = json["speed"]
-	speed_rank = json["speed_rank"]
-	top_out_count = json["top_out_count"]
+func from_json_dict(json: Dictionary) -> void:
+	box_score = int(json.get("box_score", "0"))
+	box_score_per_line = float(json.get("box_score_per_line", "0"))
+	box_score_per_line_rank = float(json.get("box_score_per_line_rank", "999"))
+	combo_score = int(json.get("combo_score", "0"))
+	combo_score_per_line = float(json.get("combo_score_per_line", "0"))
+	combo_score_per_line_rank = float(json.get("combo_score_per_line_rank", "999"))
+	lines = int(json.get("lines", "0"))
+	lines_rank = float(json.get("lines_rank", "999"))
+	lost = bool(json.get("lost", "true"))
+	score = int(json.get("score", "0"))
+	score_rank = float(json.get("score_rank", "999"))
+	seconds = float(json.get("seconds", "999999"))
+	seconds_rank = float(json.get("seconds_rank", "999"))
+	speed = float(json.get("speed", "0"))
+	speed_rank = float(json.get("speed_rank", "999"))
+	top_out_count = int(json.get("top_out_count", "999999"))
 
 
 func topped_out() -> bool:

--- a/src/main/puzzle/scenario/blocks-start.gd
+++ b/src/main/puzzle/scenario/blocks-start.gd
@@ -7,18 +7,16 @@ var used_cells := []
 var tiles := {}
 var autotile_coords := {}
 
-"""
-Populates this object from a json dictionary.
-"""
-func from_dict(dict: Dictionary) -> void:
-	if dict.has("tiles"):
-		for json_tile in dict["tiles"]:
-			var json_pos_arr: PoolStringArray = json_tile["pos"].split(" ")
-			var json_tile_arr: PoolStringArray = json_tile["tile"].split(" ")
-			var pos := Vector2(int(json_pos_arr[0]), int(json_pos_arr[1]))
-			var tile := int(json_tile_arr[0])
-			var autotile_coord := Vector2(int(json_tile_arr[1]), int(json_tile_arr[2]))
-			set_block(pos, tile, autotile_coord)
+func from_json_dict(json: Dictionary) -> void:
+	for json_tile in json.get("tiles", []):
+		var json_pos_arr: PoolStringArray = json_tile.get("pos", "").split(" ")
+		var json_tile_arr: PoolStringArray = json_tile.get("tile", "").split(" ")
+		if json_pos_arr.size() < 2 or json_tile_arr.size() < 3:
+			continue
+		var pos := Vector2(int(json_pos_arr[0]), int(json_pos_arr[1]))
+		var tile := int(json_tile_arr[0])
+		var autotile_coord := Vector2(int(json_tile_arr[1]), int(json_tile_arr[2]))
+		set_block(pos, tile, autotile_coord)
 
 
 func set_block(pos: Vector2, tile: int, autotile_coord: Vector2) -> void:

--- a/src/main/puzzle/scenario/combo-break-rules.gd
+++ b/src/main/puzzle/scenario/combo-break-rules.gd
@@ -9,10 +9,7 @@ var veg_row := false
 # by default, dropping 2 pieces breaks their combo
 var pieces := 2
 
-"""
-Populates this object with json data.
-"""
-func from_string_array(strings: Array) -> void:
-	var rules := RuleParser.new(strings)
+func from_json_string_array(json: Array) -> void:
+	var rules := RuleParser.new(json)
 	if rules.has("veg-row"): veg_row = true
 	if rules.has("pieces"): pieces = rules.int_value()

--- a/src/main/puzzle/scenario/lose-condition-rules.gd
+++ b/src/main/puzzle/scenario/lose-condition-rules.gd
@@ -7,9 +7,6 @@ have different rules.
 # by default, the player loses if they top out three times
 var top_out := 3
 
-"""
-Populates this object with json data.
-"""
-func from_string_array(strings: Array) -> void:
-	var rules := RuleParser.new(strings)
+func from_json_string_array(json: Array) -> void:
+	var rules := RuleParser.new(json)
 	if rules.has("top-out"): top_out = rules.int_value()

--- a/src/main/puzzle/scenario/other-rules.gd
+++ b/src/main/puzzle/scenario/other-rules.gd
@@ -12,8 +12,8 @@ var after_tutorial := false
 # If the player restarts, they restart from this scenario (used for tutorials)
 var start_scenario_name: String
 
-func from_string_array(strings: Array) -> void:
-	var rules := RuleParser.new(strings)
+func from_json_string_array(json: Array) -> void:
+	var rules := RuleParser.new(json)
 	if rules.has("tutorial"): tutorial = true
 	if rules.has("after-tutorial"): after_tutorial = true
 	if rules.has("start-scenario"): start_scenario_name = rules.string_value()

--- a/src/main/puzzle/scenario/piece-type-rules.gd
+++ b/src/main/puzzle/scenario/piece-type-rules.gd
@@ -9,7 +9,7 @@ var start_types: Array = []
 # pieces the player is given during a level
 var types: Array = []
 
-func from_string_array(strings: Array) -> void:
+func from_json_string_array(json: Array) -> void:
 	var json_types: Dictionary = {
 		"piece-j": PieceTypes.piece_j,
 		"piece-l": PieceTypes.piece_l,
@@ -21,7 +21,7 @@ func from_string_array(strings: Array) -> void:
 		"piece-v": PieceTypes.piece_v,
 	}
 	
-	var rules := RuleParser.new(strings)
+	var rules := RuleParser.new(json)
 	for key in json_types:
 		if rules.has(key): types.append(json_types[key])
 		if rules.has("start-%s" % key): start_types.append(json_types[key])

--- a/src/main/puzzle/scenario/rank-rules.gd
+++ b/src/main/puzzle/scenario/rank-rules.gd
@@ -17,11 +17,8 @@ var top_out_penalty := 4
 # 'true' if the results screen should be skipped. Used for tutorials.
 var skip_results: bool
 
-"""
-Populates this object with json data.
-"""
-func from_string_array(strings: Array) -> void:
-	var rules := RuleParser.new(strings)
+func from_json_string_array(json: Array) -> void:
+	var rules := RuleParser.new(json)
 	if rules.has("combo-factor"): combo_factor = rules.float_value()
 	if rules.has("box-factor"): box_factor = rules.float_value()
 	if rules.has("top-out-penalty"): top_out_penalty = rules.int_value()

--- a/src/main/puzzle/scenario/scenario-library.gd
+++ b/src/main/puzzle/scenario/scenario-library.gd
@@ -15,7 +15,7 @@ func load_scenario_from_name(name: String) -> ScenarioSettings:
 
 func load_scenario(name: String, text: String) -> ScenarioSettings:
 	var scenario_settings := ScenarioSettings.new()
-	scenario_settings.from_dict(name, parse_json(text))
+	scenario_settings.from_json_dict(name, parse_json(text))
 	return scenario_settings
 
 

--- a/src/main/puzzle/scenario/scenario-settings.gd
+++ b/src/main/puzzle/scenario/scenario-settings.gd
@@ -106,29 +106,29 @@ Populates this object with json data.
 Parameters:
 	'new_name': The scenario name used for saving statistics.
 """
-func from_dict(new_name: String, json: Dictionary) -> void:
+func from_json_dict(new_name: String, json: Dictionary) -> void:
 	name = new_name
 	set_start_level(json["start-level"])
 	if json.has("blocks-start"):
-		blocks_start.from_dict(json["blocks-start"])
+		blocks_start.from_json_dict(json["blocks-start"])
 	if json.has("combo-break"):
-		combo_break.from_string_array(json["combo-break"])
+		combo_break.from_json_string_array(json["combo-break"])
 	if json.has("finish-condition"):
-		finish_condition.from_dict(json["finish-condition"])
+		finish_condition.from_json_dict(json["finish-condition"])
 	if json.has("level-ups"):
 		for json_level_up in json["level-ups"]:
 			var level_up := Milestone.new()
-			level_up.from_dict(json_level_up)
+			level_up.from_json_dict(json_level_up)
 			level_ups.append(level_up)
 	if json.has("lose-condition"):
-		lose_condition.from_string_array(json["lose-condition"])
+		lose_condition.from_json_string_array(json["lose-condition"])
 	if json.has("other"):
-		other.from_string_array(json["other"])
+		other.from_json_string_array(json["other"])
 	if json.has("piece-types"):
-		piece_types.from_string_array(json["piece-types"])
+		piece_types.from_json_string_array(json["piece-types"])
 	if json.has("rank"):
-		rank.from_string_array(json["rank"])
+		rank.from_json_string_array(json["rank"])
 	if json.has("score"):
-		score.from_string_array(json["score"])
+		score.from_json_string_array(json["score"])
 	if json.has("win-condition"):
-		win_condition.from_dict(json["win-condition"])
+		win_condition.from_json_dict(json["win-condition"])

--- a/src/main/puzzle/scenario/score-rules.gd
+++ b/src/main/puzzle/scenario/score-rules.gd
@@ -12,11 +12,8 @@ var snack_points := 5
 # box points for clearing a row of a cake box.
 var cake_points := 10
 
-"""
-Populates this object with json data.
-"""
-func from_string_array(strings: Array) -> void:
-	var rules := RuleParser.new(strings)
+func from_json_string_array(json: Array) -> void:
+	var rules := RuleParser.new(json)
 	if rules.has("veg-row"): veg_points = rules.int_value()
 	if rules.has("snack-all"): snack_points = rules.int_value()
 	if rules.has("cake-all"): cake_points = rules.int_value()

--- a/src/main/ui/chat/chat-event.gd
+++ b/src/main/ui/chat/chat-event.gd
@@ -51,12 +51,9 @@ appearance, such as 'blue', 'soccer balls' and 'giant'.
 """
 var accent_def: Dictionary
 
-"""
-Populates this object with json data.
-"""
-func from_dict(json: Dictionary) -> void:
+func from_json_dict(json: Dictionary) -> void:
 	who = json.get("who", "")
-	text = json["text"]
+	text = json.get("text", "")
 	_parse_mood(json)
 	_parse_links(json)
 	_parse_meta(json)

--- a/src/main/ui/chat/chat-library.gd
+++ b/src/main/ui/chat/chat-library.gd
@@ -36,7 +36,7 @@ func load_chat_events_from_file(path: String) -> ChatTree:
 	file.close()
 	
 	var json_tree := _parse_json_tree(text)
-	chat_tree.from_dict(json_tree)
+	chat_tree.from_json_dict(json_tree)
 	return chat_tree
 
 

--- a/src/main/ui/chat/chat-tree.gd
+++ b/src/main/ui/chat/chat-tree.gd
@@ -74,12 +74,9 @@ func advance(link_index := -1) -> bool:
 	return did_increment
 
 
-"""
-Populates this object with json data.
-"""
-func from_dict(json: Dictionary) -> void:
+func from_json_dict(json: Dictionary) -> void:
 	for key in json.keys():
 		for json_chat_event in json[key]:
 			var event := ChatEvent.new()
-			event.from_dict(json_chat_event)
+			event.from_json_dict(json_chat_event)
 			append(key, event)

--- a/src/test/test-player-data.gd
+++ b/src/test/test-player-data.gd
@@ -5,12 +5,13 @@ configuration into JSON, since something trivial like renaming a variable or cha
 saved or loaded. That's why unit tests are particularly important for this code.
 """
 
-var _rank_result: RankResult
+const TEMP_FILENAME := "test-ground-lucky.save"
 
+var _rank_result: RankResult
 var _rank_calculator := RankCalculator.new()
 
 func before_each() -> void:
-	PlayerSave.player_data_filename = "user://scenario_history_365.save"
+	PlayerSave.player_data_filename = "user://%s" % TEMP_FILENAME
 	PlayerData.scenario_history.clear()
 	PlayerData.money = 0
 	_rank_result = RankResult.new()
@@ -20,12 +21,18 @@ func before_each() -> void:
 	_rank_result.combo_score_per_line = 17.0
 	_rank_result.score = 7890
 
+
 func after_each() -> void:
 	PlayerData.history_size = 1000
+	var save_dir := Directory.new()
+	save_dir.open("user://")
+	save_dir.remove(TEMP_FILENAME)
+
 
 func test_one_history_entry() -> void:
 	PlayerData.add_scenario_history("scenario-895", _rank_result)
 	assert_eq(PlayerData.scenario_history["scenario-895"][0].score, 7890)
+
 
 func test_two_history_entries() -> void:
 	PlayerData.add_scenario_history("scenario-895", _rank_result)
@@ -34,6 +41,7 @@ func test_two_history_entries() -> void:
 	PlayerData.add_scenario_history("scenario-895", _rank_result)
 	assert_eq(PlayerData.scenario_history["scenario-895"][0].score, 6780)
 	assert_eq(PlayerData.scenario_history["scenario-895"][1].score, 7890)
+
 
 func test_too_many_history_entries() -> void:
 	PlayerData.history_size = 3
@@ -47,9 +55,11 @@ func test_too_many_history_entries() -> void:
 	assert_eq(PlayerData.scenario_history["scenario-895"].size(), 3)
 	assert_eq(PlayerData.scenario_history["scenario-895"][0].score, 6780)
 
+
 func test_no_scenario_name() -> void:
 	PlayerData.add_scenario_history("", _rank_result)
 	assert_false(PlayerData.scenario_history.has(""))
+
 
 func test_save_and_load() -> void:
 	PlayerData.add_scenario_history("scenario-895", _rank_result)


### PR DESCRIPTION
Json data is now loaded using json.get("foo", "default") instead of
json["foo"]. This ensures that old save data is more forwards-compatible,
and people won't need to start over every time the save format is changed
slightly.

In an additional attempt to reduce the number of save-breaking changes, save
data is now stored in turbofat0.save. When additional save slots are added, they
can be named turbofat1.save and turbofat2.save

Json methods now have universal names like 'from_json_dict',
'from_json_string_array', 'to_json_dict'