### PR TITLE
CreatureLoader refactorings: repetitive code, instructor config

### DIFF
--- a/project/assets/main/dialog/boatricia/creature.json
+++ b/project/assets/main/dialog/boatricia/creature.json
@@ -3,10 +3,11 @@
   "id": "boatricia",
   "name": "Boatricia",
   "dna": {
-    "body": "1",
-    "body_rgb": "0b45a6",
     "belly": "0",
     "belly_rgb": "eec086",
+    "body": "1",
+    "body_rgb": "0b45a6",
+    "cheek": "2",
     "ear": "2",
     "eye": "3",
     "eye_rgb": "fad541 ffffff",
@@ -16,7 +17,6 @@
     "line_rgb": "41281e",
     "mouth": "1",
     "nose": "2",
-    "cheek": "2",
     "tail": "3"
   },
   "chat_theme_def": {

--- a/project/assets/main/dialog/bort/creature.json
+++ b/project/assets/main/dialog/bort/creature.json
@@ -3,10 +3,11 @@
   "id": "bort",
   "name": "Bort",
   "dna": {
-    "body": "2",
-    "body_rgb": "70843a",
     "belly": "2",
     "belly_rgb": "a9aa2f",
+    "body": "2",
+    "body_rgb": "70843a",
+    "cheek": "1",
     "ear": "3",
     "eye": "2",
     "eye_rgb": "7d4c21 e5cd7d",
@@ -16,7 +17,6 @@
     "line_rgb": "6c4331",
     "mouth": "3",
     "nose": "3",
-    "cheek": "1",
     "tail": "0"
   },
   "fatness": 1.5,

--- a/project/assets/main/dialog/ebe/creature.json
+++ b/project/assets/main/dialog/ebe/creature.json
@@ -3,10 +3,12 @@
   "id": "ebe",
   "name": "Ebe",
   "dna": {
-    "body": "1",
-    "body_rgb": "feceef",
     "belly": "1",
     "belly_rgb": "ffeffc",
+    "body": "1",
+    "body_rgb": "feceef",
+    "cheek": "2",
+    "cloth_rgb": "9999f4",
     "collar": "1",
     "ear": "1",
     "eye": "1",
@@ -17,8 +19,6 @@
     "line_rgb": "6c4331",
     "mouth": "3",
     "nose": "2",
-    "cheek": "2",
-    "cloth_rgb": "9999f4",
     "tail": "4"
   },
   "chat_theme_def": {

--- a/project/assets/main/dialog/instructor/creature.json
+++ b/project/assets/main/dialog/instructor/creature.json
@@ -1,0 +1,26 @@
+{
+  "version": "187d",
+  "id": "instructor",
+  "name": "Master Fat",
+  "dna": {
+    "instructor": "true",
+    "belly": "0",
+    "body": "1",
+    "body_rgb": "a854cb",
+    "cheek": "0",
+    "cloth_rgb": "4fa94e",
+    "collar": "0",
+    "ear": "3",
+    "eye": "2",
+    "eye_rgb": "4fa94e dbe28e",
+    "hair": "0",
+    "hair_rgb": "f1e398",
+    "head": "1",
+    "horn": "0",
+    "horn_rgb": "f1e398",
+    "line_rgb": "6c4331",
+    "mouth": "2",
+    "nose": "2",
+    "tail": "3"
+  }
+}

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -36,15 +36,10 @@ Parameters:
 func summon_instructor(replace_current: bool = false) -> void:
 	if $RestaurantView.get_customer().dna.get("instructor") == "true":
 		return
-
-	Global.creature_queue.push_front({
-		"line_rgb": "6c4331", "body_rgb": "a854cb", "cloth_rgb": "4fa94e",
-		"hair_rgb": "f1e398", "eye_rgb": "4fa94e dbe28e", "horn_rgb": "f1e398",
-		"head": "1", "body": "1",
-		"ear": "3", "horn": "0", "mouth": "2", "eye": "2", "cheek": "0", "nose": "2",
-		"hair": "0", "collar": "0", "tail": "0",
-		"instructor": "true"
-	})
+	
+	var creature_def := CreatureLoader.load_creature_def_by_id("instructor")
+	Global.creature_queue.push_front(creature_def.dna)
+	
 	if replace_current:
 		$RestaurantView.summon_creature()
 	else:


### PR DESCRIPTION
Instead of repetitive assignments to red/green/blue/black values,
CreatureLoader now uses a utility method to assign all values at once.

Moved instructor's dna into a json file, instead of hard-coding it in
puzzle.gd.

Reordered CreatureLoader methods so that private methods are at the
bottom.

Alphabetized creature.json fields.