### PR TITLE
Touch controls can be configured: size, sensitivity, arrangement

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -349,6 +349,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/state-machine.gd"
 }, {
+"base": "Reference",
+"class": "TouchSettings",
+"language": "GDScript",
+"path": "res://src/main/touch-settings.gd"
+}, {
 "base": "Control",
 "class": "TutorialHud",
 "language": "GDScript",
@@ -433,6 +438,7 @@ _global_script_class_icons={
 "Spira": "",
 "State": "",
 "StateMachine": "",
+"TouchSettings": "",
 "TutorialHud": "",
 "TutorialMessage": "",
 "VolumeSettings": ""

--- a/src/demo/ui/menu/SettingsMenuDemo.tscn
+++ b/src/demo/ui/menu/SettingsMenuDemo.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://src/main/ui/SettingsMenu.tscn" type="PackedScene" id=1]
+[ext_resource path="res://src/demo/ui/menu/settings-menu-demo.gd" type="Script" id=2]
+
+[node name="SettingsMenuDemo" type="Node"]
+script = ExtResource( 2 )
+
+[node name="SettingsMenu" parent="." instance=ExtResource( 1 )]

--- a/src/demo/ui/menu/settings-menu-demo.gd
+++ b/src/demo/ui/menu/settings-menu-demo.gd
@@ -1,0 +1,9 @@
+extends Node
+"""
+Shows the settings menu.
+
+The settings menu is invisible by default, so a demo is necessary to view it.
+"""
+
+func _ready() -> void:
+	$SettingsMenu.show()

--- a/src/main/player-data.gd
+++ b/src/main/player-data.gd
@@ -8,12 +8,9 @@ This data includes how well they've done on each level and how much money they'v
 signal money_changed(value)
 
 var scenario_history := ScenarioHistory.new()
-
 var volume_settings := VolumeSettings.new()
-
+var touch_settings := TouchSettings.new()
 var money := 0 setget set_money
-
-var _rank_calculator := RankCalculator.new()
 
 """
 Resets the player's in-memory data to a default state.

--- a/src/main/player-save.gd
+++ b/src/main/player-save.gd
@@ -59,6 +59,7 @@ func save_player_data() -> void:
 	save_json.append(generic_data("version", PLAYER_DATA_VERSION).to_json_dict())
 	save_json.append(generic_data("player-info", {"money": PlayerData.money}).to_json_dict())
 	save_json.append(generic_data("volume-settings", PlayerData.volume_settings.to_json_dict()).to_json_dict())
+	save_json.append(generic_data("touch-settings", PlayerData.touch_settings.to_json_dict()).to_json_dict())
 	for scenario_name in PlayerData.scenario_history.scenario_names():
 		var rank_results_json := []
 		for rank_result in PlayerData.scenario_history.results(scenario_name):
@@ -119,5 +120,8 @@ func _load_line(type: String, key: String, json_value) -> void:
 		"volume-settings":
 			var value: Dictionary = json_value
 			PlayerData.volume_settings.from_json_dict(value)
+		"touch-settings":
+			var value: Dictionary = json_value
+			PlayerData.touch_settings.from_json_dict(value)
 		_:
 			push_warning("Unrecognized save data type: '%s'" % type)

--- a/src/main/puzzle/Puzzle.tscn
+++ b/src/main/puzzle/Puzzle.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=52 format=2]
+[gd_scene load_steps=51 format=2]
 
 [ext_resource path="res://src/main/ui/menu/theme/h3.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/tutorial/TutorialHud.tscn" type="PackedScene" id=2]
@@ -9,12 +9,11 @@
 [ext_resource path="res://src/main/puzzle/rainbow-metaball.shader" type="Shader" id=7]
 [ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=8]
 [ext_resource path="res://src/main/puzzle/piece/PieceManager.tscn" type="PackedScene" id=9]
+[ext_resource path="res://src/main/puzzle/PuzzleTouchButtons.tscn" type="PackedScene" id=10]
 [ext_resource path="res://assets/main/ui/applause.wav" type="AudioStream" id=11]
-[ext_resource path="res://src/main/ui/touch/EightWay.tscn" type="PackedScene" id=12]
 [ext_resource path="res://src/main/ui/menu/theme/h2-font.tres" type="DynamicFont" id=13]
 [ext_resource path="res://src/main/ui/menu/theme/h4-font.tres" type="DynamicFont" id=14]
 [ext_resource path="res://src/main/puzzle/puzzle-music-manager.gd" type="Script" id=19]
-[ext_resource path="res://src/main/ui/SettingsMenu.tscn" type="PackedScene" id=20]
 [ext_resource path="res://src/main/puzzle/puzzle.gd" type="Script" id=21]
 [ext_resource path="res://src/main/puzzle/milestone-hud.gd" type="Script" id=23]
 [ext_resource path="res://src/main/puzzle/frosting-globs.gd" type="Script" id=24]
@@ -310,47 +309,7 @@ _puzzle_path = NodePath("../..")
 visible = false
 _puzzle_path = NodePath("../..")
 
-[node name="TouchButtons" type="Control" parent="Hud"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="ButtonsSw" parent="Hud/TouchButtons" instance=ExtResource( 12 )]
-anchor_left = 0.0
-anchor_top = 1.0
-anchor_right = 0.0
-anchor_bottom = 1.0
-margin_left = 10.0
-margin_top = -250.0
-margin_right = 250.0
-margin_bottom = -10.0
-_up_action = "hard_drop"
-_down_action = "soft_drop"
-_left_action = "ui_left"
-_right_action = "ui_right"
-_up_right_weight = 0.66
-_up_left_weight = 0.66
-_down_right_weight = 0.66
-_down_left_weight = 0.66
-
-[node name="ButtonsSe" parent="Hud/TouchButtons" instance=ExtResource( 12 )]
-anchor_left = 1.0
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = -250.0
-margin_top = -250.0
-margin_right = -10.0
-margin_bottom = -10.0
-_up_action = "hard_drop"
-_down_action = "rotate_ccw"
-_left_action = "soft_drop"
-_right_action = "rotate_cw"
-_up_left_weight = 0.66
-_down_right_weight = 0.66
+[node name="TouchButtons" parent="Hud" instance=ExtResource( 10 )]
 
 [node name="TopOutTracker" type="Node" parent="."]
 script = ExtResource( 30 )
@@ -425,8 +384,6 @@ codes = [ "delays" ]
 
 [node name="PuzzleMusicManager" type="Node" parent="."]
 script = ExtResource( 19 )
-
-[node name="SettingsMenu" parent="." instance=ExtResource( 20 )]
 [connection signal="after_piece_written" from="Playfield" to="." method="_on_Playfield_after_piece_written"]
 [connection signal="before_line_cleared" from="Playfield" to="FrostingGlobs" method="_on_Playfield_before_line_cleared"]
 [connection signal="box_built" from="Playfield" to="FrostingGlobs" method="_on_Playfield_box_built"]

--- a/src/main/puzzle/PuzzleTouchButtons.tscn
+++ b/src/main/puzzle/PuzzleTouchButtons.tscn
@@ -1,0 +1,33 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://src/main/puzzle/puzzle-touch-buttons.gd" type="Script" id=1]
+[ext_resource path="res://src/main/ui/touch/EightWay.tscn" type="PackedScene" id=2]
+
+[node name="TouchButtons" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ButtonsSw" parent="." instance=ExtResource( 2 )]
+anchor_left = 0.0
+anchor_top = 1.0
+anchor_right = 0.0
+anchor_bottom = 1.0
+margin_left = 10.0
+margin_top = -250.0
+margin_right = 250.0
+margin_bottom = -10.0
+
+[node name="ButtonsSe" parent="." instance=ExtResource( 2 )]
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -250.0
+margin_top = -250.0
+margin_right = -10.0
+margin_bottom = -10.0

--- a/src/main/puzzle/puzzle-touch-buttons.gd
+++ b/src/main/puzzle/puzzle-touch-buttons.gd
@@ -1,0 +1,110 @@
+extends Control
+"""
+Manages the touchscreen buttons for puzzle mode.
+"""
+
+# touchscreen control schemes the player can select in the settings menu
+const SCHEMES := {
+	TouchSettings.EASY_CONSOLE: {
+		"sw_actions": ["hard_drop", "soft_drop", "ui_left", "ui_right"],
+		"sw_weights": [1, 1, 1, 1],
+		"se_actions": ["", "rotate_ccw", "", "rotate_cw"],
+		"se_weights": [0, 0, 0, 1],
+	},
+	TouchSettings.EASY_DESKTOP: {
+		"sw_actions": ["", "rotate_cw", "rotate_ccw", ""],
+		"sw_weights": [0, 0, 1, 0],
+		"se_actions": ["hard_drop", "soft_drop", "ui_left", "ui_right"],
+		"se_weights": [1, 1, 1, 1],
+	},
+	TouchSettings.AMBI_CONSOLE: {
+		"sw_actions": ["hard_drop", "soft_drop", "ui_left", "ui_right"],
+		"sw_weights": [1, 1, 1, 1],
+		"se_actions": ["hard_drop", "rotate_ccw", "soft_drop", "rotate_cw"],
+		"se_weights": [1, 0, 0, 1],
+	},
+	TouchSettings.AMBI_DESKTOP: {
+		"sw_actions": ["hard_drop", "rotate_cw", "rotate_ccw", "soft_drop"],
+		"sw_weights": [0, 1, 1, 0],
+		"se_actions": ["hard_drop", "soft_drop", "ui_left", "ui_right"],
+		"se_weights": [1, 1, 1, 1],
+	},
+	TouchSettings.LOCO_CONSOLE: {
+		"sw_actions": ["soft_drop", "ui_right", "ui_left", "hard_drop"],
+		"sw_weights": [0, 1, 1, 0],
+		"se_actions": ["hard_drop", "rotate_ccw", "soft_drop", "rotate_cw"],
+		"se_weights": [1, 0, 0, 1],
+	},
+	TouchSettings.LOCO_DESKTOP: {
+		"sw_actions": ["soft_drop", "rotate_cw", "rotate_ccw", "hard_drop"],
+		"sw_weights": [0, 1, 1, 0],
+		"se_actions": ["hard_drop", "ui_left", "soft_drop", "ui_right"],
+		"se_weights": [1, 0, 0, 1],
+	},
+}
+
+# if false, pressing the buttons won't emit any actions.
+export (bool) var emit_actions := true setget set_emit_actions
+
+func _ready() -> void:
+	PlayerData.touch_settings.connect("settings_changed", self, "_on_TouchSettings_settings_changed")
+	_refresh_emit_actions()
+	_refresh_settings()
+
+
+func set_emit_actions(new_emit_actions: bool) -> void:
+	emit_actions = new_emit_actions
+	_refresh_emit_actions()
+
+
+"""
+Refreshes the buttons based on the emit_actions property.
+
+Propogates the setting to the EightWay child objects and makes the buttons translucent.
+"""
+func _refresh_emit_actions() -> void:
+	modulate = Color.white if emit_actions else Utils.to_transparent(Color.white, 0.33)
+	
+	if is_inside_tree():
+		$ButtonsSw.emit_actions = emit_actions
+		$ButtonsSe.emit_actions = emit_actions
+
+
+"""
+Updates the buttons based on the player's settings.
+
+This updates their location, size, how they're arranged and their sensitivity.
+"""
+func _refresh_settings() -> void:
+	# update scale/position
+	$ButtonsSw.rect_scale = Vector2(1.0, 1.0) * PlayerData.touch_settings.size
+	$ButtonsSw.rect_position.y = 600 - 10 - $ButtonsSw.rect_size.y * $ButtonsSw.rect_scale.y
+	
+	$ButtonsSe.rect_scale = Vector2(1.0, 1.0) * PlayerData.touch_settings.size
+	$ButtonsSe.rect_position.x = 1024 - 10 - $ButtonsSw.rect_size.x * $ButtonsSw.rect_scale.x
+	$ButtonsSe.rect_position.y = 600 - 10 - $ButtonsSw.rect_size.y * $ButtonsSw.rect_scale.y
+	
+	# update actions
+	var scheme_dict: Dictionary = SCHEMES.get(PlayerData.touch_settings.scheme, TouchSettings.EASY_CONSOLE)
+	$ButtonsSw.up_action = scheme_dict["sw_actions"][0]
+	$ButtonsSw.down_action = scheme_dict["sw_actions"][1]
+	$ButtonsSw.left_action = scheme_dict["sw_actions"][2]
+	$ButtonsSw.right_action = scheme_dict["sw_actions"][3]
+	$ButtonsSe.up_action = scheme_dict["se_actions"][0]
+	$ButtonsSe.down_action = scheme_dict["se_actions"][1]
+	$ButtonsSe.left_action = scheme_dict["se_actions"][2]
+	$ButtonsSe.right_action = scheme_dict["se_actions"][3]
+	
+	# update diagonal sensitivity
+	$ButtonsSw.up_left_weight = scheme_dict["sw_weights"][0] * PlayerData.touch_settings.fat_finger
+	$ButtonsSw.up_right_weight = scheme_dict["sw_weights"][1] * PlayerData.touch_settings.fat_finger
+	$ButtonsSw.down_left_weight = scheme_dict["sw_weights"][2] * PlayerData.touch_settings.fat_finger
+	$ButtonsSw.down_right_weight = scheme_dict["sw_weights"][3] * PlayerData.touch_settings.fat_finger
+	$ButtonsSe.up_left_weight = scheme_dict["se_weights"][0] * PlayerData.touch_settings.fat_finger
+	$ButtonsSe.up_right_weight = scheme_dict["se_weights"][1] * PlayerData.touch_settings.fat_finger
+	$ButtonsSe.down_left_weight = scheme_dict["se_weights"][2] * PlayerData.touch_settings.fat_finger
+	$ButtonsSe.down_right_weight = scheme_dict["se_weights"][3] * PlayerData.touch_settings.fat_finger
+
+
+func _on_TouchSettings_settings_changed() -> void:
+	_refresh_settings()

--- a/src/main/touch-settings.gd
+++ b/src/main/touch-settings.gd
@@ -1,0 +1,60 @@
+class_name TouchSettings
+"""
+Manages settings which affect the touch controls.
+"""
+
+signal settings_changed
+
+# control schemes that decide which buttons appear where
+enum ControlScheme {
+	EASY_CONSOLE,
+	EASY_DESKTOP,
+	AMBI_CONSOLE,
+	AMBI_DESKTOP,
+	LOCO_CONSOLE,
+	LOCO_DESKTOP,
+}
+
+const EASY_CONSOLE := ControlScheme.EASY_CONSOLE
+const EASY_DESKTOP := ControlScheme.EASY_DESKTOP
+const AMBI_CONSOLE := ControlScheme.AMBI_CONSOLE
+const AMBI_DESKTOP := ControlScheme.AMBI_DESKTOP
+const LOCO_CONSOLE := ControlScheme.LOCO_CONSOLE
+const LOCO_DESKTOP := ControlScheme.LOCO_DESKTOP
+
+# how large the buttons appear on screen
+var size := 1.00 setget set_size
+
+# control scheme that decides which buttons appear where
+var scheme: int = ControlScheme.EASY_CONSOLE setget set_scheme
+
+# how easy it is to mash two buttons with one finger; 0.0 = impossible, 1.0 = very easy
+var fat_finger := 0.00 setget set_fat_finger
+
+func set_size(new_size: float) -> void:
+	size = new_size
+	emit_signal("settings_changed")
+
+
+func set_scheme(new_scheme: int) -> void:
+	scheme = new_scheme
+	emit_signal("settings_changed")
+
+
+func set_fat_finger(new_fat_finger: float) -> void:
+	fat_finger = new_fat_finger
+	emit_signal("settings_changed")
+
+
+func to_json_dict() -> Dictionary:
+	return {
+		"size": size,
+		"scheme": scheme,
+		"fat-finger": fat_finger,
+	}
+
+
+func from_json_dict(json: Dictionary) -> void:
+	size = json.get("size", 1.00)
+	scheme = json.get("scheme", 0)
+	fat_finger = json.get("fat_finger", 0.67)

--- a/src/main/ui/SettingsMenu.tscn
+++ b/src/main/ui/SettingsMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=2]
@@ -7,6 +7,10 @@
 [ext_resource path="res://src/main/ui/menu/settings-menu.gd" type="Script" id=5]
 [ext_resource path="res://src/main/ui/VolumeSetting.tscn" type="PackedScene" id=6]
 [ext_resource path="res://src/main/ui/UiMenuShortcut.tres" type="ShortCut" id=7]
+[ext_resource path="res://src/main/ui/menu/settings-touch-size.gd" type="Script" id=8]
+[ext_resource path="res://src/main/puzzle/PuzzleTouchButtons.tscn" type="PackedScene" id=9]
+[ext_resource path="res://src/main/ui/settings-touch-scheme.gd" type="Script" id=10]
+[ext_resource path="res://src/main/ui/settings-touch-fat-finger.gd" type="Script" id=11]
 
 [node name="SettingsMenu" type="CanvasLayer"]
 pause_mode = 2
@@ -21,6 +25,10 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[node name="TouchButtons" parent="." instance=ExtResource( 9 )]
+visible = false
+emit_actions = false
+
 [node name="Window" type="Panel" parent="."]
 visible = false
 anchor_left = 0.5
@@ -28,16 +36,16 @@ anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 margin_left = -220.0
-margin_top = -100.0
+margin_top = -180.0
 margin_right = 220.0
-margin_bottom = 100.0
-rect_min_size = Vector2( 440, 200 )
+margin_bottom = 180.0
+rect_min_size = Vector2( 440, 360 )
 custom_styles/panel = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="UiArea" type="Control" parent="Window"]
+[node name="UiArea" type="VBoxContainer" parent="Window"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 20.0
@@ -48,59 +56,222 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="SettingsArea" type="VBoxContainer" parent="Window/UiArea"]
+[node name="Center" type="ScrollContainer" parent="Window/UiArea"]
+margin_right = 400.0
+margin_bottom = 286.0
+size_flags_vertical = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Settings" type="VBoxContainer" parent="Window/UiArea/Center"]
+margin_right = 400.0
+margin_bottom = 286.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_constants/separation = 10
+alignment = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Settings" type="Label" parent="Window/UiArea/Center/Settings"]
+margin_top = 22.0
+margin_right = 400.0
+margin_bottom = 42.0
+theme = ExtResource( 1 )
+text = "Settings"
+align = 1
+valign = 1
+
+[node name="Music" parent="Window/UiArea/Center/Settings" instance=ExtResource( 6 )]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 0.0
+margin_top = 52.0
+margin_right = 400.0
+margin_bottom = 72.0
+
+[node name="Sounds" parent="Window/UiArea/Center/Settings" instance=ExtResource( 6 )]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 0.0
+margin_top = 82.0
+margin_right = 400.0
+margin_bottom = 102.0
+_volume_type = 1
+
+[node name="Voices" parent="Window/UiArea/Center/Settings" instance=ExtResource( 6 )]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 0.0
+margin_top = 112.0
+margin_right = 400.0
+margin_bottom = 132.0
+_volume_type = 2
+
+[node name="Touch" type="Label" parent="Window/UiArea/Center/Settings"]
+margin_top = 142.0
+margin_right = 400.0
+margin_bottom = 162.0
+theme = ExtResource( 1 )
+text = "Touch"
+align = 1
+valign = 1
+
+[node name="Size" type="Control" parent="Window/UiArea/Center/Settings"]
+margin_top = 172.0
+margin_right = 400.0
+margin_bottom = 192.0
+rect_min_size = Vector2( 400, 20 )
+size_flags_horizontal = 3
+theme = ExtResource( 1 )
+script = ExtResource( 8 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Label" type="Label" parent="Window/UiArea/Center/Settings/Size"]
+anchor_bottom = 1.0
+margin_right = 36.0
+rect_min_size = Vector2( 120, 0 )
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.5
+text = "Size"
+align = 2
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Control" type="HBoxContainer" parent="Window/UiArea/Center/Settings/Size"]
+anchor_left = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
+margin_left = -267.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
 custom_constants/separation = 10
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Settings" type="VBoxContainer" parent="Window/UiArea/SettingsArea"]
+[node name="HSlider" type="HSlider" parent="Window/UiArea/Center/Settings/Size/Control"]
+margin_top = 2.0
+margin_right = 160.0
+margin_bottom = 18.0
+rect_min_size = Vector2( 160, 0 )
+size_flags_horizontal = 0
+size_flags_vertical = 4
+max_value = 11.0
+value = 1.0
+tick_count = 12
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Text" type="Label" parent="Window/UiArea/Center/Settings/Size/Control"]
+margin_left = 170.0
+margin_right = 218.0
+margin_bottom = 20.0
+theme = ExtResource( 1 )
+text = "1.00x"
+
+[node name="Scheme" type="Control" parent="Window/UiArea/Center/Settings"]
+margin_top = 202.0
 margin_right = 400.0
-margin_bottom = 120.0
+margin_bottom = 228.0
+rect_min_size = Vector2( 400, 26 )
 size_flags_horizontal = 3
-size_flags_vertical = 3
-custom_constants/separation = 10
-alignment = 1
+theme = ExtResource( 1 )
+script = ExtResource( 10 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
-[node name="Music" parent="Window/UiArea/SettingsArea/Settings" instance=ExtResource( 6 )]
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 0.0
-margin_top = 20.0
+[node name="Label" type="Label" parent="Window/UiArea/Center/Settings/Scheme"]
+anchor_bottom = 1.0
+margin_right = 66.0
+rect_min_size = Vector2( 120, 0 )
+size_flags_horizontal = 3
+size_flags_vertical = 5
+size_flags_stretch_ratio = 0.5
+text = "Scheme"
+align = 2
+valign = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="OptionButton" type="OptionButton" parent="Window/UiArea/Center/Settings/Scheme"]
+margin_left = 133.0
+margin_top = 2.0
+margin_right = 293.0
+margin_bottom = 18.0
+rect_min_size = Vector2( 160, 0 )
+size_flags_horizontal = 0
+size_flags_vertical = 4
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="FatFinger" type="Control" parent="Window/UiArea/Center/Settings"]
+margin_top = 238.0
 margin_right = 400.0
-margin_bottom = 40.0
+margin_bottom = 264.0
+rect_min_size = Vector2( 400, 26 )
+size_flags_horizontal = 3
+theme = ExtResource( 1 )
+script = ExtResource( 11 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
-[node name="Sounds" parent="Window/UiArea/SettingsArea/Settings" instance=ExtResource( 6 )]
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 0.0
-margin_top = 50.0
+[node name="Label" type="Label" parent="Window/UiArea/Center/Settings/FatFinger"]
+anchor_bottom = 1.0
+margin_right = 66.0
+rect_min_size = Vector2( 120, 0 )
+size_flags_horizontal = 3
+size_flags_vertical = 5
+size_flags_stretch_ratio = 0.5
+text = "Fat Finger"
+align = 2
+valign = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="OptionButton" type="OptionButton" parent="Window/UiArea/Center/Settings/FatFinger"]
+margin_left = 133.0
+margin_top = 2.0
+margin_right = 293.0
+margin_bottom = 18.0
+rect_min_size = Vector2( 160, 0 )
+size_flags_horizontal = 0
+size_flags_vertical = 4
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Bottom" type="Control" parent="Window/UiArea"]
+margin_top = 290.0
 margin_right = 400.0
-margin_bottom = 70.0
-_volume_type = 1
+margin_bottom = 330.0
+rect_min_size = Vector2( 0, 40 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
-[node name="Voices" parent="Window/UiArea/SettingsArea/Settings" instance=ExtResource( 6 )]
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 0.0
-margin_top = 80.0
-margin_right = 400.0
-margin_bottom = 100.0
-_volume_type = 2
-
-[node name="Ok" type="Button" parent="Window/UiArea/SettingsArea"]
+[node name="Ok" type="Button" parent="Window/UiArea/Bottom"]
 margin_left = 140.0
-margin_top = 130.0
+margin_top = 4.0
 margin_right = 260.0
-margin_bottom = 170.0
+margin_bottom = 44.0
 rect_min_size = Vector2( 120, 40 )
 size_flags_horizontal = 4
 size_flags_vertical = 4
@@ -108,11 +279,14 @@ theme = ExtResource( 3 )
 shortcut_in_tooltip = false
 shortcut = ExtResource( 7 )
 text = "Ok"
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
-[node name="ShortcutHelper" parent="Window/UiArea/SettingsArea/Ok" instance=ExtResource( 4 )]
+[node name="ShortcutHelper" parent="Window/UiArea/Bottom/Ok" instance=ExtResource( 4 )]
 action = "ui_cancel"
 
-[node name="Quit" type="Button" parent="Window/UiArea"]
+[node name="Quit" type="Button" parent="Window/UiArea/Bottom"]
 anchor_top = 1.0
 anchor_bottom = 1.0
 margin_top = -30.0
@@ -126,5 +300,8 @@ text = "Quit"
 __meta__ = {
 "_edit_use_anchors_": false
 }
-[connection signal="pressed" from="Window/UiArea/SettingsArea/Ok" to="." method="_on_Ok_pressed"]
-[connection signal="pressed" from="Window/UiArea/Quit" to="." method="_on_Quit_pressed"]
+[connection signal="value_changed" from="Window/UiArea/Center/Settings/Size/Control/HSlider" to="Window/UiArea/Center/Settings/Size" method="_on_HSlider_value_changed"]
+[connection signal="item_selected" from="Window/UiArea/Center/Settings/Scheme/OptionButton" to="Window/UiArea/Center/Settings/Scheme" method="_on_OptionButton_item_selected"]
+[connection signal="item_selected" from="Window/UiArea/Center/Settings/FatFinger/OptionButton" to="Window/UiArea/Center/Settings/FatFinger" method="_on_OptionButton_item_selected"]
+[connection signal="pressed" from="Window/UiArea/Bottom/Ok" to="." method="_on_Ok_pressed"]
+[connection signal="pressed" from="Window/UiArea/Bottom/Quit" to="." method="_on_Quit_pressed"]

--- a/src/main/ui/VolumeSetting.tscn
+++ b/src/main/ui/VolumeSetting.tscn
@@ -5,7 +5,6 @@
 [ext_resource path="res://assets/main/puzzle/squish.wav" type="AudioStream" id=3]
 [ext_resource path="res://assets/main/world/creature/combo-voice-00.wav" type="AudioStream" id=4]
 
-
 [node name="Control" type="Control"]
 anchor_left = 0.5
 anchor_top = 0.5
@@ -24,8 +23,8 @@ __meta__ = {
 }
 
 [node name="Label" type="Label" parent="."]
-margin_right = 120.0
-margin_bottom = 20.0
+anchor_bottom = 1.0
+margin_right = 50.0
 rect_min_size = Vector2( 120, 0 )
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.5
@@ -38,9 +37,8 @@ __meta__ = {
 [node name="Control" type="HBoxContainer" parent="."]
 anchor_left = 1.0
 anchor_right = 1.0
+anchor_bottom = 1.0
 margin_left = -267.0
-margin_right = -17.0
-margin_bottom = 20.0
 rect_min_size = Vector2( 240, 0 )
 size_flags_horizontal = 3
 size_flags_vertical = 3

--- a/src/main/ui/menu/practice-difficulty-selector.gd
+++ b/src/main/ui/menu/practice-difficulty-selector.gd
@@ -1,6 +1,6 @@
 extends VBoxContainer
 """
-User interface control which lets the player pick their difficulty in practice mode.
+UI control for selecting difficulty in practice mode.
 """
 
 signal difficulty_changed

--- a/src/main/ui/menu/practice-high-scores.gd
+++ b/src/main/ui/menu/practice-high-scores.gd
@@ -1,6 +1,6 @@
 extends Panel
 """
-User interface element which shows daily and all-time high scores.
+UI control which shows daily and all-time high scores.
 """
 
 func set_scenario(scenario: ScenarioSettings) -> void:

--- a/src/main/ui/menu/practice-mode-selector.gd
+++ b/src/main/ui/menu/practice-mode-selector.gd
@@ -1,6 +1,6 @@
 extends VBoxContainer
 """
-User interface control which lets the player pick their mode in practice mode.
+UI control for picking a mode in practice mode.
 
 Also displays a description of the mode, 'Score 200 points as quickly as possible!'
 """

--- a/src/main/ui/menu/settings-menu.gd
+++ b/src/main/ui/menu/settings-menu.gd
@@ -31,10 +31,11 @@ Shows the menu and pauses the scene tree.
 """
 func show() -> void:
 	$Bg.show()
+	$TouchButtons.visible = true
 	$Window.show()
 	get_tree().paused = true
-	_old_focus_owner = $Window/UiArea/SettingsArea/Ok.get_focus_owner()
-	$Window/UiArea/SettingsArea/Ok.grab_focus()
+	_old_focus_owner = $Window/UiArea/Bottom/Ok.get_focus_owner()
+	$Window/UiArea/Bottom/Ok.grab_focus()
 	emit_signal("show")
 
 
@@ -43,6 +44,7 @@ Hides the menu and unpauses the scene tree.
 """
 func hide() -> void:
 	$Bg.hide()
+	$TouchButtons.visible = false
 	$Window.hide()
 	get_tree().paused = false
 	if _old_focus_owner:

--- a/src/main/ui/menu/settings-touch-size.gd
+++ b/src/main/ui/menu/settings-touch-size.gd
@@ -1,0 +1,18 @@
+extends Control
+"""
+UI control for adjusting the touchscreen button size.
+"""
+
+# step values of 1.19
+const VALUES := [
+	0.25, 0.30, 0.35, 0.42, 0.50, 0.59, 0.71, 0.84, 1.00, 1.19, 1.42, 1.69
+]
+
+func _ready() -> void:
+	$Control/HSlider.value = Utils.find_closest(VALUES, PlayerData.touch_settings.size)
+
+
+func _on_HSlider_value_changed(index: float) -> void:
+	var value: float = VALUES[int(index)]
+	$Control/Text.text = "%04.2fx" % value
+	PlayerData.touch_settings.size = value

--- a/src/main/ui/settings-touch-fat-finger.gd
+++ b/src/main/ui/settings-touch-fat-finger.gd
@@ -1,0 +1,20 @@
+extends Control
+"""
+UI control for adjusting the touchscreen fat finger setting.
+
+The fat finger setting decides how easy it is to mash two buttons with one finger.
+"""
+
+const VALUES := [0.00, 0.50, 0.66, 0.83, 1.00]
+
+func _ready() -> void:
+	$OptionButton.add_item("Off")
+	$OptionButton.add_item("Slim")
+	$OptionButton.add_item("Plump")
+	$OptionButton.add_item("Pudge")
+	$OptionButton.add_item("Chonk")
+	$OptionButton.selected = Utils.find_closest(VALUES, PlayerData.touch_settings.scheme)
+
+
+func _on_OptionButton_item_selected(id: int) -> void:
+	PlayerData.touch_settings.fat_finger = VALUES[id]

--- a/src/main/ui/settings-touch-scheme.gd
+++ b/src/main/ui/settings-touch-scheme.gd
@@ -1,0 +1,19 @@
+extends Control
+"""
+UI control for adjusting the touchscreen control scheme.
+
+The control scheme decides which buttons appear where.
+"""
+
+func _ready() -> void:
+	$OptionButton.add_item("Easy Console")
+	$OptionButton.add_item("Easy Desktop")
+	$OptionButton.add_item("Ambi Console")
+	$OptionButton.add_item("Ambi Desktop")
+	$OptionButton.add_item("Loco Console")
+	$OptionButton.add_item("Loco Desktop")
+	$OptionButton.selected = PlayerData.touch_settings.scheme
+
+
+func _on_OptionButton_item_selected(id: int) -> void:
+	PlayerData.touch_settings.scheme = id

--- a/src/main/ui/touch/action-button.gd
+++ b/src/main/ui/touch/action-button.gd
@@ -25,6 +25,9 @@ diagonal presses.
 # the action activated by this button. also affects its appearance
 export (String) var action: String setget set_action
 
+# if false, pressing the button won't emit any actions.
+export (bool) var emit_actions: bool = true
+
 var pressed := false setget set_pressed
 
 # the current textures this button toggles between when pressed/unpressed
@@ -87,11 +90,12 @@ func set_pressed(new_pressed: bool) -> void:
 	pressed = new_pressed
 	texture = _pressed_texture if pressed else _normal_texture
 	
-	# fire the appropriate events
-	var ev := InputEventAction.new()
-	ev.action = action
-	ev.pressed = pressed
-	Input.parse_input_event(ev)
+	if emit_actions:
+		# fire the appropriate events
+		var ev := InputEventAction.new()
+		ev.action = action
+		ev.pressed = pressed
+		Input.parse_input_event(ev)
 
 
 """

--- a/src/main/ui/volume-setting-control.gd
+++ b/src/main/ui/volume-setting-control.gd
@@ -1,6 +1,6 @@
 extends Control
 """
-User interface control which lets the player adjust volume.
+UI control for adjusting volume.
 
 Updates the player's stored settings, and also updates the audio server.
 """

--- a/src/main/utils.gd
+++ b/src/main/utils.gd
@@ -121,3 +121,21 @@ static func max_value(values: Array, default := 0.0) -> float:
 	for value in range(1, len(values)):
 		max_value = max(value, max_value)
 	return max_value
+
+
+"""
+Returns the array index whose contents are closest to a target number.
+
+Utils.find_closest([1.0, 2.0, 4.0, 8.0], 6.0) = 2
+Utils.find_closest([1.0, 2.0, 4.0, 8.0], 100) = 3
+Utils.find_closest([], 100)                   = -1
+"""
+static func find_closest(values: Array, target: float) -> int:
+	if not values:
+		return -1
+	
+	var result := 0
+	for i in range(1, values.size()):
+		if abs(target - values[i]) < abs(target - values[result]):
+			result = i
+	return result

--- a/src/main/world/Overworld.tscn
+++ b/src/main/world/Overworld.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=28 format=2]
+[gd_scene load_steps=27 format=2]
 
 [ext_resource path="res://src/main/world/creature/Creature2D.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/spira.gd" type="Script" id=2]
@@ -22,8 +22,7 @@
 [ext_resource path="res://src/main/world/environment/obstacle-shadows.gd" type="Script" id=20]
 [ext_resource path="res://src/main/world/overworld-camera.gd" type="Script" id=21]
 [ext_resource path="res://src/main/world/screwport-texrect.gd" type="Script" id=22]
-[ext_resource path="res://src/main/ui/touch/EightWay.tscn" type="PackedScene" id=23]
-[ext_resource path="res://src/main/world/overworld-touch-buttons.gd" type="Script" id=24]
+[ext_resource path="res://src/main/world/OverworldTouchButtons.tscn" type="PackedScene" id=23]
 
 [sub_resource type="TileSet" id=1]
 0/name = "block-shadow.png 0"
@@ -319,43 +318,7 @@ compact = true
 visible = false
 margin_bottom = 1.99976
 
-[node name="TouchButtons" type="Control" parent="Ui/OverworldUi"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-script = ExtResource( 24 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="ButtonsSw" parent="Ui/OverworldUi/TouchButtons" instance=ExtResource( 23 )]
-anchor_left = 0.0
-anchor_top = 1.0
-anchor_right = 0.0
-anchor_bottom = 1.0
-margin_left = 10.0
-margin_top = -250.0
-margin_right = 250.0
-margin_bottom = -10.0
-_up_action = "ui_up"
-_down_action = "ui_down"
-_left_action = "ui_left"
-_right_action = "ui_right"
-_up_right_weight = 1.0
-_up_left_weight = 1.0
-_down_right_weight = 1.0
-_down_left_weight = 1.0
-
-[node name="ButtonsSe" parent="Ui/OverworldUi/TouchButtons" instance=ExtResource( 23 )]
-anchor_left = 1.0
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = -250.0
-margin_top = -250.0
-margin_right = -10.0
-margin_bottom = -10.0
-_up_action = "ui_menu"
-_down_action = "interact"
+[node name="TouchButtons" parent="Ui/OverworldUi" instance=ExtResource( 23 )]
 
 [node name="CheatCodeDetector" parent="Ui/OverworldUi" instance=ExtResource( 4 )]
 codes = [ "bigfps" ]
@@ -369,6 +332,7 @@ quit_text = "Save + Quit"
 [connection signal="chat_event_played" from="Ui/OverworldUi/ChatUi" to="Ui/OverworldUi" method="_on_ChatUi_chat_event_played"]
 [connection signal="pop_out_completed" from="Ui/OverworldUi/ChatUi" to="Ui/OverworldUi" method="_on_ChatUi_pop_out_completed"]
 [connection signal="showed_choices" from="Ui/OverworldUi/ChatUi" to="Ui/OverworldUi" method="_on_ChatUi_showed_choices"]
+[connection signal="resized" from="Ui/OverworldUi/TouchButtons" to="Ui/OverworldUi/TouchButtons" method="_on_resized"]
 [connection signal="cheat_detected" from="Ui/OverworldUi/CheatCodeDetector" to="Ui/OverworldUi/Labels/SoutheastLabels/FpsLabel" method="_on_CheatCodeDetector_cheat_detected"]
 [connection signal="hide" from="Ui/OverworldUi/SettingsMenu" to="Ui/OverworldUi/TouchButtons" method="_on_SettingsMenu_hide"]
 [connection signal="quit_pressed" from="Ui/OverworldUi/SettingsMenu" to="Ui/OverworldUi" method="_on_SettingsMenu_quit_pressed"]

--- a/src/main/world/OverworldTouchButtons.tscn
+++ b/src/main/world/OverworldTouchButtons.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://src/main/ui/touch/EightWay.tscn" type="PackedScene" id=1]
+[ext_resource path="res://src/main/world/overworld-touch-buttons.gd" type="Script" id=3]
+
+[node name="TouchButtons" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 3 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ButtonsSw" parent="." instance=ExtResource( 1 )]
+anchor_left = 0.0
+anchor_top = 1.0
+anchor_right = 0.0
+anchor_bottom = 1.0
+margin_left = 10.0
+margin_top = -250.0
+margin_right = 250.0
+margin_bottom = -10.0
+
+[node name="ButtonsSe" parent="." instance=ExtResource( 1 )]
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -250.0
+margin_top = -250.0
+margin_right = -9.99994
+margin_bottom = -10.0

--- a/src/main/world/overworld-touch-buttons.gd
+++ b/src/main/world/overworld-touch-buttons.gd
@@ -3,9 +3,27 @@ extends Control
 Touchscreen buttons displayed for the overworld.
 """
 
+# control scheme which emulates consoles; directions on left, buttons on right
+const CONSOLE_SCHEME := {
+	"sw_actions": ["ui_up", "ui_down", "ui_left", "ui_right"],
+	"sw_weights": [1, 1, 1, 1],
+	"se_actions": ["ui_menu", "interact", "", ""],
+	"se_weights": [0, 0, 0, 0],
+}
+
+# control scheme which emulates PCs; buttons on left, directions on right
+const DESKTOP_SCHEME := {
+	"sw_actions": ["ui_menu", "interact", "", ""],
+	"sw_weights": [0, 0, 0, 0],
+	"se_actions": ["ui_up", "ui_down", "ui_left", "ui_right"],
+	"se_weights": [1, 1, 1, 1],
+}
+
 func _ready() -> void:
 	if OS.has_touchscreen_ui_hint():
+		PlayerData.touch_settings.connect("settings_changed", self, "_on_TouchSettings_settings_changed")
 		show()
+		_refresh_settings()
 	else:
 		hide()
 
@@ -30,6 +48,59 @@ func hide() -> void:
 	$ButtonsSe.hide()
 
 
+"""
+Updates the buttons based on the player's settings.
+
+This updates their location and size.
+"""
+func _refresh_button_positions() -> void:
+	$ButtonsSw.rect_scale = Vector2(1.0, 1.0) * PlayerData.touch_settings.size
+	$ButtonsSw.rect_position.y = 600 - 10 - $ButtonsSw.rect_size.y * $ButtonsSw.rect_scale.y
+	
+	$ButtonsSe.rect_scale = Vector2(1.0, 1.0) * PlayerData.touch_settings.size
+	$ButtonsSe.rect_position.x = 1024 - 10 - $ButtonsSw.rect_size.x * $ButtonsSw.rect_scale.x
+	$ButtonsSe.rect_position.y = 600 - 10 - $ButtonsSw.rect_size.y * $ButtonsSw.rect_scale.y
+
+
+"""
+Updates the buttons based on the player's settings.
+
+This updates their location, size, how they're arranged and their sensitivity.
+"""
+func _refresh_settings() -> void:
+	# update scale/position
+	_refresh_button_positions()
+	
+	# update actions
+	var scheme_dict: Dictionary
+	match PlayerData.touch_settings.scheme:
+		TouchSettings.EASY_CONSOLE, TouchSettings.AMBI_CONSOLE, TouchSettings.LOCO_CONSOLE:
+			scheme_dict = CONSOLE_SCHEME
+		TouchSettings.EASY_DESKTOP, TouchSettings.AMBI_DESKTOP, TouchSettings.LOCO_DESKTOP:
+			scheme_dict = DESKTOP_SCHEME
+		_:
+			push_warning("Unrecognized touch settings scheme: %s" % PlayerData.touch_settings.scheme)
+			scheme_dict = CONSOLE_SCHEME
+	$ButtonsSw.up_action = scheme_dict["sw_actions"][0]
+	$ButtonsSw.down_action = scheme_dict["sw_actions"][1]
+	$ButtonsSw.left_action = scheme_dict["sw_actions"][2]
+	$ButtonsSw.right_action = scheme_dict["sw_actions"][3]
+	$ButtonsSe.up_action = scheme_dict["se_actions"][0]
+	$ButtonsSe.down_action = scheme_dict["se_actions"][1]
+	$ButtonsSe.left_action = scheme_dict["se_actions"][2]
+	$ButtonsSe.right_action = scheme_dict["se_actions"][3]
+	
+	# update diagonal sensitivity
+	$ButtonsSw.up_left_weight = scheme_dict["sw_weights"][0]
+	$ButtonsSw.up_right_weight = scheme_dict["sw_weights"][1]
+	$ButtonsSw.down_left_weight = scheme_dict["sw_weights"][2]
+	$ButtonsSw.down_right_weight = scheme_dict["sw_weights"][3]
+	$ButtonsSe.up_left_weight = scheme_dict["se_weights"][0]
+	$ButtonsSe.up_right_weight = scheme_dict["se_weights"][1]
+	$ButtonsSe.down_left_weight = scheme_dict["se_weights"][2]
+	$ButtonsSe.down_right_weight = scheme_dict["se_weights"][3]
+
+
 func _on_OverworldUi_chat_started() -> void:
 	hide()
 
@@ -46,3 +117,11 @@ func _on_SettingsMenu_show() -> void:
 func _on_SettingsMenu_hide() -> void:
 	if OS.has_touchscreen_ui_hint():
 		show()
+
+
+func _on_TouchSettings_settings_changed() -> void:
+	_refresh_settings()
+
+
+func _on_resized() -> void:
+	_refresh_button_positions()


### PR DESCRIPTION
Three basic arrangements are available: a simple one for beginners, an
ambidextrous one for people who want to drop with both hands, and a
crazy one for hardcore players who don't mind a learning curve.

Fixed bug when dragging from one eightway to another. Because the
eightways were marking touch events as handled, a drag event from one eightway
to the other resulted in the first eightway not receiving the "touch event is
out of range" input event.