### PR TITLE
Removed frosting pool. Removed 'remove_child' calls.

### DIFF
--- a/src/main/puzzle/Puzzle.tscn
+++ b/src/main/puzzle/Puzzle.tscn
@@ -183,6 +183,7 @@ __meta__ = {
 [node name="FrostingGlobs" type="Node2D" parent="."]
 z_index = 1
 script = ExtResource( 24 )
+_playfield_path = NodePath("../Playfield")
 
 [node name="GlobViewports" type="Node" parent="FrostingGlobs"]
 
@@ -213,10 +214,6 @@ flip_v = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
-
-[node name="GcTimer" type="Timer" parent="FrostingGlobs"]
-wait_time = 2.0
-autostart = true
 
 [node name="CreatureView" parent="." instance=ExtResource( 63 )]
 position = Vector2( 27.9925, 314.726 )
@@ -403,10 +400,9 @@ script = ExtResource( 19 )
 [connection signal="topped_out" from="PieceManager" to="TopOutTracker" method="_on_PieceManager_topped_out"]
 [connection signal="hit_gutter" from="FrostingGlobs" to="FrostingSfx" method="_on_FrostingGlobs_hit_gutter"]
 [connection signal="hit_next_pieces" from="FrostingGlobs" to="FrostingSfx" method="_on_FrostingGlobs_hit_next_pieces"]
-[connection signal="hit_playfield" from="FrostingGlobs" to="Playfield" method="_on_FrostingGlobs_hit_playfield"]
 [connection signal="hit_playfield" from="FrostingGlobs" to="FrostingSfx" method="_on_FrostingGlobs_hit_playfield"]
-[connection signal="hit_wall" from="FrostingGlobs" to="WallGlobViewports" method="_on_FrostingGlobs_hit_wall"]
+[connection signal="hit_playfield" from="FrostingGlobs" to="Playfield" method="_on_FrostingGlobs_hit_playfield"]
 [connection signal="hit_wall" from="FrostingGlobs" to="FrostingSfx" method="_on_FrostingGlobs_hit_wall"]
-[connection signal="timeout" from="FrostingGlobs/GcTimer" to="FrostingGlobs" method="_on_GcTimer_timeout"]
+[connection signal="hit_wall" from="FrostingGlobs" to="WallGlobViewports" method="_on_FrostingGlobs_hit_wall"]
 [connection signal="start_button_pressed" from="Hud/PuzzleMessages" to="." method="_on_Hud_start_button_pressed"]
 [connection signal="cheat_detected" from="CheatCodeDetector" to="Hud/PuzzleTrace" method="_on_CheatCodeDetector_cheat_detected"]

--- a/src/main/puzzle/editor/level-editor.gd
+++ b/src/main/puzzle/editor/level-editor.gd
@@ -54,7 +54,6 @@ func _start_test() -> void:
 
 func _stop_test() -> void:
 	if _test_scene:
-		remove_child(_test_scene)
 		_test_scene.queue_free()
 		_test_scene = null
 		MusicPlayer.stop()

--- a/src/main/puzzle/frosting-glob.gd
+++ b/src/main/puzzle/frosting-glob.gd
@@ -56,12 +56,6 @@ var velocity := Vector2.ZERO
 # time in milliseconds between the engine starting and this node being initialized
 var _creation_time := 0.0
 
-func _ready() -> void:
-	frame = randi() % (hframes * vframes)
-	visible = false
-	set_process(false)
-
-
 """
 Populates this object from another FrostingGlob instance.
 
@@ -95,7 +89,6 @@ Resets this frosting glob's state, including its color and position, and adds it
 """
 func initialize(new_color_int: int, new_position: Vector2) -> void:
 	_creation_time = OS.get_ticks_msec()
-	visible = true
 	color_int = new_color_int
 	falling = true
 	set_process(true)
@@ -154,27 +147,6 @@ func fade() -> void:
 
 
 """
-Move this frosting glob to a new location in the scene tree.
-
-The same glob might be spawned in the playfield, but get splattered onto a wall which is a different node.
-"""
-func reparent(new_parent: Node) -> void:
-	if new_parent == get_parent():
-		return
-	
-	# removing a node from the tree unsets some flags; we store them so they can be restored
-	var old_process := is_processing()
-	var old_visible := visible
-	
-	if is_inside_tree():
-		get_parent().remove_child(self)
-	if new_parent:
-		new_parent.add_child(self)
-		set_process(old_process)
-		visible = old_visible
-
-
-"""
 Applies gravity and checks for collisions.
 """
 func _process(delta: float)  -> void:
@@ -199,8 +171,7 @@ func _process(delta: float)  -> void:
 
 
 func _on_Tween_tween_all_completed() -> void:
-	hide()
-	set_process(false)
+	queue_free()
 
 
 func _on_FadeTimer_timeout() -> void:

--- a/src/main/puzzle/frosting-globs.gd
+++ b/src/main/puzzle/frosting-globs.gd
@@ -7,13 +7,13 @@ direction.
 """
 
 # emitted when a frosting glob hits a wall
-signal hit_wall(glob, glob_alpha)
+signal hit_wall(glob)
 
 # emitted when a frosting glob smears against the playfield, next pieces, or gutter.
 # passes in a copy of the original frosting glob, because the original remains unchanged
-signal hit_playfield(glob_copy, glob_alpha)
-signal hit_next_pieces(glob_copy, glob_alpha)
-signal hit_gutter(glob_copy, glob_alpha)
+signal hit_playfield(glob)
+signal hit_next_pieces(glob)
+signal hit_gutter(glob)
 
 # The maximum number of frosting globs we can display at once.
 const GLOB_POOL_SIZE := 800
@@ -21,38 +21,10 @@ const GLOB_POOL_SIZE := 800
 # The cell size for the TileMap containing the playfield blocks. This is used to position our globs.
 const CELL_SIZE = Vector2(36, 32)
 
-# The pool of unspawned globs. When spawning a new glob, we should look in this pool first and recycle one.
-var _offscreen_globs: Dictionary
-
-# The pool of spawned globs. We periodically check this list to move items back into unspawned_globs.
-var _onscreen_globs: Dictionary
-
-# The index of the next glob to spawn from the pool
-var _glob_index := 0
-var _rainbow_glob_index := 0
+export (NodePath) var _playfield_path: NodePath
 
 onready var FrostingGlobScene := preload("res://src/main/puzzle/FrostingGlob.tscn")
-
-onready var _puzzle: Puzzle = get_parent()
-onready var _playfield := _puzzle.get_playfield()
-
-func _ready() -> void:
-	for i in range(GLOB_POOL_SIZE):
-		var glob: FrostingGlob = FrostingGlobScene.instance()
-		_offscreen_globs[glob] = "_"
-		glob.connect("hit_wall", self, "_on_FrostingGlob_hit_wall")
-		glob.connect("hit_playfield", self, "_on_FrostingGlob_hit_playfield")
-		glob.connect("hit_next_pieces", self, "_on_FrostingGlob_hit_next_pieces")
-		glob.connect("hit_gutter", self, "_on_FrostingGlob_hit_gutter")
-
-
-func _exit_tree() -> void:
-	for glob in _offscreen_globs.keys() + _onscreen_globs.keys():
-		glob.reparent(null)
-		
-		# calling queue_free results in 'ObjectDB Instances still exist' errors, so we free globs this way
-		glob.call_deferred("free")
-
+onready var _playfield := get_node(_playfield_path)
 
 """
 Launches new frosting globs from the specified tile.
@@ -64,10 +36,6 @@ Parameters:
 	'glob_alpha': The initial alpha component of the globs. Affects their size and duration
 """
 func _spawn_globs(x: int, y: int, color_int: int, glob_count: int, glob_alpha: float = 1.0) -> void:
-	if not _offscreen_globs and not _onscreen_globs:
-		# pool is empty
-		return
-	
 	var viewport: Viewport
 	if PuzzleTileMap.is_cake_box(color_int):
 		viewport = $GlobViewports/RainbowViewport
@@ -88,14 +56,12 @@ Attempts to reuse an offscreen/expired frosting glob if one is available, but wi
 globs if needed.
 """
 func _recycle_glob(new_parent: Node = null) -> FrostingGlob:
-	var glob: FrostingGlob
-	if _offscreen_globs:
-		glob = _offscreen_globs.keys()[0]
-		_offscreen_globs.erase(glob)
-		_onscreen_globs[glob] = "_"
-	else:
-		glob = _onscreen_globs.keys()[0]
-	glob.reparent(new_parent)
+	var glob: FrostingGlob = FrostingGlobScene.instance()
+	glob.connect("hit_wall", self, "_on_FrostingGlob_hit_wall")
+	glob.connect("hit_playfield", self, "_on_FrostingGlob_hit_playfield")
+	glob.connect("hit_next_pieces", self, "_on_FrostingGlob_hit_next_pieces")
+	glob.connect("hit_gutter", self, "_on_FrostingGlob_hit_gutter")
+	new_parent.add_child(glob)
 	return glob
 
 
@@ -144,38 +110,17 @@ func _on_PieceManager_squish_moved(piece: ActivePiece, old_pos: Vector2) -> void
 
 
 func _on_FrostingGlob_hit_wall(glob: FrostingGlob) -> void:
-	emit_signal("hit_wall", glob, glob.modulate.a)
+	emit_signal("hit_wall", glob)
+	glob.queue_free()
 
 
 func _on_FrostingGlob_hit_playfield(glob: FrostingGlob) -> void:
-	var glob_copy := _recycle_glob()
-	glob_copy.copy_from(glob)
-	emit_signal("hit_playfield", glob_copy, glob_copy.modulate.a)
+	emit_signal("hit_playfield", glob)
 
 
 func _on_FrostingGlob_hit_next_pieces(glob: FrostingGlob) -> void:
-	var glob_copy := _recycle_glob()
-	glob_copy.copy_from(glob)
-	emit_signal("hit_next_pieces", glob_copy, glob_copy.modulate.a)
+	emit_signal("hit_next_pieces", glob)
 
 
 func _on_FrostingGlob_hit_gutter(glob: FrostingGlob) -> void:
-	var glob_copy := _recycle_glob()
-	glob_copy.copy_from(glob)
-	emit_signal("hit_gutter", glob_copy, glob_copy.modulate.a)
-
-
-"""
-Repopulates the pool of offscreen frosting globs.
-
-The pool of offscreen globs is populated from globs which have been onscreen too long, or which have become invisible.
-"""
-func _on_GcTimer_timeout() -> void:
-	var globs_to_erase := []
-	for glob_obj in _onscreen_globs:
-		var glob: FrostingGlob = glob_obj
-		if not glob.visible or glob.get_age() > FrostingGlob.MAX_AGE:
-			globs_to_erase.append(glob)
-	for glob in globs_to_erase:
-		_onscreen_globs.erase(glob)
-		_offscreen_globs[glob] = "_"
+	emit_signal("hit_gutter", glob)

--- a/src/main/puzzle/frosting-viewports.gd
+++ b/src/main/puzzle/frosting-viewports.gd
@@ -10,6 +10,8 @@ export (float) var glob_min_scale := 1.0
 # the maximum smear size for globs which are smeared quickly.
 export (float) var glob_max_scale := 1.0
 
+onready var FrostingGlobScene := preload("res://src/main/puzzle/FrostingGlob.tscn")
+
 func _ready() -> void:
 	$Viewport.size = rect_size
 	$RainbowViewport.size = rect_size
@@ -21,17 +23,19 @@ Adds a frosting smear.
 The glob is added to the appropriate viewport and stretched in the direction of its movement.
 """
 func add_smear(glob: FrostingGlob) -> void:
-	if glob.is_rainbow():
-		glob.reparent($RainbowViewport)
+	var new_glob: FrostingGlob = FrostingGlobScene.instance()
+	new_glob.copy_from(glob)
+	if new_glob.is_rainbow():
+		$RainbowViewport.add_child(new_glob)
 	else:
-		glob.reparent($Viewport)
-	glob.position -= get_global_transform().get_origin()
-	glob.modulate.a = clamp(glob.modulate.a + rand_range(0.1, 0.2), 0.0, 1.0)
+		$Viewport.add_child(new_glob)
+	new_glob.position -= get_global_transform().get_origin()
+	new_glob.modulate.a = clamp(new_glob.modulate.a + rand_range(0.1, 0.2), 0.0, 1.0)
 	
 	# stretch the glob in the direction of its movement
-	glob.scale.x = rand_range(glob_min_scale, glob_max_scale)
-	glob.scale.y = 1 / glob.scale.x
-	glob.scale *= 0.44
-	glob.rotation = glob.velocity.angle()
+	new_glob.scale.x = rand_range(glob_min_scale, glob_max_scale)
+	new_glob.scale.y = 1 / new_glob.scale.x
+	new_glob.scale *= 0.44
+	new_glob.rotation = new_glob.velocity.angle()
 	
-	glob.fade()
+	new_glob.fade()

--- a/src/main/puzzle/playfield.gd
+++ b/src/main/puzzle/playfield.gd
@@ -185,5 +185,5 @@ func _on_LineClearer_lines_deleted() -> void:
 	emit_signal("after_piece_written")
 
 
-func _on_FrostingGlobs_hit_playfield(glob_copy: Node, glob_alpha: float) -> void:
-	$BgGlobViewports.add_smear(glob_copy)
+func _on_FrostingGlobs_hit_playfield(glob: Node) -> void:
+	$BgGlobViewports.add_smear(glob)

--- a/src/main/puzzle/wall-frosting-sfx.gd
+++ b/src/main/puzzle/wall-frosting-sfx.gd
@@ -45,17 +45,17 @@ func _play_sfx(glob: FrostingGlob, glob_alpha: float, max_volume) -> void:
 	_splat_player_index = (_splat_player_index + 1) % _splat_players.size()
 
 
-func _on_FrostingGlobs_hit_wall(glob: FrostingGlob, glob_alpha: float) -> void:
-	_play_sfx(glob, glob_alpha, -10.0)
+func _on_FrostingGlobs_hit_wall(glob: FrostingGlob) -> void:
+	_play_sfx(glob, glob.modulate.a, -10.0)
 
 
-func _on_FrostingGlobs_hit_playfield(glob_copy: FrostingGlob, glob_alpha: float) -> void:
-	_play_sfx(glob_copy, glob_alpha, -20.0)
+func _on_FrostingGlobs_hit_playfield(glob: FrostingGlob) -> void:
+	_play_sfx(glob, glob.modulate.a, -20.0)
 
 
-func _on_FrostingGlobs_hit_next_pieces(glob_copy: FrostingGlob, glob_alpha: float) -> void:
-	_play_sfx(glob_copy, glob_alpha, -20.0)
+func _on_FrostingGlobs_hit_next_pieces(glob: FrostingGlob) -> void:
+	_play_sfx(glob, glob.modulate.a, -20.0)
 
 
-func _on_FrostingGlobs_hit_gutter(glob_copy: FrostingGlob, glob_alpha: float) -> void:
-	_play_sfx(glob_copy, glob_alpha, -20.0)
+func _on_FrostingGlobs_hit_gutter(glob: FrostingGlob) -> void:
+	_play_sfx(glob, glob.modulate.a, -20.0)

--- a/src/main/puzzle/wall-glob-viewports.gd
+++ b/src/main/puzzle/wall-glob-viewports.gd
@@ -3,5 +3,5 @@ extends FrostingViewports
 Draws frosting smears when globs collide with the four outer walls.
 """
 
-func _on_FrostingGlobs_hit_wall(glob: FrostingGlob, glob_alpha: float) -> void:
+func _on_FrostingGlobs_hit_wall(glob: FrostingGlob) -> void:
 	add_smear(glob)

--- a/src/main/ui/chat/chat-choices.gd
+++ b/src/main/ui/chat/chat-choices.gd
@@ -99,7 +99,6 @@ func _delete_old_buttons(old_buttons: Array) -> void:
 	for button_object in old_buttons:
 		var button: ChatChoiceButton = button_object
 		button.queue_free()
-		remove_child(button)
 
 
 func _button(node: Node) -> ChatChoiceButton:
@@ -113,7 +112,6 @@ Removes and recreates all chat choice buttons.
 func _refresh_child_buttons() -> void:
 	for child in get_tree().get_nodes_in_group("chat-choices"):
 		child.queue_free()
-		remove_child(child)
 	
 	var new_buttons: Array = []
 	

--- a/src/main/ui/high-score-table.gd
+++ b/src/main/ui/high-score-table.gd
@@ -39,7 +39,6 @@ func _clear_rows() -> void:
 	for child_obj in $GridContainer.get_children():
 		var child: Node = child_obj
 		child.queue_free()
-		$GridContainer.remove_child(child)
 
 
 """

--- a/src/main/ui/menu/practice-difficulty-selector.gd
+++ b/src/main/ui/menu/practice-difficulty-selector.gd
@@ -52,7 +52,6 @@ func set_difficulty_names(names: Array) -> void:
 	# clear out the old labels
 	for child in $Labels.get_children():
 		child.queue_free()
-		$Labels.remove_child(child)
 	
 	# add the new labels
 	for name_obj in names:

--- a/src/main/world/environment/grass-tufts.gd
+++ b/src/main/world/environment/grass-tufts.gd
@@ -23,7 +23,6 @@ func _ready() -> void:
 func _refresh() -> void:
 	for child in get_children():
 		child.queue_free()
-		remove_child(child)
 	
 	# add grass tufts over some of the tilemap's grassy cells
 	for cell_obj in _ground_map.get_used_cells():


### PR DESCRIPTION
Pooling frosting globs required us to move them back and forth between
several parent nodes. The remove_child calls required when moving a glob
from one parent to another sporadically altered the 2D render order because of
Godot #16213 (https://github.com/godotengine/godot/issues/16213).
This caused an unpleasant flickering effect in the frosting.

Removing the object pool addressed the issue. I've also removed all other
remove_child calls throughout the project. queue_free() will remove
children.