### PR TITLE
All puzzle modes display distance to goal.

### DIFF
--- a/assets/puzzle/scenario/oh-my.json
+++ b/assets/puzzle/scenario/oh-my.json
@@ -257,5 +257,5 @@
   "rank": [
     "skip-results"
   ],
-  "start-level": "DB"
+  "start-level": "A1"
 }

--- a/project.godot
+++ b/project.godot
@@ -94,6 +94,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/puzzle/editor/editor-playfield.gd"
 }, {
+"base": "Label",
+"class": "FontFitLabel",
+"language": "GDScript",
+"path": "res://src/main/ui/font-fit-label.gd"
+}, {
 "base": "Timer",
 "class": "FreshnessInspector",
 "language": "GDScript",
@@ -322,6 +327,7 @@ _global_script_class_icons={
 "Customer3D": "",
 "CustomerLoader": "",
 "EditorPlayfield": "",
+"FontFitLabel": "",
 "FreshnessInspector": "",
 "FrostingGlob": "",
 "JSONBeautifier": "",

--- a/src/main/puzzle/Puzzle.tscn
+++ b/src/main/puzzle/Puzzle.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=53 format=2]
+[gd_scene load_steps=58 format=2]
 
 [ext_resource path="res://src/main/puzzle/puzzle.gd" type="Script" id=1]
 [ext_resource path="res://src/main/puzzle/Playfield.tscn" type="PackedScene" id=2]
@@ -44,6 +44,11 @@
 [ext_resource path="res://src/main/puzzle/topout-tracker.gd" type="Script" id=42]
 [ext_resource path="res://src/main/puzzle/top-out.gd" type="Script" id=43]
 [ext_resource path="res://src/main/puzzle/piece-sfx.gd" type="Script" id=44]
+[ext_resource path="res://assets/ui/xolonium-16.tres" type="DynamicFont" id=45]
+[ext_resource path="res://assets/ui/xolonium-36.tres" type="DynamicFont" id=46]
+[ext_resource path="res://src/main/ui/font-fit-label.gd" type="Script" id=47]
+[ext_resource path="res://src/main/puzzle/milestone-hud.gd" type="Script" id=48]
+[ext_resource path="res://assets/puzzle/levelup.wav" type="AudioStream" id=49]
 
 [sub_resource type="ShaderMaterial" id=1]
 shader = ExtResource( 17 )
@@ -186,6 +191,10 @@ bus = "Sound Bus"
 stream = ExtResource( 26 )
 bus = "Sound Bus"
 
+[node name="LevelUpSound" type="AudioStreamPlayer" parent="PieceManager/PieceSfx"]
+stream = ExtResource( 49 )
+bus = "Sound Bus"
+
 [node name="NextPieceDisplays" parent="." instance=ExtResource( 4 )]
 margin_left = 688.0
 margin_top = 28.0
@@ -318,6 +327,7 @@ margin_top = 153.0
 margin_right = 308.0
 margin_bottom = 233.0
 rect_min_size = Vector2( 250, 40 )
+script = ExtResource( 48 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -346,10 +356,18 @@ margin_left = 150.0
 margin_top = 30.0
 margin_right = 250.0
 margin_bottom = 75.0
+rect_min_size = Vector2( 100, 45 )
 custom_fonts/font = ExtResource( 18 )
-text = "¥2000"
+text = "10"
 align = 1
 valign = 1
+autowrap = true
+max_lines_visible = 1
+script = ExtResource( 47 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+fonts = [ ExtResource( 46 ), ExtResource( 18 ), ExtResource( 45 ) ]
 
 [node name="HudHolder" type="Node2D" parent="."]
 position = Vector2( 364, 28 )

--- a/src/main/puzzle/combo-score-value-label.gd
+++ b/src/main/puzzle/combo-score-value-label.gd
@@ -11,4 +11,4 @@ func _ready() -> void:
 
 
 func _on_PuzzleScore_bonus_score_changed(value: int) -> void:
-	text = "-" if value == 0 else "+¥%s" % value
+	text = "-" if value == 0 else "+¥%s" % StringUtils.comma_sep(value)

--- a/src/main/puzzle/milestone-hud.gd
+++ b/src/main/puzzle/milestone-hud.gd
@@ -1,0 +1,154 @@
+extends Control
+"""
+Shows the user's scenario performance as a progress bar.
+
+the progress bar fills up as they approach the next level up milestone. If there are no more levelups, it fills as they
+approach the scenario's win/finish condition.
+
+A label overlaid on the progress bar shows them how much further they need to progress to reach the scenario's
+win/finish condition.
+"""
+
+# Colors used to render the level number. Easy levels are green, and hard levels are red/purple.
+const LEVEL_COLOR_0 := Color("48b968")
+const LEVEL_COLOR_1 := Color("78b948")
+const LEVEL_COLOR_2 := Color("b9b948")
+const LEVEL_COLOR_3 := Color("b95c48")
+const LEVEL_COLOR_4 := Color("b94878")
+const LEVEL_COLOR_5 := Color("b948b9")
+
+func _ready() -> void:
+	PuzzleScore.connect("combo_ended", self, "_on_PuzzleScore_combo_ended")
+	PuzzleScore.connect("lines_changed", self, "_on_PuzzleScore_lines_changed")
+	PuzzleScore.connect("score_changed", self, "_on_PuzzleScore_score_changed")
+	PuzzleScore.connect("bonus_score_changed", self, "_on_PuzzleScore_bonus_score_changed")
+	PuzzleScore.connect("after_scenario_prepared", self, "_on_PuzzleScore_after_scenario_prepared")
+	match _winish_type():
+		Milestone.CUSTOMERS:
+			$Desc.text = "Customers"
+		Milestone.LINES:
+			$Desc.text = "Lines"
+		Milestone.SCORE:
+			$Desc.text = "Money"
+		Milestone.TIME:
+			$Desc.text = "Time"
+	update_milebar()
+	$Value.pick_largest_font()
+
+
+func _process(_delta: float) -> void:
+	if not PuzzleScore.game_prepared:
+		return
+	
+	match _winish_type():
+		Milestone.TIME:
+			# update time display
+			update_milebar()
+
+
+"""
+Defines the milestone progress bar min/max values.
+"""
+func update_milebar_bounds() -> void:
+	$ProgressBar.min_value = Global.scenario_settings.level_ups[PuzzleScore.level_index].value
+	if PuzzleScore.level_index + 1 < Global.scenario_settings.level_ups.size():
+		# fill up the bar as they approach the next level
+		$ProgressBar.max_value = Global.scenario_settings.level_ups[PuzzleScore.level_index + 1].value
+	else:
+		# fill up the bar as they near their goal
+		$ProgressBar.max_value = _winish_value()
+
+
+"""
+Fills the milestone progress bar.
+"""
+func update_milebar_value() -> void:
+	var current_value: int
+	match _winish_type():
+		Milestone.CUSTOMERS:
+			current_value = PuzzleScore.customer_scores.size() - 1
+		Milestone.LINES:
+			current_value = PuzzleScore.scenario_performance.lines
+		Milestone.SCORE:
+			current_value = PuzzleScore.get_score() + PuzzleScore.get_bonus_score()
+		Milestone.TIME:
+			current_value = PuzzleScore.scenario_performance.seconds
+	$ProgressBar.value = current_value
+
+
+"""
+Updates the milestone progress bar text.
+"""
+func update_milebar_text() -> void:
+	var remaining := max(0, _winish_value() - $ProgressBar.value)
+	match _winish_type():
+		Milestone.CUSTOMERS, Milestone.LINES:
+			$Value.text = StringUtils.comma_sep(remaining)
+		Milestone.SCORE:
+			$Value.text = "¥%s" % StringUtils.comma_sep(remaining)
+		Milestone.TIME:
+			$Value.text = StringUtils.format_duration(remaining)
+
+
+"""
+Updates the milestone progress bar color.
+
+Color changes from green to red to purple as difficulty increases.
+"""
+func update_milebar_color() -> void:
+	var level_color: Color
+	if PieceSpeeds.current_speed.gravity >= 20 * PieceSpeeds.G and PieceSpeeds.current_speed.lock_delay < 20:
+		level_color = LEVEL_COLOR_5
+	elif PieceSpeeds.current_speed.gravity >= 20 * PieceSpeeds.G:
+		level_color = LEVEL_COLOR_4
+	elif PieceSpeeds.current_speed.gravity >=  1 * PieceSpeeds.G:
+		level_color = LEVEL_COLOR_3
+	elif PieceSpeeds.current_speed.gravity >= 128:
+		level_color = LEVEL_COLOR_2
+	elif PieceSpeeds.current_speed.gravity >= 32:
+		level_color = LEVEL_COLOR_1
+	else:
+		level_color = LEVEL_COLOR_0
+	$ProgressBar.get("custom_styles/fg").set_bg_color(Global.to_transparent(level_color, 0.333))
+
+
+"""
+Update the milestone hud's content during a game.
+"""
+func update_milebar() -> void:
+	update_milebar_bounds()
+	update_milebar_value()
+	update_milebar_text()
+	update_milebar_color()
+
+
+func _winish_type() -> int:
+	return Global.scenario_settings.get_winish_condition().type
+
+
+func _winish_value() -> int:
+	return Global.scenario_settings.get_winish_condition().value
+
+
+func _on_PuzzleScore_lines_changed(_value: int) -> void:
+	update_milebar()
+
+
+func _on_PuzzleScore_score_changed(_value: int) -> void:
+	update_milebar()
+
+
+func _on_PuzzleScore_bonus_score_changed(_value: int) -> void:
+	update_milebar()
+
+
+func _on_PuzzleScore_combo_ended() -> void:
+	update_milebar()
+
+
+func _on_PuzzleScore_after_scenario_prepared() -> void:
+	update_milebar()
+	
+	# Lock in the font size at the start, but leave it the same after that. It would be distracting if the font got
+	# bigger as the player progressed.
+	$Value.pick_largest_font()

--- a/src/main/puzzle/piece-sfx.gd
+++ b/src/main/puzzle/piece-sfx.gd
@@ -3,6 +3,15 @@ extends Node
 Plays sound effects when the player piece is moved.
 """
 
+func _ready() -> void:
+	PuzzleScore.connect("level_index_changed", self, "_on_PuzzleScore_level_index_changed")
+
+
+func _on_PuzzleScore_level_index_changed(value: int) -> void:
+	if value > 0:
+		$LevelUpSound.play()
+
+
 func _play_move_sfx() -> void:
 	$MoveSound.pitch_scale = 0.94
 	$MoveSound.volume_db = -4.00

--- a/src/main/puzzle/piece/piece-speeds.gd
+++ b/src/main/puzzle/piece/piece-speeds.gd
@@ -73,15 +73,39 @@ func _ready() -> void:
 	_add_speed(PieceSpeed.new( "FF", 20*G,  4, 2, 5,  8, 14, 3, 3))
 	_add_speed(PieceSpeed.new("FFF", 20*G,  4, 2, 5,  8, 12, 3, 3))
 	
-	# easter egg
-	_add_speed(PieceSpeed.new("DB", 1*G, 20, 20, 7, 16, 40, 24, 12))
-	
 	current_speed = PieceSpeeds.speed("0")
+	PuzzleScore.connect("level_index_changed", self, "_on_PuzzleScore_level_index_changed")
+	PuzzleScore.connect("lines_changed", self, "_on_PuzzleScore_lines_changed")
+	PuzzleScore.connect("after_scenario_prepared", self, "_on_PuzzleScore_after_scenario_prepared")
+
+
+func speed(string: String) -> PieceSpeed:
+	return _speeds[string]
 
 
 func _add_speed(speed: PieceSpeed) -> void:
 	_speeds[speed.level] = speed
 
 
-func speed(string: String) -> PieceSpeed:
-	return _speeds[string]
+func _update_current_speed() -> void:
+	var milestone: Milestone = Global.scenario_settings.level_ups[PuzzleScore.level_index]
+	PieceSpeeds.current_speed = PieceSpeeds.speed(milestone.get_meta("level"))
+
+
+func _on_PuzzleScore_lines_changed(value: int) -> void:
+	var new_level_index: int = PuzzleScore.level_index
+	
+	while new_level_index + 1 < Global.scenario_settings.level_ups.size() \
+			and Global.scenario_settings.level_ups[new_level_index + 1].value <= value:
+		new_level_index += 1
+	
+	if PuzzleScore.level_index != new_level_index:
+		PuzzleScore.level_index = new_level_index
+
+
+func _on_PuzzleScore_level_index_changed(value: int) -> void:
+	_update_current_speed()
+
+
+func _on_PuzzleScore_after_scenario_prepared() -> void:
+	_update_current_speed()

--- a/src/main/puzzle/puzzle-score.gd
+++ b/src/main/puzzle/puzzle-score.gd
@@ -14,28 +14,38 @@ signal game_prepared
 # emitted after everything's been erased in preparation for a new game.
 signal after_game_prepared
 
+# emitted after the scenario has customized the puzzle's settings.
+signal after_scenario_prepared
+
 signal game_started
 signal game_ended
-signal score_changed(value)
-signal bonus_score_changed(value)
+signal level_index_changed(value)
+
+# These four signals are always emitted in this order: customer_score, bonus_score, score, lines
 signal customer_score_changed(value)
+signal bonus_score_changed(value)
+signal score_changed(value)
+signal lines_changed(value)
+
 signal combo_ended
 
 # Player's performance on the current scenario
 var scenario_performance := ScenarioPerformance.new()
 
+# The scores for each customer in the current scenario (bonuses and line clears)
+var customer_scores := [0]
+
 # Bonus points awarded during the current combo. This only includes bonuses
 # and should be a round number like +55 or +130 for visual aesthetics.
 var bonus_score := 0
-
-# The scores for each customer in the current scenario (bonuses and line clears)
-var customer_scores := [0]
 
 # 'true' if the player has started a game which is still running.
 var game_active: bool
 
 # 'true' if the player has started a game, or the countdown is currently active.
 var game_prepared: bool
+
+var level_index: int setget set_level_index
 
 """
 Resets all score data to prepare for a new game.
@@ -51,15 +61,28 @@ func prepare_game() -> void:
 		Global.launched_scenario_name = Global.scenario_settings.name
 	
 	game_prepared = true
-	scenario_performance = ScenarioPerformance.new()
-	emit_signal("score_changed", 0)
-
-	bonus_score = 0
-	emit_signal("bonus_score_changed", 0)
 
 	customer_scores = [0]
+	bonus_score = 0
+	scenario_performance = ScenarioPerformance.new()
+	level_index = 0
+	
+	emit_signal("customer_score_changed", get_customer_score())
+	emit_signal("bonus_score_changed", get_bonus_score())
+	emit_signal("score_changed", get_score())
+	emit_signal("lines_changed", get_lines())
+	emit_signal("level_index_changed", level_index)
+	
 	emit_signal("game_prepared")
 	emit_signal("after_game_prepared")
+	emit_signal("after_scenario_prepared")
+
+
+func set_level_index(new_level_index: int) -> void:
+	if new_level_index == level_index:
+		return
+	level_index = new_level_index
+	emit_signal("level_index_changed", level_index)
 
 
 func start_game() -> void:
@@ -92,51 +115,62 @@ func add_line_score(combo_score: int, box_score: int) -> void:
 		# no money earned during tutorial
 		return
 	
-	scenario_performance.lines += 1
 	scenario_performance.combo_score += combo_score
 	scenario_performance.box_score += box_score
 	
-	_add_score(1)
-	_add_bonus_score(combo_score + box_score)
 	_add_customer_score(1 + combo_score + box_score)
+	_add_bonus_score(combo_score + box_score)
+	_add_score(1)
+	_add_line()
+
+	emit_signal("customer_score_changed", get_customer_score())
+	emit_signal("bonus_score_changed", get_bonus_score())
+	emit_signal("score_changed", get_score())
+	emit_signal("lines_changed", get_lines())
 
 
 """
 Ends the current combo, incrementing the score and resetting the bonus/customer scores to zero.
 """
 func end_combo() -> void:
-	_add_score(bonus_score)
-	
-	bonus_score = 0
-	emit_signal("bonus_score_changed", 0)
-	
-	if get_customer_score() == 0:
-		# don't add $0 customers. customers don't pay if they owe $0
-		pass
-	elif Global.scenario_settings.other.tutorial:
+	if Global.scenario_settings.other.tutorial:
 		# tutorial only has one customer
+		pass
+	elif get_customer_score() == 0:
+		# don't add $0 customers. customers don't pay if they owe $0
 		pass
 	else:
 		customer_scores.append(0)
-		emit_signal("customer_score_changed", 0)
-		emit_signal("combo_ended")
+	
+	_add_score(bonus_score)
+	bonus_score = 0
+		
+	emit_signal("customer_score_changed", 0)
+	emit_signal("bonus_score_changed", get_bonus_score())
+	emit_signal("score_changed", get_score())
+	emit_signal("combo_ended")
 
 
 """
 Reset all score data, such as when starting a scenario over.
 """
 func reset() -> void:
-	scenario_performance = ScenarioPerformance.new()
-	emit_signal("score_changed", 0)
+	customer_scores = [0]
+	emit_signal("customer_score_changed")
 	
 	bonus_score = 0
 	emit_signal("bonus_score_changed", 0)
 	
-	customer_scores = [0]
+	scenario_performance = ScenarioPerformance.new()
+	emit_signal("score_changed", 0)
 
 
 func get_score() -> int:
 	return scenario_performance.score
+
+
+func get_lines() -> int:
+	return scenario_performance.lines
 
 
 func get_bonus_score() -> int:
@@ -149,14 +183,15 @@ func get_customer_score() -> int:
 
 func _add_score(delta: int) -> void:
 	scenario_performance.score += delta
-	emit_signal("score_changed", get_score())
 
 
 func _add_bonus_score(delta: int) -> void:
 	bonus_score += delta
-	emit_signal("bonus_score_changed", bonus_score)
+
+
+func _add_line() -> void:
+	scenario_performance.lines += 1
 
 
 func _add_customer_score(delta: int) -> void:
 	customer_scores[customer_scores.size() - 1] += delta
-	emit_signal("customer_score_changed", get_customer_score())

--- a/src/main/puzzle/puzzle.gd
+++ b/src/main/puzzle/puzzle.gd
@@ -8,7 +8,6 @@ class to add goals, win conditions, challenges or time limits.
 # emitted a few seconds after the game ends, for displaying messages
 signal after_game_ended
 
-signal line_cleared(y, total_lines, remaining_lines, box_ints)
 signal topped_out
 
 onready var _go_voices := [$GoVoice0, $GoVoice1, $GoVoice2]
@@ -80,7 +79,6 @@ func start_game() -> void:
 Ends the game. This occurs when the player loses, wins, or runs out of time.
 """
 func end_game(delay: float, message: String) -> void:
-	PuzzleScore.end_game()
 	show_message(message)
 	yield(get_tree().create_timer(delay), "timeout")
 	emit_signal("after_game_ended")
@@ -88,27 +86,6 @@ func end_game(delay: float, message: String) -> void:
 
 func set_chalkboard_visible(visible: bool) -> void:
 	$Chalkboard.visible = visible
-
-
-"""
-Returns the milestone hud's description label.
-"""
-func miledesc() -> Label:
-	return $Chalkboard/MilestoneHud/Desc as Label
-
-
-"""
-Returns the milestone hud's progress bar.
-"""
-func milebar() -> ProgressBar:
-	return $Chalkboard/MilestoneHud/ProgressBar as ProgressBar
-
-
-"""
-Returns the milestone hud's value label.
-"""
-func milevalue() -> Label:
-	return $Chalkboard/MilestoneHud/Value as Label
 
 
 func clear_playfield() -> void:
@@ -159,7 +136,7 @@ func _on_Hud_start_button_pressed() -> void:
 
 
 """
-Relays the 'line_cleared' signal to any listeners, and triggers the 'customer feeding' animation
+Triggers the 'customer feeding' animation.
 """
 func _on_Playfield_line_cleared(y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
 	if not $Playfield.awarding_line_clear_points:
@@ -170,7 +147,6 @@ func _on_Playfield_line_cleared(y: int, total_lines: int, remaining_lines: int, 
 	var customer_talks: bool = remaining_lines == 0 and $Playfield/ComboTracker.combo >= 5 \
 			and total_lines > ($Playfield/ComboTracker.combo + 1) % 3
 	
-	emit_signal("line_cleared", y, total_lines, remaining_lines, box_ints)
 	_feed_customer(1.0 / (remaining_lines + 1))
 	
 	if customer_talks:

--- a/src/main/puzzle/scenario/Scenario.tscn
+++ b/src/main/puzzle/scenario/Scenario.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=2]
+[gd_scene load_steps=21 format=2]
 
 [ext_resource path="res://assets/ui/xolonium-24.tres" type="DynamicFont" id=1]
 [ext_resource path="res://assets/ui/blogger-sans-medium-30.tres" type="DynamicFont" id=2]
@@ -11,7 +11,6 @@
 [ext_resource path="res://assets/ui/excellent.wav" type="AudioStream" id=9]
 [ext_resource path="res://assets/ui/matchend.wav" type="AudioStream" id=10]
 [ext_resource path="res://assets/ui/applause.wav" type="AudioStream" id=11]
-[ext_resource path="res://assets/puzzle/levelup.wav" type="AudioStream" id=12]
 [ext_resource path="res://src/main/puzzle/scenario/SkillTallyItem.tscn" type="PackedScene" id=13]
 [ext_resource path="res://src/main/puzzle/scenario/tutorial-hud.gd" type="Script" id=14]
 [ext_resource path="res://assets/puzzle/scenario/tutorial-section-complete.wav" type="AudioStream" id=15]
@@ -254,10 +253,6 @@ volume_db = -4.0
 stream = ExtResource( 11 )
 bus = "Sound Bus"
 
-[node name="LevelUpSound" type="AudioStreamPlayer" parent="."]
-stream = ExtResource( 12 )
-bus = "Sound Bus"
-
 [node name="ExcellentSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 9 )
 bus = "Sound Bus"
@@ -275,7 +270,6 @@ script = ExtResource( 19 )
 
 [node name="SettingsMenu" parent="." instance=ExtResource( 20 )]
 [connection signal="after_game_ended" from="Puzzle" to="ResultsHud" method="_on_Puzzle_after_game_ended"]
-[connection signal="line_cleared" from="Puzzle" to="." method="_on_Puzzle_line_cleared"]
 [connection signal="pop_out_completed" from="TutorialHud/Message/Tween" to="TutorialHud/Message" method="_on_Tween_pop_out_completed"]
 [connection signal="tween_completed" from="TutorialHud/Message/Tween" to="TutorialHud/Message/Tween" method="_on_tween_completed"]
 [connection signal="cheat_detected" from="CheatCodeDetector" to="Puzzle/PuzzleTrace" method="_on_CheatCodeDetector_cheat_detected"]

--- a/src/main/puzzle/scenario/scenario-settings.gd
+++ b/src/main/puzzle/scenario/scenario-settings.gd
@@ -96,7 +96,7 @@ func set_win_condition(type: int, value: int, lenient_value: int = -1) -> void:
 
 
 """
-Returns either the win or finish condition, whichever is defined.
+Returns the win or finish condition, whichever is defined.
 
 If both are defined, the win condition takes precedence.
 """

--- a/src/main/puzzle/scenario/scenario.gd
+++ b/src/main/puzzle/scenario/scenario.gd
@@ -6,32 +6,11 @@ such as 'Marathon mode', a game style which gets harder and harder but theoretic
 good enough.
 """
 
-# Colors used to render the level number. Easy levels are green, and hard levels are red.
-const LEVEL_COLOR_0 := Color(0.111, 0.888, 0.111, 1)
-const LEVEL_COLOR_1 := Color(0.444, 0.888, 0.111, 1)
-const LEVEL_COLOR_2 := Color(0.888, 0.888, 0.111, 1)
-const LEVEL_COLOR_3 := Color(0.888, 0.444, 0.111, 1)
-const LEVEL_COLOR_4 := Color(0.888, 0.222, 0.111, 1)
-const LEVEL_COLOR_5 := Color(0.888, 0.111, 0.444, 1)
-
-var _xolonium_24 := preload("res://assets/ui/xolonium-24.tres")
-var _xolonium_36 := preload("res://assets/ui/xolonium-36.tres")
-var _xolonium_48 := preload("res://assets/ui/xolonium-48.tres")
-
 var _rank_calculator := RankCalculator.new()
-
-var _level := 0
-
-# milestone hud's description label, value label and progress bar
-onready var _miledesc: Label = $Puzzle.miledesc()
-onready var _milevalue: Label = $Puzzle.milevalue()
-onready var _milebar: Label = $Puzzle.milebar()
 
 func _ready() -> void:
 	PuzzleScore.reset() # erase any lines/score from previous games
-	PuzzleScore.connect("combo_ended", self, "_on_PuzzleScore_combo_ended")
 	PuzzleScore.connect("game_ended", self, "_on_PuzzleScore_game_ended")
-	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
 	PuzzleScore.connect("after_game_prepared", self, "_on_PuzzleScore_after_game_prepared")
 	
 	if Global.scenario_settings.other.tutorial:
@@ -40,57 +19,11 @@ func _ready() -> void:
 			"ear": "2", "horn": "0", "mouth": "1", "eye": "1"
 		})
 		$Puzzle/CustomerView.summon_customer()
-	init_milestone_hud()
 	prepare_scenario()
 
 
 func _physics_process(_delta: float) -> void:
-	if not PuzzleScore.game_active:
-		return
-	
-	match _winish_type():
-		Milestone.TIME:
-			check_for_match_end()
-
-
-func _process(_delta: float) -> void:
-	if not PuzzleScore.game_prepared:
-		return
-	
-	match _winish_type():
-		Milestone.SCORE, Milestone.TIME:
-			# update time display
-			_update_milestone_hud()
-
-"""
-Sets the speed level and updates the UI elements accordingly.
-"""
-func set_level(new_level:int) -> void:
-	_level = new_level
-	var milestone: Milestone = Global.scenario_settings.level_ups[new_level]
-	PieceSpeeds.current_speed = PieceSpeeds.speed(milestone.get_meta("level"))
-
-
-func init_milestone_hud() -> void:
-	match _winish_type():
-		Milestone.CUSTOMERS:
-			_miledesc.text = "Now Serving"
-			_milevalue.set("custom_fonts/font", _xolonium_36)
-			_milevalue.text = "1/%s" % _winish_value()
-		Milestone.LINES:
-			_miledesc.text = "Level"
-			_milevalue.rect_position.y = 24
-			_milevalue.set("custom_fonts/font", _xolonium_48)
-			set_level(0)
-			_update_milestone_hud()
-		Milestone.SCORE:
-			_miledesc.text = "Goal"
-			_milevalue.set("custom_fonts/font", _xolonium_24)
-			_milevalue.text = "¥%s" % _winish_value()
-		Milestone.TIME:
-			_miledesc.text = "Time"
-			_milevalue.set("custom_fonts/font", _xolonium_36)
-			_milevalue.text = StringUtils.format_duration(_winish_value())
+	check_for_match_end()
 
 
 func check_for_match_end() -> void:
@@ -99,98 +32,19 @@ func check_for_match_end() -> void:
 	
 	if _met_finish_condition(Global.scenario_settings.win_condition):
 		$ExcellentSound.play()
+		PuzzleScore.end_game()
 		$Puzzle.end_game(4.2, "You win!")
 	elif _met_finish_condition(Global.scenario_settings.finish_condition):
 		$MatchEndSound.play()
+		PuzzleScore.end_game()
 		var message := "Finish!"
 		if Global.scenario_settings.other.tutorial:
 			message = ""
 		$Puzzle.end_game(2.2, message)
 
 
-"""
-Prepare milestone hud content before the start of a game.
-
-This involves one-time setup such as fonts and progress bar boundaries.
-"""
-func _prepare_milestone_hud() -> void:
-	match _winish_type():
-		Milestone.CUSTOMERS:
-			_milebar.min_value = 1
-			_milebar.max_value = _winish_value() + 1
-		Milestone.SCORE:
-			_milevalue.set("custom_fonts/font", _xolonium_36)
-			_milebar.max_value = _winish_value()
-	
-	# Marathon mode varies its milestone progress bar color, but most modes just use white on cyan.
-	match _winish_type():
-		Milestone.LINES:
-			pass
-		_:
-			_milevalue.add_color_override("font_color", Color.white)
-			_milebar.get("custom_styles/fg").set_bg_color(Color(0.111, 0.888, 0.888, 0.333))
-
-
-"""
-Update the milestone hud's content during a game.
-
-This involves refreshing 
-"""
-func _update_milestone_hud() -> void:
-	match _winish_type():
-		Milestone.CUSTOMERS:
-			var customers := PuzzleScore.customer_scores.size()
-			_milevalue.text = "%s/%s" % [min(customers, _winish_value()), _winish_value()]
-			_milebar.value = customers
-		Milestone.LINES:
-			_milevalue.text = PieceSpeeds.current_speed.level
-			if _level + 1 < Global.scenario_settings.level_ups.size():
-				# marathon mode; fill up the bar as they approach the next level
-				_milebar.min_value = Global.scenario_settings.level_ups[_level].value
-				_milebar.max_value = Global.scenario_settings.level_ups[_level + 1].value
-			else:
-				# final level of marathon mode; fill up the bar as they near their goal
-				_milebar.min_value = Global.scenario_settings.level_ups[_level].value
-				_milebar.max_value = _winish_value()
-			_milebar.value = PuzzleScore.scenario_performance.lines
-		Milestone.SCORE:
-			_milevalue.text = StringUtils.format_duration(PuzzleScore.scenario_performance.seconds)
-			var total_score: int = PuzzleScore.get_score() + PuzzleScore.get_bonus_score()
-			_miledesc.text = "Time"
-			_milebar.value = total_score
-		Milestone.TIME:
-			_milevalue.text = \
-					StringUtils.format_duration(_winish_value() - PuzzleScore.scenario_performance.seconds)
-	
-	match _winish_type():
-		Milestone.LINES:
-			# For marathon mode, the progress bar changes from green to red as difficulty increases.
-			var level_color: Color
-			if PieceSpeeds.current_speed.gravity >= 20 * PieceSpeeds.G and PieceSpeeds.current_speed.lock_delay < 20:
-				level_color = LEVEL_COLOR_5
-			elif PieceSpeeds.current_speed.gravity >= 20 * PieceSpeeds.G:
-				level_color = LEVEL_COLOR_4
-			elif PieceSpeeds.current_speed.gravity >=  1 * PieceSpeeds.G:
-				level_color = LEVEL_COLOR_3
-			elif PieceSpeeds.current_speed.gravity >= 128:
-				level_color = LEVEL_COLOR_2
-			elif PieceSpeeds.current_speed.gravity >= 32:
-				level_color = LEVEL_COLOR_1
-			else:
-				level_color = LEVEL_COLOR_0
-			
-			_milevalue.add_color_override("font_color", level_color)
-			_milebar.get("custom_styles/fg").set_bg_color(Global.to_transparent(level_color, 0.333))
-		_:
-			pass
-
-
 func _winish_type() -> int:
 	return Global.scenario_settings.get_winish_condition().type
-
-
-func _winish_value() -> int:
-	return Global.scenario_settings.get_winish_condition().value
 
 
 func _met_finish_condition(condition: Milestone) -> bool:
@@ -211,17 +65,11 @@ func _met_finish_condition(condition: Milestone) -> bool:
 	return result
 
 
-func _on_PuzzleScore_game_prepared() -> void:
-	_prepare_milestone_hud()
-
-
 func _on_PuzzleScore_after_game_prepared() -> void:
 	prepare_scenario()
 
 
 func prepare_scenario() -> void:
-	set_level(0)
-	_update_milestone_hud()
 	prepare_blocks()
 	prepare_piece_types()
 	prepare_tutorial()
@@ -243,30 +91,6 @@ func prepare_blocks() -> void:
 func prepare_piece_types() -> void:
 	$Puzzle.set_piece_types(Global.scenario_settings.piece_types.types)
 	$Puzzle.set_piece_start_types(Global.scenario_settings.piece_types.start_types)
-
-
-func _on_Puzzle_line_cleared(y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
-	if not PuzzleScore.game_active:
-		return
-	
-	var lines: int = PuzzleScore.scenario_performance.lines
-	var new_level := _level
-	
-	while new_level + 1 < Global.scenario_settings.level_ups.size() \
-			and Global.scenario_settings.level_ups[new_level + 1].value <= lines:
-		new_level += 1
-	
-	if _level != new_level:
-		$LevelUpSound.play()
-		set_level(new_level)
-	
-	_update_milestone_hud()
-	check_for_match_end()
-
-
-func _on_PuzzleScore_combo_ended() -> void:
-	_update_milestone_hud()
-	check_for_match_end()
 
 
 """

--- a/src/main/puzzle/scenario/tutorial-hud.gd
+++ b/src/main/puzzle/scenario/tutorial-hud.gd
@@ -107,6 +107,7 @@ func _handle_squish_move_message() -> void:
 				append_message("Oh my,/ you're not supposed to know how to do that!\n\n..."
 						+ "But yes,/ squish moves can help you out of a jam.")
 				$SkillTallyItems/GridContainer/SquishMove.visible = true
+				$SkillTallyItems/GridContainer/SquishMove.increment()
 			"tutorial-beginner-2":
 				append_message("Well done!\n\nSquish moves can help you out of a jam./"
 						+ " They're also good for certain boxes.")
@@ -120,6 +121,7 @@ func _handle_make_box_message() -> void:
 						+ "...But yes,/ those boxes earn $15 when you clear them./"
 						+ " Maybe more if you're clever.")
 				$SkillTallyItems/GridContainer/SnackBox.visible = true
+				$SkillTallyItems/GridContainer/SnackBox.increment()
 			"tutorial-beginner-1":
 				append_message("Well done!\n\nThose boxes earn ¥15 when you clear them./"
 				+ " Maybe more if you're clever.")
@@ -175,7 +177,6 @@ func _advance_scenario() -> void:
 		# force match to end
 		PuzzleScore.scenario_performance.lines = 100
 		_scenario.check_for_match_end()
-		_scenario.init_milestone_hud()
 	elif _lines_cleared == 0:
 		_change_scenario("tutorial-beginner-0")
 	elif _boxes_made == 0:
@@ -205,7 +206,6 @@ func _change_scenario(name: String) -> void:
 			append_message("Nicely done!\n\nNext, try holding soft drop to squish these pieces through these gaps.")
 		"tutorial-beginner-3":
 			$SkillTallyItems/GridContainer/SnackStack.visible = true
-			$SkillTallyItems/GridContainer/SnackStack.reset()
 			append_message("One last lesson! Try holding soft drop to squish and complete these boxes.")
 		"tutorial-beginner-4":
 			# reset timer, scores

--- a/src/main/puzzle/score-value-label.gd
+++ b/src/main/puzzle/score-value-label.gd
@@ -9,4 +9,4 @@ func _ready() -> void:
 
 
 func _on_PuzzleScore_score_changed(value: int) -> void:
-	text = "¥%s" % value
+	text = "¥%s" % StringUtils.comma_sep(value)

--- a/src/main/puzzle/topout-tracker.gd
+++ b/src/main/puzzle/topout-tracker.gd
@@ -7,8 +7,9 @@ onready var _piece_manager: PieceManager = _puzzle.get_piece_manager()
 
 func make_player_lose() -> void:
 	PuzzleScore.scenario_performance.lost = true
+	PuzzleScore.end_game()
 	$GameOverSound.play()
-	_puzzle.end_game(2.4, "Game over")
+	_puzzle.end_game(2.2, "Game over")
 
 
 """

--- a/src/main/ui/SettingsMenu.tscn
+++ b/src/main/ui/SettingsMenu.tscn
@@ -12,6 +12,7 @@ pause_mode = 2
 script = ExtResource( 5 )
 
 [node name="Bg" type="ColorRect" parent="."]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 color = Color( 0, 0, 0, 0.752941 )
@@ -20,6 +21,7 @@ __meta__ = {
 }
 
 [node name="Window" type="Panel" parent="."]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5

--- a/src/main/ui/chat/ChatChoiceButton.tscn
+++ b/src/main/ui/chat/ChatChoiceButton.tscn
@@ -1,12 +1,16 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://assets/ui/chat/choice-theme.tres" type="Theme" id=1]
 [ext_resource path="res://src/main/ui/chat/mood-sprite.gd" type="Script" id=2]
 [ext_resource path="res://assets/ui/blogger-sans-medium-14.tres" type="DynamicFont" id=3]
 [ext_resource path="res://src/main/ui/chat/chat-choice-button.gd" type="Script" id=4]
-[ext_resource path="res://src/main/ui/chat/chat-choice-label.gd" type="Script" id=5]
+[ext_resource path="res://assets/ui/blogger-sans-medium-30.tres" type="DynamicFont" id=5]
 [ext_resource path="res://src/main/ui/chat/chat-choice-tween.gd" type="Script" id=6]
 [ext_resource path="res://assets/ui/chat/choice-mood-cry0.png" type="Texture" id=7]
+[ext_resource path="res://assets/ui/blogger-sans-medium-18.tres" type="DynamicFont" id=8]
+[ext_resource path="res://assets/ui/blogger-sans-medium-24.tres" type="DynamicFont" id=9]
+[ext_resource path="res://assets/ui/blogger-sans-medium-12.tres" type="DynamicFont" id=10]
+[ext_resource path="res://src/main/ui/font-fit-label.gd" type="Script" id=11]
 
 [sub_resource type="Animation" id=1]
 resource_name = "choose"
@@ -170,7 +174,7 @@ __meta__ = {
 }
 _choice_text = "Are you kidding me? That's not even close to what I said!"
 
-[node name="Label" type="Label" parent="."]
+[node name="FontFitLabel" type="Label" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 8.0
@@ -185,10 +189,11 @@ align = 1
 valign = 1
 autowrap = true
 max_lines_visible = 1
-script = ExtResource( 5 )
+script = ExtResource( 11 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+fonts = [ ExtResource( 5 ), ExtResource( 9 ), ExtResource( 8 ), ExtResource( 3 ), ExtResource( 10 ) ]
 
 [node name="MoodSprite" type="Control" parent="."]
 modulate = Color( 1, 1, 1, 0.894118 )
@@ -230,5 +235,4 @@ anims/choose = SubResource( 4 )
 [connection signal="focus_entered" from="." to="." method="_on_focus_entered"]
 [connection signal="focus_exited" from="." to="." method="_on_focus_exited"]
 [connection signal="resized" from="." to="." method="_on_resized"]
-[connection signal="resized" from="Label" to="Label" method="_on_resized"]
 [connection signal="animation_finished" from="PopAnimation" to="." method="_on_PopAnimation_animation_finished"]

--- a/src/main/ui/chat/chat-choice-button.gd
+++ b/src/main/ui/chat/chat-choice-button.gd
@@ -11,8 +11,8 @@ signal pop_choose_completed
 export (String) var _choice_text: String setget set_choice_text
 
 func _ready() -> void:
-	$Label.text = _choice_text
-	$Label.pick_largest_font()
+	$FontFitLabel.text = _choice_text
+	$FontFitLabel.pick_largest_font()
 	$MoodSprite/AnimationPlayer.advance(randf() * 2.5)
 	_set_pivot_to_center()
 
@@ -25,9 +25,9 @@ cannot wrap.
 """
 func set_choice_text(choice_text: String) -> void:
 	_choice_text = choice_text
-	if has_node("Label"):
-		$Label.text = _choice_text
-		$Label.pick_largest_font()
+	if has_node("FontFitLabel"):
+		$FontFitLabel.text = _choice_text
+		$FontFitLabel.pick_largest_font()
 
 
 """
@@ -93,7 +93,7 @@ When the chat choice is focused, it animates more visibly. The MoodSprite also b
 can read the text behind it.
 """
 func _on_focus_entered() -> void:
-	$Label.set("custom_colors/font_color", Color.white)
+	$FontFitLabel.set("custom_colors/font_color", Color.white)
 	$MoodSprite/AnimationPlayer.play("focus")
 	$MoodSprite/AnimationPlayer.advance(randf() * 2.5)
 
@@ -102,7 +102,7 @@ func _on_focus_entered() -> void:
 When the chat choice is unfocused, its animations are subtler.
 """
 func _on_focus_exited() -> void:
-	$Label.set("custom_colors/font_color", Color("6c4331"))
+	$FontFitLabel.set("custom_colors/font_color", Color("6c4331"))
 	$MoodSprite/AnimationPlayer.play("default")
 	$MoodSprite/AnimationPlayer.advance(randf() * 2.5)
 

--- a/src/main/ui/font-fit-label.gd
+++ b/src/main/ui/font-fit-label.gd
@@ -1,9 +1,6 @@
+class_name FontFitLabel
 extends Label
 """
-Label which displays the text of a chat choice button.
-
-We cannot use the button's text property because it does not support multiline text.
-
 This label changes its font dynamically based on the amount of text it needs to display. It chooses the largest font
 which will not overrun its boundaries.
 """
@@ -11,23 +8,29 @@ which will not overrun its boundaries.
 # When calculating how much text we can accommodate, there is a 3 pixel gap between each row.
 const FONT_GAP := 3
 
-# List of possible fonts ordered from largest to smallest
-onready var _fonts := [
-	preload("res://assets/ui/blogger-sans-medium-30.tres"),
-	preload("res://assets/ui/blogger-sans-medium-24.tres"),
-	preload("res://assets/ui/blogger-sans-medium-18.tres"),
-	preload("res://assets/ui/blogger-sans-medium-14.tres"),
-	preload("res://assets/ui/blogger-sans-medium-12.tres")
-]
+# Different fonts to try. Should be ordered from largest to smallest.
+export(Array, Font) var fonts := [] setget set_fonts
+
+func _ready() -> void:
+	connect("resized", self, "_on_resized")
+	pick_largest_font()
+	
+	# this class requires both autowrap and max_lines_visible to be set
+	autowrap = true
+	max_lines_visible = max(1, max_lines_visible)
+
 
 """
 Sets the label's font to the largest font which will accommodate its text.
+
+If the label's text is modified this should be called manually. This class cannot respond to text changes or override
+set_text because of Godot #29390 (https://github.com/godotengine/godot/issues/29390)
 """
 func pick_largest_font() -> void:
-	if not _fonts:
+	if not fonts:
 		return
-		
-	for font in _fonts:
+	
+	for font in fonts:
 		# start with the largest font, and try smaller and smaller fonts
 		max_lines_visible = (rect_size.y + FONT_GAP) / (font.get_height() + FONT_GAP)
 		set("custom_fonts/font", font)
@@ -36,7 +39,8 @@ func pick_largest_font() -> void:
 			break
 
 
-func _ready() -> void:
+func set_fonts(new_fonts: Array) -> void:
+	fonts = new_fonts
 	pick_largest_font()
 
 

--- a/src/main/ui/menu/MainMenu.tscn
+++ b/src/main/ui/menu/MainMenu.tscn
@@ -84,7 +84,7 @@ text = "Practice"
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
-anchor_bottom = 0.5
+anchor_bottom = 0.523333
 margin_top = -23.5
 margin_right = 512.0
 margin_bottom = 120.5
@@ -128,7 +128,6 @@ text = "Characters"
 [node name="VersionLabel" parent="." instance=ExtResource( 7 )]
 
 [node name="SettingsMenu" parent="." instance=ExtResource( 8 )]
-visible = false
 [connection signal="pressed" from="Play/Story" to="." method="_on_PlayStory_pressed"]
 [connection signal="pressed" from="Play/Practice" to="." method="_on_PlayPractice_pressed"]
 [connection signal="pressed" from="Create/Levels" to="." method="_on_CreateLevels_pressed"]

--- a/src/main/ui/menu/practice-mode-selector.gd
+++ b/src/main/ui/menu/practice-mode-selector.gd
@@ -44,10 +44,10 @@ func set_scenario(scenario: ScenarioSettings) -> void:
 			new_description = "Survive as the pieces get faster and faster! Can you clear %s lines?" \
 					% StringUtils.comma_sep(target_value)
 		"Ultra":
-			new_description = "Score %s points as quickly as possible!" \
+			new_description = "Earn ¥%s as quickly as possible!" \
 					% StringUtils.comma_sep(scenario.finish_condition.value)
 		"Sprint":
-			new_description = "Score as many points as you can in %s!" \
+			new_description = "Earn as much money as you can in %s!" \
 					% StringUtils.format_duration(scenario.finish_condition.value)
 	$Desc.text = new_description
 


### PR DESCRIPTION
A bug had been introduced where ultra no longer displayed something like
'$1000' on startup, and only displayed '2:30' in a tiny font. Upon further
consideration, I realized all modes for consistency should just display
the progress towards the goal.

Survival now displays the lines remaining. Ultra displays score remaining.
Sprint displays time remaining. The '5 customers' mode displays customers
remaining.

Also refactored the milestone label to use the same 'FontFitLabel' logic
as ChatChoiceLabel.

Extracted milestone-hud script from scenario.gd.

PuzzleScore now maintains the current level, and provides signals when
lines are cleared or the level is incremented.

Removed secret 'DB' level for easter egg. Level is no longer displayed,
and with the milestone hud changes this easter egg was becoming
cumbersome.

Made SettingsMenu components invisible so they don't block scenes in the
editor.