### PR TITLE
Reorganized level editor.

### DIFF
--- a/src/main/puzzle/editor/LevelChunkControl.tscn
+++ b/src/main/puzzle/editor/LevelChunkControl.tscn
@@ -1,12 +1,16 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=5 format=2]
 
+[ext_resource path="res://src/main/puzzle/flat-mix.shader" type="Shader" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleTileMap.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/puzzle/editor/level-chunk-control.gd" type="Script" id=3]
 
+[sub_resource type="ShaderMaterial" id=1]
+resource_local_to_scene = true
+shader = ExtResource( 1 )
+shader_param/mix_color = Color( 1, 1, 1, 0 )
+
 [node name="LevelChunkControl" type="Control"]
-margin_right = 36.0
-margin_bottom = 32.0
-rect_min_size = Vector2( 36, 32 )
+rect_min_size = Vector2( 72, 64 )
 script = ExtResource( 3 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -15,6 +19,7 @@ __meta__ = {
 [node name="ColorRect" type="ColorRect" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
+rect_min_size = Vector2( 72, 64 )
 mouse_filter = 2
 color = Color( 0.113725, 0.101961, 0.101961, 1 )
 __meta__ = {
@@ -22,5 +27,7 @@ __meta__ = {
 }
 
 [node name="TileMap" parent="." instance=ExtResource( 2 )]
+material = SubResource( 1 )
+scale = Vector2( 1, 1 )
 z_index = 0
 tile_data = PoolIntArray( 0, 1, 0, 983046, 4, 0, 1048582, 4, 0, 1114118, 4, 0 )

--- a/src/main/puzzle/editor/LevelEditor.tscn
+++ b/src/main/puzzle/editor/LevelEditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=17 format=2]
 
 [ext_resource path="res://src/main/puzzle/PuzzleTileMap.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/puzzle/editor/editor-json.gd" type="Script" id=2]
@@ -11,6 +11,19 @@
 [ext_resource path="res://src/main/ui/SettingsMenu.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/ui/UiMenuShortcut.tres" type="ShortCut" id=10]
 [ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=11]
+[ext_resource path="res://src/main/puzzle/flat-mix.shader" type="Shader" id=12]
+[ext_resource path="res://assets/main/ui/touch/move-right.png" type="Texture" id=13]
+[ext_resource path="res://assets/main/ui/touch/rotate-cw.png" type="Texture" id=14]
+
+[sub_resource type="ShaderMaterial" id=1]
+resource_local_to_scene = true
+shader = ExtResource( 12 )
+shader_param/mix_color = Color( 1, 1, 1, 0 )
+
+[sub_resource type="ShaderMaterial" id=2]
+resource_local_to_scene = true
+shader = ExtResource( 12 )
+shader_param/mix_color = Color( 1, 1, 1, 0 )
 
 [node name="LevelEditor" type="Control"]
 anchor_right = 1.0
@@ -23,249 +36,292 @@ __meta__ = {
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
+margin_left = 5.0
+margin_top = 5.0
+margin_right = -5.0
+margin_bottom = -5.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="LeftPanel" type="Control" parent="HBoxContainer"]
-margin_right = 120.0
-margin_bottom = 600.0
-rect_min_size = Vector2( 120, 600 )
+[node name="TabContainer" type="TabContainer" parent="HBoxContainer"]
+margin_right = 830.0
+margin_bottom = 590.0
+size_flags_horizontal = 3
 
-[node name="GridContainer" type="GridContainer" parent="HBoxContainer/LeftPanel"]
+[node name="Playfield" type="HBoxContainer" parent="HBoxContainer/TabContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 4.0
+margin_top = 32.0
+margin_right = -4.0
+margin_bottom = -4.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Palette" type="Control" parent="HBoxContainer/TabContainer/Playfield"]
+margin_right = 409.0
+margin_bottom = 554.0
+rect_min_size = Vector2( 120, 0 )
+size_flags_horizontal = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="VBoxContainer" type="VBoxContainer" parent="HBoxContainer/TabContainer/Playfield/Palette"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 5.0
 margin_top = 5.0
 margin_right = -5.0
 margin_bottom = -5.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Buttons" type="GridContainer" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer"]
+margin_left = 125.0
+margin_right = 273.0
+margin_bottom = 64.0
+size_flags_horizontal = 4
 columns = 2
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="RotateButton" type="Button" parent="HBoxContainer/LeftPanel/GridContainer"]
-margin_right = 36.0
-margin_bottom = 26.0
+[node name="RotateButton" type="Button" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/Buttons"]
+margin_right = 72.0
+margin_bottom = 64.0
+rect_min_size = Vector2( 72, 64 )
 theme = ExtResource( 11 )
-text = "Ro"
+icon = ExtResource( 14 )
+expand_icon = true
 
-[node name="ChangeButton" type="Button" parent="HBoxContainer/LeftPanel/GridContainer"]
-margin_left = 40.0
-margin_right = 76.0
-margin_bottom = 26.0
+[node name="ChangeButton" type="Button" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/Buttons"]
+margin_left = 76.0
+margin_right = 148.0
+margin_bottom = 64.0
+rect_min_size = Vector2( 72, 64 )
 theme = ExtResource( 11 )
-text = "Ch"
+icon = ExtResource( 13 )
+expand_icon = true
 
-[node name="Veg" parent="HBoxContainer/LeftPanel/GridContainer" instance=ExtResource( 7 )]
-margin_top = 30.0
-margin_bottom = 62.0
-script = ExtResource( 6 )
-
-[node name="Veg2x2" parent="HBoxContainer/LeftPanel/GridContainer" instance=ExtResource( 7 )]
-margin_left = 40.0
-margin_top = 30.0
-margin_right = 76.0
-margin_bottom = 62.0
-script = ExtResource( 6 )
-_veg_size = Vector2( 2, 2 )
-
-[node name="JPiece" parent="HBoxContainer/LeftPanel/GridContainer" instance=ExtResource( 7 )]
-margin_top = 66.0
-margin_bottom = 98.0
-script = ExtResource( 5 )
-
-[node name="LPiece" parent="HBoxContainer/LeftPanel/GridContainer" instance=ExtResource( 7 )]
-margin_left = 40.0
-margin_top = 66.0
-margin_right = 76.0
-margin_bottom = 98.0
-script = ExtResource( 5 )
-_editor_piece = 1
-
-[node name="OPiece" parent="HBoxContainer/LeftPanel/GridContainer" instance=ExtResource( 7 )]
-margin_top = 102.0
-margin_bottom = 134.0
-script = ExtResource( 5 )
-_editor_piece = 2
-
-[node name="PPiece" parent="HBoxContainer/LeftPanel/GridContainer" instance=ExtResource( 7 )]
-margin_left = 40.0
-margin_top = 102.0
-margin_right = 76.0
-margin_bottom = 134.0
-script = ExtResource( 5 )
-_editor_piece = 3
-
-[node name="QPiece" parent="HBoxContainer/LeftPanel/GridContainer" instance=ExtResource( 7 )]
-margin_top = 138.0
-margin_bottom = 170.0
-script = ExtResource( 5 )
-_editor_piece = 4
-
-[node name="TPiece" parent="HBoxContainer/LeftPanel/GridContainer" instance=ExtResource( 7 )]
-margin_left = 40.0
-margin_top = 138.0
-margin_right = 76.0
-margin_bottom = 170.0
-script = ExtResource( 5 )
-_editor_piece = 5
-
-[node name="UPiece" parent="HBoxContainer/LeftPanel/GridContainer" instance=ExtResource( 7 )]
-margin_top = 174.0
-margin_bottom = 206.0
-script = ExtResource( 5 )
-_editor_piece = 6
-
-[node name="VPiece" parent="HBoxContainer/LeftPanel/GridContainer" instance=ExtResource( 7 )]
-margin_left = 40.0
-margin_top = 174.0
-margin_right = 76.0
-margin_bottom = 206.0
-script = ExtResource( 5 )
-_editor_piece = 7
-
-[node name="Box3x1" parent="HBoxContainer/LeftPanel/GridContainer" instance=ExtResource( 7 )]
-margin_top = 210.0
-margin_bottom = 242.0
-script = ExtResource( 4 )
-_box_size = Vector2( 3, 1 )
-
-[node name="Box3x2" parent="HBoxContainer/LeftPanel/GridContainer" instance=ExtResource( 7 )]
-margin_left = 40.0
-margin_top = 210.0
-margin_right = 76.0
-margin_bottom = 242.0
-script = ExtResource( 4 )
-_box_size = Vector2( 3, 2 )
-
-[node name="Box3x3" parent="HBoxContainer/LeftPanel/GridContainer" instance=ExtResource( 7 )]
-margin_top = 246.0
-margin_bottom = 278.0
-script = ExtResource( 4 )
-
-[node name="Box3x4" parent="HBoxContainer/LeftPanel/GridContainer" instance=ExtResource( 7 )]
-margin_left = 40.0
-margin_top = 246.0
-margin_right = 76.0
-margin_bottom = 278.0
-script = ExtResource( 4 )
-_box_size = Vector2( 3, 4 )
-
-[node name="Box3x5" parent="HBoxContainer/LeftPanel/GridContainer" instance=ExtResource( 7 )]
-margin_top = 282.0
-margin_bottom = 314.0
-script = ExtResource( 4 )
-_box_size = Vector2( 3, 5 )
-
-[node name="CenterPanel" type="Control" parent="HBoxContainer"]
-margin_left = 124.0
-margin_right = 860.0
-margin_bottom = 600.0
-size_flags_horizontal = 3
-size_flags_vertical = 3
-
-[node name="VBoxContainer" type="VBoxContainer" parent="HBoxContainer/CenterPanel"]
-anchor_right = 1.0
-anchor_bottom = 1.0
+[node name="LevelChunks" type="GridContainer" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer"]
+margin_left = 49.0
+margin_top = 68.0
+margin_right = 349.0
+margin_bottom = 336.0
+size_flags_horizontal = 4
+columns = 4
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Playfield" type="Control" parent="HBoxContainer/CenterPanel/VBoxContainer"]
-margin_right = 736.0
-margin_bottom = 397.0
-size_flags_vertical = 3
-size_flags_stretch_ratio = 2.0
+[node name="Veg" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/LevelChunks" instance=ExtResource( 7 )]
+margin_right = 72.0
+margin_bottom = 64.0
+script = ExtResource( 6 )
+
+[node name="Veg2x2" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/LevelChunks" instance=ExtResource( 7 )]
+margin_left = 76.0
+margin_right = 148.0
+margin_bottom = 64.0
+script = ExtResource( 6 )
+_veg_size = Vector2( 2, 2 )
+
+[node name="JPiece" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/LevelChunks" instance=ExtResource( 7 )]
+margin_left = 152.0
+margin_right = 224.0
+margin_bottom = 64.0
+script = ExtResource( 5 )
+
+[node name="LPiece" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/LevelChunks" instance=ExtResource( 7 )]
+margin_left = 228.0
+margin_right = 300.0
+margin_bottom = 64.0
+script = ExtResource( 5 )
+_editor_piece = 1
+
+[node name="OPiece" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/LevelChunks" instance=ExtResource( 7 )]
+margin_top = 68.0
+margin_right = 72.0
+margin_bottom = 132.0
+script = ExtResource( 5 )
+_editor_piece = 2
+
+[node name="PPiece" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/LevelChunks" instance=ExtResource( 7 )]
+margin_left = 76.0
+margin_top = 68.0
+margin_right = 148.0
+margin_bottom = 132.0
+script = ExtResource( 5 )
+_editor_piece = 3
+
+[node name="QPiece" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/LevelChunks" instance=ExtResource( 7 )]
+margin_left = 152.0
+margin_top = 68.0
+margin_right = 224.0
+margin_bottom = 132.0
+script = ExtResource( 5 )
+_editor_piece = 4
+
+[node name="TPiece" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/LevelChunks" instance=ExtResource( 7 )]
+margin_left = 228.0
+margin_top = 68.0
+margin_right = 300.0
+margin_bottom = 132.0
+script = ExtResource( 5 )
+_editor_piece = 5
+
+[node name="UPiece" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/LevelChunks" instance=ExtResource( 7 )]
+margin_top = 136.0
+margin_right = 72.0
+margin_bottom = 200.0
+script = ExtResource( 5 )
+_editor_piece = 6
+
+[node name="VPiece" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/LevelChunks" instance=ExtResource( 7 )]
+margin_left = 76.0
+margin_top = 136.0
+margin_right = 148.0
+margin_bottom = 200.0
+script = ExtResource( 5 )
+_editor_piece = 7
+
+[node name="Box3x1" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/LevelChunks" instance=ExtResource( 7 )]
+margin_left = 152.0
+margin_top = 136.0
+margin_right = 224.0
+margin_bottom = 200.0
+script = ExtResource( 4 )
+_box_size = Vector2( 3, 1 )
+
+[node name="Box3x2" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/LevelChunks" instance=ExtResource( 7 )]
+margin_left = 228.0
+margin_top = 136.0
+margin_right = 300.0
+margin_bottom = 200.0
+script = ExtResource( 4 )
+_box_size = Vector2( 3, 2 )
+
+[node name="Box3x3" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/LevelChunks" instance=ExtResource( 7 )]
+margin_top = 204.0
+margin_right = 72.0
+margin_bottom = 268.0
+script = ExtResource( 4 )
+
+[node name="Box3x4" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/LevelChunks" instance=ExtResource( 7 )]
+margin_left = 76.0
+margin_top = 204.0
+margin_right = 148.0
+margin_bottom = 268.0
+script = ExtResource( 4 )
+_box_size = Vector2( 3, 4 )
+
+[node name="Box3x5" parent="HBoxContainer/TabContainer/Playfield/Palette/VBoxContainer/LevelChunks" instance=ExtResource( 7 )]
+margin_left = 152.0
+margin_top = 204.0
+margin_right = 224.0
+margin_bottom = 268.0
+script = ExtResource( 4 )
+_box_size = Vector2( 3, 5 )
+
+[node name="CenterPanel" type="Control" parent="HBoxContainer/TabContainer/Playfield"]
+margin_left = 413.0
+margin_right = 822.0
+margin_bottom = 554.0
+size_flags_horizontal = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Playfield" type="Control" parent="HBoxContainer/TabContainer/Playfield/CenterPanel"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -139.5
+margin_top = -275.5
+margin_right = 139.5
+margin_bottom = 275.5
+rect_min_size = Vector2( 279, 551 )
 script = ExtResource( 3 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="ZIndex" type="Node2D" parent="HBoxContainer/CenterPanel/VBoxContainer/Playfield"]
-z_index = -1
-
-[node name="Bg" type="ColorRect" parent="HBoxContainer/CenterPanel/VBoxContainer/Playfield/ZIndex"]
-margin_right = 195.0
-margin_bottom = 385.0
+[node name="Bg" type="ColorRect" parent="HBoxContainer/TabContainer/Playfield/CenterPanel/Playfield"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_right = -6.0
+margin_bottom = -12.0
+rect_min_size = Vector2( 279, 551 )
 mouse_filter = 2
 color = Color( 0.113725, 0.101961, 0.101961, 1 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="TileMap" parent="HBoxContainer/CenterPanel/VBoxContainer/Playfield/ZIndex" instance=ExtResource( 1 )]
-scale = Vector2( 0.3, 0.3 )
-tile_data = PoolIntArray( 262144, 1, 0, 262152, 1, 0, 1245184, 1, 0, 1245192, 1, 0 )
+[node name="TileMap" parent="HBoxContainer/TabContainer/Playfield/CenterPanel/Playfield/Bg" instance=ExtResource( 1 )]
+material = SubResource( 1 )
+scale = Vector2( 0.43, 0.43 )
+tile_data = PoolIntArray( 196608, 1, 0, 196616, 1, 0, 1245184, 1, 0, 1245192, 1, 0 )
 
-[node name="TileMapDropPreview" parent="HBoxContainer/CenterPanel/VBoxContainer/Playfield/ZIndex" instance=ExtResource( 1 )]
+[node name="TileMapDropPreview" parent="HBoxContainer/TabContainer/Playfield/CenterPanel/Playfield/Bg" instance=ExtResource( 1 )]
 modulate = Color( 1, 1, 1, 0.25098 )
-scale = Vector2( 0.3, 0.3 )
-tile_data = PoolIntArray( 262144, 1, 0, 262152, 1, 0, 327681, 2, 0, 327683, 2, 0, 393218, 2, 0, 393220, 2, 0, 1245184, 1, 0, 1245192, 1, 0 )
+material = SubResource( 2 )
+scale = Vector2( 0.43, 0.43 )
+tile_data = PoolIntArray( 196608, 1, 0, 196616, 1, 0, 327681, 2, 0, 327683, 2, 0, 393218, 2, 0, 393220, 2, 0, 1245184, 1, 0, 1245192, 1, 0 )
 
-[node name="Json" type="TextEdit" parent="HBoxContainer/CenterPanel/VBoxContainer"]
-margin_top = 401.0
-margin_right = 736.0
-margin_bottom = 600.0
-size_flags_vertical = 3
-text = "abc"
-script = ExtResource( 2 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="RightPanel" type="Control" parent="HBoxContainer"]
-margin_left = 864.0
-margin_right = 1024.0
-margin_bottom = 600.0
-rect_min_size = Vector2( 160, 600 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="SideButtons" type="VBoxContainer" parent="HBoxContainer/RightPanel"]
+[node name="Properties" type="Control" parent="HBoxContainer/TabContainer"]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = 5.0
-margin_top = 5.0
-margin_right = -5.0
-margin_bottom = -5.0
-rect_min_size = Vector2( 150, 0 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+margin_left = 4.0
+margin_top = 32.0
+margin_right = -4.0
+margin_bottom = -4.0
 
-[node name="ScenarioName" type="LineEdit" parent="HBoxContainer/RightPanel/SideButtons"]
-margin_right = 150.0
+[node name="SideButtons" type="VBoxContainer" parent="HBoxContainer"]
+margin_left = 834.0
+margin_right = 1014.0
+margin_bottom = 590.0
+rect_min_size = Vector2( 180, 0 )
+
+[node name="ScenarioName" type="LineEdit" parent="HBoxContainer/SideButtons"]
+margin_right = 180.0
 margin_bottom = 30.0
 rect_min_size = Vector2( 0, 20 )
 theme = ExtResource( 11 )
 text = "default"
 
-[node name="HSeparator1" type="HSeparator" parent="HBoxContainer/RightPanel/SideButtons"]
+[node name="HSeparator1" type="HSeparator" parent="HBoxContainer/SideButtons"]
 margin_top = 34.0
-margin_right = 150.0
+margin_right = 180.0
 margin_bottom = 38.0
 
-[node name="OpenFile" type="Button" parent="HBoxContainer/RightPanel/SideButtons"]
+[node name="OpenFile" type="Button" parent="HBoxContainer/SideButtons"]
 margin_top = 42.0
-margin_right = 150.0
+margin_right = 180.0
 margin_bottom = 68.0
 theme = ExtResource( 11 )
 shortcut_in_tooltip = false
 text = "Open File"
 
-[node name="OpenResource" type="Button" parent="HBoxContainer/RightPanel/SideButtons"]
+[node name="OpenResource" type="Button" parent="HBoxContainer/SideButtons"]
 margin_top = 72.0
-margin_right = 150.0
+margin_right = 180.0
 margin_bottom = 98.0
 theme = ExtResource( 11 )
 shortcut_in_tooltip = false
 text = "Open Resource"
 
-[node name="Save" type="Button" parent="HBoxContainer/RightPanel/SideButtons"]
+[node name="Save" type="Button" parent="HBoxContainer/SideButtons"]
 margin_top = 102.0
-margin_right = 150.0
+margin_right = 180.0
 margin_bottom = 128.0
 theme = ExtResource( 11 )
 shortcut_in_tooltip = false
@@ -274,14 +330,14 @@ __meta__ = {
 "_editor_description_": ""
 }
 
-[node name="HSeparator2" type="HSeparator" parent="HBoxContainer/RightPanel/SideButtons"]
+[node name="HSeparator2" type="HSeparator" parent="HBoxContainer/SideButtons"]
 margin_top = 132.0
-margin_right = 150.0
+margin_right = 180.0
 margin_bottom = 136.0
 
-[node name="Test" type="Button" parent="HBoxContainer/RightPanel/SideButtons"]
+[node name="Test" type="Button" parent="HBoxContainer/SideButtons"]
 margin_top = 140.0
-margin_right = 150.0
+margin_right = 180.0
 margin_bottom = 166.0
 theme = ExtResource( 11 )
 shortcut_in_tooltip = false
@@ -290,18 +346,22 @@ __meta__ = {
 "_editor_description_": ""
 }
 
-[node name="Filler" type="Control" parent="HBoxContainer/RightPanel/SideButtons"]
+[node name="Json" type="TextEdit" parent="HBoxContainer/SideButtons"]
 margin_top = 170.0
-margin_right = 150.0
+margin_right = 180.0
 margin_bottom = 530.0
+rect_min_size = Vector2( 160, 0 )
 size_flags_vertical = 3
+text = "abc"
+script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+_playfield_path = NodePath("../../TabContainer/Playfield/CenterPanel/Playfield")
 
-[node name="Settings" type="Button" parent="HBoxContainer/RightPanel/SideButtons"]
+[node name="Settings" type="Button" parent="HBoxContainer/SideButtons"]
 margin_top = 534.0
-margin_right = 150.0
+margin_right = 180.0
 margin_bottom = 560.0
 theme = ExtResource( 11 )
 shortcut_in_tooltip = false
@@ -311,9 +371,9 @@ __meta__ = {
 "_editor_description_": ""
 }
 
-[node name="Quit" type="Button" parent="HBoxContainer/RightPanel/SideButtons"]
+[node name="Quit" type="Button" parent="HBoxContainer/SideButtons"]
 margin_top = 564.0
-margin_right = 150.0
+margin_right = 180.0
 margin_bottom = 590.0
 theme = ExtResource( 11 )
 shortcut_in_tooltip = false
@@ -334,9 +394,9 @@ margin_bottom = 200.0
 window_title = "Open a File"
 mode = 0
 access = 2
-current_dir = "d:/workspace/turbofat"
+current_dir = "/workspace/turbofat"
 current_file = "boatricia.json"
-current_path = "d:/workspace/turbofat/boatricia.json"
+current_path = "/workspace/turbofat/boatricia.json"
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -368,22 +428,22 @@ margin_top = -200.0
 margin_right = 300.0
 margin_bottom = 200.0
 access = 2
-current_dir = "d:/workspace/turbofat"
+current_dir = "/workspace/turbofat"
 current_file = "boatricia.json"
-current_path = "d:/workspace/turbofat/boatricia.json"
+current_path = "/workspace/turbofat/boatricia.json"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="SettingsMenu" parent="." instance=ExtResource( 9 )]
-[connection signal="tile_map_changed" from="HBoxContainer/CenterPanel/VBoxContainer/Playfield" to="HBoxContainer/CenterPanel/VBoxContainer/Json" method="_on_Playfield_tile_map_changed"]
-[connection signal="text_changed" from="HBoxContainer/CenterPanel/VBoxContainer/Json" to="HBoxContainer/CenterPanel/VBoxContainer/Json" method="_on_text_changed"]
-[connection signal="pressed" from="HBoxContainer/RightPanel/SideButtons/OpenFile" to="." method="_on_OpenFile_pressed"]
-[connection signal="pressed" from="HBoxContainer/RightPanel/SideButtons/OpenResource" to="." method="_on_OpenResource_pressed"]
-[connection signal="pressed" from="HBoxContainer/RightPanel/SideButtons/Save" to="." method="_on_Save_pressed"]
-[connection signal="pressed" from="HBoxContainer/RightPanel/SideButtons/Test" to="." method="_on_Test_pressed"]
-[connection signal="pressed" from="HBoxContainer/RightPanel/SideButtons/Settings" to="SettingsMenu" method="_on_Settings_pressed"]
-[connection signal="pressed" from="HBoxContainer/RightPanel/SideButtons/Quit" to="." method="_on_Quit_pressed"]
+[connection signal="tile_map_changed" from="HBoxContainer/TabContainer/Playfield/CenterPanel/Playfield" to="HBoxContainer/SideButtons/Json" method="_on_Playfield_tile_map_changed"]
+[connection signal="pressed" from="HBoxContainer/SideButtons/OpenFile" to="." method="_on_OpenFile_pressed"]
+[connection signal="pressed" from="HBoxContainer/SideButtons/OpenResource" to="." method="_on_OpenResource_pressed"]
+[connection signal="pressed" from="HBoxContainer/SideButtons/Save" to="." method="_on_Save_pressed"]
+[connection signal="pressed" from="HBoxContainer/SideButtons/Test" to="." method="_on_Test_pressed"]
+[connection signal="text_changed" from="HBoxContainer/SideButtons/Json" to="HBoxContainer/SideButtons/Json" method="_on_text_changed"]
+[connection signal="pressed" from="HBoxContainer/SideButtons/Settings" to="SettingsMenu" method="_on_Settings_pressed"]
+[connection signal="pressed" from="HBoxContainer/SideButtons/Quit" to="." method="_on_Quit_pressed"]
 [connection signal="file_selected" from="OpenFileDialog" to="." method="_on_OpenFileDialog_file_selected"]
 [connection signal="file_selected" from="OpenResourceDialog" to="." method="_on_OpenResourceDialog_file_selected"]
 [connection signal="file_selected" from="SaveDialog" to="." method="_on_SaveDialog_file_selected"]

--- a/src/main/puzzle/editor/box-chunk.gd
+++ b/src/main/puzzle/editor/box-chunk.gd
@@ -8,8 +8,8 @@ export (PuzzleTileMap.BoxInt) var _box_type: int setget set_box_type
 export (Vector2) var _box_size: Vector2 = Vector2(3, 3) setget set_box_size
 
 func _ready() -> void:
-	$"../RotateButton".connect("pressed", self, "_on_RotateButton_pressed")
-	$"../ChangeButton".connect("pressed", self, "_on_ChangeButton_pressed")
+	$"../../Buttons/RotateButton".connect("pressed", self, "_on_RotateButton_pressed")
+	$"../../Buttons/ChangeButton".connect("pressed", self, "_on_ChangeButton_pressed")
 
 
 func set_box_type(box_type: int) -> void:

--- a/src/main/puzzle/editor/editor-json.gd
+++ b/src/main/puzzle/editor/editor-json.gd
@@ -14,7 +14,9 @@ var _json_tree: Dictionary
 var _json_blocks_start: Dictionary
 var _json_tiles: Array
 
-onready var _playfield: EditorPlayfield = $"../Playfield"
+export (NodePath) var _playfield_path: NodePath
+
+onready var _playfield: EditorPlayfield = get_node(_playfield_path)
 onready var _tile_map: TileMap = _playfield.get_tile_map()
 
 """

--- a/src/main/puzzle/editor/editor-playfield.gd
+++ b/src/main/puzzle/editor/editor-playfield.gd
@@ -12,9 +12,9 @@ signal tile_map_changed
 var dragging_right_mouse := false
 
 func _ready() -> void:
-	$ZIndex/TileMap.clear()
-	$ZIndex/TileMap/CornerMap.dirty = true
-	$ZIndex/TileMapDropPreview.clear()
+	$Bg/TileMap.clear()
+	$Bg/TileMap/CornerMap.dirty = true
+	$Bg/TileMapDropPreview.clear()
 
 
 func _gui_input(event: InputEvent) -> void:
@@ -28,19 +28,19 @@ func _gui_input(event: InputEvent) -> void:
 
 
 func can_drop_data(pos: Vector2, data: LevelChunk) -> bool:
-	var can_drop := Rect2($ZIndex/Bg.rect_position, $ZIndex/Bg.rect_size).has_point(pos)
+	var can_drop := Rect2(Vector2(0, 0), rect_size).has_point(pos)
 	if can_drop:
 		# update drop preview
-		$ZIndex/TileMapDropPreview.clear()
+		$Bg/TileMapDropPreview.clear()
 		for cell in data.used_cells:
 			var target_pos: Vector2 = _cell_pos(pos) + cell
-			_set_tilemap_block($ZIndex/TileMapDropPreview, target_pos,
+			_set_tilemap_block($Bg/TileMapDropPreview, target_pos,
 					data.tiles[cell], data.autotile_coords[cell])
 	return can_drop
 
 
 func drop_data(pos: Vector2, data: LevelChunk) -> void:
-	$ZIndex/TileMapDropPreview.clear()
+	$Bg/TileMapDropPreview.clear()
 	for cell in data.used_cells:
 		var target_pos: Vector2 = _cell_pos(pos) + cell
 		set_block(target_pos, data.tiles[cell], data.autotile_coords[cell])
@@ -48,18 +48,18 @@ func drop_data(pos: Vector2, data: LevelChunk) -> void:
 
 
 func set_block(pos: Vector2, tile: int, autotile_coord: Vector2 = Vector2.ZERO) -> void:
-	_set_tilemap_block($ZIndex/TileMap, pos, tile, autotile_coord)
+	_set_tilemap_block($Bg/TileMap, pos, tile, autotile_coord)
 
 
 func get_tile_map() -> TileMap:
-	return $ZIndex/TileMap as TileMap
+	return $Bg/TileMap as TileMap
 
 
 """
 Converts an x/y control coordinate like '58, 132' into a tilemap coordinate like '3, 2'
 """
 func _cell_pos(pos: Vector2) -> Vector2:
-	return pos * Vector2(PuzzleTileMap.COL_COUNT, PuzzleTileMap.ROW_COUNT) / $ZIndex/Bg.rect_size
+	return pos * Vector2(PuzzleTileMap.COL_COUNT, PuzzleTileMap.ROW_COUNT) / rect_size
 
 
 func _set_tilemap_block(tilemap: TileMap, pos: Vector2, tile: int, autotile_coord: Vector2) -> void:

--- a/src/main/puzzle/editor/level-chunk-control.gd
+++ b/src/main/puzzle/editor/level-chunk-control.gd
@@ -43,5 +43,5 @@ Refreshes the scale to ensure the contents of the tilemap fit inside an item in 
 """
 func _refresh_scale() -> void:
 	var extents := _tilemap_extents()
-	$TileMap.scale.x = 0.50 / (1 + max(extents.end.x, extents.end.y))
-	$TileMap.scale.y = 0.50 / (1 + max(extents.end.x, extents.end.y))
+	$TileMap.scale.x = 1.00 / (1 + max(extents.end.x, extents.end.y))
+	$TileMap.scale.y = 1.00 / (1 + max(extents.end.x, extents.end.y))

--- a/src/main/puzzle/editor/level-editor.gd
+++ b/src/main/puzzle/editor/level-editor.gd
@@ -12,8 +12,8 @@ var _test_scene: Node
 
 onready var PuzzleScene := preload("res://src/main/puzzle/Puzzle.tscn")
 
-onready var _scenario_json := $HBoxContainer/CenterPanel/VBoxContainer/Json
-onready var _scenario_name := $HBoxContainer/RightPanel/SideButtons/ScenarioName
+onready var _scenario_json := $HBoxContainer/SideButtons/Json
+onready var _scenario_name := $HBoxContainer/SideButtons/ScenarioName
 
 func _ready() -> void:
 	if not ResourceCache.is_done():
@@ -48,8 +48,8 @@ func _start_test() -> void:
 	Breadcrumb.push_trail("res://src/main/puzzle/editor/LevelEditor.tscn::test")
 	add_child(_test_scene)
 	
-	# disable the settings button while testing a level, otherwise hitting 'esc' will do two things
-	$HBoxContainer/RightPanel/SideButtons/Settings.disabled = true
+	# hide the level controls while testing a level, otherwise hitting 'esc' will do two things
+	$HBoxContainer.visible = false
 
 
 func _stop_test() -> void:
@@ -58,8 +58,8 @@ func _stop_test() -> void:
 		_test_scene = null
 		MusicPlayer.stop()
 		
-		# re-enable the settings button, which was disabled while testing the level
-		$HBoxContainer/RightPanel/SideButtons/Settings.disabled = false
+		# re-enable the level controls which was disabled while testing the level
+		$HBoxContainer.visible = true
 
 
 func _on_OpenFile_pressed() -> void:

--- a/src/main/puzzle/editor/piece-chunk.gd
+++ b/src/main/puzzle/editor/piece-chunk.gd
@@ -24,7 +24,7 @@ var _orientation := 0
 var _piece: PieceType = PieceTypes.piece_j
 
 func _ready() -> void:
-	$"../RotateButton".connect("pressed", self, "_on_RotateButton_pressed")
+	$"../../Buttons/RotateButton".connect("pressed", self, "_on_RotateButton_pressed")
 
 
 func set_editor_piece(new_editor_piece: int) -> void:

--- a/src/main/puzzle/editor/veg-chunk.gd
+++ b/src/main/puzzle/editor/veg-chunk.gd
@@ -7,8 +7,8 @@ A level editor chunk which contains a vegetable block.
 export (Vector2) var _veg_size: Vector2 = Vector2(1, 1) setget set_veg_size
 
 func _ready() -> void:
-	$"../RotateButton".connect("pressed", self, "_on_RotateButton_pressed")
-	$"../ChangeButton".connect("pressed", self, "_on_ChangeButton_pressed")
+	$"../../Buttons/RotateButton".connect("pressed", self, "_on_RotateButton_pressed")
+	$"../../Buttons/ChangeButton".connect("pressed", self, "_on_ChangeButton_pressed")
 
 
 func set_veg_size(veg_size: Vector2) -> void:


### PR DESCRIPTION
Instead of disabling/ZIndexing level editor components during a test,
they're now hidden (visible=false). JSON is now displayed vertically on
the right side of the screen.

Added placeholder 'Properties' tab in level editor. This is where other
properties such as difficulties and win conditions will go.