### PR TITLE
Added rank mode. Improved scenario format.

### DIFF
--- a/assets/puzzle/scenario/boatricia.json
+++ b/assets/puzzle/scenario/boatricia.json
@@ -1,7 +1,7 @@
 {
   "version": "15d2",
   "start-level": "0",
-  "win-condition": {
+  "finish-condition": {
     "type": "score",
     "value": "100"
   }

--- a/assets/puzzle/scenario/rank-10d.json
+++ b/assets/puzzle/scenario/rank-10d.json
@@ -1,0 +1,18 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "time-under",
+    "value": "300"
+  },
+  "start-level": "FC",
+  "finish-condition": {
+    "type": "score",
+    "value": "10000"
+  },
+  "lose-condition": [
+    "top-out 1"
+  ],
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/rank-1d.json
+++ b/assets/puzzle/scenario/rank-1d.json
@@ -1,0 +1,40 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "score",
+    "value": "1200"
+  },
+  "start-level": "A1",
+  "level-ups": [
+    {
+      "type": "lines",
+      "value": "40",
+      "level": "A2"
+    },
+    {
+      "type": "lines",
+      "value": "60",
+      "level": "A3"
+    },
+    {
+      "type": "lines",
+      "value": "80",
+      "level": "A4"
+    },
+    {
+      "type": "lines",
+      "value": "100",
+      "level": "A5"
+    }
+  ],
+  "finish-condition": {
+    "type": "lines",
+    "value": "180"
+  },
+  "lose-condition": [
+    "top-out 1"
+  ],
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/rank-1k.json
+++ b/assets/puzzle/scenario/rank-1k.json
@@ -1,5 +1,9 @@
 {
   "version": "15d2",
+  "success-condition": {
+    "type": "score",
+    "value": "1000"
+  },
   "start-level": "0",
   "level-ups": [
     {
@@ -48,15 +52,14 @@
       "level": "9"
     }
   ],
-  "success-condition": {
-    "type": "lines",
-    "value": "100"
-  },
   "finish-condition": {
     "type": "lines",
-    "value": "100"
+    "value": "150"
   },
   "lose-condition": [
     "top-out 1"
+  ],
+  "rank": [
+    "success-bonus 2"
   ]
 }

--- a/assets/puzzle/scenario/rank-2d.json
+++ b/assets/puzzle/scenario/rank-2d.json
@@ -1,0 +1,18 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "time-under",
+    "value": "300"
+  },
+  "start-level": "A5",
+  "finish-condition": {
+    "type": "score",
+    "value": "1500"
+  },
+  "lose-condition": [
+    "top-out 1"
+  ],
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/rank-2k.json
+++ b/assets/puzzle/scenario/rank-2k.json
@@ -1,0 +1,15 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "time-under",
+    "value": "180"
+  },
+  "start-level": "6",
+  "finish-condition": {
+    "type": "score",
+    "value": "500"
+  },
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/rank-3d.json
+++ b/assets/puzzle/scenario/rank-3d.json
@@ -1,0 +1,60 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "score",
+    "value": "750"
+  },
+  "start-level": "A5",
+  "level-ups": [
+    {
+      "type": "lines",
+      "value": "5",
+      "level": "A6"
+    },
+    {
+      "type": "lines",
+      "value": "10",
+      "level": "A7"
+    },
+    {
+      "type": "lines",
+      "value": "15",
+      "level": "A8"
+    },
+    {
+      "type": "lines",
+      "value": "20",
+      "level": "A9"
+    },
+    {
+      "type": "lines",
+      "value": "25",
+      "level": "AA"
+    },
+    {
+      "type": "lines",
+      "value": "30",
+      "level": "AB"
+    },
+    {
+      "type": "lines",
+      "value": "35",
+      "level": "AC"
+    },
+    {
+      "type": "lines",
+      "value": "40",
+      "level": "AD"
+    }
+  ],
+  "finish-condition": {
+    "type": "lines",
+    "value": "100"
+  },
+  "lose-condition": [
+    "top-out 1"
+  ],
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/rank-3k.json
+++ b/assets/puzzle/scenario/rank-3k.json
@@ -1,0 +1,21 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "score",
+    "value": "999"
+  },
+  "blocks-during": [
+    "clear-on-top-out"
+  ],
+  "start-level": "5",
+  "finish-condition": {
+    "type": "time-over",
+    "value": "540"
+  },
+  "lose-condition": [
+    "top-out 9"
+  ],
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/rank-4d.json
+++ b/assets/puzzle/scenario/rank-4d.json
@@ -1,0 +1,18 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "score",
+    "value": "2000"
+  },
+  "start-level": "AA",
+  "finish-condition": {
+    "type": "time-over",
+    "value": "300"
+  },
+  "lose-condition": [
+    "top-out 1"
+  ],
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/rank-4k.json
+++ b/assets/puzzle/scenario/rank-4k.json
@@ -1,0 +1,15 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "score",
+    "value": "300"
+  },
+  "start-level": "4",
+  "finish-condition": {
+    "type": "customers",
+    "value": "4"
+  },
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/rank-5d.json
+++ b/assets/puzzle/scenario/rank-5d.json
@@ -1,0 +1,45 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "score",
+    "value": "2500"
+  },
+  "start-level": "AA",
+  "level-ups": [
+    {
+      "type": "time-over",
+      "value": "60",
+      "level": "AB"
+    },
+    {
+      "type": "time-over",
+      "value": "120",
+      "level": "AC"
+    },
+    {
+      "type": "time-over",
+      "value": "180",
+      "level": "AD"
+    },
+    {
+      "type": "time-over",
+      "value": "240",
+      "level": "AA"
+    },
+    {
+      "type": "time-over",
+      "value": "300",
+      "level": "AE"
+    }
+  ],
+  "finish-condition": {
+    "type": "lines",
+    "value": "200"
+  },
+  "lose-condition": [
+    "top-out 1"
+  ],
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/rank-5k.json
+++ b/assets/puzzle/scenario/rank-5k.json
@@ -1,0 +1,15 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "score",
+    "value": "750"
+  },
+  "start-level": "3",
+  "finish-condition": {
+    "type": "lines",
+    "value": "100"
+  },
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/rank-6d.json
+++ b/assets/puzzle/scenario/rank-6d.json
@@ -1,0 +1,18 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "time-under",
+    "value": "180"
+  },
+  "start-level": "AE",
+  "finish-condition": {
+    "type": "score",
+    "value": "2000"
+  },
+  "lose-condition": [
+    "top-out 1"
+  ],
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/rank-6k.json
+++ b/assets/puzzle/scenario/rank-6k.json
@@ -1,0 +1,15 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "score",
+    "value": "200"
+  },
+  "start-level": "2",
+  "finish-condition": {
+    "type": "time-over",
+    "value": "180"
+  },
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/rank-7d.json
+++ b/assets/puzzle/scenario/rank-7d.json
@@ -1,0 +1,87 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "score",
+    "value": "4000"
+  },
+  "start-level": "A0",
+  "level-ups": [
+    {
+      "type": "lines",
+      "value": "20",
+      "level": "A1"
+    },
+    {
+      "type": "lines",
+      "value": "40",
+      "level": "A2"
+    },
+    {
+      "type": "lines",
+      "value": "60",
+      "level": "A3"
+    },
+    {
+      "type": "lines",
+      "value": "80",
+      "level": "A4"
+    },
+    {
+      "type": "lines",
+      "value": "100",
+      "level": "A5"
+    },
+
+    {
+      "type": "lines",
+      "value": "140",
+      "level": "AA"
+    },
+    {
+      "type": "lines",
+      "value": "160",
+      "level": "AC"
+    },
+    {
+      "type": "lines",
+      "value": "180",
+      "level": "AF"
+    },
+
+    {
+      "type": "lines",
+      "value": "220",
+      "level": "A1"
+    },
+    {
+      "type": "lines",
+      "value": "240",
+      "level": "A5"
+    },
+    {
+      "type": "lines",
+      "value": "260",
+      "level": "AA"
+    },
+    {
+      "type": "lines",
+      "value": "280",
+      "level": "AF"
+    },
+    {
+      "type": "lines",
+      "value": "300",
+      "level": "FA"
+    }
+  ],
+  "finish-condition": {
+    "type": "lines",
+    "value": "400"
+  },
+  "lose-condition": [
+    "top-out 1"
+  ],
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/rank-7k.json
+++ b/assets/puzzle/scenario/rank-7k.json
@@ -1,0 +1,15 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "time-under",
+    "value": "300"
+  },
+  "start-level": "1",
+  "finish-condition": {
+    "type": "score",
+    "value": "200"
+  },
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/rank-8d.json
+++ b/assets/puzzle/scenario/rank-8d.json
@@ -1,0 +1,18 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "score",
+    "value": "4000"
+  },
+  "start-level": "FA",
+  "finish-condition": {
+    "type": "time-over",
+    "value": "180"
+  },
+  "lose-condition": [
+    "top-out 1"
+  ],
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/rank-9d.json
+++ b/assets/puzzle/scenario/rank-9d.json
@@ -1,0 +1,18 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "score",
+    "value": "6000"
+  },
+  "start-level": "FB",
+  "finish-condition": {
+    "type": "lines",
+    "value": "200"
+  },
+  "lose-condition": [
+    "top-out 1"
+  ],
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/rank-m.json
+++ b/assets/puzzle/scenario/rank-m.json
@@ -1,0 +1,55 @@
+{
+  "version": "15d2",
+  "success-condition": {
+    "type": "score",
+    "value": "15000"
+  },
+  "start-level": "FA",
+  "level-ups": [
+    {
+      "type": "time-over",
+      "value": "60",
+      "level": "FB"
+    },
+    {
+      "type": "time-over",
+      "value": "120",
+      "level": "FC"
+    },
+    {
+      "type": "time-over",
+      "value": "180",
+      "level": "FD"
+    },
+    {
+      "type": "time-over",
+      "value": "240",
+      "level": "FE"
+    },
+    {
+      "type": "time-over",
+      "value": "300",
+      "level": "FF"
+    },
+    {
+      "type": "time-over",
+      "value": "360",
+      "level": "FD"
+    },
+    {
+      "type": "time-over",
+      "value": "480",
+      "level": "FFF"
+    }
+  ],
+  "finish-condition": {
+    "type": "lines",
+    "value": "600"
+  },
+  "lose-condition": [
+    "top-out 1"
+  ],
+  "rank": [
+    "success-bonus 2"
+  ]
+}

--- a/assets/puzzle/scenario/sprint-expert.json
+++ b/assets/puzzle/scenario/sprint-expert.json
@@ -2,7 +2,7 @@
   "version": "15d2",
   "start-level": "F0",
   "finish-condition": {
-    "type": "time",
+    "type": "time-over",
     "value": "180"
   }
 }

--- a/assets/puzzle/scenario/sprint-normal.json
+++ b/assets/puzzle/scenario/sprint-normal.json
@@ -2,7 +2,7 @@
   "version": "15d2",
   "start-level": "A0",
   "finish-condition": {
-    "type": "time",
+    "type": "time-over",
     "value": "150"
   }
 }

--- a/assets/puzzle/scenario/survival-expert.json
+++ b/assets/puzzle/scenario/survival-expert.json
@@ -33,7 +33,11 @@
       "level": "AF"
     }
   ],
-  "win-condition": {
+  "success-condition": {
+    "type": "lines",
+    "value": "300"
+  },
+  "finish-condition": {
     "type": "lines",
     "value": "300",
     "lenient-value": "200"

--- a/assets/puzzle/scenario/survival-hard.json
+++ b/assets/puzzle/scenario/survival-hard.json
@@ -48,7 +48,11 @@
       "level": "AA"
     }
   ],
-  "win-condition": {
+  "success-condition": {
+    "type": "lines",
+    "value": "200",
+  },
+  "finish-condition": {
     "type": "lines",
     "value": "200",
     "lenient-value": "150"

--- a/assets/puzzle/scenario/survival-master.json
+++ b/assets/puzzle/scenario/survival-master.json
@@ -28,7 +28,11 @@
       "level": "FF"
     }
   ],
-  "win-condition": {
+  "success-condition": {
+    "type": "lines",
+    "value": "500",
+  },
+  "finish-condition": {
     "type": "lines",
     "value": "500",
     "lenient-value": "300"

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,11 @@ _global_script_classes=[ {
 "path": "res://src/main/puzzle/piece/active-piece.gd"
 }, {
 "base": "Reference",
+"class": "BlocksDuring",
+"language": "GDScript",
+"path": "res://src/main/puzzle/scenario/blocks-during.gd"
+}, {
+"base": "Reference",
 "class": "BlocksStart",
 "language": "GDScript",
 "path": "res://src/main/puzzle/scenario/blocks-start.gd"
@@ -138,6 +143,11 @@ _global_script_classes=[ {
 "class": "Milestone",
 "language": "GDScript",
 "path": "res://src/main/puzzle/milestone.gd"
+}, {
+"base": "Control",
+"class": "MilestoneHud",
+"language": "GDScript",
+"path": "res://src/main/puzzle/milestone-hud.gd"
 }, {
 "base": "Control",
 "class": "MoneyLabel",
@@ -311,6 +321,7 @@ _global_script_classes=[ {
 } ]
 _global_script_class_icons={
 "ActivePiece": "",
+"BlocksDuring": "",
 "BlocksStart": "",
 "ChatAdvancer": "",
 "ChatAppearance": "",
@@ -336,6 +347,7 @@ _global_script_class_icons={
 "LoseConditionRules": "",
 "MainMenu": "",
 "Milestone": "",
+"MilestoneHud": "",
 "MoneyLabel": "",
 "MultiOutlineSprite": "",
 "NextPieceDisplay": "",

--- a/src/demo/RankCalculationDemo.tscn
+++ b/src/demo/RankCalculationDemo.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/demo/rank-calculation-demo.gd" type="Script" id=1]
+
+[node name="RankCalculationDemo" type="Label"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/src/demo/rank-calculation-demo.gd
+++ b/src/demo/rank-calculation-demo.gd
@@ -1,0 +1,176 @@
+extends Label
+"""
+Demo which performs some complex calculations to determine how fast someone would need to play to achieve a rank on a
+particular scenario.
+
+For example, to get rank 28 on the '2 kyu' scenario, a player would need to score 432 points. This is based on the
+rank requirements, the duration of the scenario, the piece speed and other factors.
+
+This was used to assign a roughly increasing level of difficulty for rank scenarios.
+"""
+
+var _data_per_rank := {
+	"7k": ["48", "1", "5:00"],
+	"6k": ["40", "2", "3:00"],
+	"5k": ["30", "3", "6:00"],
+	"4k": ["32", "4", "2:56"],
+	"3k": ["30", "5", "9:00"],
+	"2k": ["28", "6", "3:00"],
+	"1k": ["26", "0", "10:00"],
+	"1d": ["24", "A1", "6:00"],
+	"2d": ["20", "A5", "5:00"],
+	"3d": ["20", "A5", "4:00"],
+	"4d": ["16", "AA", "5:00"],
+	"5d": ["16", "AA", "6:00"],
+	"6d": ["10", "AE", "3:00"],
+	"7d": ["10", "A0", "10:00"],
+	"8d": ["7", "FA", "3:00"],
+	"9d": ["7", "FB", "4:00"],
+	"10d": ["4", "FC", "5:00"],
+	"M": ["4", "F0", "10:00"],
+}
+
+var _rank_calculator := RankCalculator.new()
+
+func _ready() -> void:
+	for data_key in _data_per_rank.keys():
+		# parse inputs
+		var target_rank: float = int(_data_per_rank[data_key][0])
+		var start_level: String = _data_per_rank[data_key][1]
+		var duration_string: String = _data_per_rank[data_key][2]
+		var seconds: float = StringUtils.parse_duration(duration_string)
+		
+		# calculate target lines and score for a fake scenario which resembles the game's scenario
+		Global.scenario_settings = _scenario_settings(data_key, start_level, seconds)
+		var target_score := _target_score(target_rank)
+		var target_lines := _target_lines(target_rank)
+		
+		# print the resulting lines and score
+		text += "Rank %s: %s points in %s (%s lines)\n" % [data_key, target_score, duration_string, target_lines]
+		
+		# for survival scenarios, also print a diminished score which is more realistic to reach under pressure
+		match(data_key):
+			"1k", "3d", "7d", "M":
+				var survival_points := (target_score - target_lines) * 0.6 + target_lines
+				text += "  (%s survival: %s points)\n" % [data_key, survival_points]
+
+
+"""
+Creates a scenario with the specified duration.
+
+The piece speed starts at the specified start level, but might increase depending on the specified data key. The speed
+increases defined in this method should align with the speed increases of the rank scenarios in the game.
+"""
+func _scenario_settings(data_key: String, start_level: String, seconds: float) -> ScenarioSettings:
+	var settings: ScenarioSettings = ScenarioSettings.new()
+	settings.set_start_level(start_level)
+	settings.set_finish_condition(Milestone.TIME_OVER, seconds)
+	
+	match(data_key):
+		"1k":
+			settings.set_start_level("0")
+			settings.add_level_up(Milestone.LINES, 10, "1")
+			settings.add_level_up(Milestone.LINES, 20, "2")
+			settings.add_level_up(Milestone.LINES, 30, "3")
+			settings.add_level_up(Milestone.LINES, 40, "4")
+			settings.add_level_up(Milestone.LINES, 50, "5")
+			settings.add_level_up(Milestone.LINES, 60, "6")
+			settings.add_level_up(Milestone.LINES, 110, "7")
+			settings.add_level_up(Milestone.LINES, 120, "8")
+			settings.add_level_up(Milestone.LINES, 130, "9")
+		"1d":
+			settings.set_start_level("A1")
+			settings.add_level_up(Milestone.LINES, 40, "A2")
+			settings.add_level_up(Milestone.LINES, 60, "A3")
+			settings.add_level_up(Milestone.LINES, 80, "A4")
+			settings.add_level_up(Milestone.LINES, 100, "A5")
+		"3d":
+			settings.set_start_level("A5")
+			settings.add_level_up(Milestone.LINES, 5, "A6")
+			settings.add_level_up(Milestone.LINES, 10, "A7")
+			settings.add_level_up(Milestone.LINES, 15, "A8")
+			settings.add_level_up(Milestone.LINES, 20, "A9")
+			settings.add_level_up(Milestone.LINES, 25, "AA")
+			settings.add_level_up(Milestone.LINES, 30, "AB")
+			settings.add_level_up(Milestone.LINES, 35, "AC")
+			settings.add_level_up(Milestone.LINES, 40, "AD")
+		"5d":
+			settings.set_start_level("AA")
+			settings.add_level_up(Milestone.TIME_OVER, 60, "AB")
+			settings.add_level_up(Milestone.TIME_OVER, 120, "AC")
+			settings.add_level_up(Milestone.TIME_OVER, 180, "AD")
+			settings.add_level_up(Milestone.TIME_OVER, 240, "AA")
+			settings.add_level_up(Milestone.TIME_OVER, 300, "AE")
+		"7d":
+			# similar to 1-dan
+			settings.set_start_level("A0")
+			settings.add_level_up(Milestone.LINES, 20, "A1")
+			settings.add_level_up(Milestone.LINES, 40, "A2")
+			settings.add_level_up(Milestone.LINES, 60, "A3")
+			settings.add_level_up(Milestone.LINES, 80, "A4")
+			settings.add_level_up(Milestone.LINES, 100, "A5")
+			
+			# ramp up to 20G
+			settings.add_level_up(Milestone.LINES, 150, "AA")
+			settings.add_level_up(Milestone.LINES, 170, "AC")
+			settings.add_level_up(Milestone.LINES, 190, "AF")
+			
+			# 20G+
+			settings.add_level_up(Milestone.LINES, 240, "A1")
+			settings.add_level_up(Milestone.LINES, 260, "A5")
+			settings.add_level_up(Milestone.LINES, 300, "AA")
+			settings.add_level_up(Milestone.LINES, 320, "AF")
+			settings.add_level_up(Milestone.LINES, 340, "FA")
+		"M":
+			settings.set_start_level("FA")
+			settings.add_level_up(Milestone.TIME_OVER, 60, "FB")
+			settings.add_level_up(Milestone.TIME_OVER, 120, "FC")
+			settings.add_level_up(Milestone.TIME_OVER, 180, "FD")
+			settings.add_level_up(Milestone.TIME_OVER, 240, "FE")
+			settings.add_level_up(Milestone.TIME_OVER, 300, "FF")
+			settings.add_level_up(Milestone.TIME_OVER, 360, "FD")
+			settings.add_level_up(Milestone.TIME_OVER, 480, "FFF")
+	return settings
+
+
+"""
+Binary search for how many points are needed to achieve the specified score_rank.
+
+This depends on the current scenario's duration and piece speed.
+"""
+func _target_score(target_rank: float) -> float:
+	var min_score := 0
+	var max_score := 50000
+	var rank_result: RankResult
+	for _i in range(20):
+		PuzzleScore.scenario_performance.score = (min_score + max_score) / 2.0
+		rank_result = _rank_calculator.calculate_rank()
+		if rank_result.score_rank > target_rank:
+			# graded poorly; we need to score more points
+			min_score = PuzzleScore.scenario_performance.score
+		else:
+			# graded well; we need to score fewer points
+			max_score = PuzzleScore.scenario_performance.score
+	return (min_score + max_score) / 2.0
+
+
+"""
+Binary search for how many lines are needed to achieve the specified line_rank.
+
+This depends on the current scenario's duration and piece speed.
+"""
+func _target_lines(target_rank: int) -> float:
+	Global.scenario_settings.finish_condition.type = Milestone.LINES
+	var min_target_lines := 0
+	var max_target_lines := 5000
+	var rank_result: RankResult
+	for _i in range(20):
+		PuzzleScore.scenario_performance.lines = ceil((min_target_lines + max_target_lines) / 2.0)
+		rank_result = _rank_calculator.calculate_rank()
+		if rank_result.lines_rank > target_rank:
+			# graded poorly; we need to clear more lines than that
+			min_target_lines = PuzzleScore.scenario_performance.lines
+		else:
+			# graded well; we need to clear fewer lines than that
+			max_target_lines = PuzzleScore.scenario_performance.lines
+	return (max_target_lines + min_target_lines) / 2.0

--- a/src/main/puzzle/milestone.gd
+++ b/src/main/puzzle/milestone.gd
@@ -11,14 +11,16 @@ enum MilestoneType {
 	CUSTOMERS,
 	LINES,
 	SCORE,
-	TIME
+	TIME_OVER,
+	TIME_UNDER
 }
 
 const NONE := MilestoneType.NONE
 const CUSTOMERS := MilestoneType.CUSTOMERS
 const LINES := MilestoneType.LINES
 const SCORE := MilestoneType.SCORE
-const TIME := MilestoneType.TIME
+const TIME_OVER := MilestoneType.TIME_OVER
+const TIME_UNDER := MilestoneType.TIME_UNDER
 
 # converts json strings into milestone types
 const JSON_MILESTONE_TYPES := {
@@ -26,13 +28,15 @@ const JSON_MILESTONE_TYPES := {
 	"customers": MilestoneType.CUSTOMERS,
 	"lines": MilestoneType.LINES,
 	"score": MilestoneType.SCORE,
-	"time": MilestoneType.TIME
+	"time-over": MilestoneType.TIME_OVER,
+	"time-under": MilestoneType.TIME_UNDER,
 }
 
 # These two parameters describe a MilestoneType and value to reach, such as scoring 50 points, clearing 10 lines
 # or surviving for 30 seconds.
 var type: int
 var value: int
+
 
 func from_json_dict(json: Dictionary) -> void:
 	type = JSON_MILESTONE_TYPES.get(json.get("type"), MilestoneType.NONE)

--- a/src/main/puzzle/piece/piece-speeds.gd
+++ b/src/main/puzzle/piece/piece-speeds.gd
@@ -96,7 +96,7 @@ func _on_PuzzleScore_lines_changed(value: int) -> void:
 	var new_level_index: int = PuzzleScore.level_index
 	
 	while new_level_index + 1 < Global.scenario_settings.level_ups.size() \
-			and Global.scenario_settings.level_ups[new_level_index + 1].value <= value:
+			and PuzzleScore.milestone_met(Global.scenario_settings.level_ups[new_level_index + 1]):
 		new_level_index += 1
 	
 	if PuzzleScore.level_index != new_level_index:

--- a/src/main/puzzle/puzzle.gd
+++ b/src/main/puzzle/puzzle.gd
@@ -84,6 +84,10 @@ func end_game(delay: float, message: String) -> void:
 	emit_signal("after_game_ended")
 
 
+func get_milestone_hud() -> MilestoneHud:
+	return $Chalkboard/MilestoneHud as MilestoneHud
+
+
 func set_chalkboard_visible(visible: bool) -> void:
 	$Chalkboard.visible = visible
 

--- a/src/main/puzzle/rank-calculator.gd
+++ b/src/main/puzzle/rank-calculator.gd
@@ -38,7 +38,7 @@ the match, and return the better of the two ranks.
 """
 func calculate_rank() -> RankResult:
 	var rank_result := _inner_calculate_rank(false)
-	if Global.scenario_settings.win_condition.has_meta("lenient_value"):
+	if Global.scenario_settings.finish_condition.has_meta("lenient_value"):
 		var rank_results_lenient := _inner_calculate_rank(true)
 		rank_result.speed_rank = min(rank_result.speed_rank, rank_results_lenient.speed_rank)
 		rank_result.lines_rank = min(rank_result.lines_rank, rank_results_lenient.lines_rank)
@@ -113,7 +113,7 @@ func _max_lpm() -> float:
 		
 		var frames_per_line := min_frames_per_line(piece_speed)
 		
-		var winish_condition: Milestone = Global.scenario_settings.get_winish_condition()
+		var finish_condition: Milestone = Global.scenario_settings.finish_condition
 		var level_lines := 100
 		if i + 1 < Global.scenario_settings.level_ups.size():
 			var level_up: Milestone = Global.scenario_settings.level_ups[i + 1]
@@ -122,14 +122,14 @@ func _max_lpm() -> float:
 					level_lines = MASTER_COMBO
 				Milestone.LINES:
 					level_lines = level_up.value
-				Milestone.TIME:
+				Milestone.TIME_OVER:
 					level_lines = level_up.value * 60 / frames_per_line
 				Milestone.SCORE:
 					level_lines = level_up.value / (master_box_score() + master_combo_score() + 1)
-		elif winish_condition.type == Milestone.LINES:
-			level_lines = winish_condition.value
-		elif winish_condition.type == Milestone.SCORE:
-			level_lines = winish_condition.value / (master_box_score() + master_combo_score() + 1)
+		elif finish_condition.type == Milestone.LINES:
+			level_lines = finish_condition.value
+		elif finish_condition.type == Milestone.SCORE:
+			level_lines = finish_condition.value / (master_box_score() + master_combo_score() + 1)
 
 		total_frames += frames_per_line * level_lines
 		total_lines += level_lines
@@ -158,21 +158,21 @@ func _inner_calculate_rank(lenient: bool) -> RankResult:
 	var target_combo_score_per_line := master_combo_score()
 	var target_lines: float
 
-	var winish_condition: Milestone = Global.scenario_settings.get_winish_condition()
+	var finish_condition: Milestone = Global.scenario_settings.finish_condition
 	
-	if winish_condition.type == Milestone.SCORE:
+	if finish_condition.type == Milestone.SCORE:
 		rank_result.compare = "-seconds"
 	
-	match winish_condition.type:
+	match finish_condition.type:
 		Milestone.CUSTOMERS:
-			target_lines = MASTER_COMBO * winish_condition.value
+			target_lines = MASTER_COMBO * finish_condition.value
 		Milestone.LINES:
-			target_lines = winish_condition.get_meta("lenient_value") if lenient else winish_condition.value
+			target_lines = finish_condition.get_meta("lenient_value") if lenient else finish_condition.value
 		Milestone.SCORE:
-			target_lines = ceil((winish_condition.value + COMBO_DEFICIT[COMBO_DEFICIT.size() - 1]) \
+			target_lines = ceil((finish_condition.value + COMBO_DEFICIT[COMBO_DEFICIT.size() - 1]) \
 					/ (target_box_score_per_line + target_combo_score_per_line + 1))
-		Milestone.TIME:
-			target_lines = max_lpm * winish_condition.value / 60.0
+		Milestone.TIME_OVER:
+			target_lines = max_lpm * finish_condition.value / 60.0
 
 	# calculate raw player performance statistics
 	rank_result.box_score = PuzzleScore.scenario_performance.box_score
@@ -189,12 +189,12 @@ func _inner_calculate_rank(lenient: bool) -> RankResult:
 	rank_result.speed = 60 * float(rank_result.lines) / max(rank_result.seconds, 1)
 	
 	# calculate rank
-	rank_result.speed_rank = clamp(log(rank_result.speed / target_speed) / log(RDF_SPEED), 0, 999)
-	rank_result.lines_rank = clamp(log(rank_result.lines / target_lines) / log(RDF_LINES), 0, 999)
-	rank_result.box_score_per_line_rank = clamp(log(
-			rank_result.box_score_per_line / target_box_score_per_line) / log(RDF_BOX_SCORE_PER_LINE), 0, 999)
-	rank_result.combo_score_per_line_rank = clamp(log(
-			rank_result.combo_score_per_line / target_combo_score_per_line) / log(RDF_COMBO_SCORE_PER_LINE), 0, 999)
+	rank_result.speed_rank = log(rank_result.speed / target_speed) / log(RDF_SPEED)
+	rank_result.lines_rank = log(rank_result.lines / target_lines) / log(RDF_LINES)
+	rank_result.box_score_per_line_rank = log(rank_result.box_score_per_line / target_box_score_per_line) \
+			/ log(RDF_BOX_SCORE_PER_LINE)
+	rank_result.combo_score_per_line_rank = log(rank_result.combo_score_per_line / target_combo_score_per_line) \
+			/ log(RDF_COMBO_SCORE_PER_LINE)
 	rank_result.seconds_rank = 999.0
 	rank_result.score_rank = 999.0
 	
@@ -208,10 +208,10 @@ func _inner_calculate_rank(lenient: bool) -> RankResult:
 				* pow(RDF_BOX_SCORE_PER_LINE, tmp_overall_rank)
 		var tmp_combo_score_per_line := target_combo_score_per_line \
 				* pow(RDF_COMBO_SCORE_PER_LINE, tmp_overall_rank)
-		if winish_condition.type == Milestone.SCORE:
+		if rank_result.compare == "-seconds":
 			var tmp_speed := target_speed * pow(RDF_SPEED, tmp_overall_rank)
 			var points_per_second := (tmp_speed * (1 + tmp_box_score_per_line + tmp_combo_score_per_line)) / 60
-			if (winish_condition.value + COMBO_DEFICIT[COMBO_DEFICIT.size() - 1]) / points_per_second \
+			if (finish_condition.value + COMBO_DEFICIT[COMBO_DEFICIT.size() - 1]) / points_per_second \
 					< rank_result.seconds:
 				overall_rank_min = tmp_overall_rank
 			else:
@@ -222,37 +222,62 @@ func _inner_calculate_rank(lenient: bool) -> RankResult:
 				overall_rank_min = tmp_overall_rank
 			else:
 				overall_rank_max = tmp_overall_rank
-	if winish_condition.type == Milestone.SCORE:
-		rank_result.seconds_rank = stepify((overall_rank_max + overall_rank_min) / 2.0, 0.01)
+	
+	if rank_result.compare == "-seconds":
+		if rank_result.lost:
+			rank_result.seconds_rank = 999
+		else:
+			rank_result.seconds_rank = stepify((overall_rank_max + overall_rank_min) / 2.0, 0.01)
 	else:
 		rank_result.score_rank = stepify((overall_rank_max + overall_rank_min) / 2.0, 0.01)
 	
-	if lenient:
-		# can't go above S++ with 'lenient' scoring
-		rank_result.speed_rank = max(1, rank_result.speed_rank)
-		rank_result.lines_rank = max(1, rank_result.lines_rank)
-		rank_result.box_score_per_line_rank = max(1, rank_result.box_score_per_line_rank)
-		rank_result.combo_score_per_line_rank = max(1, rank_result.combo_score_per_line_rank)
-		rank_result.score_rank = max(1, rank_result.score_rank)
-		rank_result.seconds_rank = max(1, rank_result.seconds_rank)
+	if PuzzleScore.milestone_met(Global.scenario_settings.success_condition):
+		if rank_result.compare == "-seconds":
+			rank_result.seconds_rank -= Global.scenario_settings.rank.success_bonus
+		else:
+			rank_result.score_rank -= Global.scenario_settings.rank.success_bonus
 	
-	if rank_result.topped_out() or rank_result.lost:
-		# if they lose without topping out, we still apply one top out penalty.
-		# this keeps people from hitting 'esc' to get a good rank
-		var penalty_count := max(1, rank_result.top_out_count)
-		var all_penalty := penalty_count * Global.scenario_settings.rank.top_out_penalty
-		rank_result.speed_rank = min(rank_result.speed_rank + all_penalty, 999)
-		rank_result.lines_rank = min(rank_result.lines_rank + all_penalty, 999)
-		rank_result.box_score_per_line_rank = min(rank_result.box_score_per_line_rank + all_penalty, 999)
-		rank_result.combo_score_per_line_rank = min(rank_result.combo_score_per_line_rank + all_penalty, 999)
-		rank_result.score_rank = min(rank_result.score_rank + all_penalty, 999)
-		rank_result.seconds_rank = min(rank_result.seconds_rank + all_penalty, 999)
-	
-	if rank_result.lost:
-		if winish_condition.type == Milestone.SCORE:
-			rank_result.seconds_rank = 999
+	_apply_top_out_penalty(rank_result)
+	_clamp_result(rank_result, lenient)
 	
 	return rank_result
+
+
+"""
+Reduces the player's ranks if they topped out.
+
+Each time the player tops out, all of their ranks are reduced by a certain amount.
+
+It's also possible for the player to lose without topping out, if they either met a special lose condition or hit
+'esc' to give up on the level. In this case, we still apply one top out penalty. This prevents people from losing on
+purpose to achieve a good rank.
+"""
+func _apply_top_out_penalty(rank_result: RankResult) -> void:
+	if rank_result.topped_out() or rank_result.lost:
+		var penalty_count := max(1, rank_result.top_out_count)
+		var all_penalty := penalty_count * Global.scenario_settings.rank.top_out_penalty
+		rank_result.speed_rank = rank_result.speed_rank + all_penalty
+		rank_result.lines_rank = rank_result.lines_rank + all_penalty
+		rank_result.box_score_per_line_rank = rank_result.box_score_per_line_rank + all_penalty
+		rank_result.combo_score_per_line_rank = rank_result.combo_score_per_line_rank + all_penalty
+		rank_result.score_rank = rank_result.score_rank + all_penalty
+		rank_result.seconds_rank = rank_result.seconds_rank + all_penalty
+
+
+"""
+Clamps the player's ranks within [0, 999] to avoid edge cases.
+
+The player cannot achieve a master rank if the lenient flag is set.
+"""
+func _clamp_result(rank_result: RankResult, lenient: bool) -> void:
+	var min_rank := 1 if lenient else 0
+	var max_rank := 999
+	rank_result.speed_rank = clamp(rank_result.speed_rank, min_rank, max_rank)
+	rank_result.lines_rank = clamp(rank_result.lines_rank, min_rank, max_rank)
+	rank_result.box_score_per_line_rank = clamp(rank_result.box_score_per_line_rank, min_rank, max_rank)
+	rank_result.combo_score_per_line_rank = clamp(rank_result.combo_score_per_line_rank, min_rank, max_rank)
+	rank_result.score_rank = clamp(rank_result.score_rank, min_rank, max_rank)
+	rank_result.seconds_rank = clamp(rank_result.seconds_rank, min_rank, max_rank)
 
 
 """

--- a/src/main/puzzle/results-hud.gd
+++ b/src/main/puzzle/results-hud.gd
@@ -121,7 +121,7 @@ func _on_Puzzle_after_game_ended() -> void:
 		return
 	
 	var customer_scores: Array = PuzzleScore.customer_scores
-	var finish_condition_type := Global.scenario_settings.get_winish_condition().type
+	var finish_condition_type := Global.scenario_settings.finish_condition.type
 	
 	show_results_message(rank_result, customer_scores, finish_condition_type)
 

--- a/src/main/puzzle/scenario/blocks-during.gd
+++ b/src/main/puzzle/scenario/blocks-during.gd
@@ -1,0 +1,11 @@
+class_name BlocksDuring
+"""
+Blocks/boxes which appear or disappear while the game is going on.
+"""
+
+# if true, the entire playfield is cleared when the player tops out
+var clear_on_top_out := false
+
+func from_json_string_array(json: Array) -> void:
+	var rules := RuleParser.new(json)
+	if rules.has("clear-on-top-out"): clear_on_top_out = true

--- a/src/main/puzzle/scenario/rank-rules.gd
+++ b/src/main/puzzle/scenario/rank-rules.gd
@@ -11,6 +11,11 @@ var box_factor := 1.0
 # needs 3x the usual combo points per line to get a good rank
 var combo_factor := 1.0
 
+# Bonus rank given if the player achieves the scenario's success condition. Useful when designing scenarios where
+# achieving a target score of 1,000 is an A grade, but failing with a score of 999 is also an A grade. This property
+# gives the player a little bump in rank so achieving the target score will always result in a higher grade.
+var success_bonus := 0.0
+
 # rank penalty applied each time the player tops out
 var top_out_penalty := 4
 
@@ -21,5 +26,6 @@ func from_json_string_array(json: Array) -> void:
 	var rules := RuleParser.new(json)
 	if rules.has("combo-factor"): combo_factor = rules.float_value()
 	if rules.has("box-factor"): box_factor = rules.float_value()
+	if rules.has("success-bonus"): success_bonus = rules.float_value()
 	if rules.has("top-out-penalty"): top_out_penalty = rules.int_value()
 	if rules.has("skip-results"): skip_results = true

--- a/src/main/puzzle/scenario/scenario-settings.gd
+++ b/src/main/puzzle/scenario/scenario-settings.gd
@@ -13,6 +13,9 @@ const SCENARIO_DATA_VERSION := "15d2"
 # Blocks/boxes which begin on the playfield.
 var blocks_start := BlocksStart.new()
 
+# Blocks/boxes which appear or disappear while the game is going on.
+var blocks_during := BlocksDuring.new()
+
 # Things that disrupt the player's combo.
 var combo_break := ComboBreakRules.new()
 
@@ -43,9 +46,9 @@ var rank := RankRules.new()
 # Rules for scoring points.
 var score := ScoreRules.new()
 
-# How the player wins. When the player wins, there's a big fanfare and celebration, it should be used for
-# accomplishments such as surviving 10 minutes or getting 1,000 points. 
-var win_condition := Milestone.new()
+# How the player succeeds. When the player succeeds, there's a big fanfare and celebration, it should be used for
+# accomplishments such as surviving 10 minutes or getting 1,000 points.
+var success_condition := Milestone.new()
 
 func _init() -> void:
 	# avoid edge cases caused by absence of a speed level
@@ -65,7 +68,7 @@ func add_level_up(type: int, value: int, level: String) -> void:
 
 func reset() -> void:
 	level_ups.clear()
-	win_condition = Milestone.new()
+	success_condition = Milestone.new()
 	finish_condition = Milestone.new()
 	name = ""
 
@@ -78,30 +81,21 @@ func set_start_level(level: String) -> void:
 """
 Sets the criteria for finishing the scenario, such as a time, score, or line goal.
 """
-func set_finish_condition(type: int, value: int) -> void:
+func set_finish_condition(type: int, value: int, lenient_value: int = -1) -> void:
 	finish_condition = Milestone.new()
 	finish_condition.type = type
 	finish_condition.value = value
-
-
-"""
-Sets the criteria for winning the scenario, such as a time, score, or line goal.
-"""
-func set_win_condition(type: int, value: int, lenient_value: int = -1) -> void:
-	win_condition = Milestone.new()
-	win_condition.type = type
-	win_condition.value = value
 	if lenient_value > -1:
-		win_condition.set_meta("lenient_value", lenient_value)
+		finish_condition.set_meta("lenient_value", lenient_value)
 
 
 """
-Returns the win or finish condition, whichever is defined.
-
-If both are defined, the win condition takes precedence.
+Sets the criteria for succeeding, such as a time or score goal.
 """
-func get_winish_condition() -> Milestone:
-	return win_condition if win_condition.type != Milestone.NONE else finish_condition
+func set_success_condition(type: int, value: int) -> void:
+	success_condition = Milestone.new()
+	success_condition.type = type
+	success_condition.value = value
 
 
 """
@@ -118,6 +112,8 @@ func from_json_dict(new_name: String, json: Dictionary) -> void:
 	set_start_level(json["start-level"])
 	if json.has("blocks-start"):
 		blocks_start.from_json_dict(json["blocks-start"])
+	if json.has("blocks-during"):
+		blocks_during.from_json_string_array(json["blocks-during"])
 	if json.has("combo-break"):
 		combo_break.from_json_string_array(json["combo-break"])
 	if json.has("finish-condition"):
@@ -137,5 +133,5 @@ func from_json_dict(new_name: String, json: Dictionary) -> void:
 		rank.from_json_string_array(json["rank"])
 	if json.has("score"):
 		score.from_json_string_array(json["score"])
-	if json.has("win-condition"):
-		win_condition.from_json_dict(json["win-condition"])
+	if json.has("success-condition"):
+		success_condition.from_json_dict(json["success-condition"])

--- a/src/main/puzzle/topout-tracker.gd
+++ b/src/main/puzzle/topout-tracker.gd
@@ -24,5 +24,8 @@ func _on_PieceManager_topped_out() -> void:
 	else:
 		var top_out_delay := PieceSpeeds.current_speed.appearance_delay + PieceSpeeds.current_speed.lock_delay
 		_playfield.break_combo()
-		_playfield.schedule_line_clears(range(Playfield.ROW_COUNT - 6, Playfield.ROW_COUNT), top_out_delay, false)
+		if Global.scenario_settings.blocks_during.clear_on_top_out:
+			_playfield.schedule_line_clears(range(0, Playfield.ROW_COUNT), top_out_delay, false)
+		else:
+			_playfield.schedule_line_clears(range(Playfield.ROW_COUNT - 6, Playfield.ROW_COUNT), top_out_delay, false)
 		_piece_manager.enter_top_out_state(top_out_delay)

--- a/src/main/string-utils.gd
+++ b/src/main/string-utils.gd
@@ -61,3 +61,11 @@ Formats a duration like 63.159 into '1:03'
 """
 static func format_duration(seconds: float) -> String:
 	return "%01d:%02d" % [int(ceil(seconds)) / 60, int(ceil(seconds)) % 60]
+
+
+"""
+Parses a duration like 1:03.159 into '63.159'
+"""
+static func parse_duration(s: String) -> float:
+	var split: Array = s.split(":")
+	return int(split[0]) * 60 + float(split[1])

--- a/src/main/ui/high-score-table.gd
+++ b/src/main/ui/high-score-table.gd
@@ -72,13 +72,16 @@ func _add_rows() -> void:
 		
 		# append score/time and grade
 		if best_result.compare == "-seconds":
+			var seconds_string := StringUtils.format_duration(best_result.seconds)
 			if best_result.lost:
-				row.append("-")
-			else:
-				row.append(StringUtils.format_duration(best_result.seconds))
+				seconds_string = "-"
+			row.append(seconds_string)
 			row.append(RankCalculator.grade(best_result.seconds_rank))
 		else:
-			row.append(StringUtils.comma_sep(best_result.score))
+			var score_string := "¥%s" % StringUtils.comma_sep(best_result.score)
+			if best_result.lost:
+				score_string += "*"
+			row.append(score_string)
 			row.append(RankCalculator.grade(best_result.score_rank))
 		
 		_add_row(row)

--- a/src/main/ui/menu/practice-difficulty-selector.gd
+++ b/src/main/ui/menu/practice-difficulty-selector.gd
@@ -31,6 +31,18 @@ func set_selected_difficulty(name: String) -> void:
 
 
 """
+Lowlights difficulty labels, turning them black.
+
+In rank mode, this lets the player see which ranks haven't yet completed.
+"""
+func set_difficulty_lowlights(lowlights: Array) -> void:
+	for i in range($Labels.get_child_count()):
+		var label: Label = $Labels.get_child(i)
+		var lowlighted: bool = lowlights.size() > i and lowlights[i]
+		label.set("custom_colors/font_color", Color.black if lowlighted else Color.white)
+
+
+"""
 Sets the difficulty names which appear as tick mark labels.
 """
 func set_difficulty_names(names: Array) -> void:

--- a/src/main/ui/menu/practice-mode-selector.gd
+++ b/src/main/ui/menu/practice-mode-selector.gd
@@ -28,6 +28,8 @@ func set_selected_mode(selected_mode: String) -> void:
 			$Buttons/Ultra.pressed = true
 		"Sprint":
 			$Buttons/Sprint.pressed = true
+		"Rank":
+			$Buttons/Rank.pressed = true
 
 
 """
@@ -37,9 +39,9 @@ func set_scenario(scenario: ScenarioSettings) -> void:
 	var new_description := ""
 	match get_selected_mode():
 		"Survival":
-			var target_value := scenario.win_condition.value
-			if scenario.win_condition.has_meta("lenient_value"):
-				target_value = scenario.win_condition.get_meta("lenient_value")
+			var target_value := scenario.finish_condition.value
+			if scenario.finish_condition.has_meta("lenient_value"):
+				target_value = scenario.finish_condition.get_meta("lenient_value")
 			
 			new_description = "Survive as the pieces get faster and faster! Can you clear %s lines?" \
 					% StringUtils.comma_sep(target_value)
@@ -49,6 +51,15 @@ func set_scenario(scenario: ScenarioSettings) -> void:
 		"Sprint":
 			new_description = "Earn as much money as you can in %s!" \
 					% StringUtils.format_duration(scenario.finish_condition.value)
+		"Rank":
+			new_description = "An escalating set of challenges."
+			match scenario.success_condition.type:
+				Milestone.SCORE:
+					new_description += " Finish with ¥%s to achieve this rank!" \
+							% StringUtils.comma_sep(scenario.success_condition.value)
+				Milestone.TIME_UNDER:
+					new_description += " Finish in %s to achieve this rank!" \
+							% StringUtils.format_duration(scenario.success_condition.value)
 	$Desc.text = new_description
 
 


### PR DESCRIPTION
Created 'rank-calculation-demo' for calculating approximate difficulty
curve for rank modes.

Replaced win-condition/finish-condition system with
finish-condition/success-condition. Levels always end with the
finish-condition, but the success-condition specifies whether the player
did a good job. A 'good job' gives them applause and a fanfare, and also
grants them the rank in rank mode.

Milestone now includes TIME_OVER and TIME_UNDER. This distinction is
necessary for Sprint mode which ends when your time exceeds a value,
versus a 'success condition' which cares about your time falling below a
value.

Added support for time-based levelups. You still only level up after clearing a
line. So you'll level up after your first line clear past the 1 minute mark, for example.