### PR TITLE
Restored FarArm creature animations.

### DIFF
--- a/project/src/main/world/creature/CreatureVisuals.tscn
+++ b/project/src/main/world/creature/CreatureVisuals.tscn
@@ -2478,19 +2478,19 @@ tracks/3/keys = {
 "values": [ 2, 2 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Neck0/HeadBobber/EmoteArmZ0:frame")
+tracks/4/path = NodePath("FarArm:frame")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
 tracks/4/enabled = true
 tracks/4/keys = {
-"times": PoolRealArray( 0, 0.966666, 0.999999, 5.93333, 5.96666, 5.99999 ),
+"times": PoolRealArray( 0, 0.957, 0.999999, 5.93333, 5.96666, 5.99999 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 0, 0, 1, 1, 0, 0 ]
+"values": [ 1, 1, 0, 0, 1, 1 ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Neck0/HeadBobber/EmoteArmZ1:frame")
+tracks/5/path = NodePath("Neck0/HeadBobber/EmoteArmZ0:frame")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -2502,31 +2502,31 @@ tracks/5/keys = {
 "values": [ 0, 0, 1, 1, 0, 0 ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("Neck0/HeadBobber/EmoteBrain:position")
-tracks/6/interp = 2
+tracks/6/path = NodePath("Neck0/HeadBobber/EmoteArmZ1:frame")
+tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
+"times": PoolRealArray( 0, 0.966666, 0.999999, 5.93333, 5.96666, 5.99999 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"update": 1,
+"values": [ 0, 0, 1, 1, 0, 0 ]
+}
+tracks/7/type = "value"
+tracks/7/path = NodePath("Neck0/HeadBobber/EmoteBrain:position")
+tracks/7/interp = 2
+tracks/7/loop_wrap = true
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/keys = {
 "times": PoolRealArray( 0, 1.5, 3, 4.5, 6 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
 "update": 0,
 "values": [ Vector2( 66.413, 228.341 ), Vector2( 66.413, 208.341 ), Vector2( 66.413, 228.341 ), Vector2( 66.413, 208.341 ), Vector2( 66.413, 228.341 ) ]
 }
-tracks/7/type = "value"
-tracks/7/path = NodePath("Neck0/HeadBobber/EmoteBrain:frame")
-tracks/7/interp = 1
-tracks/7/loop_wrap = true
-tracks/7/imported = false
-tracks/7/enabled = true
-tracks/7/keys = {
-"times": PoolRealArray( 0, 6 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 8, 8 ]
-}
 tracks/8/type = "value"
-tracks/8/path = NodePath("Neck0/HeadBobber/EmoteBrain:modulate")
+tracks/8/path = NodePath("Neck0/HeadBobber/EmoteBrain:frame")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
@@ -2534,11 +2534,11 @@ tracks/8/enabled = true
 tracks/8/keys = {
 "times": PoolRealArray( 0, 6 ),
 "transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
+"update": 1,
+"values": [ 8, 8 ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath("Neck0/HeadBobber/EmoteBrain:material:shader_param/green")
+tracks/9/path = NodePath("Neck0/HeadBobber/EmoteBrain:modulate")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
@@ -2547,10 +2547,10 @@ tracks/9/keys = {
 "times": PoolRealArray( 0, 6 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 0,
-"values": [ Color( 0.501961, 0.501961, 1, 1 ), Color( 0.501961, 0.501961, 1, 1 ) ]
+"values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
 }
 tracks/10/type = "value"
-tracks/10/path = NodePath("Neck0/HeadBobber/EmoteGlow:modulate")
+tracks/10/path = NodePath("Neck0/HeadBobber/EmoteBrain:material:shader_param/green")
 tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/imported = false
@@ -2559,10 +2559,10 @@ tracks/10/keys = {
 "times": PoolRealArray( 0, 6 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 0,
-"values": [ Color( 0, 0, 0.737255, 0.501961 ), Color( 0, 0, 0.737255, 0.501961 ) ]
+"values": [ Color( 0.501961, 0.501961, 1, 1 ), Color( 0.501961, 0.501961, 1, 1 ) ]
 }
 tracks/11/type = "value"
-tracks/11/path = NodePath("Neck0/HeadBobber/EmoteGlow:scale")
+tracks/11/path = NodePath("Neck0/HeadBobber/EmoteGlow:modulate")
 tracks/11/interp = 1
 tracks/11/loop_wrap = true
 tracks/11/imported = false
@@ -2571,39 +2571,51 @@ tracks/11/keys = {
 "times": PoolRealArray( 0, 6 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 0,
-"values": [ Vector2( 2, 2 ), Vector2( 2, 2 ) ]
+"values": [ Color( 0, 0, 0.737255, 0.501961 ), Color( 0, 0, 0.737255, 0.501961 ) ]
 }
 tracks/12/type = "value"
-tracks/12/path = NodePath("Neck0/HeadBobber/EmoteGlow:position")
+tracks/12/path = NodePath("Neck0/HeadBobber/EmoteGlow:scale")
 tracks/12/interp = 1
 tracks/12/loop_wrap = true
 tracks/12/imported = false
 tracks/12/enabled = true
 tracks/12/keys = {
-"times": PoolRealArray( 0, 0.5, 2, 3.5, 5, 6 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"times": PoolRealArray( 0, 6 ),
+"transitions": PoolRealArray( 1, 1 ),
 "update": 0,
-"values": [ Vector2( 56.261, 460.649 ), Vector2( 56.261, 460.649 ), Vector2( 56.261, 440.649 ), Vector2( 56.261, 460.649 ), Vector2( 56.261, 440.649 ), Vector2( 56.261, 460.649 ) ]
+"values": [ Vector2( 2, 2 ), Vector2( 2, 2 ) ]
 }
 tracks/13/type = "value"
-tracks/13/path = NodePath("Neck0/HeadBobber/EmoteGlow:material:blend_mode")
+tracks/13/path = NodePath("Neck0/HeadBobber/EmoteGlow:position")
 tracks/13/interp = 1
 tracks/13/loop_wrap = true
 tracks/13/imported = false
 tracks/13/enabled = true
 tracks/13/keys = {
+"times": PoolRealArray( 0, 0.5, 2, 3.5, 5, 6 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( 56.261, 460.649 ), Vector2( 56.261, 460.649 ), Vector2( 56.261, 440.649 ), Vector2( 56.261, 460.649 ), Vector2( 56.261, 440.649 ), Vector2( 56.261, 460.649 ) ]
+}
+tracks/14/type = "value"
+tracks/14/path = NodePath("Neck0/HeadBobber/EmoteGlow:material:blend_mode")
+tracks/14/interp = 1
+tracks/14/loop_wrap = true
+tracks/14/imported = false
+tracks/14/enabled = true
+tracks/14/keys = {
 "times": PoolRealArray( 0, 6 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 1,
 "values": [ 0, 0 ]
 }
-tracks/14/type = "value"
-tracks/14/path = NodePath("Neck0/HeadBobber:rotation_degrees")
-tracks/14/interp = 2
-tracks/14/loop_wrap = true
-tracks/14/imported = false
-tracks/14/enabled = true
-tracks/14/keys = {
+tracks/15/type = "value"
+tracks/15/path = NodePath("Neck0/HeadBobber:rotation_degrees")
+tracks/15/interp = 2
+tracks/15/loop_wrap = true
+tracks/15/imported = false
+tracks/15/enabled = true
+tracks/15/keys = {
 "times": PoolRealArray( 0, 0.5, 0.999999, 2, 3, 4, 5, 5.99999 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
@@ -2662,19 +2674,19 @@ tracks/3/keys = {
 "values": [ 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 4 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Neck0/HeadBobber/EmoteArmZ0:frame")
+tracks/4/path = NodePath("FarArm:frame")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
 tracks/4/enabled = true
 tracks/4/keys = {
-"times": PoolRealArray( 0, 0.966666, 0.999999, 5.93333, 5.96666, 5.99999 ),
+"times": PoolRealArray( 0, 0.966667, 0.999999, 5.93333, 5.96666, 5.99999 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 0, 0, 2, 2, 0, 0 ]
+"values": [ 1, 1, 0, 0, 1, 1 ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Neck0/HeadBobber/EmoteArmZ1:frame")
+tracks/5/path = NodePath("Neck0/HeadBobber/EmoteArmZ0:frame")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -2686,72 +2698,84 @@ tracks/5/keys = {
 "values": [ 0, 0, 2, 2, 0, 0 ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("Neck0/HeadBobber/EmoteGlow:modulate")
+tracks/6/path = NodePath("Neck0/HeadBobber/EmoteArmZ1:frame")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
-"times": PoolRealArray( 0, 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
-"update": 0,
-"values": [ Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ) ]
+"times": PoolRealArray( 0, 0.966666, 0.999999, 5.93333, 5.96666, 5.99999 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"update": 1,
+"values": [ 0, 0, 2, 2, 0, 0 ]
 }
 tracks/7/type = "value"
-tracks/7/path = NodePath("Neck0/HeadBobber/EmoteGlow:scale")
+tracks/7/path = NodePath("Neck0/HeadBobber/EmoteGlow:modulate")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/imported = false
 tracks/7/enabled = true
 tracks/7/keys = {
-"times": PoolRealArray( 0, 6 ),
-"transitions": PoolRealArray( 1, 1 ),
+"times": PoolRealArray( 0, 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ Vector2( 3, 3 ), Vector2( 3, 3 ) ]
+"values": [ Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ) ]
 }
 tracks/8/type = "value"
-tracks/8/path = NodePath("Neck0/HeadBobber/EmoteGlow:position")
+tracks/8/path = NodePath("Neck0/HeadBobber/EmoteGlow:scale")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
 tracks/8/enabled = true
 tracks/8/keys = {
-"times": PoolRealArray( 0, 0.5, 2, 3.5, 5, 5.99999 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"times": PoolRealArray( 0, 6 ),
+"transitions": PoolRealArray( 1, 1 ),
 "update": 0,
-"values": [ Vector2( 7, 726 ), Vector2( 7, 676 ), Vector2( 7, 726 ), Vector2( 7, 676 ), Vector2( 7, 726 ), Vector2( 7, 676 ) ]
+"values": [ Vector2( 3, 3 ), Vector2( 3, 3 ) ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath("Neck0/HeadBobber/EmoteGlow:material:blend_mode")
+tracks/9/path = NodePath("Neck0/HeadBobber/EmoteGlow:position")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
 tracks/9/enabled = true
 tracks/9/keys = {
-"times": PoolRealArray( 0, 6 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 0, 0 ]
+"times": PoolRealArray( 0, 0.5, 2, 3.5, 5, 5.99999 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( 7, 726 ), Vector2( 7, 676 ), Vector2( 7, 726 ), Vector2( 7, 676 ), Vector2( 7, 726 ), Vector2( 7, 676 ) ]
 }
 tracks/10/type = "value"
-tracks/10/path = NodePath("NearArm:frame")
+tracks/10/path = NodePath("Neck0/HeadBobber/EmoteGlow:material:blend_mode")
 tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/imported = false
 tracks/10/enabled = true
 tracks/10/keys = {
+"times": PoolRealArray( 0, 6 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ 0, 0 ]
+}
+tracks/11/type = "value"
+tracks/11/path = NodePath("NearArm:frame")
+tracks/11/interp = 1
+tracks/11/loop_wrap = true
+tracks/11/imported = false
+tracks/11/enabled = true
+tracks/11/keys = {
 "times": PoolRealArray( 0, 0.966666, 0.999999, 5.93333, 5.96666, 5.99999 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
 "update": 1,
 "values": [ 1, 1, 0, 0, 1, 1 ]
 }
-tracks/11/type = "value"
-tracks/11/path = NodePath("Neck0/HeadBobber:rotation_degrees")
-tracks/11/interp = 2
-tracks/11/loop_wrap = true
-tracks/11/imported = false
-tracks/11/enabled = true
-tracks/11/keys = {
+tracks/12/type = "value"
+tracks/12/path = NodePath("Neck0/HeadBobber:rotation_degrees")
+tracks/12/interp = 2
+tracks/12/loop_wrap = true
+tracks/12/imported = false
+tracks/12/enabled = true
+tracks/12/keys = {
 "times": PoolRealArray( 0, 0.5, 0.999999, 2, 3, 4, 5, 5.99999 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
@@ -2810,19 +2834,19 @@ tracks/3/keys = {
 "values": [ 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 4 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Neck0/HeadBobber/EmoteArmZ0:frame")
+tracks/4/path = NodePath("FarArm:frame")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
 tracks/4/enabled = true
 tracks/4/keys = {
-"times": PoolRealArray( 0, 0.966666, 0.999999, 5.93333, 5.96666, 5.99999 ),
+"times": PoolRealArray( 0, 0.966667, 0.999999, 5.93333, 5.96666, 5.99999 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 0, 0, 2, 2, 0, 0 ]
+"values": [ 1, 1, 0, 0, 1, 1 ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Neck0/HeadBobber/EmoteArmZ1:frame")
+tracks/5/path = NodePath("Neck0/HeadBobber/EmoteArmZ0:frame")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -2834,91 +2858,91 @@ tracks/5/keys = {
 "values": [ 0, 0, 2, 2, 0, 0 ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("Neck0/HeadBobber/EmoteGlow:modulate")
+tracks/6/path = NodePath("Neck0/HeadBobber/EmoteArmZ1:frame")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
-"times": PoolRealArray( 0, 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
-"update": 0,
-"values": [ Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ) ]
+"times": PoolRealArray( 0, 0.966666, 0.999999, 5.93333, 5.96666, 5.99999 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"update": 1,
+"values": [ 0, 0, 2, 2, 0, 0 ]
 }
 tracks/7/type = "value"
-tracks/7/path = NodePath("Neck0/HeadBobber/EmoteGlow:scale")
+tracks/7/path = NodePath("Neck0/HeadBobber/EmoteGlow:modulate")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/imported = false
 tracks/7/enabled = true
 tracks/7/keys = {
-"times": PoolRealArray( 0, 6 ),
-"transitions": PoolRealArray( 1, 1 ),
+"times": PoolRealArray( 0, 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ Vector2( 3, 3 ), Vector2( 3, 3 ) ]
+"values": [ Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ) ]
 }
 tracks/8/type = "value"
-tracks/8/path = NodePath("Neck0/HeadBobber/EmoteGlow:position")
+tracks/8/path = NodePath("Neck0/HeadBobber/EmoteGlow:scale")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
 tracks/8/enabled = true
 tracks/8/keys = {
-"times": PoolRealArray( 0, 0.5, 2, 3.5, 5, 5.99999 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"times": PoolRealArray( 0, 6 ),
+"transitions": PoolRealArray( 1, 1 ),
 "update": 0,
-"values": [ Vector2( 7, 726 ), Vector2( 7, 676 ), Vector2( 7, 726 ), Vector2( 7, 676 ), Vector2( 7, 726 ), Vector2( 7, 676 ) ]
+"values": [ Vector2( 3, 3 ), Vector2( 3, 3 ) ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath("Neck0/HeadBobber/EmoteGlow:material:blend_mode")
+tracks/9/path = NodePath("Neck0/HeadBobber/EmoteGlow:position")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
 tracks/9/enabled = true
 tracks/9/keys = {
-"times": PoolRealArray( 0, 6 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 0, 0 ]
+"times": PoolRealArray( 0, 0.5, 2, 3.5, 5, 5.99999 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( 7, 726 ), Vector2( 7, 676 ), Vector2( 7, 726 ), Vector2( 7, 676 ), Vector2( 7, 726 ), Vector2( 7, 676 ) ]
 }
 tracks/10/type = "value"
-tracks/10/path = NodePath("NearArm:frame")
+tracks/10/path = NodePath("Neck0/HeadBobber/EmoteGlow:material:blend_mode")
 tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/imported = false
 tracks/10/enabled = true
 tracks/10/keys = {
+"times": PoolRealArray( 0, 6 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ 0, 0 ]
+}
+tracks/11/type = "value"
+tracks/11/path = NodePath("NearArm:frame")
+tracks/11/interp = 1
+tracks/11/loop_wrap = true
+tracks/11/imported = false
+tracks/11/enabled = true
+tracks/11/keys = {
 "times": PoolRealArray( 0, 0.966666, 0.999999, 5.93333, 5.96666, 5.99999 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
 "update": 1,
 "values": [ 1, 1, 0, 0, 1, 1 ]
 }
-tracks/11/type = "value"
-tracks/11/path = NodePath("Neck0/HeadBobber:rotation_degrees")
-tracks/11/interp = 2
-tracks/11/loop_wrap = true
-tracks/11/imported = false
-tracks/11/enabled = true
-tracks/11/keys = {
+tracks/12/type = "value"
+tracks/12/path = NodePath("Neck0/HeadBobber:rotation_degrees")
+tracks/12/interp = 2
+tracks/12/loop_wrap = true
+tracks/12/imported = false
+tracks/12/enabled = true
+tracks/12/keys = {
 "times": PoolRealArray( 0, 0.5, 0.999999, 2, 3, 4, 5, 5.99999 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
 "values": [ 0.0, 0.0, 6.0, -6.0, 6.0, -6.0, 6.0, 0.0 ]
 }
-tracks/12/type = "value"
-tracks/12/path = NodePath("Neck0/HeadBobber:head_bob_mode")
-tracks/12/interp = 1
-tracks/12/loop_wrap = true
-tracks/12/imported = false
-tracks/12/enabled = true
-tracks/12/keys = {
-"times": PoolRealArray( 0.333333, 6 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 3, 3 ]
-}
 tracks/13/type = "value"
-tracks/13/path = NodePath("Neck0/HeadBobber:head_motion_pixels")
+tracks/13/path = NodePath("Neck0/HeadBobber:head_bob_mode")
 tracks/13/interp = 1
 tracks/13/loop_wrap = true
 tracks/13/imported = false
@@ -2926,16 +2950,28 @@ tracks/13/enabled = true
 tracks/13/keys = {
 "times": PoolRealArray( 0.333333, 6 ),
 "transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ 2.0, 2.0 ]
+"update": 1,
+"values": [ 3, 3 ]
 }
 tracks/14/type = "value"
-tracks/14/path = NodePath("Neck0/HeadBobber:head_motion_seconds")
+tracks/14/path = NodePath("Neck0/HeadBobber:head_motion_pixels")
 tracks/14/interp = 1
 tracks/14/loop_wrap = true
 tracks/14/imported = false
 tracks/14/enabled = true
 tracks/14/keys = {
+"times": PoolRealArray( 0.333333, 6 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 0,
+"values": [ 2.0, 2.0 ]
+}
+tracks/15/type = "value"
+tracks/15/path = NodePath("Neck0/HeadBobber:head_motion_seconds")
+tracks/15/interp = 1
+tracks/15/loop_wrap = true
+tracks/15/imported = false
+tracks/15/enabled = true
+tracks/15/keys = {
 "times": PoolRealArray( 0.333333, 6 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 0,
@@ -3278,19 +3314,19 @@ tracks/3/keys = {
 "values": [ 0, 2, 2 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Neck0/HeadBobber/EmoteArmZ0:frame")
+tracks/4/path = NodePath("FarArm:frame")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
 tracks/4/enabled = true
 tracks/4/keys = {
-"times": PoolRealArray( 0, 0.966666, 0.999999, 5.93333, 5.96666, 5.99999 ),
+"times": PoolRealArray( 0, 0.957, 0.999999, 5.93333, 5.96666, 5.99999 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 0, 0, 1, 1, 0, 0 ]
+"values": [ 1, 1, 0, 0, 1, 1 ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Neck0/HeadBobber/EmoteArmZ1:frame")
+tracks/5/path = NodePath("Neck0/HeadBobber/EmoteArmZ0:frame")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -3302,108 +3338,120 @@ tracks/5/keys = {
 "values": [ 0, 0, 1, 1, 0, 0 ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("Neck0/HeadBobber/EmoteBrain:position")
-tracks/6/interp = 2
+tracks/6/path = NodePath("Neck0/HeadBobber/EmoteArmZ1:frame")
+tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
+"times": PoolRealArray( 0, 0.966666, 0.999999, 5.93333, 5.96666, 5.99999 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"update": 1,
+"values": [ 0, 0, 1, 1, 0, 0 ]
+}
+tracks/7/type = "value"
+tracks/7/path = NodePath("Neck0/HeadBobber/EmoteBrain:position")
+tracks/7/interp = 2
+tracks/7/loop_wrap = true
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/keys = {
 "times": PoolRealArray( 0, 1.5, 3, 4.5, 6 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
 "update": 0,
 "values": [ Vector2( 66.413, 228.341 ), Vector2( 66.413, 208.341 ), Vector2( 66.413, 228.341 ), Vector2( 66.413, 208.341 ), Vector2( 66.413, 228.341 ) ]
 }
-tracks/7/type = "value"
-tracks/7/path = NodePath("Neck0/HeadBobber/EmoteBrain:frame")
-tracks/7/interp = 1
-tracks/7/loop_wrap = true
-tracks/7/imported = false
-tracks/7/enabled = true
-tracks/7/keys = {
-"times": PoolRealArray( 0, 6 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 8, 8 ]
-}
 tracks/8/type = "value"
-tracks/8/path = NodePath("Neck0/HeadBobber/EmoteBrain:modulate")
+tracks/8/path = NodePath("Neck0/HeadBobber/EmoteBrain:frame")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
 tracks/8/enabled = true
 tracks/8/keys = {
-"times": PoolRealArray( 0.0666667, 0.495, 6 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
-"update": 0,
-"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
+"times": PoolRealArray( 0, 6 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ 8, 8 ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath("Neck0/HeadBobber/EmoteBrain:material:shader_param/green")
+tracks/9/path = NodePath("Neck0/HeadBobber/EmoteBrain:modulate")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
 tracks/9/enabled = true
 tracks/9/keys = {
-"times": PoolRealArray( 0, 6 ),
-"transitions": PoolRealArray( 1, 1 ),
+"times": PoolRealArray( 0.0666667, 0.495, 6 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
 "update": 0,
-"values": [ Color( 0.501961, 0.501961, 1, 1 ), Color( 0.501961, 0.501961, 1, 1 ) ]
+"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
 }
 tracks/10/type = "value"
-tracks/10/path = NodePath("Neck0/HeadBobber/EmoteGlow:modulate")
+tracks/10/path = NodePath("Neck0/HeadBobber/EmoteBrain:material:shader_param/green")
 tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/imported = false
 tracks/10/enabled = true
 tracks/10/keys = {
-"times": PoolRealArray( 0, 0.5, 6 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
+"times": PoolRealArray( 0, 6 ),
+"transitions": PoolRealArray( 1, 1 ),
 "update": 0,
-"values": [ Color( 0, 0, 0.737255, 0 ), Color( 0, 0, 0.737255, 0.501961 ), Color( 0, 0, 0.737255, 0.501961 ) ]
+"values": [ Color( 0.501961, 0.501961, 1, 1 ), Color( 0.501961, 0.501961, 1, 1 ) ]
 }
 tracks/11/type = "value"
-tracks/11/path = NodePath("Neck0/HeadBobber/EmoteGlow:scale")
+tracks/11/path = NodePath("Neck0/HeadBobber/EmoteGlow:modulate")
 tracks/11/interp = 1
 tracks/11/loop_wrap = true
 tracks/11/imported = false
 tracks/11/enabled = true
 tracks/11/keys = {
-"times": PoolRealArray( 0, 6 ),
-"transitions": PoolRealArray( 1, 1 ),
+"times": PoolRealArray( 0, 0.5, 6 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
 "update": 0,
-"values": [ Vector2( 2, 2 ), Vector2( 2, 2 ) ]
+"values": [ Color( 0, 0, 0.737255, 0 ), Color( 0, 0, 0.737255, 0.501961 ), Color( 0, 0, 0.737255, 0.501961 ) ]
 }
 tracks/12/type = "value"
-tracks/12/path = NodePath("Neck0/HeadBobber/EmoteGlow:position")
+tracks/12/path = NodePath("Neck0/HeadBobber/EmoteGlow:scale")
 tracks/12/interp = 1
 tracks/12/loop_wrap = true
 tracks/12/imported = false
 tracks/12/enabled = true
 tracks/12/keys = {
-"times": PoolRealArray( 0, 0.5, 2, 3.5, 5, 6 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"times": PoolRealArray( 0, 6 ),
+"transitions": PoolRealArray( 1, 1 ),
 "update": 0,
-"values": [ Vector2( 56.261, 460.649 ), Vector2( 56.261, 460.649 ), Vector2( 56.261, 440.649 ), Vector2( 56.261, 460.649 ), Vector2( 56.261, 440.649 ), Vector2( 56.261, 460.649 ) ]
+"values": [ Vector2( 2, 2 ), Vector2( 2, 2 ) ]
 }
 tracks/13/type = "value"
-tracks/13/path = NodePath("Neck0/HeadBobber/EmoteGlow:material:blend_mode")
+tracks/13/path = NodePath("Neck0/HeadBobber/EmoteGlow:position")
 tracks/13/interp = 1
 tracks/13/loop_wrap = true
 tracks/13/imported = false
 tracks/13/enabled = true
 tracks/13/keys = {
+"times": PoolRealArray( 0, 0.5, 2, 3.5, 5, 6 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( 56.261, 460.649 ), Vector2( 56.261, 460.649 ), Vector2( 56.261, 440.649 ), Vector2( 56.261, 460.649 ), Vector2( 56.261, 440.649 ), Vector2( 56.261, 460.649 ) ]
+}
+tracks/14/type = "value"
+tracks/14/path = NodePath("Neck0/HeadBobber/EmoteGlow:material:blend_mode")
+tracks/14/interp = 1
+tracks/14/loop_wrap = true
+tracks/14/imported = false
+tracks/14/enabled = true
+tracks/14/keys = {
 "times": PoolRealArray( 0, 6 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 1,
 "values": [ 0, 0 ]
 }
-tracks/14/type = "value"
-tracks/14/path = NodePath("Neck0/HeadBobber:rotation_degrees")
-tracks/14/interp = 2
-tracks/14/loop_wrap = true
-tracks/14/imported = false
-tracks/14/enabled = true
-tracks/14/keys = {
+tracks/15/type = "value"
+tracks/15/path = NodePath("Neck0/HeadBobber:rotation_degrees")
+tracks/15/interp = 2
+tracks/15/loop_wrap = true
+tracks/15/imported = false
+tracks/15/enabled = true
+tracks/15/keys = {
 "times": PoolRealArray( 0, 0.5, 0.999999, 2, 3, 4, 5, 5.99999 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
@@ -3462,19 +3510,19 @@ tracks/3/keys = {
 "values": [ 0, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 4 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Neck0/HeadBobber/EmoteArmZ0:frame")
+tracks/4/path = NodePath("FarArm:frame")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
 tracks/4/enabled = true
 tracks/4/keys = {
-"times": PoolRealArray( 0, 0.966666, 0.999999, 5.93333, 5.96666, 5.99999 ),
+"times": PoolRealArray( 0, 0.966667, 0.999999, 5.93333, 5.96666, 5.99999 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 0, 0, 2, 2, 0, 0 ]
+"values": [ 1, 1, 0, 0, 1, 1 ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Neck0/HeadBobber/EmoteArmZ1:frame")
+tracks/5/path = NodePath("Neck0/HeadBobber/EmoteArmZ0:frame")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -3486,72 +3534,84 @@ tracks/5/keys = {
 "values": [ 0, 0, 2, 2, 0, 0 ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("Neck0/HeadBobber/EmoteGlow:modulate")
+tracks/6/path = NodePath("Neck0/HeadBobber/EmoteArmZ1:frame")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
-"times": PoolRealArray( 0.0666667, 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
-"update": 0,
-"values": [ Color( 0, 0, 0, 0 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ) ]
+"times": PoolRealArray( 0, 0.966666, 0.999999, 5.93333, 5.96666, 5.99999 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"update": 1,
+"values": [ 0, 0, 2, 2, 0, 0 ]
 }
 tracks/7/type = "value"
-tracks/7/path = NodePath("Neck0/HeadBobber/EmoteGlow:scale")
+tracks/7/path = NodePath("Neck0/HeadBobber/EmoteGlow:modulate")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/imported = false
 tracks/7/enabled = true
 tracks/7/keys = {
-"times": PoolRealArray( 0, 6 ),
-"transitions": PoolRealArray( 1, 1 ),
+"times": PoolRealArray( 0.0666667, 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ Vector2( 3, 3 ), Vector2( 3, 3 ) ]
+"values": [ Color( 0, 0, 0, 0 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ) ]
 }
 tracks/8/type = "value"
-tracks/8/path = NodePath("Neck0/HeadBobber/EmoteGlow:position")
+tracks/8/path = NodePath("Neck0/HeadBobber/EmoteGlow:scale")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
 tracks/8/enabled = true
 tracks/8/keys = {
-"times": PoolRealArray( 0, 0.5, 2, 3.5, 5, 5.99999 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"times": PoolRealArray( 0, 6 ),
+"transitions": PoolRealArray( 1, 1 ),
 "update": 0,
-"values": [ Vector2( 7, 726 ), Vector2( 7, 676 ), Vector2( 7, 726 ), Vector2( 7, 676 ), Vector2( 7, 726 ), Vector2( 7, 676 ) ]
+"values": [ Vector2( 3, 3 ), Vector2( 3, 3 ) ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath("Neck0/HeadBobber/EmoteGlow:material:blend_mode")
+tracks/9/path = NodePath("Neck0/HeadBobber/EmoteGlow:position")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
 tracks/9/enabled = true
 tracks/9/keys = {
-"times": PoolRealArray( 0, 6 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 0, 0 ]
+"times": PoolRealArray( 0, 0.5, 2, 3.5, 5, 5.99999 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( 7, 726 ), Vector2( 7, 676 ), Vector2( 7, 726 ), Vector2( 7, 676 ), Vector2( 7, 726 ), Vector2( 7, 676 ) ]
 }
 tracks/10/type = "value"
-tracks/10/path = NodePath("NearArm:frame")
+tracks/10/path = NodePath("Neck0/HeadBobber/EmoteGlow:material:blend_mode")
 tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/imported = false
 tracks/10/enabled = true
 tracks/10/keys = {
+"times": PoolRealArray( 0, 6 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ 0, 0 ]
+}
+tracks/11/type = "value"
+tracks/11/path = NodePath("NearArm:frame")
+tracks/11/interp = 1
+tracks/11/loop_wrap = true
+tracks/11/imported = false
+tracks/11/enabled = true
+tracks/11/keys = {
 "times": PoolRealArray( 0, 0.966666, 0.999999, 5.93333, 5.96666, 5.99999 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
 "update": 1,
 "values": [ 1, 1, 0, 0, 1, 1 ]
 }
-tracks/11/type = "value"
-tracks/11/path = NodePath("Neck0/HeadBobber:rotation_degrees")
-tracks/11/interp = 2
-tracks/11/loop_wrap = true
-tracks/11/imported = false
-tracks/11/enabled = true
-tracks/11/keys = {
+tracks/12/type = "value"
+tracks/12/path = NodePath("Neck0/HeadBobber:rotation_degrees")
+tracks/12/interp = 2
+tracks/12/loop_wrap = true
+tracks/12/imported = false
+tracks/12/enabled = true
+tracks/12/keys = {
 "times": PoolRealArray( 0, 0.5, 0.999999, 2, 3, 4, 5, 5.99999 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
@@ -3610,19 +3670,19 @@ tracks/3/keys = {
 "values": [ 0, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 4 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Neck0/HeadBobber/EmoteArmZ0:frame")
+tracks/4/path = NodePath("FarArm:frame")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
 tracks/4/enabled = true
 tracks/4/keys = {
-"times": PoolRealArray( 0, 0.966666, 0.999999, 5.93333, 5.96666, 5.99999 ),
+"times": PoolRealArray( 0, 0.966667, 0.999999, 5.93333, 5.96666, 5.99999 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 0, 0, 2, 2, 0, 0 ]
+"values": [ 1, 1, 0, 0, 1, 1 ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Neck0/HeadBobber/EmoteArmZ1:frame")
+tracks/5/path = NodePath("Neck0/HeadBobber/EmoteArmZ0:frame")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -3634,31 +3694,31 @@ tracks/5/keys = {
 "values": [ 0, 0, 2, 2, 0, 0 ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("Neck0/HeadBobber/EmoteGlow:modulate")
+tracks/6/path = NodePath("Neck0/HeadBobber/EmoteArmZ1:frame")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
-"times": PoolRealArray( 0.0666667, 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
-"update": 0,
-"values": [ Color( 0, 0, 0, 0 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ) ]
+"times": PoolRealArray( 0, 0.966666, 0.999999, 5.93333, 5.96666, 5.99999 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"update": 1,
+"values": [ 0, 0, 2, 2, 0, 0 ]
 }
 tracks/7/type = "value"
-tracks/7/path = NodePath("Neck0/HeadBobber/EmoteGlow:scale")
+tracks/7/path = NodePath("Neck0/HeadBobber/EmoteGlow:modulate")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/imported = false
 tracks/7/enabled = true
 tracks/7/keys = {
-"times": PoolRealArray( 0, 6 ),
-"transitions": PoolRealArray( 1, 1 ),
+"times": PoolRealArray( 0.0666667, 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ Vector2( 3, 3 ), Vector2( 3, 3 ) ]
+"values": [ Color( 0, 0, 0, 0 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ), Color( 0, 0, 0, 0.627451 ), Color( 0, 0, 0, 0.376471 ) ]
 }
 tracks/8/type = "value"
-tracks/8/path = NodePath("Neck0/HeadBobber/EmoteGlow:material:blend_mode")
+tracks/8/path = NodePath("Neck0/HeadBobber/EmoteGlow:scale")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
@@ -3666,47 +3726,47 @@ tracks/8/enabled = true
 tracks/8/keys = {
 "times": PoolRealArray( 0, 6 ),
 "transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 0, 0 ]
+"update": 0,
+"values": [ Vector2( 3, 3 ), Vector2( 3, 3 ) ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath("NearArm:frame")
+tracks/9/path = NodePath("Neck0/HeadBobber/EmoteGlow:material:blend_mode")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
 tracks/9/enabled = true
 tracks/9/keys = {
+"times": PoolRealArray( 0, 6 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ 0, 0 ]
+}
+tracks/10/type = "value"
+tracks/10/path = NodePath("NearArm:frame")
+tracks/10/interp = 1
+tracks/10/loop_wrap = true
+tracks/10/imported = false
+tracks/10/enabled = true
+tracks/10/keys = {
 "times": PoolRealArray( 0, 0.966666, 0.999999, 5.93333, 5.96666, 5.99999 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
 "update": 1,
 "values": [ 1, 1, 0, 0, 1, 1 ]
 }
-tracks/10/type = "value"
-tracks/10/path = NodePath("Neck0/HeadBobber:rotation_degrees")
-tracks/10/interp = 2
-tracks/10/loop_wrap = true
-tracks/10/imported = false
-tracks/10/enabled = true
-tracks/10/keys = {
+tracks/11/type = "value"
+tracks/11/path = NodePath("Neck0/HeadBobber:rotation_degrees")
+tracks/11/interp = 2
+tracks/11/loop_wrap = true
+tracks/11/imported = false
+tracks/11/enabled = true
+tracks/11/keys = {
 "times": PoolRealArray( 0, 0.5, 0.999999, 2, 3, 4, 5, 5.99999 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
 "values": [ 0.0, 0.0, 6.0, -6.0, 6.0, -6.0, 6.0, 0.0 ]
 }
-tracks/11/type = "value"
-tracks/11/path = NodePath("Neck0/HeadBobber:head_bob_mode")
-tracks/11/interp = 1
-tracks/11/loop_wrap = true
-tracks/11/imported = false
-tracks/11/enabled = true
-tracks/11/keys = {
-"times": PoolRealArray( 0.333333, 6 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 3, 3 ]
-}
 tracks/12/type = "value"
-tracks/12/path = NodePath("Neck0/HeadBobber:head_motion_pixels")
+tracks/12/path = NodePath("Neck0/HeadBobber:head_bob_mode")
 tracks/12/interp = 1
 tracks/12/loop_wrap = true
 tracks/12/imported = false
@@ -3714,16 +3774,28 @@ tracks/12/enabled = true
 tracks/12/keys = {
 "times": PoolRealArray( 0.333333, 6 ),
 "transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ 2.0, 2.0 ]
+"update": 1,
+"values": [ 3, 3 ]
 }
 tracks/13/type = "value"
-tracks/13/path = NodePath("Neck0/HeadBobber:head_motion_seconds")
+tracks/13/path = NodePath("Neck0/HeadBobber:head_motion_pixels")
 tracks/13/interp = 1
 tracks/13/loop_wrap = true
 tracks/13/imported = false
 tracks/13/enabled = true
 tracks/13/keys = {
+"times": PoolRealArray( 0.333333, 6 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 0,
+"values": [ 2.0, 2.0 ]
+}
+tracks/14/type = "value"
+tracks/14/path = NodePath("Neck0/HeadBobber:head_motion_seconds")
+tracks/14/interp = 1
+tracks/14/loop_wrap = true
+tracks/14/imported = false
+tracks/14/enabled = true
+tracks/14/keys = {
 "times": PoolRealArray( 0.333333, 6 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 0,
@@ -4051,7 +4123,7 @@ tracks/2/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Neck0/HeadBobber/EyeZ0:frame")
+tracks/3/path = NodePath("FarArm:frame")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -4063,7 +4135,7 @@ tracks/3/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Neck0/HeadBobber/EyeZ1:frame")
+tracks/4/path = NodePath("Neck0/HeadBobber/EyeZ0:frame")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -4075,7 +4147,7 @@ tracks/4/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Neck0/HeadBobber/EmoteEyeZ0:frame")
+tracks/5/path = NodePath("Neck0/HeadBobber/EyeZ1:frame")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -4084,15 +4156,27 @@ tracks/5/keys = {
 "times": PoolRealArray( 0, 0.1, 6 ),
 "transitions": PoolRealArray( 1, 1, 1 ),
 "update": 1,
-"values": [ 0, 1, 1 ]
+"values": [ 1, 0, 0 ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("Neck0/HeadBobber/EmoteEyeZ1:frame")
+tracks/6/path = NodePath("Neck0/HeadBobber/EmoteEyeZ0:frame")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
+"times": PoolRealArray( 0, 0.1, 6 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 1,
+"values": [ 0, 1, 1 ]
+}
+tracks/7/type = "value"
+tracks/7/path = NodePath("Neck0/HeadBobber/EmoteEyeZ1:frame")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/keys = {
 "times": PoolRealArray( 0, 0.1, 6 ),
 "transitions": PoolRealArray( 1, 1, 1 ),
 "update": 1,
@@ -4138,7 +4222,7 @@ tracks/2/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Neck0/HeadBobber/EyeZ0:frame")
+tracks/3/path = NodePath("FarArm:frame")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -4150,7 +4234,7 @@ tracks/3/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Neck0/HeadBobber/EyeZ1:frame")
+tracks/4/path = NodePath("Neck0/HeadBobber/EyeZ0:frame")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -4162,7 +4246,7 @@ tracks/4/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Neck0/HeadBobber/EmoteEyeZ0:frame")
+tracks/5/path = NodePath("Neck0/HeadBobber/EyeZ1:frame")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -4171,10 +4255,10 @@ tracks/5/keys = {
 "times": PoolRealArray( 0, 0.1, 6 ),
 "transitions": PoolRealArray( 1, 1, 1 ),
 "update": 1,
-"values": [ 0, 1, 1 ]
+"values": [ 1, 0, 0 ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("Neck0/HeadBobber/EmoteEyeZ1:frame")
+tracks/6/path = NodePath("Neck0/HeadBobber/EmoteEyeZ0:frame")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
@@ -4186,79 +4270,79 @@ tracks/6/keys = {
 "values": [ 0, 1, 1 ]
 }
 tracks/7/type = "value"
-tracks/7/path = NodePath("Neck0/HeadBobber/EmoteBrain:material:shader_param/green")
+tracks/7/path = NodePath("Neck0/HeadBobber/EmoteEyeZ1:frame")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/imported = false
 tracks/7/enabled = true
 tracks/7/keys = {
-"times": PoolRealArray( 0.1 ),
-"transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ Color( 1, 1, 0.24, 1 ) ]
+"times": PoolRealArray( 0, 0.1, 6 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 1,
+"values": [ 0, 1, 1 ]
 }
 tracks/8/type = "value"
-tracks/8/path = NodePath("Neck0/HeadBobber/EmoteBrain:modulate")
+tracks/8/path = NodePath("Neck0/HeadBobber/EmoteBrain:material:shader_param/green")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
 tracks/8/enabled = true
 tracks/8/keys = {
-"times": PoolRealArray( 0, 0.1, 6 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
+"times": PoolRealArray( 0.1 ),
+"transitions": PoolRealArray( 1 ),
 "update": 0,
-"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
+"values": [ Color( 1, 1, 0.24, 1 ) ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath("Neck0/HeadBobber/EmoteBrain:frame")
+tracks/9/path = NodePath("Neck0/HeadBobber/EmoteBrain:modulate")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
 tracks/9/enabled = true
 tracks/9/keys = {
-"times": PoolRealArray( 0, 0.2, 0.4, 0.6, 0.8, 1, 1.2, 1.4, 1.6, 1.8, 2, 2.2, 2.4, 2.6, 2.8, 3, 3.2, 3.4, 3.6, 3.8, 4, 4.2, 4.4, 4.6, 4.8, 5, 5.2, 5.4, 5.6, 5.8, 6 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
-"update": 1,
-"values": [ 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4 ]
+"times": PoolRealArray( 0, 0.1, 6 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
 }
 tracks/10/type = "value"
-tracks/10/path = NodePath("Neck0/HeadBobber:head_bob_mode")
+tracks/10/path = NodePath("Neck0/HeadBobber/EmoteBrain:frame")
 tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/imported = false
 tracks/10/enabled = true
 tracks/10/keys = {
-"times": PoolRealArray( 0, 0.1, 6 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
+"times": PoolRealArray( 0, 0.2, 0.4, 0.6, 0.8, 1, 1.2, 1.4, 1.6, 1.8, 2, 2.2, 2.4, 2.6, 2.8, 3, 3.2, 3.4, 3.6, 3.8, 4, 4.2, 4.4, 4.6, 4.8, 5, 5.2, 5.4, 5.6, 5.8, 6 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 1, 2, 2 ]
+"values": [ 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4, 3, 4 ]
 }
 tracks/11/type = "value"
-tracks/11/path = NodePath("Neck0/HeadBobber/EmoteBrain:position")
+tracks/11/path = NodePath("Neck0/HeadBobber:head_bob_mode")
 tracks/11/interp = 1
 tracks/11/loop_wrap = true
 tracks/11/imported = false
 tracks/11/enabled = true
 tracks/11/keys = {
-"times": PoolRealArray( 0, 6 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ Vector2( 255.118, 133.989 ), Vector2( 255.118, 133.989 ) ]
+"times": PoolRealArray( 0, 0.1, 6 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 1,
+"values": [ 1, 2, 2 ]
 }
 tracks/12/type = "value"
-tracks/12/path = NodePath("Neck0/HeadBobber:head_motion_seconds")
+tracks/12/path = NodePath("Neck0/HeadBobber/EmoteBrain:position")
 tracks/12/interp = 1
 tracks/12/loop_wrap = true
 tracks/12/imported = false
 tracks/12/enabled = true
 tracks/12/keys = {
-"times": PoolRealArray( 0, 0.1, 6 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
+"times": PoolRealArray( 0, 6 ),
+"transitions": PoolRealArray( 1, 1 ),
 "update": 0,
-"values": [ 6.5, 0.3, 0.3 ]
+"values": [ Vector2( 255.118, 133.989 ), Vector2( 255.118, 133.989 ) ]
 }
 tracks/13/type = "value"
-tracks/13/path = NodePath("Neck0/HeadBobber:head_motion_pixels")
+tracks/13/path = NodePath("Neck0/HeadBobber:head_motion_seconds")
 tracks/13/interp = 1
 tracks/13/loop_wrap = true
 tracks/13/imported = false
@@ -4267,15 +4351,27 @@ tracks/13/keys = {
 "times": PoolRealArray( 0, 0.1, 6 ),
 "transitions": PoolRealArray( 1, 1, 1 ),
 "update": 0,
-"values": [ 2.0, 6.5, 6.5 ]
+"values": [ 6.5, 0.3, 0.3 ]
 }
-tracks/14/type = "audio"
-tracks/14/path = NodePath("EmoteAnims/EmoteSfx")
+tracks/14/type = "value"
+tracks/14/path = NodePath("Neck0/HeadBobber:head_motion_pixels")
 tracks/14/interp = 1
 tracks/14/loop_wrap = true
 tracks/14/imported = false
 tracks/14/enabled = true
 tracks/14/keys = {
+"times": PoolRealArray( 0, 0.1, 6 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ 2.0, 6.5, 6.5 ]
+}
+tracks/15/type = "audio"
+tracks/15/path = NodePath("EmoteAnims/EmoteSfx")
+tracks/15/interp = 1
+tracks/15/loop_wrap = true
+tracks/15/imported = false
+tracks/15/enabled = true
+tracks/15/keys = {
 "clips": [ {
 "end_offset": 0.0,
 "start_offset": 0.0,
@@ -5012,6 +5108,18 @@ tracks/5/keys = {
 "update": 1,
 "values": [ 0, 1, 1 ]
 }
+tracks/6/type = "value"
+tracks/6/path = NodePath("FarArm:frame")
+tracks/6/interp = 1
+tracks/6/loop_wrap = true
+tracks/6/imported = false
+tracks/6/enabled = true
+tracks/6/keys = {
+"times": PoolRealArray( 0, 0.1, 6 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 1,
+"values": [ 1, 0, 0 ]
+}
 
 [sub_resource type="Animation" id=103]
 length = 6.0
@@ -5112,7 +5220,7 @@ tracks/7/keys = {
 "values": [ 1, 0, 0 ]
 }
 tracks/8/type = "value"
-tracks/8/path = NodePath("Neck0/HeadBobber:head_bob_mode")
+tracks/8/path = NodePath("FarArm:frame")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
@@ -5121,10 +5229,10 @@ tracks/8/keys = {
 "times": PoolRealArray( 0, 0.1, 6 ),
 "transitions": PoolRealArray( 1, 1, 1 ),
 "update": 1,
-"values": [ 1, 3, 3 ]
+"values": [ 1, 0, 0 ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath("Neck0/HeadBobber/EmoteHead:modulate")
+tracks/9/path = NodePath("Neck0/HeadBobber:head_bob_mode")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
@@ -5132,11 +5240,11 @@ tracks/9/enabled = true
 tracks/9/keys = {
 "times": PoolRealArray( 0, 0.1, 6 ),
 "transitions": PoolRealArray( 1, 1, 1 ),
-"update": 0,
-"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
+"update": 1,
+"values": [ 1, 3, 3 ]
 }
 tracks/10/type = "value"
-tracks/10/path = NodePath("Neck0/HeadBobber:head_motion_pixels")
+tracks/10/path = NodePath("Neck0/HeadBobber/EmoteHead:modulate")
 tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/imported = false
@@ -5145,10 +5253,10 @@ tracks/10/keys = {
 "times": PoolRealArray( 0, 0.1, 6 ),
 "transitions": PoolRealArray( 1, 1, 1 ),
 "update": 0,
-"values": [ 2.0, 2.0, 2.0 ]
+"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
 }
 tracks/11/type = "value"
-tracks/11/path = NodePath("Neck0/HeadBobber:head_motion_seconds")
+tracks/11/path = NodePath("Neck0/HeadBobber:head_motion_pixels")
 tracks/11/interp = 1
 tracks/11/loop_wrap = true
 tracks/11/imported = false
@@ -5157,15 +5265,27 @@ tracks/11/keys = {
 "times": PoolRealArray( 0, 0.1, 6 ),
 "transitions": PoolRealArray( 1, 1, 1 ),
 "update": 0,
-"values": [ 6.5, 0.1, 0.1 ]
+"values": [ 2.0, 2.0, 2.0 ]
 }
-tracks/12/type = "audio"
-tracks/12/path = NodePath("EmoteAnims/EmoteSfx")
+tracks/12/type = "value"
+tracks/12/path = NodePath("Neck0/HeadBobber:head_motion_seconds")
 tracks/12/interp = 1
 tracks/12/loop_wrap = true
 tracks/12/imported = false
 tracks/12/enabled = true
 tracks/12/keys = {
+"times": PoolRealArray( 0, 0.1, 6 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ 6.5, 0.1, 0.1 ]
+}
+tracks/13/type = "audio"
+tracks/13/path = NodePath("EmoteAnims/EmoteSfx")
+tracks/13/interp = 1
+tracks/13/loop_wrap = true
+tracks/13/imported = false
+tracks/13/enabled = true
+tracks/13/keys = {
 "clips": [ {
 "end_offset": 0.0,
 "start_offset": 0.0,
@@ -5201,68 +5321,68 @@ tracks/1/keys = {
 "values": [ 0, 1, 1 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("Neck0/HeadBobber/EmoteBrain:frame")
+tracks/2/path = NodePath("FarArm:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
 tracks/2/enabled = true
 tracks/2/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
+"times": PoolRealArray( 0, 0.1, 6 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
 "update": 1,
-"values": [ 1 ]
+"values": [ 1, 0, 0 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Neck0/HeadBobber/EmoteBrain:modulate")
+tracks/3/path = NodePath("Neck0/HeadBobber/EmoteBrain:frame")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
 tracks/3/enabled = true
 tracks/3/keys = {
-"times": PoolRealArray( 0, 0.5, 6.1 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
-"update": 0,
-"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ 1 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Neck0/HeadBobber/EmoteBrain:scale")
+tracks/4/path = NodePath("Neck0/HeadBobber/EmoteBrain:modulate")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
 tracks/4/enabled = true
 tracks/4/keys = {
+"times": PoolRealArray( 0, 0.5, 6.1 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 1 ) ]
+}
+tracks/5/type = "value"
+tracks/5/path = NodePath("Neck0/HeadBobber/EmoteBrain:scale")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/keys = {
 "times": PoolRealArray( 0, 0.1, 0.2, 0.3 ),
 "transitions": PoolRealArray( 1, 1, 1, 1 ),
 "update": 0,
 "values": [ Vector2( 2, 2 ), Vector2( 1.6, 2.4 ), Vector2( 2.4, 1.6 ), Vector2( 2, 2 ) ]
 }
-tracks/5/type = "value"
-tracks/5/path = NodePath("Neck0/HeadBobber/EmoteBrain:position")
-tracks/5/interp = 2
-tracks/5/loop_wrap = true
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/keys = {
-"times": PoolRealArray( 0, 1, 2, 3, 4, 5, 6 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1 ),
-"update": 0,
-"values": [ Vector2( -18, -36 ), Vector2( -18, -56 ), Vector2( -18, -36 ), Vector2( -18, -56 ), Vector2( -18, -36 ), Vector2( -18, -56 ), Vector2( -18, -36 ) ]
-}
 tracks/6/type = "value"
-tracks/6/path = NodePath("Neck0/HeadBobber:rotation_degrees")
+tracks/6/path = NodePath("Neck0/HeadBobber/EmoteBrain:position")
 tracks/6/interp = 2
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
-"times": PoolRealArray( 0, 0.1, 1.5, 3, 4.5, 6 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"times": PoolRealArray( 0, 1, 2, 3, 4, 5, 6 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ 0.0, -16.0, -12.0, -16.0, -12.0, -16.0 ]
+"values": [ Vector2( -18, -36 ), Vector2( -18, -56 ), Vector2( -18, -36 ), Vector2( -18, -56 ), Vector2( -18, -36 ), Vector2( -18, -56 ), Vector2( -18, -36 ) ]
 }
 tracks/7/type = "value"
-tracks/7/path = NodePath("Neck0/HeadBobber/EmoteBrain:rotation_degrees")
-tracks/7/interp = 1
+tracks/7/path = NodePath("Neck0/HeadBobber:rotation_degrees")
+tracks/7/interp = 2
 tracks/7/loop_wrap = true
 tracks/7/imported = false
 tracks/7/enabled = true
@@ -5270,15 +5390,27 @@ tracks/7/keys = {
 "times": PoolRealArray( 0, 0.1, 1.5, 3, 4.5, 6 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ 0.0, 16.0, 12.0, 16.0, 12.0, 16.0 ]
+"values": [ 0.0, -16.0, -12.0, -16.0, -12.0, -16.0 ]
 }
-tracks/8/type = "audio"
-tracks/8/path = NodePath("EmoteAnims/EmoteSfx")
+tracks/8/type = "value"
+tracks/8/path = NodePath("Neck0/HeadBobber/EmoteBrain:rotation_degrees")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
 tracks/8/enabled = true
 tracks/8/keys = {
+"times": PoolRealArray( 0, 0.1, 1.5, 3, 4.5, 6 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"update": 0,
+"values": [ 0.0, 16.0, 12.0, 16.0, 12.0, 16.0 ]
+}
+tracks/9/type = "audio"
+tracks/9/path = NodePath("EmoteAnims/EmoteSfx")
+tracks/9/interp = 1
+tracks/9/loop_wrap = true
+tracks/9/imported = false
+tracks/9/enabled = true
+tracks/9/keys = {
 "clips": [ {
 "end_offset": 0.0,
 "start_offset": 0.0,
@@ -5453,7 +5585,7 @@ tracks/1/keys = {
 "values": [ Vector2( 0, 0 ), Vector2( 0, 0 ), Vector2( -33.0066, 0 ), Vector2( -57.6266, 0 ), Vector2( -92.1684, -10.4094 ), Vector2( -169.023, 2.7095 ), Vector2( -428.053, 6.5144 ) ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("FarLeg:position")
+tracks/2/path = NodePath("FarArm:position")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -5462,10 +5594,10 @@ tracks/2/keys = {
 "times": PoolRealArray( 0, 1, 1.5, 2, 3, 5, 10 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ Vector2( 0, 0 ), Vector2( 0, 0 ), Vector2( 30.091, 0 ), Vector2( 50.086, 0 ), Vector2( 88.6123, -15.1179 ), Vector2( 186.882, -22.8557 ), Vector2( 451.803, -42.8278 ) ]
+"values": [ Vector2( 0, 0 ), Vector2( 0, 0 ), Vector2( 33.8707, -11.0956 ), Vector2( 54.353, -31.0902 ), Vector2( 82.1504, -88.6357 ), Vector2( 166.083, -175.299 ), Vector2( 371.881, -397.689 ) ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Neck0:position")
+tracks/3/path = NodePath("FarLeg:position")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -5474,10 +5606,10 @@ tracks/3/keys = {
 "times": PoolRealArray( 0, 1, 1.5, 2, 3, 5, 10 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ Vector2( 0, 0 ), Vector2( 0, 0 ), Vector2( -16.9513, -24.525 ), Vector2( -21.4271, -54 ), Vector2( -29.6163, -133.714 ), Vector2( -59.2814, -259.238 ), Vector2( -147.073, -557.208 ) ]
+"values": [ Vector2( 0, 0 ), Vector2( 0, 0 ), Vector2( 30.091, 0 ), Vector2( 50.086, 0 ), Vector2( 88.6123, -15.1179 ), Vector2( 186.882, -22.8557 ), Vector2( 451.803, -42.8278 ) ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Collar:position")
+tracks/4/path = NodePath("Neck0:position")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -5486,63 +5618,75 @@ tracks/4/keys = {
 "times": PoolRealArray( 0, 1, 1.5, 2, 3, 5, 10 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ Vector2( 0, -100 ), Vector2( 0, -100 ), Vector2( -16.951, -124.525 ), Vector2( -24.0967, -156.67 ), Vector2( -33.6205, -235.049 ), Vector2( -65.2842, -367.896 ), Vector2( -152.865, -668.787 ) ]
+"values": [ Vector2( 0, 0 ), Vector2( 0, 0 ), Vector2( -16.9513, -24.525 ), Vector2( -21.4271, -54 ), Vector2( -29.6163, -133.714 ), Vector2( -59.2814, -259.238 ), Vector2( -147.073, -557.208 ) ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Body/Viewport/Body/NeckBlend:position")
+tracks/5/path = NodePath("Collar:position")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
 tracks/5/enabled = true
 tracks/5/keys = {
-"times": PoolRealArray( 0, 1, 1.5, 2, 3 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
+"times": PoolRealArray( 0, 1, 1.5, 2, 3, 5, 10 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ Vector2( -1.11823, -102.515 ), Vector2( -1.11823, -102.515 ), Vector2( 16.118, -127.515 ), Vector2( 21.118, -152.515 ), Vector2( 21.118, -232.515 ) ]
+"values": [ Vector2( 0, -100 ), Vector2( 0, -100 ), Vector2( -16.951, -124.525 ), Vector2( -24.0967, -156.67 ), Vector2( -33.6205, -235.049 ), Vector2( -65.2842, -367.896 ), Vector2( -152.865, -668.787 ) ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("BodySweat:process_material:emission_sphere_radius")
+tracks/6/path = NodePath("Body/Viewport/Body/NeckBlend:position")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
-"times": PoolRealArray( 0, 1, 3, 10 ),
-"transitions": PoolRealArray( 1, 1, 1, 1 ),
+"times": PoolRealArray( 0, 1, 1.5, 2, 3 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ 50.0, 50.0, 135.0, 460.0 ]
+"values": [ Vector2( -1.11823, -102.515 ), Vector2( -1.11823, -102.515 ), Vector2( 16.118, -127.515 ), Vector2( 21.118, -152.515 ), Vector2( 21.118, -232.515 ) ]
 }
 tracks/7/type = "value"
-tracks/7/path = NodePath("BodySweat:position")
+tracks/7/path = NodePath("BodySweat:process_material:emission_sphere_radius")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/imported = false
 tracks/7/enabled = true
 tracks/7/keys = {
-"times": PoolRealArray( 0, 1, 1.5, 2, 5, 10 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"times": PoolRealArray( 0, 1, 3, 10 ),
+"transitions": PoolRealArray( 1, 1, 1, 1 ),
 "update": 0,
-"values": [ Vector2( -10, -50 ), Vector2( -10, -50 ), Vector2( 0, -50 ), Vector2( -2.5, -60 ), Vector2( -10, -140 ), Vector2( 0, -240 ) ]
+"values": [ 50.0, 50.0, 135.0, 460.0 ]
 }
 tracks/8/type = "value"
-tracks/8/path = NodePath("Collar:rotation_degrees")
+tracks/8/path = NodePath("BodySweat:position")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
 tracks/8/enabled = true
 tracks/8/keys = {
-"times": PoolRealArray( 0, 1, 2, 3, 5, 10 ),
+"times": PoolRealArray( 0, 1, 1.5, 2, 5, 10 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ 0.0, 0.0, -4.46358, -9.26012, -12.8267, -16.3329 ]
+"values": [ Vector2( -10, -50 ), Vector2( -10, -50 ), Vector2( 0, -50 ), Vector2( -2.5, -60 ), Vector2( -10, -140 ), Vector2( 0, -240 ) ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath("TailZ1:position")
+tracks/9/path = NodePath("Collar:rotation_degrees")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
 tracks/9/enabled = true
 tracks/9/keys = {
+"times": PoolRealArray( 0, 1, 2, 3, 5, 10 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"update": 0,
+"values": [ 0.0, 0.0, -4.46358, -9.26012, -12.8267, -16.3329 ]
+}
+tracks/10/type = "value"
+tracks/10/path = NodePath("TailZ1:position")
+tracks/10/interp = 1
+tracks/10/loop_wrap = true
+tracks/10/imported = false
+tracks/10/enabled = true
+tracks/10/keys = {
 "times": PoolRealArray( 0, 1, 1.5, 2, 3, 5, 10 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
@@ -5577,7 +5721,7 @@ tracks/1/keys = {
 "values": [ Vector2( 0, 0 ), Vector2( 0, 0 ), Vector2( 7.253, 0 ), Vector2( 10.179, 0 ), Vector2( 5.30226, -8.29047 ), Vector2( -20.6977, 2.7095 ), Vector2( -59.4692, 6.5144 ) ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("FarLeg:position")
+tracks/2/path = NodePath("FarArm:position")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -5586,10 +5730,10 @@ tracks/2/keys = {
 "times": PoolRealArray( 0, 1, 1.5, 2, 3, 5, 10 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ Vector2( 0, 0 ), Vector2( 0, 0 ), Vector2( 30.091, 0 ), Vector2( 50.086, 0 ), Vector2( 88.6123, -15.1179 ), Vector2( 186.882, -22.8557 ), Vector2( 451.803, -42.8278 ) ]
+"values": [ Vector2( 0, 0 ), Vector2( 0, 0 ), Vector2( 33.8707, -11.0956 ), Vector2( 54.353, -31.0902 ), Vector2( 82.1504, -88.6357 ), Vector2( 166.083, -175.299 ), Vector2( 371.881, -397.689 ) ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Neck0:position")
+tracks/3/path = NodePath("FarLeg:position")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -5598,10 +5742,10 @@ tracks/3/keys = {
 "times": PoolRealArray( 0, 1, 1.5, 2, 3, 5, 10 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ Vector2( 0, 0 ), Vector2( 0, 0 ), Vector2( 0, -24.525 ), Vector2( 4, -54 ), Vector2( 17, -121 ), Vector2( 17, -255 ), Vector2( 81.7715, -561.446 ) ]
+"values": [ Vector2( 0, 0 ), Vector2( 0, 0 ), Vector2( 30.091, 0 ), Vector2( 50.086, 0 ), Vector2( 88.6123, -15.1179 ), Vector2( 186.882, -22.8557 ), Vector2( 451.803, -42.8278 ) ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Collar:position")
+tracks/4/path = NodePath("Neck0:position")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -5610,51 +5754,63 @@ tracks/4/keys = {
 "times": PoolRealArray( 0, 1, 1.5, 2, 3, 5, 10 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ Vector2( 0, -100 ), Vector2( 0, -100 ), Vector2( 0, -124.525 ), Vector2( 4, -154 ), Vector2( 17, -221 ), Vector2( 17, -355 ), Vector2( 81.771, -661.446 ) ]
+"values": [ Vector2( 0, 0 ), Vector2( 0, 0 ), Vector2( 0, -24.525 ), Vector2( 4, -54 ), Vector2( 17, -121 ), Vector2( 17, -255 ), Vector2( 81.7715, -561.446 ) ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("BodySweat:process_material:emission_sphere_radius")
+tracks/5/path = NodePath("Collar:position")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
 tracks/5/enabled = true
 tracks/5/keys = {
-"times": PoolRealArray( 0, 1, 3, 10 ),
-"transitions": PoolRealArray( 1, 1, 1, 1 ),
+"times": PoolRealArray( 0, 1, 1.5, 2, 3, 5, 10 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ 50.0, 50.0, 135.0, 460.0 ]
+"values": [ Vector2( 0, -100 ), Vector2( 0, -100 ), Vector2( 0, -124.525 ), Vector2( 4, -154 ), Vector2( 17, -221 ), Vector2( 17, -355 ), Vector2( 81.771, -661.446 ) ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("BodySweat:position")
+tracks/6/path = NodePath("BodySweat:process_material:emission_sphere_radius")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
-"times": PoolRealArray( 0, 1, 1.5, 2, 5, 10 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
+"times": PoolRealArray( 0, 1, 3, 10 ),
+"transitions": PoolRealArray( 1, 1, 1, 1 ),
 "update": 0,
-"values": [ Vector2( -10, -50 ), Vector2( -10, -50 ), Vector2( 0, -50 ), Vector2( -2.5, -60 ), Vector2( -10, -140 ), Vector2( 0, -240 ) ]
+"values": [ 50.0, 50.0, 135.0, 460.0 ]
 }
 tracks/7/type = "value"
-tracks/7/path = NodePath("Collar:rotation_degrees")
+tracks/7/path = NodePath("BodySweat:position")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/imported = false
 tracks/7/enabled = true
 tracks/7/keys = {
-"times": PoolRealArray( 0, 10 ),
-"transitions": PoolRealArray( 1, 1 ),
+"times": PoolRealArray( 0, 1, 1.5, 2, 5, 10 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ 0.0, 0.0 ]
+"values": [ Vector2( -10, -50 ), Vector2( -10, -50 ), Vector2( 0, -50 ), Vector2( -2.5, -60 ), Vector2( -10, -140 ), Vector2( 0, -240 ) ]
 }
 tracks/8/type = "value"
-tracks/8/path = NodePath("TailZ0:position")
+tracks/8/path = NodePath("Collar:rotation_degrees")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
 tracks/8/enabled = true
 tracks/8/keys = {
+"times": PoolRealArray( 0, 10 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 0,
+"values": [ 0.0, 0.0 ]
+}
+tracks/9/type = "value"
+tracks/9/path = NodePath("TailZ0:position")
+tracks/9/interp = 1
+tracks/9/loop_wrap = true
+tracks/9/imported = false
+tracks/9/enabled = true
+tracks/9/keys = {
 "times": PoolRealArray( 0, 1, 1.5, 2, 3, 5, 10 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
@@ -5676,7 +5832,7 @@ tracks/0/keys = {
 "values": [ 2 ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("NearLeg:frame")
+tracks/1/path = NodePath("FarArm:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -5688,7 +5844,7 @@ tracks/1/keys = {
 "values": [ 2 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("NearArm:frame")
+tracks/2/path = NodePath("NearLeg:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -5700,7 +5856,7 @@ tracks/2/keys = {
 "values": [ 2 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("FarArm:frame")
+tracks/3/path = NodePath("NearArm:frame")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -5727,7 +5883,7 @@ tracks/0/keys = {
 "values": [ 1 ]
 }
 tracks/1/type = "value"
-tracks/1/path = NodePath("NearLeg:frame")
+tracks/1/path = NodePath("FarArm:frame")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -5739,7 +5895,7 @@ tracks/1/keys = {
 "values": [ 1 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("NearArm:frame")
+tracks/2/path = NodePath("NearLeg:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -5751,7 +5907,7 @@ tracks/2/keys = {
 "values": [ 1 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("FarArm:frame")
+tracks/3/path = NodePath("NearArm:frame")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -5792,19 +5948,19 @@ tracks/1/keys = {
 "values": [ 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 15 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("FarLeg:frame")
+tracks/2/path = NodePath("FarArm:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
 tracks/2/enabled = true
 tracks/2/keys = {
-"times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
+"times": PoolRealArray( 0, 0.6 ),
+"transitions": PoolRealArray( 1, 1 ),
 "update": 1,
-"values": [ 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 15 ]
+"values": [ 2, 2 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Body:rect_position")
+tracks/3/path = NodePath("FarLeg:frame")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -5812,40 +5968,52 @@ tracks/3/enabled = true
 tracks/3/keys = {
 "times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
-"update": 0,
-"values": [ Vector2( -580, -848 ), Vector2( -580, -850 ), Vector2( -580, -852 ), Vector2( -580, -851 ), Vector2( -580, -850 ), Vector2( -580, -849 ), Vector2( -580, -848 ), Vector2( -580, -850 ), Vector2( -580, -852 ), Vector2( -580, -851 ), Vector2( -580, -850 ), Vector2( -580, -849 ), Vector2( -580, -848 ) ]
+"update": 1,
+"values": [ 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 15 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Neck0/HeadBobber:head_bob_mode")
+tracks/4/path = NodePath("Body:rect_position")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
 tracks/4/enabled = true
 tracks/4/keys = {
-"times": PoolRealArray( 0, 0.6 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 0, 0 ]
+"times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( -580, -848 ), Vector2( -580, -850 ), Vector2( -580, -852 ), Vector2( -580, -851 ), Vector2( -580, -850 ), Vector2( -580, -849 ), Vector2( -580, -848 ), Vector2( -580, -850 ), Vector2( -580, -852 ), Vector2( -580, -851 ), Vector2( -580, -850 ), Vector2( -580, -849 ), Vector2( -580, -848 ) ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Neck0/HeadBobber:position")
+tracks/5/path = NodePath("Neck0/HeadBobber:head_bob_mode")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
 tracks/5/enabled = true
 tracks/5/keys = {
-"times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
-"update": 0,
-"values": [ Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -100 ), Vector2( 0, -101 ), Vector2( 0, -100 ), Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -100 ), Vector2( 0, -101 ), Vector2( 0, -100 ), Vector2( 0, -99 ) ]
+"times": PoolRealArray( 0, 0.6 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ 0, 0 ]
 }
-tracks/6/type = "method"
-tracks/6/path = NodePath(".")
+tracks/6/type = "value"
+tracks/6/path = NodePath("Neck0/HeadBobber:position")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
+"times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -100 ), Vector2( 0, -101 ), Vector2( 0, -100 ), Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -100 ), Vector2( 0, -101 ), Vector2( 0, -100 ), Vector2( 0, -99 ) ]
+}
+tracks/7/type = "method"
+tracks/7/path = NodePath(".")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/keys = {
 "times": PoolRealArray( 0.25, 0.55 ),
 "transitions": PoolRealArray( 1, 1 ),
 "values": [ {
@@ -5886,7 +6054,7 @@ tracks/1/keys = {
 "values": [ 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 3 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("FarLeg:frame")
+tracks/2/path = NodePath("FarArm:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -5898,7 +6066,7 @@ tracks/2/keys = {
 "values": [ 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 3 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Body:rect_position")
+tracks/3/path = NodePath("FarLeg:frame")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -5906,40 +6074,52 @@ tracks/3/enabled = true
 tracks/3/keys = {
 "times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
-"update": 0,
-"values": [ Vector2( -580, -848 ), Vector2( -580, -850 ), Vector2( -580, -852 ), Vector2( -580, -851 ), Vector2( -580, -850 ), Vector2( -580, -849 ), Vector2( -580, -848 ), Vector2( -580, -850 ), Vector2( -580, -852 ), Vector2( -580, -851 ), Vector2( -580, -850 ), Vector2( -580, -849 ), Vector2( -580, -848 ) ]
+"update": 1,
+"values": [ 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 3 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Neck0/HeadBobber:head_bob_mode")
+tracks/4/path = NodePath("Body:rect_position")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
 tracks/4/enabled = true
 tracks/4/keys = {
-"times": PoolRealArray( 0, 0.6 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 0, 0 ]
+"times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( -580, -848 ), Vector2( -580, -850 ), Vector2( -580, -852 ), Vector2( -580, -851 ), Vector2( -580, -850 ), Vector2( -580, -849 ), Vector2( -580, -848 ), Vector2( -580, -850 ), Vector2( -580, -852 ), Vector2( -580, -851 ), Vector2( -580, -850 ), Vector2( -580, -849 ), Vector2( -580, -848 ) ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Neck0/HeadBobber:position")
+tracks/5/path = NodePath("Neck0/HeadBobber:head_bob_mode")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
 tracks/5/enabled = true
 tracks/5/keys = {
-"times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
-"update": 0,
-"values": [ Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -100 ), Vector2( 0, -101 ), Vector2( 0, -100 ), Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -100 ), Vector2( 0, -101 ), Vector2( 0, -100 ), Vector2( 0, -99 ) ]
+"times": PoolRealArray( 0, 0.6 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ 0, 0 ]
 }
-tracks/6/type = "method"
-tracks/6/path = NodePath(".")
+tracks/6/type = "value"
+tracks/6/path = NodePath("Neck0/HeadBobber:position")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
+"times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -100 ), Vector2( 0, -101 ), Vector2( 0, -100 ), Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -100 ), Vector2( 0, -101 ), Vector2( 0, -100 ), Vector2( 0, -99 ) ]
+}
+tracks/7/type = "method"
+tracks/7/path = NodePath(".")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/keys = {
 "times": PoolRealArray( 0.25, 0.55 ),
 "transitions": PoolRealArray( 1, 1 ),
 "values": [ {
@@ -5950,13 +6130,13 @@ tracks/6/keys = {
 "method": "emit_sfx_signal"
 } ]
 }
-tracks/7/type = "value"
-tracks/7/path = NodePath("FarArm:frame")
-tracks/7/interp = 1
-tracks/7/loop_wrap = true
-tracks/7/imported = false
-tracks/7/enabled = true
-tracks/7/keys = {
+tracks/8/type = "value"
+tracks/8/path = NodePath("FarArm:frame")
+tracks/8/interp = 1
+tracks/8/loop_wrap = true
+tracks/8/imported = false
+tracks/8/enabled = true
+tracks/8/keys = {
 "times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 1,
@@ -6162,43 +6342,43 @@ tracks/1/keys = {
 "values": [ 22, 21, 20, 21, 22 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("FarLeg:frame")
+tracks/2/path = NodePath("FarArm:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
 tracks/2/enabled = true
 tracks/2/keys = {
-"times": PoolRealArray( 0, 0.133333, 0.266667, 0.4, 0.533333 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
+"times": PoolRealArray( 0, 0.533333 ),
+"transitions": PoolRealArray( 1, 1 ),
 "update": 1,
-"values": [ 14, 15, 16, 15, 14 ]
+"values": [ 2, 2 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Body:rect_position")
+tracks/3/path = NodePath("FarLeg:frame")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
 tracks/3/enabled = true
 tracks/3/keys = {
-"times": PoolRealArray( 0, 0.266667, 0.533333 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
-"update": 0,
-"values": [ Vector2( -580, -849 ), Vector2( -580, -851 ), Vector2( -580, -849 ) ]
+"times": PoolRealArray( 0, 0.133333, 0.266667, 0.4, 0.533333 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
+"update": 1,
+"values": [ 14, 15, 16, 15, 14 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Neck0/HeadBobber:head_bob_mode")
+tracks/4/path = NodePath("Body:rect_position")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
 tracks/4/enabled = true
 tracks/4/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 1,
-"values": [ 1 ]
+"times": PoolRealArray( 0, 0.266667, 0.533333 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( -580, -849 ), Vector2( -580, -851 ), Vector2( -580, -849 ) ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Neck0/HeadBobber:position")
+tracks/5/path = NodePath("Neck0/HeadBobber:head_bob_mode")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -6206,16 +6386,28 @@ tracks/5/enabled = true
 tracks/5/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ Vector2( 0, -100 ) ]
+"update": 1,
+"values": [ 1 ]
 }
-tracks/6/type = "method"
-tracks/6/path = NodePath(".")
+tracks/6/type = "value"
+tracks/6/path = NodePath("Neck0/HeadBobber:position")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ Vector2( 0, -100 ) ]
+}
+tracks/7/type = "method"
+tracks/7/path = NodePath(".")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/keys = {
 "times": PoolRealArray( 0.133333, 0.4 ),
 "transitions": PoolRealArray( 1, 1 ),
 "values": [ {
@@ -6256,7 +6448,7 @@ tracks/1/keys = {
 "values": [ 6, 7, 8, 7, 6 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("FarLeg:frame")
+tracks/2/path = NodePath("FarArm:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -6265,34 +6457,34 @@ tracks/2/keys = {
 "times": PoolRealArray( 0, 0.133333, 0.266667, 0.4, 0.533333 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 14, 13, 12, 13, 14 ]
+"values": [ 5, 6, 7, 6, 5 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Body:rect_position")
+tracks/3/path = NodePath("FarLeg:frame")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
 tracks/3/enabled = true
 tracks/3/keys = {
-"times": PoolRealArray( 0, 0.266667, 0.533333 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
-"update": 0,
-"values": [ Vector2( -580, -849 ), Vector2( -580, -851 ), Vector2( -580, -849 ) ]
+"times": PoolRealArray( 0, 0.133333, 0.266667, 0.4, 0.533333 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
+"update": 1,
+"values": [ 14, 13, 12, 13, 14 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Neck0/HeadBobber:head_bob_mode")
+tracks/4/path = NodePath("Body:rect_position")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
 tracks/4/enabled = true
 tracks/4/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 1,
-"values": [ 1 ]
+"times": PoolRealArray( 0, 0.266667, 0.533333 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( -580, -849 ), Vector2( -580, -851 ), Vector2( -580, -849 ) ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Neck0/HeadBobber:position")
+tracks/5/path = NodePath("Neck0/HeadBobber:head_bob_mode")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -6300,16 +6492,28 @@ tracks/5/enabled = true
 tracks/5/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ Vector2( 0, -100 ) ]
+"update": 1,
+"values": [ 1 ]
 }
-tracks/6/type = "method"
-tracks/6/path = NodePath(".")
+tracks/6/type = "value"
+tracks/6/path = NodePath("Neck0/HeadBobber:position")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ Vector2( 0, -100 ) ]
+}
+tracks/7/type = "method"
+tracks/7/path = NodePath(".")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/keys = {
 "times": PoolRealArray( 0.133333, 0.4 ),
 "transitions": PoolRealArray( 1, 1 ),
 "values": [ {
@@ -6320,13 +6524,13 @@ tracks/6/keys = {
 "method": "emit_sfx_signal"
 } ]
 }
-tracks/7/type = "value"
-tracks/7/path = NodePath("FarArm:frame")
-tracks/7/interp = 1
-tracks/7/loop_wrap = true
-tracks/7/imported = false
-tracks/7/enabled = true
-tracks/7/keys = {
+tracks/8/type = "value"
+tracks/8/path = NodePath("FarArm:frame")
+tracks/8/interp = 1
+tracks/8/loop_wrap = true
+tracks/8/imported = false
+tracks/8/enabled = true
+tracks/8/keys = {
 "times": PoolRealArray( 0, 0.133333, 0.266667, 0.4, 0.533334 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
 "update": 1,
@@ -6362,31 +6566,31 @@ tracks/1/keys = {
 "values": [ 33, 34, 35, 36, 37, 38, 33, 34, 35, 36, 37, 38, 33 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("Body:rect_position")
+tracks/2/path = NodePath("FarArm:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
 tracks/2/enabled = true
 tracks/2/keys = {
-"times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
-"update": 0,
-"values": [ Vector2( -580, -848 ), Vector2( -580, -854 ), Vector2( -580, -852 ), Vector2( -580, -850 ), Vector2( -580, -848 ), Vector2( -580, -854 ), Vector2( -580, -852 ), Vector2( -580, -850 ), Vector2( -580, -848 ), Vector2( -580, -854 ), Vector2( -580, -852 ), Vector2( -580, -850 ), Vector2( -580, -848 ) ]
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ 0 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Neck0/HeadBobber:head_bob_mode")
+tracks/3/path = NodePath("FarLeg:frame")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
 tracks/3/enabled = true
 tracks/3/keys = {
-"times": PoolRealArray( 0, 0.6 ),
-"transitions": PoolRealArray( 1, 1 ),
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
 "update": 1,
-"values": [ 0, 0 ]
+"values": [ 0 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Neck0/HeadBobber:position")
+tracks/4/path = NodePath("Body:rect_position")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -6395,15 +6599,39 @@ tracks/4/keys = {
 "times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 0,
-"values": [ Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -103 ), Vector2( 0, -101 ), Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -103 ), Vector2( 0, -101 ), Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -103 ), Vector2( 0, -101 ), Vector2( 0, -99 ) ]
+"values": [ Vector2( -580, -848 ), Vector2( -580, -854 ), Vector2( -580, -852 ), Vector2( -580, -850 ), Vector2( -580, -848 ), Vector2( -580, -854 ), Vector2( -580, -852 ), Vector2( -580, -850 ), Vector2( -580, -848 ), Vector2( -580, -854 ), Vector2( -580, -852 ), Vector2( -580, -850 ), Vector2( -580, -848 ) ]
 }
-tracks/5/type = "method"
-tracks/5/path = NodePath(".")
+tracks/5/type = "value"
+tracks/5/path = NodePath("Neck0/HeadBobber:head_bob_mode")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
 tracks/5/enabled = true
 tracks/5/keys = {
+"times": PoolRealArray( 0, 0.6 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ 0, 0 ]
+}
+tracks/6/type = "value"
+tracks/6/path = NodePath("Neck0/HeadBobber:position")
+tracks/6/interp = 1
+tracks/6/loop_wrap = true
+tracks/6/imported = false
+tracks/6/enabled = true
+tracks/6/keys = {
+"times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -103 ), Vector2( 0, -101 ), Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -103 ), Vector2( 0, -101 ), Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -103 ), Vector2( 0, -101 ), Vector2( 0, -99 ) ]
+}
+tracks/7/type = "method"
+tracks/7/path = NodePath(".")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/keys = {
 "times": PoolRealArray( 0.2, 0.4, 0.6 ),
 "transitions": PoolRealArray( 1, 1, 1 ),
 "values": [ {
@@ -6416,18 +6644,6 @@ tracks/5/keys = {
 "args": [ "landed" ],
 "method": "emit_sfx_signal"
 } ]
-}
-tracks/6/type = "value"
-tracks/6/path = NodePath("FarLeg:frame")
-tracks/6/interp = 1
-tracks/6/loop_wrap = true
-tracks/6/imported = false
-tracks/6/enabled = true
-tracks/6/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 1,
-"values": [ 0 ]
 }
 
 [sub_resource type="Animation" id=117]
@@ -6459,7 +6675,7 @@ tracks/1/keys = {
 "values": [ 27, 28, 29, 30, 31, 32, 27, 28, 29, 30, 31, 32, 27 ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("FarLeg:frame")
+tracks/2/path = NodePath("FarArm:frame")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -6468,10 +6684,10 @@ tracks/2/keys = {
 "times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 27, 28, 29, 30, 31, 32, 27, 28, 29, 30, 31, 32, 27 ]
+"values": [ 15, 16, 17, 18, 19, 20, 15, 16, 17, 18, 19, 20, 15 ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("Body:rect_position")
+tracks/3/path = NodePath("FarLeg:frame")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -6479,40 +6695,52 @@ tracks/3/enabled = true
 tracks/3/keys = {
 "times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
-"update": 0,
-"values": [ Vector2( -580, -848 ), Vector2( -580, -854 ), Vector2( -580, -852 ), Vector2( -580, -850 ), Vector2( -580, -848 ), Vector2( -580, -854 ), Vector2( -580, -852 ), Vector2( -580, -850 ), Vector2( -580, -848 ), Vector2( -580, -854 ), Vector2( -580, -852 ), Vector2( -580, -850 ), Vector2( -580, -848 ) ]
+"update": 1,
+"values": [ 27, 28, 29, 30, 31, 32, 27, 28, 29, 30, 31, 32, 27 ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("Neck0/HeadBobber:head_bob_mode")
+tracks/4/path = NodePath("Body:rect_position")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
 tracks/4/enabled = true
 tracks/4/keys = {
-"times": PoolRealArray( 0, 0.6 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 1,
-"values": [ 0, 0 ]
+"times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( -580, -848 ), Vector2( -580, -854 ), Vector2( -580, -852 ), Vector2( -580, -850 ), Vector2( -580, -848 ), Vector2( -580, -854 ), Vector2( -580, -852 ), Vector2( -580, -850 ), Vector2( -580, -848 ), Vector2( -580, -854 ), Vector2( -580, -852 ), Vector2( -580, -850 ), Vector2( -580, -848 ) ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("Neck0/HeadBobber:position")
+tracks/5/path = NodePath("Neck0/HeadBobber:head_bob_mode")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
 tracks/5/enabled = true
 tracks/5/keys = {
-"times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
-"update": 0,
-"values": [ Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -103 ), Vector2( 0, -101 ), Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -103 ), Vector2( 0, -101 ), Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -103 ), Vector2( 0, -101 ), Vector2( 0, -99 ) ]
+"times": PoolRealArray( 0, 0.6 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ 0, 0 ]
 }
-tracks/6/type = "method"
-tracks/6/path = NodePath(".")
+tracks/6/type = "value"
+tracks/6/path = NodePath("Neck0/HeadBobber:position")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
+"times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -103 ), Vector2( 0, -101 ), Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -103 ), Vector2( 0, -101 ), Vector2( 0, -99 ), Vector2( 0, -99 ), Vector2( 0, -103 ), Vector2( 0, -101 ), Vector2( 0, -99 ) ]
+}
+tracks/7/type = "method"
+tracks/7/path = NodePath(".")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/keys = {
 "times": PoolRealArray( 0.2, 0.4, 0.6 ),
 "transitions": PoolRealArray( 1, 1, 1 ),
 "values": [ {
@@ -6525,18 +6753,6 @@ tracks/6/keys = {
 "args": [ "landed" ],
 "method": "emit_sfx_signal"
 } ]
-}
-tracks/7/type = "value"
-tracks/7/path = NodePath("FarArm:frame")
-tracks/7/interp = 1
-tracks/7/loop_wrap = true
-tracks/7/imported = false
-tracks/7/enabled = true
-tracks/7/keys = {
-"times": PoolRealArray( 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
-"update": 1,
-"values": [ 15, 16, 17, 18, 19, 20, 15, 16, 17, 18, 19, 20, 15 ]
 }
 
 [sub_resource type="Animation" id=118]


### PR DESCRIPTION
The godot editor deleted all of these animations in 93ce7c52. This had
several side effects including creatures growing a third arm when emoting,
arms remaining still during movement animations, and disappearing as the
creature got fatter.

It's hard to remember what could have made the Godot editor do something so
destructive. Maybe I copied the FarArm node to create the Collar node, and
the editor got confused. Maybe I renamed it, and then renamed it back.

Closes #543, #500, #301.