### PR TITLE
Resolve code warnings.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -473,6 +473,11 @@ Scenario="*res://src/main/puzzle/scenario/scenario.gd"
 StringUtils="*res://src/main/string-utils.gd"
 Utils="*res://src/main/utils.gd"
 
+[debug]
+
+gdscript/warnings/narrowing_conversion=false
+gdscript/warnings/return_value_discarded=false
+
 [display]
 
 window/stretch/mode="2d"

--- a/project/src/demo/packed-sprite-demo.gd
+++ b/project/src/demo/packed-sprite-demo.gd
@@ -7,7 +7,7 @@ Keys:
 	Arrows: Move the sprite and print its offset.
 """
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	if Input.is_action_just_pressed("interact"):
 		$PackedSprite.frame = wrapi($PackedSprite.frame + 1, 0, $PackedSprite.frame_count)
 	if Input.is_action_just_pressed("ui_right"):

--- a/project/src/demo/ui/touch/eight-way-demo.gd
+++ b/project/src/demo/ui/touch/eight-way-demo.gd
@@ -19,7 +19,7 @@ func _input(event: InputEvent) -> void:
 		KEY_MINUS: $EightWay.rect_scale /= 1.3
 
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	var output := ""
 	for action in actions:
 		if Input.is_action_just_pressed(action):

--- a/project/src/main/freshness-inspector.gd
+++ b/project/src/main/freshness-inspector.gd
@@ -84,6 +84,7 @@ func freshest_start(bgm: AudioStreamPlayer) -> float:
 	var freshest_start_index := 0
 	var min_staleness: int = 0
 	var staleness: int = 0
+	# warning-ignore:integer_division
 	var r: int = freshness_record.size() / 2
 	for l in range(0, freshness_record.size()):
 		# advance the 'freshness window'

--- a/project/src/main/music-tween.gd
+++ b/project/src/main/music-tween.gd
@@ -30,7 +30,7 @@ func fade_in(player: AudioStreamPlayer) -> void:
 """
 When a music track is faded out, we stop it from playing.
 """
-func _on_tween_completed(object: Object, key: String) -> void:
+func _on_tween_completed(object: Object, _key: String) -> void:
 	if object is AudioStreamPlayer:
 		if object.volume_db == MusicPlayer.MIN_VOLUME:
 			object.stop()

--- a/project/src/main/puzzle/PuzzleTileMap.tscn
+++ b/project/src/main/puzzle/PuzzleTileMap.tscn
@@ -15,12 +15,12 @@ resource_local_to_scene = true
 shader = ExtResource( 9 )
 shader_param/mix_color = Color( 1, 1, 1, 0 )
 
-[sub_resource type="ShaderMaterial" id=4]
+[sub_resource type="ShaderMaterial" id=2]
 resource_local_to_scene = true
 shader = ExtResource( 9 )
 shader_param/mix_color = Color( 1, 1, 1, 0 )
 
-[sub_resource type="TileSet" id=2]
+[sub_resource type="TileSet" id=3]
 0/name = "blocks-corners.png 2"
 0/texture = ExtResource( 1 )
 0/tex_offset = Vector2( 0, 0 )
@@ -43,7 +43,7 @@ shader_param/mix_color = Color( 1, 1, 1, 0 )
 0/shapes = [  ]
 0/z_index = 0
 
-[sub_resource type="TileSet" id=3]
+[sub_resource type="TileSet" id=4]
 0/name = "blocks-shadows.png 0"
 0/texture = ExtResource( 8 )
 0/tex_offset = Vector2( 0, -64 )
@@ -119,8 +119,8 @@ tile_data = PoolIntArray( 983046, 4, 0, 1048582, 4, 0, 1114118, 4, 0 )
 script = ExtResource( 5 )
 
 [node name="CornerMap" parent="." instance=ExtResource( 3 )]
-material = SubResource( 4 )
-tile_set = SubResource( 2 )
+material = SubResource( 2 )
+tile_set = SubResource( 3 )
 
 [node name="Viewport" type="Viewport" parent="."]
 size = Vector2( 324, 544 )
@@ -132,7 +132,7 @@ modulate = Color( 0, 0, 0, 1 )
 show_behind_parent = true
 position = Vector2( 0, -96 )
 scale = Vector2( 0.5, 0.5 )
-tile_set = SubResource( 3 )
+tile_set = SubResource( 4 )
 cell_size = Vector2( 72, 64 )
 format = 1
 tile_data = PoolIntArray( 1114113, 0, 2, 1179649, 0, 9, 1179650, 0, 3, 1179651, 0, 4 )

--- a/project/src/main/puzzle/box-builder.gd
+++ b/project/src/main/puzzle/box-builder.gd
@@ -21,7 +21,7 @@ func _ready() -> void:
 	set_physics_process(false)
 
 
-func _physics_process(delta: float) -> void:
+func _physics_process(_delta: float) -> void:
 	remaining_box_build_frames -= 1
 	if remaining_box_build_frames <= 0:
 		# stop processing if we're done building boxes

--- a/project/src/main/puzzle/build-box-sfx.gd
+++ b/project/src/main/puzzle/build-box-sfx.gd
@@ -10,7 +10,7 @@ onready var _build_snack_box_sounds := [
 		preload("res://assets/main/puzzle/build-snack-box3.wav"),
 	]
 
-func _on_Playfield_box_built(x: int, y: int, width: int, height: int, color: int) -> void:
+func _on_Playfield_box_built(_x: int, _y: int, _width: int, _height: int, color: int) -> void:
 	match color:
 		0, 1, 2, 3:
 			$BuildSnackBoxSound.stream = _build_snack_box_sounds[color]

--- a/project/src/main/puzzle/combo-tracker.gd
+++ b/project/src/main/puzzle/combo-tracker.gd
@@ -46,14 +46,14 @@ func _on_PuzzleScore_game_prepared() -> void:
 	combo = 0
 
 
-func _on_Playfield_box_built(x: int, y: int, width: int, height: int, color_int: int) -> void:
+func _on_Playfield_box_built(_x: int, _y: int, _width: int, _height: int, _color_int: int) -> void:
 	piece_continued_combo = true
 	if combo_break != 0:
 		combo_break = 0
 		emit_signal("combo_break_changed", combo_break)
 
 
-func _on_Playfield_line_cleared(y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
+func _on_Playfield_line_cleared(_y: int, _total_lines: int, _remaining_lines: int, box_ints: Array) -> void:
 	if Scenario.settings.combo_break.veg_row:
 		if box_ints.empty():
 			piece_broke_combo = true
@@ -90,7 +90,7 @@ func _on_PuzzleScore_game_ended() -> void:
 """
 Increments the combo and score for the specified line clear.
 """
-func _on_Playfield_before_line_cleared(y, total_lines, remaining_lines, box_ints) -> void:
+func _on_Playfield_before_line_cleared(_y, _total_lines, _remaining_lines, box_ints) -> void:
 	combo += 1
 	var combo_score: int = COMBO_SCORE_ARR[clamp(combo - 1, 0, COMBO_SCORE_ARR.size() - 1)]
 	var box_score := 0

--- a/project/src/main/puzzle/frosting-globs.gd
+++ b/project/src/main/puzzle/frosting-globs.gd
@@ -70,7 +70,7 @@ When a line is cleared, we generate frosting globs for any boxes involved in the
 
 This must be called before the line is cleared so that we can evaluate the food blocks before they're erased.
 """
-func _on_Playfield_before_line_cleared(y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
+func _on_Playfield_before_line_cleared(y: int, _total_lines: int, _remaining_lines: int, _box_ints: Array) -> void:
 	for x in range(PuzzleTileMap.COL_COUNT):
 		var color_int: int
 		var glob_count: int

--- a/project/src/main/puzzle/leaf-poofs.gd
+++ b/project/src/main/puzzle/leaf-poofs.gd
@@ -78,7 +78,7 @@ func _poof_count(veg_cell_count: int) -> int:
 """
 If the specified row includes enough vegetable cells, we spawn leaf poofs nearby.
 """
-func _on_Playfield_before_line_cleared(y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
+func _on_Playfield_before_line_cleared(y: int, _total_lines: int, _remaining_lines: int, _box_ints: Array) -> void:
 	var veg_columns := []
 	for x in range(PuzzleTileMap.COL_COUNT):
 		if _puzzle_tile_map.get_cell(x, y) in [PuzzleTileMap.TILE_VEG, PuzzleTileMap.TILE_PIECE]:

--- a/project/src/main/puzzle/line-clear-sfx.gd
+++ b/project/src/main/puzzle/line-clear-sfx.gd
@@ -51,7 +51,7 @@ onready var _veg_erase_sounds := [$VegEraseSound1, $VegEraseSound2, $VegEraseSou
 
 onready var _combo_tracker: ComboTracker = $"../ComboTracker"
 
-func _play_thump_sound(y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
+func _play_thump_sound(_y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
 	var sound_index := clamp(total_lines - remaining_lines - 1, 0, _line_erase_sounds.size() - 1)
 	var sound: AudioStreamPlayer
 	if box_ints:
@@ -69,7 +69,7 @@ Plays an escalating sound for the current combo.
 For smaller combos this goes through a list of sound effects with higher pitches. For larger combos this loops through
 a repeating list where the repetition is concealed using a shepard tone.
 """
-func _play_combo_sound(y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
+func _play_combo_sound(_y: int, _total_lines: int, _remaining_lines: int, _box_ints: Array) -> void:
 	var sound: AudioStream
 	if _combo_tracker.combo <= 0:
 		# lines were cleared from top out or another unusual case. don't play combo sounds
@@ -83,7 +83,7 @@ func _play_combo_sound(y: int, total_lines: int, remaining_lines: int, box_ints:
 		$ComboSound.play()
 
 
-func _play_box_sound(y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
+func _play_box_sound(_y: int, _total_lines: int, _remaining_lines: int, box_ints: Array) -> void:
 	var sound: AudioStreamPlayer
 	if box_ints.has(PuzzleTileMap.BoxInt.CAKE):
 		sound = $ClearCakePieceSound

--- a/project/src/main/puzzle/line-clearer.gd
+++ b/project/src/main/puzzle/line-clearer.gd
@@ -47,7 +47,7 @@ func _ready() -> void:
 	PuzzleScore.connect("finish_triggered", self, "_on_PuzzleScore_finish_triggered")
 
 
-func _physics_process(delta: float) -> void:
+func _physics_process(_delta: float) -> void:
 	# clear lines from lines_being_cleared
 	while _cleared_line_index < lines_being_cleared.size() \
 			and remaining_line_erase_frames <= _remaining_line_clear_timings[_cleared_line_index]:
@@ -268,6 +268,7 @@ Non-full vegetable lines are erased simultaneously with the nearest line clear.
 This method takes a list of cleared lines and erased lines, and pairs all of the erased lines to the nearest cleared
 line.
 """
+# warning-ignore:shadowed_variable
 static func closest_clears(lines_being_cleared: Array, lines_being_erased: Array) -> Array:
 	var closest_clears := lines_being_erased.duplicate()
 	if not lines_being_cleared:

--- a/project/src/main/puzzle/piece-sfx.gd
+++ b/project/src/main/puzzle/piece-sfx.gd
@@ -50,7 +50,7 @@ func _on_PieceManager_initial_das_moved_right() -> void:
 	_play_move_sfx()
 
 
-func _on_PieceManager_squish_moved(piece: ActivePiece, old_pos: Vector2) -> void:
+func _on_PieceManager_squish_moved(_piece: ActivePiece, _old_pos: Vector2) -> void:
 	$SquishSound.play()
 
 # Rotation events ----------------------------------------------------------------

--- a/project/src/main/puzzle/piece/active-piece.gd
+++ b/project/src/main/puzzle/piece/active-piece.gd
@@ -75,18 +75,18 @@ Parameters:
 	'is_cell_blocked': A callback function which returns 'true' if a specified cell is blocked, either because it lies
 		outside the playfield or is obstructed by a block
 	
-	'pos': The desired position to move the piece to
+	'new_pos': The desired position to move the piece to
 	
-	'orientation': The desired orientation to rotate the piece to
+	'new_orientation': The desired orientation to rotate the piece to
 """
-func can_move_piece_to(is_cell_blocked: FuncRef, pos: Vector2, orientation: int) -> bool:
+func can_move_piece_to(is_cell_blocked: FuncRef, new_pos: Vector2, new_orientation: int) -> bool:
 	var valid_target_pos := true
 	if type.pos_arr.empty():
 		# Return 'false' for an empty piece to avoid an infinite loop
 		valid_target_pos = false
 	else:
-		for block_pos in type.pos_arr[orientation]:
-			valid_target_pos = valid_target_pos and not is_cell_blocked.call_func(pos + block_pos)
+		for block_pos in type.pos_arr[new_orientation]:
+			valid_target_pos = valid_target_pos and not is_cell_blocked.call_func(new_pos + block_pos)
 	return valid_target_pos
 
 

--- a/project/src/main/puzzle/piece/next-piece-displays.gd
+++ b/project/src/main/puzzle/piece/next-piece-displays.gd
@@ -14,7 +14,7 @@ var _next_piece_displays := []
 func _ready() -> void:
 	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
 	for i in range(DISPLAY_COUNT):
-		_add_display(i, 5, 5 + i * (486 / (DISPLAY_COUNT - 1)), 0.5)
+		_add_display(i, 5, 5 + i * (486.0 / (DISPLAY_COUNT - 1)), 0.5)
 
 
 """

--- a/project/src/main/puzzle/piece/piece-speeds.gd
+++ b/project/src/main/puzzle/piece/piece-speeds.gd
@@ -90,7 +90,7 @@ func _update_current_speed() -> void:
 	PieceSpeeds.current_speed = PieceSpeeds.speed(MilestoneManager.prev_milestone().get_meta("level"))
 
 
-func _on_PuzzleScore_level_index_changed(value: int) -> void:
+func _on_PuzzleScore_level_index_changed(_value: int) -> void:
 	_update_current_speed()
 
 

--- a/project/src/main/puzzle/playfield-fx.gd
+++ b/project/src/main/puzzle/playfield-fx.gd
@@ -94,7 +94,7 @@ func reset() -> void:
 	$LightMap.modulate = Color.transparent
 	$GlowMap.modulate = Color.transparent
 	_calculate_brightness(0)
-	_refresh_tilemaps(0)
+	_refresh_tilemaps()
 
 
 func _init_tile_set() -> void:
@@ -182,7 +182,7 @@ func _calculate_brightness(combo: int) -> void:
 """
 Calculates the new light pattern and refreshes the tilemaps.
 """
-func _refresh_tilemaps(combo: int) -> void:
+func _refresh_tilemaps() -> void:
 	$BgStrobe.color = Utils.to_transparent(_color)
 	
 	var new_pattern: Array
@@ -205,12 +205,12 @@ func _refresh_tilemaps(combo: int) -> void:
 			$GlowMap.set_cell(x, y, tile)
 
 
-func _on_Playfield_before_line_cleared(y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
+func _on_Playfield_before_line_cleared(_y: int, _total_lines: int, _remaining_lines: int, box_ints: Array) -> void:
 	_calculate_brightness(_combo_tracker.combo)
 	_calculate_line_color(box_ints)
 	_pattern_y += 1
 	_start_glow_tween()
-	_refresh_tilemaps(_combo_tracker.combo)
+	_refresh_tilemaps()
 
 
 """
@@ -220,16 +220,16 @@ func _on_ComboTracker_combo_break_changed(value: int) -> void:
 	if value >= 2:
 		if _pattern != OFF_PATTERN:
 			reset()
-			_refresh_tilemaps(value)
+			_refresh_tilemaps()
 	else:
-		_refresh_tilemaps(value)
+		_refresh_tilemaps()
 
 
 """
 When the player builds a box we brighten the combo lights again.
 """
-func _on_Playfield_box_built(x: int, y: int, width: int, height: int, color_int: int) -> void:
-	_refresh_tilemaps(_combo_tracker.combo)
+func _on_Playfield_box_built(_x: int, _y: int, _width: int, _height: int, _color_int: int) -> void:
+	_refresh_tilemaps()
 	_start_glow_tween()
 
 

--- a/project/src/main/puzzle/puzzle-tile-map.gd
+++ b/project/src/main/puzzle/puzzle-tile-map.gd
@@ -86,8 +86,8 @@ Deletes the specified row in the tile map, dropping all higher rows down to fill
 """
 func delete_row(y: int) -> void:
 	# First, erase and store all the old cells which are dropping
-	var piece_colors_to_set: Dictionary
-	var autotile_coords_to_set: Dictionary
+	var piece_colors_to_set := {}
+	var autotile_coords_to_set := {}
 	for cell in get_used_cells():
 		if cell.y > y:
 			# cells below the deleted row are left alone
@@ -205,7 +205,6 @@ If we didn't perform this step, the chopped-off bottom of a bread box would stil
 bottom of a bread box looks like a delicious frosted snack and the player can tell it's special.
 """
 func _disconnect_box(x: int, y: int) -> void:
-	var old_autotile_coord: Vector2 = get_cell_autotile_coord(x, y)
 	_disconnect_block(x, y - 1, Connect.DOWN)
 	_disconnect_block(x, y + 1, Connect.UP)
 

--- a/project/src/main/puzzle/puzzle-trace.gd
+++ b/project/src/main/puzzle/puzzle-trace.gd
@@ -10,7 +10,7 @@ onready var _playfield:Playfield = _puzzle.get_playfield()
 onready var _combo_tracker:ComboTracker = _puzzle.get_node("Playfield/ComboTracker")
 onready var _piece_manager:PieceManager= _puzzle.get_piece_manager()
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	if visible:
 		var new_text: String = ""
 		

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -5,8 +5,6 @@ Represents a minimal puzzle game with a piece, playfield of pieces, and next pie
 class to add goals, win conditions, challenges or time limits.
 """
 
-signal topped_out
-
 # the previously launched food color. stored to avoid showing the same color twice consecutively
 var _food_color: Color
 
@@ -100,7 +98,7 @@ func _on_Hud_start_button_pressed() -> void:
 """
 Triggers the 'creature feeding' animation.
 """
-func _on_Playfield_line_cleared(y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
+func _on_Playfield_line_cleared(_y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
 	# Calculate whether or not the creature should say something positive about the combo. The creature talks after
 	var creature_talks: bool = remaining_lines == 0 and $Playfield/ComboTracker.combo >= 5 \
 			and total_lines > ($Playfield/ComboTracker.combo + 1) % 3

--- a/project/src/main/puzzle/results-hud.gd
+++ b/project/src/main/puzzle/results-hud.gd
@@ -52,7 +52,7 @@ func show_results_message(rank_result: RankResult, creature_scores: Array, finis
 
 
 func _append_creature_scores(rank_result: RankResult, creature_scores: Array, \
-		finish_condition_type: int, text: String) -> String:
+		_finish_condition_type: int, text: String) -> String:
 	# Append creature scores
 	for i in range(creature_scores.size()):
 		var creature_score: int = creature_scores[i]
@@ -70,7 +70,7 @@ func _append_creature_scores(rank_result: RankResult, creature_scores: Array, \
 	return text
 
 
-func _append_grade_information(rank_result: RankResult, creature_scores: Array, \
+func _append_grade_information(rank_result: RankResult, _creature_scores: Array, \
 		finish_condition_type: int, text: String) -> String:
 	# We add a '?' to make the player aware if their rank is adjusted because they topped out or lost.
 	var topped_out := ""

--- a/project/src/main/puzzle/scenario/scenario-settings.gd
+++ b/project/src/main/puzzle/scenario/scenario-settings.gd
@@ -137,21 +137,21 @@ func from_json_dict(new_name: String, json: Dictionary) -> void:
 		success_condition.from_json_dict(json["success-condition"])
 
 
-func load_from_resource(name: String) -> void:
-	load_from_text(name, FileUtils.get_file_as_text(scenario_path(name)))
+func load_from_resource(new_name: String) -> void:
+	load_from_text(new_name, FileUtils.get_file_as_text(scenario_path(new_name)))
 
 
-func load_from_text(name: String, text: String) -> void:
-	from_json_dict(name, parse_json(text))
+func load_from_text(new_name: String, text: String) -> void:
+	from_json_dict(new_name, parse_json(text))
 
 
-static func scenario_path(name: String) -> String:
-	return "res://assets/main/puzzle/scenario/%s.json" % name
+static func scenario_path(scenario_name: String) -> String:
+	return "res://assets/main/puzzle/scenario/%s.json" % scenario_name
 
 
 static func scenario_name(path: String) -> String:
 	return path.get_file().trim_suffix(".json")
 
 
-static func scenario_filename(name: String) -> String:
-	return "%s.json" % name
+static func scenario_filename(scenario_name: String) -> String:
+	return "%s.json" % scenario_name

--- a/project/src/main/puzzle/tutorial/skill-tally-item.gd
+++ b/project/src/main/puzzle/tutorial/skill-tally-item.gd
@@ -95,10 +95,10 @@ func _refresh_puzzle() -> void:
 Returns the signal names for a node.
 """
 static func _get_signal_names(object: Object) -> Dictionary:
-	var signal_names: Dictionary = {}
+	var result: Dictionary = {}
 	for signal_dict in object.get_signal_list():
-		signal_names[signal_dict.name] = signal_dict.name
-	return signal_names
+		result[signal_dict.name] = signal_dict.name
+	return result
 
 
 """
@@ -143,15 +143,15 @@ func _on_skill_performed() -> void:
 	increment()
 
 
-func _on_PieceManager_squish_moved(piece: ActivePiece, old_pos: Vector2) -> void:
+func _on_PieceManager_squish_moved(_piece: ActivePiece, _old_pos: Vector2) -> void:
 	increment()
 
 
-func _on_Playfield_line_cleared(y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
+func _on_Playfield_line_cleared(_y: int, _total_lines: int, _remaining_lines: int, _box_ints: Array) -> void:
 	increment()
 
 
-func _on_Playfield_box_built(x: int, y: int, width: int, height: int, color: int) -> void:
+func _on_Playfield_box_built(_x: int, _y: int, _width: int, _height: int, _color: int) -> void:
 	increment()
 
 

--- a/project/src/main/puzzle/tutorial/tutorial-hud.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-hud.gd
@@ -90,12 +90,12 @@ func _on_PieceManager_piece_spawned() -> void:
 	_did_build_cake = false
 
 
-func _on_PieceManager_squish_moved(piece: ActivePiece, old_pos: Vector2) -> void:
+func _on_PieceManager_squish_moved(_piece: ActivePiece, _old_pos: Vector2) -> void:
 	_did_squish_move = true
 	_squish_moves += 1
 
 
-func _on_Playfield_box_built(x: int, y: int, width: int, height: int, color: int) -> void:
+func _on_Playfield_box_built(_x: int, _y: int, _width: int, _height: int, color: int) -> void:
 	_did_build_box = true
 	_boxes_built += 1
 	
@@ -103,7 +103,7 @@ func _on_Playfield_box_built(x: int, y: int, width: int, height: int, color: int
 		_did_build_cake = true
 
 
-func _on_Playfield_line_cleared(y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
+func _on_Playfield_line_cleared(_y: int, _total_lines: int, _remaining_lines: int, _box_ints: Array) -> void:
 	_did_line_clear = true
 	_lines_cleared += 1
 
@@ -159,7 +159,6 @@ func _on_Playfield_after_piece_written() -> void:
 	_handle_build_box_message()
 	_handle_snack_stack_message()
 	
-	var scenario_name := Scenario.settings.name
 	match Scenario.settings.name:
 		"tutorial-beginner-0":
 			if _lines_cleared >= 2: _advance_scenario()

--- a/project/src/main/puzzle/wall-frosting-sfx.gd
+++ b/project/src/main/puzzle/wall-frosting-sfx.gd
@@ -30,7 +30,7 @@ Play sound effects for a collision.
 
 Globs with a higher alpha component appear larger, and play louder sounds.
 """
-func _play_sfx(glob: FrostingGlob, glob_alpha: float, max_volume) -> void:
+func _play_sfx(glob_alpha: float, max_volume: float) -> void:
 	var player: AudioStreamPlayer = _splat_players[_splat_player_index]
 	player.stream = _splat_sfx[randi() % _splat_sfx.size()]
 	player.pitch_scale = rand_range(1.90, 2.10)
@@ -46,16 +46,16 @@ func _play_sfx(glob: FrostingGlob, glob_alpha: float, max_volume) -> void:
 
 
 func _on_FrostingGlobs_hit_wall(glob: FrostingGlob) -> void:
-	_play_sfx(glob, glob.modulate.a, -10.0)
+	_play_sfx(glob.modulate.a, -10.0)
 
 
 func _on_FrostingGlobs_hit_playfield(glob: FrostingGlob) -> void:
-	_play_sfx(glob, glob.modulate.a, -20.0)
+	_play_sfx(glob.modulate.a, -20.0)
 
 
 func _on_FrostingGlobs_hit_next_pieces(glob: FrostingGlob) -> void:
-	_play_sfx(glob, glob.modulate.a, -20.0)
+	_play_sfx(glob.modulate.a, -20.0)
 
 
 func _on_FrostingGlobs_hit_gutter(glob: FrostingGlob) -> void:
-	_play_sfx(glob, glob.modulate.a, -20.0)
+	_play_sfx(glob.modulate.a, -20.0)

--- a/project/src/main/resource-cache.gd
+++ b/project/src/main/resource-cache.gd
@@ -9,6 +9,7 @@ By preloading resources used throughout the game, we have a slower startup time 
 during the game.
 """
 
+# warning-ignore:unused_signal
 signal finished_loading
 
 # number of threads to launch; 1 is slower, but more than 4 doesn't seem to help
@@ -57,13 +58,13 @@ func start_load() -> void:
 		# Godot issue #12699; threads not supported for HTML5
 		pass
 	else:
-		for i in range(THREAD_COUNT):
+		for _i in range(THREAD_COUNT):
 			var thread := Thread.new()
 			thread.start(self, "_preload_all_pngs")
 			_load_threads.append(thread)
 
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	if OS.has_feature("web") and _remaining_resource_paths:
 		var start_usec := OS.get_ticks_usec()
 		# Web targets do not support background threads, so we load a few resources every frame
@@ -90,9 +91,9 @@ func is_done() -> bool:
 Loads all pngs in the /assets directory and stores the resulting resources in our cache
 
 Parameters:
-	'userdata': Unused; needed for threads
+	'_userdata': Unused; needed for threads
 """
-func _preload_all_pngs(userdata: Object) -> void:
+func _preload_all_pngs(_userdata: Object) -> void:
 	while _remaining_resource_paths and not _exiting:
 		_preload_next_png()
 

--- a/project/src/main/ui/chat/chat-choice-button.gd
+++ b/project/src/main/ui/chat/chat-choice-button.gd
@@ -112,5 +112,5 @@ func _on_resized() -> void:
 	_set_pivot_to_center()
 
 
-func _on_PopAnimation_animation_finished(anim_name: String) -> void:
+func _on_PopAnimation_animation_finished(_anim_name: String) -> void:
 	emit_signal("pop_choose_completed")

--- a/project/src/main/ui/chat/chat-choices.gd
+++ b/project/src/main/ui/chat/chat-choices.gd
@@ -148,7 +148,7 @@ func _on_ChatChoiceButton_focus_entered() -> void:
 	$PopSound.play()
 
 
-func _on_ChatChoiceButton_gui_input(event: InputEvent) -> void:
+func _on_ChatChoiceButton_gui_input(_event: InputEvent) -> void:
 	# swallow input; player shouldn't move when answering dialog prompts
 	get_tree().set_input_as_handled()
 

--- a/project/src/main/ui/chat/chat-frame.gd
+++ b/project/src/main/ui/chat/chat-frame.gd
@@ -76,7 +76,7 @@ func play_chat_event(chat_event: ChatEvent, nametag_right: bool, squished: bool)
 	# update the UI's appearance
 	$ChatLineLabel.update_appearance(chat_theme)
 	$ChatLinePanel.update_appearance(chat_theme, chat_line_size)
-	$ChatLinePanel/NametagPanel.show_label(chat_theme, nametag_right, chat_line_size)
+	$ChatLinePanel/NametagPanel.show_label(chat_theme, nametag_right)
 
 
 func chat_window_showing() -> bool:

--- a/project/src/main/ui/chat/chat-line-label.gd
+++ b/project/src/main/ui/chat/chat-line-label.gd
@@ -76,7 +76,7 @@ func show_message(text_with_lulls: String, initial_pause: float = 0.0) -> int:
 	set_process(true)
 	text = text_with_lulls.replace("/", "")
 	pick_smallest_size()
-	_calculate_pauses(text_with_lulls)
+	_calculate_pauses(text_with_lulls, initial_pause)
 	return chosen_size_index
 
 

--- a/project/src/main/ui/chat/chat-ui.gd
+++ b/project/src/main/ui/chat/chat-ui.gd
@@ -20,8 +20,8 @@ var _accept_action_duration := 0.0
 var _rewind_action_duration := 0.0
 
 func _process(delta: float) -> void:
-	_rewind_action_duration = _rewind_action_duration + delta if Input.is_action_pressed("rewind_text") else 0
-	_accept_action_duration = _accept_action_duration + delta if Input.is_action_pressed("ui_accept") else 0
+	_rewind_action_duration = _rewind_action_duration + delta if Input.is_action_pressed("rewind_text") else 0.0
+	_accept_action_duration = _accept_action_duration + delta if Input.is_action_pressed("ui_accept") else 0.0
 
 
 func _input(event: InputEvent) -> void:
@@ -68,7 +68,6 @@ The player can tap the advance button to make dialog appear faster or advance to
 advance button to continuously advance the text.
 """
 func _handle_advance_action(event: InputEvent) -> void:
-	var handled_event := false
 	var advance_action := false
 	if event.is_action_pressed("ui_accept"):
 		# if the player presses the 'interact' button, advance the text

--- a/project/src/main/ui/chat/nametag-panel.gd
+++ b/project/src/main/ui/chat/nametag-panel.gd
@@ -52,11 +52,11 @@ func hide_labels() -> void:
 Recolors and repositions the nametag based on the current accent definition.
 
 Parameters:
-	'chat_line_size': The size of the chat line window. This is needed for the nametag to reposition itself around it.
+	'chat_theme': metadata about the chat window's appearance.
 	
 	'nametag_right': true/false if the nametag should be drawn on the right/left side of the frame.
 """
-func show_label(chat_theme: ChatTheme, nametag_right: bool, chat_line_size: int) -> void:
+func show_label(chat_theme: ChatTheme, nametag_right: bool) -> void:
 	hide_labels()
 	visible = _nametag_size != ChatTheme.NAMETAG_OFF
 	if not visible:

--- a/project/src/main/ui/chat/touch-translator.gd
+++ b/project/src/main/ui/chat/touch-translator.gd
@@ -37,7 +37,7 @@ func _input(event: InputEvent) -> void:
 			_emit_ui_accept_event(false, false)
 
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	if _touch_index != -1:
 		# emit an echo event
 		_emit_ui_accept_event(true, true)
@@ -84,7 +84,7 @@ func _on_ChatUi_showed_choices() -> void:
 	_disable_translation()
 
 
-func _on_ChatChoices_chat_choice_chosen(choice_index) -> void:
+func _on_ChatChoices_chat_choice_chosen(_choice_index: int) -> void:
 	_enable_translation()
 
 

--- a/project/src/main/ui/fps-label.gd
+++ b/project/src/main/ui/fps-label.gd
@@ -3,7 +3,7 @@ extends Label
 Renders the current frames-per-second to the screen, '60.00 fps'
 """
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	text = "%.2f fps" % Engine.get_frames_per_second()
 
 

--- a/project/src/main/ui/menu/loading-screen.gd
+++ b/project/src/main/ui/menu/loading-screen.gd
@@ -8,7 +8,7 @@ func _ready() -> void:
 	ResourceCache.start_load()
 
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	$ProgressBar.value = 100.0 * ResourceCache.get_progress()
 
 

--- a/project/src/main/ui/menu/practice-difficulty-selector.gd
+++ b/project/src/main/ui/menu/practice-difficulty-selector.gd
@@ -8,7 +8,7 @@ signal difficulty_changed
 # difficulties which appear as tick mark labels
 var _difficulty_names: Array setget set_difficulty_names
 
-func _on_Slider_value_changed(value: float) -> void:
+func _on_Slider_value_changed(_value: float) -> void:
 	emit_signal("difficulty_changed")
 
 """

--- a/project/src/main/ui/menu/practice-menu.gd
+++ b/project/src/main/ui/menu/practice-menu.gd
@@ -70,7 +70,6 @@ func _ready() -> void:
 	# default mode/difficulty if the player hasn't played a scenario recently
 	var current_mode: String = "Ultra"
 	var current_difficulty: String = "Normal"
-	var current_scenario_name: String = "ultra-normal"
 	
 	for category_obj in SCENARIO_CATEGORIES:
 		var category: Array = category_obj
@@ -88,7 +87,6 @@ func _ready() -> void:
 		if scenario_name == Scenario.settings.name:
 			# if they've just played a practice mode scenario, we default to that scenario
 			current_mode = mode
-			current_scenario_name = scenario_name
 			current_difficulty = difficulty
 	
 	# grab focus so the player can navigate with the keyboard

--- a/project/src/main/ui/touch/eight-way.gd
+++ b/project/src/main/ui/touch/eight-way.gd
@@ -58,7 +58,7 @@ func _input(event: InputEvent) -> void:
 		_touch_dir = (event.position as Vector2 - center) / rect_scale
 		if _touch_dir.length() < RADIUS:
 			_touch_index = event.index
-			_press_buttons(event)
+			_press_buttons()
 		elif event.index == _touch_index:
 			_touch_index = -1
 			_release_buttons()
@@ -124,18 +124,18 @@ func _release_buttons() -> void:
 
 
 """
-Press the buttons associated with the specified touch event.
+Press the buttons associated with the newest touch event.
 
 This also emits InputEvents for any action buttons pressed or released.
 """
-func _press_buttons(event: InputEvent) -> void:
+func _press_buttons() -> void:
 	# cardinal direction; 0 = right, 1 = down, 2 = left, 3 = right
 	var touch_cardinal_dir := wrapi(round(2 * _touch_dir.angle() / PI), 0, 4)
 	
-	var up_right_pressed := _diagonalness(_touch_dir, Vector2(1.0, -1.0)) < up_right_weight
-	var up_left_pressed := _diagonalness(_touch_dir, Vector2(-1.0, -1.0)) < up_left_weight
-	var down_right_pressed := _diagonalness(_touch_dir, Vector2(1.0, 1.0)) < down_right_weight
-	var down_left_pressed := _diagonalness(_touch_dir, Vector2(-1.0, 1.0)) < down_left_weight
+	var up_right_pressed := _diagonalness(Vector2(1.0, -1.0)) < up_right_weight
+	var up_left_pressed := _diagonalness(Vector2(-1.0, -1.0)) < up_left_weight
+	var down_right_pressed := _diagonalness(Vector2(1.0, 1.0)) < down_right_weight
+	var down_left_pressed := _diagonalness(Vector2(-1.0, 1.0)) < down_left_weight
 	
 	_right.pressed = touch_cardinal_dir == 0 or up_right_pressed or down_right_pressed
 	_down.pressed = touch_cardinal_dir == 1 or down_right_pressed or down_left_pressed
@@ -149,5 +149,5 @@ Returns a number [0.0, 4.0] for how close the touch is to the specified diagonal
 0.0 = very close, 4.0 = very far. A value less than 1.0 indicates the touch is in the same correct quadrant as the
 diagonal.
 """
-func _diagonalness(_touch_dir: Vector2, diagonal_direction: Vector2) -> float:
+func _diagonalness(diagonal_direction: Vector2) -> float:
 	return abs(8 * _touch_dir.angle_to(diagonal_direction) / PI)

--- a/project/src/main/world/chat-icon.gd
+++ b/project/src/main/world/chat-icon.gd
@@ -32,7 +32,7 @@ func _ready() -> void:
 
 
 func _physics_process(delta: float) -> void:
-	bounce_phase += delta * (2.5 if focused else 1)
+	bounce_phase += delta * (2.5 if focused else 1.0)
 	if bounce_phase * BOUNCES_PER_SECOND * PI > 10.0:
 		# keep bounce_phase bounded, otherwise a sprite will jitter slightly 3 billion millenia from now
 		bounce_phase -= 2 / BOUNCES_PER_SECOND
@@ -85,11 +85,13 @@ func _refresh() -> void:
 	
 	if is_inside_tree():
 		if bubble_type == BubbleType.NONE:
-			get_parent().remove_from_group("chattables")
+			if get_parent().is_in_group("chattables"):
+				get_parent().remove_from_group("chattables")
 			if ChattableManager.is_connected("focus_changed", self, "_on_ChattableManager_focus_changed"):
 				ChattableManager.disconnect("focus_changed", self, "_on_ChattableManager_focus_changed")
 		else:
-			get_parent().add_to_group("chattables")
+			if not get_parent().is_in_group("chattables"):
+				get_parent().add_to_group("chattables")
 			ChattableManager.connect("focus_changed", self, "_on_ChattableManager_focus_changed")
 
 

--- a/project/src/main/world/creature/creature-2d.gd
+++ b/project/src/main/world/creature/creature-2d.gd
@@ -148,10 +148,6 @@ func orient_toward(target: Node2D) -> void:
 		_creature.set_orientation(Creature.Orientation.SOUTHWEST)
 
 
-func summon(creature_def: Dictionary, use_defaults: bool = true) -> void:
-	_creature.summon(creature_def, use_defaults)
-
-
 func play_hello_voice(force: bool = false) -> void:
 	_creature.play_hello_voice(force)
 
@@ -220,7 +216,6 @@ func _maybe_play_bonk_sound(old_non_iso_velocity: Vector2) -> void:
 
 
 func _update_animation() -> void:
-	var old_orientation: int = _creature.orientation
 	if _non_iso_walk_direction.length() > 0:
 		play_movement_animation("run", _non_iso_walk_direction)
 	elif _creature.movement_mode:

--- a/project/src/main/world/creature/creature-shadow.gd
+++ b/project/src/main/world/creature/creature-shadow.gd
@@ -19,7 +19,7 @@ func _ready() -> void:
 	visible = false
 
 
-func _physics_process(delta: float) -> void:
+func _physics_process(_delta: float) -> void:
 	visible = _creature.visible
 	position = _creature.position + _shadow_offset
 

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -25,14 +25,11 @@ signal before_creature_arrived
 # emitted when a creature arrives and sits down
 signal creature_arrived
 
-# emitted when a creature stands up and leaves.
-# creatures don't leave anymore, but they used to leave while new textures were loaded.
-signal creature_left
-
 # emitted when a movement animation starts (e.g Spira starts running in a direction)
 signal movement_animation_started(anim_name)
 
 # emitted during the 'run' animation when the creature touches the ground
+# warning-ignore:unused_signal
 signal landed
 
 signal orientation_changed(old_orientation, new_orientation)

--- a/project/src/main/world/creature/emote-anims.gd
+++ b/project/src/main/world/creature/emote-anims.gd
@@ -56,7 +56,7 @@ onready var _emote_sprites := [
 	$"../Sprites/Neck0/HeadBobber/EmoteGlow",
 ]
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	if Engine.is_editor_hint():
 		# avoid playing animations in editor. manually set frames instead
 		_apply_default_eye_frames()
@@ -245,7 +245,7 @@ func _apply_tool_script_workaround() -> void:
 		_creature = $".."
 
 
-func _on_animation_finished(anim_name) -> void:
+func _on_animation_finished(_anim_name: String) -> void:
 	if _prev_mood in EMOTE_ANIMS.keys():
 		unemote()
 		yield($ResetTween, "tween_all_completed")

--- a/project/src/main/world/creature/mouth-anims.gd
+++ b/project/src/main/world/creature/mouth-anims.gd
@@ -14,7 +14,7 @@ func _ready() -> void:
 	set_process(false)
 
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	if Engine.is_editor_hint():
 		# avoid playing animations in editor. manually set frames instead
 		_apply_default_frames()
@@ -67,6 +67,6 @@ func _on_Creature_before_creature_arrived() -> void:
 	_apply_default_frames()
 
 
-func _on_Creature_orientation_changed(old_orientation: int, new_orientation: int) -> void:
+func _on_Creature_orientation_changed(_old_orientation: int, _new_orientation: int) -> void:
 	if is_processing() and not Engine.is_editor_hint():
 		_play_mouth_ambient_animation()

--- a/project/src/main/world/overworld-camera.gd
+++ b/project/src/main/world/overworld-camera.gd
@@ -29,7 +29,7 @@ var close_up_position: Vector2
 onready var _spira: Spira = get_node(_spira_path)
 onready var _overworld_ui: OverworldUi = get_node(_overworld_ui_path)
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	# calculate the position to zoom in to
 	var bounding_box := Rect2(_spira.position, Vector2(0, 0))
 	for chatter in _overworld_ui.chatters:

--- a/project/src/main/world/restaurant/creature-view.gd
+++ b/project/src/main/world/restaurant/creature-view.gd
@@ -13,7 +13,7 @@ func _ready() -> void:
 	PuzzleScore.connect("combo_ended", self, "_on_PuzzleScore_combo_ended")
 
 
-func _physics_process(delta: float) -> void:
+func _physics_process(_delta: float) -> void:
 	if $FatPlayer.get_fatness() != get_creature_2d().get_fatness():
 		$FatPlayer.set_fatness(get_creature_2d().get_fatness())
 

--- a/project/src/main/world/restaurant/restaurant-scene.gd
+++ b/project/src/main/world/restaurant/restaurant-scene.gd
@@ -43,7 +43,7 @@ Parameters:
 	'creature_def': The colors and textures used to draw the creature.
 """
 func summon_creature(creature_def: Dictionary, creature_index: int = -1) -> void:
-	get_creature_2d(creature_index).summon(creature_def)
+	get_creature_2d(creature_index).set_creature_def(creature_def)
 	_get_seat(creature_index).refresh()
 
 


### PR DESCRIPTION
Ignored 'narrowing conversion' warnings. Working with TileMaps requires
narrowing conversions all over the place because of the lack of a Vector2i
class in GDScript. If Godot #18324
(https://github.com/godotengine/godot/issues/18324) is addressed then we can
unignore this warning.

Ignored 'return value discarded' warnings. Node.connect() returns an enum we do
not need, and we call this code 88 places within our code.  Alternatively we
could suppress this with 'var _err = connect' but I'm not a fan of making code
worse or more esoteric for the sake of suppressing warnings.

Removed unused Puzzle.topped_out signal.

Removed redundant Creature2D.summon method. This made sense when the
method was asynchronous, but now it simply sets the creature_ref.

Prepended unused parameters with underscores. Suppressed some warnings
which were false positives or deliberate things we're doing (e.g
deliberate integer division)