### PR TITLE
Slower lock times for novices. Faster DAS for experts.

### DIFF
--- a/src/main/puzzle/PuzzleHud.tscn
+++ b/src/main/puzzle/PuzzleHud.tscn
@@ -47,6 +47,7 @@ margin_bottom = 79.0
 size_flags_horizontal = 0
 size_flags_vertical = 0
 custom_fonts/font = ExtResource( 3 )
+shortcut_in_tooltip = false
 shortcut = SubResource( 2 )
 text = "Back"
 __meta__ = {

--- a/src/main/puzzle/piece/active-piece.gd
+++ b/src/main/puzzle/piece/active-piece.gd
@@ -103,7 +103,7 @@ Parameters:
 	'kicks': A list of positions to try.
 
 Returns:
-	The new 'kicked' position for the piece, or null if the piece could not be kicked.
+	The new 'kicked' position for the piece, or (0, 0) if the piece could not be kicked.
 """
 func kick_piece(is_cell_blocked: FuncRef, target_pos: Vector2, target_orientation: int, kicks: Array = []) -> Vector2:
 	if kicks == []:

--- a/src/main/puzzle/piece/piece-speed.gd
+++ b/src/main/puzzle/piece/piece-speed.gd
@@ -22,7 +22,7 @@ var delayed_auto_shift_delay: int
 # number of frames to pause before locking a piece into the playfield
 var lock_delay: int
 
-# number of frames to pause after locking a piece into the playfield
+# number of frames to pause after locking a piece, when the player can lock cancel and squish
 var post_lock_delay: int
 
 # number of frames to pause when clearing a line

--- a/src/main/puzzle/piece/piece-speeds.gd
+++ b/src/main/puzzle/piece/piece-speeds.gd
@@ -28,19 +28,19 @@ var _speeds := {}
 
 func _ready() -> void:
 	# tutorial; piece does not drop
-	_add_speed(PieceSpeed.new("T",   0, 20, 36, 7, 16, 40, 24, 12))
+	_add_speed(PieceSpeed.new("T",   0, 20, 36, 7, 16, 60, 24, 12))
 	
 	# beginner; 10-30 blocks per minute
-	_add_speed(PieceSpeed.new("0",   4, 20, 36, 7, 16, 40, 24, 12))
-	_add_speed(PieceSpeed.new("1",   5, 20, 36, 7, 16, 40, 24, 12))
-	_add_speed(PieceSpeed.new("2",   6, 20, 36, 7, 16, 40, 24, 12))
-	_add_speed(PieceSpeed.new("3",   8, 20, 36, 7, 16, 40, 24, 12))
-	_add_speed(PieceSpeed.new("4",  10, 20, 36, 7, 16, 40, 24, 12))
-	_add_speed(PieceSpeed.new("5",  12, 20, 36, 7, 16, 40, 24, 12))
-	_add_speed(PieceSpeed.new("6",  16, 20, 36, 7, 16, 40, 24, 12))
-	_add_speed(PieceSpeed.new("7",  24, 20, 36, 7, 16, 40, 24, 12))
-	_add_speed(PieceSpeed.new("8",  32, 20, 36, 7, 16, 40, 24, 12))
-	_add_speed(PieceSpeed.new("9",  48, 20, 36, 7, 16, 40, 24, 12))
+	_add_speed(PieceSpeed.new("0",   4, 20, 36, 7, 16, 60, 24, 12))
+	_add_speed(PieceSpeed.new("1",   5, 20, 36, 7, 16, 60, 24, 12))
+	_add_speed(PieceSpeed.new("2",   6, 20, 36, 7, 16, 60, 24, 12))
+	_add_speed(PieceSpeed.new("3",   8, 20, 36, 7, 16, 60, 24, 12))
+	_add_speed(PieceSpeed.new("4",  10, 20, 36, 7, 16, 60, 24, 12))
+	_add_speed(PieceSpeed.new("5",  12, 20, 36, 7, 16, 60, 24, 12))
+	_add_speed(PieceSpeed.new("6",  16, 20, 36, 7, 16, 60, 24, 12))
+	_add_speed(PieceSpeed.new("7",  24, 20, 36, 7, 16, 60, 24, 12))
+	_add_speed(PieceSpeed.new("8",  32, 20, 36, 7, 16, 60, 24, 12))
+	_add_speed(PieceSpeed.new("9",  48, 20, 36, 7, 16, 60, 24, 12))
 	
 	# normal; 30-60 blocks per minute
 	_add_speed(PieceSpeed.new("A0",    4, 20, 20, 7, 16, 40, 24, 12))
@@ -63,15 +63,15 @@ func _ready() -> void:
 	_add_speed(PieceSpeed.new("AF", 20*G, 16, 12, 7, 10, 30, 12,  6))
 	
 	# crazy; 120-250 blocks per minute
-	_add_speed(PieceSpeed.new( "F0",    4, 12, 8, 7, 10, 24, 6, 3))
-	_add_speed(PieceSpeed.new( "F1",  1*G, 12, 8, 7, 10, 24, 6, 3))
-	_add_speed(PieceSpeed.new( "FA", 20*G, 12, 8, 7, 10, 24, 6, 3))
-	_add_speed(PieceSpeed.new( "FB", 20*G,  8, 6, 5,  7, 22, 5, 3))
-	_add_speed(PieceSpeed.new( "FC", 20*G,  6, 4, 5,  7, 20, 4, 3))
-	_add_speed(PieceSpeed.new( "FD", 20*G,  4, 2, 5,  7, 18, 3, 3))
-	_add_speed(PieceSpeed.new( "FE", 20*G,  4, 2, 5,  7, 16, 3, 3))
-	_add_speed(PieceSpeed.new( "FF", 20*G,  4, 2, 5,  7, 14, 3, 3))
-	_add_speed(PieceSpeed.new("FFF", 20*G,  4, 2, 5,  7, 12, 3, 3))
+	_add_speed(PieceSpeed.new( "F0",    4, 12, 8, 5,  8, 24, 6, 3))
+	_add_speed(PieceSpeed.new( "F1",  1*G, 12, 8, 5,  8, 24, 6, 3))
+	_add_speed(PieceSpeed.new( "FA", 20*G, 12, 8, 5,  8, 24, 6, 3))
+	_add_speed(PieceSpeed.new( "FB", 20*G,  8, 6, 5,  8, 22, 5, 3))
+	_add_speed(PieceSpeed.new( "FC", 20*G,  6, 4, 5,  8, 20, 4, 3))
+	_add_speed(PieceSpeed.new( "FD", 20*G,  4, 2, 5,  8, 18, 3, 3))
+	_add_speed(PieceSpeed.new( "FE", 20*G,  4, 2, 5,  8, 16, 3, 3))
+	_add_speed(PieceSpeed.new( "FF", 20*G,  4, 2, 5,  8, 14, 3, 3))
+	_add_speed(PieceSpeed.new("FFF", 20*G,  4, 2, 5,  8, 12, 3, 3))
 	
 	# easter egg
 	_add_speed(PieceSpeed.new("DB", 1*G, 20, 20, 7, 16, 40, 24, 12))

--- a/src/main/ui/ScenarioMenu.tscn
+++ b/src/main/ui/ScenarioMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://src/main/ui/scenario-menu.gd" type="Script" id=1]
 [ext_resource path="res://assets/puzzle/wood-backdrop.png" type="Texture" id=2]
@@ -10,6 +10,7 @@
 [ext_resource path="res://src/main/ui/marathon-button.gd" type="Script" id=8]
 [ext_resource path="res://assets/ui/xolonium-36.tres" type="DynamicFont" id=9]
 [ext_resource path="res://assets/ui/xolonium-24.tres" type="DynamicFont" id=10]
+[ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=11]
 
 [node name="ScenarioMenu" type="Control"]
 anchor_right = 1.0
@@ -217,6 +218,9 @@ text = "Tutorial"
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
+[node name="CheatCodeDetector" parent="." instance=ExtResource( 11 )]
+codes = [ "unlock" ]
 [connection signal="chose_scenario" from="VBoxContainer/Sprint/Normal" to="." method="_on_ScenarioButton_chose_scenario"]
 [connection signal="chose_scenario" from="VBoxContainer/Sprint/Expert" to="." method="_on_ScenarioButton_chose_scenario"]
 [connection signal="chose_scenario" from="VBoxContainer/Ultra/Normal" to="." method="_on_ScenarioButton_chose_scenario"]
@@ -229,3 +233,4 @@ __meta__ = {
 [connection signal="pressed" from="OverworldButton" to="." method="_on_OverworldButton_pressed"]
 [connection signal="pressed" from="LevelEditorButton" to="." method="_on_LevelEditorButton_pressed"]
 [connection signal="pressed" from="TutorialButton" to="." method="_on_TutorialButton_pressed"]
+[connection signal="cheat_detected" from="CheatCodeDetector" to="." method="_on_CheatCodeDetector_cheat_detected"]

--- a/src/main/ui/scenario-button.gd
+++ b/src/main/ui/scenario-button.gd
@@ -23,6 +23,15 @@ func disable(unlock_message: String) -> void:
 	$Best.text = unlock_message
 
 
+func enable() -> void:
+	$Button.text = scenario_name.split("-")[1].capitalize()
+	$Button.disabled = false
+
+
+func is_disabled() -> bool:
+	return $Button.disabled
+
+
 """
 Calculates the label text for displaying a player's best scenario performance.
 """

--- a/src/main/ui/scenario-menu.gd
+++ b/src/main/ui/scenario-menu.gd
@@ -50,3 +50,22 @@ func _on_LevelEditorButton_pressed() -> void:
 
 func _on_TutorialButton_pressed() -> void:
 	launch_scenario(BEGINNER_TUTORIAL_SCENARIO)
+
+
+func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDetector):
+	if cheat == "unlock":
+		var enabled_count := 0
+		for button_obj in [
+			$VBoxContainer/Sprint/Expert,
+			$VBoxContainer/Ultra/Hard,
+			$VBoxContainer/Ultra/Expert,
+			$VBoxContainer/Marathon/Hard,
+			$VBoxContainer/Marathon/Expert,
+			$VBoxContainer/Marathon/Master
+		]:
+			var button: ScenarioButton = button_obj
+			if button.is_disabled():
+				button.enable()
+				enabled_count += 1
+		if enabled_count >= 1:
+			detector.play_cheat_sound(true)


### PR DESCRIPTION
A playtester reported that the lock time of 40 frames felt too oppressive
for what's meant to be a casual game. I've slowed it down to 60 frames for
the beginner levels (0-9)

I found the DAS reduction from FA to FB to be jarring when progressing
through expert difficulties; the pieces felt out of control with only 5 frames
of DAS. I've decreased it to 5 frames for FA as well, so now it feels out of
control all the time. Ha ha.

We can let players adjust their own DAS if they hate it. 5 frames feels OK
to me now that I've practiced it.