### PR TITLE
PieceManager no longer uses input singleton in _physics_process

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -104,6 +104,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/ui/font-fit-label.gd"
 }, {
+"base": "Node",
+"class": "FrameInput",
+"language": "GDScript",
+"path": "res://src/main/puzzle/piece/frame-input.gd"
+}, {
 "base": "Timer",
 "class": "FreshnessInspector",
 "language": "GDScript",
@@ -339,6 +344,7 @@ _global_script_class_icons={
 "CreatureLoader": "",
 "EditorPlayfield": "",
 "FontFitLabel": "",
+"FrameInput": "",
 "FreshnessInspector": "",
 "FrostingGlob": "",
 "JSONBeautifier": "",

--- a/src/main/puzzle/Puzzle.tscn
+++ b/src/main/puzzle/Puzzle.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=70 format=2]
+[gd_scene load_steps=51 format=2]
 
 [ext_resource path="res://src/main/ui/menu/theme/h3.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/tutorial/tutorial-hud.tscn" type="PackedScene" id=2]
@@ -8,29 +8,16 @@
 [ext_resource path="res://src/main/puzzle/ResultsHud.tscn" type="PackedScene" id=6]
 [ext_resource path="res://src/main/puzzle/rainbow-metaball.shader" type="Shader" id=7]
 [ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=8]
-[ext_resource path="res://src/main/puzzle/PuzzleTileSet.tres" type="TileSet" id=9]
-[ext_resource path="res://src/main/puzzle/piece/CornerMap.tscn" type="PackedScene" id=10]
+[ext_resource path="res://src/main/puzzle/piece/PieceManager.tscn" type="PackedScene" id=9]
 [ext_resource path="res://assets/main/ui/applause.wav" type="AudioStream" id=11]
-[ext_resource path="res://src/main/puzzle/PuzzleTileMap.tscn" type="PackedScene" id=12]
 [ext_resource path="res://src/main/ui/menu/theme/h2-font.tres" type="DynamicFont" id=13]
 [ext_resource path="res://src/main/ui/menu/theme/h4-font.tres" type="DynamicFont" id=14]
 [ext_resource path="res://src/main/puzzle/puzzle-music-manager.gd" type="Script" id=19]
 [ext_resource path="res://src/main/ui/SettingsMenu.tscn" type="PackedScene" id=20]
 [ext_resource path="res://src/main/puzzle/puzzle.gd" type="Script" id=21]
-[ext_resource path="res://src/main/puzzle/piece/piece-manager.gd" type="Script" id=22]
 [ext_resource path="res://src/main/puzzle/milestone-hud.gd" type="Script" id=23]
 [ext_resource path="res://src/main/puzzle/frosting-globs.gd" type="Script" id=24]
-[ext_resource path="res://src/main/puzzle/piece-sfx.gd" type="Script" id=25]
-[ext_resource path="res://src/main/puzzle/stretch-map.gd" type="Script" id=26]
-[ext_resource path="res://src/main/puzzle/piece/states/game-ended.gd" type="Script" id=27]
-[ext_resource path="res://src/main/puzzle/piece/states/prelock.gd" type="Script" id=28]
-[ext_resource path="res://src/main/puzzle/piece/states/prespawn.gd" type="Script" id=29]
 [ext_resource path="res://src/main/puzzle/topout-tracker.gd" type="Script" id=30]
-[ext_resource path="res://src/main/puzzle/piece/states/move-piece.gd" type="Script" id=31]
-[ext_resource path="res://src/main/state-machine.gd" type="Script" id=32]
-[ext_resource path="res://src/main/puzzle/piece/states/wait-for-playfield.gd" type="Script" id=33]
-[ext_resource path="res://src/main/puzzle/piece/states/none.gd" type="Script" id=34]
-[ext_resource path="res://src/main/puzzle/top-out.gd" type="Script" id=35]
 [ext_resource path="res://src/main/ui/font-fit-label.gd" type="Script" id=36]
 [ext_resource path="res://assets/main/ui/go.wav" type="AudioStream" id=38]
 [ext_resource path="res://assets/main/ui/ready.wav" type="AudioStream" id=39]
@@ -42,18 +29,12 @@
 [ext_resource path="res://assets/main/world/chef/gameover-voice0.wav" type="AudioStream" id=46]
 [ext_resource path="res://assets/main/ui/gameover.wav" type="AudioStream" id=47]
 [ext_resource path="res://assets/main/world/chef/gameover-voice2.wav" type="AudioStream" id=48]
-[ext_resource path="res://assets/main/puzzle/move.wav" type="AudioStream" id=49]
-[ext_resource path="res://assets/main/puzzle/levelup.wav" type="AudioStream" id=50]
 [ext_resource path="res://assets/main/ui/excellent.wav" type="AudioStream" id=51]
 [ext_resource path="res://assets/main/ui/matchend.wav" type="AudioStream" id=52]
 [ext_resource path="res://assets/main/world/chef/go-voice0.wav" type="AudioStream" id=53]
 [ext_resource path="res://assets/main/world/chef/go-voice1.wav" type="AudioStream" id=54]
 [ext_resource path="res://assets/main/world/chef/go-voice2.wav" type="AudioStream" id=55]
-[ext_resource path="res://assets/main/puzzle/squish.wav" type="AudioStream" id=56]
 [ext_resource path="res://assets/main/world/chef/gameover-voice1.wav" type="AudioStream" id=57]
-[ext_resource path="res://assets/main/puzzle/lock.wav" type="AudioStream" id=58]
-[ext_resource path="res://assets/main/puzzle/rotate0.wav" type="AudioStream" id=59]
-[ext_resource path="res://assets/main/puzzle/rotate1.wav" type="AudioStream" id=60]
 [ext_resource path="res://src/main/puzzle/Score.tscn" type="PackedScene" id=61]
 [ext_resource path="res://src/main/puzzle/PuzzleHud.tscn" type="PackedScene" id=62]
 [ext_resource path="res://src/main/world/restaurant/CreatureView.tscn" type="PackedScene" id=63]
@@ -61,7 +42,6 @@
 [ext_resource path="res://src/main/puzzle/Playfield.tscn" type="PackedScene" id=65]
 [ext_resource path="res://src/main/puzzle/chalkboard.gd" type="Script" id=66]
 [ext_resource path="res://src/main/puzzle/start-end-sfx.gd" type="Script" id=67]
-
 
 [sub_resource type="ShaderMaterial" id=1]
 shader = ExtResource( 4 )
@@ -128,85 +108,7 @@ margin_top = 28.0
 margin_right = 688.0
 margin_bottom = 572.0
 
-[node name="PieceManager" type="Control" parent="."]
-margin_left = 364.0
-margin_top = 28.0
-margin_right = 688.0
-margin_bottom = 572.0
-rect_clip_content = true
-script = ExtResource( 22 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="TileMap" parent="PieceManager" instance=ExtResource( 12 )]
-position = Vector2( 0, -96 )
-
-[node name="StretchMap" type="TileMap" parent="PieceManager"]
-position = Vector2( 0, -96 )
-scale = Vector2( 0.5, 0.5 )
-z_index = 1
-tile_set = ExtResource( 9 )
-cell_size = Vector2( 72, 64 )
-format = 1
-tile_data = PoolIntArray( 196613, 0, 196608, 262147, 0, 196608, 262148, 0, 196608, 262149, 0, 196608 )
-script = ExtResource( 26 )
-
-[node name="CornerMap" parent="PieceManager/StretchMap" instance=ExtResource( 10 )]
-
-[node name="States" type="Node" parent="PieceManager"]
-script = ExtResource( 32 )
-
-[node name="None" type="Node" parent="PieceManager/States"]
-script = ExtResource( 34 )
-
-[node name="Prespawn" type="Node" parent="PieceManager/States"]
-script = ExtResource( 29 )
-
-[node name="MovePiece" type="Node" parent="PieceManager/States"]
-script = ExtResource( 31 )
-
-[node name="Prelock" type="Node" parent="PieceManager/States"]
-script = ExtResource( 28 )
-
-[node name="WaitForPlayfield" type="Node" parent="PieceManager/States"]
-script = ExtResource( 33 )
-
-[node name="TopOut" type="Node" parent="PieceManager/States"]
-script = ExtResource( 35 )
-
-[node name="GameEnded" type="Node" parent="PieceManager/States"]
-script = ExtResource( 27 )
-
-[node name="PieceSfx" type="Node" parent="PieceManager"]
-script = ExtResource( 25 )
-
-[node name="Rotate0Sound" type="AudioStreamPlayer" parent="PieceManager/PieceSfx"]
-stream = ExtResource( 59 )
-volume_db = -4.0
-bus = "Sound Bus"
-
-[node name="Rotate1Sound" type="AudioStreamPlayer" parent="PieceManager/PieceSfx"]
-stream = ExtResource( 60 )
-volume_db = -4.0
-bus = "Sound Bus"
-
-[node name="MoveSound" type="AudioStreamPlayer" parent="PieceManager/PieceSfx"]
-stream = ExtResource( 49 )
-volume_db = -4.0
-bus = "Sound Bus"
-
-[node name="LockSound" type="AudioStreamPlayer" parent="PieceManager/PieceSfx"]
-stream = ExtResource( 58 )
-bus = "Sound Bus"
-
-[node name="SquishSound" type="AudioStreamPlayer" parent="PieceManager/PieceSfx"]
-stream = ExtResource( 56 )
-bus = "Sound Bus"
-
-[node name="LevelUpSound" type="AudioStreamPlayer" parent="PieceManager/PieceSfx"]
-stream = ExtResource( 50 )
-bus = "Sound Bus"
+[node name="PieceManager" parent="." instance=ExtResource( 9 )]
 
 [node name="NextPieceDisplays" parent="." instance=ExtResource( 64 )]
 margin_left = 688.0
@@ -489,21 +391,5 @@ script = ExtResource( 19 )
 [connection signal="before_line_cleared" from="Playfield" to="FrostingGlobs" method="_on_Playfield_before_line_cleared"]
 [connection signal="box_made" from="Playfield" to="FrostingGlobs" method="_on_Playfield_box_made"]
 [connection signal="line_cleared" from="Playfield" to="." method="_on_Playfield_line_cleared"]
-[connection signal="das_moved_left" from="PieceManager" to="PieceManager/PieceSfx" method="_on_PieceManager_das_moved_left"]
-[connection signal="das_moved_right" from="PieceManager" to="PieceManager/PieceSfx" method="_on_PieceManager_das_moved_right"]
-[connection signal="initial_das_moved_left" from="PieceManager" to="PieceManager/PieceSfx" method="_on_PieceManager_initial_das_moved_left"]
-[connection signal="initial_das_moved_right" from="PieceManager" to="PieceManager/PieceSfx" method="_on_PieceManager_initial_das_moved_right"]
-[connection signal="initial_rotated_left" from="PieceManager" to="PieceManager/PieceSfx" method="_on_PieceManager_initial_rotated_left"]
-[connection signal="initial_rotated_right" from="PieceManager" to="PieceManager/PieceSfx" method="_on_PieceManager_initial_rotated_right"]
-[connection signal="initial_rotated_twice" from="PieceManager" to="PieceManager/PieceSfx" method="_on_PieceManager_initial_rotated_twice"]
-[connection signal="lock_cancelled" from="PieceManager" to="PieceManager/PieceSfx" method="_on_PieceManager_lock_cancelled"]
-[connection signal="lock_started" from="PieceManager" to="PieceManager/PieceSfx" method="_on_PieceManager_lock_started"]
-[connection signal="moved_left" from="PieceManager" to="PieceManager/PieceSfx" method="_on_PieceManager_moved_left"]
-[connection signal="moved_right" from="PieceManager" to="PieceManager/PieceSfx" method="_on_PieceManager_moved_right"]
-[connection signal="rotated_left" from="PieceManager" to="PieceManager/PieceSfx" method="_on_PieceManager_rotated_left"]
-[connection signal="rotated_right" from="PieceManager" to="PieceManager/PieceSfx" method="_on_PieceManager_rotated_right"]
-[connection signal="squish_moved" from="PieceManager" to="PieceManager/PieceSfx" method="_on_PieceManager_squish_moved"]
-[connection signal="topped_out" from="PieceManager" to="TopOutTracker" method="_on_PieceManager_topped_out"]
-[connection signal="entered_state" from="PieceManager/States" to="PieceManager" method="_on_States_entered_state"]
 [connection signal="start_button_pressed" from="HudHolder/Hud" to="." method="_on_Hud_start_button_pressed"]
 [connection signal="cheat_detected" from="CheatCodeDetector" to="PuzzleTrace" method="_on_CheatCodeDetector_cheat_detected"]

--- a/src/main/puzzle/piece/PieceManager.tscn
+++ b/src/main/puzzle/piece/PieceManager.tscn
@@ -1,0 +1,169 @@
+[gd_scene load_steps=24 format=2]
+
+[ext_resource path="res://src/main/puzzle/piece/frame-input.gd" type="Script" id=1]
+[ext_resource path="res://src/main/puzzle/PuzzleTileSet.tres" type="TileSet" id=2]
+[ext_resource path="res://src/main/puzzle/piece/piece-manager.gd" type="Script" id=3]
+[ext_resource path="res://assets/main/puzzle/move.wav" type="AudioStream" id=4]
+[ext_resource path="res://assets/main/puzzle/levelup.wav" type="AudioStream" id=5]
+[ext_resource path="res://assets/main/puzzle/rotate0.wav" type="AudioStream" id=6]
+[ext_resource path="res://assets/main/puzzle/rotate1.wav" type="AudioStream" id=7]
+[ext_resource path="res://assets/main/puzzle/lock.wav" type="AudioStream" id=8]
+[ext_resource path="res://src/main/puzzle/PuzzleTileMap.tscn" type="PackedScene" id=9]
+[ext_resource path="res://src/main/puzzle/piece/CornerMap.tscn" type="PackedScene" id=10]
+[ext_resource path="res://src/main/puzzle/piece/states/prelock.gd" type="Script" id=11]
+[ext_resource path="res://src/main/puzzle/piece-sfx.gd" type="Script" id=13]
+[ext_resource path="res://src/main/puzzle/piece/states/game-ended.gd" type="Script" id=14]
+[ext_resource path="res://src/main/puzzle/stretch-map.gd" type="Script" id=15]
+[ext_resource path="res://src/main/puzzle/piece/states/prespawn.gd" type="Script" id=16]
+[ext_resource path="res://src/main/puzzle/piece/states/none.gd" type="Script" id=17]
+[ext_resource path="res://src/main/puzzle/piece/states/move-piece.gd" type="Script" id=18]
+[ext_resource path="res://src/main/state-machine.gd" type="Script" id=19]
+[ext_resource path="res://src/main/puzzle/piece/states/wait-for-playfield.gd" type="Script" id=20]
+[ext_resource path="res://src/main/puzzle/top-out.gd" type="Script" id=21]
+[ext_resource path="res://assets/main/puzzle/blocks/blocks-corners.png" type="Texture" id=22]
+[ext_resource path="res://assets/main/puzzle/squish.wav" type="AudioStream" id=23]
+
+[sub_resource type="TileSet" id=1]
+0/name = "blocks-corners.png 2"
+0/texture = ExtResource( 22 )
+0/tex_offset = Vector2( 0, 0 )
+0/modulate = Color( 1, 1, 1, 1 )
+0/region = Rect2( 2, 2, 76, 284 )
+0/tile_mode = 2
+0/autotile/icon_coordinate = Vector2( 0, 0 )
+0/autotile/tile_size = Vector2( 36, 32 )
+0/autotile/spacing = 4
+0/autotile/occluder_map = [  ]
+0/autotile/navpoly_map = [  ]
+0/autotile/priority_map = [  ]
+0/autotile/z_index_map = [  ]
+0/occluder_offset = Vector2( 0, 0 )
+0/navigation_offset = Vector2( 0, 0 )
+0/shape_offset = Vector2( 0, 0 )
+0/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+0/shape_one_way = false
+0/shape_one_way_margin = 0.0
+0/shapes = [  ]
+0/z_index = 0
+
+[node name="PieceManager" type="Control"]
+margin_left = 364.0
+margin_top = 28.0
+margin_right = 688.0
+margin_bottom = 572.0
+rect_clip_content = true
+script = ExtResource( 3 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="TileMap" parent="." instance=ExtResource( 9 )]
+position = Vector2( 0, -96 )
+
+[node name="StretchMap" type="TileMap" parent="."]
+position = Vector2( 0, -96 )
+scale = Vector2( 0.5, 0.5 )
+z_index = 1
+tile_set = ExtResource( 2 )
+cell_size = Vector2( 72, 64 )
+format = 1
+tile_data = PoolIntArray( 196613, 0, 196608, 262147, 0, 196608, 262148, 0, 196608, 262149, 0, 196608 )
+script = ExtResource( 15 )
+
+[node name="CornerMap" parent="StretchMap" instance=ExtResource( 10 )]
+tile_set = SubResource( 1 )
+
+[node name="States" type="Node" parent="."]
+script = ExtResource( 19 )
+
+[node name="None" type="Node" parent="States"]
+script = ExtResource( 17 )
+
+[node name="Prespawn" type="Node" parent="States"]
+script = ExtResource( 16 )
+
+[node name="MovePiece" type="Node" parent="States"]
+script = ExtResource( 18 )
+
+[node name="Prelock" type="Node" parent="States"]
+script = ExtResource( 11 )
+
+[node name="WaitForPlayfield" type="Node" parent="States"]
+script = ExtResource( 20 )
+
+[node name="TopOut" type="Node" parent="States"]
+script = ExtResource( 21 )
+
+[node name="GameEnded" type="Node" parent="States"]
+script = ExtResource( 14 )
+
+[node name="PieceSfx" type="Node" parent="."]
+script = ExtResource( 13 )
+
+[node name="Rotate0Sound" type="AudioStreamPlayer" parent="PieceSfx"]
+stream = ExtResource( 6 )
+volume_db = -4.0
+bus = "Sound Bus"
+
+[node name="Rotate1Sound" type="AudioStreamPlayer" parent="PieceSfx"]
+stream = ExtResource( 7 )
+volume_db = -4.0
+bus = "Sound Bus"
+
+[node name="MoveSound" type="AudioStreamPlayer" parent="PieceSfx"]
+stream = ExtResource( 4 )
+volume_db = -4.0
+bus = "Sound Bus"
+
+[node name="LockSound" type="AudioStreamPlayer" parent="PieceSfx"]
+stream = ExtResource( 8 )
+bus = "Sound Bus"
+
+[node name="SquishSound" type="AudioStreamPlayer" parent="PieceSfx"]
+stream = ExtResource( 23 )
+bus = "Sound Bus"
+
+[node name="LevelUpSound" type="AudioStreamPlayer" parent="PieceSfx"]
+stream = ExtResource( 5 )
+bus = "Sound Bus"
+
+[node name="InputLeft" type="Node" parent="."]
+script = ExtResource( 1 )
+action = "ui_left"
+cancel_action = "ui_right"
+
+[node name="InputRight" type="Node" parent="."]
+script = ExtResource( 1 )
+action = "ui_right"
+cancel_action = "ui_left"
+
+[node name="InputCw" type="Node" parent="."]
+script = ExtResource( 1 )
+action = "rotate_cw"
+
+[node name="InputCcw" type="Node" parent="."]
+script = ExtResource( 1 )
+action = "rotate_ccw"
+
+[node name="InputSoftDrop" type="Node" parent="."]
+script = ExtResource( 1 )
+action = "soft_drop"
+
+[node name="InputHardDrop" type="Node" parent="."]
+script = ExtResource( 1 )
+action = "hard_drop"
+[connection signal="das_moved_left" from="." to="PieceSfx" method="_on_PieceManager_das_moved_left"]
+[connection signal="das_moved_right" from="." to="PieceSfx" method="_on_PieceManager_das_moved_right"]
+[connection signal="initial_das_moved_left" from="." to="PieceSfx" method="_on_PieceManager_initial_das_moved_left"]
+[connection signal="initial_das_moved_right" from="." to="PieceSfx" method="_on_PieceManager_initial_das_moved_right"]
+[connection signal="initial_rotated_left" from="." to="PieceSfx" method="_on_PieceManager_initial_rotated_left"]
+[connection signal="initial_rotated_right" from="." to="PieceSfx" method="_on_PieceManager_initial_rotated_right"]
+[connection signal="initial_rotated_twice" from="." to="PieceSfx" method="_on_PieceManager_initial_rotated_twice"]
+[connection signal="lock_cancelled" from="." to="PieceSfx" method="_on_PieceManager_lock_cancelled"]
+[connection signal="lock_started" from="." to="PieceSfx" method="_on_PieceManager_lock_started"]
+[connection signal="moved_left" from="." to="PieceSfx" method="_on_PieceManager_moved_left"]
+[connection signal="moved_right" from="." to="PieceSfx" method="_on_PieceManager_moved_right"]
+[connection signal="rotated_left" from="." to="PieceSfx" method="_on_PieceManager_rotated_left"]
+[connection signal="rotated_right" from="." to="PieceSfx" method="_on_PieceManager_rotated_right"]
+[connection signal="squish_moved" from="." to="PieceSfx" method="_on_PieceManager_squish_moved"]
+[connection signal="entered_state" from="States" to="." method="_on_States_entered_state"]

--- a/src/main/puzzle/piece/frame-input.gd
+++ b/src/main/puzzle/piece/frame-input.gd
@@ -1,0 +1,42 @@
+class_name FrameInput
+extends Node
+"""
+Tracks the state of an input action over time.
+"""
+
+# The action to track
+export (String) var action: String
+
+# An action which negates this one if pressed. For example if the player holds 'ui_left' and presses 'ui_right',
+# 'ui_left' no longer gets triggered.
+export (String) var cancel_action: String
+
+var just_pressed: bool
+var pressed: bool
+var frames: int
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed(action, false):
+		just_pressed = true
+		pressed = true
+	elif event.is_action_released(action):
+		pressed = false
+		frames = 0
+	
+	if cancel_action and event.is_action_pressed(cancel_action, false):
+		just_pressed = false
+		pressed = false
+		frames = 0
+
+
+func _physics_process(_delta: float) -> void:
+	if pressed:
+		frames += 1
+	just_pressed = false
+
+
+"""
+Returns true if the player held the input long enough to trigger DAS.
+"""
+func is_das_active() -> bool:
+	return frames >= PieceSpeeds.current_speed.delayed_auto_shift_delay

--- a/src/main/puzzle/puzzle-trace.gd
+++ b/src/main/puzzle/puzzle-trace.gd
@@ -6,21 +6,46 @@ Shows diagnostics for the piece physics. Enabled with the cheat code 'delays'.
 onready var _puzzle:Puzzle = get_parent()
 onready var _playfield:Playfield = _puzzle.get_node("Playfield")
 onready var _combo_tracker:ComboTracker = _puzzle.get_node("Playfield/ComboTracker")
-onready var _pieceManager:PieceManager= _puzzle.get_piece_manager()
+onready var _piece_manager:PieceManager= _puzzle.get_piece_manager()
 
 func _process(delta: float) -> void:
 	if visible:
 		var new_text: String = ""
+		
 		new_text += "%1d" % [min(9, _combo_tracker.combo_break)]
-		new_text += "l" if _playfield._remaining_line_clear_frames > 0 else "-"
-		new_text += "b" if _playfield._remaining_box_build_frames > 0 else "-"
+		new_text += "l" if _playfield.remaining_line_clear_frames > 0 else "-"
+		new_text += "b" if _playfield.remaining_box_build_frames > 0 else "-"
 		new_text += "r" if _playfield.ready_for_new_piece() else "-"
-		var das: bool = _pieceManager._input_left_frames > PieceSpeeds.current_speed.delayed_auto_shift_delay \
-				or _pieceManager._input_right_frames > PieceSpeeds.current_speed.delayed_auto_shift_delay
-		new_text += "D" if das else "-"
-		new_text += "%1d%1d" % [min(9, _pieceManager._input_left_frames), min(9, _pieceManager._input_right_frames)]
-		new_text += " %s(%02d)" % [_pieceManager.get_state().name.left(4), min(99, _pieceManager.get_state().frames)]
+		new_text += " %s(%02d)" % [_piece_manager.get_state().name.left(4), min(99, _piece_manager.get_state().frames)]
+		new_text += "\n"
+		
+		new_text += input_char(_piece_manager.get_node("InputLeft"), "l")
+		new_text += input_char(_piece_manager.get_node("InputRight"), "r")
+		new_text += input_char(_piece_manager.get_node("InputCw"), "z")
+		new_text += input_char(_piece_manager.get_node("InputCcw"), "x")
+		new_text += input_char(_piece_manager.get_node("InputSoftDrop"), "d")
+		new_text += input_char(_piece_manager.get_node("InputHardDrop"), "u")
+		var max_input_frames := 0
+		max_input_frames = max(max_input_frames, _piece_manager.get_node("InputLeft").frames)
+		max_input_frames = max(max_input_frames, _piece_manager.get_node("InputRight").frames)
+		max_input_frames = max(max_input_frames, _piece_manager.get_node("InputCw").frames)
+		max_input_frames = max(max_input_frames, _piece_manager.get_node("InputCcw").frames)
+		max_input_frames = max(max_input_frames, _piece_manager.get_node("InputSoftDrop").frames)
+		max_input_frames = max(max_input_frames, _piece_manager.get_node("InputHardDrop").frames)
+		new_text += " %02d" % [min(99, max_input_frames)]
 		text = new_text
+
+
+"""
+Returns a FrameInput object as a single-character string.
+"""
+func input_char(frame_input: FrameInput, character: String) -> String:
+	if not frame_input.pressed:
+		return "-"
+	elif not frame_input.is_das_active():
+		return character
+	else:
+		return character.to_upper()
 
 
 func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDetector) -> void:

--- a/src/main/ui/HighScoreTable.tscn
+++ b/src/main/ui/HighScoreTable.tscn
@@ -3,7 +3,6 @@
 [ext_resource path="res://src/main/ui/high-score-table.gd" type="Script" id=2]
 [ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=3]
 
-
 [node name="HighScoreTable" type="VBoxContainer"]
 margin_right = 412.0
 margin_bottom = 152.0


### PR DESCRIPTION
Utilizing the input singleton circumvents the input event mechanism, so
that we can't do things like ignore inputs when the user is navigating
menus.