### PR TITLE
Refactored CreatureVisuals methods, signals, repetitive code.

### DIFF
--- a/project/src/main/world/creature/Creature.tscn
+++ b/project/src/main/world/creature/Creature.tscn
@@ -531,8 +531,8 @@ bus = "Sound Bus"
 stream = ExtResource( 5 )
 volume_db = -4.0
 bus = "Sound Bus"
-[connection signal="creature_arrived" from="CreatureOutline/Viewport/Visuals" to="." method="_on_CreatureVisuals_creature_arrived"]
-[connection signal="creature_arrived" from="CreatureOutline/Viewport/Visuals" to="CreatureSfx" method="_on_CreatureVisuals_creature_arrived"]
+[connection signal="dna_loaded" from="CreatureOutline/Viewport/Visuals" to="." method="_on_CreatureVisuals_dna_loaded"]
+[connection signal="dna_loaded" from="CreatureOutline/Viewport/Visuals" to="CreatureSfx" method="_on_CreatureVisuals_dna_loaded"]
 [connection signal="food_eaten" from="CreatureOutline/Viewport/Visuals" to="." method="_on_CreatureVisuals_food_eaten"]
 [connection signal="food_eaten" from="CreatureOutline/Viewport/Visuals" to="CreatureSfx" method="_on_CreatureVisuals_food_eaten"]
 [connection signal="landed" from="CreatureOutline/Viewport/Visuals" to="." method="_on_CreatureVisuals_landed"]

--- a/project/src/main/world/creature/CreatureVisuals.tscn
+++ b/project/src/main/world/creature/CreatureVisuals.tscn
@@ -879,7 +879,7 @@ root_node = NodePath("..")
 [node name="TailPlayer" parent="." instance=ExtResource( 29 )]
 
 [node name="Tween" type="Tween" parent="."]
-[connection signal="creature_arrived" from="." to="IdleTimer" method="_on_CreatureVisuals_creature_arrived"]
+[connection signal="dna_loaded" from="." to="IdleTimer" method="_on_CreatureVisuals_dna_loaded"]
 [connection signal="movement_mode_changed" from="." to="FarArm" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Sprint" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="FarLeg" method="_on_CreatureVisuals_movement_mode_changed"]

--- a/project/src/main/world/creature/creature-curve.gd
+++ b/project/src/main/world/creature/creature-curve.gd
@@ -95,7 +95,7 @@ Can be overridden to disconnect additional listeners.
 func disconnect_creature_visuals_listeners() -> void:
 	creature_visuals.disconnect("visual_fatness_changed", self, "_on_CreatureVisuals_visual_fatness_changed")
 	creature_visuals.disconnect("orientation_changed", self, "_on_CreatureVisuals_orientation_changed")
-	creature_visuals.disconnect("creature_arrived", self, "_on_CreatureVisuals_creature_arrived")
+	creature_visuals.disconnect("dna_loaded", self, "_on_CreatureVisuals_dna_loaded")
 
 
 """
@@ -106,7 +106,7 @@ Can be overridden to connect additional listeners.
 func connect_creature_visuals_listeners() -> void:
 	creature_visuals.connect("visual_fatness_changed", self, "_on_CreatureVisuals_visual_fatness_changed")
 	creature_visuals.connect("orientation_changed", self, "_on_CreatureVisuals_orientation_changed")
-	creature_visuals.connect("creature_arrived", self, "_on_CreatureVisuals_creature_arrived")
+	creature_visuals.connect("dna_loaded", self, "_on_CreatureVisuals_dna_loaded")
 
 
 func _refresh_creature_visuals_path() -> void:
@@ -168,5 +168,5 @@ func _on_CreatureVisuals_orientation_changed(_old_orientation: int, _new_orienta
 	refresh_visible()
 
 
-func _on_CreatureVisuals_creature_arrived() -> void:
+func _on_CreatureVisuals_dna_loaded() -> void:
 	_refresh_curve()

--- a/project/src/main/world/creature/creature-sfx.gd
+++ b/project/src/main/world/creature/creature-sfx.gd
@@ -109,7 +109,7 @@ func _on_CreatureVisuals_food_eaten() -> void:
 	$Munch.play()
 
 
-func _on_CreatureVisuals_creature_arrived() -> void:
+func _on_CreatureVisuals_dna_loaded() -> void:
 	if Engine.is_editor_hint():
 		# Skip the sound effects if we're using this as an editor tool
 		return

--- a/project/src/main/world/creature/creature-shadow.gd
+++ b/project/src/main/world/creature/creature-shadow.gd
@@ -38,10 +38,10 @@ func _refresh_creature_path() -> void:
 	
 	if _creature and _creature.is_connected("visual_fatness_changed", self, "_on_Creature_visual_fatness_changed"):
 		_creature.disconnect("visual_fatness_changed", self, "_on_Creature_visual_fatness_changed")
-		_creature.disconnect("creature_arrived", self, "_on_Creature_creature_arrived")
+		_creature.disconnect("dna_loaded", self, "_on_Creature_dna_loaded")
 	_creature = get_node(creature_path)
 	_creature.connect("visual_fatness_changed", self, "_on_Creature_visual_fatness_changed")
-	_creature.connect("creature_arrived", self, "_on_Creature_creature_arrived")
+	_creature.connect("dna_loaded", self, "_on_Creature_dna_loaded")
 	
 	position = _creature.position + shadow_offset
 	if _creature.creature_visuals:
@@ -54,5 +54,5 @@ func _on_Creature_visual_fatness_changed() -> void:
 	$FatPlayer.stop()
 
 
-func _on_Creature_creature_arrived() -> void:
+func _on_Creature_dna_loaded() -> void:
 	$Sprite.scale = Vector2(0.17, 0.17) * shadow_scale * _creature.creature_visuals.scale.y

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -9,7 +9,7 @@ signal fatness_changed
 signal visual_fatness_changed
 signal creature_name_changed
 
-signal creature_arrived
+signal dna_loaded
 
 signal food_eaten
 
@@ -391,9 +391,9 @@ func _on_Creature_fatness_changed() -> void:
 	emit_signal("fatness_changed")
 
 
-func _on_CreatureVisuals_creature_arrived() -> void:
+func _on_CreatureVisuals_dna_loaded() -> void:
 	visible = true
-	emit_signal("creature_arrived")
+	emit_signal("dna_loaded")
 
 
 func _on_CreatureVisuals_food_eaten() -> void:

--- a/project/src/main/world/creature/ear-player.gd
+++ b/project/src/main/world/creature/ear-player.gd
@@ -41,7 +41,6 @@ func _refresh_creature_visuals_path() -> void:
 		return
 	
 	if _creature_visuals:
-		_creature_visuals.disconnect("before_creature_arrived", self, "_on_CreatureVisuals_before_creature_arrived")
 		_creature_visuals.disconnect("orientation_changed", self, "_on_CreatureVisuals_orientation_changed")
 		_creature_visuals.get_idle_timer().disconnect(
 				"idle_animation_started", self, "_on_IdleTimer_idle_animation_started")
@@ -50,14 +49,9 @@ func _refresh_creature_visuals_path() -> void:
 	
 	_creature_visuals = get_node(creature_visuals_path)
 	
-	_creature_visuals.connect("before_creature_arrived", self, "_on_CreatureVisuals_before_creature_arrived")
 	_creature_visuals.connect("orientation_changed", self, "_on_CreatureVisuals_orientation_changed")
 	_creature_visuals.get_idle_timer().connect("idle_animation_started", self, "_on_IdleTimer_idle_animation_started")
 	_creature_visuals.get_idle_timer().connect("idle_animation_stopped", self, "_on_IdleTimer_idle_animation_stopped")
-
-
-func _on_CreatureVisuals_before_creature_arrived() -> void:
-	stop()
 
 
 func _on_CreatureVisuals_orientation_changed(_old_orientation: int, new_orientation: int) -> void:

--- a/project/src/main/world/creature/head-sweat-squirts.gd
+++ b/project/src/main/world/creature/head-sweat-squirts.gd
@@ -23,12 +23,12 @@ func _refresh_creature_visuals_path() -> void:
 	
 	if _creature_visuals:
 		_creature_visuals.disconnect("comfort_changed", self, "_on_CreatureVisuals_comfort_changed")
-		_creature_visuals.disconnect("creature_arrived", self, "_on_CreatureVisuals_creature_arrived")
+		_creature_visuals.disconnect("dna_loaded", self, "_on_CreatureVisuals_dna_loaded")
 	
 	_creature_visuals = get_node(creature_visuals_path)
 	
 	_creature_visuals.connect("comfort_changed", self, "_on_CreatureVisuals_comfort_changed")
-	_creature_visuals.connect("creature_arrived", self, "_on_CreatureVisuals_creature_arrived")
+	_creature_visuals.connect("dna_loaded", self, "_on_CreatureVisuals_dna_loaded")
 
 
 func _on_CreatureVisuals_comfort_changed() -> void:
@@ -38,6 +38,6 @@ func _on_CreatureVisuals_comfort_changed() -> void:
 		amount = lerp(3, 8, sweat_amount)
 
 
-func _on_CreatureVisuals_creature_arrived() -> void:
+func _on_CreatureVisuals_dna_loaded() -> void:
 	var particles_material: ParticlesMaterial = process_material
 	particles_material.scale = _creature_visuals.scale.x * 1.7

--- a/project/src/main/world/creature/idle-timer.gd
+++ b/project/src/main/world/creature/idle-timer.gd
@@ -107,5 +107,5 @@ func _on_timeout() -> void:
 """
 Restarts the idle timer when a new creature shows up.
 """
-func _on_CreatureVisuals_creature_arrived() -> void:
+func _on_CreatureVisuals_dna_loaded() -> void:
 	_update_state(true)

--- a/project/src/main/world/creature/mouth-player.gd
+++ b/project/src/main/world/creature/mouth-player.gd
@@ -62,7 +62,6 @@ func _refresh_creature_visuals_path() -> void:
 		return
 	
 	if _creature_visuals:
-		_creature_visuals.disconnect("before_creature_arrived", self, "_on_CreatureVisuals_before_creature_arrived")
 		_creature_visuals.disconnect("orientation_changed", self, "_on_CreatureVisuals_orientation_changed")
 		_emote_player.disconnect("animation_started", self, "_on_EmotePlayer_animation_started")
 		_creature_visuals.get_idle_timer().disconnect(
@@ -73,7 +72,6 @@ func _refresh_creature_visuals_path() -> void:
 	_creature_visuals = get_node(creature_visuals_path)
 	_emote_player = _creature_visuals.get_emote_player()
 	
-	_creature_visuals.connect("before_creature_arrived", self, "_on_CreatureVisuals_before_creature_arrived")
 	_creature_visuals.connect("orientation_changed", self, "_on_CreatureVisuals_orientation_changed")
 	_emote_player.connect("animation_started", self, "_on_EmotePlayer_animation_started")
 	_creature_visuals.get_idle_timer().connect("idle_animation_started", self, "_on_IdleTimer_idle_animation_started")
@@ -110,10 +108,6 @@ problems.
 func _apply_tool_script_workaround() -> void:
 	if not _creature_visuals:
 		_creature_visuals = get_parent()
-
-
-func _on_CreatureVisuals_before_creature_arrived() -> void:
-	stop()
 
 
 func _on_CreatureVisuals_orientation_changed(_old_orientation: int, _new_orientation: int) -> void:

--- a/project/src/main/world/restaurant/RestaurantScene.tscn
+++ b/project/src/main/world/restaurant/RestaurantScene.tscn
@@ -906,12 +906,12 @@ one_shot = true
 [node name="SuppressSfxTimer" type="Timer" parent="DoorChime"]
 one_shot = true
 autostart = true
-[connection signal="creature_arrived" from="Creature1" to="DoorChime" method="_on_CreatureVisuals_creature_arrived"]
+[connection signal="dna_loaded" from="Creature1" to="DoorChime" method="_on_CreatureVisuals_dna_loaded"]
 [connection signal="food_eaten" from="Creature1" to="." method="_on_CreatureVisuals_food_eaten"]
-[connection signal="creature_arrived" from="Creature2" to="DoorChime" method="_on_CreatureVisuals_creature_arrived"]
+[connection signal="dna_loaded" from="Creature2" to="DoorChime" method="_on_CreatureVisuals_dna_loaded"]
 [connection signal="food_eaten" from="Creature2" to="." method="_on_CreatureVisuals_food_eaten"]
-[connection signal="creature_arrived" from="Creature3" to="DoorChime" method="_on_CreatureVisuals_creature_arrived"]
+[connection signal="dna_loaded" from="Creature3" to="DoorChime" method="_on_CreatureVisuals_dna_loaded"]
 [connection signal="food_eaten" from="Creature3" to="." method="_on_CreatureVisuals_food_eaten"]
-[connection signal="creature_arrived" from="Player" to="DoorChime" method="_on_CreatureVisuals_creature_arrived"]
+[connection signal="dna_loaded" from="Player" to="DoorChime" method="_on_CreatureVisuals_dna_loaded"]
 [connection signal="food_eaten" from="Player" to="." method="_on_CreatureVisuals_food_eaten"]
 [connection signal="timeout" from="DoorChime/ChimeTimer" to="DoorChime" method="_on_ChimeTimer_timeout"]

--- a/project/src/main/world/restaurant/door-chime.gd
+++ b/project/src/main/world/restaurant/door-chime.gd
@@ -17,7 +17,7 @@ func play_door_chime() -> void:
 	play()
 
 
-func _on_CreatureVisuals_creature_arrived() -> void:
+func _on_CreatureVisuals_dna_loaded() -> void:
 	if not $SuppressSfxTimer.is_stopped():
 		# suppress door chime at the start of a scenario
 		return


### PR DESCRIPTION
Split CreatureVisuals._update_creature_properties into _unassign and
_assign methods. These are slightly more descriptive and help separate and
document the two distinct pieces of functionality the method was doing.

Extracted _add_visuals_node, _remove_visuals_node utility methods to cut
down on repetitive code.

The creature_arrived signal is now named 'dna_loaded' which is more
descriptive. This was originally named 'creature_arrived' because it coincided
with arriving at the restaurant, but now that is not always the case as it
applies to creatures being loaded in the overworld or elsewhere.

I removed the before_creature_arrived signal. It was only used for stopping
animations which is now unnecessary as the animation players get removed.