### PR TITLE
New u-piece 'shaft kick'

### DIFF
--- a/src/main/puzzle/piece/piece-types.gd
+++ b/src/main/puzzle/piece/piece-types.gd
@@ -29,29 +29,29 @@ const KICKS_T := [
 		[Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1), Vector2( 0, -1)],
 		[Vector2( 1,  0), Vector2( 1, -1), Vector2( 0, -1), Vector2(-1,  0)],
 		[Vector2( 1,  0), Vector2( 1,  1), Vector2( 0,  1), Vector2(-1,  0)],
-		[Vector2(-1,  0), Vector2(-1,  1), Vector2( 0, -1), Vector2( 0,  1)]
+		[Vector2(-1,  0), Vector2(-1,  1), Vector2( 0, -1), Vector2( 0,  1)],
 	]
 
 
 const KICKS_U := [
-		[Vector2( 1, -1), Vector2( 1, -2), Vector2( 0,  1), Vector2( 1,  1), Vector2( 1,  0)],
-		[Vector2(-1,  1), Vector2(-1,  2), Vector2( 0, -1), Vector2(-1, -1), Vector2(-1,  0)],
-		[Vector2(-1, -1), Vector2(-1, -2), Vector2( 0,  1), Vector2(-1,  1), Vector2(-1,  0)],
-		[Vector2( 1,  1), Vector2( 1,  2), Vector2( 0, -1), Vector2( 1, -1), Vector2( 1,  0)]
+		[Vector2( 1,  0), Vector2( 1, -1), Vector2( 0, -1), Vector2( 1,  1), Vector2( 0,  1), Vector2( 1, -2)],
+		[Vector2(-1,  0), Vector2(-1,  1), Vector2( 0, -1), Vector2(-1, -1), Vector2( 0,  1), Vector2(-1,  2)],
+		[Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1), Vector2(-1,  1), Vector2( 0, -1), Vector2(-1, -2)],
+		[Vector2( 1,  0), Vector2( 1,  1), Vector2( 0,  1), Vector2( 1, -1), Vector2( 0, -1), Vector2( 1,  2)],
 	]
 
 const KICKS_P := [
 		[Vector2( 0, -1), Vector2(-1, -1), Vector2( 0,  1), Vector2(-1,  0)],
 		[Vector2( 1,  0), Vector2( 1, -1), Vector2( 0, -1), Vector2( 0,  1)],
 		[Vector2( 0,  1), Vector2( 1,  1), Vector2( 0, -1), Vector2(-1,  0)],
-		[Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1)]
+		[Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1)],
 	]
 
 const KICKS_Q := [
 		[Vector2(-1,  0), Vector2(-1, -1), Vector2( 0, -1), Vector2( 0,  1)],
 		[Vector2( 0, -1), Vector2( 1, -1), Vector2( 0,  1), Vector2( 1,  0)],
 		[Vector2( 1,  0), Vector2( 1,  1), Vector2( 0,  1), Vector2( 0, -1)],
-		[Vector2( 0,  1), Vector2(-1,  1), Vector2( 0, -1), Vector2( 1,  0)]
+		[Vector2( 0,  1), Vector2(-1,  1), Vector2( 0, -1), Vector2( 1,  0)],
 	]
 
 const KICKS_V := [

--- a/src/test/test-piece-kicks-jl.gd
+++ b/src/test/test-piece-kicks-jl.gd
@@ -18,7 +18,7 @@ func test_j_lwallkick_cw() -> void:
 		"  j ",
 		"    ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_lwallkick_ccw() -> void:
@@ -36,7 +36,7 @@ func test_j_lwallkick_ccw() -> void:
 		"    ",
 		"    ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_lwallkick_cw() -> void:
@@ -54,7 +54,7 @@ func test_l_lwallkick_cw() -> void:
 		"l   ",
 		"    ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_lwallkick_ccw() -> void:
@@ -72,7 +72,7 @@ func test_l_lwallkick_ccw() -> void:
 		"    ",
 		"    ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 
@@ -91,7 +91,7 @@ func test_j_rwallkick_cw() -> void:
 		"    ",
 		"    ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_rwallkick_ccw() -> void:
@@ -109,7 +109,7 @@ func test_j_rwallkick_ccw() -> void:
 		"   j",
 		"    ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_rwallkick_cw() -> void:
@@ -127,7 +127,7 @@ func test_l_rwallkick_cw() -> void:
 		"    ",
 		"    ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_rwallkick_ccw() -> void:
@@ -145,7 +145,7 @@ func test_l_rwallkick_ccw() -> void:
 		" l  ",
 		"    ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_floorkick_cw() -> void:
@@ -161,7 +161,7 @@ func test_j_floorkick_cw() -> void:
 		" j   ",
 		" j   ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_floorkick_ccw() -> void:
@@ -177,7 +177,7 @@ func test_j_floorkick_ccw() -> void:
 		"   j ",
 		"  jj ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_floorkick_cw() -> void:
@@ -193,7 +193,7 @@ func test_l_floorkick_cw() -> void:
 		" l   ",
 		" ll  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_floorkick_ccw() -> void:
@@ -209,7 +209,7 @@ func test_l_floorkick_ccw() -> void:
 		"   l ",
 		"   l ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 """
@@ -228,7 +228,7 @@ func test_j_vee_kick0() -> void:
 		"   :j",
 		"   jj",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_vee_kick1() -> void:
@@ -244,7 +244,7 @@ func test_j_vee_kick1() -> void:
 		"::j  ",
 		"     ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_vee_kick2() -> void:
@@ -260,7 +260,7 @@ func test_j_vee_kick2() -> void:
 		"j:   ",
 		"j:   ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_vee_kick3() -> void:
@@ -276,7 +276,7 @@ func test_j_vee_kick3() -> void:
 		": j::",
 		": jjj",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_vee_kick_cw0() -> void:
@@ -292,7 +292,7 @@ func test_l_vee_kick_cw0() -> void:
 		"l:   ",
 		"ll   ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_vee_kick1() -> void:
@@ -308,7 +308,7 @@ func test_l_vee_kick1() -> void:
 		"  l::",
 		"     ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_vee_kick2() -> void:
@@ -324,7 +324,7 @@ func test_l_vee_kick2() -> void:
 		"   :l",
 		"   :l",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_vee_kick3() -> void:
@@ -340,7 +340,7 @@ func test_l_vee_kick3() -> void:
 		"::l :",
 		"lll :",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 """
@@ -361,7 +361,7 @@ func test_j_gold_kick0() -> void:
 		"::j::",
 		":jj::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_gold_kick1() -> void:
@@ -379,7 +379,7 @@ func test_j_gold_kick1() -> void:
 		"j:  :",
 		"jjj :",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_gold_kick2() -> void:
@@ -397,7 +397,7 @@ func test_j_gold_kick2() -> void:
 		"  j::",
 		"  j  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_gold_kick3() -> void:
@@ -415,7 +415,7 @@ func test_j_gold_kick3() -> void:
 		"   :j",
 		"   ::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_gold_kick0() -> void:
@@ -433,7 +433,7 @@ func test_l_gold_kick0() -> void:
 		"::l::",
 		"::ll:",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_gold_kick1() -> void:
@@ -451,7 +451,7 @@ func test_l_gold_kick1() -> void:
 		":  :l",
 		": lll",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_gold_kick2() -> void:
@@ -469,7 +469,7 @@ func test_l_gold_kick2() -> void:
 		"::l  ",
 		"  l  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_gold_kick3() -> void:
@@ -487,7 +487,7 @@ func test_l_gold_kick3() -> void:
 		"l:   ",
 		"::   ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 """
@@ -510,7 +510,7 @@ func test_j_golder_kick() -> void:
 		":::j:",
 		"::jj:",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_golder_kick() -> void:
@@ -530,7 +530,7 @@ func test_l_golder_kick() -> void:
 		":l:::",
 		":ll::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_climb_kick0() -> void:
@@ -548,7 +548,7 @@ func test_j_climb_kick0() -> void:
 		":  ::",
 		":  ::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_climb_kick1() -> void:
@@ -566,7 +566,7 @@ func test_j_climb_kick1() -> void:
 		":  ::",
 		":  ::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_climb_kick2() -> void:
@@ -584,7 +584,7 @@ func test_j_climb_kick2() -> void:
 		":  ::",
 		":  ::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_climb_kick3() -> void:
@@ -600,7 +600,7 @@ func test_j_climb_kick3() -> void:
 		": j  ",
 		":::  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_climb_kick4() -> void:
@@ -616,7 +616,7 @@ func test_j_climb_kick4() -> void:
 		":: j ",
 		":    ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_climb_kick5() -> void:
@@ -634,7 +634,7 @@ func test_j_climb_kick5() -> void:
 		" :::",
 		" :::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_climb_kick0() -> void:
@@ -652,7 +652,7 @@ func test_l_climb_kick0() -> void:
 		"::  :",
 		"::  :",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_climb_kick1() -> void:
@@ -670,7 +670,7 @@ func test_l_climb_kick1() -> void:
 		"::  :",
 		"::  :",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_climb_kick2() -> void:
@@ -688,7 +688,7 @@ func test_l_climb_kick2() -> void:
 		"::  :",
 		"::  :",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_climb_kick3() -> void:
@@ -704,7 +704,7 @@ func test_l_climb_kick3() -> void:
 		"  l :",
 		"  :::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_climb_kick4() -> void:
@@ -720,7 +720,7 @@ func test_l_climb_kick4() -> void:
 		" l ::",
 		"    :",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_climb_kick5() -> void:
@@ -738,7 +738,7 @@ func test_l_climb_kick5() -> void:
 		"::: ",
 		"::: ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 """
@@ -759,7 +759,7 @@ func test_j_hammer_kick0() -> void:
 		"jjj:",
 		"::j:",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_hammer_kick() -> void:
@@ -777,7 +777,7 @@ func test_l_hammer_kick() -> void:
 		":lll",
 		":l::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 """
@@ -798,7 +798,7 @@ func test_j_plant_kick0() -> void:
 		"::j::",
 		"::j::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_plant_kick1() -> void:
@@ -816,7 +816,7 @@ func test_j_plant_kick1() -> void:
 		":: ::",
 		":: ::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_plant_kick0() -> void:
@@ -834,7 +834,7 @@ func test_l_plant_kick0() -> void:
 		"::l::",
 		"::l::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_plant_kick1() -> void:
@@ -852,7 +852,7 @@ func test_l_plant_kick1() -> void:
 		":: ::",
 		":: ::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 """
@@ -873,7 +873,7 @@ func test_j_snack_kick0() -> void:
 		"  j::",
 		"::j::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_snack_kick1() -> void:
@@ -891,7 +891,7 @@ func test_j_snack_kick1() -> void:
 		"   j::",
 		"   j::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_snack_kick2() -> void:
@@ -909,7 +909,7 @@ func test_j_snack_kick2() -> void:
 		"::j::",
 		":::::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_j_snack_kick3() -> void:
@@ -929,7 +929,7 @@ func test_j_snack_kick3() -> void:
 		"::j::",
 		":::::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_snack_kick0() -> void:
@@ -947,7 +947,7 @@ func test_l_snack_kick0() -> void:
 		"::l  ",
 		"::l::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_snack_kick1() -> void:
@@ -965,7 +965,7 @@ func test_l_snack_kick1() -> void:
 		"::l   ",
 		"::l:: ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_snack_kick2() -> void:
@@ -983,7 +983,7 @@ func test_l_snack_kick2() -> void:
 		"::l::",
 		":::::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_l_snack_kick3() -> void:
@@ -1003,4 +1003,4 @@ func test_l_snack_kick3() -> void:
 		"::l::",
 		":::::",
 	]
-	_assert_kick()
+	assert_kick()

--- a/src/test/test-piece-kicks-qp.gd
+++ b/src/test/test-piece-kicks-qp.gd
@@ -14,7 +14,7 @@ func test_p_floorkick_cw() -> void:
 		"  pp ",
 		"  pp ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_p_floorkick_ccw() -> void:
@@ -28,7 +28,7 @@ func test_p_floorkick_ccw() -> void:
 		"  pp ",
 		"  p  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_q_floorkick_cw() -> void:
@@ -42,7 +42,7 @@ func test_q_floorkick_cw() -> void:
 		" qq  ",
 		"  q  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_q_floorkick_ccw() -> void:
@@ -56,7 +56,7 @@ func test_q_floorkick_ccw() -> void:
 		" qq  ",
 		" qq  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_p_rwallkick_cw() -> void:
@@ -74,7 +74,7 @@ func test_p_rwallkick_cw() -> void:
 		"    ",
 		"    ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_p_lwallkick_ccw() -> void:
@@ -92,7 +92,7 @@ func test_p_lwallkick_ccw() -> void:
 		" pp ",
 		"    ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_q_rwallkick_cw() -> void:
@@ -110,7 +110,7 @@ func test_q_rwallkick_cw() -> void:
 		" qq ",
 		"    ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_q_lwallkick_ccw() -> void:
@@ -128,7 +128,7 @@ func test_q_lwallkick_ccw() -> void:
 		"    ",
 		"    ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 """
@@ -147,7 +147,7 @@ func test_p_pump_kick0() -> void:
 		" pp:",
 		":ppp",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_p_pump_kick1() -> void:
@@ -161,7 +161,7 @@ func test_p_pump_kick1() -> void:
 		":   ",
 		"ppp ",
 		":pp "]
-	_assert_kick()
+	assert_kick()
 
 
 func test_p_pump_kick2() -> void:
@@ -177,7 +177,7 @@ func test_p_pump_kick2() -> void:
 		" ppp",
 		"  ::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_p_pump_kick3() -> void:
@@ -195,7 +195,7 @@ func test_p_pump_kick3() -> void:
 		":pp:",
 		": ::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_q_pump_kick0() -> void:
@@ -209,7 +209,7 @@ func test_q_pump_kick0() -> void:
 		"    ",
 		":qq ",
 		"qqq:"]
-	_assert_kick()
+	assert_kick()
 
 
 func test_q_pump_kick1() -> void:
@@ -223,7 +223,7 @@ func test_q_pump_kick1() -> void:
 		"   :",
 		" qqq",
 		" qq:"]
-	_assert_kick()
+	assert_kick()
 
 
 func test_q_pump_kick2() -> void:
@@ -239,7 +239,7 @@ func test_q_pump_kick2() -> void:
 		"qqq ",
 		"::  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_q_pump_kick3() -> void:
@@ -257,7 +257,7 @@ func test_q_pump_kick3() -> void:
 		":qq:",
 		":: :",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 """
@@ -279,7 +279,7 @@ func test_p_murky_kick0() -> void:
 		"  pp",
 		"  pp",
 		" :p:"]
-	_assert_kick()
+	assert_kick()
 
 
 func test_p_murky_kick1() -> void:
@@ -293,7 +293,7 @@ func test_p_murky_kick1() -> void:
 		"pp  ",
 		"pp  ",
 		"::: "]
-	_assert_kick()
+	assert_kick()
 
 
 func test_p_murky_kick2() -> void:
@@ -307,7 +307,7 @@ func test_p_murky_kick2() -> void:
 		" pp ",
 		" pp ",
 		"  ::"]
-	_assert_kick()
+	assert_kick()
 
 
 func test_q_murky_kick0() -> void:
@@ -326,7 +326,7 @@ func test_q_murky_kick0() -> void:
 		"qq  ",
 		"qq  ",
 		":q: "]
-	_assert_kick()
+	assert_kick()
 
 
 func test_q_murky_kick1() -> void:
@@ -340,7 +340,7 @@ func test_q_murky_kick1() -> void:
 		"  qq",
 		"  qq",
 		" :::"]
-	_assert_kick()
+	assert_kick()
 
 
 func test_q_murky_kick2() -> void:
@@ -354,7 +354,7 @@ func test_q_murky_kick2() -> void:
 		" qq ",
 		" qq ",
 		"::  "]
-	_assert_kick()
+	assert_kick()
 
 
 func test_p_climb_kick0() -> void:
@@ -372,7 +372,7 @@ func test_p_climb_kick0() -> void:
 		"::pp ",
 		"::   ",
 		"::  :"]
-	_assert_kick()
+	assert_kick()
 
 
 func test_p_failed_climb_kick1() -> void:
@@ -390,7 +390,7 @@ func test_p_failed_climb_kick1() -> void:
 		"::pp ",
 		"::p  ",
 		"::   "]
-	_assert_kick()
+	assert_kick()
 
 
 func test_q_climb_kick0() -> void:
@@ -408,7 +408,7 @@ func test_q_climb_kick0() -> void:
 		" qq::",
 		"   ::",
 		":  ::"]
-	_assert_kick()
+	assert_kick()
 
 
 func test_q_failed_climb_kick1() -> void:
@@ -426,4 +426,4 @@ func test_q_failed_climb_kick1() -> void:
 		" qq::",
 		"  q::",
 		"   ::"]
-	_assert_kick()
+	assert_kick()

--- a/src/test/test-piece-kicks-t.gd
+++ b/src/test/test-piece-kicks-t.gd
@@ -23,7 +23,7 @@ func test_rose_kick_left() -> void:
 		"tt ",
 		"t: ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_rose_kick_down0() -> void:
@@ -39,7 +39,7 @@ func test_rose_kick_down0() -> void:
 		":t ",
 		"ttt",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_rose_kick_down1() -> void:
@@ -55,7 +55,7 @@ func test_rose_kick_down1() -> void:
 		" t:",
 		"ttt",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_rose_kick_right() -> void:
@@ -71,7 +71,7 @@ func test_rose_kick_right() -> void:
 		" tt",
 		" :t",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 """
@@ -92,7 +92,7 @@ func test_duck_kick_down0() -> void:
 		":tt:",
 		":t::"
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_duck_kick_down1() -> void:
@@ -108,7 +108,7 @@ func test_duck_kick_down1() -> void:
 		":tt:",
 		"::t:"
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_duck_kick_left0() -> void:
@@ -124,7 +124,7 @@ func test_duck_kick_left0() -> void:
 		"ttt:",
 		" : :"
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_duck_kick_left1() -> void:
@@ -140,7 +140,7 @@ func test_duck_kick_left1() -> void:
 		"ttt:",
 		" t :"
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_duck_kick_right0() -> void:
@@ -156,7 +156,7 @@ func test_duck_kick_right0() -> void:
 		":ttt",
 		": : "
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_duck_kick_right1() -> void:
@@ -172,7 +172,7 @@ func test_duck_kick_right1() -> void:
 		":ttt",
 		": t "
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_duck_kick_up0() -> void:
@@ -188,7 +188,7 @@ func test_duck_kick_up0() -> void:
 		"  tt ",
 		"  t  "
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_duck_kick_up1() -> void:
@@ -204,7 +204,7 @@ func test_duck_kick_up1() -> void:
 		" tt  ",
 		"  t  "
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_floorkick_cw() -> void:
@@ -220,7 +220,7 @@ func test_floorkick_cw() -> void:
 		" tt  ",
 		" t   "
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_floorkick_ccw() -> void:
@@ -236,7 +236,7 @@ func test_floorkick_ccw() -> void:
 		"  tt ",
 		"   t "
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_lwallkick0() -> void:
@@ -254,7 +254,7 @@ func test_lwallkick0() -> void:
 		"     ",
 		"     "
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_lwallkick1() -> void:
@@ -272,7 +272,7 @@ func test_lwallkick1() -> void:
 		" t   ",
 		"     "
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_rwallkick0() -> void:
@@ -290,7 +290,7 @@ func test_rwallkick0() -> void:
 		"     ",
 		"     "
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_rwallkick1() -> void:
@@ -308,7 +308,7 @@ func test_rwallkick1() -> void:
 		"   t ",
 		"     "
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_climb_kick_cw() -> void:
@@ -324,7 +324,7 @@ func test_climb_kick_cw() -> void:
 		":  ::",
 		":: ::"
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_climb_kick_ccw() -> void:
@@ -340,7 +340,7 @@ func test_climb_kick_ccw() -> void:
 		"::  :",
 		":: ::"
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_failed_climb_kick_cw() -> void:
@@ -356,7 +356,7 @@ func test_failed_climb_kick_cw() -> void:
 		"ttt:",
 		":: :"
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_failed_climb_kick_ccw() -> void:
@@ -372,4 +372,4 @@ func test_failed_climb_kick_ccw() -> void:
 		":ttt",
 		": ::"
 	]
-	_assert_kick()
+	assert_kick()

--- a/src/test/test-piece-kicks-u.gd
+++ b/src/test/test-piece-kicks-u.gd
@@ -3,7 +3,7 @@ extends "res://src/test/test-piece-kicks.gd"
 Tests the u piece's kick behavior.
 """
 
-func test_u_floorkick_cw() -> void:
+func test_floorkick_cw() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -16,10 +16,10 @@ func test_u_floorkick_cw() -> void:
 		" u   ",
 		" uu  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_u_floorkick_ccw() -> void:
+func test_floorkick_ccw() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -32,10 +32,10 @@ func test_u_floorkick_ccw() -> void:
 		"   u ",
 		"  uu ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_u_rwallkick_cw() -> void:
+func test_rwallkick_cw() -> void:
 	from_grid = [
 		"    ",
 		"  uu",
@@ -45,15 +45,15 @@ func test_u_rwallkick_cw() -> void:
 	]
 	to_grid = [
 		"    ",
-		"    ",
 		" u u",
 		" uuu",
 		"    ",
+		"    ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_u_lwallkick_ccw() -> void:
+func test_lwallkick_ccw() -> void:
 	from_grid = [
 		"    ",
 		"uu  ",
@@ -63,18 +63,18 @@ func test_u_lwallkick_ccw() -> void:
 	]
 	to_grid = [
 		"    ",
-		"    ",
 		"u u ",
 		"uuu ",
 		"    ",
+		"    ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 """
 A spire kick is when a u piece rotates while a block is in its gap.
 """
-func test_u_spire_kick_cw0() -> void:
+func test_spire_kick_cw0() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -87,10 +87,10 @@ func test_u_spire_kick_cw0() -> void:
 		"  uu ",
 		"  :  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_u_spire_kick_cw1() -> void:
+func test_spire_kick_cw1() -> void:
 	from_grid = [
 		"     ",
 		"uu   ",
@@ -105,10 +105,10 @@ func test_u_spire_kick_cw1() -> void:
 		"     ",
 		"     ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_u_spire_kick_cw2() -> void:
+func test_spire_kick_cw2() -> void:
 	from_grid = [
 		"     ",
 		"   uu",
@@ -123,10 +123,10 @@ func test_u_spire_kick_cw2() -> void:
 		"     ",
 		"     ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_u_spire_kick_ccw0() -> void:
+func test_spire_kick_ccw0() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -139,10 +139,10 @@ func test_u_spire_kick_ccw0() -> void:
 		" uu  ",
 		"  :  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_u_spire_kick_ccw1() -> void:
+func test_spire_kick_ccw1() -> void:
 	from_grid = [
 		"     ",
 		"   uu",
@@ -157,10 +157,10 @@ func test_u_spire_kick_ccw1() -> void:
 		"     ",
 		"     ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_u_spire_kick_ccw2() -> void:
+func test_spire_kick_ccw2() -> void:
 	from_grid = [
 		"     ",
 		"uu   ",
@@ -175,13 +175,13 @@ func test_u_spire_kick_ccw2() -> void:
 		"     ",
 		"     ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 """
-'loutish kicks' and 'moutish kicks' demonstrate what happens when the U piece is boxed in by two corners
+a 'diagonalnw kick' is when the u piece is boxed in by the nw/se corners
 """
-func test_u_loutish_kick_cw0() -> void:
+func test_diagonalnw_kick_ur() -> void:
 	from_grid = [
 		"::   ",
 		":u u ",
@@ -194,26 +194,10 @@ func test_u_loutish_kick_cw0() -> void:
 		" u  :",
 		" uu::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_u_moutish_kick_ccw0() -> void:
-	from_grid = [
-		"   ::",
-		" u u:",
-		":uuu ",
-		"::   ",
-	]
-	to_grid = [
-		"   ::",
-		"  uu:",
-		":  u ",
-		"::uu ",
-	]
-	_assert_kick()
-
-
-func test_u_loutish_kick_cw1() -> void:
+func test_diagonalnw_kick_rd() -> void:
 	from_grid = [
 		"::  ",
 		":uu ",
@@ -228,28 +212,10 @@ func test_u_loutish_kick_cw1() -> void:
 		"   :",
 		"  ::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_u_moutish_kick_ccw1() -> void:
-	from_grid = [
-		"  ::",
-		" uu:",
-		" u  ",
-		":uu ",
-		"::  ",
-	]
-	to_grid = [
-		"  ::",
-		"u u:",
-		"uuu ",
-		":   ",
-		"::  ",
-	]
-	_assert_kick()
-
-
-func test_u_loutish_kick_cw2() -> void:
+func test_diagonalnw_kick_dl() -> void:
 	from_grid = [
 		"::   ",
 		":uuu ",
@@ -262,26 +228,10 @@ func test_u_loutish_kick_cw2() -> void:
 		"  u :",
 		" uu::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_u_moutish_kick_ccw2() -> void:
-	from_grid = [
-		"   ::",
-		" uuu:",
-		":u u ",
-		"::   ",
-	]
-	to_grid = [
-		"   ::",
-		"  uu:",
-		": u  ",
-		"::uu ",
-	]
-	_assert_kick()
-
-
-func test_u_loutish_kick_cw3() -> void:
+func test_diagonalnw_kick_lu() -> void:
 	from_grid = [
 		"::  ",
 		":uu ",
@@ -296,14 +246,67 @@ func test_u_loutish_kick_cw3() -> void:
 		"   :",
 		"  ::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_u_moutish_kick_cw3() -> void:
+"""
+a 'diagonalne kick' is when the u piece is boxed in by the ne/sw corners
+"""
+func test_diagonalne_kick_ur() -> void:
+	from_grid = [
+		"   ::",
+		" u u:",
+		":uuu ",
+		"::   ",
+	]
+	to_grid = [
+		"   ::",
+		"  uu:",
+		": u  ",
+		"::uu ",
+	]
+	assert_kick()
+
+
+func test_diagonalne_kick_rd() -> void:
 	from_grid = [
 		"  ::",
 		" uu:",
 		" u  ",
+		":uu ",
+		"::  ",
+	]
+	to_grid = [
+		"  ::",
+		"uuu:",
+		"u u ",
+		":   ",
+		"::  ",
+	]
+	assert_kick()
+
+
+func test_diagonalne_kick_dl() -> void:
+	from_grid = [
+		"   ::",
+		" uuu:",
+		":u u ",
+		"::   ",
+	]
+	to_grid = [
+		"   ::",
+		"  uu:",
+		":  u ",
+		"::uu ",
+	]
+	assert_kick()
+
+
+func test_diagonalne_kick_lu() -> void:
+	from_grid = [
+		"  ::",
+		" uu:",
+		"  u ",
 		":uu ",
 		"::  ",
 	]
@@ -314,5 +317,134 @@ func test_u_moutish_kick_cw3() -> void:
 		":   ",
 		"::  ",
 	]
-	_assert_kick()
+	assert_kick()
 
+
+"""
+a 'shaft kick' is when the u piece rotates after being dropped down a narrow shaft
+"""
+func test_shaft_kick_lu0() -> void:
+	from_grid = [
+		"  ::",
+		"uu::",
+		" u  ",
+		"uu  ",
+	]
+	to_grid = [
+		"  ::",
+		"  ::",
+		"u u ",
+		"uuu ",
+	]
+	assert_kick()
+
+
+func test_shaft_kick_lu1() -> void:
+	from_grid = [
+		"::  ",
+		"::uu",
+		"   u",
+		"  uu",
+	]
+	to_grid = [
+		"::  ",
+		"::  ",
+		" u u",
+		" uuu",
+	]
+	assert_kick()
+
+
+func test_shaft_kick_ld0() -> void:
+	from_grid = [
+		"  ::",
+		"uu::",
+		" u  ",
+		"uu  ",
+	]
+	to_grid = [
+		"  ::",
+		"  ::",
+		"uuu ",
+		"u u ",
+	]
+	assert_kick()
+
+
+func test_shaft_kick_ld1() -> void:
+	from_grid = [
+		"::  ",
+		"::uu",
+		"   u",
+		"  uu",
+	]
+	to_grid = [
+		"::  ",
+		"::  ",
+		" uuu",
+		" u u",
+	]
+	assert_kick()
+
+func test_shaft_kick_ru0() -> void:
+	from_grid = [
+		"  ::",
+		"uu::",
+		"u   ",
+		"uu  ",
+	]
+	to_grid = [
+		"  ::",
+		"  ::",
+		"u u ",
+		"uuu ",
+	]
+	assert_kick()
+
+
+func test_shaft_kick_ru1() -> void:
+	from_grid = [
+		"::  ",
+		"::uu",
+		"  u ",
+		"  uu",
+	]
+	to_grid = [
+		"::  ",
+		"::  ",
+		" u u",
+		" uuu",
+	]
+	assert_kick()
+
+
+func test_shaft_kick_rd0() -> void:
+	from_grid = [
+		"  ::",
+		"uu::",
+		"u   ",
+		"uu  ",
+	]
+	to_grid = [
+		"  ::",
+		"  ::",
+		"uuu ",
+		"u u ",
+	]
+	assert_kick()
+
+
+func test_shaft_kick_rd1() -> void:
+	from_grid = [
+		"::  ",
+		"::uu",
+		"  u ",
+		"  uu",
+	]
+	to_grid = [
+		"::  ",
+		"::  ",
+		" uuu",
+		" u u",
+	]
+	assert_kick()

--- a/src/test/test-piece-kicks-v.gd
+++ b/src/test/test-piece-kicks-v.gd
@@ -3,7 +3,7 @@ extends "res://src/test/test-piece-kicks.gd"
 Tests the v piece's kick behavior.
 """
 
-func test_v_climb_kick_cw0() -> void:
+func test_climb_kick_cw0() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -18,10 +18,10 @@ func test_v_climb_kick_cw0() -> void:
 		"   v ",
 		"  :::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_climb_kick_cw1() -> void:
+func test_climb_kick_cw1() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -36,10 +36,10 @@ func test_v_climb_kick_cw1() -> void:
 		"  v::",
 		"  :::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_climb_kick_cw2() -> void:
+func test_climb_kick_cw2() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -54,10 +54,10 @@ func test_v_climb_kick_cw2() -> void:
 		"  :::",
 		"  :::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_climb_kick_cw3() -> void:
+func test_climb_kick_cw3() -> void:
 	from_grid = [
 		"    ",
 		"vvv ",
@@ -70,10 +70,10 @@ func test_v_climb_kick_cw3() -> void:
 		" vvv",
 		" : :",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_climb_kick_cw4() -> void:
+func test_climb_kick_cw4() -> void:
 	from_grid = [
 		"    ",
 		"vvv:",
@@ -86,10 +86,10 @@ func test_v_climb_kick_cw4() -> void:
 		"vvv ",
 		" : :",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_climb_kick_ccw0() -> void:
+func test_climb_kick_ccw0() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -104,10 +104,10 @@ func test_v_climb_kick_ccw0() -> void:
 		" v   ",
 		":::  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_climb_kick_ccw1() -> void:
+func test_climb_kick_ccw1() -> void:
 	from_grid = [
 		"      ",
 		"      ",
@@ -122,10 +122,10 @@ func test_v_climb_kick_ccw1() -> void:
 		"::v   ",
 		":::   ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_climb_kick_ccw2() -> void:
+func test_climb_kick_ccw2() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -140,10 +140,10 @@ func test_v_climb_kick_ccw2() -> void:
 		":::  ",
 		":::  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_climb_kick_ccw3() -> void:
+func test_climb_kick_ccw3() -> void:
 	from_grid = [
 		"    ",
 		" vvv",
@@ -156,10 +156,10 @@ func test_v_climb_kick_ccw3() -> void:
 		"vvv ",
 		": : ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_climb_kick_ccw4() -> void:
+func test_climb_kick_ccw4() -> void:
 	from_grid = [
 		"    ",
 		":vvv",
@@ -172,13 +172,13 @@ func test_v_climb_kick_ccw4() -> void:
 		" vvv",
 		": : ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 """
 A 'snack kick' is when a v piece rotates around an o piece to make a snack block.
 """
-func test_v_snack_kick_cw() -> void:
+func test_snack_kick_cw() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -193,10 +193,10 @@ func test_v_snack_kick_cw() -> void:
 		"  ::v",
 		"  ::v",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_snack_kick_ccw() -> void:
+func test_snack_kick_ccw() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -211,10 +211,10 @@ func test_v_snack_kick_ccw() -> void:
 		"v::  ",
 		"v::  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_snack_kick_down_ccw() -> void:
+func test_snack_kick_down_ccw() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -231,10 +231,10 @@ func test_v_snack_kick_down_ccw() -> void:
 		":v:::",
 		" vvv ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_snack_kick_down_cw() -> void:
+func test_snack_kick_down_cw() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -251,13 +251,13 @@ func test_v_snack_kick_down_cw() -> void:
 		":::v:",
 		" vvv ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 """
 The v piece can't technically wall kick, but it can kick against other blocks similar to a wall kick
 """
-func test_v_rwallkick_cw0() -> void:
+func test_rwallkick_cw0() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -272,10 +272,10 @@ func test_v_rwallkick_cw0() -> void:
 		"  v  ",
 		"  v::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_rwallkick_cw1() -> void:
+func test_rwallkick_cw1() -> void:
 	from_grid = [
 		"    :",
 		"    :",
@@ -290,10 +290,10 @@ func test_v_rwallkick_cw1() -> void:
 		" v   ",
 		" v   ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_rwallkick_cw2() -> void:
+func test_rwallkick_cw2() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -308,10 +308,10 @@ func test_v_rwallkick_cw2() -> void:
 		"   v ",
 		"   v:",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_lwallkick_cw3() -> void:
+func test_lwallkick_cw3() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -326,10 +326,10 @@ func test_v_lwallkick_cw3() -> void:
 		"   v ",
 		":vvv ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_lwallkick_cw4() -> void:
+func test_lwallkick_cw4() -> void:
 	from_grid = [
 		":    ",
 		":    ",
@@ -344,10 +344,10 @@ func test_v_lwallkick_cw4() -> void:
 		" v   ",
 		" vvv ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_lwallkick_ccw0() -> void:
+func test_lwallkick_ccw0() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -362,10 +362,10 @@ func test_v_lwallkick_ccw0() -> void:
 		"  v  ",
 		"::v  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_lwallkick_ccw1() -> void:
+func test_lwallkick_ccw1() -> void:
 	from_grid = [
 		":    ",
 		":    ",
@@ -380,10 +380,10 @@ func test_v_lwallkick_ccw1() -> void:
 		"   v ",
 		"   v ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_lwallkick_ccw2() -> void:
+func test_lwallkick_ccw2() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -398,11 +398,11 @@ func test_v_lwallkick_ccw2() -> void:
 		" v   ",
 		":v   ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 
-func test_v_rwallkick_ccw3() -> void:
+func test_rwallkick_ccw3() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -417,10 +417,10 @@ func test_v_rwallkick_ccw3() -> void:
 		" v   ",
 		" vvv:",
 	]
-	_assert_kick()
+	assert_kick()
 
 
-func test_v_rwallkick_ccw4() -> void:
+func test_rwallkick_ccw4() -> void:
 	from_grid = [
 		"    :",
 		"    :",
@@ -435,7 +435,7 @@ func test_v_rwallkick_ccw4() -> void:
 		"   v ",
 		" vvv ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 """
@@ -454,7 +454,7 @@ func test_ritzy_kick_cw0() -> void:
 		":vvv",
 		"   :",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_ritzy_kick_cw1() -> void:
@@ -470,7 +470,7 @@ func test_ritzy_kick_cw1() -> void:
 		" v  ",
 		":v  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_ritzy_kick_cw2() -> void:
@@ -486,7 +486,7 @@ func test_ritzy_kick_cw2() -> void:
 		"  v ",
 		"  v ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_ritzy_kick_cw3() -> void:
@@ -502,7 +502,7 @@ func test_ritzy_kick_cw3() -> void:
 		"vvv ",
 		" :: ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_ritzy_kick_ccw0() -> void:
@@ -518,7 +518,7 @@ func test_ritzy_kick_ccw0() -> void:
 		"vvv:",
 		":   ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_ritzy_kick_ccw1() -> void:
@@ -534,7 +534,7 @@ func test_ritzy_kick_ccw1() -> void:
 		"  v ",
 		"  v:",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_ritzy_kick_ccw2() -> void:
@@ -550,7 +550,7 @@ func test_ritzy_kick_ccw2() -> void:
 		" v  ",
 		" v  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_ritzy_kick_ccw3() -> void:
@@ -566,7 +566,7 @@ func test_ritzy_kick_ccw3() -> void:
 		" vvv",
 		" :: ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 """
@@ -588,7 +588,7 @@ func test_plant_kick_cw0() -> void:
 		"::v::",
 		"::v::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_plant_kick_cw1() -> void:
@@ -606,7 +606,7 @@ func test_plant_kick_cw1() -> void:
 		":: ::",
 		":: ::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_plant_kick_cw2() -> void:
@@ -620,7 +620,7 @@ func test_plant_kick_cw2() -> void:
 		"::v::",
 		"  vvv",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_plant_kick_cw3() -> void:
@@ -638,7 +638,7 @@ func test_plant_kick_cw3() -> void:
 		"  v::",
 		"  v::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_plant_kick_ccw0() -> void:
@@ -656,7 +656,7 @@ func test_plant_kick_ccw0() -> void:
 		"::v::",
 		"::v::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_plant_kick_ccw1() -> void:
@@ -674,7 +674,7 @@ func test_plant_kick_ccw1() -> void:
 		":: ::",
 		":: ::",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_plant_kick_ccw2() -> void:
@@ -688,7 +688,7 @@ func test_plant_kick_ccw2() -> void:
 		"::v::",
 		"vvv  ",
 	]
-	_assert_kick()
+	assert_kick()
 
 
 func test_plant_kick_ccw3() -> void:
@@ -706,5 +706,5 @@ func test_plant_kick_ccw3() -> void:
 		"::v::",
 		"::v::",
 	]
-	_assert_kick()
+	assert_kick()
 


### PR DESCRIPTION
This piece kick was missing, which meant you could drop a u-piece down a
2-cell shaft and be unable to rotate it at the bottom.

I've added this kick and rearranged the existing kicks in an attempt to
keep the u-piece kicks in line with the j and l pieces.