### PR TITLE
Scenario history is saved more efficiently.

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -240,6 +240,11 @@ _global_script_classes=[ {
 "path": "res://src/main/puzzle/scenario/scenario.gd"
 }, {
 "base": "Reference",
+"class": "ScenarioHistory",
+"language": "GDScript",
+"path": "res://src/main/puzzle/scenario/scenario-history.gd"
+}, {
+"base": "Reference",
 "class": "ScenarioPerformance",
 "language": "GDScript",
 "path": "res://src/main/puzzle/scenario/scenario-performance.gd"
@@ -346,6 +351,7 @@ _global_script_class_icons={
 "RankRules": "",
 "RuleParser": "",
 "Scenario": "",
+"ScenarioHistory": "",
 "ScenarioPerformance": "",
 "ScenarioSettings": "",
 "ScoreRules": "",

--- a/src/main/player-data.gd
+++ b/src/main/player-data.gd
@@ -7,21 +7,11 @@ This data includes how well they've done on each level and how much money they'v
 
 signal money_changed(value)
 
-"""
-Stores every RankResult the player has received for different scenarios. This is currently used for calculating high
-scores, but could eventually be used for displaying statistics or calculating rewards.
-
-key: (String) Scenario name 
-value: (Array) All RankResults for the specified scenario
-"""
-var scenario_history := {}
+var scenario_history := ScenarioHistory.new()
 
 var volume_settings := VolumeSettings.new()
 
 var money := 0 setget set_money
-
-# how many records we can store before we start deleting old ones
-var history_size := 1000
 
 var _rank_calculator := RankCalculator.new()
 
@@ -29,79 +19,9 @@ var _rank_calculator := RankCalculator.new()
 Resets the player's in-memory data to a default state.
 """
 func reset() -> void:
-	scenario_history.clear()
+	scenario_history.reset()
+	volume_settings.reset()
 	money = 0
-	volume_settings.reset_to_default()
-
-
-"""
-Returns a player's best performances for a specific scenario.
-
-Parameters:
-	'scenario': The name of the scenario to evaluate
-	
-	'daily': If true, only performances with today's date are included
-	
-	'property': (Optional) The property evaluated to determine which of the player's RankResults was the best, such
-		as 'score' or 'seconds'. Defaults to 'score'.
-"""
-func get_best_scenario_results(scenario: String, daily: bool, property: String = "score") -> Array:
-	if not scenario_history.has(scenario):
-		return []
-	
-	var results: Array = scenario_history[scenario].duplicate()
-	if daily:
-		# only include items with today's date
-		var now := OS.get_datetime()
-		var daily_results := []
-		for result_obj in results:
-			var result: RankResult = result_obj
-			if result.timestamp["year"] == now["year"] \
-					and result.timestamp["month"] == now["month"] \
-					and result.timestamp["day"] == now["day"]:
-				daily_results.append(result)
-		results = daily_results
-	
-	if property == "seconds":
-		results.sort_custom(self, "_compare_by_seconds")
-	else:
-		results.sort_custom(self, "_compare_by_score")
-	return results
-
-
-func _compare_by_seconds(a: RankResult, b: RankResult) -> bool:
-	# when comparing seconds, dying disqualifies you
-	if a.lost and b.lost:
-		return a.lines > b.lines
-	if a.lost != b.lost:
-		return b.lost
-	# when comparing seconds, lower is better
-	return a.seconds < b.seconds
-
-
-func _compare_by_score(a: RankResult, b: RankResult) -> bool:
-	return a.score > b.score
-
-
-func get_last_scenario_result(scenario: String) -> RankResult:
-	if not scenario_history.has(scenario) or scenario_history[scenario].empty():
-		return null
-	return scenario_history[scenario][0]
-
-
-"""
-Records the current scenario performance to the player's history.
-"""
-func add_scenario_history(scenario: String, rank_result: RankResult) -> void:
-	if not scenario:
-		# can't store history without a scenario name
-		return
-	
-	if not scenario_history.has(scenario):
-		scenario_history[scenario] = []
-	scenario_history[scenario].push_front(rank_result)
-	if scenario_history[scenario].size() > history_size:
-		scenario_history[scenario].resize(history_size)
 
 
 func set_money(new_money: int) -> void:

--- a/src/main/player-save.gd
+++ b/src/main/player-save.gd
@@ -87,11 +87,11 @@ func save_player_data() -> void:
 	save_json.append(generic_data("version", PLAYER_DATA_VERSION).to_json_dict())
 	save_json.append(generic_data("player-info", {"money": PlayerData.money}).to_json_dict())
 	save_json.append(generic_data("volume-settings", PlayerData.volume_settings.to_json_dict()).to_json_dict())
-	for key in PlayerData.scenario_history.keys():
+	for scenario_name in PlayerData.scenario_history.scenario_names():
 		var rank_results_json := []
-		for rank_result in PlayerData.scenario_history[key]:
+		for rank_result in PlayerData.scenario_history.results(scenario_name):
 			rank_results_json.append(rank_result.to_json_dict())
-		save_json.append(named_data("scenario-history", key, rank_results_json).to_json_dict())
+		save_json.append(named_data("scenario-history", scenario_name, rank_results_json).to_json_dict())
 	FileUtils.write_file(player_data_filename, to_json(save_json))
 
 
@@ -134,7 +134,8 @@ func _load_line(type: String, key: String, json_value) -> void:
 			for rank_result_json in value:
 				var rank_result := RankResult.new()
 				rank_result.from_json_dict(rank_result_json)
-				PlayerData.add_scenario_history(key, rank_result)
+				PlayerData.scenario_history.add(key, rank_result)
+			PlayerData.scenario_history.prune(key)
 		"volume-settings":
 			var value: Dictionary = json_value
 			PlayerData.volume_settings.from_json_dict(value)

--- a/src/main/puzzle/results-hud.gd
+++ b/src/main/puzzle/results-hud.gd
@@ -116,7 +116,7 @@ func _on_PuzzleScore_game_prepared() -> void:
 
 
 func _on_Puzzle_after_game_ended() -> void:
-	var rank_result: RankResult = PlayerData.get_last_scenario_result(Global.scenario_settings.name)
+	var rank_result: RankResult = PlayerData.scenario_history.prev_result(Global.scenario_settings.name)
 	if not rank_result or Global.scenario_settings.rank.skip_results:
 		return
 	

--- a/src/main/puzzle/scenario/scenario-history.gd
+++ b/src/main/puzzle/scenario/scenario-history.gd
@@ -1,0 +1,118 @@
+class_name ScenarioHistory
+"""
+Stores the best results the player has achieved for different scenarios. This is currently used for calculating high
+scores, but could eventually be used for displaying statistics or calculating rewards.
+"""
+
+# how many daily and all-time records we can store before we start deleting old ones
+var max_size := 3
+
+# key: scenario name
+# value: array of RankResults for the specified scenario
+var rank_results := {}
+
+func scenario_names() -> Array:
+	return rank_results.keys()
+
+
+"""
+Resets the scenario history to its default empty state.
+"""
+func reset() -> void:
+	rank_results.clear()
+
+
+"""
+Returns a player's performances for a specific scenario.
+"""
+func results(scenario: String) -> Array:
+	return rank_results.get(scenario, [])
+
+
+"""
+Returns a player's best performances for a specific scenario.
+
+Parameters:
+	'scenario': The name of the scenario to evaluate
+	
+	'daily': If true, only performances with today's date are included
+	
+	'property': (Optional) The property evaluated to determine which of the player's RankResults was the best, such
+		as 'score' or 'seconds'. Defaults to 'score'.
+"""
+func best_results(scenario: String, daily: bool) -> Array:
+	if not rank_results.has(scenario):
+		return []
+	
+	var results: Array = rank_results[scenario].duplicate()
+	if daily:
+		# only include items with today's date
+		var now := OS.get_datetime()
+		var daily_results := []
+		for result_obj in results:
+			var result: RankResult = result_obj
+			if result.timestamp["year"] == now["year"] \
+					and result.timestamp["month"] == now["month"] \
+					and result.timestamp["day"] == now["day"]:
+				daily_results.append(result)
+		results = daily_results
+	
+	if ScenarioSettings.compare_seconds(scenario):
+		results.sort_custom(self, "_compare_by_seconds")
+	else:
+		results.sort_custom(self, "_compare_by_score")
+	return results.slice(0, max_size - 1)
+
+
+func prev_result(scenario: String) -> RankResult:
+	if not rank_results.has(scenario) or rank_results[scenario].empty():
+		return null
+	return rank_results[scenario][0]
+
+
+"""
+Records the current scenario performance to the player's history.
+
+'add' should be followed by 'prune' to ensure the history does not grow too large.
+"""
+func add(scenario: String, rank_result: RankResult) -> void:
+	if not scenario:
+		# can't store history without a scenario name
+		return
+	
+	if not rank_results.has(scenario):
+		rank_results[scenario] = []
+	rank_results[scenario].push_front(rank_result)
+
+
+func has(scenario: String) -> bool:
+	return rank_results.has(scenario) and rank_results.get(scenario).size() >= 1
+
+
+"""
+Prunes the history down to only the best daily results, best all-time results, and the most recent result.
+"""
+func prune(scenario: String) -> void:
+	if not has(scenario):
+		return
+	
+	# collect the best scores, but reinsert the newest score at index 0 for prev_result()
+	var best: Dictionary = {}
+	for result in best_results(scenario, false) + best_results(scenario, true):
+		best[result] = ""
+	best.erase(rank_results[scenario][0])
+	rank_results[scenario] = [rank_results[scenario][0]] + best.keys()
+
+
+func _compare_by_seconds(a: RankResult, b: RankResult) -> bool:
+	# when comparing seconds, dying disqualifies you
+	if a.lost and b.lost:
+		return a.score > b.score
+	if a.lost != b.lost:
+		return b.lost
+	# when comparing seconds, lower is better
+	return a.seconds < b.seconds
+
+
+func _compare_by_score(a: RankResult, b: RankResult) -> bool:
+	return a.score > b.score

--- a/src/main/puzzle/scenario/scenario-settings.gd
+++ b/src/main/puzzle/scenario/scenario-settings.gd
@@ -139,3 +139,12 @@ func from_json_dict(new_name: String, json: Dictionary) -> void:
 		score.from_json_string_array(json["score"])
 	if json.has("win-condition"):
 		win_condition.from_json_dict(json["win-condition"])
+
+
+"""
+Returns true if the specified scenario should be compared using seconds instead of score.
+
+This is true for 'ultra mode' where a lower time is better, and score is a tiebreaker.
+"""
+static func compare_seconds(scenario: String) -> bool:
+	return scenario.begins_with("ultra-")

--- a/src/main/puzzle/scenario/scenario.gd
+++ b/src/main/puzzle/scenario/scenario.gd
@@ -276,7 +276,8 @@ func _on_PuzzleScore_game_ended() -> void:
 	# ensure score is up to date before calculating rank
 	PuzzleScore.end_combo()
 	var rank_result := _rank_calculator.calculate_rank()
-	PlayerData.add_scenario_history(Global.launched_scenario_name, rank_result)
+	PlayerData.scenario_history.add(Global.launched_scenario_name, rank_result)
+	PlayerData.scenario_history.prune(Global.launched_scenario_name)
 	PlayerData.money += rank_result.score
 	PlayerSave.save_player_data()
 	

--- a/src/main/ui/high-score-table.gd
+++ b/src/main/ui/high-score-table.gd
@@ -52,14 +52,8 @@ func _add_rows() -> void:
 	if not _scenario:
 		return
 	
-	var best_results: Array
-	if _scenario.name.begins_with("ultra-"):
-		best_results = PlayerData.get_best_scenario_results(_scenario.name, _daily, "seconds")
-	else:
-		best_results = PlayerData.get_best_scenario_results(_scenario.name, _daily)
-	
-	for i in range(min(best_results.size(), 3)):
-		var best_result: RankResult = best_results[i]
+	for best_result_obj in PlayerData.scenario_history.best_results(_scenario.name, _daily):
+		var best_result: RankResult = best_result_obj
 		var row := []
 		
 		# append timestamp
@@ -77,7 +71,7 @@ func _add_rows() -> void:
 		row.append(StringUtils.comma_sep(best_result.lines))
 		
 		# append score/time and grade
-		if _scenario.name.begins_with("ultra-"):
+		if ScenarioSettings.compare_seconds(_scenario.name):
 			if best_result.lost:
 				row.append("-")
 			else:

--- a/src/main/ui/menu/main-menu.gd
+++ b/src/main/ui/menu/main-menu.gd
@@ -10,7 +10,7 @@ Includes buttons starting a new game, launching the level editor, and exiting th
 const BEGINNER_TUTORIAL_SCENARIO := "tutorial-beginner-0"
 
 func _ready() -> void:
-	if not PlayerData.scenario_history.has(BEGINNER_TUTORIAL_SCENARIO):
+	if not PlayerData.scenario_history.scenario_names().has(BEGINNER_TUTORIAL_SCENARIO):
 		var scenario_settings := ScenarioLibrary.load_scenario_from_name(BEGINNER_TUTORIAL_SCENARIO)
 		Global.overworld_puzzle = false
 		ScenarioLibrary.push_scenario_trail(scenario_settings)

--- a/src/main/volume-settings.gd
+++ b/src/main/volume-settings.gd
@@ -35,7 +35,7 @@ func set_bus_volume_linear(volume_type: int, value: float) -> void:
 """
 Resets the sound, music and voice volumes to their default values.
 """
-func reset_to_default() -> void:
+func reset() -> void:
 	from_json_dict({})
 
 

--- a/src/test/test-backwards-compatible.gd
+++ b/src/test/test-backwards-compatible.gd
@@ -17,7 +17,6 @@ func before_each() -> void:
 
 
 func after_each() -> void:
-	PlayerData.history_size = 1000
 	var save_dir := Directory.new()
 	save_dir.open("user://")
 	save_dir.remove(TEMP_FILENAME)
@@ -26,16 +25,16 @@ func after_each() -> void:
 
 func test_lost_true() -> void:
 	# scenario where the player topped out and lost
-	assert_true(PlayerData.scenario_history.has("sprint-normal"))
-	var history_sprint: RankResult = PlayerData.scenario_history.get("sprint-normal")[0]
+	assert_true(PlayerData.scenario_history.scenario_names().has("sprint-normal"))
+	var history_sprint: RankResult = PlayerData.scenario_history.results("sprint-normal")[0]
 	assert_eq(history_sprint.lost, true)
 	assert_eq(history_sprint.top_out_count, 1)
 
 
 func test_lost_false() -> void:
 	# scenario where the player survived
-	assert_true(PlayerData.scenario_history.has("ultra-normal"))
-	var history_ultra: RankResult = PlayerData.scenario_history.get("ultra-normal")[0]
+	assert_true(PlayerData.scenario_history.scenario_names().has("ultra-normal"))
+	var history_ultra: RankResult = PlayerData.scenario_history.results("ultra-normal")[0]
 	assert_eq(history_ultra.lost, false)
 	assert_eq(history_ultra.top_out_count, 0)
 
@@ -47,15 +46,15 @@ func test_money_preserved() -> void:
 
 func test_survival_records_preserved() -> void:
 	# 'survival mode' used to be called 'marathon mode'
-	assert_true(PlayerData.scenario_history.has("survival-normal"))
-	var history_survival: RankResult = PlayerData.scenario_history.get("survival-normal")[0]
+	assert_true(PlayerData.scenario_history.scenario_names().has("survival-normal"))
+	var history_survival: RankResult = PlayerData.scenario_history.results("survival-normal")[0]
 	assert_eq(history_survival.lost, false)
 	assert_eq(history_survival.score, 1335)
 
 
 func test_timestamp_created() -> void:
-	assert_true(PlayerData.scenario_history.has("ultra-normal"))
-	var history_ultra: RankResult = PlayerData.scenario_history.get("ultra-normal")[0]
+	assert_true(PlayerData.scenario_history.scenario_names().has("ultra-normal"))
+	var history_ultra: RankResult = PlayerData.scenario_history.results("ultra-normal")[0]
 	
 	# save data doesn't include timestamp, so we make one up
 	assert_true(history_ultra.timestamp.has("year"))

--- a/src/test/test-player-data.gd
+++ b/src/test/test-player-data.gd
@@ -8,7 +8,6 @@ saved or loaded. That's why unit tests are particularly important for this code.
 const TEMP_FILENAME := "test-ground-lucky.save"
 
 var _rank_result: RankResult
-var _rank_calculator := RankCalculator.new()
 
 func before_each() -> void:
 	PlayerSave.player_data_filename = "user://%s" % TEMP_FILENAME
@@ -23,48 +22,15 @@ func before_each() -> void:
 
 
 func after_each() -> void:
-	PlayerData.history_size = 1000
 	var save_dir := Directory.new()
 	save_dir.open("user://")
 	save_dir.remove(TEMP_FILENAME)
 
 
-func test_one_history_entry() -> void:
-	PlayerData.add_scenario_history("scenario-895", _rank_result)
-	assert_eq(PlayerData.scenario_history["scenario-895"][0].score, 7890)
-
-
-func test_two_history_entries() -> void:
-	PlayerData.add_scenario_history("scenario-895", _rank_result)
-	_rank_result = RankResult.new()
-	_rank_result.score = 6780
-	PlayerData.add_scenario_history("scenario-895", _rank_result)
-	assert_eq(PlayerData.scenario_history["scenario-895"][0].score, 6780)
-	assert_eq(PlayerData.scenario_history["scenario-895"][1].score, 7890)
-
-
-func test_too_many_history_entries() -> void:
-	PlayerData.history_size = 3
-	PlayerData.add_scenario_history("scenario-895", _rank_result)
-	PlayerData.add_scenario_history("scenario-895", _rank_result)
-	PlayerData.add_scenario_history("scenario-895", _rank_result)
-	PlayerData.add_scenario_history("scenario-895", _rank_result)
-	_rank_result = RankResult.new()
-	_rank_result.score = 6780
-	PlayerData.add_scenario_history("scenario-895", _rank_result)
-	assert_eq(PlayerData.scenario_history["scenario-895"].size(), 3)
-	assert_eq(PlayerData.scenario_history["scenario-895"][0].score, 6780)
-
-
-func test_no_scenario_name() -> void:
-	PlayerData.add_scenario_history("", _rank_result)
-	assert_false(PlayerData.scenario_history.has(""))
-
-
 func test_save_and_load() -> void:
-	PlayerData.add_scenario_history("scenario-895", _rank_result)
+	PlayerData.scenario_history.add("scenario-895", _rank_result)
 	PlayerSave.save_player_data()
-	PlayerData.scenario_history.clear()
+	PlayerData.reset()
 	PlayerSave.load_player_data()
 	assert_true(PlayerData.scenario_history.has("scenario-895"))
-	assert_eq(PlayerData.scenario_history["scenario-895"][0].score, 7890)
+	assert_eq(PlayerData.scenario_history.results("scenario-895")[0].score, 7890)

--- a/src/test/test-scenario-history.gd
+++ b/src/test/test-scenario-history.gd
@@ -1,0 +1,67 @@
+extends "res://addons/gut/test.gd"
+"""
+Unit test demonstrating the reading/writing/pruning of history data.
+"""
+
+var _scenario_history := ScenarioHistory.new()
+
+func before_each() -> void:
+	_scenario_history.reset()
+
+
+static func rank_result(score: int = 7890) -> RankResult:
+	var result := RankResult.new()
+	result.seconds = 600.0
+	result.lines = 300
+	result.box_score_per_line = 9.3
+	result.combo_score_per_line = 17.0
+	result.score = score
+	return result
+
+
+func test_prune_one() -> void:
+	_scenario_history.add("scenario-895", rank_result(7890))
+	_scenario_history.prune("scenario-895")
+	
+	assert_eq(_scenario_history.results("scenario-895")[0].score, 7890)
+
+
+func test_prune_two() -> void:
+	_scenario_history.add("scenario-895", rank_result(7890))
+	_scenario_history.add("scenario-895", rank_result(6780))
+	_scenario_history.prune("scenario-895")
+	
+	assert_eq(_scenario_history.results("scenario-895")[0].score, 6780)
+	assert_eq(_scenario_history.results("scenario-895")[1].score, 7890)
+
+
+func test_prune_many() -> void:
+	_scenario_history.add("scenario-895", rank_result(500))
+	_scenario_history.add("scenario-895", rank_result(700))
+	_scenario_history.add("scenario-895", rank_result(30))
+	_scenario_history.add("scenario-895", rank_result(10))
+	_scenario_history.add("scenario-895", rank_result(600))
+	_scenario_history.add("scenario-895", rank_result(20))
+	_scenario_history.add("scenario-895", rank_result(40))
+	assert_eq(_scenario_history.results("scenario-895").size(), 7)
+	
+	_scenario_history.prune("scenario-895")
+	assert_eq(_scenario_history.results("scenario-895").size(), 4)
+
+
+func test_prev_after_prune() -> void:
+	_scenario_history.add("scenario-895", rank_result(500))
+	_scenario_history.add("scenario-895", rank_result(700))
+	_scenario_history.add("scenario-895", rank_result(30))
+	_scenario_history.add("scenario-895", rank_result(10))
+	_scenario_history.add("scenario-895", rank_result(600))
+	_scenario_history.add("scenario-895", rank_result(20))
+	_scenario_history.add("scenario-895", rank_result(40))
+	_scenario_history.prune("scenario-895")
+	
+	assert_eq(_scenario_history.prev_result("scenario-895").score, 40)
+
+
+func test_no_scenario_name() -> void:
+	_scenario_history.add("", rank_result())
+	assert_false(_scenario_history.scenario_names().has(""))


### PR DESCRIPTION
The previous design which saved the newest 1,000 (!) scores for each mode had
two flaws.

1. Each score takes about 500 bytes of disk space, so 1,000 scores would
take up 500k of memory and disk space for a single scenario.

2. In the unlikely change that a player played a single scenario more than
1,000 times, the previous strategy would always kick out the oldest record
which could be the player's high score. It would take a great player 5-6 hours
of playing nothing but Ultra Normal to finally kick out their oldest
score, so this is unlikely but it could happen.

The new design saves a maximum of 7 scores: the player's newest score,
their top 3 daily scores, and the top 3 all-time scores.

Extracted ScenarioHistory from PlayerData.