### PR TITLE
Control improvements; left+right, ccw+cw. Hid puzzle buttons.

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -602,10 +602,6 @@ soft_drop={
  ]
 }
 
-[input_devices]
-
-pointing/emulate_touch_from_mouse=true
-
 [rendering]
 
 quality/2d/gles2_use_nvidia_rect_flicker_workaround=true

--- a/src/main/puzzle/piece-sfx.gd
+++ b/src/main/puzzle/piece-sfx.gd
@@ -74,6 +74,10 @@ func _on_PieceManager_rotated_left() -> void:
 func _on_PieceManager_rotated_right() -> void:
 	$Rotate1Sound.play()
 
+
+func _on_PieceManager_rotated_twice() -> void:
+	$Rotate0Sound.play()
+
 # Other events -------------------------------------------------------------------
 
 func _on_PieceManager_lock_started() -> void:

--- a/src/main/puzzle/piece/PieceManager.tscn
+++ b/src/main/puzzle/piece/PieceManager.tscn
@@ -124,5 +124,6 @@ action = "hard_drop"
 [connection signal="moved_right" from="." to="PieceSfx" method="_on_PieceManager_moved_right"]
 [connection signal="rotated_left" from="." to="PieceSfx" method="_on_PieceManager_rotated_left"]
 [connection signal="rotated_right" from="." to="PieceSfx" method="_on_PieceManager_rotated_right"]
+[connection signal="rotated_twice" from="." to="PieceSfx" method="_on_PieceManager_rotated_twice"]
 [connection signal="squish_moved" from="." to="PieceSfx" method="_on_PieceManager_squish_moved"]
 [connection signal="entered_state" from="States" to="." method="_on_States_entered_state"]

--- a/src/main/puzzle/piece/active-piece.gd
+++ b/src/main/puzzle/piece/active-piece.gd
@@ -42,28 +42,29 @@ func setType(new_type: PieceType) -> void:
 """
 Returns the orientation the piece will be in if it rotates clockwise.
 """
-func get_cw_orientation(in_orientation := -1) -> int:
-	if in_orientation == -1:
-		in_orientation = orientation
-	return (in_orientation + 1) % type.pos_arr.size()
+func get_cw_orientation() -> int:
+	return wrapi(orientation + 1, 0, type.pos_arr.size())
 
 
 """
 Returns the orientation the piece will be in if it rotates 180 degrees.
 """
-func get_flip_orientation(in_orientation := -1) -> int:
-	if in_orientation == -1:
-		in_orientation = orientation
-	return (in_orientation + 2) % type.pos_arr.size()
+func get_flip_orientation() -> int:
+	return wrapi(orientation + 2, 0, type.pos_arr.size())
+
+
+"""
+Returns the position the piece will be in if it rotates 180 degrees.
+"""
+func get_flip_position() -> Vector2:
+	return pos + type.flips[orientation]
 
 
 """
 Returns the orientation the piece will be in if it rotates counter-clockwise.
 """
-func get_ccw_orientation(in_orientation := -1) -> int:
-	if in_orientation == -1:
-		in_orientation = orientation
-	return (in_orientation + 3) % type.pos_arr.size()
+func get_ccw_orientation() -> int:
+	return wrapi(orientation - 1, 0, type.pos_arr.size())
 
 
 """
@@ -119,7 +120,7 @@ func kick_piece(is_cell_blocked: FuncRef, target_pos: Vector2, target_orientatio
 	
 	var successful_kick: Vector2
 	for kick in kicks:
-		if kick.y < 0 and floor_kicks >= type.max_floor_kicks:
+		if kick.y < 0 and not can_floor_kick():
 			if _trace_kicks: print("no: ", kick, " (too many floor kicks)")
 			continue
 		if can_move_piece_to(is_cell_blocked, target_pos + kick, target_orientation):
@@ -130,3 +131,7 @@ func kick_piece(is_cell_blocked: FuncRef, target_pos: Vector2, target_orientatio
 			if _trace_kicks: print("no: ", kick)
 	if _trace_kicks: print("-")
 	return successful_kick
+
+
+func can_floor_kick() -> bool:
+	return floor_kicks < type.max_floor_kicks

--- a/src/main/puzzle/piece/frame-input.gd
+++ b/src/main/puzzle/piece/frame-input.gd
@@ -26,9 +26,14 @@ func _unhandled_input(event: InputEvent) -> void:
 	elif event.is_action_released(action):
 		_pressed = false
 	
-	if cancel_action and event.is_action_pressed(cancel_action):
-		_just_pressed = false
-		_pressed = false
+	if cancel_action:
+		if event.is_action_pressed(cancel_action):
+			_just_pressed = false
+			_pressed = false
+		elif event.is_action_released(cancel_action) and Input.is_action_pressed(action) and not _pressed:
+			# player was holding both buttons, but let go of the cancel_button
+			_just_pressed = true
+			_pressed = true
 
 
 func _physics_process(_delta: float) -> void:

--- a/src/main/puzzle/piece/piece-type.gd
+++ b/src/main/puzzle/piece/piece-type.gd
@@ -26,11 +26,14 @@ var cw_kicks: Array
 # array of piece kicks to try when rotating counterclockwise
 var ccw_kicks: Array
 
+# position the piece should kick to when flipping in place
+var flips: Array
+
 # maximum number of 'floor kicks', kicks which move the piece upward
 var max_floor_kicks: int
 
-func _init(init_string: String, init_pos_arr: Array, init_color_arr: Array, init_kicks: Array,
-		init_max_floor_kicks := 3) -> void:
+func _init(init_string: String, init_pos_arr: Array, init_color_arr: Array,
+		init_kicks: Array, init_flips: Array, init_max_floor_kicks := 3) -> void:
 	string = init_string
 	pos_arr = init_pos_arr
 	color_arr = init_color_arr
@@ -51,6 +54,7 @@ func _init(init_string: String, init_pos_arr: Array, init_color_arr: Array, init
 			for i in range(cw_kick.size()):
 				ccw_kick[i] = Vector2(-cw_kick[i].x, -cw_kick[i].y)
 			ccw_kicks += [ccw_kick]
+	flips = init_flips
 	max_floor_kicks = init_max_floor_kicks
 
 

--- a/src/main/puzzle/piece/piece-types.gd
+++ b/src/main/puzzle/piece/piece-types.gd
@@ -97,7 +97,8 @@ var piece_j := PieceType.new("j",
 		[Vector2(10, 0), Vector2(4, 0), Vector2(3, 0), Vector2(1, 0)],
 		[Vector2(8, 0), Vector2(12, 0), Vector2(6, 0), Vector2(1, 0)],
 		[Vector2(2, 0), Vector2(3, 0), Vector2(8, 0), Vector2(5, 0)]],
-		KICKS_J
+		KICKS_J,
+		[Vector2(0, -1), Vector2(1, 0), Vector2(0, 1), Vector2(-1, 0)]
 	)
 
 var piece_l := PieceType.new("l",
@@ -111,7 +112,8 @@ var piece_l := PieceType.new("l",
 		[Vector2(2, 1), Vector2(3, 1), Vector2(9, 1), Vector2(4, 1)],
 		[Vector2(10, 1), Vector2(12, 1), Vector2(4, 1), Vector2(1, 1)],
 		[Vector2(8, 1), Vector2(6, 1), Vector2(3, 1), Vector2(1, 1)]],
-		KICKS_L
+		KICKS_L,
+		[Vector2(0, -1), Vector2(1, 0), Vector2(0, 1), Vector2(-1, 0)]
 	)
 
 var piece_o := PieceType.new("o",
@@ -121,7 +123,8 @@ var piece_o := PieceType.new("o",
 		# color data
 		[[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)],
 		[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)]],
-		KICKS_NONE
+		KICKS_NONE,
+		[Vector2(0, 0), Vector2(0, 0), Vector2(0, 0), Vector2(0, 0)]
 	)
 
 var piece_p := PieceType.new("p",
@@ -135,7 +138,8 @@ var piece_p := PieceType.new("p",
 		[Vector2(2, 0), Vector2(10, 0), Vector2(7, 0), Vector2(9, 0), Vector2(5, 0)],
 		[Vector2(10, 0), Vector2(6, 0), Vector2(9, 0), Vector2(13, 0), Vector2(4, 0)],
 		[Vector2(10, 0), Vector2(6, 0), Vector2(11, 0), Vector2(5, 0), Vector2(1, 0)]],
-		KICKS_P
+		KICKS_P,
+		[Vector2(0, -1), Vector2(1, 0), Vector2(0, 1), Vector2(-1, 0)]
 	)
 
 var piece_q := PieceType.new("q",
@@ -149,7 +153,8 @@ var piece_q := PieceType.new("q",
 		[Vector2(10, 1), Vector2(6, 1), Vector2(9, 1), Vector2(7, 1), Vector2(1, 1)],
 		[Vector2(10, 1), Vector2(6, 1), Vector2(8, 1), Vector2(13, 1), Vector2(5, 1)],
 		[Vector2(2, 1), Vector2(11, 1), Vector2(6, 1), Vector2(9, 1), Vector2(5, 1)]],
-		KICKS_Q
+		KICKS_Q,
+		[Vector2(0, -1), Vector2(1, 0), Vector2(0, 1), Vector2(-1, 0)]
 	)
 
 var piece_t := PieceType.new("t",
@@ -163,7 +168,8 @@ var piece_t := PieceType.new("t",
 		[Vector2(2, 2), Vector2(11, 2), Vector2(4, 2), Vector2(1, 2)],
 		[Vector2(8, 2), Vector2(14, 2), Vector2(4, 2), Vector2(1, 2)],
 		[Vector2(2, 2), Vector2(8, 2), Vector2(7, 2), Vector2(1, 2)]],
-		KICKS_T
+		KICKS_T,
+		[Vector2(0, -1), Vector2(1, 0), Vector2(0, 1), Vector2(-1, 0)]
 	)
 
 var piece_u := PieceType.new("u",
@@ -178,6 +184,7 @@ var piece_u := PieceType.new("u",
 		[Vector2(2, 2), Vector2(2, 2), Vector2(9, 2), Vector2(12, 2), Vector2(5, 2)],
 		[Vector2(10, 2), Vector2(4, 2), Vector2(3, 2), Vector2(9, 2), Vector2(4, 2)]],
 		KICKS_U,
+		[Vector2(0, 0), Vector2(-1, 0), Vector2(0, 0), Vector2(1, 0)],
 		5 # u-piece allows additional floor kicks because it kicks the floor twice if you rotate it four times
 	)
 
@@ -192,8 +199,9 @@ var piece_v := PieceType.new("v",
 		[Vector2(10, 3), Vector2(12, 3), Vector2(4, 3), Vector2(3, 3), Vector2(1, 3)],
 		[Vector2(8, 3), Vector2(12, 3), Vector2(6, 3), Vector2(3, 3), Vector2(1, 3)],
 		[Vector2(2, 3), Vector2(3, 3), Vector2(8, 3), Vector2(12, 3), Vector2(5, 3)]],
-		KICKS_V
+		KICKS_V,
+		[Vector2(0, 0), Vector2(0, 0), Vector2(0, 0), Vector2(0, 0)]
 	)
 
-var piece_null := PieceType.new("_", [[]], [[]], KICKS_NONE)
+var piece_null := PieceType.new("_", [[]], [[]], KICKS_NONE, [])
 var all_types := [piece_j, piece_l, piece_o, piece_p, piece_q, piece_t, piece_u, piece_v];

--- a/src/main/puzzle/puzzle-touch-buttons.gd
+++ b/src/main/puzzle/puzzle-touch-buttons.gd
@@ -31,7 +31,7 @@ const SCHEMES := {
 	},
 	TouchSettings.LOCO_CONSOLE: {
 		"sw_actions": ["soft_drop", "ui_right", "ui_left", "hard_drop"],
-		"sw_weights": [0, 1, 1, 0],
+		"sw_weights": [0, 1, 0, 0],
 		"se_actions": ["hard_drop", "rotate_ccw", "soft_drop", "rotate_cw"],
 		"se_weights": [1, 0, 0, 1],
 	},
@@ -39,7 +39,7 @@ const SCHEMES := {
 		"sw_actions": ["soft_drop", "rotate_cw", "rotate_ccw", "hard_drop"],
 		"sw_weights": [0, 1, 1, 0],
 		"se_actions": ["hard_drop", "ui_left", "soft_drop", "ui_right"],
-		"se_weights": [1, 0, 0, 1],
+		"se_weights": [1, 0, 0, 0],
 	},
 }
 
@@ -47,9 +47,13 @@ const SCHEMES := {
 export (bool) var emit_actions := true setget set_emit_actions
 
 func _ready() -> void:
-	PlayerData.touch_settings.connect("settings_changed", self, "_on_TouchSettings_settings_changed")
-	_refresh_emit_actions()
-	_refresh_settings()
+	if OS.has_touchscreen_ui_hint():
+		PlayerData.touch_settings.connect("settings_changed", self, "_on_TouchSettings_settings_changed")
+		_refresh_emit_actions()
+		_refresh_settings()
+		show()
+	else:
+		hide()
 
 
 func set_emit_actions(new_emit_actions: bool) -> void:

--- a/src/main/world/overworld-touch-buttons.gd
+++ b/src/main/world/overworld-touch-buttons.gd
@@ -22,8 +22,8 @@ const DESKTOP_SCHEME := {
 func _ready() -> void:
 	if OS.has_touchscreen_ui_hint():
 		PlayerData.touch_settings.connect("settings_changed", self, "_on_TouchSettings_settings_changed")
-		show()
 		_refresh_settings()
+		show()
 	else:
 		hide()
 


### PR DESCRIPTION
Fixed left/right puzzle input issue. If you pressed left, then pressed right,
then released right -- the piece would not move left. While this isn't a
problem the way people usually play, it resulted in an unintuitive state where
you'd be holding the left arrow key with the piece stuck to the right wall.

Loco touchscreen controls no longer accept ui_left/ui_right together.

Pressing both rotate buttons simultaneously flips a piece.

Hid puzzle screen touch buttons. These were always visible, but they
should only be visible in touch mode.