### PR TITLE
Fixed fat finger setting; setting wasn't saved because of typo

### DIFF
--- a/project/src/main/touch-settings.gd
+++ b/project/src/main/touch-settings.gd
@@ -54,7 +54,7 @@ func to_json_dict() -> Dictionary:
 	return {
 		"size": size,
 		"scheme": scheme,
-		"fat-finger": fat_finger,
+		"fat_finger": fat_finger,
 	}
 
 


### PR DESCRIPTION
The setting was 'fat-finger' in one place but 'fat_finger' in the other.

Closes #509