### PR TITLE
.tscn resources are cached, improving scene launch performance.

### DIFF
--- a/project/src/main/breadcrumb.gd
+++ b/project/src/main/breadcrumb.gd
@@ -49,4 +49,7 @@ Changes the running scene to the one at the front of the breadcrumb trail.
 """
 func _change_scene() -> void:
 	if trail:
-		get_tree().change_scene(trail.front())
+		if ResourceCache.has_cached_resource(trail.front()):
+			get_tree().change_scene_to(ResourceCache.get_cached_resource(trail.front()))
+		else:
+			get_tree().change_scene(trail.front())


### PR DESCRIPTION
Caching these resources improves the puzzle launch time from about 2
seconds to about 1 second.

Caching .tscn resources requires some special handling, since loading them
in a threaded manner causes problems. We need to load all of the resources
normally, and then load the scenes in the main thread.

Performance could be further improved by initializing and reusing a single
puzzle scene instead of initializing a new scene every time -- but this
introduces a lot of bugs reinitializing the scene, as well as errors/warnings
exiting the game.