### PR TITLE
Fixed U/Q/P wall kicks which caused floor kicks.

### DIFF
--- a/project/src/main/puzzle/piece/piece-types.gd
+++ b/project/src/main/puzzle/piece/piece-types.gd
@@ -24,30 +24,30 @@ const KICKS_T := [
 
 const KICKS_U := [
 		[Vector2( 0, -1), Vector2(-1, -1), Vector2(-1,  0), Vector2(-1,  1), Vector2( 0, -2)],
-		[Vector2( 0,  1), Vector2( 1,  1), Vector2( 1,  0), Vector2( 1, -1), Vector2( 0,  2)],
+		[Vector2( 0,  1), Vector2( 1,  0), Vector2( 1,  1), Vector2( 1, -1), Vector2( 0,  2)],
 		
 		[Vector2( 1,  0), Vector2( 1, -1), Vector2( 0,  1), Vector2( 1,  1), Vector2( 0,  2)],
-		[Vector2(-1,  0), Vector2(-1,  1), Vector2( 0, -1), Vector2(-1, -1), Vector2( 0, -2)],
+		[Vector2( 0, -1), Vector2(-1,  0), Vector2(-1,  1), Vector2(-1, -1), Vector2( 0, -2)],
 		
-		[Vector2( 1,  0), Vector2( 1,  1), Vector2( 0, -1), Vector2( 1, -1), Vector2( 0, -2)],
-		[Vector2( 0,  1), Vector2(-1, -1), Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  2)],
+		[Vector2( 0, -1), Vector2( 1,  1), Vector2( 1,  0), Vector2( 1, -1), Vector2( 0, -2)],
+		[Vector2( 0,  1), Vector2(-1,  0), Vector2(-1, -1), Vector2(-1,  1), Vector2( 0,  2)],
 		
 		[Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2(-1, -1), Vector2( 0,  2)],
-		[Vector2( 0, -1), Vector2( 1, -1), Vector2( 1,  0), Vector2( 1,  1), Vector2( 0, -2)],
+		[Vector2( 0, -1), Vector2( 1,  0), Vector2( 1, -1), Vector2( 1,  1), Vector2( 0, -2)],
 	]
 
 const KICKS_P := [
-		[Vector2( 0, -1), Vector2(-1, -1), Vector2( 0,  1), Vector2(-1,  0)],
+		[Vector2( 0, -1), Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1)],
 		[Vector2( 1,  0), Vector2( 1, -1), Vector2( 0, -1), Vector2( 0,  1)],
-		[Vector2( 0,  1), Vector2( 1,  1), Vector2( 0, -1), Vector2( 1,  0)],
+		[Vector2( 0,  1), Vector2( 1,  0), Vector2( 1,  1), Vector2( 0, -1)],
 		[Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1)],
 	]
 
 const KICKS_Q := [
 		[Vector2(-1,  0), Vector2(-1, -1), Vector2( 0, -1), Vector2( 0,  1)],
-		[Vector2( 0, -1), Vector2( 1, -1), Vector2( 0,  1), Vector2( 1,  0)],
+		[Vector2( 0, -1), Vector2( 1,  0), Vector2( 1, -1), Vector2( 0,  1)],
 		[Vector2( 1,  0), Vector2( 1,  1), Vector2( 0,  1), Vector2( 0, -1)],
-		[Vector2( 0,  1), Vector2(-1,  1), Vector2( 0, -1), Vector2(-1,  0)],
+		[Vector2( 0,  1), Vector2(-1,  0), Vector2(-1,  1), Vector2( 0, -1)],
 	]
 
 const KICKS_V := [

--- a/project/src/test/test-piece-kicks-qp.gd
+++ b/project/src/test/test-piece-kicks-qp.gd
@@ -59,7 +59,7 @@ func test_q_floorkick_ccw() -> void:
 	assert_kick()
 
 
-func test_p_rwallkick_cw() -> void:
+func test_p_rwallkick_l0() -> void:
 	from_grid = [
 		"    ",
 		"  pp",
@@ -77,7 +77,25 @@ func test_p_rwallkick_cw() -> void:
 	assert_kick()
 
 
-func test_p_lwallkick_ccw() -> void:
+func test_p_rwallkick_l2() -> void:
+	from_grid = [
+		"    ",
+		"  pp",
+		"  pp",
+		"  p ",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		"    ",
+		" pp ",
+		" ppp",
+		"    ",
+	]
+	assert_kick()
+
+
+func test_p_lwallkick_r0() -> void:
 	from_grid = [
 		"    ",
 		" p  ",
@@ -87,15 +105,33 @@ func test_p_lwallkick_ccw() -> void:
 	]
 	to_grid = [
 		"    ",
-		"    ",
 		"ppp ",
 		" pp ",
+		"    ",
 		"    ",
 	]
 	assert_kick()
 
 
-func test_q_rwallkick_cw() -> void:
+func test_q_lwallkick_r2() -> void:
+	from_grid = [
+		"    ",
+		"qq  ",
+		"qq  ",
+		" q  ",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		"    ",
+		" qq ",
+		"qqq ",
+		"    ",
+	]
+	assert_kick()
+
+
+func test_q_rwallkick_l0() -> void:
 	from_grid = [
 		"    ",
 		"  q ",
@@ -105,15 +141,15 @@ func test_q_rwallkick_cw() -> void:
 	]
 	to_grid = [
 		"    ",
-		"    ",
 		" qqq",
 		" qq ",
+		"    ",
 		"    ",
 	]
 	assert_kick()
 
 
-func test_q_lwallkick_ccw() -> void:
+func test_q_lwallkick_r0() -> void:
 	from_grid = [
 		"    ",
 		"qq  ",
@@ -399,32 +435,32 @@ func test_p_climb_r0() -> void:
 		"     ",
 		"     ",
 		":: p ",
-		"::pp ",
+		"::pp:",
 		"::pp:"]
 	to_grid = [
 		"     ",
 		"     ",
 		" ppp ",
 		"::pp ",
-		"::   ",
+		"::  :",
 		"::  :"]
 	assert_kick()
 
 
-func test_q_climb_l0_failed() -> void:
+func test_q_climb_l0() -> void:
 	from_grid = [
 		"     ",
 		"     ",
 		"     ",
 		" q ::",
-		" qq::",
+		":qq::",
 		":qq::"]
 	to_grid = [
 		"     ",
 		"     ",
 		" qqq ",
 		" qq::",
-		"   ::",
+		":  ::",
 		":  ::"]
 	assert_kick()
 

--- a/project/src/test/test-piece-kicks-u.gd
+++ b/project/src/test/test-piece-kicks-u.gd
@@ -3,7 +3,7 @@ extends "res://src/test/test-piece-kicks.gd"
 Tests the u piece's kick behavior.
 """
 
-func test_floorkick_cw() -> void:
+func test_floorkick_2l() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -19,7 +19,7 @@ func test_floorkick_cw() -> void:
 	assert_kick()
 
 
-func test_floorkick_ccw() -> void:
+func test_floorkick_2r() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -35,7 +35,25 @@ func test_floorkick_ccw() -> void:
 	assert_kick()
 
 
-func test_rwallkick_cw() -> void:
+func test_rwallkick_r0() -> void:
+	from_grid = [
+		"    ",
+		"  uu",
+		"   u",
+		"  uu",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		" uuu",
+		" u u",
+		"    ",
+		"    ",
+	]
+	assert_kick()
+
+
+func test_rwallkick_r2() -> void:
 	from_grid = [
 		"    ",
 		"  uu",
@@ -53,7 +71,97 @@ func test_rwallkick_cw() -> void:
 	assert_kick()
 
 
-func test_lwallkick_ccw() -> void:
+func test_rwallkick_l0() -> void:
+	from_grid = [
+		"    ",
+		"  uu",
+		"  u ",
+		"  uu",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		" uuu",
+		" u u",
+		"    ",
+		"    ",
+	]
+	assert_kick()
+
+
+func test_rwallkick_l2() -> void:
+	from_grid = [
+		"    ",
+		"  uu",
+		"  u ",
+		"  uu",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		" u u",
+		" uuu",
+		"    ",
+		"    ",
+	]
+	assert_kick()
+
+
+func test_lwallkick_r0() -> void:
+	from_grid = [
+		"    ",
+		"uu  ",
+		" u  ",
+		"uu  ",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		"uuu ",
+		"u u ",
+		"    ",
+		"    ",
+	]
+	assert_kick()
+
+
+func test_lwallkick_r2() -> void:
+	from_grid = [
+		"    ",
+		"uu  ",
+		" u  ",
+		"uu  ",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		"u u ",
+		"uuu ",
+		"    ",
+		"    ",
+	]
+	assert_kick()
+
+
+func test_lwallkick_l0() -> void:
+	from_grid = [
+		"    ",
+		"uu  ",
+		"u   ",
+		"uu  ",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		"uuu ",
+		"u u ",
+		"    ",
+		"    ",
+	]
+	assert_kick()
+
+
+func test_lwallkick_l2() -> void:
 	from_grid = [
 		"    ",
 		"uu  ",
@@ -74,7 +182,7 @@ func test_lwallkick_ccw() -> void:
 """
 A spire kick is when a u piece rotates while a block is in its gap.
 """
-func test_spire_kick_cw0() -> void:
+func test_spire_kick_0r() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -90,7 +198,7 @@ func test_spire_kick_cw0() -> void:
 	assert_kick()
 
 
-func test_spire_kick_cw1() -> void:
+func test_spire_kick_r2() -> void:
 	from_grid = [
 		"     ",
 		"uu   ",
@@ -108,7 +216,7 @@ func test_spire_kick_cw1() -> void:
 	assert_kick()
 
 
-func test_spire_kick_cw2() -> void:
+func test_spire_kick_l0() -> void:
 	from_grid = [
 		"     ",
 		"   uu",
@@ -126,7 +234,7 @@ func test_spire_kick_cw2() -> void:
 	assert_kick()
 
 
-func test_spire_kick_ccw0() -> void:
+func test_spire_kick_0l() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -142,7 +250,7 @@ func test_spire_kick_ccw0() -> void:
 	assert_kick()
 
 
-func test_spire_kick_ccw1() -> void:
+func test_spire_kick_l2() -> void:
 	from_grid = [
 		"     ",
 		"   uu",
@@ -160,7 +268,7 @@ func test_spire_kick_ccw1() -> void:
 	assert_kick()
 
 
-func test_spire_kick_ccw2() -> void:
+func test_spire_kick_r0() -> void:
 	from_grid = [
 		"     ",
 		"uu   ",
@@ -181,7 +289,7 @@ func test_spire_kick_ccw2() -> void:
 """
 a 'diagonalnw kick' is when the u piece is boxed in by the nw/se corners
 """
-func test_diagonalnw_kick_0r() -> void:
+func test_diagonalnw_kick_2l() -> void:
 	from_grid = [
 		"::   ",
 		":u u ",
@@ -197,7 +305,7 @@ func test_diagonalnw_kick_0r() -> void:
 	assert_kick()
 
 
-func test_diagonalnw_kick_r2() -> void:
+func test_diagonalnw_kick_l0() -> void:
 	from_grid = [
 		"::  ",
 		":uu ",
@@ -215,7 +323,7 @@ func test_diagonalnw_kick_r2() -> void:
 	assert_kick()
 
 
-func test_diagonalnw_kick_2l() -> void:
+func test_diagonalnw_kick_0r() -> void:
 	from_grid = [
 		"::   ",
 		":uuu ",
@@ -231,7 +339,7 @@ func test_diagonalnw_kick_2l() -> void:
 	assert_kick()
 
 
-func test_diagonalnw_kick_l0() -> void:
+func test_diagonalnw_kick_r2() -> void:
 	from_grid = [
 		"::  ",
 		":uu ",
@@ -252,7 +360,7 @@ func test_diagonalnw_kick_l0() -> void:
 """
 a 'diagonalne kick' is when the u piece is boxed in by the ne/sw corners
 """
-func test_diagonalne_kick_0r() -> void:
+func test_diagonalne_kick_2l() -> void:
 	from_grid = [
 		"   ::",
 		" u u:",
@@ -260,15 +368,15 @@ func test_diagonalne_kick_0r() -> void:
 		"::   ",
 	]
 	to_grid = [
-		"   ::",
-		"  uu:",
-		": u  ",
-		"::uu ",
+		" uu::",
+		" u  :",
+		":uu  ",
+		"::   ",
 	]
 	assert_kick()
 
 
-func test_diagonalne_kick_r2() -> void:
+func test_diagonalne_kick_l0() -> void:
 	from_grid = [
 		"  ::",
 		" uu:",
@@ -286,7 +394,7 @@ func test_diagonalne_kick_r2() -> void:
 	assert_kick()
 
 
-func test_diagonalne_kick_2l() -> void:
+func test_diagonalne_kick_0r() -> void:
 	from_grid = [
 		"   ::",
 		" uuu:",
@@ -302,7 +410,7 @@ func test_diagonalne_kick_2l() -> void:
 	assert_kick()
 
 
-func test_diagonalne_kick_l0() -> void:
+func test_diagonalne_kick_r2() -> void:
 	from_grid = [
 		"  ::",
 		" uu:",
@@ -323,113 +431,18 @@ func test_diagonalne_kick_l0() -> void:
 """
 a 'shaft kick' is when the u piece rotates after being dropped down a narrow shaft
 """
-func test_shaft_kick_l0_0() -> void:
-	from_grid = [
-		"  ::",
-		"uu::",
-		" u  ",
-		"uu  ",
-	]
-	to_grid = [
-		"  ::",
-		"  ::",
-		"u u ",
-		"uuu ",
-	]
-	assert_kick()
-
-
-func test_shaft_kick_l0_1() -> void:
-	from_grid = [
-		"::  ",
-		"::uu",
-		"   u",
-		"  uu",
-	]
-	to_grid = [
-		"::  ",
-		"::  ",
-		" u u",
-		" uuu",
-	]
-	assert_kick()
-
-
-func test_shaft_kick_l2_0() -> void:
-	from_grid = [
-		"  ::",
-		"uu::",
-		" u  ",
-		"uu  ",
-	]
-	to_grid = [
-		"  ::",
-		"  ::",
-		"uuu ",
-		"u u ",
-	]
-	assert_kick()
-
-
-func test_shaft_kick_l2_1() -> void:
-	from_grid = [
-		"::  ",
-		"::uu",
-		"   u",
-		"  uu",
-	]
-	to_grid = [
-		"::  ",
-		"::  ",
-		" uuu",
-		" u u",
-	]
-	assert_kick()
-
-func test_shaft_kick_r0_0() -> void:
-	from_grid = [
-		"  ::",
-		"uu::",
-		"u   ",
-		"uu  ",
-	]
-	to_grid = [
-		"  ::",
-		"  ::",
-		"u u ",
-		"uuu ",
-	]
-	assert_kick()
-
-
-func test_shaft_kick_r0_1() -> void:
-	from_grid = [
-		"::  ",
-		"::uu",
-		"  u ",
-		"  uu",
-	]
-	to_grid = [
-		"::  ",
-		"::  ",
-		" u u",
-		" uuu",
-	]
-	assert_kick()
-
-
 func test_shaft_kick_r2_0() -> void:
 	from_grid = [
 		"  ::",
 		"uu::",
-		"u   ",
+		" u  ",
 		"uu  ",
 	]
 	to_grid = [
 		"  ::",
 		"  ::",
-		"uuu ",
 		"u u ",
+		"uuu ",
 	]
 	assert_kick()
 
@@ -438,6 +451,101 @@ func test_shaft_kick_r2_1() -> void:
 	from_grid = [
 		"::  ",
 		"::uu",
+		"   u",
+		"  uu",
+	]
+	to_grid = [
+		"::  ",
+		"::  ",
+		" u u",
+		" uuu",
+	]
+	assert_kick()
+
+
+func test_shaft_kick_r0_0() -> void:
+	from_grid = [
+		"  ::",
+		"uu::",
+		" u  ",
+		"uu  ",
+	]
+	to_grid = [
+		"  ::",
+		"  ::",
+		"uuu ",
+		"u u ",
+	]
+	assert_kick()
+
+
+func test_shaft_kick_r0_1() -> void:
+	from_grid = [
+		"::  ",
+		"::uu",
+		"   u",
+		"  uu",
+	]
+	to_grid = [
+		"::  ",
+		"::  ",
+		" uuu",
+		" u u",
+	]
+	assert_kick()
+
+func test_shaft_kick_l2_0() -> void:
+	from_grid = [
+		"  ::",
+		"uu::",
+		"u   ",
+		"uu  ",
+	]
+	to_grid = [
+		"  ::",
+		"  ::",
+		"u u ",
+		"uuu ",
+	]
+	assert_kick()
+
+
+func test_shaft_kick_l2_1() -> void:
+	from_grid = [
+		"::  ",
+		"::uu",
+		"  u ",
+		"  uu",
+	]
+	to_grid = [
+		"::  ",
+		"::  ",
+		" u u",
+		" uuu",
+	]
+	assert_kick()
+
+
+func test_shaft_kick_l0_0() -> void:
+	from_grid = [
+		"  ::",
+		"uu::",
+		"u   ",
+		"uu  ",
+	]
+	to_grid = [
+		"  ::",
+		"  ::",
+		"uuu ",
+		"u u ",
+	]
+	assert_kick()
+
+
+func test_shaft_kick_l0_1() -> void:
+	from_grid = [
+		"::  ",
+		"::uu",
 		"  u ",
 		"  uu",
 	]
@@ -450,7 +558,7 @@ func test_shaft_kick_r2_1() -> void:
 	assert_kick()
 
 
-func test_climb_kick_r2() -> void:
+func test_climb_kick_l0() -> void:
 	from_grid = [
 		"    ",
 		" uu ",
@@ -466,7 +574,7 @@ func test_climb_kick_r2() -> void:
 	assert_kick()
 
 
-func test_climb_kick_l0() -> void:
+func test_climb_kick_r0() -> void:
 	from_grid = [
 		"    ",
 		" uu ",
@@ -533,7 +641,7 @@ func test_ledge_kick_right_l0() -> void:
 	assert_kick()
 
 
-func test_ledge_kick_left_0r() -> void:
+func test_ledge_kick_left_0l() -> void:
 	from_grid = [
 		"    ",
 		"uuu ",
@@ -549,7 +657,7 @@ func test_ledge_kick_left_0r() -> void:
 	assert_kick()
 
 
-func test_ledge_kick_left_r2() -> void:
+func test_ledge_kick_left_l2() -> void:
 	from_grid = [
 		"uu  ",
 		"u   ",
@@ -565,7 +673,7 @@ func test_ledge_kick_left_r2() -> void:
 	assert_kick()
 
 
-func test_ledge_kick_left_l0() -> void:
+func test_ledge_kick_left_r0() -> void:
 	from_grid = [
 		"uu  ",
 		" u  ",
@@ -573,9 +681,9 @@ func test_ledge_kick_left_l0() -> void:
 		":   ",
 	]
 	to_grid = [
-		"    ",
 		"uuu ",
 		"u u ",
+		"    ",
 		":   ",
 	]
 	assert_kick()


### PR DESCRIPTION
Rotating a U/Q/P piece against the wall in a certain way trigged a floor
kick. This is bad because it results in unintuitive behavior where you
could cause a piece to hover by rotating it against a wall, or be
forbidden from rotating it once it landed.