### PR TITLE
Pushed sfx, sprite orientation logic out of creature.

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -119,6 +119,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/puzzle/frosting-glob.gd"
 }, {
+"base": "Sprite",
+"class": "HeadBobber",
+"language": "GDScript",
+"path": "res://src/main/world/restaurant/head-bobber.gd"
+}, {
 "base": "Reference",
 "class": "JSONBeautifier",
 "language": "GDScript",
@@ -347,6 +352,7 @@ _global_script_class_icons={
 "FrameInput": "",
 "FreshnessInspector": "",
 "FrostingGlob": "",
+"HeadBobber": "",
 "JSONBeautifier": "",
 "LevelChunk": "",
 "LevelChunkControl": "",

--- a/src/main/world/creature-3d.gd
+++ b/src/main/world/creature-3d.gd
@@ -10,7 +10,7 @@ var foothold_radius := 2.0
 func _ready() -> void:
 	$CollisionShape.disabled = true
 	$ShadowMesh.visible = false
-	$Viewport/Creature/Shadow.visible = false
+	$Viewport/Creature/Sprites/Shadow.visible = false
 	var creature_def := get_creature_def()
 	if creature_def:
 		$Viewport/Creature.summon(creature_def)
@@ -71,7 +71,7 @@ func orient_toward(spatial: Spatial) -> void:
 
 
 func get_orientation() -> int:
-	return $Viewport/Creature.get_orientation()
+	return $Viewport/Creature.orientation
 
 
 func _on_Creature_creature_arrived() -> void:

--- a/src/main/world/restaurant/Creature.tscn
+++ b/src/main/world/restaurant/Creature.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=120 format=2]
+[gd_scene load_steps=124 format=2]
 
 [ext_resource path="res://src/main/world/restaurant/fat-player.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/restaurant/smooth-path-outline.gd" type="Script" id=2]
@@ -46,6 +46,10 @@
 [ext_resource path="res://assets/main/world/creature/munch3.wav" type="AudioStream" id=44]
 [ext_resource path="res://src/main/world/multi-outline.shader" type="Shader" id=45]
 [ext_resource path="res://src/main/world/rgb-palette.shader" type="Shader" id=46]
+[ext_resource path="res://src/main/world/restaurant/creature-sfx.gd" type="Script" id=47]
+[ext_resource path="res://src/main/world/restaurant/creature-sprite.gd" type="Script" id=48]
+[ext_resource path="res://src/main/world/restaurant/mouth-anims.gd" type="Script" id=49]
+[ext_resource path="res://src/main/world/restaurant/head-bobber.gd" type="Script" id=50]
 [ext_resource path="res://assets/main/world/creature/1/emote-brain-sheet.png" type="Texture" id=53]
 [ext_resource path="res://assets/main/ui/chat/emote-think0.wav" type="AudioStream" id=54]
 [ext_resource path="res://src/main/world/restaurant/emote-anims.gd" type="Script" id=58]
@@ -239,7 +243,7 @@ blend_mode = 1
 resource_local_to_scene = true
 shader = ExtResource( 46 )
 shader_param/red = Color( 1, 1, 1, 1 )
-shader_param/green = Color( 1, 0.552941, 0.67451, 1 )
+shader_param/green = Color( 1, 1, 0.24, 1 )
 shader_param/blue = Color( 0, 0, 0, 1 )
 shader_param/black = Color( 0, 0, 0, 1 )
 
@@ -256,7 +260,7 @@ length = 4.0
 loop = true
 step = 0.166667
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Mouth:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Mouth:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -273,7 +277,7 @@ length = 4.0
 loop = true
 step = 0.166667
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Mouth:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Mouth:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -289,7 +293,7 @@ tracks/0/keys = {
 length = 0.6
 step = 0.0333333
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Mouth:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Mouth:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -301,7 +305,7 @@ tracks/0/keys = {
 "values": [ 1, 2, 3, 4, 5, 6, 7, 1, 7, 8, 8, 7, 7, 1, 1 ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("Sprites/Neck0/Neck1/Food:frame")
+tracks/1/path = NodePath("Sprites/Neck0/HeadBobber/Food:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -313,7 +317,7 @@ tracks/1/keys = {
 "values": [ 0, 0, 1, 2, 0, 0 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("Sprites/Neck0/Neck1/FoodLaser:frame")
+tracks/2/path = NodePath("Sprites/Neck0/HeadBobber/FoodLaser:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -329,7 +333,7 @@ tracks/2/keys = {
 length = 0.8
 step = 0.0333333
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Mouth:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Mouth:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -341,7 +345,7 @@ tracks/0/keys = {
 "values": [ 3, 4, 5, 6, 7, 1, 7, 8, 8, 7, 7, 1, 1 ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("Sprites/Neck0/Neck1/Food:frame")
+tracks/1/path = NodePath("Sprites/Neck0/HeadBobber/Food:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -353,7 +357,7 @@ tracks/1/keys = {
 "values": [ 1, 2, 0, 0 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("Sprites/Neck0/Neck1/FoodLaser:frame")
+tracks/2/path = NodePath("Sprites/Neck0/HeadBobber/FoodLaser:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -369,7 +373,7 @@ tracks/2/keys = {
 loop = true
 step = 0.0833333
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Mouth:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Mouth:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -385,7 +389,7 @@ tracks/0/keys = {
 loop = true
 step = 0.0833333
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Mouth:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Mouth:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -401,7 +405,7 @@ tracks/0/keys = {
 length = 0.333333
 step = 0.0333333
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Mouth:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Mouth:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -413,7 +417,7 @@ tracks/0/keys = {
 "values": [ 1, 14, 15, 16, 17, 18, 19, 20, 21, 13 ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("Sprites/Neck0/Neck1/Food:frame")
+tracks/1/path = NodePath("Sprites/Neck0/HeadBobber/Food:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -425,7 +429,7 @@ tracks/1/keys = {
 "values": [ 0, 0, 1, 2, 0, 0 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("Sprites/Neck0/Neck1/FoodLaser:frame")
+tracks/2/path = NodePath("Sprites/Neck0/HeadBobber/FoodLaser:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -437,7 +441,7 @@ tracks/2/keys = {
 "values": [ 0, 0, 1, 2, 0, 0 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Sprites/Neck0/Neck1/Mouth:z_index")
+tracks/3/path = NodePath("Sprites/Neck0/HeadBobber/Mouth:z_index")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -449,7 +453,7 @@ tracks/3/keys = {
 "values": [ 0, 1, 1, 0 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Sprites/Neck0/Neck1/Food:z_index")
+tracks/4/path = NodePath("Sprites/Neck0/HeadBobber/Food:z_index")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -465,7 +469,7 @@ tracks/4/keys = {
 length = 0.266666
 step = 0.0333333
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Mouth:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Mouth:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -477,7 +481,7 @@ tracks/0/keys = {
 "values": [ 15, 16, 17, 18, 19, 20, 21, 13 ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("Sprites/Neck0/Neck1/Food:frame")
+tracks/1/path = NodePath("Sprites/Neck0/HeadBobber/Food:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -489,7 +493,7 @@ tracks/1/keys = {
 "values": [ 1, 2, 0, 0 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("Sprites/Neck0/Neck1/FoodLaser:frame")
+tracks/2/path = NodePath("Sprites/Neck0/HeadBobber/FoodLaser:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -501,7 +505,7 @@ tracks/2/keys = {
 "values": [ 1, 2, 0, 0 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Sprites/Neck0/Neck1/Mouth:z_index")
+tracks/3/path = NodePath("Sprites/Neck0/HeadBobber/Mouth:z_index")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -513,7 +517,7 @@ tracks/3/keys = {
 "values": [ 1, 1, 0 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Sprites/Neck0/Neck1/Food:z_index")
+tracks/4/path = NodePath("Sprites/Neck0/HeadBobber/Food:z_index")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -530,7 +534,7 @@ length = 7.99999
 loop = true
 step = 0.0333333
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Eyes:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Eyes:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -560,7 +564,7 @@ tracks/1/keys = {
 loop = true
 step = 1.0
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Eyes:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Eyes:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -589,7 +593,7 @@ tracks/1/keys = {
 [sub_resource type="Animation" id=38]
 length = 6.0
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Eyes:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Eyes:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -601,7 +605,7 @@ tracks/0/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("Sprites/Neck0/Neck1/EmoteEyes:frame")
+tracks/1/path = NodePath("Sprites/Neck0/HeadBobber/EmoteEyes:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -613,7 +617,7 @@ tracks/1/keys = {
 "values": [ 0, 9, 9 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:position")
+tracks/2/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:position")
 tracks/2/interp = 2
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -625,7 +629,7 @@ tracks/2/keys = {
 "values": [ Vector2( 66.413, 228.341 ), Vector2( 66.413, 208.341 ), Vector2( 66.413, 228.341 ), Vector2( 66.413, 208.341 ), Vector2( 66.413, 228.341 ) ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:frame")
+tracks/3/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:frame")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -637,7 +641,7 @@ tracks/3/keys = {
 "values": [ 8, 8 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:modulate")
+tracks/4/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:modulate")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -649,7 +653,7 @@ tracks/4/keys = {
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:material:shader_param/green")
+tracks/5/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:material:shader_param/green")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -661,7 +665,7 @@ tracks/5/keys = {
 "values": [ Color( 0.501961, 0.501961, 1, 1 ), Color( 0.501961, 0.501961, 1, 1 ) ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:modulate")
+tracks/6/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:modulate")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
@@ -673,7 +677,7 @@ tracks/6/keys = {
 "values": [ Color( 0, 0, 0.737255, 0 ), Color( 0, 0, 0.737255, 0.501961 ), Color( 0, 0, 0.737255, 0.501961 ) ]
 }
 tracks/7/type = "value"
-tracks/7/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:scale")
+tracks/7/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:scale")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/imported = false
@@ -685,7 +689,7 @@ tracks/7/keys = {
 "values": [ Vector2( 2, 2 ), Vector2( 2, 2 ) ]
 }
 tracks/8/type = "value"
-tracks/8/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:position")
+tracks/8/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:position")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
@@ -697,7 +701,7 @@ tracks/8/keys = {
 "values": [ Vector2( 56.261, 460.649 ), Vector2( 56.261, 460.649 ), Vector2( 56.261, 440.649 ), Vector2( 56.261, 460.649 ), Vector2( 56.261, 440.649 ), Vector2( 56.261, 460.649 ) ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath("Sprites/Neck0/Neck1:rotation_degrees")
+tracks/9/path = NodePath("Sprites/Neck0/HeadBobber:rotation_degrees")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
@@ -709,7 +713,7 @@ tracks/9/keys = {
 "values": [ 0.0, 8.0, 4.0, 8.0, 4.0 ]
 }
 tracks/10/type = "value"
-tracks/10/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:rotation_degrees")
+tracks/10/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:rotation_degrees")
 tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/imported = false
@@ -721,7 +725,7 @@ tracks/10/keys = {
 "values": [ 0.0, -8.0, -4.0, -8.0, -4.0 ]
 }
 tracks/11/type = "value"
-tracks/11/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:material:blend_mode")
+tracks/11/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:material:blend_mode")
 tracks/11/interp = 1
 tracks/11/loop_wrap = true
 tracks/11/imported = false
@@ -752,7 +756,7 @@ resource_name = "cry1"
 length = 6.0
 step = 0.05
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Eyes:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Eyes:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -764,7 +768,7 @@ tracks/0/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("Sprites/Neck0/Neck1/EmoteEyes:frame")
+tracks/1/path = NodePath("Sprites/Neck0/HeadBobber/EmoteEyes:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -776,7 +780,7 @@ tracks/1/keys = {
 "values": [ 0, 9, 9 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:material:blend_mode")
+tracks/2/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:material:blend_mode")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -788,7 +792,7 @@ tracks/2/keys = {
 "values": [ 0, 0 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Sprites/Neck0/Neck1/EmoteHead:modulate")
+tracks/3/path = NodePath("Sprites/Neck0/HeadBobber/EmoteHead:modulate")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -800,7 +804,7 @@ tracks/3/keys = {
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Sprites/Neck0/Neck1/EmoteHead:frame")
+tracks/4/path = NodePath("Sprites/Neck0/HeadBobber/EmoteHead:frame")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -812,7 +816,7 @@ tracks/4/keys = {
 "values": [ 0, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8, 5 ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath(".:head_bob_mode")
+tracks/5/path = NodePath("Sprites/Neck0/HeadBobber:head_bob_mode")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -824,7 +828,7 @@ tracks/5/keys = {
 "values": [ 1, 2, 2 ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath(".:head_motion_seconds")
+tracks/6/path = NodePath("Sprites/Neck0/HeadBobber:head_motion_seconds")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
@@ -836,7 +840,7 @@ tracks/6/keys = {
 "values": [ 6.5, 0.3, 0.3 ]
 }
 tracks/7/type = "value"
-tracks/7/path = NodePath(".:head_motion_pixels")
+tracks/7/path = NodePath("Sprites/Neck0/HeadBobber:head_motion_pixels")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/imported = false
@@ -852,7 +856,7 @@ tracks/7/keys = {
 length = 0.6
 step = 0.0333333
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Eyes:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Eyes:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -868,7 +872,7 @@ tracks/0/keys = {
 length = 0.8
 step = 0.0333333
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Eyes:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Eyes:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -883,7 +887,7 @@ tracks/0/keys = {
 [sub_resource type="Animation" id=42]
 length = 6.0
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/EmoteArms:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/EmoteArms:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -919,7 +923,7 @@ tracks/2/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Sprites/Neck0/Neck1/Eyes:frame")
+tracks/3/path = NodePath("Sprites/Neck0/HeadBobber/Eyes:frame")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -931,7 +935,7 @@ tracks/3/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Sprites/Neck0/Neck1/EmoteEyes:frame")
+tracks/4/path = NodePath("Sprites/Neck0/HeadBobber/EmoteEyes:frame")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -946,7 +950,7 @@ tracks/4/keys = {
 [sub_resource type="Animation" id=43]
 length = 6.0
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/EmoteArms:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/EmoteArms:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -982,7 +986,7 @@ tracks/2/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Sprites/Neck0/Neck1/Eyes:frame")
+tracks/3/path = NodePath("Sprites/Neck0/HeadBobber/Eyes:frame")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -994,7 +998,7 @@ tracks/3/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Sprites/Neck0/Neck1/EmoteEyes:frame")
+tracks/4/path = NodePath("Sprites/Neck0/HeadBobber/EmoteEyes:frame")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -1006,7 +1010,7 @@ tracks/4/keys = {
 "values": [ 0, 1, 1 ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:material:shader_param/green")
+tracks/5/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:material:shader_param/green")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -1018,7 +1022,7 @@ tracks/5/keys = {
 "values": [ Color( 1, 1, 0.24, 1 ) ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:modulate")
+tracks/6/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:modulate")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
@@ -1030,7 +1034,7 @@ tracks/6/keys = {
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
 }
 tracks/7/type = "value"
-tracks/7/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:frame")
+tracks/7/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:frame")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/imported = false
@@ -1042,7 +1046,7 @@ tracks/7/keys = {
 "values": [ 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4 ]
 }
 tracks/8/type = "value"
-tracks/8/path = NodePath(".:head_bob_mode")
+tracks/8/path = NodePath("Sprites/Neck0/HeadBobber:head_bob_mode")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
@@ -1054,7 +1058,7 @@ tracks/8/keys = {
 "values": [ 1, 2, 2 ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:position")
+tracks/9/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:position")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
@@ -1066,7 +1070,7 @@ tracks/9/keys = {
 "values": [ Vector2( 255.118, 133.989 ), Vector2( 255.118, 133.989 ) ]
 }
 tracks/10/type = "value"
-tracks/10/path = NodePath(".:head_motion_seconds")
+tracks/10/path = NodePath("Sprites/Neck0/HeadBobber:head_motion_seconds")
 tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/imported = false
@@ -1078,7 +1082,7 @@ tracks/10/keys = {
 "values": [ 6.5, 0.3, 0.3 ]
 }
 tracks/11/type = "value"
-tracks/11/path = NodePath(".:head_motion_pixels")
+tracks/11/path = NodePath("Sprites/Neck0/HeadBobber:head_motion_pixels")
 tracks/11/interp = 1
 tracks/11/loop_wrap = true
 tracks/11/imported = false
@@ -1107,7 +1111,7 @@ tracks/12/keys = {
 [sub_resource type="Animation" id=44]
 length = 6.0
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Eyes:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Eyes:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -1119,7 +1123,7 @@ tracks/0/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("Sprites/Neck0/Neck1/EmoteEyes:frame")
+tracks/1/path = NodePath("Sprites/Neck0/HeadBobber/EmoteEyes:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -1131,7 +1135,7 @@ tracks/1/keys = {
 "values": [ 0, 3, 3 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:frame")
+tracks/2/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -1143,7 +1147,7 @@ tracks/2/keys = {
 "values": [ 0, 9, 10, 11, 9, 10, 11, 9, 10, 11, 9, 10, 11, 9 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:modulate")
+tracks/3/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:modulate")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -1155,7 +1159,7 @@ tracks/3/keys = {
 "values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:modulate")
+tracks/4/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:modulate")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -1167,7 +1171,7 @@ tracks/4/keys = {
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 0 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0.392157 ), Color( 1, 0.372549, 0.203922, 0 ) ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:material:blend_mode")
+tracks/5/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:material:blend_mode")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -1179,7 +1183,7 @@ tracks/5/keys = {
 "values": [ 1, 1 ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:position")
+tracks/6/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:position")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
@@ -1191,7 +1195,7 @@ tracks/6/keys = {
 "values": [ Vector2( -95.728, 468.808 ), Vector2( -95.728, 468.808 ), Vector2( -48.962, 376.968 ), Vector2( -48.962, 376.968 ), Vector2( 60.158, 385.276 ), Vector2( 60.158, 385.276 ), Vector2( -95.728, 468.808 ), Vector2( -95.728, 468.808 ), Vector2( -48.962, 376.968 ), Vector2( -48.962, 376.968 ), Vector2( 60.158, 385.276 ), Vector2( 60.158, 385.276 ), Vector2( -95.728, 468.808 ), Vector2( -95.728, 468.808 ), Vector2( -48.962, 376.968 ), Vector2( -48.962, 376.968 ), Vector2( 60.158, 385.276 ), Vector2( 60.158, 385.276 ), Vector2( -95.728, 468.808 ), Vector2( -95.728, 468.808 ), Vector2( -48.962, 376.968 ), Vector2( -48.962, 376.968 ), Vector2( 60.158, 385.276 ), Vector2( 60.158, 385.276 ) ]
 }
 tracks/7/type = "value"
-tracks/7/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:material:shader_param/green")
+tracks/7/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:material:shader_param/green")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/imported = false
@@ -1203,7 +1207,7 @@ tracks/7/keys = {
 "values": [ Color( 1, 0.682353, 0.6, 1 ), Color( 1, 0.682353, 0.6, 1 ) ]
 }
 tracks/8/type = "value"
-tracks/8/path = NodePath(".:head_bob_mode")
+tracks/8/path = NodePath("Sprites/Neck0/HeadBobber:head_bob_mode")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
@@ -1215,7 +1219,7 @@ tracks/8/keys = {
 "values": [ 1, 3, 3 ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:position")
+tracks/9/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:position")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
@@ -1227,7 +1231,7 @@ tracks/9/keys = {
 "values": [ Vector2( -25.4782, 211.932 ), Vector2( -25.4782, 211.932 ) ]
 }
 tracks/10/type = "value"
-tracks/10/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:scale")
+tracks/10/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:scale")
 tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/imported = false
@@ -1239,7 +1243,7 @@ tracks/10/keys = {
 "values": [ Vector2( 2, 2 ), Vector2( 2, 2 ) ]
 }
 tracks/11/type = "value"
-tracks/11/path = NodePath(".:head_motion_pixels")
+tracks/11/path = NodePath("Sprites/Neck0/HeadBobber:head_motion_pixels")
 tracks/11/interp = 1
 tracks/11/loop_wrap = true
 tracks/11/imported = false
@@ -1251,7 +1255,7 @@ tracks/11/keys = {
 "values": [ 2.0, 2.0, 2.0 ]
 }
 tracks/12/type = "value"
-tracks/12/path = NodePath(".:head_motion_seconds")
+tracks/12/path = NodePath("Sprites/Neck0/HeadBobber:head_motion_seconds")
 tracks/12/interp = 1
 tracks/12/loop_wrap = true
 tracks/12/imported = false
@@ -1280,7 +1284,7 @@ tracks/13/keys = {
 [sub_resource type="Animation" id=45]
 length = 6.0
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Eyes:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Eyes:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -1292,7 +1296,7 @@ tracks/0/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("Sprites/Neck0/Neck1/EmoteEyes:frame")
+tracks/1/path = NodePath("Sprites/Neck0/HeadBobber/EmoteEyes:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -1304,7 +1308,7 @@ tracks/1/keys = {
 "values": [ 0, 4, 5, 6, 7, 8, 4, 5, 6, 7, 8, 4, 5, 6, 7, 8, 4, 5, 6, 7, 8, 4, 5, 6, 7, 8, 4, 5, 6, 7, 8, 4, 5, 6, 7, 8, 4, 5, 6, 7, 8, 4 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:frame")
+tracks/2/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -1316,7 +1320,7 @@ tracks/2/keys = {
 "values": [ 0, 5, 5 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:modulate")
+tracks/3/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:modulate")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -1328,7 +1332,7 @@ tracks/3/keys = {
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:scale")
+tracks/4/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:scale")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -1340,7 +1344,7 @@ tracks/4/keys = {
 "values": [ Vector2( 1, 1 ), Vector2( 1.2, 0.8 ), Vector2( 0.8, 1.2 ), Vector2( 1, 1 ) ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:position")
+tracks/5/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:position")
 tracks/5/interp = 2
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -1376,7 +1380,7 @@ tracks/7/keys = {
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
 }
 tracks/8/type = "value"
-tracks/8/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:modulate")
+tracks/8/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:modulate")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
@@ -1388,7 +1392,7 @@ tracks/8/keys = {
 "values": [ Color( 1, 1, 1, 0 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ) ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:scale")
+tracks/9/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:scale")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
@@ -1400,7 +1404,7 @@ tracks/9/keys = {
 "values": [ Vector2( 3, 3 ) ]
 }
 tracks/10/type = "value"
-tracks/10/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:position")
+tracks/10/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:position")
 tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/imported = false
@@ -1412,7 +1416,7 @@ tracks/10/keys = {
 "values": [ Vector2( 7.13472, 726.013 ), Vector2( 7.135, 676.013 ), Vector2( 7.13472, 726.013 ), Vector2( 7.135, 676.013 ), Vector2( 7.13472, 726.013 ), Vector2( 7.135, 676.013 ) ]
 }
 tracks/11/type = "value"
-tracks/11/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:material:blend_mode")
+tracks/11/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:material:blend_mode")
 tracks/11/interp = 1
 tracks/11/loop_wrap = true
 tracks/11/imported = false
@@ -1453,7 +1457,7 @@ tracks/13/keys = {
 [sub_resource type="Animation" id=46]
 length = 6.0
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Eyes:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Eyes:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -1465,7 +1469,7 @@ tracks/0/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("Sprites/Neck0/Neck1/EmoteEyes:frame")
+tracks/1/path = NodePath("Sprites/Neck0/HeadBobber/EmoteEyes:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -1480,7 +1484,7 @@ tracks/1/keys = {
 [sub_resource type="Animation" id=47]
 length = 6.0
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Eyes:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Eyes:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -1492,7 +1496,7 @@ tracks/0/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("Sprites/Neck0/Neck1/EmoteEyes:frame")
+tracks/1/path = NodePath("Sprites/Neck0/HeadBobber/EmoteEyes:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -1504,7 +1508,7 @@ tracks/1/keys = {
 "values": [ 0, 1, 1 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:modulate")
+tracks/2/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:modulate")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -1516,7 +1520,7 @@ tracks/2/keys = {
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:material:shader_param/green")
+tracks/3/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:material:shader_param/green")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -1528,7 +1532,7 @@ tracks/3/keys = {
 "values": [ Color( 1, 0.552941, 0.67451, 1 ), Color( 1, 0.552941, 0.67451, 1 ) ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:frame")
+tracks/4/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:frame")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -1540,7 +1544,7 @@ tracks/4/keys = {
 "values": [ 2, 2 ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:scale")
+tracks/5/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:scale")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -1552,7 +1556,7 @@ tracks/5/keys = {
 "values": [ Vector2( 1, 1 ), Vector2( 1.2, 0.8 ), Vector2( 0.7, 1.3 ), Vector2( 1, 1 ) ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:position")
+tracks/6/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:position")
 tracks/6/interp = 2
 tracks/6/loop_wrap = true
 tracks/6/imported = false
@@ -1564,7 +1568,7 @@ tracks/6/keys = {
 "values": [ Vector2( -18.2593, -72.9644 ), Vector2( -18.259, -72.964 ), Vector2( -18.259, -42.964 ), Vector2( -18.259, -72.964 ), Vector2( -18.259, -42.964 ), Vector2( -18.259, -72.964 ), Vector2( -18.259, -42.964 ), Vector2( -18.259, -72.964 ), Vector2( -18.259, -42.964 ), Vector2( -18.259, -72.964 ), Vector2( -18.259, -42.964 ), Vector2( -18.259, -72.964 ), Vector2( -18.259, -42.964 ), Vector2( -18.259, -72.964 ), Vector2( -18.259, -42.964 ), Vector2( -18.259, -72.964 ), Vector2( -18.259, -42.964 ), Vector2( -18.259, -72.964 ), Vector2( -18.259, -42.964 ), Vector2( -18.259, -72.964 ), Vector2( -18.259, -42.964 ), Vector2( -18.259, -42.964 ) ]
 }
 tracks/7/type = "value"
-tracks/7/path = NodePath("Sprites/Neck0/Neck1:rotation_degrees")
+tracks/7/path = NodePath("Sprites/Neck0/HeadBobber:rotation_degrees")
 tracks/7/interp = 2
 tracks/7/loop_wrap = true
 tracks/7/imported = false
@@ -1576,7 +1580,7 @@ tracks/7/keys = {
 "values": [ 0.0, 4.0, -4.0, 4.0, -4.0, 4.0, -4.0, 4.0 ]
 }
 tracks/8/type = "value"
-tracks/8/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:rotation_degrees")
+tracks/8/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:rotation_degrees")
 tracks/8/interp = 2
 tracks/8/loop_wrap = true
 tracks/8/imported = false
@@ -1588,7 +1592,7 @@ tracks/8/keys = {
 "values": [ 0.0, -4.0, 4.0, -4.0, 4.0, -4.0, 4.0, -4.0 ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:modulate")
+tracks/9/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:modulate")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
@@ -1600,7 +1604,7 @@ tracks/9/keys = {
 "values": [ Color( 0.54902, 0.133333, 0.380392, 0 ), Color( 0.54902, 0.133333, 0.380392, 1 ), Color( 0.54902, 0.133333, 0.380392, 1 ) ]
 }
 tracks/10/type = "value"
-tracks/10/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:scale")
+tracks/10/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:scale")
 tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/imported = false
@@ -1612,7 +1616,7 @@ tracks/10/keys = {
 "values": [ Vector2( 1.8, 0.8 ), Vector2( 1.8, 0.8 ) ]
 }
 tracks/11/type = "value"
-tracks/11/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:rotation_degrees")
+tracks/11/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:rotation_degrees")
 tracks/11/interp = 2
 tracks/11/loop_wrap = true
 tracks/11/imported = false
@@ -1624,7 +1628,7 @@ tracks/11/keys = {
 "values": [ 0.0, -4.0, 4.0, -4.0, 4.0, -4.0, 4.0, -4.0 ]
 }
 tracks/12/type = "value"
-tracks/12/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:position")
+tracks/12/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:position")
 tracks/12/interp = 2
 tracks/12/loop_wrap = true
 tracks/12/imported = false
@@ -1636,7 +1640,7 @@ tracks/12/keys = {
 "values": [ Vector2( 25.3166, 262.374 ), Vector2( 25.3166, 262.374 ) ]
 }
 tracks/13/type = "value"
-tracks/13/path = NodePath("Sprites/Neck0/Neck1/EmoteGlow:material:blend_mode")
+tracks/13/path = NodePath("Sprites/Neck0/HeadBobber/EmoteGlow:material:blend_mode")
 tracks/13/interp = 1
 tracks/13/loop_wrap = true
 tracks/13/imported = false
@@ -1665,7 +1669,7 @@ tracks/14/keys = {
 [sub_resource type="Animation" id=48]
 length = 6.0
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Eyes:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Eyes:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -1677,7 +1681,7 @@ tracks/0/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("Sprites/Neck0/Neck1/EmoteEyes:frame")
+tracks/1/path = NodePath("Sprites/Neck0/HeadBobber/EmoteEyes:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -1689,7 +1693,7 @@ tracks/1/keys = {
 "values": [ 0, 2, 2 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("Sprites/Neck0/Neck1/EmoteArms:frame")
+tracks/2/path = NodePath("Sprites/Neck0/HeadBobber/EmoteArms:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -1716,7 +1720,7 @@ tracks/3/keys = {
 [sub_resource type="Animation" id=49]
 length = 6.0
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Eyes:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Eyes:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -1728,7 +1732,7 @@ tracks/0/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("Sprites/Neck0/Neck1/EmoteEyes:frame")
+tracks/1/path = NodePath("Sprites/Neck0/HeadBobber/EmoteEyes:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -1740,7 +1744,7 @@ tracks/1/keys = {
 "values": [ 0, 2, 2 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("Sprites/Neck0/Neck1/EmoteHead:frame")
+tracks/2/path = NodePath("Sprites/Neck0/HeadBobber/EmoteHead:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -1752,7 +1756,7 @@ tracks/2/keys = {
 "values": [ 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Sprites/Neck0/Neck1/EmoteArms:frame")
+tracks/3/path = NodePath("Sprites/Neck0/HeadBobber/EmoteArms:frame")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -1788,7 +1792,7 @@ tracks/5/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath(".:head_bob_mode")
+tracks/6/path = NodePath("Sprites/Neck0/HeadBobber:head_bob_mode")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
@@ -1800,7 +1804,7 @@ tracks/6/keys = {
 "values": [ 1, 3, 3 ]
 }
 tracks/7/type = "value"
-tracks/7/path = NodePath("Sprites/Neck0/Neck1/EmoteHead:modulate")
+tracks/7/path = NodePath("Sprites/Neck0/HeadBobber/EmoteHead:modulate")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/imported = false
@@ -1812,7 +1816,7 @@ tracks/7/keys = {
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
 }
 tracks/8/type = "value"
-tracks/8/path = NodePath(".:head_motion_pixels")
+tracks/8/path = NodePath("Sprites/Neck0/HeadBobber:head_motion_pixels")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
@@ -1824,7 +1828,7 @@ tracks/8/keys = {
 "values": [ 2.0, 2.0, 2.0 ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath(".:head_motion_seconds")
+tracks/9/path = NodePath("Sprites/Neck0/HeadBobber:head_motion_seconds")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
@@ -1853,7 +1857,7 @@ tracks/10/keys = {
 [sub_resource type="Animation" id=50]
 length = 6.0
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/EmoteArms:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/EmoteArms:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -1877,7 +1881,7 @@ tracks/1/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:frame")
+tracks/2/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -1889,7 +1893,7 @@ tracks/2/keys = {
 "values": [ 1 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:modulate")
+tracks/3/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:modulate")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -1901,7 +1905,7 @@ tracks/3/keys = {
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:scale")
+tracks/4/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:scale")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -1913,7 +1917,7 @@ tracks/4/keys = {
 "values": [ Vector2( 1, 1 ), Vector2( 0.8, 1.2 ), Vector2( 1.2, 0.8 ), Vector2( 1, 1 ) ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:position")
+tracks/5/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:position")
 tracks/5/interp = 2
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -1925,7 +1929,7 @@ tracks/5/keys = {
 "values": [ Vector2( -18, -36 ), Vector2( -18, -56 ), Vector2( -18, -36 ), Vector2( -18, -56 ), Vector2( -18, -36 ), Vector2( -18, -56 ), Vector2( -18, -36 ) ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("Sprites/Neck0/Neck1:rotation_degrees")
+tracks/6/path = NodePath("Sprites/Neck0/HeadBobber:rotation_degrees")
 tracks/6/interp = 2
 tracks/6/loop_wrap = true
 tracks/6/imported = false
@@ -1937,7 +1941,7 @@ tracks/6/keys = {
 "values": [ 0.0, -16.0, -12.0, -16.0, -12.0, -16.0 ]
 }
 tracks/7/type = "value"
-tracks/7/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:rotation_degrees")
+tracks/7/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:rotation_degrees")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/imported = false
@@ -1966,7 +1970,7 @@ tracks/8/keys = {
 [sub_resource type="Animation" id=51]
 length = 6.0
 tracks/0/type = "value"
-tracks/0/path = NodePath("Sprites/Neck0/Neck1/Eyes:frame")
+tracks/0/path = NodePath("Sprites/Neck0/HeadBobber/Eyes:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -1978,7 +1982,7 @@ tracks/0/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("Sprites/Neck0/Neck1/EmoteEyes:frame")
+tracks/1/path = NodePath("Sprites/Neck0/HeadBobber/EmoteEyes:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -1990,7 +1994,7 @@ tracks/1/keys = {
 "values": [ 0, 4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 6, 7 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:modulate")
+tracks/2/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:modulate")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -2002,7 +2006,7 @@ tracks/2/keys = {
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ) ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:frame")
+tracks/3/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:frame")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -2014,7 +2018,7 @@ tracks/3/keys = {
 "values": [ 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:position")
+tracks/4/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:position")
 tracks/4/interp = 2
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -2026,7 +2030,7 @@ tracks/4/keys = {
 "values": [ Vector2( -18.259, -54.299 ), Vector2( -18.259, -84.299 ), Vector2( -18.259, -54.299 ), Vector2( -18.2593, -74.2989 ), Vector2( -18.259, -54.299 ), Vector2( -18.2593, -74.2989 ) ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Sprites/Neck0/Neck1:rotation_degrees")
+tracks/5/path = NodePath("Sprites/Neck0/HeadBobber:rotation_degrees")
 tracks/5/interp = 2
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -2038,7 +2042,7 @@ tracks/5/keys = {
 "values": [ 0.0, -6.0, 6.0, -6.0, 6.0, -6.0, 6.0, -6.0 ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:rotation_degrees")
+tracks/6/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:rotation_degrees")
 tracks/6/interp = 2
 tracks/6/loop_wrap = true
 tracks/6/imported = false
@@ -2050,7 +2054,7 @@ tracks/6/keys = {
 "values": [ 0.0, 6.0, -6.0, 6.0, -6.0, 6.0, -6.0, 6.0 ]
 }
 tracks/7/type = "value"
-tracks/7/path = NodePath("Sprites/Neck0/Neck1/EmoteBrain:scale")
+tracks/7/path = NodePath("Sprites/Neck0/HeadBobber/EmoteBrain:scale")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/imported = false
@@ -2151,7 +2155,7 @@ tracks/5/keys = {
 "values": [ Vector2( 0, 0 ), Vector2( 0, 0 ), Vector2( 0, -24.525 ), Vector2( 4, -54 ), Vector2( 17, -121 ), Vector2( 17, -255 ), Vector2( 81.7715, -561.446 ) ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("Shadow:scale")
+tracks/6/path = NodePath("Sprites/Shadow:scale")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
@@ -2357,13 +2361,6 @@ __meta__ = {
 "_editor_description_": ""
 }
 
-[node name="Shadow" type="Sprite" parent="."]
-self_modulate = Color( 0.521569, 0.368627, 0.270588, 1 )
-light_mask = 2
-scale = Vector2( 0.17, 0.17 )
-z_index = -20
-texture = ExtResource( 14 )
-
 [node name="Sprites" type="Node2D" parent="."]
 __meta__ = {
 "_editor_description_": "Container for all of the creature's parts, to enable flipping by MovementAnims"
@@ -2378,7 +2375,7 @@ texture = ExtResource( 60 )
 offset = Vector2( 0, -239 )
 vframes = 2
 hframes = 8
-frame = 1
+frame = 7
 
 [node name="Outline" type="Sprite" parent="Sprites/FarMovement"]
 light_mask = 2
@@ -2393,6 +2390,9 @@ scale = Vector2( 0.418, 0.418 )
 offset = Vector2( 0, -239 )
 hframes = 3
 frame = 1
+script = ExtResource( 48 )
+creature_path = NodePath("../..")
+invisible_while_moving = true
 
 [node name="Outline" type="Sprite" parent="Sprites/FarArm"]
 light_mask = 2
@@ -2407,6 +2407,9 @@ scale = Vector2( 0.418, 0.418 )
 offset = Vector2( 0, -239 )
 hframes = 3
 frame = 1
+script = ExtResource( 48 )
+creature_path = NodePath("../..")
+invisible_while_moving = true
 
 [node name="Outline" type="Sprite" parent="Sprites/FarLeg"]
 light_mask = 2
@@ -2420,14 +2423,8 @@ light_mask = 2
 rotation = 0.00355033
 curve = SubResource( 7 )
 script = ExtResource( 3 )
-spline_length = 25.0
-_smooth = false
-_straighten = false
-closed = true
-line_color = Color( 0, 0, 0, 1 )
 fill_color = Color( 0, 0, 0, 1 )
 line_width = 2.0
-_fatness = 1.0
 editing = false
 
 [node name="Outline" type="Path2D" parent="Sprites/Body"]
@@ -2451,6 +2448,8 @@ rotation = 3.13804
 scale = Vector2( 0.418, -0.418 )
 hframes = 3
 frame = 1
+script = ExtResource( 48 )
+creature_path = NodePath("../../..")
 
 [node name="NearLeg" type="Sprite" parent="Sprites"]
 light_mask = 2
@@ -2459,6 +2458,9 @@ scale = Vector2( 0.418, 0.418 )
 offset = Vector2( 0, -239 )
 hframes = 3
 frame = 1
+script = ExtResource( 48 )
+creature_path = NodePath("../..")
+invisible_while_moving = true
 
 [node name="Outline" type="Sprite" parent="Sprites/NearLeg"]
 light_mask = 2
@@ -2473,6 +2475,9 @@ scale = Vector2( 0.418, 0.418 )
 offset = Vector2( 0, -239 )
 hframes = 3
 frame = 1
+script = ExtResource( 48 )
+creature_path = NodePath("../..")
+invisible_while_moving = true
 
 [node name="Outline" type="Sprite" parent="Sprites/NearArm"]
 light_mask = 2
@@ -2485,97 +2490,110 @@ __meta__ = {
 "_editor_description_": "Neck0 offsets the head's position as the creature grows in size."
 }
 
-[node name="Neck1" type="Sprite" parent="Sprites/Neck0"]
+[node name="HeadBobber" type="Sprite" parent="Sprites/Neck0"]
 light_mask = 2
 position = Vector2( 0, -100 )
 scale = Vector2( 0.418, 0.418 )
 hframes = 3
 frame = 1
+script = ExtResource( 50 )
 __meta__ = {
 "_editor_description_": "Neck1 offsets the head's position as the creature bobs their head up and down"
 }
 
-[node name="EarZ0" type="Sprite" parent="Sprites/Neck0/Neck1"]
+[node name="EarZ0" type="Sprite" parent="Sprites/Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 11 )
 hframes = 3
 frame = 1
+script = ExtResource( 48 )
+creature_path = NodePath("../../../..")
 
-[node name="Outline" type="Sprite" parent="Sprites/Neck0/Neck1/EarZ0"]
+[node name="Outline" type="Sprite" parent="Sprites/Neck0/HeadBobber/EarZ0"]
 light_mask = 2
 material = SubResource( 12 )
 script = ExtResource( 4 )
 
-[node name="HornZ0" type="Sprite" parent="Sprites/Neck0/Neck1"]
+[node name="HornZ0" type="Sprite" parent="Sprites/Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 13 )
 hframes = 3
 frame = 1
+script = ExtResource( 48 )
+creature_path = NodePath("../../../..")
 
-[node name="Outline" type="Sprite" parent="Sprites/Neck0/Neck1/HornZ0"]
+[node name="Outline" type="Sprite" parent="Sprites/Neck0/HeadBobber/HornZ0"]
 light_mask = 2
 material = SubResource( 14 )
 script = ExtResource( 4 )
 
-[node name="Head" type="Sprite" parent="Sprites/Neck0/Neck1"]
+[node name="Head" type="Sprite" parent="Sprites/Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 15 )
 hframes = 3
 frame = 1
+script = ExtResource( 48 )
+creature_path = NodePath("../../../..")
 
-[node name="Outline" type="Sprite" parent="Sprites/Neck0/Neck1/Head"]
+[node name="Outline" type="Sprite" parent="Sprites/Neck0/HeadBobber/Head"]
 light_mask = 2
 material = SubResource( 16 )
 script = ExtResource( 4 )
 
-[node name="EarZ1" type="Sprite" parent="Sprites/Neck0/Neck1"]
+[node name="EarZ1" type="Sprite" parent="Sprites/Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 11 )
 hframes = 3
 frame = 1
+script = ExtResource( 48 )
+creature_path = NodePath("../../../..")
 
-[node name="Outline" type="Sprite" parent="Sprites/Neck0/Neck1/EarZ1"]
+[node name="Outline" type="Sprite" parent="Sprites/Neck0/HeadBobber/EarZ1"]
 light_mask = 2
 material = SubResource( 17 )
 script = ExtResource( 4 )
 
-[node name="HornZ1" type="Sprite" parent="Sprites/Neck0/Neck1"]
+[node name="HornZ1" type="Sprite" parent="Sprites/Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 13 )
 hframes = 3
 frame = 1
+script = ExtResource( 48 )
+creature_path = NodePath("../../../..")
 
-[node name="Outline" type="Sprite" parent="Sprites/Neck0/Neck1/HornZ1"]
+[node name="Outline" type="Sprite" parent="Sprites/Neck0/HeadBobber/HornZ1"]
 light_mask = 2
 material = SubResource( 14 )
 script = ExtResource( 4 )
 
-[node name="EarZ2" type="Sprite" parent="Sprites/Neck0/Neck1"]
+[node name="EarZ2" type="Sprite" parent="Sprites/Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 18 )
 hframes = 3
 frame = 1
+script = ExtResource( 48 )
+creature_path = NodePath("../../../..")
 
-[node name="Outline" type="Sprite" parent="Sprites/Neck0/Neck1/EarZ2"]
+[node name="Outline" type="Sprite" parent="Sprites/Neck0/HeadBobber/EarZ2"]
 light_mask = 2
 material = SubResource( 19 )
 script = ExtResource( 4 )
 
-[node name="Mouth" type="Sprite" parent="Sprites/Neck0/Neck1"]
+[node name="Mouth" type="Sprite" parent="Sprites/Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 20 )
 vframes = 2
 hframes = 8
-frame = 1
+frame = 12
 
-[node name="Outline" type="Sprite" parent="Sprites/Neck0/Neck1/Mouth"]
+[node name="Outline" type="Sprite" parent="Sprites/Neck0/HeadBobber/Mouth"]
 light_mask = 2
 material = SubResource( 21 )
 z_index = -2
@@ -2584,34 +2602,34 @@ hframes = 8
 frame = 1
 script = ExtResource( 4 )
 
-[node name="Eyes" type="Sprite" parent="Sprites/Neck0/Neck1"]
+[node name="Eyes" type="Sprite" parent="Sprites/Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 22 )
 hframes = 4
 frame = 1
 
-[node name="Outline" type="Sprite" parent="Sprites/Neck0/Neck1/Eyes"]
+[node name="Outline" type="Sprite" parent="Sprites/Neck0/HeadBobber/Eyes"]
 light_mask = 2
 material = SubResource( 23 )
 hframes = 4
 frame = 1
 script = ExtResource( 4 )
 
-[node name="Food" type="Sprite" parent="Sprites/Neck0/Neck1"]
+[node name="Food" type="Sprite" parent="Sprites/Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 z_index = 1
 hframes = 3
 
-[node name="FoodLaser" type="Sprite" parent="Sprites/Neck0/Neck1"]
+[node name="FoodLaser" type="Sprite" parent="Sprites/Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 position = Vector2( 1024, 0 )
 z_index = 1
 hframes = 3
 
-[node name="EmoteArms" type="Sprite" parent="Sprites/Neck0/Neck1"]
+[node name="EmoteArms" type="Sprite" parent="Sprites/Neck0/HeadBobber"]
 light_mask = 2
 material = SubResource( 1 )
 position = Vector2( 0, 234.708 )
@@ -2619,13 +2637,13 @@ texture = ExtResource( 62 )
 offset = Vector2( 0, -239 )
 hframes = 3
 
-[node name="Outline" type="Sprite" parent="Sprites/Neck0/Neck1/EmoteArms"]
+[node name="Outline" type="Sprite" parent="Sprites/Neck0/HeadBobber/EmoteArms"]
 light_mask = 2
 material = SubResource( 2 )
 offset = Vector2( 0, -239 )
 script = ExtResource( 4 )
 
-[node name="EmoteEyes" type="Sprite" parent="Sprites/Neck0/Neck1"]
+[node name="EmoteEyes" type="Sprite" parent="Sprites/Neck0/HeadBobber"]
 light_mask = 2
 material = SubResource( 24 )
 position = Vector2( 0, 256 )
@@ -2634,7 +2652,7 @@ offset = Vector2( 0, -239 )
 vframes = 2
 hframes = 8
 
-[node name="EmoteGlow" type="Sprite" parent="Sprites/Neck0/Neck1"]
+[node name="EmoteGlow" type="Sprite" parent="Sprites/Neck0/HeadBobber"]
 modulate = Color( 0.54902, 0.133333, 0.380392, 0 )
 light_mask = 2
 material = SubResource( 25 )
@@ -2643,18 +2661,18 @@ scale = Vector2( 1.8, 0.8 )
 texture = ExtResource( 67 )
 offset = Vector2( 0, -239 )
 
-[node name="EmoteBrain" type="Sprite" parent="Sprites/Neck0/Neck1"]
+[node name="EmoteBrain" type="Sprite" parent="Sprites/Neck0/HeadBobber"]
 modulate = Color( 1, 1, 1, 0 )
 light_mask = 2
 material = SubResource( 26 )
-position = Vector2( -18.259, -54.299 )
+position = Vector2( 255.118, 133.989 )
 texture = ExtResource( 53 )
 offset = Vector2( 0, -239 )
 vframes = 2
 hframes = 8
-frame = 6
+frame = 4
 
-[node name="EmoteHead" type="Sprite" parent="Sprites/Neck0/Neck1"]
+[node name="EmoteHead" type="Sprite" parent="Sprites/Neck0/HeadBobber"]
 modulate = Color( 1, 1, 1, 0 )
 light_mask = 2
 position = Vector2( 35.83, 239.786 )
@@ -2674,17 +2692,31 @@ texture = ExtResource( 65 )
 offset = Vector2( 0, -239 )
 hframes = 6
 
+[node name="Shadow" type="Sprite" parent="Sprites"]
+self_modulate = Color( 0.521569, 0.368627, 0.270588, 1 )
+show_behind_parent = true
+light_mask = 2
+scale = Vector2( 0.17, 0.17 )
+z_index = -20
+texture = ExtResource( 14 )
+
 [node name="Mouth0Anims" type="AnimationPlayer" parent="."]
 anims/ambient-nw = SubResource( 28 )
 anims/ambient-se = SubResource( 29 )
 anims/eat = SubResource( 30 )
 anims/eat-again = SubResource( 31 )
+script = ExtResource( 49 )
+mouth_path = NodePath("../Sprites/Neck0/HeadBobber/Mouth")
+north_frame = 12
 
 [node name="Mouth1Anims" type="AnimationPlayer" parent="."]
 anims/ambient-nw = SubResource( 32 )
 anims/ambient-se = SubResource( 33 )
 anims/eat = SubResource( 34 )
 anims/eat-again = SubResource( 35 )
+script = ExtResource( 49 )
+mouth_path = NodePath("../Sprites/Neck0/HeadBobber/Mouth")
+north_frame = 17
 
 [node name="EmoteAnims" type="AnimationPlayer" parent="."]
 anims/ambient = SubResource( 36 )
@@ -2704,6 +2736,7 @@ anims/sweat1 = SubResource( 49 )
 anims/think0 = SubResource( 50 )
 anims/think1 = SubResource( 51 )
 script = ExtResource( 58 )
+eyes_path = NodePath("../Sprites/Neck0/HeadBobber/Eyes")
 
 [node name="ResetTween" type="Tween" parent="EmoteAnims"]
 
@@ -2724,256 +2757,295 @@ anims/run-se = SubResource( 57 )
 
 [node name="Tween" type="Tween" parent="."]
 
-[node name="Munch0" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="CreatureSfx" type="Node" parent="."]
+script = ExtResource( 47 )
+
+[node name="Munch0" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 20 )
 bus = "Voice Bus"
 
-[node name="Munch1" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="Munch1" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 25 )
 bus = "Voice Bus"
 
-[node name="Munch2" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="Munch2" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 26 )
 bus = "Voice Bus"
 
-[node name="Munch3" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="Munch3" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 44 )
 bus = "Voice Bus"
 
-[node name="Munch4" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="Munch4" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 21 )
 bus = "Voice Bus"
 
-[node name="DoorChime0" type="AudioStreamPlayer2D" parent="."]
+[node name="DoorChime0" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 108.587, 210.527 )
 stream = ExtResource( 15 )
 volume_db = -4.0
 max_distance = 4000.0
 bus = "Sound Bus"
 
-[node name="DoorChime1" type="AudioStreamPlayer2D" parent="."]
+[node name="DoorChime1" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 108.587, 210.527 )
 stream = ExtResource( 11 )
 volume_db = -4.0
 max_distance = 4000.0
 bus = "Sound Bus"
 
-[node name="DoorChime2" type="AudioStreamPlayer2D" parent="."]
+[node name="DoorChime2" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 108.587, 210.527 )
 stream = ExtResource( 24 )
 volume_db = -4.0
 max_distance = 4000.0
 bus = "Sound Bus"
 
-[node name="DoorChime3" type="AudioStreamPlayer2D" parent="."]
+[node name="DoorChime3" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 108.587, 210.527 )
 stream = ExtResource( 16 )
 volume_db = -4.0
 max_distance = 4000.0
 bus = "Sound Bus"
 
-[node name="DoorChime4" type="AudioStreamPlayer2D" parent="."]
+[node name="DoorChime4" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 108.587, 210.527 )
 stream = ExtResource( 18 )
 volume_db = -4.0
 max_distance = 4000.0
 bus = "Sound Bus"
 
-[node name="ComboVoice00" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice00" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 10 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice01" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice01" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 36 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice02" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice02" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 33 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice03" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice03" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 41 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice04" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice04" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 29 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice05" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice05" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 34 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice06" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice06" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 32 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice07" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice07" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 35 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice08" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice08" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 43 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice09" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice09" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 30 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice10" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice10" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 42 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice11" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice11" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 39 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice12" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice12" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 40 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice13" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice13" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 19 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice14" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice14" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 12 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice15" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice15" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 23 )
 volume_db = 6.0
 max_distance = 4000.0
 attenuation = 0.466517
 bus = "Voice Bus"
 
-[node name="ComboVoice16" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice16" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 22 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice17" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice17" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 17 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice18" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice18" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 27 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="ComboVoice19" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="ComboVoice19" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 13 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="HelloVoice0" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="HelloVoice0" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 31 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="HelloVoice1" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="HelloVoice1" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 37 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="HelloVoice2" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="HelloVoice2" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 7 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="HelloVoice3" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="HelloVoice3" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 28 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="GoodbyeVoice0" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="GoodbyeVoice0" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 38 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="GoodbyeVoice1" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="GoodbyeVoice1" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 6 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="GoodbyeVoice2" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="GoodbyeVoice2" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 9 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="GoodbyeVoice3" type="AudioStreamPlayer2D" parent="."]
-position = Vector2( 160, 0 )
+[node name="GoodbyeVoice3" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( 268.587, 210.527 )
 stream = ExtResource( 8 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
+[connection signal="before_creature_arrived" from="." to="Mouth0Anims" method="_on_Creature_before_creature_arrived"]
+[connection signal="before_creature_arrived" from="." to="EmoteAnims" method="_on_Creature_before_creature_arrived"]
+[connection signal="before_creature_arrived" from="." to="Mouth1Anims" method="_on_Creature_before_creature_arrived"]
+[connection signal="creature_arrived" from="." to="CreatureSfx" method="_on_Creature_creature_arrived"]
+[connection signal="food_eaten" from="." to="CreatureSfx" method="_on_Creature_food_eaten"]
+[connection signal="movement_mode_changed" from="." to="Sprites/Body" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/FarArm" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/FarLeg" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/Body/NeckBlend" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/Neck0/HeadBobber/EarZ2" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/NearArm" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/Neck0/HeadBobber/HornZ0" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/Neck0/HeadBobber/EarZ1" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/Neck0/HeadBobber/EarZ0" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/Neck0/HeadBobber/Head" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/NearLeg" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/Neck0/HeadBobber/HornZ1" method="_on_Creature_movement_mode_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/FarArm" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/FarLeg" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/Body/NeckBlend" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/Neck0/HeadBobber/EarZ2" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/NearArm" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/Neck0/HeadBobber/HornZ0" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/Neck0/HeadBobber/EarZ1" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/Neck0/HeadBobber/EarZ0" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/Neck0/HeadBobber/Head" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/NearLeg" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/Neck0/HeadBobber/HornZ1" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Mouth0Anims" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Mouth1Anims" method="_on_Creature_orientation_changed"]
 [connection signal="animation_finished" from="EmoteAnims" to="EmoteAnims" method="_on_animation_finished"]
+[connection signal="before_mood_switched" from="EmoteAnims" to="." method="_on_EmoteAnims_before_mood_switched"]
 [connection signal="animation_started" from="MovementAnims" to="." method="_on_MovementAnims_animation_started"]

--- a/src/main/world/restaurant/creature-body.gd
+++ b/src/main/world/restaurant/creature-body.gd
@@ -117,3 +117,7 @@ func set_fatness(fatness: float) -> void:
 
 func get_fatness() -> float:
 	return _fatness
+
+
+func _on_Creature_movement_mode_changed(movement_mode: bool) -> void:
+	visible = not movement_mode

--- a/src/main/world/restaurant/creature-loader.gd
+++ b/src/main/world/restaurant/creature-loader.gd
@@ -101,33 +101,33 @@ func _load_texture(creature_def: Dictionary, node_path: String, key: String, fil
 Loads the resources for a creature's ears based on a creature definition.
 """
 func _load_ear(creature_def: Dictionary) -> void:
-	_load_texture(creature_def, "Neck0/Neck1/EarZ0", "ear", "ear-z0-sheet")
-	_load_texture(creature_def, "Neck0/Neck1/EarZ1", "ear", "ear-z1-sheet")
-	_load_texture(creature_def, "Neck0/Neck1/EarZ2", "ear", "ear-z2-sheet")
+	_load_texture(creature_def, "Neck0/HeadBobber/EarZ0", "ear", "ear-z0-sheet")
+	_load_texture(creature_def, "Neck0/HeadBobber/EarZ1", "ear", "ear-z1-sheet")
+	_load_texture(creature_def, "Neck0/HeadBobber/EarZ2", "ear", "ear-z2-sheet")
 
 
 """
 Loads the resources for a creature's horn based on a creature definition.
 """
 func _load_horn(creature_def: Dictionary) -> void:
-	_load_texture(creature_def, "Neck0/Neck1/HornZ0", "horn", "horn-z0-sheet")
-	_load_texture(creature_def, "Neck0/Neck1/HornZ1", "horn", "horn-z1-sheet")
+	_load_texture(creature_def, "Neck0/HeadBobber/HornZ0", "horn", "horn-z0-sheet")
+	_load_texture(creature_def, "Neck0/HeadBobber/HornZ1", "horn", "horn-z1-sheet")
 
 
 """
 Loads the resources for a creature's mouth based on a creature definition.
 """
 func _load_mouth(creature_def: Dictionary) -> void:
-	_load_texture(creature_def, "Neck0/Neck1/Mouth", "mouth", "mouth-sheet")
-	_load_texture(creature_def, "Neck0/Neck1/Food", "mouth", "food-sheet")
-	_load_texture(creature_def, "Neck0/Neck1/FoodLaser", "mouth", "food-laser-sheet")
+	_load_texture(creature_def, "Neck0/HeadBobber/Mouth", "mouth", "mouth-sheet")
+	_load_texture(creature_def, "Neck0/HeadBobber/Food", "mouth", "food-sheet")
+	_load_texture(creature_def, "Neck0/HeadBobber/FoodLaser", "mouth", "food-laser-sheet")
 
 
 """
 Loads the resources for a creature's eyes based on a creature definition.
 """
 func _load_eye(creature_def: Dictionary) -> void:
-	_load_texture(creature_def, "Neck0/Neck1/Eyes", "eye", "eyes-sheet")
+	_load_texture(creature_def, "Neck0/HeadBobber/Eyes", "eye", "eyes-sheet")
 
 
 """
@@ -142,7 +142,7 @@ func _load_body(creature_def: Dictionary) -> void:
 	_load_texture(creature_def, "Body/NeckBlend", "body", "neck-sheet")
 	_load_texture(creature_def, "NearLeg", "body", "leg-z1-sheet")
 	_load_texture(creature_def, "NearArm", "body", "arm-z1-sheet")
-	_load_texture(creature_def, "Neck0/Neck1/Head", "body", "head-sheet")
+	_load_texture(creature_def, "Neck0/HeadBobber/Head", "body", "head-sheet")
 
 
 """
@@ -157,31 +157,31 @@ func _load_colors(creature_def: Dictionary) -> void:
 	creature_def["property:Body/Outline:line_color"] = line_color
 	creature_def["shader:NearLeg/Outline:black"] = line_color
 	creature_def["shader:NearArm/Outline:black"] = line_color
-	creature_def["shader:Neck0/Neck1/EarZ0/Outline:black"] = line_color
-	creature_def["shader:Neck0/Neck1/HornZ0/Outline:black"] = line_color
-	creature_def["shader:Neck0/Neck1/Head/Outline:black"] = line_color
-	creature_def["shader:Neck0/Neck1/EarZ1/Outline:black"] = line_color
-	creature_def["shader:Neck0/Neck1/HornZ1/Outline:black"] = line_color
-	creature_def["shader:Neck0/Neck1/EarZ2/Outline:black"] = line_color
-	creature_def["shader:Neck0/Neck1/Mouth/Outline:black"] = line_color
-	creature_def["shader:Neck0/Neck1/Eyes/Outline:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/EarZ0/Outline:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/HornZ0/Outline:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/Head/Outline:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/EarZ1/Outline:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/HornZ1/Outline:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/EarZ2/Outline:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/Mouth/Outline:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/Eyes/Outline:black"] = line_color
 	creature_def["shader:FarArm:black"] = line_color
 	creature_def["shader:FarLeg:black"] = line_color
 	creature_def["property:Body:line_color"] = line_color
 	creature_def["shader:Body/NeckBlend:black"] = line_color
 	creature_def["shader:NearArm:black"] = line_color
 	creature_def["shader:NearLeg:black"] = line_color
-	creature_def["shader:Neck0/Neck1/EarZ0:black"] = line_color
-	creature_def["shader:Neck0/Neck1/HornZ0:black"] = line_color
-	creature_def["shader:Neck0/Neck1/Head:black"] = line_color
-	creature_def["shader:Neck0/Neck1/EarZ1:black"] = line_color
-	creature_def["shader:Neck0/Neck1/HornZ1:black"] = line_color
-	creature_def["shader:Neck0/Neck1/EarZ2:black"] = line_color
-	creature_def["shader:Neck0/Neck1/Mouth:black"] = line_color
-	creature_def["shader:Neck0/Neck1/Eyes:black"] = line_color
-	creature_def["shader:Neck0/Neck1/EmoteArms:black"] = line_color
-	creature_def["shader:Neck0/Neck1/EmoteEyes:black"] = line_color
-	creature_def["shader:Neck0/Neck1/EmoteBrain:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/EarZ0:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/HornZ0:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/Head:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/EarZ1:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/HornZ1:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/EarZ2:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/Mouth:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/Eyes:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/EmoteArms:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/EmoteEyes:black"] = line_color
+	creature_def["shader:Neck0/HeadBobber/EmoteBrain:black"] = line_color
 	creature_def["shader:EmoteBody:black"] = line_color
 	
 	var body_color: Color
@@ -192,15 +192,15 @@ func _load_colors(creature_def: Dictionary) -> void:
 	creature_def["shader:Body/NeckBlend:red"] = body_color
 	creature_def["shader:NearLeg:red"] = body_color
 	creature_def["shader:NearArm:red"] = body_color
-	creature_def["shader:Neck0/Neck1/EarZ0:red"] = body_color
-	creature_def["shader:Neck0/Neck1/HornZ0:red"] = body_color
-	creature_def["shader:Neck0/Neck1/Head:red"] = body_color
-	creature_def["shader:Neck0/Neck1/EarZ1:red"] = body_color
-	creature_def["shader:Neck0/Neck1/HornZ1:red"] = body_color
-	creature_def["shader:Neck0/Neck1/EarZ2:red"] = body_color
-	creature_def["shader:Neck0/Neck1/Mouth:red"] = body_color
-	creature_def["shader:Neck0/Neck1/Eyes:red"] = body_color
-	creature_def["shader:Neck0/Neck1/EmoteArms:red"] = body_color
+	creature_def["shader:Neck0/HeadBobber/EarZ0:red"] = body_color
+	creature_def["shader:Neck0/HeadBobber/HornZ0:red"] = body_color
+	creature_def["shader:Neck0/HeadBobber/Head:red"] = body_color
+	creature_def["shader:Neck0/HeadBobber/EarZ1:red"] = body_color
+	creature_def["shader:Neck0/HeadBobber/HornZ1:red"] = body_color
+	creature_def["shader:Neck0/HeadBobber/EarZ2:red"] = body_color
+	creature_def["shader:Neck0/HeadBobber/Mouth:red"] = body_color
+	creature_def["shader:Neck0/HeadBobber/Eyes:red"] = body_color
+	creature_def["shader:Neck0/HeadBobber/EmoteArms:red"] = body_color
 	
 	var body_fill_color: Color
 	if line_color and body_color:
@@ -212,11 +212,11 @@ func _load_colors(creature_def: Dictionary) -> void:
 	if creature_def.has("eye_rgb"):
 		eye_color = Color(creature_def.eye_rgb.split(" ")[0])
 		eye_shine_color = Color(creature_def.eye_rgb.split(" ")[1])
-	creature_def["shader:Neck0/Neck1/Eyes:green"] = eye_color
-	creature_def["shader:Neck0/Neck1/Eyes:blue"] = eye_shine_color
+	creature_def["shader:Neck0/HeadBobber/Eyes:green"] = eye_color
+	creature_def["shader:Neck0/HeadBobber/Eyes:blue"] = eye_shine_color
 
 	var horn_color: Color
 	if creature_def.has("horn_rgb"):
 		horn_color = Color(creature_def.horn_rgb)
-	creature_def["shader:Neck0/Neck1/HornZ0:green"] = horn_color
-	creature_def["shader:Neck0/Neck1/HornZ1:green"] = horn_color
+	creature_def["shader:Neck0/HeadBobber/HornZ0:green"] = horn_color
+	creature_def["shader:Neck0/HeadBobber/HornZ1:green"] = horn_color

--- a/src/main/world/restaurant/creature-sfx.gd
+++ b/src/main/world/restaurant/creature-sfx.gd
@@ -1,0 +1,120 @@
+extends Node
+"""
+Plays creature-related sound effects.
+"""
+
+# delays between when creature arrives and when door chime is played (in seconds)
+const CHIME_DELAYS: Array = [0.2, 0.3, 0.5, 1.0, 1.5]
+
+# sounds the creatures make when they enter the restaurant
+onready var hello_voices := [$HelloVoice0, $HelloVoice1, $HelloVoice2, $HelloVoice3]
+
+# sounds which get played when a creature shows up
+onready var chime_sounds := [$DoorChime0, $DoorChime1, $DoorChime2, $DoorChime3, $DoorChime4]
+
+# sounds which get played when the creature eats
+onready var _munch_sounds := [$Munch0, $Munch1, $Munch2, $Munch3, $Munch4]
+
+# satisfied sounds the creatures make when a player builds a big combo
+onready var _combo_voices := [
+	$ComboVoice00, $ComboVoice01, $ComboVoice02, $ComboVoice03,
+	$ComboVoice04, $ComboVoice05, $ComboVoice06, $ComboVoice07,
+	$ComboVoice08, $ComboVoice09, $ComboVoice10, $ComboVoice11,
+	$ComboVoice12, $ComboVoice13, $ComboVoice14, $ComboVoice15,
+	$ComboVoice16, $ComboVoice17, $ComboVoice18, $ComboVoice19,
+]
+
+# sounds the creatures make when they ask for their check
+onready var _goodbye_voices := [$GoodbyeVoice0, $GoodbyeVoice1, $GoodbyeVoice2, $GoodbyeVoice3]
+
+# we suppress the first door chime. we usually cheat and play the chime after the creature appears, but that doesn't
+# work when we can see them appear
+var _suppress_one_chime := true
+
+# index of the most recent combo sound that was played
+var _combo_voice_index := 0
+
+# current voice stream player. we track this to prevent a creature from saying two things at once
+var _current_voice_stream: AudioStreamPlayer2D
+
+"""
+Sets the relative position of sound effects related to the restaurant door. Each seat has a different position
+relative to the restaurant's entrance; some are close to the door, some are far away.
+
+Parameter: 'position' is the position of the door relative to this seat, in world coordinates.
+"""
+func set_door_sound_position(door_sound_position: Vector2) -> void:
+	for chime_sound in chime_sounds:
+		chime_sound.position = door_sound_position
+	for hello_voice in hello_voices:
+		hello_voice.position = door_sound_position
+
+
+"""
+Plays a 'mmm!' voice sample, for when a player builds a big combo.
+"""
+func play_combo_voice() -> void:
+	_combo_voice_index = (_combo_voice_index + 1 + randi() % (_combo_voices.size() - 1)) % _combo_voices.size()
+	_play_voice(_combo_voices[_combo_voice_index])
+
+
+"""
+Plays a 'hello!' voice sample, for when a creature enters the restaurant
+"""
+func play_hello_voice() -> void:
+	if Global.should_chat():
+		_play_voice(hello_voices[randi() % hello_voices.size()])
+
+
+"""
+Plays a 'check please!' voice sample, for when a creature is ready to leave
+"""
+func play_goodbye_voice() -> void:
+	if Global.should_chat():
+		_play_voice(_goodbye_voices[randi() % _goodbye_voices.size()])
+
+
+"""
+Plays a door chime sound effect, for when a creature enters the restaurant.
+
+Parameter: 'delay' is the delay in seconds before the chime sound plays. The default value of '-1' results in a random
+	delay.
+"""
+func play_door_chime(delay: float = -1) -> void:
+	if Scenario.settings.other.tutorial:
+		# suppress door chime for tutorials
+		return
+	
+	if delay < 0:
+		delay = CHIME_DELAYS[randi() % CHIME_DELAYS.size()]
+	yield(get_tree().create_timer(delay), "timeout")
+	chime_sounds[randi() % chime_sounds.size()].play()
+	yield(get_tree().create_timer(0.5), "timeout")
+	play_hello_voice()
+
+
+"""
+Plays a voice sample, interrupting any other voice samples which are currently playing for this specific creature.
+"""
+func _play_voice(audio_stream: AudioStreamPlayer2D) -> void:
+	if _current_voice_stream and _current_voice_stream.playing:
+		_current_voice_stream.stop()
+	audio_stream.play()
+	_current_voice_stream = _combo_voices[_combo_voice_index]
+
+
+func _on_Creature_food_eaten() -> void:
+	var munch_sound: AudioStreamPlayer2D = _munch_sounds[randi() % _munch_sounds.size()]
+	munch_sound.pitch_scale = rand_range(0.96, 1.04)
+	_play_voice(munch_sound)
+
+
+func _on_Creature_creature_arrived() -> void:
+	if Engine.is_editor_hint():
+		# Skip the sound effects if we're using this as an editor tool
+		pass
+	else:
+		if _suppress_one_chime:
+			_suppress_one_chime = false
+		else:
+			play_door_chime()

--- a/src/main/world/restaurant/creature-sprite.gd
+++ b/src/main/world/restaurant/creature-sprite.gd
@@ -1,0 +1,22 @@
+extends Sprite
+"""
+Sprites which toggles between a single 'toward the camera' and 'away from the camera' frame
+"""
+
+export (NodePath) var creature_path: NodePath
+export (bool) var invisible_while_moving := false
+
+onready var _creature: Creature = get_node(creature_path)
+
+func _on_Creature_orientation_changed(orientation: int) -> void:
+	if orientation in [Creature.SOUTHWEST, Creature.SOUTHEAST]:
+		# facing south; initialize textures to forward-facing frame
+		frame = 1
+	else:
+		# facing north; initialize textures to backward-facing frame
+		frame = 2
+
+
+func _on_Creature_movement_mode_changed(movement_mode: bool) -> void:
+	if invisible_while_moving:
+		visible = not movement_mode

--- a/src/main/world/restaurant/creature.gd
+++ b/src/main/world/restaurant/creature.gd
@@ -18,6 +18,9 @@ slower since the creature's assets will need to be loaded for the scene.
 # emitted on the frame when the food is launched into the creature's mouth
 signal food_eaten
 
+# emitted before a creature arrives and sits down
+signal before_creature_arrived
+
 # emitted when a creature arrives and sits down
 signal creature_arrived
 
@@ -34,6 +37,9 @@ signal landed
 # emitted during the 'jump' animation when the creature leaves the ground
 signal jumped
 
+signal orientation_changed(orientation)
+signal movement_mode_changed(movement_mode)
+
 # directions the creature can face
 enum Orientation {
 	SOUTHEAST,
@@ -42,16 +48,10 @@ enum Orientation {
 	NORTHEAST,
 }
 
-# ways the creature's head can move ambiently
-enum HeadBobMode {
-	OFF, # no movement
-	BOB, # nodding vertically
-	BOUNCE, # bouncing vertically like a ball hitting the floor
-	SHUDDER, # shaking left and right
-}
-
-# delays between when creature arrives and when door chime is played (in seconds)
-const CHIME_DELAYS: Array = [0.2, 0.3, 0.5, 1.0, 1.5]
+const SOUTHEAST = Orientation.SOUTHEAST
+const SOUTHWEST = Orientation.SOUTHWEST
+const NORTHWEST = Orientation.NORTHWEST
+const NORTHEAST = Orientation.NORTHEAST
 
 # in the editor, this rotates between a set of different creature appearances
 export (int) var _creature_preset := -1 setget set_creature_preset
@@ -60,19 +60,7 @@ export (int) var _creature_preset := -1 setget set_creature_preset
 export (bool) var _movement_mode := false setget set_movement_mode
 
 # the direction the creature is facing
-export (Orientation) var _orientation := Orientation.SOUTHEAST setget set_orientation, get_orientation
-
-# these three fields control the creature's head motion: how it's moving, as well as how much/how fast
-export (HeadBobMode) var head_bob_mode := HeadBobMode.BOB setget set_head_bob_mode
-export (float) var head_motion_pixels := 2.0
-export (float) var head_motion_seconds := 6.5
-
-# the creature's head bobs up and down slowly, these constants control how much it bobs
-const HEAD_BOB_SECONDS := 6.5
-const HEAD_BOB_PIXELS := 2.0
-
-# the total number of seconds which have elapsed since the object was created
-var _total_seconds := 0.0
+export (Orientation) var orientation := Orientation.SOUTHEAST setget set_orientation
 
 # the index of the previously launched food color. stored to avoid showing the same color twice consecutively
 var _food_color_index := 0
@@ -80,98 +68,23 @@ var _food_color_index := 0
 # the definition of the creature who was most recently summoned
 var _creature_def: Dictionary
 
-# we suppress the first door chime. we usually cheat and play the chime after the creature appears, but that doesn't
-# work when we can see them appear
-var _suppress_one_chime := true
-
-# index of the most recent combo sound that was played
-var _combo_voice_index := 0
-
-# current voice stream player. we track this to prevent a creature from saying two things at once
-var _current_voice_stream: AudioStreamPlayer2D
-
 var _creature_loader := CreatureLoader.new()
 
 # used to temporarily suppress sfx signals. used when skipping to the middle of animations which play sfx
 var _suppress_sfx_signal_timer := 0.0
-
-# sounds the creatures make when they enter the restaurant
-onready var hello_voices := [$HelloVoice0, $HelloVoice1, $HelloVoice2, $HelloVoice3]
-
-# sounds which get played when a creature shows up
-onready var chime_sounds := [$DoorChime0, $DoorChime1, $DoorChime2, $DoorChime3, $DoorChime4]
-
-# sounds which get played when the creature eats
-onready var _munch_sounds := [$Munch0, $Munch1, $Munch2, $Munch3, $Munch4]
-
-# satisfied sounds the creatures make when a player builds a big combo
-onready var _combo_voices := [
-	$ComboVoice00, $ComboVoice01, $ComboVoice02, $ComboVoice03,
-	$ComboVoice04, $ComboVoice05, $ComboVoice06, $ComboVoice07,
-	$ComboVoice08, $ComboVoice09, $ComboVoice10, $ComboVoice11,
-	$ComboVoice12, $ComboVoice13, $ComboVoice14, $ComboVoice15,
-	$ComboVoice16, $ComboVoice17, $ComboVoice18, $ComboVoice19,
-]
-
-# sounds the creatures make when they ask for their check
-onready var _goodbye_voices := [$GoodbyeVoice0, $GoodbyeVoice1, $GoodbyeVoice2, $GoodbyeVoice3]
-
-# sprites which toggle between a single 'toward the camera' and 'away from the camera' frame
-onready var _rotatable_sprites := [
-	$Sprites/FarArm,
-	$Sprites/FarLeg,
-	$Sprites/Body/NeckBlend,
-	$Sprites/NearLeg,
-	$Sprites/NearArm,
-	$Sprites/Neck0/Neck1/EarZ0,
-	$Sprites/Neck0/Neck1/HornZ0,
-	$Sprites/Neck0/Neck1/Head,
-	$Sprites/Neck0/Neck1/EarZ1,
-	$Sprites/Neck0/Neck1/HornZ1,
-	$Sprites/Neck0/Neck1/EarZ2,
-]
 
 onready var _mouth_animation_player := $Mouth0Anims
 
 func _ready() -> void:
 	# Update creature's appearance based on their behavior and orientation
 	_update_movement_mode()
-	set_orientation(_orientation)
+	set_orientation(orientation)
+	_mouth_animation_player.set_process(true)
 
 
 func _process(delta: float) -> void:
 	if _suppress_sfx_signal_timer > 0.0:
 		_suppress_sfx_signal_timer -= delta
-	
-	if Engine.is_editor_hint():
-		# avoid playing animations, bouncing head in editor. manually set frames instead
-		_apply_default_mouth_and_eye_frames()
-	else:
-		if not _mouth_animation_player.is_playing():
-			_play_mouth_ambient_animation()
-
-		if _orientation in [Orientation.SOUTHWEST, Orientation.SOUTHEAST]:
-			if not $EmoteAnims.is_playing():
-				$EmoteAnims.play("ambient")
-				$EmoteAnims.advance(randf() * $EmoteAnims.current_animation_length)
-		else:
-			if $EmoteAnims.is_playing():
-				$EmoteAnims.stop()
-			$Sprites/Neck0/Neck1/Eyes.frame = 0
-
-		_total_seconds += delta
-		if has_node("Sprites/Neck0/Neck1"):
-			var head_phase := _total_seconds * PI / head_motion_seconds
-			if head_bob_mode == HeadBobMode.BOB:
-				var bob_amount := head_motion_pixels * sin(2 * head_phase)
-				$Sprites/Neck0/Neck1.position.y = -100 + bob_amount
-			elif head_bob_mode == HeadBobMode.BOUNCE:
-				var bounce_amount := head_motion_pixels * (1 - 2 * abs(sin(head_phase)))
-				$Sprites/Neck0/Neck1.position.y = -100 + bounce_amount
-			elif head_bob_mode == HeadBobMode.SHUDDER:
-				var shudder_amount := head_motion_pixels * clamp(2 * sin(2 * head_phase), -1.0, 1.0)
-				$Sprites/Neck0/Neck1.position.x = shudder_amount
-				$Sprites/Neck0/Neck1.position.y = -100
 
 
 """
@@ -198,12 +111,6 @@ func set_fatness(fatness: float) -> void:
 	$FatPlayer.set_fatness(fatness)
 
 
-func set_head_bob_mode(new_head_bob_mode: int) -> void:
-	head_bob_mode = new_head_bob_mode
-	# Some head bob animations like 'shudder' offset the x position; reset it back to the center
-	$Sprites/Neck0/Neck1.position.x = 0
-
-
 """
 This function manually assigns fields which Godot would ideally assign automatically by calling _ready. It is a
 workaround for Godot issue #16974 (https://github.com/godotengine/godot/issues/16974)
@@ -213,22 +120,9 @@ functionality and throws errors when it is used as a tool. This function manuall
 problems.
 """
 func _apply_tool_script_workaround() -> void:
-	if not _rotatable_sprites:
-		_rotatable_sprites = [
-			$Sprites/FarArm,
-			$Sprites/FarLeg,
-			$Sprites/NearLeg,
-			$Sprites/NearArm,
-			$Sprites/Body/NeckBlend,
-			$Sprites/Neck0/Neck1/EarZ0,
-			$Sprites/Neck0/Neck1/HornZ0,
-			$Sprites/Neck0/Neck1/Head,
-			$Sprites/Neck0/Neck1/EarZ1,
-			$Sprites/Neck0/Neck1/HornZ1,
-			$Sprites/Neck0/Neck1/EarZ2,
-		]
 	if not _mouth_animation_player:
 		_mouth_animation_player = $Mouth0Anims
+		_mouth_animation_player.set_process(true)
 
 
 """
@@ -237,8 +131,8 @@ Sets the creature's orientation, and alters their appearance appropriately.
 If the creature swaps between facing left or right, certain sprites are flipped horizontally. If the creature swaps
 between facing forward or backward, certain sprites play different animations or toggle between different frames.
 """
-func set_orientation(orientation: int) -> void:
-	_orientation = orientation
+func set_orientation(new_orientation: int) -> void:
+	orientation = new_orientation
 	if not get_tree():
 		# avoid 'node not found' errors when tree is null
 		return
@@ -246,31 +140,27 @@ func set_orientation(orientation: int) -> void:
 	if Engine.is_editor_hint():
 		_apply_tool_script_workaround()
 	
-	if _orientation in [Orientation.SOUTHWEST, Orientation.SOUTHEAST]:
+	if orientation in [Orientation.SOUTHWEST, Orientation.SOUTHEAST]:
 		# facing south; initialize textures to forward-facing frames
 		$Sprites/Neck0.z_index = 0
-		for sprite in _rotatable_sprites:
-			sprite.frame = 1
 	else:
 		# facing north; initialize textures to backward-facing frames
 		$Sprites/Neck0.z_index = -1
-		for sprite in _rotatable_sprites:
-			sprite.frame = 2
-	
-	_play_mouth_ambient_animation()
 	
 	# sprites are drawn facing southeast/northwest, and are horizontally flipped for other directions
 	$Sprites.scale = \
-			Vector2(1, 1) if _orientation in [Orientation.SOUTHEAST, Orientation.NORTHWEST] else Vector2(-1, 1)
+			Vector2(1, 1) if orientation in [Orientation.SOUTHEAST, Orientation.NORTHWEST] else Vector2(-1, 1)
 	
 	# Body is rendered facing southeast/northeast, and is horizontally flipped for other directions. Unfortunately
 	# its parent object is already flipped in some cases, making the following line of code quite unintuitive.
 	$Sprites/Body.scale = \
-			Vector2(1, 1) if _orientation in [Orientation.SOUTHEAST, Orientation.SOUTHWEST] else Vector2(-1, 1)
+			Vector2(1, 1) if orientation in [Orientation.SOUTHEAST, Orientation.SOUTHWEST] else Vector2(-1, 1)
+	
+	emit_signal("orientation_changed", orientation)
 
 
-func get_orientation() -> int:
-	return _orientation
+func set_door_sound_position(door_sound_position: Vector2) -> void:
+	$CreatureSfx.set_door_sound_position(door_sound_position)
 
 
 """
@@ -288,25 +178,6 @@ func set_creature_preset(creature_preset: int) -> void:
 		_apply_tool_script_workaround()
 		# only summon in the editor; otherwise we get NPEs because our children are uninitialized
 		summon(CreatureLoader.DEFINITIONS[clamp(creature_preset, 0, CreatureLoader.DEFINITIONS.size() - 1)])
-
-
-"""
-Plays a door chime sound effect, for when a creature enters the restaurant.
-
-Parameter: 'delay' is the delay in seconds before the chime sound plays. The default value of '-1' results in a random
-	delay.
-"""
-func play_door_chime(delay: float = -1) -> void:
-	if Scenario.settings.other.tutorial:
-		# suppress door chime for tutorials
-		return
-	
-	if delay < 0:
-		delay = CHIME_DELAYS[randi() % CHIME_DELAYS.size()]
-	yield(get_tree().create_timer(delay), "timeout")
-	chime_sounds[randi() % chime_sounds.size()].play()
-	yield(get_tree().create_timer(0.5), "timeout")
-	play_hello_voice()
 
 
 """
@@ -382,21 +253,17 @@ Parameters:
 		no delay.
 """
 func show_food_effects(delay := 0.0) -> void:
-	var munch_sound: AudioStreamPlayer2D = _munch_sounds[randi() % _munch_sounds.size()]
-	munch_sound.pitch_scale = rand_range(0.96, 1.04)
-
 	# avoid using the same color twice consecutively
 	_food_color_index = (_food_color_index + 1 + randi() % (Playfield.FOOD_COLORS.size() - 1)) \
 			% Playfield.FOOD_COLORS.size()
 	var food_color: Color = Playfield.FOOD_COLORS[_food_color_index]
-	$Sprites/Neck0/Neck1/Food.modulate = food_color
-	$Sprites/Neck0/Neck1/FoodLaser.modulate = food_color
+	$Sprites/Neck0/HeadBobber/Food.modulate = food_color
+	$Sprites/Neck0/HeadBobber/FoodLaser.modulate = food_color
 
 	if delay >= 0.0:
 		yield(get_tree().create_timer(delay), "timeout")
-	play_voice(munch_sound)
-	$Tween.interpolate_property($Sprites/Neck0/Neck1, "position:x",
-			clamp($Sprites/Neck0/Neck1.position.x - 6, -20, 0), 0, 0.5,
+	$Tween.interpolate_property($Sprites/Neck0/HeadBobber, "position:x",
+			clamp($Sprites/Neck0/HeadBobber.position.x - 6, -20, 0), 0, 0.5,
 			Tween.TRANS_QUINT, Tween.EASE_IN_OUT)
 	$Tween.start()
 	emit_signal("food_eaten")
@@ -406,34 +273,14 @@ func show_food_effects(delay := 0.0) -> void:
 Plays a 'mmm!' voice sample, for when a player builds a big combo.
 """
 func play_combo_voice() -> void:
-	_combo_voice_index = (_combo_voice_index + 1 + randi() % (_combo_voices.size() - 1)) % _combo_voices.size()
-	play_voice(_combo_voices[_combo_voice_index])
-
-
-"""
-Plays a 'hello!' voice sample, for when a creature enters the restaurant
-"""
-func play_hello_voice() -> void:
-	if Global.should_chat():
-		play_voice(hello_voices[randi() % hello_voices.size()])
+	$CreatureSfx.play_combo_voice()
 
 
 """
 Plays a 'check please!' voice sample, for when a creature is ready to leave
 """
 func play_goodbye_voice() -> void:
-	if Global.should_chat():
-		play_voice(_goodbye_voices[randi() % _goodbye_voices.size()])
-
-
-"""
-Plays a voice sample, interrupting any other voice samples which are currently playing for this specific creature.
-"""
-func play_voice(audio_stream: AudioStreamPlayer2D) -> void:
-	if _current_voice_stream and _current_voice_stream.playing:
-		_current_voice_stream.stop()
-	audio_stream.play()
-	_current_voice_stream = _combo_voices[_combo_voice_index]
+	$CreatureSfx.play_goodbye_voice()
 
 
 """
@@ -455,9 +302,9 @@ func play_movement_animation(animation_prefix: String, movement_direction: Vecto
 			# tiny movement vectors are often the result of a collision. we ignore these to avoid constantly flipping
 			# their orientation if they're mashing themselves into a wall
 			var new_orientation := _compute_orientation(movement_direction)
-			if new_orientation != _orientation:
+			if new_orientation != orientation:
 				set_orientation(new_orientation)
-		var suffix := "se" if _orientation in [Orientation.SOUTHEAST, Orientation.SOUTHWEST] else "nw"
+		var suffix := "se" if orientation in [Orientation.SOUTHEAST, Orientation.SOUTHWEST] else "nw"
 		animation_name = "%s-%s" % [animation_prefix, suffix]
 		if _movement_mode != true:
 			set_movement_mode(true)
@@ -482,14 +329,14 @@ of 'southeast'.
 func _compute_orientation(direction: Vector2) -> int:
 	if direction.length() == 0:
 		# we default to the current orientation if given a zero-length vector
-		return _orientation
+		return orientation
 	
 	# preserve the old orientation if it's close to the new orientation. this prevents us from flipping repeatedly
 	# when our direction puts us between two orientations.
-	var new_orientation: int = _orientation
+	var new_orientation: int = orientation
 	# unrounded orientation is a float in the range [-2.0, 2.0]
 	var unrounded_orientation := -2 * direction.angle_to(Vector2.RIGHT) / PI
-	if abs(unrounded_orientation - _orientation) >= 0.6 and abs(unrounded_orientation + 4 - _orientation) >= 0.6:
+	if abs(unrounded_orientation - orientation) >= 0.6 and abs(unrounded_orientation + 4 - orientation) >= 0.6:
 		# convert the float orientation [-2.0, 2.0] to an int orientation [0, 3]
 		new_orientation = wrapi(int(round(unrounded_orientation)), 0, 4)
 	return new_orientation
@@ -499,6 +346,7 @@ func set_movement_mode(movement_mode: bool) -> void:
 	_movement_mode = movement_mode
 	if is_inside_tree():
 		_update_movement_mode()
+		emit_signal("movement_mode_changed", _movement_mode)
 
 
 """
@@ -524,50 +372,15 @@ func play_mood(mood: int) -> void:
 
 
 """
-Plays an appropriate mouth ambient animation for the creature's orientation.
-"""
-func _play_mouth_ambient_animation() -> void:
-	if _orientation in [Orientation.SOUTHWEST, Orientation.SOUTHEAST]:
-		_mouth_animation_player.play("ambient-se")
-	else:
-		_mouth_animation_player.play("ambient-nw")
-
-
-"""
 Updates the visibility/position of nodes based on whether this creature is sitting or walking.
 """
 func _update_movement_mode() -> void:
-	if _movement_mode == false:
+	if not _movement_mode:
 		# reset position/size attributes that get altered during movement
 		$Sprites/Neck0.position = Vector2.ZERO
 	
 	# movement sprites are visible if movement_mode is true
 	$Sprites/FarMovement.visible = _movement_mode
-
-	# most other sprites are not visible if movement_mode is true
-	$Sprites/FarArm.visible = not _movement_mode
-	$Sprites/FarLeg.visible = not _movement_mode
-	$Sprites/Body.visible = not _movement_mode
-	$Sprites/NearLeg.visible = not _movement_mode
-	$Sprites/NearArm.visible = not _movement_mode
-
-
-"""
-Updates the mouth and eye frames to an appropriate frame for the creature's orientation.
-
-Usually the mouth and eyes are controlled by an animation. But when they're not, this method ensures they still look
-reasonable.
-"""
-func _apply_default_mouth_and_eye_frames() -> void:
-	if _mouth_animation_player == $Mouth0Anims:
-		$Sprites/Neck0/Neck1/Mouth.frame = 1 if _orientation in [Orientation.SOUTHWEST, Orientation.SOUTHEAST] else 12
-	elif _mouth_animation_player == $Mouth1Anims:
-		$Sprites/Neck0/Neck1/Mouth.frame = 1 if _orientation in [Orientation.SOUTHWEST, Orientation.SOUTHEAST] else 17
-	
-	if _orientation in [Orientation.SOUTHWEST, Orientation.SOUTHEAST]:
-		$Sprites/Neck0/Neck1/Eyes.frame = 1
-	else:
-		$Sprites/Neck0/Neck1/Eyes.frame = 0
 
 
 """
@@ -578,21 +391,24 @@ func _update_creature_properties() -> void:
 	if Engine.is_editor_hint():
 		_apply_tool_script_workaround()
 	
+	emit_signal("before_creature_arrived")
+	
 	# stop any AnimationPlayers, otherwise two AnimationPlayers might fight over control of the sprite
 	_mouth_animation_player.stop()
 	$EmoteAnims.stop()
 	
-	# reset the mouth frame, otherwise we could have one strange transition frame
-	_apply_default_mouth_and_eye_frames()
+	emit_signal("before_creature_arrived")
 	
 	if _creature_def.has("mouth"):
 		# set the sprite's color/texture properties
+		_mouth_animation_player.set_process(false)
 		if _creature_def.mouth == "1":
 			_mouth_animation_player = $Mouth0Anims
 		elif _creature_def.mouth == "2":
 			_mouth_animation_player = $Mouth1Anims
 		else:
 			print("Invalid mouth: %s", _creature_def.mouth)
+		_mouth_animation_player.set_process(true)
 	
 	for key in _creature_def.keys():
 		if key.find("property:") == 0:
@@ -606,15 +422,6 @@ func _update_creature_properties() -> void:
 	$Sprites/Body.update()
 	visible = true
 	emit_signal("creature_arrived")
-	
-	if Engine.is_editor_hint():
-		# Skip the sound effects if we're using this as an editor tool
-		pass
-	else:
-		if _suppress_one_chime:
-			_suppress_one_chime = false
-		else:
-			play_door_chime()
 
 
 """
@@ -631,7 +438,7 @@ func emit_sfx_signal(signal_name: String) -> void:
 
 func _on_EmoteAnims_before_mood_switched() -> void:
 	# some moods modify the sprites for our eyes and arms, so we reset them
-	set_orientation(_orientation)
+	set_orientation(orientation)
 
 
 func _on_MovementAnims_animation_started(anim_name: String) -> void:

--- a/src/main/world/restaurant/head-bobber.gd
+++ b/src/main/world/restaurant/head-bobber.gd
@@ -1,0 +1,55 @@
+class_name HeadBobber
+extends Sprite
+"""
+Bobs the character's head up and down.
+
+Provides a few different 'bob modes', so that the character can shudder, nod, or laugh in different situations.
+"""
+
+# ways the creature's head can move ambiently
+enum HeadBobMode {
+	OFF, # no movement
+	BOB, # nodding vertically
+	BOUNCE, # bouncing vertically like a ball hitting the floor
+	SHUDDER, # shaking left and right
+}
+
+const BOB_OFF := HeadBobMode.OFF
+const BOB_BOB := HeadBobMode.BOB
+const BOB_BOUNCE := HeadBobMode.BOUNCE
+const BOB_SHUDDER := HeadBobMode.SHUDDER
+
+# these three fields control the creature's head motion: how it's moving, as well as how much/how fast
+export (HeadBobMode) var head_bob_mode := HeadBobMode.BOB setget set_head_bob_mode
+export (float) var head_motion_pixels := 2.0
+export (float) var head_motion_seconds := 6.5
+
+# the creature's head bobs up and down slowly, these constants control how much it bobs
+const HEAD_BOB_SECONDS := 6.5
+const HEAD_BOB_PIXELS := 2.0
+
+# the total number of seconds which have elapsed since the object was created
+var _total_seconds := 0.0
+
+func _process(delta: float) -> void:
+	if Engine.is_editor_hint():
+		return
+	
+	_total_seconds += delta
+	var head_phase := _total_seconds * PI / head_motion_seconds
+	if head_bob_mode == HeadBobMode.BOB:
+		var bob_amount := head_motion_pixels * sin(2 * head_phase)
+		position.y = -100 + bob_amount
+	elif head_bob_mode == HeadBobMode.BOUNCE:
+		var bounce_amount := head_motion_pixels * (1 - 2 * abs(sin(head_phase)))
+		position.y = -100 + bounce_amount
+	elif head_bob_mode == HeadBobMode.SHUDDER:
+		var shudder_amount := head_motion_pixels * clamp(2 * sin(2 * head_phase), -1.0, 1.0)
+		position.x = shudder_amount
+		position.y = -100
+
+
+func set_head_bob_mode(new_head_bob_mode: int) -> void:
+	head_bob_mode = new_head_bob_mode
+	# Some head bob animations like 'shudder' offset the x position; reset it back to the center
+	position.x = 0

--- a/src/main/world/restaurant/mouth-anims.gd
+++ b/src/main/world/restaurant/mouth-anims.gd
@@ -1,0 +1,57 @@
+extends AnimationPlayer
+"""
+An AnimationPlayer which animates mouths.
+"""
+
+export (NodePath) var mouth_path: NodePath
+
+# A frame to switch to when the creature faces away from the camera.
+export (int) var north_frame: int
+
+onready var _mouth: Sprite = get_node(mouth_path)
+onready var _creature: Creature = $".."
+
+func _ready() -> void:
+	set_process(false)
+
+
+func _process(delta: float) -> void:
+	if Engine.is_editor_hint():
+		# avoid playing animations in editor. manually set frames instead
+		_apply_default_frames()
+	else:
+		if not is_playing():
+			_play_mouth_ambient_animation()
+
+
+"""
+Plays an appropriate mouth ambient animation for the creature's orientation.
+"""
+func _play_mouth_ambient_animation() -> void:
+	if _creature.orientation in [Creature.SOUTHWEST, Creature.SOUTHEAST]:
+		play("ambient-se")
+	else:
+		play("ambient-nw")
+
+
+"""
+Updates the frame to something appropriate for the creature's orientation.
+
+Usually the frame is controlled by an animation. But when it's not, this ensures it still looks reasonable.
+"""
+func _apply_default_frames() -> void:
+	_mouth.frame = 1 if _creature.orientation in [Creature.SOUTHWEST, Creature.SOUTHEAST] else north_frame
+
+
+"""
+Reset the mouth frame when loading a new creature appearance.
+
+If we don't reset the eye frame, we have one strange transition frame.
+"""
+func _on_Creature_before_creature_arrived() -> void:
+	_apply_default_frames()
+
+
+func _on_Creature_orientation_changed(orientation: int) -> void:
+	if is_processing():
+		_play_mouth_ambient_animation()

--- a/src/main/world/restaurant/seat.gd
+++ b/src/main/world/restaurant/seat.gd
@@ -21,10 +21,7 @@ func refresh() -> void:
 	if _creature and _creature.is_visible_in_tree():
 		# draw a shadow on the creature's stool
 		$Stool0L.texture = preload("res://assets/main/world/restaurant/stool-occupied.png")
-		for chime_sound in _creature.chime_sounds:
-			chime_sound.position = _door_sound_position
-		for hello_voice in _creature.hello_voices:
-			hello_voice.position = _door_sound_position
+		_creature.set_door_sound_position(_door_sound_position)
 	else:
 		# remove the shadow from the creature's stool
 		$Stool0L.texture = preload("res://assets/main/world/restaurant/stool.png")

--- a/src/main/world/spira.gd
+++ b/src/main/world/spira.gd
@@ -184,7 +184,7 @@ func _process_jump_buffers(was_on_floor: bool) -> void:
 
 
 func _update_animation() -> void:
-	var old_orientation: int = $Viewport/Creature.get_orientation()
+	var old_orientation: int = $Viewport/Creature.orientation
 	if _slipping:
 		play_movement_animation("jump", _get_xy_velocity())
 	elif _jumping:


### PR DESCRIPTION
Extracted creature-sfx.gd from creature.gd, for creature sound effects
(chime, eating sounds, voices)

Extracted creature-sprite.gd from creature.gd, for orienting creature
sprites and making them invisible/visible as the creature moves

Extracted head-bobber.gd from creature.gd for handling 'head bob' effects,
including shuddering and laughing and other motions

Extracted mouth-anims.gd from creature.gd for managing mouth animations

Moved ambient animation logic from creature.gd into emote-anims.gd

creature.gd is still too big -- but, this is a start.