### PR TITLE
Creature now only has one ear/mouth AnimationPlayer at once.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -129,11 +129,6 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/creature-library.gd"
 }, {
-"base": "Reference",
-"class": "CreatureLoader",
-"language": "GDScript",
-"path": "res://src/main/world/creature/creature-loader.gd"
-}, {
 "base": "PackedSprite",
 "class": "CreaturePackedSprite",
 "language": "GDScript",
@@ -524,7 +519,6 @@ _global_script_class_icons={
 "CreatureDef": "",
 "CreatureEditor": "",
 "CreatureLibrary": "",
-"CreatureLoader": "",
 "CreaturePackedSprite": "",
 "CreaturePaletteDemo": "",
 "CreatureShadow": "",
@@ -616,6 +610,7 @@ default_bus_layout="res://src/main/ui/default_bus_layout.tres"
 Breadcrumb="*res://src/main/breadcrumb.gd"
 ChatLibrary="*res://src/main/ui/chat/chat-library.gd"
 ChattableManager="*res://src/main/world/chattable-manager.gd"
+CreatureLoader="*res://src/main/world/creature/creature-loader.gd"
 Global="*res://src/main/global.gd"
 MilestoneManager="*res://src/main/puzzle/milestone-manager.gd"
 MusicPlayer="*res://src/main/MusicPlayer.tscn"

--- a/project/src/main/world/creature/Ear1Player.tscn
+++ b/project/src/main/world/creature/Ear1Player.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource path="res://src/main/world/creature/ear-player.gd" type="Script" id=1]
 
-[sub_resource type="Animation" id=1]
+[sub_resource type="Animation" id=86]
 length = 6.0
 loop = true
 tracks/0/type = "value"
@@ -29,25 +29,8 @@ tracks/1/keys = {
 "update": 1,
 "values": [ 1, 3, 4, 3, 1, 5, 1 ]
 }
-tracks/2/type = "method"
-tracks/2/path = NodePath("Ear1Player")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/keys = {
-"times": PoolRealArray( 0.5, 3.5 ),
-"transitions": PoolRealArray( 1, 1 ),
-"values": [ {
-"args": [  ],
-"method": "advance_animation_randomly"
-}, {
-"args": [  ],
-"method": "advance_animation_randomly"
-} ]
-}
 
-[sub_resource type="Animation" id=2]
+[sub_resource type="Animation" id=87]
 length = 2.0
 step = 0.0666667
 tracks/0/type = "value"
@@ -75,7 +58,7 @@ tracks/1/keys = {
 "values": [ 1, 5, 1, 3, 4, 3, 1, 5, 1, 3, 4, 3, 1, 5, 1, 1 ]
 }
 
-[sub_resource type="Animation" id=3]
+[sub_resource type="Animation" id=88]
 length = 4.0
 step = 0.0333333
 tracks/0/type = "value"
@@ -103,8 +86,8 @@ tracks/1/keys = {
 "values": [ 1, 1, 5, 1, 3, 4, 3, 1, 5, 1, 3, 4, 3, 1, 5, 1, 3, 4, 3, 1, 1 ]
 }
 
-[node name="Ear1Player" type="AnimationPlayer"]
-anims/ambient = SubResource( 1 )
-anims/idle-ear-wiggle0 = SubResource( 2 )
-anims/idle-ear-wiggle1 = SubResource( 3 )
+[node name="EarPlayer" type="AnimationPlayer"]
+anims/ambient = SubResource( 86 )
+anims/idle-ear-wiggle0 = SubResource( 87 )
+anims/idle-ear-wiggle1 = SubResource( 88 )
 script = ExtResource( 1 )

--- a/project/src/main/world/creature/Ear2Player.tscn
+++ b/project/src/main/world/creature/Ear2Player.tscn
@@ -42,23 +42,6 @@ tracks/2/keys = {
 "update": 1,
 "values": [ 1, 5, 1, 3, 4, 5, 1, 3, 4, 4 ]
 }
-tracks/3/type = "method"
-tracks/3/path = NodePath("Ear2Player")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/keys = {
-"times": PoolRealArray( 1, 5 ),
-"transitions": PoolRealArray( 1, 1 ),
-"values": [ {
-"args": [  ],
-"method": "advance_animation_randomly"
-}, {
-"args": [  ],
-"method": "advance_animation_randomly"
-} ]
-}
 
 [sub_resource type="Animation" id=2]
 length = 2.0
@@ -140,7 +123,7 @@ tracks/2/keys = {
 "values": [ 1, 1, 3, 5, 1, 3, 4, 3, 5, 1, 3, 4, 3, 5, 1, 3, 4, 4 ]
 }
 
-[node name="Ear2Player" type="AnimationPlayer"]
+[node name="EarPlayer" type="AnimationPlayer"]
 anims/ambient = SubResource( 1 )
 anims/idle-ear-wiggle0 = SubResource( 2 )
 anims/idle-ear-wiggle1 = SubResource( 3 )

--- a/project/src/main/world/creature/Ear3Player.tscn
+++ b/project/src/main/world/creature/Ear3Player.tscn
@@ -41,23 +41,6 @@ tracks/2/keys = {
 "update": 1,
 "values": [ 1, 3, 4, 3, 1, 5, 1 ]
 }
-tracks/3/type = "method"
-tracks/3/path = NodePath("Ear3Player")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/keys = {
-"times": PoolRealArray( 0.5, 3.5 ),
-"transitions": PoolRealArray( 1, 1 ),
-"values": [ {
-"args": [  ],
-"method": "advance_animation_randomly"
-}, {
-"args": [  ],
-"method": "advance_animation_randomly"
-} ]
-}
 
 [sub_resource type="Animation" id=2]
 length = 2.0
@@ -139,7 +122,7 @@ tracks/2/keys = {
 "values": [ 1, 1, 5, 1, 3, 4, 3, 1, 5, 1, 3, 4, 3, 1, 5, 1, 3, 4, 3, 1, 1 ]
 }
 
-[node name="Ear3Player" type="AnimationPlayer"]
+[node name="EarPlayer" type="AnimationPlayer"]
 anims/ambient = SubResource( 1 )
 anims/idle-ear-wiggle0 = SubResource( 2 )
 anims/idle-ear-wiggle1 = SubResource( 3 )

--- a/project/src/main/world/creature/Mouth1Player.tscn
+++ b/project/src/main/world/creature/Mouth1Player.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource path="res://src/main/world/creature/mouth-player.gd" type="Script" id=1]
 
-[sub_resource type="Animation" id=1]
+[sub_resource type="Animation" id=89]
 length = 4.0
 loop = true
 step = 0.166667
@@ -31,7 +31,7 @@ tracks/1/keys = {
 "values": [ 2, 2 ]
 }
 
-[sub_resource type="Animation" id=2]
+[sub_resource type="Animation" id=90]
 length = 4.0
 loop = true
 step = 0.166667
@@ -60,7 +60,7 @@ tracks/1/keys = {
 "values": [ 1, 1 ]
 }
 
-[sub_resource type="Animation" id=3]
+[sub_resource type="Animation" id=91]
 length = 0.6
 step = 0.0333333
 tracks/0/type = "value"
@@ -126,7 +126,7 @@ tracks/4/keys = {
 "values": [ 1, 8, 10, 9, 7, 6, 4, 1, 4, 6, 6, 4, 4, 1, 1 ]
 }
 
-[sub_resource type="Animation" id=4]
+[sub_resource type="Animation" id=92]
 length = 0.8
 step = 0.0333333
 tracks/0/type = "value"
@@ -192,7 +192,7 @@ tracks/4/keys = {
 "values": [ 10, 9, 7, 6, 4, 1, 4, 6, 6, 4, 4, 1, 1 ]
 }
 
-[sub_resource type="Animation" id=5]
+[sub_resource type="Animation" id=93]
 length = 4.0
 step = 0.0333333
 tracks/0/type = "value"
@@ -220,7 +220,7 @@ tracks/1/keys = {
 "values": [ 1, 6, 7, 9, 10, 9, 10, 9, 7, 9, 7, 6, 4, 1, 4, 6, 6, 4, 4, 1, 1 ]
 }
 
-[sub_resource type="Animation" id=6]
+[sub_resource type="Animation" id=94]
 length = 4.0
 step = 0.0333333
 tracks/0/type = "value"
@@ -248,12 +248,11 @@ tracks/1/keys = {
 "values": [ 1, 6, 7, 9, 10, 9, 7, 9, 7, 6, 4, 1, 4, 6, 6, 4, 4, 1, 1 ]
 }
 
-[node name="Mouth1Player" type="AnimationPlayer"]
-anims/ambient-nw = SubResource( 1 )
-anims/ambient-se = SubResource( 2 )
-anims/eat = SubResource( 3 )
-anims/eat-again = SubResource( 4 )
-anims/idle-yawn0 = SubResource( 5 )
-anims/idle-yawn1 = SubResource( 6 )
+[node name="MouthPlayer" type="AnimationPlayer"]
+anims/ambient-nw = SubResource( 89 )
+anims/ambient-se = SubResource( 90 )
+anims/eat = SubResource( 91 )
+anims/eat-again = SubResource( 92 )
+anims/idle-yawn0 = SubResource( 93 )
+anims/idle-yawn1 = SubResource( 94 )
 script = ExtResource( 1 )
-emote_player_path = NodePath("../EmotePlayer")

--- a/project/src/main/world/creature/Mouth2Player.tscn
+++ b/project/src/main/world/creature/Mouth2Player.tscn
@@ -366,7 +366,7 @@ tracks/3/keys = {
 "values": [ 1, 1, 3, 4, 5, 9, 10, 9, 10, 9, 5, 4, 3, 1, 1 ]
 }
 
-[node name="Mouth2Player" type="AnimationPlayer"]
+[node name="MouthPlayer" type="AnimationPlayer"]
 anims/ambient-nw = SubResource( 1 )
 anims/ambient-se = SubResource( 2 )
 anims/eat = SubResource( 3 )
@@ -374,4 +374,3 @@ anims/eat-again = SubResource( 4 )
 anims/idle-yawn0 = SubResource( 5 )
 anims/idle-yawn1 = SubResource( 6 )
 script = ExtResource( 1 )
-emote_player_path = NodePath("../EmotePlayer")

--- a/project/src/main/world/creature/Mouth3Player.tscn
+++ b/project/src/main/world/creature/Mouth3Player.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource path="res://src/main/world/creature/mouth-player.gd" type="Script" id=1]
 
-[sub_resource type="Animation" id=1]
+[sub_resource type="Animation" id=89]
 length = 4.0
 loop = true
 step = 0.166667
@@ -31,7 +31,7 @@ tracks/1/keys = {
 "values": [ 2, 2 ]
 }
 
-[sub_resource type="Animation" id=2]
+[sub_resource type="Animation" id=90]
 length = 4.0
 loop = true
 step = 0.166667
@@ -60,7 +60,7 @@ tracks/1/keys = {
 "values": [ 1, 1 ]
 }
 
-[sub_resource type="Animation" id=3]
+[sub_resource type="Animation" id=91]
 length = 4.0
 loop = true
 step = 0.166667
@@ -77,7 +77,7 @@ tracks/0/keys = {
 "values": [ 5, 6, 7, 6, 5 ]
 }
 
-[sub_resource type="Animation" id=4]
+[sub_resource type="Animation" id=92]
 length = 0.6
 step = 0.0333333
 tracks/0/type = "value"
@@ -143,7 +143,7 @@ tracks/4/keys = {
 "values": [ 3, 6, 10, 9, 8, 6, 4, 1, 3, 4, 4, 3, 3, 1, 1 ]
 }
 
-[sub_resource type="Animation" id=5]
+[sub_resource type="Animation" id=93]
 length = 0.8
 step = 0.0333333
 tracks/0/type = "value"
@@ -209,7 +209,7 @@ tracks/4/keys = {
 "values": [ 10, 9, 8, 6, 4, 1, 3, 4, 4, 3, 3, 1, 1 ]
 }
 
-[sub_resource type="Animation" id=6]
+[sub_resource type="Animation" id=94]
 length = 4.0
 step = 0.0333333
 tracks/0/type = "value"
@@ -237,7 +237,7 @@ tracks/1/keys = {
 "values": [ 1, 4, 7, 9, 10, 9, 10, 9, 7, 9, 7, 4, 3, 1, 3, 3, 1, 1, 3, 3, 1, 1 ]
 }
 
-[sub_resource type="Animation" id=7]
+[sub_resource type="Animation" id=95]
 length = 4.0
 step = 0.0333333
 tracks/0/type = "value"
@@ -265,13 +265,12 @@ tracks/1/keys = {
 "values": [ 1, 4, 7, 9, 10, 9, 7, 9, 7, 4, 3, 1, 3, 4, 4, 3, 3, 1, 1 ]
 }
 
-[node name="Mouth3Player" type="AnimationPlayer"]
-anims/ambient-nw = SubResource( 1 )
-anims/ambient-se = SubResource( 2 )
-anims/ambient-unhappy = SubResource( 3 )
-anims/eat = SubResource( 4 )
-anims/eat-again = SubResource( 5 )
-anims/idle-yawn0 = SubResource( 6 )
-anims/idle-yawn1 = SubResource( 7 )
+[node name="MouthPlayer" type="AnimationPlayer"]
+anims/ambient-nw = SubResource( 89 )
+anims/ambient-se = SubResource( 90 )
+anims/ambient-unhappy = SubResource( 91 )
+anims/eat = SubResource( 92 )
+anims/eat-again = SubResource( 93 )
+anims/idle-yawn0 = SubResource( 94 )
+anims/idle-yawn1 = SubResource( 95 )
 script = ExtResource( 1 )
-emote_player_path = NodePath("../EmotePlayer")

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -1,4 +1,6 @@
-class_name CreatureLoader
+#tool #uncomment to view creature in editor
+extends Node
+
 """
 Loads creature resources based on creature definitions. For example, a creature definition might describe high-level
 information about the creature's appearance, such as 'she has red eyes' or 'she has a star on her forehead'. This
@@ -12,11 +14,45 @@ const MAX_FATNESS := 10.0
 # How long it takes a creature to grow to a new size
 const GROWTH_SECONDS := 0.12
 
+# AnimationPlayer scenes with animations for each type of mouth
+var _mouth_player_scenes := {
+	"1": preload("res://src/main/world/creature/Mouth1Player.tscn"),
+	"2": preload("res://src/main/world/creature/Mouth2Player.tscn"),
+	"3": preload("res://src/main/world/creature/Mouth3Player.tscn"),
+}
+
+# AnimationPlayer scenes with animations for each type of ear
+var _ear_player_scenes := {
+	"1": preload("res://src/main/world/creature/Ear1Player.tscn"),
+	"2": preload("res://src/main/world/creature/Ear2Player.tscn"),
+	"3": preload("res://src/main/world/creature/Ear3Player.tscn"),
+}
+
 """
 Returns a random creature definition.
 """
-static func random_def() -> Dictionary:
+func random_def() -> Dictionary:
 	return DnaUtils.random_creature_palette()
+
+
+"""
+Returns an AnimationPlayer for the specified type type of mouth.
+"""
+func new_mouth_player(mouth_key: String) -> AnimationPlayer:
+	var result: AnimationPlayer
+	if _mouth_player_scenes.has(mouth_key):
+		result = _mouth_player_scenes[mouth_key].instance()
+	return result
+
+
+"""
+Returns an AnimationPlayer for the specified type of ear.
+"""
+func new_ear_player(ear_key: String) -> AnimationPlayer:
+	var result: AnimationPlayer
+	if _ear_player_scenes.has(ear_key):
+		result = _ear_player_scenes[ear_key].instance()
+	return result
 
 
 """
@@ -30,7 +66,7 @@ Parameters:
 	'dna': Defines high-level information about the creature's appearance, such as 'she has red eyes'. The response
 		includes granular information such as 'her Eye/Sprint/TxMap/RGB value is ff3030'.
 """
-static func load_details(dna: Dictionary) -> void:
+func load_details(dna: Dictionary) -> void:
 	_load_head(dna)
 	_load_body(dna)
 	_load_colors(dna)
@@ -52,7 +88,7 @@ Parameters:
 	'filename': The stripped-down filename of the resource to look up. All creature texture files have a path of
 		res://assets/main/world/creature/0/{something}.png, so this parameter only specifies the {something}.
 """
-static func _load_texture(dna: Dictionary, node_path: String, key: String, filename: String) -> void:
+func _load_texture(dna: Dictionary, node_path: String, key: String, filename: String) -> void:
 	# load the texture resource
 	var resource_path: String
 	var frame_data: String
@@ -82,7 +118,7 @@ static func _load_texture(dna: Dictionary, node_path: String, key: String, filen
 """
 Loads the resources for a creature's head based on a creature definition.
 """
-static func _load_head(dna: Dictionary) -> void:
+func _load_head(dna: Dictionary) -> void:
 	_load_texture(dna, "Collar", "collar", "collar-packed")
 	_load_texture(dna, "Neck0/HeadBobber/Head", "head", "head-packed")
 	
@@ -114,7 +150,7 @@ static func _load_head(dna: Dictionary) -> void:
 """
 Loads the resources for a creature's arms, legs and torso based on a creature definition.
 """
-static func _load_body(dna: Dictionary) -> void:
+func _load_body(dna: Dictionary) -> void:
 	# All creatures have a body, but this class supports passing in an empty creature definition to unload the
 	# textures from creature sprites. So we leave those textures as null if we're not explicitly told to draw the
 	# creature's body.
@@ -135,7 +171,7 @@ static func _load_body(dna: Dictionary) -> void:
 """
 Assigns the creature's colors based on a creature definition.
 """
-static func _load_colors(dna: Dictionary) -> void:
+func _load_colors(dna: Dictionary) -> void:
 	var line_color: Color
 	if dna.has("line_rgb"):
 		line_color = Color(dna.line_rgb)
@@ -256,11 +292,11 @@ static func _load_colors(dna: Dictionary) -> void:
 	dna["shader:Neck0/HeadBobber/HornZ1:green"] = horn_color
 
 
-static func load_creature_def_by_id(id: String) -> CreatureDef:
+func load_creature_def_by_id(id: String) -> CreatureDef:
 	return load_creature_def("res://assets/main/dialog/%s/creature.json" % id)
 
 
-static func load_creature_def(path: String) -> CreatureDef:
+func load_creature_def(path: String) -> CreatureDef:
 	var creature_def_text: String = FileUtils.get_file_as_text(path)
 	var parsed = parse_json(creature_def_text)
 	var creature_def: CreatureDef

--- a/project/src/main/world/creature/ear-player.gd
+++ b/project/src/main/world/creature/ear-player.gd
@@ -4,12 +4,12 @@ extends AnimationPlayer
 An AnimationPlayer which animates ears.
 """
 
-onready var _creature_visuals: CreatureVisuals = get_parent()
+export (NodePath) var creature_visuals_path: NodePath setget set_creature_visuals_path
+
+var _creature_visuals: CreatureVisuals
 
 func _ready() -> void:
-	_creature_visuals.connect("before_creature_arrived", self, "_on_CreatureVisuals_before_creature_arrived")
-	_creature_visuals.connect("orientation_changed", self, "_on_CreatureVisuals_orientation_changed")
-	set_process(false)
+	_refresh_creature_visuals_path()
 
 
 func _process(_delta: float) -> void:
@@ -23,6 +23,11 @@ func _process(_delta: float) -> void:
 			advance(randf() * current_animation_length)
 
 
+func set_creature_visuals_path(new_creature_visuals_path: NodePath) -> void:
+	creature_visuals_path = new_creature_visuals_path
+	_refresh_creature_visuals_path()
+
+
 """
 Randomly advances the current animation up to 1.0 seconds. Used to ensure all creatures don't wiggle their ears
 synchronously.
@@ -31,21 +36,40 @@ func advance_animation_randomly() -> void:
 	advance(min(randf(), randf()))
 
 
-func _on_IdleTimer_idle_animation_started(anim_name) -> void:
-	if is_processing() and anim_name in get_animation_list():
-		play(anim_name)
+func _refresh_creature_visuals_path() -> void:
+	if not (is_inside_tree() and creature_visuals_path):
+		return
+	
+	if _creature_visuals:
+		_creature_visuals.disconnect("before_creature_arrived", self, "_on_CreatureVisuals_before_creature_arrived")
+		_creature_visuals.disconnect("orientation_changed", self, "_on_CreatureVisuals_orientation_changed")
+		_creature_visuals.get_idle_timer().disconnect(
+				"idle_animation_started", self, "_on_IdleTimer_idle_animation_started")
+		_creature_visuals.get_idle_timer().disconnect(
+				"idle_animation_stopped", self, "_on_IdleTimer_idle_animation_stopped")
+	
+	_creature_visuals = get_node(creature_visuals_path)
+	
+	_creature_visuals.connect("before_creature_arrived", self, "_on_CreatureVisuals_before_creature_arrived")
+	_creature_visuals.connect("orientation_changed", self, "_on_CreatureVisuals_orientation_changed")
+	_creature_visuals.get_idle_timer().connect("idle_animation_started", self, "_on_IdleTimer_idle_animation_started")
+	_creature_visuals.get_idle_timer().connect("idle_animation_stopped", self, "_on_IdleTimer_idle_animation_stopped")
 
 
 func _on_CreatureVisuals_before_creature_arrived() -> void:
-	if is_processing():
-		stop()
+	stop()
 
 
 func _on_CreatureVisuals_orientation_changed(_old_orientation: int, new_orientation: int) -> void:
-	if is_processing() and not new_orientation in [CreatureVisuals.SOUTHWEST, CreatureVisuals.SOUTHEAST]:
+	if not new_orientation in [CreatureVisuals.SOUTHWEST, CreatureVisuals.SOUTHEAST]:
 		stop()
 
 
+func _on_IdleTimer_idle_animation_started(anim_name) -> void:
+	if anim_name in get_animation_list():
+		play(anim_name)
+
+
 func _on_IdleTimer_idle_animation_stopped() -> void:
-	if is_processing() and current_animation.begins_with("idle"):
+	if current_animation.begins_with("idle"):
 		stop()


### PR DESCRIPTION
Instead of having three AnimationPlayers and turning them on/off, it now only
has one. This solution scales better, and we'll eventually need to do something
similar for bodies so it's helpful to have the framework in place.

CreatureLoader hosts the preloaded list of AnimationPlayers. These cannot go in
CreatureVisuals or it causes a circular reference. CreatureLoader is now an
autoloaded node instead of a static class.