### PR TITLE
Refactoring: classes reuse magic numbers (sizes, positions)

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -300,6 +300,11 @@ _global_script_classes=[ {
 "path": "res://src/main/puzzle/puzzle.gd"
 }, {
 "base": "Reference",
+"class": "PuzzleAreas",
+"language": "GDScript",
+"path": "res://src/main/puzzle/puzzle-areas.gd"
+}, {
+"base": "Reference",
 "class": "PuzzlePerformance",
 "language": "GDScript",
 "path": "res://src/main/puzzle/puzzle-performance.gd"
@@ -468,6 +473,7 @@ _global_script_class_icons={
 "PieceTypeRules": "",
 "Playfield": "",
 "Puzzle": "",
+"PuzzleAreas": "",
 "PuzzlePerformance": "",
 "PuzzleTileMap": "",
 "RankCalculator": "",

--- a/project/src/main/puzzle/Playfield.tscn
+++ b/project/src/main/puzzle/Playfield.tscn
@@ -276,8 +276,8 @@ bus = "Sound Bus"
 [node name="BuildSnackBoxSound" type="AudioStreamPlayer" parent="BuildBoxSfx"]
 bus = "Sound Bus"
 [connection signal="after_piece_written" from="." to="ComboTracker" method="_on_Playfield_after_piece_written"]
-[connection signal="before_line_cleared" from="." to="TileMapClip/PlayfieldFx" method="_on_Playfield_before_line_cleared"]
 [connection signal="before_line_cleared" from="." to="TileMapClip/LeafPoofs" method="_on_Playfield_before_line_cleared"]
+[connection signal="before_line_cleared" from="." to="TileMapClip/PlayfieldFx" method="_on_Playfield_before_line_cleared"]
 [connection signal="before_line_cleared" from="." to="LineClearSfx" method="_on_Playfield_before_line_cleared"]
 [connection signal="before_line_cleared" from="." to="ComboTracker" method="_on_Playfield_before_line_cleared"]
 [connection signal="box_built" from="." to="TileMapClip/PlayfieldFx" method="_on_Playfield_box_built"]

--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -184,6 +184,8 @@ __meta__ = {
 z_index = 1
 script = ExtResource( 24 )
 puzzle_tile_map_path = NodePath("../Playfield/TileMapClip/TileMap")
+playfield_path = NodePath("../Playfield")
+next_piece_displays_path = NodePath("../NextPieceDisplays")
 
 [node name="GlobViewports" type="Node" parent="FrostingGlobs"]
 
@@ -398,7 +400,6 @@ script = ExtResource( 19 )
 [connection signal="line_cleared" from="Playfield" to="." method="_on_Playfield_line_cleared"]
 [connection signal="squish_moved" from="PieceManager" to="FrostingGlobs" method="_on_PieceManager_squish_moved"]
 [connection signal="topped_out" from="PieceManager" to="TopOutTracker" method="_on_PieceManager_topped_out"]
-[connection signal="hit_gutter" from="FrostingGlobs" to="FrostingSfx" method="_on_FrostingGlobs_hit_gutter"]
 [connection signal="hit_next_pieces" from="FrostingGlobs" to="FrostingSfx" method="_on_FrostingGlobs_hit_next_pieces"]
 [connection signal="hit_playfield" from="FrostingGlobs" to="Playfield" method="_on_FrostingGlobs_hit_playfield"]
 [connection signal="hit_playfield" from="FrostingGlobs" to="FrostingSfx" method="_on_FrostingGlobs_hit_playfield"]

--- a/project/src/main/puzzle/frosting-glob.gd
+++ b/project/src/main/puzzle/frosting-glob.gd
@@ -13,22 +13,8 @@ signal hit_playfield(glob)
 # emitted when the glob smears against the next piece area
 signal hit_next_pieces(glob)
 
-# emitted when the glob smears against the gutter below the next piece area
-signal hit_gutter(glob)
-
 const MAX_INITIAL_VELOCITY := Vector2(600, -500)
 const GRAVITY := 2400
-
-# the area within the four outer walls
-const WALLED_AREA := Rect2(364, 28, 388, 544)
-
-# the playfield area behind the blocks
-const PLAYFIELD_AREA := Rect2(364, 28, 324, 544)
-
-const NEXT_PIECES_AREA := Rect2(688, 28, 64, 484)
-
-# the gutter below the next piece area
-const GUTTER_AREA := Rect2(688, 512, 64, 60)
 
 # how long globs are visible while falling
 const FALL_DURATION := 0.6
@@ -41,6 +27,8 @@ const FADE_DURATION := 1.5
 
 # the duration when a glob should be recycled, even if it's somehow still visible
 const MAX_AGE := 7.0
+
+var puzzle_areas: PuzzleAreas
 
 # the PuzzleTileMap food color index for this glob (brown, pink, bread, white, cake)
 var color_int := -1
@@ -67,6 +55,7 @@ Parameters:
 """
 func copy_from(glob: Node) -> void:
 	initialize(glob.color_int, glob.position)
+	puzzle_areas = glob.puzzle_areas
 	falling = glob.falling
 	velocity = glob.velocity
 	smear_time = glob.smear_time
@@ -85,7 +74,7 @@ func is_rainbow() -> bool:
 
 
 """
-Resets this frosting glob's state, including its color and position, and adds it to the scene tree.
+Resets this frosting glob's state, including its color and position.
 """
 func initialize(new_color_int: int, new_position: Vector2) -> void:
 	_creation_time = OS.get_ticks_msec()
@@ -159,14 +148,12 @@ func _process(delta: float)  -> void:
 	if smear_time > 0.0:
 		smear_time -= delta
 		if smear_time <= 0.0:
-			if PLAYFIELD_AREA.has_point(position):
+			if puzzle_areas.playfield_area.has_point(position):
 				emit_signal("hit_playfield", self)
-			elif NEXT_PIECES_AREA.has_point(position):
+			elif puzzle_areas.next_pieces_area.has_point(position):
 				emit_signal("hit_next_pieces", self)
-			elif GUTTER_AREA.has_point(position):
-				emit_signal("hit_gutter", self)
 	
-	if not WALLED_AREA.has_point(position):
+	if not puzzle_areas.walled_area.has_point(position):
 		emit_signal("hit_wall", self)
 
 

--- a/project/src/main/puzzle/puzzle-areas.gd
+++ b/project/src/main/puzzle/puzzle-areas.gd
@@ -1,0 +1,13 @@
+class_name PuzzleAreas
+"""
+Positional information about the puzzle screen for frosting physics.
+"""
+
+# the playfield area behind the blocks
+var playfield_area: Rect2
+
+# the upper area behind the next pieces
+var next_pieces_area: Rect2
+
+# the area within the four outer walls
+var walled_area: Rect2

--- a/project/src/main/puzzle/wall-frosting-sfx.gd
+++ b/project/src/main/puzzle/wall-frosting-sfx.gd
@@ -55,7 +55,3 @@ func _on_FrostingGlobs_hit_playfield(glob: FrostingGlob) -> void:
 
 func _on_FrostingGlobs_hit_next_pieces(glob: FrostingGlob) -> void:
 	_play_sfx(glob.modulate.a, -20.0)
-
-
-func _on_FrostingGlobs_hit_gutter(glob: FrostingGlob) -> void:
-	_play_sfx(glob.modulate.a, -20.0)

--- a/project/src/main/ui/chat/ChatFrame.tscn
+++ b/project/src/main/ui/chat/ChatFrame.tscn
@@ -213,7 +213,7 @@ script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
-sizes = [ Vector2( 360, 80 ), Vector2( 540, 80 ), Vector2( 540, 120 ), Vector2( 720, 120 ) ]
+chat_line_panel_path = NodePath("../ChatLinePanel")
 
 [node name="BebebeSound" type="AudioStreamPlayer" parent="ChatLineLabel"]
 stream = ExtResource( 13 )

--- a/project/src/main/ui/chat/chat-line-label.gd
+++ b/project/src/main/ui/chat/chat-line-label.gd
@@ -23,6 +23,8 @@ const PAUSE_CHARACTERS := {
 	"\n": 0.80,
 }
 
+export (NodePath) var chat_line_panel_path: NodePath
+
 # Stores the delay in seconds for each visible_characters index.
 var _visible_character_pauses := {}
 
@@ -32,7 +34,16 @@ var _pause := 0.0
 # 1.0 = slow, 2.0 = normal, 3.0 = faster, 5.0 = fastest, 1000000.0 = fastestest
 var _text_speed := 2.0
 
+onready var chat_line_panel: ChatLinePanel = get_node(chat_line_panel_path)
+
 func _ready() -> void:
+	# Populate the chat line sizes based on the chat line panel sizes.
+	# They're the same except for a little padding on the outside.
+	var new_sizes := []
+	for panel_size in chat_line_panel.panel_sizes.values():
+		new_sizes.append(panel_size - Vector2(60, 40))
+	set_sizes(new_sizes)
+	
 	# hidden by default to avoid firing signals and playing sounds
 	hide_message()
 

--- a/project/src/main/ui/chat/chat-line-panel.gd
+++ b/project/src/main/ui/chat/chat-line-panel.gd
@@ -12,16 +12,16 @@ const PULSE_AMOUNT := Vector2(0.015, 0.030)
 # The number of available background textures
 const CHAT_TEXTURE_COUNT := 16
 
-# The panel squishes over time. This field is used to calculate the squish amount
-var _total_time := 0.0
-
 # Longer lines of dialog are displayed in bigger panels
-onready var _panel_sizes := {
+var panel_sizes := {
 	ChatTheme.LINE_SMALL: Vector2(420, 120),
 	ChatTheme.LINE_MEDIUM: Vector2(600, 120),
 	ChatTheme.LINE_LARGE: Vector2(600, 160),
 	ChatTheme.LINE_XL: Vector2(780, 160),
 }
+
+# The panel squishes over time. This field is used to calculate the squish amount
+var _total_time := 0.0
 
 # Background textures which scroll behind the chat window
 var _accent_textures := []
@@ -48,7 +48,7 @@ Parameters:
 		smaller/larger window.
 """
 func update_appearance(chat_theme: ChatTheme, chat_line_size: int) -> void:
-	rect_size = _panel_sizes[chat_line_size]
+	rect_size = panel_sizes[chat_line_size]
 	rect_position = Vector2(512, 100) - rect_size / 2
 	
 	material.set_shader_param("accent_amount", 0.40 if chat_theme.dark else 0.24)


### PR DESCRIPTION
ChatLinePanel, ChatLineLabel now share information about chat box sizes.

FrostingGlob's playfield areas are now calculated based on the position of
the playfield and next piece controls, instead of being hard-coded as
constants.

Removed 'gutter area' which frosting globs could hit. I originally
separated this because I wanted to spread frosting there, but now it seems
unnecessary.