### PR TITLE
Don't reset lock if doing combo hard drop + squish move

### DIFF
--- a/project/src/main/puzzle/piece/PieceManager.tscn
+++ b/project/src/main/puzzle/piece/PieceManager.tscn
@@ -214,5 +214,5 @@ bus = "Sound Bus"
 [connection signal="hard_dropped" from="Physics/Dropper" to="." method="_on_Dropper_hard_dropped"]
 [connection signal="soft_dropped" from="Physics/Dropper" to="." method="_on_Dropper_soft_dropped"]
 [connection signal="lock_cancelled" from="Physics/Squisher" to="." method="_on_Squisher_lock_cancelled"]
-[connection signal="squish_moved" from="Physics/Squisher" to="." method="_on_Squisher_squish_moved"]
 [connection signal="squish_moved" from="Physics/Squisher" to="Physics/Dropper" method="_on_Squisher_squish_moved"]
+[connection signal="squish_moved" from="Physics/Squisher" to="." method="_on_Squisher_squish_moved"]

--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -172,8 +172,15 @@ func move_piece() -> void:
 	
 	if old_piece_pos != piece.pos or old_piece_orientation != piece.orientation:
 		$Physics/Squisher.squish_state = PieceSquisher.UNKNOWN
-		if piece.lock > 0 and not $Physics/Dropper.did_hard_drop:
-			piece.perform_lock_reset()
+		if piece.lock > 0:
+			if $Physics/Dropper.did_hard_drop:
+				# hard drop doesn't cause lock reset
+				pass
+			elif $Physics/Squisher.did_squish and $Input/HardDrop.is_pressed():
+				# don't reset lock if doing a combination hard drop + squish move
+				pass
+			else:
+				piece.perform_lock_reset()
 
 
 """

--- a/project/src/main/puzzle/piece/piece-squisher.gd
+++ b/project/src/main/puzzle/piece/piece-squisher.gd
@@ -20,11 +20,19 @@ const VALID = SquishState.VALID
 
 export (NodePath) var input_path: NodePath
 
+# 'true' if the player did a squish move this frame
+var did_squish: bool
+
 # potential source/target for the current squish move
 var squish_state: int = SquishState.UNKNOWN
 var _squish_target_pos: Vector2
 
 onready var input: PieceInput = get_node(input_path)
+
+
+func _physics_process(_delta: float) -> void:
+	did_squish = false
+
 
 func attempt_squish(piece: ActivePiece) -> void:
 	if not input.is_soft_drop_pressed() \
@@ -68,6 +76,7 @@ func _squish_to_target(piece: ActivePiece) -> void:
 	var old_pos := piece.pos
 	piece.move_to_target()
 	piece.gravity = 0
+	did_squish = true
 	emit_signal("squish_moved", piece, old_pos)
 
 


### PR DESCRIPTION
Before, if you did a combination hard drop + squish move, the piece would
immediately lock if the piece squished once, but it would do a lock reset
if the piece squished twice. This made it difficult to play quickly, since
sometimes you needed to hard drop twice, and sometimes only once.