### PR TITLE
'First customer' fix. Move door chime. creature_def change.

### DIFF
--- a/src/demo/world/restaurant/creature-view-demo.gd
+++ b/src/demo/world/restaurant/creature-view-demo.gd
@@ -23,7 +23,7 @@ func _ready() -> void:
 func _input(event: InputEvent) -> void:
 	match Utils.key_scancode(event):
 		KEY_F: _creature().feed()
-		KEY_D: _creature().get_node("CreatureSfx").play_door_chime(0)
+		KEY_D: _creature().get_node("CreatureSfx").play_door_chime()
 		KEY_V:
 			Global.greetiness = 2
 			_creature().get_node("CreatureSfx").play_goodbye_voice()

--- a/src/main/puzzle/puzzle.gd
+++ b/src/main/puzzle/puzzle.gd
@@ -23,7 +23,9 @@ func _ready() -> void:
 			"line_rgb": "6c4331", "body_rgb": "a854cb", "eye_rgb": "4fa94e dbe28e", "horn_rgb": "f1e398",
 			"ear": "3", "horn": "0", "mouth": "2", "eye": "2"
 		})
-	$CreatureView.summon_creature()
+		$CreatureView.summon_creature()
+	
+	$CreatureView.get_creature().play_hello_voice(true)
 
 
 func get_playfield() -> Playfield:

--- a/src/main/puzzle/scenario/scenario.gd
+++ b/src/main/puzzle/scenario/scenario.gd
@@ -63,5 +63,5 @@ func push_scenario_trail(scenario_settings: ScenarioSettings, creature_def: Dict
 	Scenario.settings = scenario_settings
 	PuzzleScore.reset()
 	Scenario.launched_scenario_name = scenario_settings.name
-	Global.creature_queue.push_back(creature_def)
+	Global.creature_queue.push_front(creature_def)
 	Breadcrumb.push_trail("res://src/main/puzzle/Puzzle.tscn")

--- a/src/main/ui/overworld-ui.gd
+++ b/src/main/ui/overworld-ui.gd
@@ -121,8 +121,8 @@ func _on_ChatUi_chat_event_played(chat_event: ChatEvent) -> void:
 				scenario = StringUtils.substring_after(meta_item, "scenario-")
 		if scenario:
 			_launched_scenario = Scenario.load_scenario_from_name(scenario)
-			if chatters[0].has_method("get_creature_def"):
-				_scenario_creature_def = chatters[0].get_creature_def()
+			if chatters[0].has_meta("creature_def"):
+				_scenario_creature_def = chatters[0].get_meta("creature_def")
 
 
 func _on_ChatUi_showed_choices() -> void:

--- a/src/main/world/boatricia.gd
+++ b/src/main/world/boatricia.gd
@@ -8,10 +8,8 @@ func _ready() -> void:
 	set_meta("chat_name", "Boatricia")
 	set_meta("chat_theme_def", {"accent_scale":0.33, "accent_swapped": true,
 			"accent_texture": 1, "color": "0b45a6", "dark": true})
-
-"""
-Boatricia is dark blue with short stubby horns.
-"""
-func get_creature_def() -> Dictionary:
-	return {"line_rgb": "41281e", "body_rgb": "0b45a6", "eye_rgb": "fad541 ffffff", "horn_rgb": "282828",
-		"ear": "2", "horn": "0", "mouth": "1", "eye": "3"}
+	
+	# Boatricia is dark blue with short stubby horns.
+	set_creature_def({
+		"line_rgb": "41281e", "body_rgb": "0b45a6", "eye_rgb": "fad541 ffffff", "horn_rgb": "282828",
+		"ear": "2", "horn": "0", "mouth": "1", "eye": "3"})

--- a/src/main/world/bort.gd
+++ b/src/main/world/bort.gd
@@ -6,14 +6,10 @@ Script for showing a creature 'Bort' in the 3D overworld.
 func _ready() -> void:
 	set_meta("chat_id", "bort")
 	set_meta("chat_name", "Bort")
-	set_meta("chat_theme_def", {"accent_scale":1.3,"accent_swapped":false,"accent_texture":0,"color":"6f83db"})
-
-
-"""
-Bort is light blue with a tentacle mouth.
-"""
-func get_creature_def() -> Dictionary:
-	return {
+	set_meta("chat_theme_def", {"accent_scale": 1.3, "accent_swapped": false,
+		"accent_texture": 0, "color": "6f83db"})
+	
+	# Bort is light blue with a tentacle mouth.
+	set_creature_def({
 		"line_rgb": "6c4331", "body_rgb": "6f83db", "eye_rgb": "374265 eaf2f4", "horn_rgb": "f1e398",
-		"ear": "3", "horn": "1", "mouth": "2", "eye": "1"
-	}
+		"ear": "3", "horn": "1", "mouth": "2", "eye": "1"})

--- a/src/main/world/creature/Creature.tscn
+++ b/src/main/world/creature/Creature.tscn
@@ -2733,17 +2733,18 @@ position = Vector2( 268.587, 210.527 )
 max_distance = 4000.0
 bus = "Voice Bus"
 
-[node name="DoorChime" type="AudioStreamPlayer2D" parent="CreatureSfx"]
-position = Vector2( 108.587, 210.527 )
-volume_db = -4.0
-max_distance = 4000.0
-bus = "Sound Bus"
-
 [node name="Voice" type="AudioStreamPlayer2D" parent="CreatureSfx"]
 position = Vector2( 268.587, 210.527 )
 volume_db = 6.0
 max_distance = 4000.0
 bus = "Voice Bus"
+
+[node name="HelloTimer" type="Timer" parent="CreatureSfx"]
+one_shot = true
+
+[node name="SuppressSfxTimer" type="Timer" parent="CreatureSfx"]
+one_shot = true
+autostart = true
 [connection signal="before_creature_arrived" from="." to="Mouth0Anims" method="_on_Creature_before_creature_arrived"]
 [connection signal="before_creature_arrived" from="." to="Mouth1Anims" method="_on_Creature_before_creature_arrived"]
 [connection signal="before_creature_arrived" from="." to="EmoteAnims" method="_on_Creature_before_creature_arrived"]
@@ -2752,28 +2753,29 @@ bus = "Voice Bus"
 [connection signal="movement_mode_changed" from="." to="Sprites/Body" method="_on_Creature_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Sprites/FarLeg" method="_on_Creature_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Sprites/FarArm" method="_on_Creature_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Sprites/Neck0/HeadBobber/Head" method="_on_Creature_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Sprites/NearArm" method="_on_Creature_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Sprites/Neck0/HeadBobber/EarZ1" method="_on_Creature_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Sprites/Neck0/HeadBobber/HornZ1" method="_on_Creature_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Sprites/Body/NeckBlend" method="_on_Creature_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Sprites/Neck0/HeadBobber/EarZ2" method="_on_Creature_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Sprites/NearLeg" method="_on_Creature_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Sprites/Neck0/HeadBobber/HornZ0" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/Neck0/HeadBobber/Head" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/Neck0/HeadBobber/EarZ1" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/NearArm" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/Neck0/HeadBobber/EarZ2" method="_on_Creature_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Sprites/Neck0/HeadBobber/EarZ0" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/NearLeg" method="_on_Creature_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprites/Neck0/HeadBobber/HornZ1" method="_on_Creature_movement_mode_changed"]
 [connection signal="orientation_changed" from="." to="Sprites/FarLeg" method="_on_Creature_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Sprites/FarArm" method="_on_Creature_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Sprites/Neck0/HeadBobber/Head" method="_on_Creature_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Sprites/NearArm" method="_on_Creature_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Sprites/Neck0/HeadBobber/EarZ1" method="_on_Creature_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Sprites/Neck0/HeadBobber/HornZ1" method="_on_Creature_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Sprites/Body/NeckBlend" method="_on_Creature_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Sprites/Neck0/HeadBobber/EarZ2" method="_on_Creature_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Sprites/NearLeg" method="_on_Creature_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Sprites/Neck0/HeadBobber/HornZ0" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/Neck0/HeadBobber/Head" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/Neck0/HeadBobber/EarZ1" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/NearArm" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/Neck0/HeadBobber/EarZ2" method="_on_Creature_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Sprites/Neck0/HeadBobber/EarZ0" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/NearLeg" method="_on_Creature_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Sprites/Neck0/HeadBobber/HornZ1" method="_on_Creature_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Mouth0Anims" method="_on_Creature_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Mouth1Anims" method="_on_Creature_orientation_changed"]
 [connection signal="animation_finished" from="EmoteAnims" to="EmoteAnims" method="_on_animation_finished"]
 [connection signal="before_mood_switched" from="EmoteAnims" to="." method="_on_EmoteAnims_before_mood_switched"]
 [connection signal="animation_started" from="MovementAnims" to="." method="_on_MovementAnims_animation_started"]
+[connection signal="timeout" from="CreatureSfx/HelloTimer" to="CreatureSfx" method="_on_HelloTimer_timeout"]

--- a/src/main/world/creature/creature-3d.gd
+++ b/src/main/world/creature/creature-3d.gd
@@ -11,16 +11,11 @@ func _ready() -> void:
 	$CollisionShape.disabled = true
 	$ShadowMesh.visible = false
 	$Viewport/Creature/Sprites/Shadow.visible = false
-	var creature_def := get_creature_def()
-	if creature_def:
-		$Viewport/Creature.summon(creature_def)
 
 
-"""
-Subclasses can override this method to define the creature's appearance.
-"""
-func get_creature_def() -> Dictionary:
-	return {}
+func set_creature_def(creature_def: Dictionary) -> void:
+	set_meta("creature_def", creature_def)
+	$Viewport/Creature.summon(creature_def)
 
 
 """

--- a/src/main/world/creature/creature.gd
+++ b/src/main/world/creature/creature.gd
@@ -159,10 +159,6 @@ func set_orientation(new_orientation: int) -> void:
 	emit_signal("orientation_changed", orientation)
 
 
-func set_door_sound_position(door_sound_position: Vector2) -> void:
-	$CreatureSfx.set_door_sound_position(door_sound_position)
-
-
 """
 If you make Creature a tool and play with the 'creature_preset' editor setting, you can view a creature in the editor.
 
@@ -270,6 +266,13 @@ func show_food_effects(delay := 0.0) -> void:
 
 
 """
+Plays a 'hello!' voice sample, for when a creature enters the restaurant
+"""
+func play_hello_voice(force: bool = false) -> void:
+	$CreatureSfx.play_hello_voice(force)
+
+
+"""
 Plays a 'mmm!' voice sample, for when a player builds a big combo.
 """
 func play_combo_voice() -> void:
@@ -279,8 +282,8 @@ func play_combo_voice() -> void:
 """
 Plays a 'check please!' voice sample, for when a creature is ready to leave
 """
-func play_goodbye_voice() -> void:
-	$CreatureSfx.play_goodbye_voice()
+func play_goodbye_voice(force: bool = false) -> void:
+	$CreatureSfx.play_goodbye_voice(force)
 
 
 """

--- a/src/main/world/ebe.gd
+++ b/src/main/world/ebe.gd
@@ -7,12 +7,8 @@ func _ready() -> void:
 	set_meta("chat_id", "ebe")
 	set_meta("chat_name", "Ebe")
 	set_meta("chat_theme_def", {"accent_scale":0.87,"accent_swapped":true,"accent_texture":15,"color":"b47922"})
-
-"""
-Ebe is brown with a beak mouth.
-"""
-func get_creature_def() -> Dictionary:
-	return {
+	
+	# Ebe is brown with a beak mouth.
+	set_creature_def({
 		"line_rgb": "6c4331", "body_rgb": "b47922", "eye_rgb": "7d4c21 e5cd7d", "horn_rgb": "f1e398",
-		"ear": "1", "horn": "2", "mouth": "1", "eye": "2"
-	}
+		"ear": "1", "horn": "2", "mouth": "1", "eye": "2"})

--- a/src/main/world/restaurant/CreatureView.tscn
+++ b/src/main/world/restaurant/CreatureView.tscn
@@ -6,7 +6,6 @@
 [ext_resource path="res://src/main/world/restaurant/creature-view.gd" type="Script" id=4]
 [ext_resource path="res://src/main/world/creature/fat-player.gd" type="Script" id=5]
 
-
 [sub_resource type="Animation" id=1]
 resource_name = "fat"
 length = 10.0

--- a/src/main/world/restaurant/RestaurantScene.tscn
+++ b/src/main/world/restaurant/RestaurantScene.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/restaurant/Seat.tscn" type="PackedScene" id=2]
+[ext_resource path="res://src/main/world/restaurant/door-chime.gd" type="Script" id=3]
 [ext_resource path="res://assets/main/world/restaurant/wall-metal.png" type="Texture" id=5]
 [ext_resource path="res://assets/main/world/restaurant/wall-metal-shadow.png" type="Texture" id=7]
 [ext_resource path="res://assets/main/world/shadow-oval-2.png" type="Texture" id=11]
@@ -11,7 +12,6 @@
 [ext_resource path="res://assets/main/world/restaurant/poster1.png" type="Texture" id=15]
 [ext_resource path="res://assets/main/world/restaurant/poster0.png" type="Texture" id=16]
 [ext_resource path="res://src/main/world/restaurant/restaurant-scene.gd" type="Script" id=24]
-
 
 [node name="RestaurantScene" type="Node2D"]
 light_mask = 2
@@ -169,6 +169,25 @@ z_index = 20
 
 [node name="Seat3" parent="." instance=ExtResource( 2 )]
 position = Vector2( 2380, 585 )
+
+[node name="DoorChime" type="AudioStreamPlayer2D" parent="."]
+position = Vector2( -120, 200 )
+volume_db = -4.0
+max_distance = 4000.0
+bus = "Sound Bus"
+script = ExtResource( 3 )
+
+[node name="ChimeTimer" type="Timer" parent="DoorChime"]
+wait_time = 0.5
+one_shot = true
+
+[node name="SuppressSfxTimer" type="Timer" parent="DoorChime"]
+one_shot = true
+autostart = true
+[connection signal="creature_arrived" from="Creature1" to="DoorChime" method="_on_Creature_creature_arrived"]
 [connection signal="food_eaten" from="Creature1" to="." method="_on_Creature_food_eaten"]
+[connection signal="creature_arrived" from="Creature2" to="DoorChime" method="_on_Creature_creature_arrived"]
 [connection signal="food_eaten" from="Creature2" to="." method="_on_Creature_food_eaten"]
+[connection signal="creature_arrived" from="Creature3" to="DoorChime" method="_on_Creature_creature_arrived"]
 [connection signal="food_eaten" from="Creature3" to="." method="_on_Creature_food_eaten"]
+[connection signal="timeout" from="DoorChime/ChimeTimer" to="DoorChime" method="_on_ChimeTimer_timeout"]

--- a/src/main/world/restaurant/door-chime.gd
+++ b/src/main/world/restaurant/door-chime.gd
@@ -1,0 +1,25 @@
+extends AudioStreamPlayer2D
+"""
+Door chime which rings when a customer enters the restaurant.
+"""
+
+# sounds which get played when a creature shows up
+onready var _chime_sounds := [
+	preload("res://assets/main/world/door-chime0.wav"),
+	preload("res://assets/main/world/door-chime1.wav"),
+	preload("res://assets/main/world/door-chime2.wav"),
+	preload("res://assets/main/world/door-chime3.wav"),
+	preload("res://assets/main/world/door-chime4.wav"),
+]
+
+func _on_Creature_creature_arrived() -> void:
+	if not $SuppressSfxTimer.is_stopped():
+		# suppress door chime at the start of a scenario
+		return
+	
+	$ChimeTimer.start()
+
+
+func _on_ChimeTimer_timeout() -> void:
+	stream = _chime_sounds[randi() % _chime_sounds.size()]
+	play()

--- a/src/main/world/restaurant/restaurant-scene.gd
+++ b/src/main/world/restaurant/restaurant-scene.gd
@@ -21,7 +21,6 @@ onready var _creatures := [$Creature1, $Creature2, $Creature3]
 func _ready() -> void:
 	for i in range(3):
 		_get_seat(i).set_creature(_creatures[i])
-		_get_seat(i).set_door_sound_position(Vector2(-500 - 1000 * i, 0))
 		_get_seat(i).refresh()
 
 

--- a/src/main/world/restaurant/seat.gd
+++ b/src/main/world/restaurant/seat.gd
@@ -7,7 +7,6 @@ This script contains logic for scaling an injected 'creature shadow' object as t
 """
 
 var _creature: Creature setget set_creature
-var _door_sound_position: Vector2
 
 func set_creature(creature: Creature) -> void:
 	_creature = creature
@@ -21,18 +20,6 @@ func refresh() -> void:
 	if _creature and _creature.is_visible_in_tree():
 		# draw a shadow on the creature's stool
 		$Stool0L.texture = preload("res://assets/main/world/restaurant/stool-occupied.png")
-		_creature.set_door_sound_position(_door_sound_position)
 	else:
 		# remove the shadow from the creature's stool
 		$Stool0L.texture = preload("res://assets/main/world/restaurant/stool.png")
-
-
-"""
-Sets the relative position of sound effects related to the restaurant door. Each seat has a different position
-relative to the restaurant's entrance; some are close to the door, some are far away.
-
-Parameter: 'position' is the position of the door relative to this seat, in world coordinates.
-"""
-func set_door_sound_position(door_sound_position: Vector2) -> void:
-	_door_sound_position = door_sound_position
-	refresh()

--- a/src/main/world/spira.gd
+++ b/src/main/world/spira.gd
@@ -75,6 +75,11 @@ func _ready() -> void:
 	._ready()
 	$CollisionShape.disabled = false
 	ChattableManager.set_spira(self)
+	
+	# Spira is dark red with black eyes.
+	set_creature_def({
+		"line_rgb": "6c4331", "body_rgb": "b23823", "eye_rgb": "282828 dedede", "horn_rgb": "f1e398",
+		"ear": "1", "horn": "1", "mouth": "2", "eye": "1"})
 
 
 func _physics_process(delta) -> void:
@@ -117,16 +122,6 @@ func _unhandled_input(_event: InputEvent) -> void:
 			# only start the jump buffer when pressing the button, not when holding it
 			$JumpBuffer.start()
 		get_tree().set_input_as_handled()
-
-
-"""
-Spira is dark red with black eyes.
-"""
-func get_creature_def() -> Dictionary:
-	return {
-		"line_rgb": "6c4331", "body_rgb": "b23823", "eye_rgb": "282828 dedede", "horn_rgb": "f1e398",
-		"ear": "1", "horn": "1", "mouth": "2", "eye": "1"
-	}
 
 
 """


### PR DESCRIPTION
Fixed regression introduced in 379b73d4 (pushing Scenario logic into child
classes) where scenarios no longer featured the overworld creature you
spoke with. That creature was ousted from the restaurant because we
summmoned a fourth creature.

Moved door chime from Creature into RestaurantScene. This makes sense
thematically but also keeps our code cleaner.

Resolved 'resumed after yield, but class instance is gone' errors when
playing door chimes. This was caused because the door chime logic was all
in one function with yield statements. It's now handled by timers.

Creature's 'creature_def' attribute is now a metadata property, instead of
a function. This is the same as how chat_theme_def is handled.