### PR TITLE
Fixed kick tests. Added 'bump kicks' for p/q pieces

### DIFF
--- a/project/src/main/puzzle/piece/piece-types.gd
+++ b/project/src/main/puzzle/piece/piece-types.gd
@@ -42,7 +42,7 @@ const KICKS_U := [
 const KICKS_P := [
 		[Vector2( 0, -1), Vector2(-1, -1), Vector2( 0,  1), Vector2(-1,  0)],
 		[Vector2( 1,  0), Vector2( 1, -1), Vector2( 0, -1), Vector2( 0,  1)],
-		[Vector2( 0,  1), Vector2( 1,  1), Vector2( 0, -1), Vector2(-1,  0)],
+		[Vector2( 0,  1), Vector2( 1,  1), Vector2( 0, -1), Vector2( 1,  0)],
 		[Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1)],
 	]
 
@@ -50,7 +50,7 @@ const KICKS_Q := [
 		[Vector2(-1,  0), Vector2(-1, -1), Vector2( 0, -1), Vector2( 0,  1)],
 		[Vector2( 0, -1), Vector2( 1, -1), Vector2( 0,  1), Vector2( 1,  0)],
 		[Vector2( 1,  0), Vector2( 1,  1), Vector2( 0,  1), Vector2( 0, -1)],
-		[Vector2( 0,  1), Vector2(-1,  1), Vector2( 0, -1), Vector2( 1,  0)],
+		[Vector2( 0,  1), Vector2(-1,  1), Vector2( 0, -1), Vector2(-1,  0)],
 	]
 
 const KICKS_V := [

--- a/project/src/test/test-piece-kicks-qp.gd
+++ b/project/src/test/test-piece-kicks-qp.gd
@@ -427,3 +427,134 @@ func test_q_climb_l0_failed() -> void:
 		"   ::",
 		":  ::"]
 	assert_kick()
+
+
+"""
+A 'bump kick' is when the bulky part of a p/q piece bumps into a block and gets nudged out of the way
+"""
+func test_p_bump_kick_0r() -> void:
+	from_grid = [
+		"  :::",
+		" ppp:",
+		"  pp:",
+		"   ::",
+	]
+	to_grid = [
+		"  :::",
+		"  p :",
+		" pp :",
+		" pp::",
+	]
+	assert_kick()
+
+
+func test_p_bump_kick_r2() -> void:
+	from_grid = [
+		"     ",
+		"  p  ",
+		" pp: ",
+		":pp: ",
+	]
+	to_grid = [
+		"     ",
+		"pp   ",
+		"ppp: ",
+		":  : ",
+	]
+	assert_kick()
+
+
+func test_p_bump_kick_2l() -> void:
+	from_grid = [
+		"     ",
+		"::   ",
+		":pp  ",
+		":ppp ",
+	]
+	to_grid = [
+		"     ",
+		"::pp ",
+		": pp ",
+		": p  ",
+	]
+	assert_kick()
+
+
+func test_p_bump_kick_l0() -> void:
+	from_grid = [
+		" ::::",
+		" :pp:",
+		" :pp ",
+		"  p  ",
+	]
+	to_grid = [
+		" ::::",
+		" :  :",
+		" :ppp",
+		"   pp",
+	]
+	assert_kick()
+
+
+func test_q_bump_kick_0l() -> void:
+	from_grid = [
+		":::  ",
+		":qqq ",
+		":qq  ",
+		"::   ",
+	]
+	to_grid = [
+		":::  ",
+		": q  ",
+		": qq ",
+		"::qq ",
+	]
+	assert_kick()
+
+
+func test_q_bump_kick_l2() -> void:
+	from_grid = [
+		"     ",
+		"  q  ",
+		" :qq ",
+		" :qq:",
+	]
+	to_grid = [
+		"     ",
+		"   qq",
+		" :qqq",
+		" :  :",
+	]
+	assert_kick()
+
+
+func test_q_bump_kick_2r() -> void:
+	from_grid = [
+		"     ",
+		"   ::",
+		"  qq:",
+		" qqq:",
+	]
+	to_grid = [
+		"     ",
+		" qq::",
+		" qq :",
+		"  q :",
+	]
+	assert_kick()
+
+
+func test_q_bump_kick_r0() -> void:
+	from_grid = [
+		":::: ",
+		":qq: ",
+		" qq: ",
+		"  q  ",
+	]
+	to_grid = [
+		":::: ",
+		":  : ",
+		"qqq: ",
+		"qq   ",
+	]
+	assert_kick()

--- a/project/src/test/test-piece-kicks.gd
+++ b/project/src/test/test-piece-kicks.gd
@@ -87,17 +87,18 @@ func _kick_piece() -> Vector2:
 	_from_piece = _create_active_piece(from_grid)
 	_to_piece = _create_active_piece(to_grid)
 	
+	var piece := _create_active_piece(from_grid)
+	piece.target_orientation = _to_piece.orientation
+	
 	# if the piece is blocked, kick the piece
-	if not _to_piece.can_move_to(_from_piece.pos, _to_piece.orientation):
-		_to_piece.target_pos = _from_piece.pos
-		_to_piece.target_orientation = _to_piece.orientation
-		_to_piece.kick_piece()
+	if not piece.can_move_to(piece.target_pos, piece.target_orientation):
+		piece.kick_piece()
 	
 	# if the piece is still blocked, it's a failed kick
-	if not _to_piece.can_move_to(_to_piece.pos, _to_piece.orientation):
+	if not piece.can_move_to(piece.target_pos, piece.target_orientation):
 		result = FAILED_KICK
 	else:
-		result = _to_piece.pos - _from_piece.pos
+		result = piece.target_pos - piece.pos
 	return result
 
 
@@ -146,6 +147,7 @@ func _create_active_piece(ascii_grid: Array) -> ActivePiece:
 	if not _active_piece:
 		push_error("Could not find piece position/orientation in '%s' grid"\
 				% ("from" if ascii_grid == from_grid else "to"))
+	_active_piece.reset_target()
 	return _active_piece
 
 


### PR DESCRIPTION
Kick tests were inadvertently invalidated in 6d79347b when the PieceManager's
inputs were refactored. They would always pass. I've fixed them so they
can fail again.

Added new 'bump kicks'; I ran into this today where I couldn't rotate a
piece that I should have been able to.