### PR TITLE
Removed volume slider increments.

### DIFF
--- a/src/main/ui/VolumeSetting.tscn
+++ b/src/main/ui/VolumeSetting.tscn
@@ -55,7 +55,7 @@ rect_min_size = Vector2( 160, 0 )
 size_flags_horizontal = 0
 size_flags_vertical = 4
 max_value = 1.0
-step = 0.1
+step = 0.0
 tick_count = 11
 __meta__ = {
 "_edit_use_anchors_": false


### PR DESCRIPTION
I had increments to make it easy to specifically pick specific settings.
But, some users have their volume set to where 5% or 10% is too loud.

Flexibility is more important than the obsessive players who want their sliders
exactly perfectly in the center.