### PR TITLE
Improved Creature.tscn behavior in editor. Changed eye frames.

### DIFF
--- a/delint.sh
+++ b/delint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# analyzes code for stylistic errors, printing them to the console
+################################################################################
+# Analyzes code for stylistic errors, printing them to the console
 
 # functions missing return type
 grep -R -n "^func.*):$" --include="*.gd" ./project/src
@@ -17,8 +18,11 @@ grep -R -n "var [^:]* = " --include="*.gd" ./project/src \
   | grep -v " = parse_json(" \
   | grep -v "chat-event.gd:73"
 
-find ./project/src -name *.TMP
-find ./project/src -name *.gd~
+find ./project/src -name "*.TMP"
+find ./project/src -name "*.gd~"
 
 # project settings which are enabled temporarily, but shouldn't be pushed
 grep "emulate_touch_from_mouse=true" ./project/project.godot 
+
+# check for enabled creature tool scripts; these should be disabled before merging
+grep -lR "^tool #uncomment to view creature in editor" project/src/main/world/creature

--- a/edit-creature.sh
+++ b/edit-creature.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+################################################################################
+# This script toggles the 'tool' keyword for our creature scripts as a
+# workaround for Godot #40000
+# (https://github.com/godotengine/godot/issues/40000)
+#
+# edit-creature.sh on: Enable creature editing in the editor. This causes errors
+#     in the Godot console.
+#
+# edit-creature.sh off: Disable creature editing in the editor. This fixes the
+#     errors in the Godot console.
+
+tool_line='tool #uncomment to view creature in editor'
+
+if [ "$1" = "on" ]
+then
+  # uncomment 'tool' lines to allow editing
+  grep -lRZE "$tool_line" project/src/main/world/creature | xargs -0 -l sed -i "s/^#$tool_line/$tool_line/g"
+elif [ "$1" = "off" ]
+then
+  # comment out 'tool' lines to fix errors
+  grep -lRZE "$tool_line" project/src/main/world/creature | xargs -0 -l sed -i "s/^$tool_line/#$tool_line/g"
+else
+  echo "Usage:"
+  echo "  $0 on: Enable creature editing"
+  echo "  $0 off: Disable creature editing"
+fi

--- a/generate_export_presets.sh
+++ b/generate_export_presets.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 ################################################################################
 # This script generates our export_presets.cfg and project.godot files. It
 # updates version numbers and sensitive properties which cannot be kept in

--- a/project/assets/main/world/creature/1/eyes-packed.json
+++ b/project/assets/main/world/creature/1/eyes-packed.json
@@ -1,6 +1,6 @@
 { "frames": [
    {
-    "filename": "eyes-packed 0.png",
+    "filename": "eyes-1 0.png",
     "frame": { "x": 126, "y": 75, "w": 1, "h": 1 },
     "rotated": false,
     "trimmed": true,
@@ -9,7 +9,7 @@
     "duration": 100
    },
    {
-    "filename": "eyes-packed 1.png",
+    "filename": "eyes-1 1.png",
     "frame": { "x": 0, "y": 0, "w": 121, "h": 79 },
     "rotated": false,
     "trimmed": true,
@@ -18,7 +18,16 @@
     "duration": 100
    },
    {
-    "filename": "eyes-packed 2.png",
+    "filename": "eyes-1 2.png",
+    "frame": { "x": 126, "y": 75, "w": 1, "h": 1 },
+    "rotated": false,
+    "trimmed": true,
+    "spriteSourceSize": { "x": 0, "y": 0, "w": 1, "h": 1 },
+    "sourceSize": { "w": 512, "h": 512 },
+    "duration": 100
+   },
+   {
+    "filename": "eyes-1 3.png",
     "frame": { "x": 0, "y": 84, "w": 118, "h": 71 },
     "rotated": false,
     "trimmed": true,
@@ -27,7 +36,7 @@
     "duration": 100
    },
    {
-    "filename": "eyes-packed 3.png",
+    "filename": "eyes-1 4.png",
     "frame": { "x": 126, "y": 0, "w": 115, "h": 70 },
     "rotated": false,
     "trimmed": true,
@@ -38,7 +47,7 @@
  ],
  "meta": {
   "app": "http://www.aseprite.org/",
-  "version": "1.2.20-x64",
+  "version": "1.2.21-x64",
   "image": "eyes-packed.png",
   "format": "RGBA8888",
   "size": { "w": 241, "h": 155 },

--- a/project/assets/main/world/creature/2/eyes-packed.json
+++ b/project/assets/main/world/creature/2/eyes-packed.json
@@ -1,6 +1,6 @@
 { "frames": [
    {
-    "filename": "eyes-packed 0.png",
+    "filename": "eyes-1 0.png",
     "frame": { "x": 113, "y": 0, "w": 1, "h": 1 },
     "rotated": false,
     "trimmed": true,
@@ -9,7 +9,7 @@
     "duration": 100
    },
    {
-    "filename": "eyes-packed 1.png",
+    "filename": "eyes-1 1.png",
     "frame": { "x": 0, "y": 0, "w": 108, "h": 58 },
     "rotated": false,
     "trimmed": true,
@@ -18,7 +18,16 @@
     "duration": 100
    },
    {
-    "filename": "eyes-packed 2.png",
+    "filename": "eyes-1 2.png",
+    "frame": { "x": 113, "y": 0, "w": 1, "h": 1 },
+    "rotated": false,
+    "trimmed": true,
+    "spriteSourceSize": { "x": 0, "y": 0, "w": 1, "h": 1 },
+    "sourceSize": { "w": 512, "h": 512 },
+    "duration": 100
+   },
+   {
+    "filename": "eyes-1 3.png",
     "frame": { "x": 0, "y": 0, "w": 108, "h": 58 },
     "rotated": false,
     "trimmed": true,
@@ -27,7 +36,7 @@
     "duration": 100
    },
    {
-    "filename": "eyes-packed 3.png",
+    "filename": "eyes-1 4.png",
     "frame": { "x": 0, "y": 0, "w": 108, "h": 58 },
     "rotated": false,
     "trimmed": true,
@@ -38,7 +47,7 @@
  ],
  "meta": {
   "app": "http://www.aseprite.org/",
-  "version": "1.2.20-x64",
+  "version": "1.2.21-x64",
   "image": "eyes-packed.png",
   "format": "RGBA8888",
   "size": { "w": 114, "h": 58 },

--- a/project/assets/main/world/creature/3/eyes-packed.json
+++ b/project/assets/main/world/creature/3/eyes-packed.json
@@ -1,6 +1,6 @@
 { "frames": [
    {
-    "filename": "eyes-packed 0.png",
+    "filename": "eyes-1 0.png",
     "frame": { "x": 240, "y": 0, "w": 1, "h": 1 },
     "rotated": false,
     "trimmed": true,
@@ -9,7 +9,7 @@
     "duration": 100
    },
    {
-    "filename": "eyes-packed 1.png",
+    "filename": "eyes-1 1.png",
     "frame": { "x": 0, "y": 0, "w": 115, "h": 81 },
     "rotated": false,
     "trimmed": true,
@@ -18,7 +18,16 @@
     "duration": 100
    },
    {
-    "filename": "eyes-packed 2.png",
+    "filename": "eyes-1 2.png",
+    "frame": { "x": 240, "y": 0, "w": 1, "h": 1 },
+    "rotated": false,
+    "trimmed": true,
+    "spriteSourceSize": { "x": 0, "y": 0, "w": 1, "h": 1 },
+    "sourceSize": { "w": 512, "h": 512 },
+    "duration": 100
+   },
+   {
+    "filename": "eyes-1 3.png",
     "frame": { "x": 120, "y": 0, "w": 115, "h": 73 },
     "rotated": false,
     "trimmed": true,
@@ -27,7 +36,7 @@
     "duration": 100
    },
    {
-    "filename": "eyes-packed 3.png",
+    "filename": "eyes-1 4.png",
     "frame": { "x": 120, "y": 78, "w": 117, "h": 66 },
     "rotated": false,
     "trimmed": true,
@@ -38,7 +47,7 @@
  ],
  "meta": {
   "app": "http://www.aseprite.org/",
-  "version": "1.2.20-x64",
+  "version": "1.2.21-x64",
   "image": "eyes-packed.png",
   "format": "RGBA8888",
   "size": { "w": 241, "h": 144 },

--- a/project/project.godot
+++ b/project/project.godot
@@ -114,6 +114,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/world/creature/creature-loader.gd"
 }, {
+"base": "PackedSprite",
+"class": "CreaturePackedSprite",
+"language": "GDScript",
+"path": "res://src/main/world/creature/creature-packed-sprite.gd"
+}, {
 "base": "Node2D",
 "class": "CreatureVisuals",
 "language": "GDScript",
@@ -391,6 +396,7 @@ _global_script_class_icons={
 "Connect": "",
 "Creature": "",
 "CreatureLoader": "",
+"CreaturePackedSprite": "",
 "CreatureVisuals": "",
 "EditorPlayfield": "",
 "FontFitLabel": "",

--- a/project/src/main/packed-sprite.gd
+++ b/project/src/main/packed-sprite.gd
@@ -79,6 +79,8 @@ Loads the Aseprite json file.
 Stores the offset and region_rect for each frame.
 """
 func _load_frame_data() -> void:
+	_frame_src_rects.clear()
+	_frame_dest_rects.clear()
 	if not frame_data:
 		return
 	
@@ -92,8 +94,6 @@ func _load_frame_data() -> void:
 		json_frames = json_root["frames"].values()
 	
 	# store json frame data as Rect2 instances
-	_frame_src_rects.clear()
-	_frame_dest_rects.clear()
 	for json_frame in json_frames:
 		_frame_src_rects.append(json_to_rect2(json_frame["frame"]))
 		_frame_dest_rects.append(json_to_rect2(json_frame["spriteSourceSize"]))

--- a/project/src/main/world/creature/Creature.tscn
+++ b/project/src/main/world/creature/Creature.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=82 format=2]
+[gd_scene load_steps=76 format=2]
 
 [ext_resource path="res://src/main/world/rgb-palette.shader" type="Shader" id=1]
 [ext_resource path="res://src/main/world/creature/creature-visuals.gd" type="Script" id=2]
@@ -10,7 +10,6 @@
 [ext_resource path="res://assets/main/ui/chat/emote-rage1.wav" type="AudioStream" id=8]
 [ext_resource path="res://assets/main/world/creature/1/emote-arms-packed.png" type="Texture" id=9]
 [ext_resource path="res://assets/main/world/creature/1/emote-brain-packed.png" type="Texture" id=10]
-[ext_resource path="res://assets/main/world/creature/1/movement-z0-packed.png" type="Texture" id=11]
 [ext_resource path="res://assets/main/ui/chat/emote-rage0.wav" type="AudioStream" id=12]
 [ext_resource path="res://assets/main/world/creature/1/emote-body-packed.png" type="Texture" id=13]
 [ext_resource path="res://assets/main/ui/chat/emote-laugh1.wav" type="AudioStream" id=14]
@@ -30,11 +29,6 @@
 [ext_resource path="res://src/main/world/creature/creature-packed-sprite.gd" type="Script" id=28]
 [ext_resource path="res://src/main/world/creature/emote-anims.gd" type="Script" id=29]
 [ext_resource path="res://src/main/world/creature/mouth-anims.gd" type="Script" id=30]
-[ext_resource path="res://assets/main/world/creature/1/leg-z0-packed.png" type="Texture" id=32]
-[ext_resource path="res://assets/main/world/creature/1/arm-z0-packed.png" type="Texture" id=34]
-[ext_resource path="res://assets/main/world/creature/1/neck-packed.png" type="Texture" id=35]
-[ext_resource path="res://assets/main/world/creature/1/leg-z1-packed.png" type="Texture" id=42]
-[ext_resource path="res://assets/main/world/creature/1/arm-z1-packed.png" type="Texture" id=43]
 
 [sub_resource type="ShaderMaterial" id=1]
 resource_local_to_scene = true
@@ -140,7 +134,6 @@ shader_param/black = Color( 0, 0, 0, 1 )
 
 [sub_resource type="CanvasItemMaterial" id=14]
 resource_local_to_scene = true
-blend_mode = 1
 
 [sub_resource type="ShaderMaterial" id=15]
 resource_local_to_scene = true
@@ -506,7 +499,7 @@ tracks/0/keys = {
 "times": PoolRealArray( 0, 7.86667, 7.9, 7.93333, 7.96667 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 1, 1, 3, 2, 1 ]
+"values": [ 1, 1, 4, 3, 1 ]
 }
 tracks/1/type = "method"
 tracks/1/path = NodePath("EmoteAnims")
@@ -827,7 +820,7 @@ tracks/0/keys = {
 "times": PoolRealArray( 0, 0.0333333, 0.0666667, 0.533333, 0.566667, 0.6 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 1, 2, 3, 3, 2, 1 ]
+"values": [ 1, 3, 4, 4, 3, 1 ]
 }
 
 [sub_resource type="Animation" id=31]
@@ -843,7 +836,7 @@ tracks/0/keys = {
 "times": PoolRealArray( 0, 0.699999, 0.733333, 0.766667 ),
 "transitions": PoolRealArray( 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 3, 3, 2, 1 ]
+"values": [ 4, 4, 3, 1 ]
 }
 
 [sub_resource type="Animation" id=32]
@@ -2228,6 +2221,45 @@ script = ExtResource( 3 )
 
 [node name="Visuals" type="Node2D" parent="."]
 script = ExtResource( 2 )
+creature_def = {
+"property:Body:fill_color": Color( 0, 0, 0, 1 ),
+"property:Body:line_color": Color( 0, 0, 0, 1 ),
+"shader:Body/NeckBlend:black": Color( 0, 0, 0, 1 ),
+"shader:Body/NeckBlend:red": Color( 0, 0, 0, 1 ),
+"shader:EmoteBody:black": Color( 0, 0, 0, 1 ),
+"shader:FarArm:black": Color( 0, 0, 0, 1 ),
+"shader:FarArm:red": Color( 0, 0, 0, 1 ),
+"shader:FarLeg:black": Color( 0, 0, 0, 1 ),
+"shader:FarLeg:red": Color( 0, 0, 0, 1 ),
+"shader:NearArm:black": Color( 0, 0, 0, 1 ),
+"shader:NearArm:red": Color( 0, 0, 0, 1 ),
+"shader:NearLeg:black": Color( 0, 0, 0, 1 ),
+"shader:NearLeg:red": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/EarZ0:black": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/EarZ0:red": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/EarZ1:black": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/EarZ1:red": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/EarZ2:black": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/EarZ2:red": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/EmoteArms:black": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/EmoteArms:red": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/EmoteBrain:black": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/EmoteEyes:black": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/Eyes:black": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/Eyes:blue": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/Eyes:green": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/Eyes:red": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/Head:black": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/Head:red": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/HornZ0:black": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/HornZ0:green": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/HornZ0:red": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/HornZ1:black": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/HornZ1:green": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/HornZ1:red": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/Mouth:black": Color( 0, 0, 0, 1 ),
+"shader:Neck0/HeadBobber/Mouth:red": Color( 0, 0, 0, 1 )
+}
 
 [node name="Viewport" type="Viewport" parent="Visuals"]
 size = Vector2( 1024, 1024 )
@@ -2245,8 +2277,6 @@ light_mask = 2
 material = SubResource( 1 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 27 )
-texture = ExtResource( 11 )
-frame_data = "res://assets/main/world/creature/1/movement-z0-packed.json"
 rect_size = Vector2( 512, 512 )
 offset = Vector2( 0, -119 )
 
@@ -2255,8 +2285,6 @@ light_mask = 2
 material = SubResource( 2 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 28 )
-texture = ExtResource( 34 )
-frame_data = "res://assets/main/world/creature/1/arm-z0-packed.json"
 rect_size = Vector2( 512, 512 )
 frame = 1
 offset = Vector2( 0, -119 )
@@ -2267,8 +2295,6 @@ light_mask = 2
 material = SubResource( 3 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 28 )
-texture = ExtResource( 32 )
-frame_data = "res://assets/main/world/creature/1/leg-z0-packed.json"
 rect_size = Vector2( 512, 512 )
 frame = 1
 offset = Vector2( 0, -119 )
@@ -2295,18 +2321,14 @@ position = Vector2( -1.11823, -102.515 )
 rotation = 3.13804
 scale = Vector2( 0.836, -0.836 )
 script = ExtResource( 28 )
-texture = ExtResource( 35 )
-frame_data = "res://assets/main/world/creature/1/neck-packed.json"
 rect_size = Vector2( 512, 512 )
-frame = 2
+frame = 1
 
 [node name="NearLeg" type="Node2D" parent="Visuals/Viewport/Sprites"]
 light_mask = 2
 material = SubResource( 6 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 28 )
-texture = ExtResource( 42 )
-frame_data = "res://assets/main/world/creature/1/leg-z1-packed.json"
 rect_size = Vector2( 512, 512 )
 frame = 1
 offset = Vector2( 0, -119 )
@@ -2317,8 +2339,6 @@ light_mask = 2
 material = SubResource( 1 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 28 )
-texture = ExtResource( 43 )
-frame_data = "res://assets/main/world/creature/1/arm-z1-packed.json"
 rect_size = Vector2( 512, 512 )
 frame = 1
 offset = Vector2( 0, -119 )
@@ -2408,7 +2428,7 @@ show_behind_parent = true
 light_mask = 2
 material = SubResource( 12 )
 scale = Vector2( 2, 2 )
-script = ExtResource( 27 )
+script = ExtResource( 28 )
 rect_size = Vector2( 512, 512 )
 frame = 1
 
@@ -2514,7 +2534,6 @@ anims/ambient-se = SubResource( 19 )
 anims/eat = SubResource( 20 )
 anims/eat-again = SubResource( 21 )
 script = ExtResource( 30 )
-mouth_path = NodePath("../Viewport/Sprites/Neck0/HeadBobber/Mouth")
 
 [node name="Mouth1Anims" type="AnimationPlayer" parent="Visuals"]
 anims/ambient-nw = SubResource( 22 )
@@ -2522,7 +2541,6 @@ anims/ambient-se = SubResource( 23 )
 anims/eat = SubResource( 24 )
 anims/eat-again = SubResource( 25 )
 script = ExtResource( 30 )
-mouth_path = NodePath("../Viewport/Sprites/Neck0/HeadBobber/Mouth")
 
 [node name="EmoteAnims" type="AnimationPlayer" parent="Visuals"]
 anims/ambient = SubResource( 26 )
@@ -2542,7 +2560,6 @@ anims/sweat1 = SubResource( 39 )
 anims/think0 = SubResource( 40 )
 anims/think1 = SubResource( 41 )
 script = ExtResource( 29 )
-eyes_path = NodePath("../Viewport/Sprites/Neck0/HeadBobber/Eyes")
 
 [node name="ResetTween" type="Tween" parent="Visuals/EmoteAnims"]
 
@@ -2591,35 +2608,35 @@ bus = "Sound Bus"
 stream = ExtResource( 5 )
 volume_db = -4.0
 bus = "Sound Bus"
+[connection signal="before_creature_arrived" from="Visuals" to="Visuals/EmoteAnims" method="_on_CreatureVisuals_before_creature_arrived"]
 [connection signal="before_creature_arrived" from="Visuals" to="Visuals/Mouth0Anims" method="_on_CreatureVisuals_before_creature_arrived"]
 [connection signal="before_creature_arrived" from="Visuals" to="Visuals/Mouth1Anims" method="_on_CreatureVisuals_before_creature_arrived"]
-[connection signal="before_creature_arrived" from="Visuals" to="Visuals/EmoteAnims" method="_on_CreatureVisuals_before_creature_arrived"]
 [connection signal="creature_arrived" from="Visuals" to="." method="_on_CreatureVisuals_creature_arrived"]
 [connection signal="creature_arrived" from="Visuals" to="CreatureSfx" method="_on_CreatureVisuals_creature_arrived"]
 [connection signal="food_eaten" from="Visuals" to="CreatureSfx" method="_on_CreatureVisuals_food_eaten"]
 [connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/Body" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/NearLeg" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/FarArm" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/FarLeg" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/Body/NeckBlend" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/NearArm" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/Head" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="Visuals" to="Visuals/Viewport/Sprites/FarLeg" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="orientation_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="Visuals" to="Visuals/Viewport/Sprites/NearLeg" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="Visuals" to="Visuals/Viewport/Sprites/FarArm" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="Visuals" to="Visuals/Viewport/Sprites/FarLeg" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="Visuals" to="Visuals/Viewport/Sprites/Body/NeckBlend" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="Visuals" to="Visuals/Viewport/Sprites/NearArm" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="Visuals" to="Visuals/Viewport/Sprites/Neck0/HeadBobber/Head" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="Visuals" to="Visuals/Viewport/Sprites/FarLeg" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="Visuals" to="Visuals/Mouth0Anims" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="Visuals" to="Visuals/Mouth1Anims" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="animation_finished" from="Visuals/EmoteAnims" to="Visuals/EmoteAnims" method="_on_animation_finished"]

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -78,7 +78,7 @@ func _load_texture(creature_def: Dictionary, node_path: String, key: String, fil
 	# load the texture resource
 	var resource_path: String
 	var frame_data: String
-	var resource: Resource;
+	var resource: Resource
 	if not creature_def.has(key):
 		# The key was not specified in the creature definition. This is not an error condition, a creature might not
 		# have an 'ear' key if she doesn't have ears.
@@ -211,3 +211,35 @@ func _load_colors(creature_def: Dictionary) -> void:
 		horn_color = Color(creature_def.horn_rgb)
 	creature_def["shader:Neck0/HeadBobber/HornZ0:green"] = horn_color
 	creature_def["shader:Neck0/HeadBobber/HornZ1:green"] = horn_color
+
+
+"""
+If the specified key is not associated with a value, this method associates it with the given value.
+"""
+static func put_if_absent(creature_def: Dictionary, key: String, value) -> void:
+	creature_def[key] = creature_def.get(key, value)
+
+
+"""
+Fill in the creature's missing traits with random values.
+
+Otherwise, missing values will be left empty, leading to invisible body parts or strange colors.
+"""
+static func fill_creature_def(creature_def: Dictionary) -> Dictionary:
+	# duplicate the creature_def so that we don't modify the original
+	var result := creature_def.duplicate()
+	put_if_absent(result, "line_rgb", "6c4331")
+	put_if_absent(result, "body_rgb", "b23823")
+	put_if_absent(result, "eye_rgb", "282828 dedede")
+	put_if_absent(result, "horn_rgb", "f1e398")
+	
+	if ResourceCache.minimal_resources:
+		# avoid loading unnecessary resources for things like the level editor
+		pass
+	else:
+		put_if_absent(result, "eye", ["1", "1", "1", "2", "3"][randi() % 5])
+		put_if_absent(result, "ear", ["1", "1", "1", "2", "3"][randi() % 5])
+		put_if_absent(result, "horn", ["0", "0", "0", "1", "2"][randi() % 5])
+		put_if_absent(result, "mouth", ["1", "1", "2"][randi() % 3])
+	put_if_absent(result, "body", "1")
+	return result

--- a/project/src/main/world/creature/creature-packed-sprite.gd
+++ b/project/src/main/world/creature/creature-packed-sprite.gd
@@ -1,5 +1,5 @@
-# uncomment to view creature in editor
-#tool
+#tool #uncomment to view creature in editor
+class_name CreaturePackedSprite
 extends PackedSprite
 """
 Sprites which toggles between a single 'toward the camera' and 'away from the camera' frame
@@ -7,17 +7,20 @@ Sprites which toggles between a single 'toward the camera' and 'away from the ca
 
 export (bool) var invisible_while_moving := false
 
-func _on_CreatureVisuals_orientation_changed(old_orientation: int, new_orientation: int) -> void:
-	if new_orientation in [Creature.SOUTHWEST, Creature.SOUTHEAST]:
-		if old_orientation in [Creature.SOUTHWEST, Creature.SOUTHEAST]:
-			# we were already facing southwest/southeast; don't interrupt our animation
-			pass
-		else:
-			# facing south; initialize textures to forward-facing frame
-			set_frame(1)
+func update_orientation(orientation: int) -> void:
+	if orientation in [CreatureVisuals.SOUTHWEST, CreatureVisuals.SOUTHEAST]:
+		# facing south; initialize textures to forward-facing frame
+		set_frame(1)
 	else:
 		# facing north; initialize textures to backward-facing frame
 		set_frame(2)
+
+
+func _on_CreatureVisuals_orientation_changed(old_orientation: int, new_orientation: int) -> void:
+	if (new_orientation in [CreatureVisuals.SOUTHWEST, CreatureVisuals.SOUTHEAST]) \
+			!= (old_orientation in [CreatureVisuals.SOUTHWEST, CreatureVisuals.SOUTHEAST]):
+		# we went from facing south to north, or from facing north to south
+		update_orientation(new_orientation)
 
 
 func _on_CreatureVisuals_movement_mode_changed(movement_mode: bool) -> void:

--- a/project/src/main/world/creature/creature-sprite.gd
+++ b/project/src/main/world/creature/creature-sprite.gd
@@ -1,5 +1,4 @@
-# uncomment to view creature in editor
-#tool
+#tool #uncomment to view creature in editor
 extends Sprite
 """
 Sprites which toggles between a single 'toward the camera' and 'away from the camera' frame

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -43,7 +43,7 @@ var _non_iso_velocity := Vector2.ZERO
 var _iso_walk_direction := Vector2.ZERO
 var _non_iso_walk_direction := Vector2.ZERO
 
-onready var _creature: CreatureVisuals = $Visuals
+onready var _creature_visuals: CreatureVisuals = $Visuals
 
 func _ready() -> void:
 	_refresh()
@@ -59,11 +59,11 @@ func _physics_process(delta: float) -> void:
 
 
 func set_fatness(new_fatness: float) -> void:
-	_creature.set_fatness(new_fatness)
+	_creature_visuals.set_fatness(new_fatness)
 
 
 func get_fatness() -> float:
-	return _creature.get_fatness()
+	return _creature_visuals.get_fatness()
 
 
 func set_non_iso_walk_direction(new_direction: Vector2) -> void:
@@ -111,7 +111,7 @@ Parameters:
 	'movement_direction': A vector in the (X, Y) direction the creature is moving.
 """
 func play_movement_animation(animation_prefix: String, movement_direction: Vector2 = Vector2.ZERO) -> void:
-	_creature.play_movement_animation(animation_prefix, movement_direction)
+	_creature_visuals.play_movement_animation(animation_prefix, movement_direction)
 
 
 """
@@ -121,14 +121,14 @@ Parameters:
 	'mood': The creature's new mood from ChatEvent.Mood
 """
 func play_mood(mood: int) -> void:
-	_creature.play_mood(mood)
+	_creature_visuals.play_mood(mood)
 
 
 """
 Orients this creature so they're facing the specified target.
 """
 func orient_toward(target: Node2D) -> void:
-	if not _creature.is_idle():
+	if not _creature_visuals.is_idle():
 		# don't change this creature's orientation if they're performing an activity
 		return
 	
@@ -143,10 +143,10 @@ func orient_toward(target: Node2D) -> void:
 
 	if direction_dot > 0:
 		# the target is to the right; face right
-		_creature.set_orientation(SOUTHEAST)
+		_creature_visuals.set_orientation(SOUTHEAST)
 	elif direction_dot < 0:
 		# the target is to the left; face left
-		_creature.set_orientation(SOUTHWEST)
+		_creature_visuals.set_orientation(SOUTHWEST)
 
 
 """
@@ -171,13 +171,14 @@ func play_goodbye_voice(force: bool = false) -> void:
 
 
 func feed(food_color: Color) -> void:
-	_creature.feed(food_color)
+	_creature_visuals.feed(food_color)
 
 
 func _refresh() -> void:
 	if is_inside_tree():
 		if creature_def:
-			_creature.summon(creature_def)
+			var filled_creature_def := CreatureLoader.fill_creature_def(creature_def)
+			_creature_visuals.creature_def = filled_creature_def
 		if not chat_id:
 			$ChatIcon.bubble_type = ChatIcon.BubbleType.NONE
 
@@ -228,7 +229,7 @@ func _maybe_play_bonk_sound(old_non_iso_velocity: Vector2) -> void:
 func _update_animation() -> void:
 	if _non_iso_walk_direction.length() > 0:
 		play_movement_animation("run", _non_iso_walk_direction)
-	elif _creature.movement_mode:
+	elif _creature_visuals.movement_mode:
 		play_movement_animation("idle", _non_iso_velocity)
 
 

--- a/project/src/main/world/creature/head-bobber.gd
+++ b/project/src/main/world/creature/head-bobber.gd
@@ -49,6 +49,12 @@ func _process(delta: float) -> void:
 		position.y = -100
 
 
+func reset_head_bob() -> void:
+	set_head_bob_mode(BOB_BOB)
+	head_motion_pixels = HEAD_BOB_PIXELS
+	head_motion_seconds = HEAD_BOB_SECONDS
+
+
 func set_head_bob_mode(new_mode: int) -> void:
 	head_bob_mode = new_mode
 	# Some head bob animations like 'shudder' offset the x position; reset it back to the center

--- a/project/src/main/world/creature/mouth-anims.gd
+++ b/project/src/main/world/creature/mouth-anims.gd
@@ -1,47 +1,29 @@
-# uncomment to view creature in editor
-#tool
+#tool #uncomment to view creature in editor
 extends AnimationPlayer
 """
 An AnimationPlayer which animates mouths.
 """
 
-export (NodePath) var mouth_path: NodePath
-
-onready var _mouth: PackedSprite = get_node(mouth_path)
-onready var _creature: CreatureVisuals = $".."
+onready var _creature_visuals: CreatureVisuals = $".."
 
 func _ready() -> void:
 	set_process(false)
 
 
 func _process(_delta: float) -> void:
-	if Engine.is_editor_hint():
-		# avoid playing animations in editor. manually set frames instead
-		_apply_default_frames()
-	else:
-		if not is_playing():
-			_play_mouth_ambient_animation()
+	if not Engine.is_editor_hint():
+		# avoid playing animations in editor
+		_play_mouth_ambient_animation()
 
 
 """
 Plays an appropriate mouth ambient animation for the creature's orientation.
 """
 func _play_mouth_ambient_animation() -> void:
-	if _creature.orientation in [Creature.SOUTHWEST, Creature.SOUTHEAST]:
+	if _creature_visuals.orientation in [Creature.SOUTHWEST, Creature.SOUTHEAST]:
 		play("ambient-se")
 	else:
 		play("ambient-nw")
-
-
-"""
-Updates the frame to something appropriate for the creature's orientation.
-
-Usually the frame is controlled by an animation. But when it's not, this ensures it still looks reasonable.
-"""
-func _apply_default_frames() -> void:
-	if Engine.is_editor_hint():
-		_apply_tool_script_workaround()
-	_mouth.frame = 1 if _creature.orientation in [Creature.SOUTHWEST, Creature.SOUTHEAST] else 2
 
 
 """
@@ -53,9 +35,8 @@ functionality and throws errors when it is used as a tool. This function manuall
 problems.
 """
 func _apply_tool_script_workaround() -> void:
-	if not _creature:
-		_mouth = get_node(mouth_path)
-		_creature = $".."
+	if not _creature_visuals:
+		_creature_visuals = $".."
 
 
 """
@@ -64,7 +45,9 @@ Reset the mouth frame when loading a new creature appearance.
 If we don't reset the eye frame, we have one strange transition frame.
 """
 func _on_CreatureVisuals_before_creature_arrived() -> void:
-	_apply_default_frames()
+	if Engine.is_editor_hint():
+		_apply_tool_script_workaround()
+	_creature_visuals.reset_frames()
 
 
 func _on_CreatureVisuals_orientation_changed(_old_orientation: int, _new_orientation: int) -> void:

--- a/project/src/main/world/viewport-outline-material.tres
+++ b/project/src/main/world/viewport-outline-material.tres
@@ -6,5 +6,5 @@
 resource_local_to_scene = true
 shader = ExtResource( 1 )
 shader_param/width = 2.5
-shader_param/black = Color( 0.423529, 0.262745, 0.192157, 1 )
+shader_param/black = Color( 0.254902, 0.156863, 0.117647, 1 )
 shader_param/edge_fix_factor = 0.001


### PR DESCRIPTION
Creature tool scripts can now be toggled with an `edit-creature.sh`
shell script. The creature's appearance can be manipulated and reset with
three new properties, 'reset_frames', 'reset_creature' and
'random_creature'.

Eyes now have a north-facing frame 2, just like mouths and other body
parts. This lets eyes reuse the same 'CreaturePackedSprite' logic as all
other body parts. Eyes aren't visible when facing away, but eventually they
might be. (When that happens we'll need them on a different Z-layer than they
are now.)

Split 'fill_creature_def' function out of 'summon'. 'Summon' is now just
'set_creature_def'.

Minor refactoring. Fixed inconsistencies in shell scripts (unquoted
strings, header style). Renamed inaccurate 'creature' fields to
'creature_visuals'.