### PR TITLE
Fixed MilestoneHud crash when changing scenarios

### DIFF
--- a/src/main/puzzle/editor/level-editor.gd
+++ b/src/main/puzzle/editor/level-editor.gd
@@ -40,6 +40,7 @@ func _load_scenario(path: String) -> void:
 
 func _start_test() -> void:
 	Scenario.settings = Scenario.load_scenario(_scenario_name.text, _scenario_json.text)
+	PuzzleScore.reset()
 	Scenario.launched_scenario_name = Scenario.settings.name
 	_test_scene = PuzzleScene.instance()
 	

--- a/src/main/puzzle/puzzle.gd
+++ b/src/main/puzzle/puzzle.gd
@@ -12,7 +12,6 @@ func _ready() -> void:
 		# when launched standalone, we don't load creature resources (they're slow)
 		ResourceCache.minimal_resources = true
 	
-	PuzzleScore.reset() # erase any lines/score from previous games
 	PuzzleScore.connect("game_ended", self, "_on_PuzzleScore_game_ended")
 	$Playfield/TileMapClip/TileMap/Viewport/ShadowMap.piece_tile_map = $PieceManager/TileMap
 	

--- a/src/main/puzzle/scenario/scenario.gd
+++ b/src/main/puzzle/scenario/scenario.gd
@@ -61,6 +61,7 @@ Parameters:
 """
 func push_scenario_trail(scenario_settings: ScenarioSettings, creature_def: Dictionary = {}) -> void:
 	Scenario.settings = scenario_settings
+	PuzzleScore.reset()
 	Scenario.launched_scenario_name = scenario_settings.name
 	Global.creature_queue.push_back(creature_def)
 	Breadcrumb.push_trail("res://src/main/puzzle/Puzzle.tscn")


### PR DESCRIPTION
If you played a level with levelups (such as Survival) and levelled up a few
times, and then played a level without levelups (such as Ultra), MilestoneHud
would default to a level which didn't exist, and throw an array index out of
bounds exception.