### PR TITLE
Fixed thin shader lines at boundaries, overlaps.

### DIFF
--- a/project/src/main/world/creature/body-shadows.shader
+++ b/project/src/main/world/creature/body-shadows.shader
@@ -36,11 +36,14 @@ void fragment()
 	// apply the shadow and decoration colors to the red parts of the texture
 	rgba_in.rgb = mix(rgba_in.rgb, color_in.rgb, color_in.a * rgba_in.r);
 	
-	// the output color defaults to the black replacement color. we then apply other colors over top of it
+
+	// mix black/red/blue/green colors sequentially. if all rgb components are equal, we first mix in 100% of the red
+	// color, then 50% of the green color, then 33% of the blue color.
+	float black_amount = max(0.0, 1.0 - rgba_in.r / rgba_in.a - rgba_in.g / rgba_in.a - rgba_in.b / rgba_in.a);
 	vec4 rgb_out = black;
-	rgb_out = mix(rgb_out, red.rgba, rgba_in.r * rgba_in.a);
-	rgb_out = mix(rgb_out, green.rgba, rgba_in.g * rgba_in.a);
-	rgb_out = mix(rgb_out, blue.rgba, rgba_in.b * rgba_in.a);
+	rgb_out = mix(rgb_out, red, rgba_in.r / max(0.00001, rgba_in.r + black_amount));
+	rgb_out = mix(rgb_out, green, rgba_in.g / max(0.00001, rgba_in.g + rgba_in.r + black_amount));
+	rgb_out = mix(rgb_out, blue, rgba_in.b / max(0.00001, rgba_in.b + rgba_in.g + rgba_in.r + black_amount));
 	
 	// assign final color for the pixel, and preserve transparency
 	COLOR = vec4(rgb_out.rgb, rgba_in.a);

--- a/project/src/main/world/rgb-palette.shader
+++ b/project/src/main/world/rgb-palette.shader
@@ -18,13 +18,14 @@ uniform vec4 black : hint_color;
 void fragment() {
 	vec4 rgba_in = texture(TEXTURE, UV);
 	
-	// color defaults to the black replacement color
+	// mix black/red/blue/green colors sequentially. if all rgb components are equal, we first mix in 100% of the red
+	// color, then 50% of the green color, then 33% of the blue color.
+	float black_amount = max(0.0, 1.0 - rgba_in.r - rgba_in.g - rgba_in.b);
 	vec4 rgb_out = black;
-	
-	// mix in other colors based on the red, green and blue components of the source image
-	rgb_out = mix(rgb_out, red.rgba, rgba_in.r);
-	rgb_out = mix(rgb_out, green.rgba, rgba_in.g);
-	rgb_out = mix(rgb_out, blue.rgba, rgba_in.b);
+	rgb_out = mix(rgb_out, red, rgba_in.r / max(0.00001, rgba_in.r + black_amount));
+	rgb_out = mix(rgb_out, green, rgba_in.g / max(0.00001, rgba_in.g + rgba_in.r + black_amount));
+	rgb_out = mix(rgb_out, blue, rgba_in.b / max(0.00001, rgba_in.b + rgba_in.g + rgba_in.r + black_amount));
+	rgb_out.a = rgba_in.a;
 	
 	// Assign final color for the pixel, and preserve transparency
 	COLOR = vec4(rgb_out.rgb, rgba_in.a * rgb_out.a);


### PR DESCRIPTION
This was noticable at the top of the neck as described in #492. But, it
also became noticable around the eyes and face after facial colors were
introduced recently.

This bug was caused because red/green/blue are mixed one after the other
-- but the old math would mix in red 33%, green 33% and blue 33% for
example, resulting in a color which still had some black in it. The new
logic will mix in red 100%, green 50%, and blue 33% for an opaque color
which is evenly distributed between all three colors.