### PR TITLE
Fix Creature sfx refactoring issues. Fixed CreatureViewDemo

### DIFF
--- a/src/demo/world/restaurant/CreatureViewDemo.tscn
+++ b/src/demo/world/restaurant/CreatureViewDemo.tscn
@@ -3,7 +3,6 @@
 [ext_resource path="res://src/demo/world/restaurant/creature-view-demo.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/restaurant/CreatureView.tscn" type="PackedScene" id=2]
 
-
 [node name="Demo" type="Node2D"]
 script = ExtResource( 1 )
 

--- a/src/demo/world/restaurant/creature-view-demo.gd
+++ b/src/demo/world/restaurant/creature-view-demo.gd
@@ -23,8 +23,10 @@ func _ready() -> void:
 func _input(event: InputEvent) -> void:
 	match Utils.key_scancode(event):
 		KEY_F: _creature().feed()
-		KEY_D: _creature().play_door_chime(0)
-		KEY_V: _creature().play_goodbye_voice()
+		KEY_D: _creature().get_node("CreatureSfx").play_door_chime(0)
+		KEY_V:
+			Global.greetiness = 2
+			_creature().get_node("CreatureSfx").play_goodbye_voice()
 		KEY_0, KEY_1, KEY_2, KEY_3, KEY_4, KEY_5, KEY_6, KEY_7, KEY_8, KEY_9:
 			$CreatureView.get_creature().set_fatness(FATNESS_KEYS[Utils.key_num(event)])
 		KEY_Q: $CreatureView.set_current_creature_index(0)

--- a/src/main/global.gd
+++ b/src/main/global.gd
@@ -14,10 +14,10 @@ var _benchmark_start_times := Dictionary()
 
 # A number in the range [-1, 1] which corresponds to how many greetings we've given recently. If it's close to 1,
 # we're very unlikely to receive a greeting. If it's close to -1, we're very likely to receive a greeting.
-var _greetiness := 0.0
+var greetiness := 0.0
 
 func _process(delta: float) -> void:
-	_greetiness = clamp(_greetiness + delta * GREETINGS_PER_MINUTE / 60, -1.0, 1.0)
+	greetiness = clamp(greetiness + delta * GREETINGS_PER_MINUTE / 60, -1.0, 1.0)
 
 
 """
@@ -48,8 +48,8 @@ frequently because those sounds are associated with negative reinforcement (brok
 """
 func should_chat() -> bool:
 	var should_chat := true
-	if _greetiness + randf() > 1.0:
-		_greetiness -= 1.0 / GREETINGS_PER_MINUTE
+	if greetiness + randf() > 1.0:
+		greetiness -= 1.0 / GREETINGS_PER_MINUTE
 	else:
 		should_chat = false
 	return should_chat

--- a/src/main/world/creature/Creature.tscn
+++ b/src/main/world/creature/Creature.tscn
@@ -2757,7 +2757,7 @@ anims/run-se = SubResource( 57 )
 
 [node name="Tween" type="Tween" parent="."]
 
-[node name="CreatureSfx" type="Node" parent="."]
+[node name="CreatureSfx" type="Node2D" parent="."]
 script = ExtResource( 4 )
 
 [node name="Munch0" type="AudioStreamPlayer2D" parent="CreatureSfx"]


### PR DESCRIPTION
CreatureSfx was not a Node2D, so the spatial aspects of the creature's
voices were not working.

CreatureViewDemo's 'V' command was not always playing sounds because of the
greetiness parameter. There were also some runtime errors caused by
Creature refactorings.