### PR TITLE
High score system no longer relies on 'ultra-' prefix

### DIFF
--- a/src/main/old-save.gd
+++ b/src/main/old-save.gd
@@ -70,6 +70,7 @@ func transform_old_save() -> void:
 	transformer.sub("\"marathon-", "\"survival-")
 	transformer.sub("scenario_name", "key")
 	transformer.sub("scen{\"scenario_history\":(\\[.*\\])(.*)}", "{\"type\":\"scenario-history\",\"value\":$1$2},")
+	transformer.sub("({[^{}]*)(}.*\"ultra-)", "$1,\"compare\":\"-seconds\"$2")
 	transformer.sub("\"died\":false", "\"top_out_count\":0,\"lost\":false")
 	transformer.sub("\"died\":true", "\"top_out_count\":1,\"lost\":true")
 	transformer.transformed = "[%s]" % transformer.transformed

--- a/src/main/puzzle/rank-calculator.gd
+++ b/src/main/puzzle/rank-calculator.gd
@@ -159,7 +159,10 @@ func _inner_calculate_rank(lenient: bool) -> RankResult:
 	var target_lines: float
 
 	var winish_condition: Milestone = Global.scenario_settings.get_winish_condition()
-
+	
+	if winish_condition.type == Milestone.SCORE:
+		rank_result.compare = "-seconds"
+	
 	match winish_condition.type:
 		Milestone.CUSTOMERS:
 			target_lines = MASTER_COMBO * winish_condition.value

--- a/src/main/puzzle/rank-result.gd
+++ b/src/main/puzzle/rank-result.gd
@@ -6,6 +6,11 @@ cleared, as well as derived statistics such as the computed lines-per-minute ran
 
 var timestamp := OS.get_datetime()
 
+# how this rank result should be compared:
+# '-seconds': lowest seconds is best
+# '+score': highest score is best (default)
+var compare := "+score"
+
 # player's speed in lines per minute.
 var speed := 0.0
 var speed_rank := 0.0
@@ -46,6 +51,7 @@ func to_json_dict() -> Dictionary:
 		"combo_score": combo_score,
 		"combo_score_per_line": combo_score_per_line,
 		"combo_score_per_line_rank": combo_score_per_line_rank,
+		"compare": compare,
 		"lines": lines,
 		"lines_rank": lines_rank,
 		"lost": lost,
@@ -66,6 +72,7 @@ func from_json_dict(json: Dictionary) -> void:
 	combo_score = int(json.get("combo_score", "0"))
 	combo_score_per_line = float(json.get("combo_score_per_line", "0"))
 	combo_score_per_line_rank = float(json.get("combo_score_per_line_rank", "999"))
+	compare = json.get("compare", "+score")
 	lines = int(json.get("lines", "0"))
 	lines_rank = float(json.get("lines_rank", "999"))
 	lost = bool(json.get("lost", "true"))

--- a/src/main/puzzle/scenario/scenario-history.gd
+++ b/src/main/puzzle/scenario/scenario-history.gd
@@ -57,10 +57,14 @@ func best_results(scenario: String, daily: bool) -> Array:
 				daily_results.append(result)
 		results = daily_results
 	
-	if ScenarioSettings.compare_seconds(scenario):
-		results.sort_custom(self, "_compare_by_seconds")
-	else:
-		results.sort_custom(self, "_compare_by_score")
+	if results:
+		# sort results
+		var result: RankResult = results[0]
+		match result.compare:
+			"-seconds":
+				results.sort_custom(self, "_compare_by_low_seconds")
+			_:
+				results.sort_custom(self, "_compare_by_high_score")
 	return results.slice(0, max_size - 1)
 
 
@@ -104,7 +108,7 @@ func prune(scenario: String) -> void:
 	rank_results[scenario] = [rank_results[scenario][0]] + best.keys()
 
 
-func _compare_by_seconds(a: RankResult, b: RankResult) -> bool:
+func _compare_by_low_seconds(a: RankResult, b: RankResult) -> bool:
 	# when comparing seconds, dying disqualifies you
 	if a.lost and b.lost:
 		return a.score > b.score
@@ -114,5 +118,5 @@ func _compare_by_seconds(a: RankResult, b: RankResult) -> bool:
 	return a.seconds < b.seconds
 
 
-func _compare_by_score(a: RankResult, b: RankResult) -> bool:
+func _compare_by_high_score(a: RankResult, b: RankResult) -> bool:
 	return a.score > b.score

--- a/src/main/puzzle/scenario/scenario-settings.gd
+++ b/src/main/puzzle/scenario/scenario-settings.gd
@@ -139,12 +139,3 @@ func from_json_dict(new_name: String, json: Dictionary) -> void:
 		score.from_json_string_array(json["score"])
 	if json.has("win-condition"):
 		win_condition.from_json_dict(json["win-condition"])
-
-
-"""
-Returns true if the specified scenario should be compared using seconds instead of score.
-
-This is true for 'ultra mode' where a lower time is better, and score is a tiebreaker.
-"""
-static func compare_seconds(scenario: String) -> bool:
-	return scenario.begins_with("ultra-")

--- a/src/main/ui/high-score-table.gd
+++ b/src/main/ui/high-score-table.gd
@@ -71,7 +71,7 @@ func _add_rows() -> void:
 		row.append(StringUtils.comma_sep(best_result.lines))
 		
 		# append score/time and grade
-		if ScenarioSettings.compare_seconds(_scenario.name):
+		if best_result.compare == "-seconds":
 			if best_result.lost:
 				row.append("-")
 			else:

--- a/src/main/ui/menu/PracticeMenu.tscn
+++ b/src/main/ui/menu/PracticeMenu.tscn
@@ -118,7 +118,6 @@ rect_min_size = Vector2( 120, 0 )
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_fonts/font = ExtResource( 6 )
-disabled = true
 toggle_mode = true
 group = ExtResource( 14 )
 text = "Rank"
@@ -181,15 +180,15 @@ max_value = 3.0
 tick_count = 4
 
 [node name="Labels" type="HBoxContainer" parent="VBoxContainer/Difficulty"]
-margin_left = 192.0
+margin_left = 188.0
 margin_top = 68.0
-margin_right = 792.0
+margin_right = 796.0
 margin_bottom = 88.0
-rect_min_size = Vector2( 600, 0 )
+rect_min_size = Vector2( 608, 0 )
 size_flags_horizontal = 4
 
 [node name="Normal" type="Label" parent="VBoxContainer/Difficulty/Labels"]
-margin_right = 98.0
+margin_right = 99.0
 margin_bottom = 20.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.5
@@ -197,8 +196,8 @@ custom_fonts/font = ExtResource( 7 )
 text = "Normal"
 
 [node name="Hard" type="Label" parent="VBoxContainer/Difficulty/Labels"]
-margin_left = 102.0
-margin_right = 298.0
+margin_left = 103.0
+margin_right = 301.0
 margin_bottom = 20.0
 size_flags_horizontal = 3
 custom_fonts/font = ExtResource( 7 )
@@ -206,8 +205,8 @@ text = "Hard"
 align = 1
 
 [node name="Expert" type="Label" parent="VBoxContainer/Difficulty/Labels"]
-margin_left = 302.0
-margin_right = 498.0
+margin_left = 305.0
+margin_right = 503.0
 margin_bottom = 20.0
 size_flags_horizontal = 3
 custom_fonts/font = ExtResource( 7 )
@@ -215,8 +214,8 @@ text = "Expert"
 align = 1
 
 [node name="Master" type="Label" parent="VBoxContainer/Difficulty/Labels"]
-margin_left = 502.0
-margin_right = 600.0
+margin_left = 507.0
+margin_right = 608.0
 margin_bottom = 20.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.5

--- a/src/test/test-backwards-compatible.gd
+++ b/src/test/test-backwards-compatible.gd
@@ -65,6 +65,22 @@ func test_timestamp_created() -> void:
 	assert_true(history_ultra.timestamp.has("second"))
 
 
+func test_compare_seconds() -> void:
+	assert_true(PlayerData.scenario_history.scenario_names().has("ultra-normal"))
+	var history_ultra: RankResult = PlayerData.scenario_history.results("ultra-normal")[0]
+	
+	# ultra records should be compared by lowest seconds. this 'compare' field didn't exist before
+	assert_eq(history_ultra.compare, "-seconds")
+
+
+func test_compare_score() -> void:
+	assert_true(PlayerData.scenario_history.scenario_names().has("sprint-normal"))
+	var history_sprint: RankResult = PlayerData.scenario_history.results("sprint-normal")[0]
+	
+	# sprint records should be compared by highest score. this 'compare' field didn't exist before
+	assert_eq(history_sprint.compare, "+score")
+
+
 func test_volume() -> void:
 	assert_almost_eq(PlayerData.volume_settings.get_bus_volume_linear(VolumeSettings.MUSIC), 0.500, 0.01)
 	assert_almost_eq(PlayerData.volume_settings.get_bus_volume_linear(VolumeSettings.SOUND), 0.500, 0.01)


### PR DESCRIPTION
The old logic looked at a scenario name to see if it started with
'ultra-', and those scenarios were compared differently. This is a poor
design because it requires all goal-based scenarios to start with the word
'ultra-'.

Now, we take any scenarios with a 'score' goal and give them a different
'compare' property. For now this can be '+score' or '-seconds', but in the
future other scenarios could have other definitions of what it means to
'do a good job at a level'. Some might compare how many or how few customers
you served, reaching a target score in as few lines as possible, or
maximizing the number of boxes made. These could all be represented in
data as something like '+customers', '-customers', '-lines' or
'+box_score'.