### PR TITLE
Fixed creatures overblinking, stuck looking over shoulder

### DIFF
--- a/project/src/demo/ui/chat/mood-demo.gd
+++ b/project/src/demo/ui/chat/mood-demo.gd
@@ -1,6 +1,6 @@
 extends Node
 """
-A demo which shows off the creature's range of emotions
+A demo which shows off the creature's range of emotions and idle animations
 
 Keys:
 	[1]: Default mood
@@ -8,21 +8,37 @@ Keys:
 	[A, S, D, F]: Think0 (Pensive), Think1 (Confused), Cry0 (Disappointed), Cry1 (Distraught)
 	[Z, X, C, V]: Sweat0 (Nervous), Sweat1 (Fidgety), Rage0 (Upset), Rage1 (Rage)
 	[=]: Make the creature fat
+	
+	[Shift + Q, W]: Look over shoulder
+	[Shift + E, R]: Yawn
+	[Shift + A, S]: Close eyes
+	[Shift + D, F]: Wiggle ears
 """
 
 func _input(event: InputEvent) -> void:
-	match(Utils.key_scancode(event)):
-		KEY_1: $Creature.play_mood(ChatEvent.Mood.DEFAULT)
-		KEY_Q: $Creature.play_mood(ChatEvent.Mood.SMILE0)
-		KEY_W: $Creature.play_mood(ChatEvent.Mood.SMILE1)
-		KEY_E: $Creature.play_mood(ChatEvent.Mood.LAUGH0)
-		KEY_R: $Creature.play_mood(ChatEvent.Mood.LAUGH1)
-		KEY_A: $Creature.play_mood(ChatEvent.Mood.THINK0)
-		KEY_S: $Creature.play_mood(ChatEvent.Mood.THINK1)
-		KEY_D: $Creature.play_mood(ChatEvent.Mood.CRY0)
-		KEY_F: $Creature.play_mood(ChatEvent.Mood.CRY1)
-		KEY_Z: $Creature.play_mood(ChatEvent.Mood.SWEAT0)
-		KEY_X: $Creature.play_mood(ChatEvent.Mood.SWEAT1)
-		KEY_C: $Creature.play_mood(ChatEvent.Mood.RAGE0)
-		KEY_V: $Creature.play_mood(ChatEvent.Mood.RAGE1)
-		KEY_EQUAL: $Creature.set_fatness(3)
+	if Input.is_key_pressed(KEY_SHIFT):
+		match(Utils.key_scancode(event)):
+			KEY_Q: $Creature.creature_visuals.play_idle_animation("idle-look-over-shoulder0")
+			KEY_W: $Creature.creature_visuals.play_idle_animation("idle-look-over-shoulder1")
+			KEY_E: $Creature.creature_visuals.play_idle_animation("idle-yawn0")
+			KEY_R: $Creature.creature_visuals.play_idle_animation("idle-yawn1")
+			KEY_A: $Creature.creature_visuals.play_idle_animation("idle-close-eyes0")
+			KEY_S: $Creature.creature_visuals.play_idle_animation("idle-close-eyes1")
+			KEY_D: $Creature.creature_visuals.play_idle_animation("idle-ear-wiggle0")
+			KEY_F: $Creature.creature_visuals.play_idle_animation("idle-ear-wiggle1")
+	else:
+		match(Utils.key_scancode(event)):
+			KEY_1: $Creature.play_mood(ChatEvent.Mood.DEFAULT)
+			KEY_Q: $Creature.play_mood(ChatEvent.Mood.SMILE0)
+			KEY_W: $Creature.play_mood(ChatEvent.Mood.SMILE1)
+			KEY_E: $Creature.play_mood(ChatEvent.Mood.LAUGH0)
+			KEY_R: $Creature.play_mood(ChatEvent.Mood.LAUGH1)
+			KEY_A: $Creature.play_mood(ChatEvent.Mood.THINK0)
+			KEY_S: $Creature.play_mood(ChatEvent.Mood.THINK1)
+			KEY_D: $Creature.play_mood(ChatEvent.Mood.CRY0)
+			KEY_F: $Creature.play_mood(ChatEvent.Mood.CRY1)
+			KEY_Z: $Creature.play_mood(ChatEvent.Mood.SWEAT0)
+			KEY_X: $Creature.play_mood(ChatEvent.Mood.SWEAT1)
+			KEY_C: $Creature.play_mood(ChatEvent.Mood.RAGE0)
+			KEY_V: $Creature.play_mood(ChatEvent.Mood.RAGE1)
+			KEY_EQUAL: $Creature.set_fatness(3)

--- a/project/src/main/world/creature/CreatureVisuals.tscn
+++ b/project/src/main/world/creature/CreatureVisuals.tscn
@@ -1593,6 +1593,7 @@ tracks/1/keys = {
 
 [sub_resource type="Animation" id=70]
 length = 7.99999
+loop = true
 step = 0.0333333
 tracks/0/type = "value"
 tracks/0/path = NodePath("Neck0/HeadBobber/EyeZ0:frame")
@@ -6891,11 +6892,8 @@ light_mask = 2
 material = SubResource( 1 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
 offset = Vector2( 0, -119 )
 invisible_while_sprinting = true
 
@@ -6904,11 +6902,8 @@ light_mask = 2
 material = SubResource( 2 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
 offset = Vector2( 0, -119 )
 invisible_while_sprinting = true
 
@@ -6918,11 +6913,8 @@ light_mask = 2
 material = SubResource( 3 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 50 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 6
-centered = true
 offset = Vector2( 0, -119 )
 
 [node name="TailZ0" type="Node2D" parent="."]
@@ -7039,7 +7031,6 @@ script = ExtResource( 40 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
-belly = 0
 curve_defs_by_belly = {
 1: [ {
 "curve_def": [ [ Vector2( -16.4229, -16.8725 ), Vector2( -0.827609, -19.5058 ), Vector2( 0.827609, 19.5058 ) ], [ Vector2( 18.2874, 11.2822 ), Vector2( -14.9663, 1.17112 ), Vector2( 14.9663, -1.17112 ) ], [ Vector2( 49.4005, -24.8763 ), Vector2( 0.670203, 16.3499 ), Vector2( -0.670203, -16.3499 ) ], [ Vector2( 12.944, -59.7323 ), Vector2( 15.2832, -1.67112 ), Vector2( -15.2832, 1.67112 ) ], [ Vector2( -16.4229, -19.2536 ), Vector2( -0.144124, -20.4429 ), Vector2( 0.144124, 20.4429 ) ] ],
@@ -7068,7 +7059,6 @@ curve_defs_by_belly = {
 "fatness": 10.0
 } ]
 }
-_save_belly = false
 
 [node name="Viewport" type="Viewport" parent="BodyColors"]
 size = Vector2( 1200, 1200 )
@@ -7114,16 +7104,10 @@ self_modulate = Color( 1, 1, 1, 1 )
 position = Vector2( 580, 850 )
 curve = SubResource( 12 )
 script = ExtResource( 3 )
-spline_length = 25.0
-_smooth = false
-_straighten = false
-closed = true
-line_color = Color( 0, 0, 0, 1 )
 fill_color = Color( 1, 0, 0, 1 )
 line_width = 2.0
 creature_visuals_path = NodePath("../../..")
 editing = false
-_save_curve = false
 curve_defs = [ {
 "curve_def": [ [ Vector2( -11.158, -72.0639 ), Vector2( 24.9977, 0.341151 ), Vector2( -32.9037, -0.449047 ) ], [ Vector2( -62.0516, -16.4455 ), Vector2( -0.631155, -31.5491 ), Vector2( 0.500038, 24.995 ) ], [ Vector2( -13.1955, 28.0658 ), Vector2( -27.2528, -0.551655 ), Vector2( 30.9852, 0.627207 ) ], [ Vector2( 37.7671, -13.4088 ), Vector2( -0.010441, 25 ), Vector2( 0.011404, -27.3082 ) ], [ Vector2( -11.0971, -72.0781 ), Vector2( 27.0964, -1.30105 ), Vector2( -24.9712, 1.19901 ) ] ],
 "fatness": 1.0
@@ -7143,31 +7127,22 @@ curve_defs = [ {
 "curve_def": [ [ Vector2( -1.29367, -658.921 ), Vector2( 24.9962, 0.436254 ), Vector2( -186.573, -3.25622 ) ], [ Vector2( -494.142, -156.333 ), Vector2( -4.48658, -290.76 ), Vector2( 3.44123, 223.014 ) ], [ Vector2( -18.8258, 204.05 ), Vector2( -219.143, -2.18805 ), Vector2( 241.903, 2.4153 ) ], [ Vector2( 497.398, -131.008 ), Vector2( 2.04043, 215.119 ), Vector2( -3.31852, -349.867 ) ], [ Vector2( 0.654327, -658.921 ), Vector2( 194.42, -4.10986 ), Vector2( -24.9945, 0.528361 ) ] ],
 "fatness": 10.0
 } ]
-visible_when_facing_north = true
 
 [node name="NeckBlend" type="Node2D" parent="Body/Viewport/Body"]
 position = Vector2( -1.11823, -102.515 )
 rotation = 3.13804
 scale = Vector2( 0.836, -0.836 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="NearLeg" type="Node2D" parent="."]
 light_mask = 2
 material = SubResource( 13 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
 offset = Vector2( 0, -119 )
 invisible_while_sprinting = true
 
@@ -7176,11 +7151,8 @@ light_mask = 2
 material = SubResource( 3 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
 offset = Vector2( 0, -119 )
 invisible_while_sprinting = true
 
@@ -7203,13 +7175,8 @@ material = SubResource( 18 )
 position = Vector2( 0, -100 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="Neck0" type="Sprite" parent="."]
 __meta__ = {
@@ -7234,13 +7201,8 @@ light_mask = 2
 material = SubResource( 19 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="EarZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -7248,13 +7210,8 @@ light_mask = 2
 material = SubResource( 20 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="HornZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -7262,13 +7219,8 @@ light_mask = 2
 material = SubResource( 21 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="CheekZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -7276,13 +7228,8 @@ light_mask = 2
 material = SubResource( 22 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="Head" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -7290,13 +7237,8 @@ light_mask = 2
 material = SubResource( 23 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="Chin" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -7305,7 +7247,7 @@ material = SubResource( 24 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 2 )
 rect_size = Vector2( 512, 512 )
-frame = 1
+frame = 2
 
 [node name="EarZ1" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -7313,13 +7255,8 @@ light_mask = 2
 material = SubResource( 20 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="CheekZ1" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -7327,13 +7264,8 @@ light_mask = 2
 material = SubResource( 25 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="EarZ2" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -7341,13 +7273,8 @@ light_mask = 2
 material = SubResource( 26 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="Mouth" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -7356,7 +7283,7 @@ material = SubResource( 27 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 2 )
 rect_size = Vector2( 512, 512 )
-frame = 1
+frame = 2
 
 [node name="EyeZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -7397,13 +7324,8 @@ light_mask = 2
 material = SubResource( 29 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="HornZ1" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -7411,13 +7333,8 @@ light_mask = 2
 material = SubResource( 30 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="Nose" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -7425,13 +7342,8 @@ light_mask = 2
 material = SubResource( 31 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="EyeZ1" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -7448,13 +7360,8 @@ light_mask = 2
 material = SubResource( 32 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="HairZ2" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -7462,13 +7369,8 @@ light_mask = 2
 material = SubResource( 33 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="EmoteEyeZ1" type="Node2D" parent="Neck0/HeadBobber"]
 light_mask = 2
@@ -7711,57 +7613,64 @@ movement_anims_path = NodePath("../MovementAnims")
 
 [node name="Tween" type="Tween" parent="."]
 [connection signal="creature_arrived" from="." to="IdleTimer" method="_on_CreatureVisuals_creature_arrived"]
-[connection signal="movement_mode_changed" from="." to="Body/Viewport/Body" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="FatSpriteMover" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Body/Viewport/Body/NeckBlend" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="FarLeg" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Sprint" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="FarArm" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Collar" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ0" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ1" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="NearLeg" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Collar" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ0" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="NearArm" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ1" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ0" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Body/Viewport/Body/NeckBlend" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ1" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ2" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Nose" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ2" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="FatSpriteMover" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="orientation_changed" from="." to="FarLeg" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="FarArm" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Collar" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ0" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ1" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="NearLeg" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ0" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="NearArm" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Body/Viewport/Body/NeckBlend" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ1" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ2" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Nose" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ2" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ2" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ1" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Body/Viewport/Body" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="orientation_changed" from="." to="Mouth1Anims" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Mouth2Anims" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Mouth3Anims" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="EmoteAnims" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="TailAnims" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="start_idle_animation" from="IdleTimer" to="Ear2Anims" method="_on_IdleTimer_start_idle_animation"]
-[connection signal="start_idle_animation" from="IdleTimer" to="Ear3Anims" method="_on_IdleTimer_start_idle_animation"]
-[connection signal="start_idle_animation" from="IdleTimer" to="Ear1Anims" method="_on_IdleTimer_start_idle_animation"]
-[connection signal="start_idle_animation" from="IdleTimer" to="Mouth1Anims" method="_on_IdleTimer_start_idle_animation"]
-[connection signal="start_idle_animation" from="IdleTimer" to="Mouth2Anims" method="_on_IdleTimer_start_idle_animation"]
-[connection signal="start_idle_animation" from="IdleTimer" to="Mouth3Anims" method="_on_IdleTimer_start_idle_animation"]
-[connection signal="start_idle_animation" from="IdleTimer" to="EmoteAnims" method="_on_IdleTimer_start_idle_animation"]
+[connection signal="orientation_changed" from="." to="Body/Viewport/Body/NeckBlend" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="FarLeg" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="FarArm" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="NearLeg" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Collar" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="NearArm" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ1" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Nose" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ2" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ2" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ1" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="idle_animation_started" from="IdleTimer" to="Ear1Anims" method="_on_IdleTimer_idle_animation_started"]
+[connection signal="idle_animation_started" from="IdleTimer" to="Ear2Anims" method="_on_IdleTimer_idle_animation_started"]
+[connection signal="idle_animation_started" from="IdleTimer" to="Ear3Anims" method="_on_IdleTimer_idle_animation_started"]
+[connection signal="idle_animation_started" from="IdleTimer" to="Mouth1Anims" method="_on_IdleTimer_idle_animation_started"]
+[connection signal="idle_animation_started" from="IdleTimer" to="Mouth2Anims" method="_on_IdleTimer_idle_animation_started"]
+[connection signal="idle_animation_started" from="IdleTimer" to="Mouth3Anims" method="_on_IdleTimer_idle_animation_started"]
+[connection signal="idle_animation_started" from="IdleTimer" to="EmoteAnims" method="_on_IdleTimer_idle_animation_started"]
+[connection signal="idle_animation_stopped" from="IdleTimer" to="Ear1Anims" method="_on_IdleTimer_idle_animation_stopped"]
+[connection signal="idle_animation_stopped" from="IdleTimer" to="Ear2Anims" method="_on_IdleTimer_idle_animation_stopped"]
+[connection signal="idle_animation_stopped" from="IdleTimer" to="Ear3Anims" method="_on_IdleTimer_idle_animation_stopped"]
+[connection signal="idle_animation_stopped" from="IdleTimer" to="Mouth1Anims" method="_on_IdleTimer_idle_animation_stopped"]
+[connection signal="idle_animation_stopped" from="IdleTimer" to="Mouth2Anims" method="_on_IdleTimer_idle_animation_stopped"]
+[connection signal="idle_animation_stopped" from="IdleTimer" to="Mouth3Anims" method="_on_IdleTimer_idle_animation_stopped"]
+[connection signal="idle_animation_stopped" from="IdleTimer" to="EmoteAnims" method="_on_IdleTimer_idle_animation_stopped"]
 [connection signal="animation_finished" from="EmoteAnims" to="EmoteAnims" method="_on_animation_finished"]

--- a/project/src/main/world/creature/creature-visuals.gd
+++ b/project/src/main/world/creature/creature-visuals.gd
@@ -163,6 +163,10 @@ func set_fatness(new_fatness: float) -> void:
 	emit_signal("fatness_changed")
 
 
+func play_idle_animation(idle_anim: String) -> void:
+	$IdleTimer.play_idle_animation(idle_anim)
+
+
 """
 This function manually assigns fields which Godot would ideally assign automatically by calling _ready. It is a
 workaround for Godot issue #16974 (https://github.com/godotengine/godot/issues/16974)
@@ -401,6 +405,8 @@ Parameters:
 	'mood': The creature's new mood from ChatEvent.Mood
 """
 func play_mood(mood: int) -> void:
+	$IdleTimer.stop_idle_animation()
+	
 	if mood == ChatEvent.Mood.NONE:
 		pass
 	elif mood == ChatEvent.Mood.DEFAULT:

--- a/project/src/main/world/creature/ear-anims.gd
+++ b/project/src/main/world/creature/ear-anims.gd
@@ -31,7 +31,7 @@ func advance_animation_randomly() -> void:
 	advance(min(randf(), randf()))
 
 
-func _on_IdleTimer_start_idle_animation(anim_name) -> void:
+func _on_IdleTimer_idle_animation_started(anim_name) -> void:
 	if is_processing() and anim_name in get_animation_list():
 		play(anim_name)
 
@@ -43,4 +43,9 @@ func _on_CreatureVisuals_before_creature_arrived() -> void:
 
 func _on_CreatureVisuals_orientation_changed(_old_orientation: int, new_orientation: int) -> void:
 	if is_processing() and not new_orientation in [CreatureVisuals.SOUTHWEST, CreatureVisuals.SOUTHEAST]:
+		stop()
+
+
+func _on_IdleTimer_idle_animation_stopped() -> void:
+	if is_processing() and current_animation.begins_with("idle"):
 		stop()

--- a/project/src/main/world/creature/emote-anims.gd
+++ b/project/src/main/world/creature/emote-anims.gd
@@ -114,6 +114,7 @@ func stop(reset: bool = true) -> void:
 Randomly advances the current animation up to 2.0 seconds. Used to ensure all creatures don't blink synchronously.
 """
 func advance_animation_randomly() -> void:
+	var old_animation_position := current_animation_position
 	advance(randf() * 2.0)
 
 
@@ -288,6 +289,7 @@ func unemote_immediate() -> void:
 	$"../FarArm".update_orientation(_creature_visuals.orientation)
 	_emote_eye_z0.frame = 0
 	_emote_eye_z1.frame = 0
+	_creature_visuals.reset_eye_frames()
 	_head_bobber.rotation_degrees = 0
 	for emote_sprite in _emote_sprites:
 		emote_sprite.rotation_degrees = 0
@@ -400,11 +402,17 @@ func _on_animation_finished(anim_name: String) -> void:
 		_post_unemote()
 
 
-func _on_IdleTimer_start_idle_animation(anim_name: String) -> void:
+func _on_IdleTimer_idle_animation_started(anim_name: String) -> void:
 	if is_processing() and anim_name in get_animation_list():
+		unemote_immediate()
 		play(anim_name)
 
 
 func _on_CreatureVisuals_orientation_changed(_old_orientation: int, new_orientation: int) -> void:
 	if is_processing() and not new_orientation in [CreatureVisuals.SOUTHWEST, CreatureVisuals.SOUTHEAST]:
+		unemote_immediate()
+
+
+func _on_IdleTimer_idle_animation_stopped() -> void:
+	if is_processing() and current_animation.begins_with("idle"):
 		unemote_immediate()

--- a/project/src/main/world/creature/idle-timer.gd
+++ b/project/src/main/world/creature/idle-timer.gd
@@ -3,9 +3,18 @@ extends Timer
 Launches idle animations periodically.
 
 Idle animations are launched if the creature remains in the 'ambient' state for awhile.
+
+This class does not play any animations itself. It sends signals to tell AnimationPlayers when they should start and
+stop playing idle animations.
 """
 
-signal start_idle_animation(anim_name)
+# notifies AnimationPlayers that an idle animation should play.
+signal idle_animation_started(anim_name)
+
+# notifies AnimationPlayers that any current idle animation should be interrupted. this class has no concept of how
+# long each animation takes or whether they're still playing, so it's possible this signal will be emitted when no
+# idle animation is active.
+signal idle_animation_stopped()
 
 # the average amount of seconds to wait before launching an idle animation
 const IDLE_FREQUENCY := 24.0
@@ -37,8 +46,23 @@ func _ready() -> void:
 	_update_state(true)
 
 
+func play_idle_animation(idle_anim: String) -> void:
+	emit_signal("idle_animation_started", idle_anim)
+	_update_state(true)
+
+
 func restart() -> void:
 	_update_state(true)
+
+
+"""
+Stops the currently playing idle animation.
+
+This class has no concept of how long an animation is or whether it's still playing, but it emits a signal which
+animation players can listen for.
+"""
+func stop_idle_animation() -> void:
+	emit_signal("idle_animation_stopped")
 
 
 """
@@ -76,7 +100,7 @@ Launches an idle animation and restarts the timer.
 func _on_timeout() -> void:
 	var idle_anim: String = Utils.rand_value(IDLE_ANIMS)
 	if idle_anim:
-		emit_signal("start_idle_animation", idle_anim)
+		emit_signal("idle_animation_started", idle_anim)
 	_update_state(true)
 
 

--- a/project/src/main/world/creature/mouth-anims.gd
+++ b/project/src/main/world/creature/mouth-anims.gd
@@ -84,7 +84,7 @@ func _on_CreatureVisuals_orientation_changed(_old_orientation: int, _new_orienta
 		_play_mouth_ambient_animation()
 
 
-func _on_IdleTimer_start_idle_animation(anim_name: String) -> void:
+func _on_IdleTimer_idle_animation_started(anim_name: String) -> void:
 	if is_processing() and anim_name in get_animation_list():
 		play(anim_name)
 
@@ -92,3 +92,8 @@ func _on_IdleTimer_start_idle_animation(anim_name: String) -> void:
 func _on_EmoteAnims_animation_started(_anim_name: String) -> void:
 	if current_animation.begins_with("ambient-"):
 		_play_mouth_ambient_animation()
+
+
+func _on_IdleTimer_idle_animation_stopped() -> void:
+	if is_processing() and current_animation.begins_with("idle"):
+		stop()


### PR DESCRIPTION
Fixed a bug where creatures would blink too often. The blink ambient
animation didn't loop, and every time it stopped it would reset to a
random point in the middle.

Fixed a bug where creatures would get stuck looking over their shoulder.
This is because an idle animation would start but then be interrupted.
There's a new 'stop_idle_animation' signal which tells nodes to undo any
of their idle animation stuff.

Changed 'start_idle_animation' signal to 'idle_animation_started' for
consistency with AnimationPlayer

Closes #527.