### PR TITLE
2D overworld camera zooms in during conversations.

### DIFF
--- a/src/main/world/Overworld.tscn
+++ b/src/main/world/Overworld.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=2]
+[gd_scene load_steps=25 format=2]
 
 [ext_resource path="res://src/main/world/creature/Creature2D.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/spira.gd" type="Script" id=2]
@@ -20,6 +20,7 @@
 [ext_resource path="res://src/main/world/creature/CreatureShadow.tscn" type="PackedScene" id=18]
 [ext_resource path="res://assets/main/world/environment/block-shadow.png" type="Texture" id=19]
 [ext_resource path="res://src/main/world/environment/obstacle-shadows.gd" type="Script" id=20]
+[ext_resource path="res://src/main/world/overworld-camera.gd" type="Script" id=21]
 
 [sub_resource type="TileSet" id=1]
 0/name = "block-shadow.png 0"
@@ -149,10 +150,6 @@ creature_def = {
 "mouth": "2"
 }
 
-[node name="Camera2D" type="Camera2D" parent="World/Obstacles/Spira"]
-current = true
-smoothing_enabled = true
-
 [node name="Bort" parent="World/Obstacles" instance=ExtResource( 1 )]
 position = Vector2( 313.439, 344.721 )
 creature_def = {
@@ -232,6 +229,16 @@ texture = ExtResource( 13 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="World/Obstacles/GlowySphere"]
 shape = SubResource( 3 )
+
+[node name="Camera" type="Camera2D" parent="World"]
+position = Vector2( 150, 150 )
+current = true
+smoothing_enabled = true
+script = ExtResource( 21 )
+_spira_path = NodePath("../Obstacles/Spira")
+_overworld_ui_path = NodePath("../../Ui/OverworldUi")
+
+[node name="Tween" type="Tween" parent="World/Camera"]
 
 [node name="Ui" type="CanvasLayer" parent="."]
 
@@ -315,6 +322,8 @@ codes = [ "bigfps" ]
 
 [node name="SettingsMenu" parent="Ui/OverworldUi" instance=ExtResource( 6 )]
 quit_text = "Save + Quit"
+[connection signal="chat_ended" from="Ui/OverworldUi" to="World/Camera" method="_on_OverworldUi_chat_ended"]
+[connection signal="chat_started" from="Ui/OverworldUi" to="World/Camera" method="_on_OverworldUi_chat_started"]
 [connection signal="chat_event_played" from="Ui/OverworldUi/ChatUi" to="Ui/OverworldUi" method="_on_ChatUi_chat_event_played"]
 [connection signal="pop_out_completed" from="Ui/OverworldUi/ChatUi" to="Ui/OverworldUi" method="_on_ChatUi_pop_out_completed"]
 [connection signal="showed_choices" from="Ui/OverworldUi/ChatUi" to="Ui/OverworldUi" method="_on_ChatUi_showed_choices"]

--- a/src/main/world/overworld-camera.gd
+++ b/src/main/world/overworld-camera.gd
@@ -1,0 +1,64 @@
+extends Camera2D
+"""
+Overworld camera. Follows the main character and zooms in during conversations.
+"""
+
+const ZOOM_DURATION := 1.0
+
+# zoom amount for conversations
+const ZOOM_CLOSE_UP := Vector2(0.5, 0.5)
+
+# zoom amount when running around
+const ZOOM_DEFAULT := Vector2(1.0, 1.0)
+
+# how far from the camera center spira needs to be before the camera zooms out
+const AUTO_ZOOM_OUT_DISTANCE := 100.0
+
+export (NodePath) var _spira_path: NodePath
+export (NodePath) var _overworld_ui_path: NodePath
+
+# 'true' if the camera should currently be zoomed in for a conversation
+var close_up: bool setget set_close_up
+
+# 0.0 = zoomed out, 1.0 = zoomed in
+var close_up_pct := 0.0
+
+# the position to zoom in to. the midpoint of the smallest rectangle containing all chatters
+var close_up_position: Vector2
+
+onready var _spira: Spira = get_node(_spira_path)
+onready var _overworld_ui: OverworldUi = get_node(_overworld_ui_path)
+
+func _process(delta: float) -> void:
+	# calculate the position to zoom in to
+	var bounding_box := Rect2(_spira.position, Vector2(0, 0))
+	for chatter in _overworld_ui.chatters:
+		bounding_box = bounding_box.expand(chatter.position)
+	close_up_position = bounding_box.position + bounding_box.size * 0.5
+	
+	position = lerp(_spira.position, close_up_position, close_up_pct)
+	zoom = lerp(ZOOM_DEFAULT, ZOOM_CLOSE_UP, close_up_pct)
+	
+	if close_up and _spira.position.distance_to(close_up_position) > AUTO_ZOOM_OUT_DISTANCE:
+		# player left the chat area; zoom back out
+		set_close_up(false)
+
+
+func set_close_up(new_close_up: bool) -> void:
+	if close_up == new_close_up:
+		# don't launch tween if the value is the same
+		return
+	
+	close_up = new_close_up
+	$Tween.remove_all()
+	$Tween.interpolate_property(self, "close_up_pct", close_up_pct, 1.0 if close_up else 0.0,
+			ZOOM_DURATION, Tween.TRANS_QUAD, Tween.EASE_OUT)
+	$Tween.start()
+
+
+func _on_OverworldUi_chat_started() -> void:
+	set_close_up(true)
+
+
+func _on_OverworldUi_chat_ended() -> void:
+	set_close_up(false)


### PR DESCRIPTION
I initially tried to develop this in a way that mirrored the 3D camera, by
having two cameras in different places and toggling which was active.
However unlike 3D, there is no 2D concept of 'smoothly switch from this
target to that target', and the community-suggested solution appears to be
to create a third 'tweening camera' to temporarily lerp between the two
other cameras. Implementing this clumsy solution of two cameras and a
temporary tweening camera was glitchy and involved a lot of custom code,
some of which is available on issue #352.

This single camera approach has a risk of violating SRP and bloating into a
huge class if we have additional events or areas with custom camera behavior.
But, it seems to be the design that's best supported for 2D.