### PR TITLE
Fixed UI issues, crashes with level editor

### DIFF
--- a/project/src/main/puzzle/editor/LevelEditor.tscn
+++ b/project/src/main/puzzle/editor/LevelEditor.tscn
@@ -268,12 +268,14 @@ __meta__ = {
 [node name="TileMap" parent="HBoxContainer/TabContainer/Playfield/CenterPanel/Playfield/Bg" instance=ExtResource( 1 )]
 material = SubResource( 1 )
 scale = Vector2( 0.43, 0.43 )
+z_index = 0
 tile_data = PoolIntArray( 196608, 1, 0, 196616, 1, 0, 1245184, 1, 0, 1245192, 1, 0 )
 
 [node name="TileMapDropPreview" parent="HBoxContainer/TabContainer/Playfield/CenterPanel/Playfield/Bg" instance=ExtResource( 1 )]
 modulate = Color( 1, 1, 1, 0.25098 )
 material = SubResource( 2 )
 scale = Vector2( 0.43, 0.43 )
+z_index = 0
 tile_data = PoolIntArray( 196608, 1, 0, 196616, 1, 0, 327681, 2, 0, 327683, 2, 0, 393218, 2, 0, 393220, 2, 0, 1245184, 1, 0, 1245192, 1, 0 )
 
 [node name="Properties" type="Control" parent="HBoxContainer/TabContainer"]

--- a/project/src/main/puzzle/editor/editor-json.gd
+++ b/project/src/main/puzzle/editor/editor-json.gd
@@ -47,7 +47,7 @@ func refresh_tile_map() -> void:
 			var pos := Vector2(int(json_pos_arr[0]), int(json_pos_arr[1]))
 			var tile := int(json_tile_arr[0])
 			var autotile_coord := Vector2(int(json_tile_arr[1]), int(json_tile_arr[2]))
-			_playfield.tilemap.set_block(pos, tile, autotile_coord)
+			_tile_map.set_block(pos, tile, autotile_coord)
 
 
 """


### PR DESCRIPTION
The level editor playfield was being drawn over top of pop up windows,
making it difficult to save.

The level editor also crashed because of some tilemap/tile_map
refactorings recently.