### PR TITLE
Fixed autotile bug when clearing boxes next to vegetables.

### DIFF
--- a/project/src/main/puzzle/puzzle-tile-map.gd
+++ b/project/src/main/puzzle/puzzle-tile-map.gd
@@ -243,8 +243,10 @@ If we didn't perform this step, the chopped-off bottom of a bread box would stil
 bottom of a bread box looks like a delicious frosted snack and the player can tell it's special.
 """
 func _disconnect_box(pos: Vector2) -> void:
-	_disconnect_block(pos + Vector2.UP, Connect.DOWN)
-	_disconnect_block(pos + Vector2.DOWN, Connect.UP)
+	if get_cellv(pos + Vector2.UP) == TILE_BOX:
+		_disconnect_block(pos + Vector2.UP, Connect.DOWN)
+	if get_cellv(pos + Vector2.DOWN) == TILE_BOX:
+		_disconnect_block(pos + Vector2.DOWN, Connect.UP)
 
 
 """


### PR DESCRIPTION
Clearing a line with a box would check the adjacent autotile coordinates,
but it wouldn't check the adjacent cell types. This meant it could make
vegetable blocks change to a different vegetable.