### PR TITLE
Added explicit 'squish drop' logic.

### DIFF
--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -176,9 +176,8 @@ func move_piece() -> void:
 			if $Physics/Dropper.did_hard_drop:
 				# hard drop doesn't cause lock reset
 				pass
-			elif $Physics/Squisher.did_squish and $Input/HardDrop.is_pressed() \
-					and not piece.can_move_to(piece.pos + Vector2(0, 1), piece.orientation):
-				# don't reset lock if doing a combination hard drop + squish move
+			elif $Physics/Squisher.did_squish_drop:
+				# don't reset lock if doing a squish drop
 				pass
 			else:
 				piece.perform_lock_reset()


### PR DESCRIPTION
Before, squish drops were sort of an accident of how the controls happened
to work, but this resulted in a few idiosyncracies:

  * squish drops resulted in multiple squish signals
  * squish drops requiring piece movement would cause a lock reset
  * squish drops had a delay proportionate to the number of pieces being
    squished through

I've added explicit logic where if the player is pressing hard drop and
soft drop, it triggers different logic which calculates the lowest
possible squish target and rockets the piece there.