### PR TITLE
Simplified PuzzleScore signals. 'chat-choices' group.

### DIFF
--- a/src/main/puzzle/combo-score-value-label.gd
+++ b/src/main/puzzle/combo-score-value-label.gd
@@ -6,9 +6,10 @@ This only includes bonuses and should be a round number like +55 or +130 for vis
 """
 
 func _ready() -> void:
-	PuzzleScore.connect("bonus_score_changed", self, "_on_PuzzleScore_bonus_score_changed")
+	PuzzleScore.connect("score_changed", self, "_on_PuzzleScore_score_changed")
 	text = "-"
 
 
-func _on_PuzzleScore_bonus_score_changed(value: int) -> void:
-	text = "-" if value == 0 else "+¥%s" % StringUtils.comma_sep(value)
+func _on_PuzzleScore_score_changed() -> void:
+	var bonus_score := PuzzleScore.get_bonus_score()
+	text = "-" if bonus_score == 0 else "+¥%s" % StringUtils.comma_sep(bonus_score)

--- a/src/main/puzzle/piece/piece-speeds.gd
+++ b/src/main/puzzle/piece/piece-speeds.gd
@@ -75,7 +75,7 @@ func _ready() -> void:
 	
 	current_speed = PieceSpeeds.speed("0")
 	PuzzleScore.connect("level_index_changed", self, "_on_PuzzleScore_level_index_changed")
-	PuzzleScore.connect("lines_changed", self, "_on_PuzzleScore_lines_changed")
+	PuzzleScore.connect("score_changed", self, "_on_PuzzleScore_score_changed")
 	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
 
 
@@ -92,7 +92,7 @@ func _update_current_speed() -> void:
 	PieceSpeeds.current_speed = PieceSpeeds.speed(milestone.get_meta("level"))
 
 
-func _on_PuzzleScore_lines_changed(value: int) -> void:
+func _on_PuzzleScore_score_changed() -> void:
 	var new_level_index: int = PuzzleScore.level_index
 	
 	while new_level_index + 1 < Scenario.settings.level_ups.size() \

--- a/src/main/puzzle/puzzle-score.gd
+++ b/src/main/puzzle/puzzle-score.gd
@@ -22,11 +22,7 @@ signal after_game_ended
 
 signal level_index_changed(value)
 
-# These four signals are always emitted in this order: creature_score, bonus_score, score, lines
-signal creature_score_changed(value)
-signal bonus_score_changed(value)
-signal score_changed(value)
-signal lines_changed(value)
+signal score_changed
 
 signal combo_ended
 
@@ -112,10 +108,7 @@ func add_line_score(combo_score: int, box_score: int) -> void:
 	_add_score(1)
 	_add_line()
 
-	emit_signal("creature_score_changed", get_creature_score())
-	emit_signal("bonus_score_changed", get_bonus_score())
-	emit_signal("score_changed", get_score())
-	emit_signal("lines_changed", get_lines())
+	emit_signal("score_changed")
 
 
 """
@@ -134,9 +127,7 @@ func end_combo() -> void:
 	_add_score(bonus_score)
 	bonus_score = 0
 		
-	emit_signal("creature_score_changed", 0)
-	emit_signal("bonus_score_changed", get_bonus_score())
-	emit_signal("score_changed", get_score())
+	emit_signal("score_changed")
 	emit_signal("combo_ended")
 
 

--- a/src/main/puzzle/score-value-label.gd
+++ b/src/main/puzzle/score-value-label.gd
@@ -8,5 +8,5 @@ func _ready() -> void:
 	text = "¥0"
 
 
-func _on_PuzzleScore_score_changed(value: int) -> void:
-	text = "¥%s" % StringUtils.comma_sep(value)
+func _on_PuzzleScore_score_changed() -> void:
+	text = "¥%s" % StringUtils.comma_sep(PuzzleScore.get_score())

--- a/src/main/ui/chat/ChatChoiceButton.tscn
+++ b/src/main/ui/chat/ChatChoiceButton.tscn
@@ -12,10 +12,6 @@
 [ext_resource path="res://src/main/ui/blogger-sans-medium-12.tres" type="DynamicFont" id=10]
 [ext_resource path="res://src/main/ui/font-fit-label.gd" type="Script" id=11]
 
-
-
-
-
 [sub_resource type="Animation" id=1]
 resource_name = "choose"
 length = 0.3

--- a/src/main/ui/chat/chat-choice-button.gd
+++ b/src/main/ui/chat/chat-choice-button.gd
@@ -15,6 +15,7 @@ func _ready() -> void:
 	$FontFitLabel.pick_largest_font()
 	$MoodSprite/AnimationPlayer.advance(randf() * 2.5)
 	_set_pivot_to_center()
+	add_to_group("chat-choices")
 
 
 """

--- a/src/main/ui/chat/chat-choices.gd
+++ b/src/main/ui/chat/chat-choices.gd
@@ -67,11 +67,9 @@ func show_choices(choices: Array, moods: Array) -> void:
 	_refresh_child_buttons()
 	
 	if choices:
-		for child in get_children():
-			var button: ChatChoiceButton = _button(child)
-			if button:
-				button.grab_focus()
-				break
+		for button in get_tree().get_nodes_in_group("chat-choices"):
+			button.grab_focus()
+			break
 
 
 func is_showing_choices() -> bool:
@@ -113,11 +111,9 @@ func _button(node: Node) -> ChatChoiceButton:
 Removes and recreates all chat choice buttons.
 """
 func _refresh_child_buttons() -> void:
-	for child in get_children():
-		var button: ChatChoiceButton = _button(child)
-		if button:
-			child.queue_free()
-			remove_child(child)
+	for child in get_tree().get_nodes_in_group("chat-choices"):
+		child.queue_free()
+		remove_child(child)
 	
 	var new_buttons: Array = []
 	
@@ -165,11 +161,7 @@ Makes all the chat choice buttons disappear and emits a signal with the player's
 The chat choice buttons remain as children of this node so they can be animated away.
 """
 func _on_ChatChoiceButton_pressed() -> void:
-	var old_buttons := []
-	for child in get_children():
-		var button: ChatChoiceButton = _button(child)
-		if button:
-			old_buttons.append(button)
+	var old_buttons := get_tree().get_nodes_in_group("chat-choices")
 
 	# determine the currently selected choice
 	var choice_index := -1

--- a/src/main/ui/menu/LoadingScreen.tscn
+++ b/src/main/ui/menu/LoadingScreen.tscn
@@ -4,7 +4,6 @@
 [ext_resource path="res://src/main/ui/menu/theme/h1.theme" type="Theme" id=2]
 [ext_resource path="res://assets/main/puzzle/wood-backdrop.png" type="Texture" id=3]
 
-
 [node name="LoadingScreen" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0


### PR DESCRIPTION
PuzzleScore had four different signals for different aspects of the score
changing, which was overkill.

Refactored 'chat choice' logic to use button groups. Button groups are
basically intended for this case, of "there's a bunch of of nodes in the
scene tree of this one type, and i want to do something with them'