### PR TITLE
Piece inputs are buffered. Fixed broken top out behavior.

### DIFF
--- a/src/main/puzzle/Puzzle.tscn
+++ b/src/main/puzzle/Puzzle.tscn
@@ -391,5 +391,6 @@ script = ExtResource( 19 )
 [connection signal="before_line_cleared" from="Playfield" to="FrostingGlobs" method="_on_Playfield_before_line_cleared"]
 [connection signal="box_made" from="Playfield" to="FrostingGlobs" method="_on_Playfield_box_made"]
 [connection signal="line_cleared" from="Playfield" to="." method="_on_Playfield_line_cleared"]
+[connection signal="topped_out" from="PieceManager" to="TopOutTracker" method="_on_PieceManager_topped_out"]
 [connection signal="start_button_pressed" from="HudHolder/Hud" to="." method="_on_Hud_start_button_pressed"]
 [connection signal="cheat_detected" from="CheatCodeDetector" to="PuzzleTrace" method="_on_CheatCodeDetector_cheat_detected"]

--- a/src/main/puzzle/piece/FrameInput.tscn
+++ b/src/main/puzzle/piece/FrameInput.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/main/puzzle/piece/frame-input.gd" type="Script" id=1]
+
+[node name="FrameInput" type="Node"]
+script = ExtResource( 1 )
+
+[node name="Buffer" type="Timer" parent="."]
+process_mode = 0
+wait_time = 0.15
+one_shot = true

--- a/src/main/puzzle/piece/PieceManager.tscn
+++ b/src/main/puzzle/piece/PieceManager.tscn
@@ -1,6 +1,5 @@
 [gd_scene load_steps=24 format=2]
 
-[ext_resource path="res://src/main/puzzle/piece/frame-input.gd" type="Script" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleTileSet.tres" type="TileSet" id=2]
 [ext_resource path="res://src/main/puzzle/piece/piece-manager.gd" type="Script" id=3]
 [ext_resource path="res://assets/main/puzzle/move.wav" type="AudioStream" id=4]
@@ -11,6 +10,7 @@
 [ext_resource path="res://src/main/puzzle/PuzzleTileMap.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/puzzle/piece/CornerMap.tscn" type="PackedScene" id=10]
 [ext_resource path="res://src/main/puzzle/piece/states/prelock.gd" type="Script" id=11]
+[ext_resource path="res://src/main/puzzle/piece/FrameInput.tscn" type="PackedScene" id=12]
 [ext_resource path="res://src/main/puzzle/piece-sfx.gd" type="Script" id=13]
 [ext_resource path="res://src/main/puzzle/piece/states/game-ended.gd" type="Script" id=14]
 [ext_resource path="res://src/main/puzzle/stretch-map.gd" type="Script" id=15]
@@ -127,30 +127,24 @@ bus = "Sound Bus"
 stream = ExtResource( 5 )
 bus = "Sound Bus"
 
-[node name="InputLeft" type="Node" parent="."]
-script = ExtResource( 1 )
+[node name="InputLeft" parent="." instance=ExtResource( 12 )]
 action = "ui_left"
 cancel_action = "ui_right"
 
-[node name="InputRight" type="Node" parent="."]
-script = ExtResource( 1 )
+[node name="InputRight" parent="." instance=ExtResource( 12 )]
 action = "ui_right"
 cancel_action = "ui_left"
 
-[node name="InputCw" type="Node" parent="."]
-script = ExtResource( 1 )
+[node name="InputCw" parent="." instance=ExtResource( 12 )]
 action = "rotate_cw"
 
-[node name="InputCcw" type="Node" parent="."]
-script = ExtResource( 1 )
+[node name="InputCcw" parent="." instance=ExtResource( 12 )]
 action = "rotate_ccw"
 
-[node name="InputSoftDrop" type="Node" parent="."]
-script = ExtResource( 1 )
+[node name="InputSoftDrop" parent="." instance=ExtResource( 12 )]
 action = "soft_drop"
 
-[node name="InputHardDrop" type="Node" parent="."]
-script = ExtResource( 1 )
+[node name="InputHardDrop" parent="." instance=ExtResource( 12 )]
 action = "hard_drop"
 [connection signal="das_moved_left" from="." to="PieceSfx" method="_on_PieceManager_das_moved_left"]
 [connection signal="das_moved_right" from="." to="PieceSfx" method="_on_PieceManager_das_moved_right"]

--- a/src/main/puzzle/piece/frame-input.gd
+++ b/src/main/puzzle/piece/frame-input.gd
@@ -2,6 +2,8 @@ class_name FrameInput
 extends Node
 """
 Tracks the state of an input action over time.
+
+Also provides support for buffered inputs. The buffer duration is dictated by the child timer.
 """
 
 # The action to track
@@ -11,32 +13,67 @@ export (String) var action: String
 # 'ui_left' no longer gets triggered.
 export (String) var cancel_action: String
 
-var just_pressed: bool
-var pressed: bool
+var _just_pressed: bool
+var _pressed: bool
+
 var frames: int
+var _buffer: bool
 
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed(action, false):
-		just_pressed = true
-		pressed = true
+		_just_pressed = true
+		_pressed = true
 	elif event.is_action_released(action):
-		pressed = false
-		frames = 0
+		_pressed = false
 	
 	if cancel_action and event.is_action_pressed(cancel_action, false):
-		just_pressed = false
-		pressed = false
-		frames = 0
+		_just_pressed = false
+		_pressed = false
 
 
 func _physics_process(_delta: float) -> void:
-	if pressed:
-		frames += 1
-	just_pressed = false
+	frames = frames + 1 if _pressed else 0
+	
+	if _buffer and _just_pressed:
+		$Buffer.start()
+	
+	_just_pressed = false
+
+
+func is_pressed() -> bool:
+	return _pressed or _just_pressed
+
+
+func is_just_pressed() -> bool:
+	return _just_pressed
+
+
+"""
+Records any inputs to a buffer to be replayed later.
+"""
+func buffer_input() -> void:
+	_buffer = true
+
+
+"""
+Replays any inputs which were pressed while buffering.
+"""
+func pop_buffered_input() -> void:
+	_buffer = false
+	if not $Buffer.is_stopped():
+		_just_pressed = true
+		$Buffer.stop()
+
+
+"""
+Marks the 'just pressed' event as handled, to avoid a buffered input from triggering two events.
+"""
+func set_input_as_handled() -> void:
+	_just_pressed = false
 
 
 """
 Returns true if the player held the input long enough to trigger DAS.
 """
 func is_das_active() -> bool:
-	return frames >= PieceSpeeds.current_speed.delayed_auto_shift_delay
+	return _pressed and frames >= PieceSpeeds.current_speed.delayed_auto_shift_delay

--- a/src/main/puzzle/piece/states/prelock.gd
+++ b/src/main/puzzle/piece/states/prelock.gd
@@ -8,6 +8,7 @@ func update(piece_manager: PieceManager) -> String:
 	if piece_manager.apply_player_input():
 		new_state_name = "MovePiece"
 	elif frames >= PieceSpeeds.current_speed.post_lock_delay:
+		piece_manager.buffer_inputs()
 		piece_manager.write_piece_to_playfield()
 		var spawn_delay: float
 		if piece_manager.is_playfield_clearing_lines():

--- a/src/main/puzzle/piece/states/prespawn.gd
+++ b/src/main/puzzle/piece/states/prespawn.gd
@@ -6,6 +6,7 @@ State: The piece will spawn soon.
 func update(piece_manager: PieceManager) -> String:
 	var new_state_name := ""
 	if frames >= piece_manager.piece.spawn_delay:
+		piece_manager.pop_buffered_inputs()
 		if piece_manager.spawn_piece():
 			new_state_name = "MovePiece"
 		else:

--- a/src/main/puzzle/puzzle-trace.gd
+++ b/src/main/puzzle/puzzle-trace.gd
@@ -21,8 +21,8 @@ func _process(delta: float) -> void:
 		
 		new_text += input_char(_piece_manager.get_node("InputLeft"), "l")
 		new_text += input_char(_piece_manager.get_node("InputRight"), "r")
-		new_text += input_char(_piece_manager.get_node("InputCw"), "z")
-		new_text += input_char(_piece_manager.get_node("InputCcw"), "x")
+		new_text += input_char(_piece_manager.get_node("InputCw"), "x")
+		new_text += input_char(_piece_manager.get_node("InputCcw"), "z")
 		new_text += input_char(_piece_manager.get_node("InputSoftDrop"), "d")
 		new_text += input_char(_piece_manager.get_node("InputHardDrop"), "u")
 		var max_input_frames := 0
@@ -40,7 +40,7 @@ func _process(delta: float) -> void:
 Returns a FrameInput object as a single-character string.
 """
 func input_char(frame_input: FrameInput, character: String) -> String:
-	if not frame_input.pressed:
+	if not frame_input.is_pressed():
 		return "-"
 	elif not frame_input.is_das_active():
 		return character

--- a/src/main/puzzle/puzzle.gd
+++ b/src/main/puzzle/puzzle.gd
@@ -8,6 +8,10 @@ class to add goals, win conditions, challenges or time limits.
 signal topped_out
 
 func _ready() -> void:
+	if not ResourceCache.is_done():
+		# when launched standalone, we don't load creature resources (they're slow)
+		ResourceCache.minimal_resources = true
+	
 	PuzzleScore.reset() # erase any lines/score from previous games
 	PuzzleScore.connect("game_ended", self, "_on_PuzzleScore_game_ended")
 	$Playfield/TileMapClip/TileMap/Viewport/ShadowMap.piece_tile_map = $PieceManager/TileMap

--- a/src/main/puzzle/rank-calculator.gd
+++ b/src/main/puzzle/rank-calculator.gd
@@ -188,6 +188,8 @@ func _populate_rank_fields(rank_result: RankResult, lenient: bool) -> void:
 	
 	var finish_condition: Milestone = Scenario.settings.finish_condition
 	match finish_condition.type:
+		Milestone.NONE:
+			target_lines = 999999
 		Milestone.CUSTOMERS:
 			target_lines = MASTER_COMBO * finish_condition.value
 		Milestone.LINES:

--- a/src/main/world/restaurant/Creature.tscn
+++ b/src/main/world/restaurant/Creature.tscn
@@ -2420,8 +2420,14 @@ light_mask = 2
 rotation = 0.00355033
 curve = SubResource( 7 )
 script = ExtResource( 3 )
+spline_length = 25.0
+_smooth = false
+_straighten = false
+closed = true
+line_color = Color( 0, 0, 0, 1 )
 fill_color = Color( 0, 0, 0, 1 )
 line_width = 2.0
+_fatness = 1.0
 editing = false
 
 [node name="Outline" type="Path2D" parent="Sprites/Body"]


### PR DESCRIPTION
The player is now given a 120 ms window where they can press a rotation or
movement key before the piece spawns, and it will move/rotate the piece.
This prevents the feeling of 'swallowed inputs' when you press an input a
few frames before the piece spawns.

Recent refactoring made it so the player would never 'top out'; pieces
would continue to spawn forever.