### PR TITLE
Fat creatures can now appear on the overworld.

### DIFF
--- a/project/assets/main/dialog/bort/creature.json
+++ b/project/assets/main/dialog/bort/creature.json
@@ -14,6 +14,7 @@
     "line_rgb": "6c4331",
     "mouth": "2"
   },
+  "fatness": 2.0,
   "chat_theme_def": {
     "accent_scale": 2.6,
     "accent_swapped": false,

--- a/project/src/demo/ui/chat/mood-demo.gd
+++ b/project/src/demo/ui/chat/mood-demo.gd
@@ -7,6 +7,7 @@ Keys:
 	[Q, W, E, R]: Smile0 (Happy), Smile1 (Love), Laugh0 (Tickled), Laugh1 (Laughing)
 	[A, S, D, F]: Think0 (Pensive), Think1 (Confused), Cry0 (Disappointed), Cry1 (Distraught)
 	[Z, X, C, V]: Sweat0 (Nervous), Sweat1 (Fidgety), Rage0 (Upset), Rage1 (Rage)
+	[=]: Make the creature fat
 """
 
 func _input(event: InputEvent) -> void:
@@ -24,3 +25,4 @@ func _input(event: InputEvent) -> void:
 		KEY_X: $Creature.play_mood(ChatEvent.Mood.SWEAT1)
 		KEY_C: $Creature.play_mood(ChatEvent.Mood.RAGE0)
 		KEY_V: $Creature.play_mood(ChatEvent.Mood.RAGE1)
+		KEY_EQUAL: $Creature.set_fatness(3)

--- a/project/src/main/packed-sprite.gd
+++ b/project/src/main/packed-sprite.gd
@@ -11,6 +11,8 @@ frame within the sprite sheet, as well as the position where it should be drawn.
 This spatial data is available in a separate Aseprite json file.
 """
 
+signal frame_changed
+
 export (Texture) var texture: Texture
 
 # the path of the Aseprite json file containing spatial data for the packed texture
@@ -57,6 +59,7 @@ func set_rect_size(new_rect_size: Vector2) -> void:
 func set_frame(new_frame: int) -> void:
 	frame = new_frame
 	update()
+	emit_signal("frame_changed")
 
 
 func set_centered(new_centered: bool) -> void:

--- a/project/src/main/world/chat-icon.gd
+++ b/project/src/main/world/chat-icon.gd
@@ -27,6 +27,9 @@ export (BubbleType) var bubble_type: int setget set_bubble_type
 # 'true' if this bubble should appear on the right side, 'false' if it's on the left side
 export (bool) var right_side := true setget set_right_side
 
+# the position the bubble should point to
+export (Vector2) var target_position: Vector2 setget set_target_position
+
 var bounce_phase := 0.0
 var focused := false
 
@@ -41,7 +44,7 @@ func _physics_process(delta: float) -> void:
 		# keep bounce_phase bounded, otherwise a sprite will jitter slightly 3 billion millenia from now
 		bounce_phase -= 2 / BOUNCE_DURATION
 	
-	position.y = -52 - abs(BOUNCE_HEIGHT * sin(bounce_phase * BOUNCE_DURATION * PI))
+	position.y = target_position.y - 52 - abs(BOUNCE_HEIGHT * sin(bounce_phase * BOUNCE_DURATION * PI))
 
 
 func set_bubble_type(new_bubble_type: int) -> void:
@@ -51,8 +54,12 @@ func set_bubble_type(new_bubble_type: int) -> void:
 
 func set_right_side(new_right_side: bool) -> void:
 	right_side = new_right_side
-	position.x = 64 if right_side else -64
-	flip_h = not right_side
+	_refresh()
+
+
+func set_target_position(new_target_position: Vector2) -> void:
+	target_position = new_target_position
+	_refresh()
 
 
 """
@@ -84,6 +91,8 @@ func vanish() -> void:
 
 
 func _refresh() -> void:
+	position.x = target_position.x + (64 if right_side else -64)
+	flip_h = not right_side
 	visible = bubble_type != BubbleType.NONE
 	frame = randi() % 3 + (3 if bubble_type == BubbleType.THOUGHT else 0)
 	

--- a/project/src/main/world/chattable-manager.gd
+++ b/project/src/main/world/chattable-manager.gd
@@ -34,8 +34,20 @@ func _physics_process(_delta: float) -> void:
 			if spira == chattable_obj:
 				continue
 			var chattable: Node2D = chattable_obj
-			var distance: float = Global.from_iso(chattable.global_transform.origin) \
-					.distance_to(Global.from_iso(spira.global_transform.origin))
+			
+			var chattable_pos: Vector2 = chattable.global_transform.origin
+			var spira_pos: Vector2 = spira.global_transform.origin
+			
+			if "chat_extents" in chattable:
+				# if the chattable object has extents, we measure from its closest point
+				var new_chattable_pos := chattable_pos
+				new_chattable_pos.x += clamp(spira_pos.x - chattable_pos.x,
+						-chattable.chat_extents.x, chattable.chat_extents.x)
+				new_chattable_pos.y += clamp(spira_pos.y - chattable_pos.y,
+						-chattable.chat_extents.y, chattable.chat_extents.y)
+				chattable_pos = new_chattable_pos
+			
+			var distance: float = Global.from_iso(chattable_pos).distance_to(Global.from_iso(spira_pos))
 			if distance <= min_distance:
 				min_distance = distance
 				new_focus = chattable

--- a/project/src/main/world/creature/Creature.tscn
+++ b/project/src/main/world/creature/Creature.tscn
@@ -1,11 +1,13 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://src/main/world/creature/CreatureVisuals.tscn" type="PackedScene" id=1]
+[ext_resource path="res://src/main/world/creature/creature-chat-icon.gd" type="Script" id=2]
 [ext_resource path="res://src/main/world/creature/creature.gd" type="Script" id=3]
 [ext_resource path="res://src/main/world/ChatIcon.tscn" type="PackedScene" id=4]
 [ext_resource path="res://assets/main/world/creature/move-bonk.wav" type="AudioStream" id=5]
 [ext_resource path="res://src/main/viewport-outline-material.tres" type="Material" id=6]
 [ext_resource path="res://assets/main/world/creature/move-hop.wav" type="AudioStream" id=7]
+[ext_resource path="res://src/main/world/creature/creature-collision-shape.gd" type="Script" id=8]
 [ext_resource path="res://src/main/world/creature/creature-sfx.gd" type="Script" id=23]
 
 [sub_resource type="ViewportTexture" id=1]
@@ -13,12 +15,15 @@ flags = 5
 viewport_path = NodePath("CreatureOutline/Viewport")
 
 [sub_resource type="RectangleShape2D" id=2]
+resource_local_to_scene = true
 extents = Vector2( 28, 14 )
 
 [node name="Creature" type="KinematicBody2D"]
 script = ExtResource( 3 )
 
 [node name="ChatIcon" parent="." instance=ExtResource( 4 )]
+script = ExtResource( 2 )
+creature_visuals_path = NodePath("../CreatureOutline/Viewport/Visuals")
 
 [node name="CreatureOutline" type="Node2D" parent="."]
 
@@ -69,6 +74,8 @@ autostart = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource( 2 )
+script = ExtResource( 8 )
+creature_visuals_path = NodePath("../CreatureOutline/Viewport/Visuals")
 
 [node name="HopSound" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource( 7 )
@@ -85,3 +92,4 @@ bus = "Sound Bus"
 [connection signal="food_eaten" from="CreatureOutline/Viewport/Visuals" to="CreatureSfx" method="_on_CreatureVisuals_food_eaten"]
 [connection signal="visual_fatness_changed" from="CreatureOutline/Viewport/Visuals" to="." method="_on_CreatureVisuals_visual_fatness_changed"]
 [connection signal="timeout" from="CreatureSfx/HelloTimer" to="CreatureSfx" method="_on_HelloTimer_timeout"]
+[connection signal="extents_changed" from="CollisionShape2D" to="." method="_on_CollisionShape2D_extents_changed"]

--- a/project/src/main/world/creature/CreatureVisuals.tscn
+++ b/project/src/main/world/creature/CreatureVisuals.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=78 format=2]
+[gd_scene load_steps=79 format=2]
 
 [ext_resource path="res://src/main/world/rgb-palette.shader" type="Shader" id=1]
 [ext_resource path="res://src/main/packed-sprite.gd" type="Script" id=2]
@@ -23,6 +23,7 @@
 [ext_resource path="res://assets/main/world/creature/1/emote-head-packed.png" type="Texture" id=21]
 [ext_resource path="res://assets/main/ui/chat/emote-sweat1.wav" type="AudioStream" id=22]
 [ext_resource path="res://src/main/world/creature/body-shadows.shader" type="Shader" id=23]
+[ext_resource path="res://src/main/world/creature/arm-shadow.gd" type="Script" id=24]
 [ext_resource path="res://src/main/world/creature/creature-visuals.gd" type="Script" id=37]
 [ext_resource path="res://src/main/world/creature/creature-curve.gd" type="Script" id=38]
 [ext_resource path="res://src/main/world/creature/body-colors.gd" type="Script" id=40]
@@ -54,7 +55,7 @@ shader_param/black = Color( 0, 0, 0, 1 )
 [sub_resource type="Curve2D" id=4]
 resource_local_to_scene = true
 _data = {
-"points": PoolVector2Array( 0.0132871, -28.7557, -0.0132871, 28.7557, -71.9184, -48.9366, -35.1478, -0.510676, 35.1478, 0.510676, 4.40906, 0.451691, -1.01159, 23.918, 1.01159, -23.918, 78.4915, -51.1815, 39.4804, 0.0106763, -39.4804, -0.0106763, 11.1438, -102.815, -0.98502, -37.2608, 0.98502, 37.2608, -71.9184, -51.1815 )
+"points": PoolVector2Array( 0.0132871, -28.7557, -0.0132871, 28.7557, -71.9184, -48.9366, -35.1478, -0.510676, 35.1478, 0.510676, 4.40906, 0.451688, -1.01159, 23.918, 1.01159, -23.918, 78.4915, -51.1815, 39.4804, 0.0106763, -39.4804, -0.0106763, 11.1438, -102.815, -0.98502, -37.2608, 0.98502, 37.2608, -71.9184, -51.1815 )
 }
 
 [sub_resource type="Curve2D" id=5]
@@ -94,7 +95,7 @@ shader_param/color_texture = SubResource( 8 )
 [sub_resource type="Curve2D" id=11]
 resource_local_to_scene = true
 _data = {
-"points": PoolVector2Array( 24.9977, 0.341151, -32.9037, -0.449047, -11.158, -72.0639, -0.631155, -31.5491, 0.500038, 24.995, -62.0516, -16.4455, -27.2528, -0.551655, 30.9852, 0.627207, -13.1955, 28.0658, -0.010441, 25, 0.011404, -27.3082, 37.7671, -13.4088, 27.0964, -1.30105, -24.9712, 1.19901, -11.0971, -72.0781 )
+"points": PoolVector2Array( 24.9977, 0.341151, -32.9037, -0.449047, -11.158, -72.0639, -0.631155, -31.5491, 0.500038, 24.995, -62.0516, -16.4455, -27.2528, -0.551655, 30.9852, 0.627207, -13.1955, 28.0658, -0.0104411, 25, 0.0114041, -27.3082, 37.7671, -13.4088, 27.0964, -1.30105, -24.9712, 1.19901, -11.0971, -72.0781 )
 }
 
 [sub_resource type="ShaderMaterial" id=12]
@@ -2341,6 +2342,7 @@ dna = {
 "shader:Neck0/HeadBobber/Mouth:black": Color( 0, 0, 0, 1 ),
 "shader:Neck0/HeadBobber/Mouth:red": Color( 0, 0, 0, 1 )
 }
+visual_fatness = 1.0
 
 [node name="FarMovement" type="Node2D" parent="."]
 visible = false
@@ -2419,7 +2421,7 @@ curve_defs = [ {
 [node name="ArmShadow" type="Path2D" parent="BodyShadows/Viewport/Body"]
 self_modulate = Color( 1, 1, 1, 1 )
 curve = SubResource( 5 )
-script = ExtResource( 38 )
+script = ExtResource( 24 )
 line_color = Color( 0, 0, 0, 0 )
 fill_color = Color( 0, 0, 0, 1 )
 creature_visuals_path = NodePath("../../../..")
@@ -2444,6 +2446,7 @@ curve_defs = [ {
 "fatness": 10.0
 } ]
 visible_when_facing_north = false
+near_arm_path = NodePath("../../../../NearArm")
 
 [node name="BellyShadow" type="Path2D" parent="BodyShadows/Viewport/Body"]
 self_modulate = Color( 1, 1, 1, 1 )
@@ -2574,7 +2577,7 @@ curve_defs = [ {
 } ]
 
 [node name="NeckBlend" type="Node2D" parent="Body/Viewport/Body"]
-position = Vector2( -1.11823, -102.515 )
+position = Vector2( 21.118, -232.515 )
 rotation = 3.13804
 scale = Vector2( 0.836, -0.836 )
 script = ExtResource( 6 )
@@ -2728,11 +2731,11 @@ rect_size = Vector2( 512, 512 )
 offset = Vector2( 0, -119 )
 
 [node name="EmoteGlow" type="Sprite" parent="Neck0/HeadBobber"]
-modulate = Color( 0.54902, 0.133333, 0.380392, 0 )
+modulate = Color( 1, 1, 1, 0 )
 light_mask = 2
 material = SubResource( 20 )
-position = Vector2( 25.3166, 262.374 )
-scale = Vector2( 1.8, 0.8 )
+position = Vector2( 7.13472, 726.013 )
+scale = Vector2( 3, 3 )
 texture = ExtResource( 4 )
 offset = Vector2( 0, -239 )
 __meta__ = {
@@ -2743,13 +2746,12 @@ __meta__ = {
 modulate = Color( 1, 1, 1, 0 )
 light_mask = 2
 material = SubResource( 21 )
-position = Vector2( -18.2593, -72.9644 )
+position = Vector2( -39.1146, -33.5241 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 2 )
 texture = ExtResource( 10 )
 frame_data = "res://assets/main/world/creature/1/emote-brain-packed.json"
 rect_size = Vector2( 256, 256 )
-frame = 2
 offset = Vector2( 0, -119 )
 
 [node name="EmoteHead" type="Node2D" parent="Neck0/HeadBobber"]
@@ -2829,31 +2831,30 @@ anims/run-se = SubResource( 51 )
 [connection signal="before_creature_arrived" from="." to="Mouth1Anims" method="_on_CreatureVisuals_before_creature_arrived"]
 [connection signal="before_creature_arrived" from="." to="EmoteAnims" method="_on_CreatureVisuals_before_creature_arrived"]
 [connection signal="movement_mode_changed" from="." to="Body/Viewport/Body" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="NearLeg" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Body/Viewport/Body/NeckBlend" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="NearArm" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="FarLeg" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Body/Viewport/Body/NeckBlend" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="NearLeg" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="NearArm" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="FarArm" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="orientation_changed" from="." to="BodyColors/Viewport/Body/Belly" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="FarArm" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="orientation_changed" from="." to="FarLeg" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Body/Viewport/Body/NeckBlend" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="NearLeg" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="NearArm" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="FarArm" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Mouth0Anims" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Mouth1Anims" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="NearLeg" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Body/Viewport/Body/NeckBlend" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="NearArm" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="FarLeg" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="FarArm" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="animation_finished" from="EmoteAnims" to="EmoteAnims" method="_on_animation_finished"]
 [connection signal="before_mood_switched" from="EmoteAnims" to="." method="_on_EmoteAnims_before_mood_switched"]
 [connection signal="animation_started" from="MovementAnims" to="." method="_on_MovementAnims_animation_started"]

--- a/project/src/main/world/creature/arm-shadow.gd
+++ b/project/src/main/world/creature/arm-shadow.gd
@@ -1,0 +1,24 @@
+extends CreatureCurve
+"""
+The shadow drawn below the creature's arm.
+"""
+
+export (NodePath) var near_arm_path: NodePath
+
+onready var _near_arm: CreaturePackedSprite = get_node(near_arm_path)
+
+func _ready() -> void:
+	_near_arm.connect("frame_changed", self, "_on_NearArm_frame_changed")
+
+
+"""
+Updates the 'visible' property based on the arm's current frame.
+"""
+func refresh_visible() -> void:
+	.refresh_visible()
+	if _near_arm.frame == 0:
+		visible = false
+
+
+func _on_NearArm_frame_changed() -> void:
+	refresh_visible()

--- a/project/src/main/world/creature/creature-chat-icon.gd
+++ b/project/src/main/world/creature/creature-chat-icon.gd
@@ -1,0 +1,25 @@
+extends ChatIcon
+"""
+A visual icon which appears next to something the player can interact with.
+"""
+
+export (NodePath) var creature_visuals_path: NodePath
+
+onready var _creature_visuals: CreatureVisuals = get_node(creature_visuals_path)
+
+func _ready() -> void:
+	_creature_visuals.connect("head_moved", self, "_on_CreatureVisuals_head_moved")
+	_refresh_target_position()
+
+
+"""
+Reposition the icon next to the creature's head.
+
+If we don't reposition the icon, it gets lost behind creatures that are fat.
+"""
+func _refresh_target_position() -> void:
+	set_target_position(_creature_visuals.get_node("Neck0").position * 0.4)
+
+
+func _on_CreatureVisuals_head_moved() -> void:
+	_refresh_target_position()

--- a/project/src/main/world/creature/creature-collision-shape.gd
+++ b/project/src/main/world/creature/creature-collision-shape.gd
@@ -1,0 +1,34 @@
+extends CollisionShape2D
+"""
+Collision shape for creatures on the overworld.
+"""
+
+# emitted when the collision shape's extents change
+signal extents_changed(value)
+
+export (NodePath) var creature_visuals_path: NodePath
+
+onready var _creature_visuals: CreatureVisuals = get_node(creature_visuals_path)
+
+func _ready() -> void:
+	_creature_visuals.connect("visual_fatness_changed", self, "_on_CreatureVisuals_visual_fatness_changed")
+	_refresh()
+
+
+"""
+Increases the collision shape size for fatter creatures.
+"""
+func _refresh() -> void:
+	var rectangle_shape: RectangleShape2D = shape
+	
+	# increase collision shape size for fatter creatures
+	rectangle_shape.extents = Vector2(16, 8) * _creature_visuals.visual_fatness
+	
+	# small creatures still occupy a minimal amount of space
+	rectangle_shape.extents.x = max(rectangle_shape.extents.x, 28)
+	rectangle_shape.extents.y = max(rectangle_shape.extents.y, 14)
+	emit_signal("extents_changed", rectangle_shape.extents)
+
+
+func _on_CreatureVisuals_visual_fatness_changed() -> void:
+	_refresh()

--- a/project/src/main/world/creature/creature-curve.gd
+++ b/project/src/main/world/creature/creature-curve.gd
@@ -61,18 +61,13 @@ func save_curve(value: bool) -> void:
 
 
 """
-Recalculates the curve coordinates based on how fat the creature is.
-
-Parameters:
-	'fatness': How fat the creature's body is; 5.0 = 5x normal size
+Updates the 'visible' property based on the creature's orientation.
 """
-func _on_CreatureVisuals_visual_fatness_changed() -> void:
-	_refresh_curve()
-
-
-func _on_CreatureVisuals_orientation_changed(old_orientation: int, new_orientation: int) -> void:
-	if not visible_when_facing_north:
-		visible = new_orientation in [CreatureVisuals.SOUTHWEST, CreatureVisuals.SOUTHEAST]
+func refresh_visible() -> void:
+	visible = true
+	if not visible_when_facing_north \
+			and _creature_visuals.orientation in [CreatureVisuals.NORTHWEST, CreatureVisuals.NORTHEAST]:
+		visible = false
 
 
 func set_curve_defs(new_curve_defs: Array) -> void:
@@ -107,3 +102,17 @@ func _refresh_curve() -> void:
 			var point_out: Vector2 = lerp(curve_def_low.curve_def[i][2], curve_def_high.curve_def[i][2], f_pct)
 			curve.add_point(point_pos, point_in, point_out)
 	update()
+
+
+"""
+Recalculates the curve coordinates based on how fat the creature is.
+
+Parameters:
+	'fatness': How fat the creature's body is; 5.0 = 5x normal size
+"""
+func _on_CreatureVisuals_visual_fatness_changed() -> void:
+	_refresh_curve()
+
+
+func _on_CreatureVisuals_orientation_changed(old_orientation: int, new_orientation: int) -> void:
+	refresh_visible()

--- a/project/src/main/world/creature/creature-def.gd
+++ b/project/src/main/world/creature/creature-def.gd
@@ -21,6 +21,9 @@ var chat_theme_def: Dictionary
 # filenames containing dialog
 var dialog: Array
 
+# how fat the creature's body is; 5.0 = 5x normal size
+var fatness := 1.0
+
 func from_json_dict(json: Dictionary) -> void:
 	if json.get("version") != "170e":
 		push_warning("Unrecognized creature data version: '%s'" % json.get("version"))
@@ -29,5 +32,6 @@ func from_json_dict(json: Dictionary) -> void:
 	dna = json.get("dna", {})
 	chat_theme_def = json.get("chat_theme_def", {})
 	dialog = json.get("dialog", [])
+	fatness = json.get("fatness", 1.0)
 	if dialog:
 		chat_path = "res://assets/main/dialog/%s/%s.json" % [creature_id, dialog[0]]

--- a/project/src/main/world/creature/creature-visuals.gd
+++ b/project/src/main/world/creature/creature-visuals.gd
@@ -36,6 +36,10 @@ signal movement_mode_changed(movement_mode)
 signal fatness_changed
 signal visual_fatness_changed
 
+# emitted by FatSpriteMover when it moves the head by making the creature fatter
+# warning-ignore:unused_signal
+signal head_moved
+
 # directions the creature can face
 enum Orientation {
 	SOUTHEAST,

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -35,6 +35,7 @@ var creature_def: CreatureDef
 var chat_path: String setget set_chat_path
 var creature_name: String setget set_creature_name
 var chat_theme_def: Dictionary setget set_chat_theme_def
+var chat_extents: Vector2
 
 # 'true' if the creature is being slowed by friction while stopping or turning
 var _friction := false
@@ -203,6 +204,8 @@ func _refresh_creature_id() -> void:
 		set_creature_name(creature_def.creature_name)
 		set_chat_path(creature_def.chat_path)
 		set_chat_theme_def(creature_def.chat_theme_def)
+		set_fatness(creature_def.fatness)
+		_creature_visuals.set_visual_fatness(creature_def.fatness)
 
 
 func _refresh_dna() -> void:
@@ -289,3 +292,7 @@ func _on_CreatureVisuals_food_eaten() -> void:
 
 func _on_CreatureVisuals_visual_fatness_changed() -> void:
 	emit_signal("visual_fatness_changed")
+
+
+func _on_CollisionShape2D_extents_changed(value: Vector2) -> void:
+	chat_extents = value

--- a/project/src/main/world/creature/fat-sprite-mover.gd
+++ b/project/src/main/world/creature/fat-sprite-mover.gd
@@ -19,7 +19,7 @@ func _on_CreatureVisuals_visual_fatness_changed() -> void:
 	_refresh_sprite_positions()
 
 
-func _on_CreatureVisuals_orientation_changed(old_orientation: int, new_orientation: int) -> void:
+func _on_CreatureVisuals_orientation_changed(_old_orientation: int, _new_orientation: int) -> void:
 	_refresh_sprite_positions()
 
 
@@ -27,3 +27,4 @@ func _refresh_sprite_positions() -> void:
 	play("fat-se" if _creature_visuals.orientation in [Creature.SOUTHWEST, Creature.SOUTHEAST] else "fat-nw")
 	advance(_creature_visuals.visual_fatness)
 	stop()
+	_creature_visuals.emit_signal("head_moved")


### PR DESCRIPTION
Eventually, creatures will show up fatter as you feed them more. For now
it's just a hard-coded value in the creature definition.

Most emotes work for fat creatures. Their arm shadow disappears
appropriately when they bring their arms up to their face. The 'rage cloud'
emote doesn't look very good, but that's a hard one to fix. I opened #461 to
document this.