### PR TITLE
Save finish/success data. Must pass tutorial.

### DIFF
--- a/src/main/old-save.gd
+++ b/src/main/old-save.gd
@@ -207,4 +207,4 @@ func _append_compare_flag_for_0517(save_json_text: String) -> String:
 			for value_obj in save_item.get("value"):
 				var value: Dictionary = value_obj
 				value["compare"] = "-seconds"
-	return to_json(json_save_items)
+	return JSON.print(json_save_items, " ")

--- a/src/main/player-save.gd
+++ b/src/main/player-save.gd
@@ -65,7 +65,11 @@ func save_player_data() -> void:
 		for rank_result in PlayerData.scenario_history.results(scenario_name):
 			rank_results_json.append(rank_result.to_json_dict())
 		save_json.append(named_data("scenario-history", scenario_name, rank_results_json).to_json_dict())
-	FileUtils.write_file(player_data_filename, to_json(save_json))
+	save_json.append(generic_data("successful-scenarios",
+			PlayerData.scenario_history.successful_scenarios).to_json_dict())
+	save_json.append(generic_data("finished-scenarios",
+			PlayerData.scenario_history.finished_scenarios).to_json_dict())
+	FileUtils.write_file(player_data_filename, JSON.print(save_json, " "))
 
 
 """
@@ -117,6 +121,12 @@ func _load_line(type: String, key: String, json_value) -> void:
 				rank_result.from_json_dict(rank_result_json)
 				PlayerData.scenario_history.add(key, rank_result)
 			PlayerData.scenario_history.prune(key)
+		"finished-scenarios":
+			var value: Dictionary = json_value
+			PlayerData.scenario_history.finished_scenarios = value
+		"successful-scenarios":
+			var value: Dictionary = json_value
+			PlayerData.scenario_history.successful_scenarios = value
 		"volume-settings":
 			var value: Dictionary = json_value
 			PlayerData.volume_settings.from_json_dict(value)

--- a/src/main/puzzle/puzzle-score.gd
+++ b/src/main/puzzle/puzzle-score.gd
@@ -31,7 +31,7 @@ signal score_changed
 signal combo_ended
 
 enum EndResult {
-	WON, # The player succeeded.
+	WON, # The player was successful.
 	FINISHED, # The player survived until the end.
 	LOST, # The player gave up or failed.
 }

--- a/src/main/puzzle/scenario/scenario-history.gd
+++ b/src/main/puzzle/scenario/scenario-history.gd
@@ -11,6 +11,14 @@ var max_size := 3
 # value: array of RankResults for the specified scenario
 var rank_results := {}
 
+# key: scenario name
+# value: date when the player was first successful at the scenario
+var successful_scenarios := {}
+
+# key: scenario name
+# value: date when the player first finished the scenario
+var finished_scenarios := {}
+
 func scenario_names() -> Array:
 	return rank_results.keys()
 
@@ -87,6 +95,10 @@ func add(scenario: String, rank_result: RankResult) -> void:
 	if not rank_results.has(scenario):
 		rank_results[scenario] = []
 	rank_results[scenario].push_front(rank_result)
+	if rank_result.success and not successful_scenarios.has(scenario):
+		successful_scenarios[scenario] = OS.get_datetime()
+	if not rank_result.lost and not successful_scenarios.has(scenario):
+		finished_scenarios[scenario] = OS.get_datetime()
 
 
 func has(scenario: String) -> bool:

--- a/src/main/ui/menu/main-menu.gd
+++ b/src/main/ui/menu/main-menu.gd
@@ -10,7 +10,7 @@ Includes buttons starting a new game, launching the level editor, and exiting th
 const BEGINNER_TUTORIAL_SCENARIO := "tutorial-beginner-0"
 
 func _ready() -> void:
-	if not PlayerData.scenario_history.scenario_names().has(BEGINNER_TUTORIAL_SCENARIO):
+	if not PlayerData.scenario_history.finished_scenarios.has(BEGINNER_TUTORIAL_SCENARIO):
 		var settings := ScenarioSettings.new()
 		settings.load_from_resource(BEGINNER_TUTORIAL_SCENARIO)
 		Scenario.overworld_puzzle = false

--- a/src/main/ui/menu/practice-difficulty-selector.gd
+++ b/src/main/ui/menu/practice-difficulty-selector.gd
@@ -52,6 +52,8 @@ func set_difficulty_names(names: Array) -> void:
 	# clear out the old labels
 	for child in $Labels.get_children():
 		child.queue_free()
+		# remove_child to ensure old labels don't affect lowlight calculations
+		$Labels.remove_child(child)
 	
 	# add the new labels
 	for name_obj in names:

--- a/src/main/ui/menu/practice-menu.gd
+++ b/src/main/ui/menu/practice-menu.gd
@@ -122,20 +122,7 @@ func _calculate_lowlights() -> void:
 	
 	for difficulty in mode_difficulties[_get_mode()]:
 		var scenario: ScenarioSettings = scenarios["%s %s" % [_get_mode(), difficulty]]
-		_rank_lowlights.append(_calculate_lowlight(scenario))
-
-
-"""
-Calculates whether the specified scenario should be lowlighted.
-
-If the player achieved the success condition without losing, the scenario appears lit up. Otherwise it's lowlighted.
-"""
-func _calculate_lowlight(scenario: ScenarioSettings) -> bool:
-	var best_results: Array = PlayerData.scenario_history.best_results(scenario.name, false)
-	if not best_results:
-		return true
-	
-	return not best_results[0].success
+		_rank_lowlights.append(not PlayerData.scenario_history.successful_scenarios.has(scenario.name))
 
 
 func _get_mode() -> String:


### PR DESCRIPTION
The save data now includes a list of all scenarios which were finished
successfully (lost = false) and a list of all scenarios which were
successful (success = true). This allows menus and game logic to trivially
check in O(1) time whether the player's passed a scenario.

The player must pass the tutorial to play the game. Before they could fail
the tutorial, quit the game, re-launch the game and have no way to play
the tutorial.

Fixed bug where rank highlights/lowlights were rendered incorrectly. This
was introduced by the recent removal of remove_child() calls, some of
which had side effects.