### PR TITLE
Tutorial bugs: star seeds, instructor, music volume, messages

### DIFF
--- a/delint.sh
+++ b/delint.sh
@@ -28,3 +28,6 @@ grep "emulate_touch_from_mouse=true" ./project/project.godot
 
 # check for enabled creature tool scripts; these should be disabled before merging
 grep -lR "^tool #uncomment to view creature in editor" project/src/main/world/creature
+
+# check for print statements that got left in by mistake
+git diff master | grep print\(

--- a/project/project.godot
+++ b/project/project.godot
@@ -389,7 +389,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/world/creature/smooth-path.gd"
 }, {
-"base": "Creature",
+"base": "Reference",
 "class": "Spira",
 "language": "GDScript",
 "path": "res://src/main/world/creature/spira.gd"

--- a/project/src/main/music-player.gd
+++ b/project/src/main/music-player.gd
@@ -110,8 +110,17 @@ Gradually fades a track in.
 Usually it's OK for a track to start abrubtly, but sometimes we want to fade music in more gradually.
 """
 func fade_in() -> void:
-	current_bgm.volume_db = -40.0
-	$MusicTween.fade_in(current_bgm)
+	current_bgm.volume_db = MIN_VOLUME
+	$MusicTween.fade_in(current_bgm, max_volume(current_bgm))
+
+
+"""
+Returns the volume a song should play at.
+
+The tutorial music is noticably quieter than the other songs, so we increase its volume.
+"""
+func max_volume(bgm: AudioStreamPlayer) -> float:
+	return 4.0 if current_bgm == _tutorial_bgm else MAX_VOLUME
 
 
 """
@@ -121,7 +130,7 @@ func stop() -> void:
 	if current_bgm == null:
 		return
 	
-	$MusicTween.fade_out(current_bgm)
+	$MusicTween.fade_out(current_bgm, MIN_VOLUME)
 	current_bgm = null
 	emit_signal("bgm_changed", current_bgm)
 
@@ -137,6 +146,6 @@ func play_music(new_bgm: AudioStreamPlayer, from_position: float = 0.0) -> void:
 	
 	stop()
 	current_bgm = new_bgm
-	current_bgm.volume_db = 0.0
+	current_bgm.volume_db = max_volume(new_bgm)
 	current_bgm.play(from_position)
 	emit_signal("bgm_changed", current_bgm)

--- a/project/src/main/music-tween.gd
+++ b/project/src/main/music-tween.gd
@@ -10,20 +10,20 @@ const FADE_IN_DURATION := 2.5
 """
 Gradually silences a music track.
 """
-func fade_out(player: AudioStreamPlayer) -> void:
+func fade_out(player: AudioStreamPlayer, min_volume: float) -> void:
 	stop(player, "volume_db")
 	remove(player, "volume_db")
-	interpolate_property(player, "volume_db", player.volume_db, MusicPlayer.MIN_VOLUME, FADE_OUT_DURATION)
+	interpolate_property(player, "volume_db", player.volume_db, min_volume, FADE_OUT_DURATION)
 	start()
 
 
 """
 Gradually raises a music track to full volume.
 """
-func fade_in(player: AudioStreamPlayer) -> void:
+func fade_in(player: AudioStreamPlayer, max_volume: float) -> void:
 	stop(player, "volume_db")
 	remove(player, "volume_db")
-	interpolate_property(player, "volume_db", player.volume_db, MusicPlayer.MAX_VOLUME, FADE_IN_DURATION)
+	interpolate_property(player, "volume_db", player.volume_db, max_volume, FADE_IN_DURATION)
 	start()
 
 

--- a/project/src/main/puzzle/piece/active-piece.gd
+++ b/project/src/main/puzzle/piece/active-piece.gd
@@ -42,7 +42,7 @@ Parameters:
 	'init_type': Piece shape, color, kick information
 	
 	'init_is_cell_blocked': A callback function which returns 'true' if a specified cell is
-			blocked, either because it lies outside the playfield or is obstructed by a block
+		blocked, either because it lies outside the playfield or is obstructed by a block
 """
 func _init(init_type: PieceType, init_cell_blocked_func: FuncRef) -> void:
 	type = init_type

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -158,8 +158,8 @@ func _on_LineClearer_line_cleared(y: int, total_lines: int, remaining_lines: int
 
 
 func _on_LineClearer_lines_deleted(lines: Array) -> void:
-	emit_signal("after_piece_written")
 	emit_signal("lines_deleted", lines)
+	emit_signal("after_piece_written")
 
 
 func _on_FrostingGlobs_hit_playfield(glob: Node) -> void:

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -21,13 +21,33 @@ func _ready() -> void:
 		$CreatureView.summon_creature(i)
 	
 	if Scenario.settings.other.tutorial:
-		Global.creature_queue.push_front({
-			"line_rgb": "6c4331", "body_rgb": "a854cb", "eye_rgb": "4fa94e dbe28e", "horn_rgb": "f1e398",
-			"ear": "3", "horn": "0", "mouth": "2", "eye": "2", "cheek": "0", "nose": "2"
-		})
-		$CreatureView.summon_creature()
+		summon_instructor(true)
 	
 	$CreatureView.get_creature_2d().play_hello_voice(true)
+
+
+"""
+Summon an instructor who leads tutorials.
+
+Parameters:
+	'replace_current': 'true' if the instructor should replace the currently visible customer, or false if the camera
+		should scroll to the instructor.
+"""
+func summon_instructor(replace_current: bool = false) -> void:
+	if $CreatureView.get_creature_2d().dna.get("instructor") == "true":
+		return
+	
+	Global.creature_queue.push_front({
+		"line_rgb": "6c4331", "body_rgb": "a854cb", "eye_rgb": "4fa94e dbe28e", "horn_rgb": "f1e398",
+		"ear": "3", "horn": "0", "mouth": "2", "eye": "2", "cheek": "0", "nose": "2",
+		"instructor": "true"
+	})
+	if replace_current:
+		$CreatureView.summon_creature()
+	else:
+		var new_creature_index: int = ($CreatureView.get_current_creature_index() + 1) % 2
+		$CreatureView.summon_creature(new_creature_index)
+		$CreatureView.scroll_to_new_creature(new_creature_index)
 
 
 func _input(event: InputEvent) -> void:

--- a/project/src/main/puzzle/scenario/scenario.gd
+++ b/project/src/main/puzzle/scenario/scenario.gd
@@ -11,6 +11,9 @@ This class needs to be a node because it provides utility methods which utilize 
 # emitted after the scenario has customized the puzzle's settings.
 signal settings_changed
 
+# The mandatory tutorial the player must complete before playing the game
+const BEGINNER_TUTORIAL := "tutorial-beginner-0"
+
 # The settings for the scenario currently being launched or played
 var settings := ScenarioSettings.new() setget switch_scenario
 

--- a/project/src/main/puzzle/star-seeds.gd
+++ b/project/src/main/puzzle/star-seeds.gd
@@ -91,8 +91,16 @@ func _add_wobblers_for_box(rect: Rect2, color_int: int) -> void:
 	else:
 		# create a random arrangement
 		wobbler_positions = []
+		var prev_position := randi() % int(rect.size.x)
 		for _y in range(rect.size.y):
-			wobbler_positions.append(randi() % int(rect.size.x))
+			var new_position
+			if rect.size.x < 2:
+				new_position = 0
+			else:
+				# avoid placing two wobblers above each other
+				new_position = (prev_position + 1 + randi() % int(rect.size.x - 1)) % int(rect.size.x)
+			wobbler_positions.append(new_position)
+			prev_position = new_position
 	
 	for wobbler_y in range(rect.size.y):
 		var wobbler: Wobbler

--- a/project/src/main/puzzle/tutorial/tutorial-hud.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-hud.gd
@@ -4,9 +4,6 @@ extends Control
 UI items specific for puzzle tutorials.
 """
 
-# The mandatory tutorial the player must complete before playing the game
-const BEGINNER_TUTORIAL_SCENARIO := "tutorial-beginner-0"
-
 export (NodePath) var puzzle_path: NodePath
 
 onready var _puzzle:Puzzle = get_node(puzzle_path)
@@ -43,7 +40,7 @@ func _ready() -> void:
 				+ " You seem to already be familiar with this sort of game,/ so let's dive right in.")
 		yield(get_tree().create_timer(0.80), "timeout")
 		_puzzle.show_start_button()
-		if PlayerData.scenario_history.finished_scenarios.has(BEGINNER_TUTORIAL_SCENARIO):
+		if PlayerData.scenario_history.finished_scenarios.has(Scenario.BEGINNER_TUTORIAL):
 			_puzzle.show_back_button()
 
 
@@ -250,6 +247,9 @@ func _flash() -> void:
 
 
 func _on_PuzzleScore_game_prepared() -> void:
+	# summon the instructor. this is redundant for the first attempt of a tutorial, but necessary when retrying
+	_puzzle.summon_instructor()
+	
 	_lines_cleared = 0
 	_boxes_built = 0
 	_squish_moves = 0

--- a/project/src/main/puzzle/tutorial/tutorial-message.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-message.gd
@@ -95,6 +95,8 @@ func append_big_message(text_with_lulls: String) -> void:
 
 
 func _append_message_with_font(text_with_lulls, font) -> void:
+	# remove the pop out timer. otherwise a new message would inherit the timer from an old message
+	_pop_out_timer = 0
 	if not visible:
 		$Tween.pop_in()
 	

--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -6,11 +6,8 @@ The menu the user sees when they start the game.
 Includes buttons starting a new game, launching the level editor, and exiting the game.
 """
 
-# The mandatory tutorial the player must complete before seeing the main menu
-const BEGINNER_TUTORIAL_SCENARIO := "tutorial-beginner-0"
-
 func _ready() -> void:
-	if not PlayerData.scenario_history.finished_scenarios.has(BEGINNER_TUTORIAL_SCENARIO):
+	if not PlayerData.scenario_history.finished_scenarios.has(Scenario.BEGINNER_TUTORIAL):
 		_launch_tutorial()
 	
 	# Fade in music when redirected from a scene with no music, such as the level editor
@@ -23,7 +20,7 @@ func _ready() -> void:
 
 func _launch_tutorial() -> void:
 	var settings := ScenarioSettings.new()
-	settings.load_from_resource(BEGINNER_TUTORIAL_SCENARIO)
+	settings.load_from_resource(Scenario.BEGINNER_TUTORIAL)
 	Scenario.overworld_puzzle = false
 	Scenario.push_scenario_trail(settings)
 

--- a/project/src/main/world/restaurant/creature-view.gd
+++ b/project/src/main/world/restaurant/creature-view.gd
@@ -36,13 +36,18 @@ func set_current_creature_index(new_index: int) -> void:
 """
 Scroll to a new creature and replace the old creature.
 """
-func scroll_to_new_creature() -> void:
-	var creature_index: int = $SceneClip/CreatureSwitcher/Scene.current_creature_index
-	var new_creature_index: int = (creature_index + randi() % 2 + 1) % 3
+func scroll_to_new_creature(new_creature_index: int = -1) -> void:
+	var old_creature_index: int = get_current_creature_index()
+	if new_creature_index == -1:
+		new_creature_index = (old_creature_index + randi() % 2 + 1) % 3
 	set_current_creature_index(new_creature_index)
 	$SceneClip/CreatureSwitcher/Scene.get_creature_2d().restart_idle_timer()
 	yield(get_tree().create_timer(0.5), "timeout")
-	summon_creature(creature_index)
+	summon_creature(old_creature_index)
+
+
+func get_current_creature_index() -> int:
+	return $SceneClip/CreatureSwitcher/Scene.current_creature_index
 
 
 """


### PR DESCRIPTION
Fixed bug where star seeds sometimes lingered during tutorial. This bug was
caused because the after_piece_written and lines_deleted signals were emitted in
the wrong order. This meant when changing tutorial scenes, the scene would
change, and then the new star seeds would get moved around based on the cleared
lines.

Star seeds for incomplete boxes (such as in the third part of the tutorial) are
no longer placed adjacent if possible.

Instructor is now summoned when restarting a tutorial. Before, if you restarted
a tutorial after customers showed up, the random customer would lead the tutorial.

Increased tutorial music volume. The tutorial music is about 4 db quieter
than other songs, so I've turned up its in-game volume to compensate.
It was kind of jarring when the 'real music' kicked in before, because it
was a lot louder.

Fixed bug where message would sometimes be blanked out when restarting a
tutorial. This was because the pop_out_timer wasn't reset, so a message
might be marked to pop out, and then an important message appears
but disappears before it can be read.