### PR TITLE
DNA is trimmed before being saved.

### DIFF
--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -276,7 +276,7 @@ func set_creature_def(new_creature_def: CreatureDef) -> void:
 func get_creature_def() -> CreatureDef:
 	var result := CreatureDef.new()
 	result.creature_id = creature_id
-	result.dna = dna
+	result.dna = DnaUtils.trim_dna(dna)
 	result.creature_name = creature_name
 	result.creature_short_name = creature_short_name
 	result.dialog = dialog

--- a/project/src/main/world/creature/dna-utils.gd
+++ b/project/src/main/world/creature/dna-utils.gd
@@ -210,6 +210,20 @@ func _ready() -> void:
 
 
 """
+Return a minimal copy of the specified dna.
+
+CreatureLoader populates the dna dictionary with redundant properties such as textures and shader properties. This
+returns a version of the dna with that extra stuff stripped out so it doesn't clutter our save files.
+"""
+func trim_dna(dna: Dictionary) -> Dictionary:
+	var result := {}
+	for allele in ALLELES:
+		if dna.has(allele):
+			result[allele] = dna[allele]
+	return result
+
+
+"""
 Fill in the creature's missing traits with random values.
 
 Otherwise, missing values will be left empty, leading to invisible body parts or strange colors.


### PR DESCRIPTION
DNA is trimmed so it doesn't include extra textures and shader properties.
This gets rid of some visual clutter in the save files and also
significantly reduces the size.

Closes #567.