### PR TITLE
Added gamepad support.

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -478,40 +478,84 @@ ui_select={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":3,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
+ui_cancel={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777217,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":1,"pressure":0.0,"pressed":false,"script":null)
+ ]
+}
+ui_left={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
+ ]
+}
+ui_right={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":15,"pressure":0.0,"pressed":false,"script":null)
+ ]
+}
+ui_up={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
+ ]
+}
+ui_down={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777234,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
+ ]
+}
+ui_menu={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777217,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
+ ]
+}
+jump={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":88,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":1,"pressure":0.0,"pressed":false,"script":null)
+ ]
+}
+interact={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":90,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
+ ]
+}
+rewind_text={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777237,"unicode":0,"echo":false,"script":null)
+ ]
+}
 rotate_cw={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":88,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":1,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
 rotate_ccw={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":90,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
 hard_drop={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777237,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":3,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
 soft_drop={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777234,"unicode":0,"echo":false,"script":null)
- ]
-}
-jump={
-"deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":88,"unicode":0,"echo":false,"script":null)
- ]
-}
-interact={
-"deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":90,"unicode":0,"echo":false,"script":null)
- ]
-}
-rewind_text={
-"deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777237,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":2,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
 

--- a/src/main/puzzle/PuzzleHud.tscn
+++ b/src/main/puzzle/PuzzleHud.tscn
@@ -7,7 +7,6 @@
 [ext_resource path="res://src/main/puzzle/puzzle-hud.gd" type="Script" id=5]
 [ext_resource path="res://src/main/ui/blogger-sans-medium-18.tres" type="DynamicFont" id=6]
 
-
 [sub_resource type="InputEventAction" id=1]
 action = "ui_cancel"
 
@@ -73,6 +72,7 @@ margin_top = -27.0
 margin_right = 70.0
 margin_bottom = 27.5
 theme = ExtResource( 3 )
+shortcut_in_tooltip = false
 text = "Start"
 
 [node name="BackButton" type="Button" parent="."]

--- a/src/main/puzzle/editor/LevelEditor.tscn
+++ b/src/main/puzzle/editor/LevelEditor.tscn
@@ -9,7 +9,7 @@
 [ext_resource path="res://src/main/puzzle/editor/LevelChunkControl.tscn" type="PackedScene" id=7]
 [ext_resource path="res://src/main/puzzle/editor/level-editor.gd" type="Script" id=8]
 [ext_resource path="res://src/main/ui/SettingsMenu.tscn" type="PackedScene" id=9]
-[ext_resource path="res://src/main/ui/UiCancelShortcut.tres" type="ShortCut" id=10]
+[ext_resource path="res://src/main/ui/UiMenuShortcut.tres" type="ShortCut" id=10]
 
 [node name="LevelEditor" type="Control"]
 anchor_right = 1.0
@@ -247,18 +247,21 @@ margin_bottom = 32.0
 margin_top = 36.0
 margin_right = 110.0
 margin_bottom = 56.0
+shortcut_in_tooltip = false
 text = "Open File"
 
 [node name="OpenResource" type="Button" parent="HBoxContainer/RightPanel/SideButtons"]
 margin_top = 60.0
 margin_right = 110.0
 margin_bottom = 80.0
+shortcut_in_tooltip = false
 text = "Open Resource"
 
 [node name="Save" type="Button" parent="HBoxContainer/RightPanel/SideButtons"]
 margin_top = 84.0
 margin_right = 110.0
 margin_bottom = 104.0
+shortcut_in_tooltip = false
 text = "Save"
 __meta__ = {
 "_editor_description_": ""
@@ -273,6 +276,7 @@ margin_bottom = 112.0
 margin_top = 116.0
 margin_right = 110.0
 margin_bottom = 136.0
+shortcut_in_tooltip = false
 text = "Test"
 __meta__ = {
 "_editor_description_": ""
@@ -291,6 +295,7 @@ __meta__ = {
 margin_top = 546.0
 margin_right = 110.0
 margin_bottom = 566.0
+shortcut_in_tooltip = false
 shortcut = ExtResource( 10 )
 text = "Settings"
 __meta__ = {
@@ -301,6 +306,7 @@ __meta__ = {
 margin_top = 570.0
 margin_right = 110.0
 margin_bottom = 590.0
+shortcut_in_tooltip = false
 text = "Quit"
 __meta__ = {
 "_editor_description_": ""

--- a/src/main/puzzle/topout-tracker.gd
+++ b/src/main/puzzle/topout-tracker.gd
@@ -6,7 +6,7 @@ onready var _playfield: Playfield = _puzzle.get_playfield()
 onready var _piece_manager: PieceManager = _puzzle.get_piece_manager()
 
 func _input(event: InputEvent) -> void:
-	if PuzzleScore.game_active and event.is_action_pressed("ui_cancel"):
+	if PuzzleScore.game_active and event.is_action_pressed("ui_menu"):
 		make_player_lose()
 
 

--- a/src/main/ui/ButtonShortcutHelper.tscn
+++ b/src/main/ui/ButtonShortcutHelper.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/main/ui/button-shortcut-helper.gd" type="Script" id=1]
+
+[node name="ShortcutHelper" type="Node"]
+script = ExtResource( 1 )

--- a/src/main/ui/SettingsMenu.tscn
+++ b/src/main/ui/SettingsMenu.tscn
@@ -1,12 +1,12 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=2]
 [ext_resource path="res://src/main/ui/menu/theme/h3.theme" type="Theme" id=3]
+[ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/ui/menu/settings-menu.gd" type="Script" id=5]
 [ext_resource path="res://src/main/ui/VolumeSetting.tscn" type="PackedScene" id=6]
-[ext_resource path="res://src/main/ui/UiCancelShortcut.tres" type="ShortCut" id=7]
-
+[ext_resource path="res://src/main/ui/UiMenuShortcut.tres" type="ShortCut" id=7]
 
 [node name="SettingsMenu" type="CanvasLayer"]
 pause_mode = 2
@@ -108,6 +108,9 @@ theme = ExtResource( 3 )
 shortcut_in_tooltip = false
 shortcut = ExtResource( 7 )
 text = "Ok"
+
+[node name="ShiveringQuestion" parent="Window/UiArea/SettingsArea/Ok" instance=ExtResource( 4 )]
+action = "ui_cancel"
 
 [node name="Quit" type="Button" parent="Window/UiArea"]
 anchor_top = 1.0

--- a/src/main/ui/UiMenuShortcut.tres
+++ b/src/main/ui/UiMenuShortcut.tres
@@ -1,0 +1,7 @@
+[gd_resource type="ShortCut" load_steps=2 format=2]
+
+[sub_resource type="InputEventAction" id=1]
+action = "ui_menu"
+
+[resource]
+shortcut = SubResource( 1 )

--- a/src/main/ui/button-shortcut-helper.gd
+++ b/src/main/ui/button-shortcut-helper.gd
@@ -1,0 +1,45 @@
+extends Node
+"""
+Manages shortcuts for buttons in some weird edge cases.
+
+Sometimes we want two actions to activate a button, such as a menu which is launched with the start button. The player
+would expect the 'back' button or 'menu' button to close the menu, but only one shortcut can be bound to the closing
+of the menu. This node is capable of assigning a second shortcut to a button.
+
+Sometimes we want two actions assigned to the same key, such as the 'escape' key which is bound to both 'ui_back' and
+'ui_menu'. But, sometimes a menu might include separate cancel and menu buttons, in which case 'escape' would press
+both. This node is capable of overriding that behavior, and pressing only one button when two actions are activated
+simultaneously.
+"""
+
+# the action which activates the button
+export (String) var action: String
+
+# (optional) a second action which is also required to activate the button
+export (String) var overridden_action: String
+
+# the button this helper will activate
+onready var button: Button = get_parent()
+
+func _input(event: InputEvent) -> void:
+	if not event.is_action(action):
+		return
+	if not get_parent().is_visible_in_tree():
+		# do not activate invisible buttons
+		return
+	if overridden_action \
+			and not Input.is_action_pressed(overridden_action) \
+			and not Input.is_action_just_released(overridden_action):
+		# if an 'overridden_action' is defined, only activate when both actions are activated
+		return
+	
+	if event.is_action_pressed(action):
+		# workaround for Godot #35172; setting button pressed to true doesn't work without toggle mode
+		button.toggle_mode = true
+		button.pressed = true
+	if event.is_action_released(action):
+		# workaround for Godot #35172; setting button pressed to true doesn't work without toggle mode
+		button.pressed = false
+		button.toggle_mode = false
+		button.emit_signal("pressed")
+	get_tree().set_input_as_handled()

--- a/src/main/ui/menu/MainMenu.tscn
+++ b/src/main/ui/menu/MainMenu.tscn
@@ -9,7 +9,6 @@
 [ext_resource path="res://src/main/ui/SettingsMenu.tscn" type="PackedScene" id=8]
 [ext_resource path="res://src/main/ui/menu/theme/h2-font-outline.tres" type="DynamicFont" id=9]
 
-
 [node name="MainMenu" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -125,6 +124,7 @@ disabled = true
 text = "Characters"
 
 [node name="System" parent="." instance=ExtResource( 5 )]
+_quit_on_cancel = false
 
 [node name="VersionLabel" parent="." instance=ExtResource( 7 )]
 

--- a/src/main/ui/menu/PracticeMenu.tscn
+++ b/src/main/ui/menu/PracticeMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://src/main/ui/menu/practice-menu.gd" type="Script" id=1]
 [ext_resource path="res://src/main/ui/menu/practice-difficulty-selector.gd" type="Script" id=2]
@@ -6,7 +6,8 @@
 [ext_resource path="res://src/main/ui/SettingsMenu.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/ui/menu/system-buttons.gd" type="Script" id=5]
 [ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=6]
-[ext_resource path="res://src/main/ui/UiCancelShortcut.tres" type="ShortCut" id=8]
+[ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=7]
+[ext_resource path="res://src/main/ui/UiMenuShortcut.tres" type="ShortCut" id=8]
 [ext_resource path="res://src/main/ui/menu/theme/h3.theme" type="Theme" id=9]
 [ext_resource path="res://assets/main/puzzle/wood-backdrop.png" type="Texture" id=10]
 [ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=12]
@@ -14,7 +15,6 @@
 [ext_resource path="res://src/main/ui/menu/mode-buttongroup.tres" type="ButtonGroup" id=14]
 [ext_resource path="res://src/main/ui/menu/practice-mode-selector.gd" type="Script" id=15]
 [ext_resource path="res://src/main/ui/menu/theme/h2-font-outline.tres" type="DynamicFont" id=17]
-
 
 [node name="PracticeMenu" type="Control"]
 anchor_right = 1.0
@@ -83,6 +83,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = ExtResource( 9 )
 toggle_mode = true
+shortcut_in_tooltip = false
 pressed = true
 group = ExtResource( 14 )
 text = "Survival"
@@ -96,6 +97,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = ExtResource( 9 )
 toggle_mode = true
+shortcut_in_tooltip = false
 group = ExtResource( 14 )
 text = "Ultra"
 
@@ -108,6 +110,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = ExtResource( 9 )
 toggle_mode = true
+shortcut_in_tooltip = false
 group = ExtResource( 14 )
 text = "Sprint"
 
@@ -120,6 +123,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = ExtResource( 9 )
 toggle_mode = true
+shortcut_in_tooltip = false
 group = ExtResource( 14 )
 text = "Rank"
 
@@ -132,6 +136,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = ExtResource( 9 )
 toggle_mode = true
+shortcut_in_tooltip = false
 group = ExtResource( 14 )
 text = "Sandbox"
 
@@ -239,6 +244,7 @@ rect_min_size = Vector2( 180, 60 )
 size_flags_horizontal = 4
 size_flags_vertical = 4
 theme = ExtResource( 9 )
+shortcut_in_tooltip = false
 text = "Start"
 
 [node name="Settings" type="Button" parent="VBoxContainer/System"]
@@ -250,8 +256,12 @@ rect_min_size = Vector2( 116, 28 )
 size_flags_horizontal = 4
 size_flags_vertical = 4
 theme = ExtResource( 6 )
+shortcut_in_tooltip = false
 shortcut = ExtResource( 8 )
 text = "Settings"
+
+[node name="ShortcutHelper" parent="VBoxContainer/System/Settings" instance=ExtResource( 7 )]
+action = "ui_cancel"
 
 [node name="Quit" type="Button" parent="VBoxContainer/System"]
 margin_left = 434.0
@@ -262,6 +272,7 @@ rect_min_size = Vector2( 116, 28 )
 size_flags_horizontal = 4
 size_flags_vertical = 4
 theme = ExtResource( 6 )
+shortcut_in_tooltip = false
 text = "Quit"
 
 [node name="HighScores" type="Panel" parent="VBoxContainer"]

--- a/src/main/ui/menu/SplashScreen.tscn
+++ b/src/main/ui/menu/SplashScreen.tscn
@@ -8,7 +8,6 @@
 [ext_resource path="res://src/main/ui/SettingsMenu.tscn" type="PackedScene" id=6]
 [ext_resource path="res://src/main/ui/menu/theme/h1.theme" type="Theme" id=7]
 
-
 [node name="SplashScreen" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -69,6 +68,7 @@ __meta__ = {
 }
 
 [node name="System" parent="." instance=ExtResource( 5 )]
+_quit_on_cancel = false
 
 [node name="VersionLabel" parent="." instance=ExtResource( 2 )]
 

--- a/src/main/ui/menu/SystemButtons.tscn
+++ b/src/main/ui/menu/SystemButtons.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/ui/menu/system-buttons.gd" type="Script" id=2]
-[ext_resource path="res://src/main/ui/UiCancelShortcut.tres" type="ShortCut" id=3]
-
+[ext_resource path="res://src/main/ui/UiMenuShortcut.tres" type="ShortCut" id=3]
+[ext_resource path="res://src/main/ui/UiCancelShortcut.tres" type="ShortCut" id=4]
+[ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=5]
 
 [node name="System" type="VBoxContainer"]
 anchor_top = 1.0
@@ -28,6 +29,10 @@ shortcut_in_tooltip = false
 shortcut = ExtResource( 3 )
 text = "Settings"
 
+[node name="ShortcutHelper" parent="Settings" instance=ExtResource( 5 )]
+action = "ui_cancel"
+overridden_action = "ui_menu"
+
 [node name="Quit" type="Button" parent="."]
 margin_left = 454.0
 margin_top = 38.0
@@ -36,6 +41,8 @@ margin_bottom = 66.0
 rect_min_size = Vector2( 116, 28 )
 size_flags_horizontal = 4
 size_flags_vertical = 4
+shortcut_in_tooltip = false
+shortcut = ExtResource( 4 )
 text = "Quit"
 [connection signal="pressed" from="Settings" to="." method="_on_Settings_pressed"]
 [connection signal="pressed" from="Quit" to="." method="_on_Quit_pressed"]

--- a/src/main/ui/menu/settings-menu.gd
+++ b/src/main/ui/menu/settings-menu.gd
@@ -10,6 +10,9 @@ signal quit_pressed
 # The text on the menu's quit button
 export (String, "Quit", "Save + Quit") var quit_text: String setget set_quit_text
 
+# the UI control which was focused before this settings menu popped up
+var _old_focus_owner: Control
+
 func _ready() -> void:
 	# starts invisible
 	hide()
@@ -28,6 +31,7 @@ func show() -> void:
 	$Bg.show()
 	$Window.show()
 	get_tree().paused = true
+	_old_focus_owner = $Window/UiArea/SettingsArea/Ok.get_focus_owner()
 	$Window/UiArea/SettingsArea/Ok.grab_focus()
 
 
@@ -38,6 +42,9 @@ func hide() -> void:
 	$Bg.hide()
 	$Window.hide()
 	get_tree().paused = false
+	if _old_focus_owner:
+		_old_focus_owner.grab_focus()
+		_old_focus_owner = null
 
 
 func _on_Ok_pressed() -> void:

--- a/src/main/ui/menu/system-buttons.gd
+++ b/src/main/ui/menu/system-buttons.gd
@@ -3,9 +3,34 @@ extends VBoxContainer
 Navigational buttons which occur on most menu screens.
 """
 
+# If true, the `ui_cancel` action will activate the quit button. This should be unset in contexts where the 'quit'
+# button does something destructive such as quitting the game or abandoning an editor.
+export (bool) var _quit_on_cancel: bool = true setget set_quit_on_cancel
+
+onready var _ui_cancel_shortcut := preload("res://src/main/ui/UiCancelShortcut.tres")
+
 signal settings_pressed
 
 signal quit_pressed
+
+func _ready() -> void:
+	refresh()
+
+
+func set_quit_on_cancel(quit_on_cancel: bool):
+	_quit_on_cancel = quit_on_cancel
+	if is_inside_tree():
+		refresh()
+
+
+func refresh() -> void:
+	if _quit_on_cancel:
+		$Quit.shortcut = _ui_cancel_shortcut
+		$Settings/ShortcutHelper.overridden_action = "ui_menu"
+	else:
+		$Quit.shortcut = null
+		$Settings/ShortcutHelper.overridden_action = ""
+
 
 func _on_Quit_pressed() -> void:
 	emit_signal("quit_pressed")

--- a/src/main/ui/overworld-ui.gd
+++ b/src/main/ui/overworld-ui.gd
@@ -36,7 +36,7 @@ func _input(event: InputEvent) -> void:
 	if not chatters and event.is_action_pressed("interact") and ChattableManager.get_focused():
 		get_tree().set_input_as_handled()
 		start_chat()
-	if not chatters and event.is_action_pressed("ui_cancel"):
+	if not chatters and event.is_action_pressed("ui_menu"):
 		$SettingsMenu.show()
 		get_tree().set_input_as_handled()
 

--- a/src/main/world/environment/nature-library.tres
+++ b/src/main/world/environment/nature-library.tres
@@ -7,7 +7,6 @@
 [ext_resource path="res://assets/main/world/environment/stone.material" type="Material" id=5]
 [ext_resource path="res://assets/main/world/environment/grass_tuft.material" type="Material" id=6]
 
-
 [sub_resource type="SpatialMaterial" id=1]
 flags_transparent = true
 albedo_color = Color( 0, 1, 0, 0 )


### PR DESCRIPTION
InputMappings now use 'escape' key as both ui_cancel and ui_menu. This
requires some unusual logic to handle the case where both actions are
activated at once.

Disabled 'shortcut in tooltip' for buttons.

Due to Godot #28914, InputEventAction shortcuts have crazy tooltips like
(InputEventAction : action=test, pressed=(true))