### PR TITLE
'nook das' activates even if piece isn't moving.

### DIFF
--- a/project/src/main/puzzle/piece/piece-mover.gd
+++ b/project/src/main/puzzle/piece/piece-mover.gd
@@ -104,16 +104,17 @@ func apply_move_input(piece: ActivePiece) -> void:
 			piece.move_to_target()
 			_horizontal_movement_count += 1
 			emit_signal(movement_signal)
-		
-		# To prevent pieces from slipping past nooks before DAS, we automatically trigger DAS if you're pushing a
-		# piece towards an obstruction. We even trigger DAS if the piece already moved successfully.
-		#
-		# Otherwise, there are some unusual scenarios where, for example, 'O' pieces in a 3-column well will get
-		# instant DAS to the right (where they're blocked) but not to the left (where they can move)
-		if input.is_left_pressed() and not piece.can_move_to(piece.pos + Vector2.LEFT, piece.orientation):
-			input.set_left_das_active()
-		if input.is_right_pressed() and not piece.can_move_to(piece.pos + Vector2.RIGHT, piece.orientation):
-			input.set_right_das_active()
+	
+	# To prevent pieces from slipping past nooks before DAS, we automatically trigger DAS if you're pushing a
+	# piece towards an obstruction. We trigger DAS if the piece already moved successfully, or they're pressing the
+	# direction but DAS hasn't yet activated.
+	#
+	# Otherwise, there are some unusual scenarios where, for example, 'O' pieces in a 3-column well will get
+	# instant DAS to the right (where they're blocked) but not to the left (where they can move)
+	if input.is_left_pressed() and not piece.can_move_to(piece.pos + Vector2.LEFT, piece.orientation):
+		input.set_left_das_active()
+	if input.is_right_pressed() and not piece.can_move_to(piece.pos + Vector2.RIGHT, piece.orientation):
+		input.set_right_das_active()
 
 
 """


### PR DESCRIPTION
Otherwise there was an edge case where you're holding a piece against a
nook, but the piece skips the nook in a very specific case:

1. the piece is moved left successfully, while soft dropping, and not
blocked on the left
2. the piece becomes blocked with the left as it drops, but DAS is not yet
active
3. the piece goes past the nook before DAS activates