### PR TITLE
Markov model allows fractional values. Removed multi-word animals

### DIFF
--- a/project/assets/main/editor/creature/animals.txt
+++ b/project/assets/main/editor/creature/animals.txt
@@ -17,7 +17,6 @@ asp
 ass
 baboon
 badger
-bald eagle
 bandicoot
 barnacle
 barracuda
@@ -32,11 +31,7 @@ beetle
 bird
 bison
 blackbird
-black panther
-black widow
 bluebird
-blue jay
-blue whale
 boa
 boar
 bobcat
@@ -77,7 +72,6 @@ cow
 coyote
 crab
 crane
-crane fly
 crayfish
 cricket
 crocodile
@@ -98,7 +92,6 @@ dove
 dragonfly
 duck
 dugong
-dung beetle
 dunlin
 eagle
 earthworm
@@ -108,7 +101,6 @@ eel
 egret
 eland
 elephant
-elephant seal
 elk
 emu
 ermine
@@ -130,8 +122,6 @@ gaur
 gazelle
 gecko
 gerbil
-giant panda
-giant squid
 gibbon
 giraffe
 gnat
@@ -144,23 +134,16 @@ gopher
 gorilla
 goshawk
 grasshopper
-grizzly bear
-ground shark
-ground sloth
 grouse
 guan
 guanaco
-guinea fowl
-guinea pig
 gull
 haddock
 halibut
-hammerhead shark
 hamster
 hare
 hawk
 hedgehog
-hermit crab
 heron
 herring
 hippopotamus
@@ -169,7 +152,6 @@ horse
 hoverfly
 human
 hummingbird
-humpback whale
 hyena
 ibex
 ibis
@@ -214,7 +196,6 @@ mallard
 mammal
 manatee
 mandrill
-manta ray
 mantis
 marmoset
 marmot
@@ -273,7 +254,6 @@ porpoise
 possum
 prairiedog
 prawn
-praying mantis
 primate
 puffin
 puma
@@ -288,8 +268,6 @@ ram
 rat
 rattlesnake
 raven
-red deer
-red panda
 redpanda
 reindeer
 reptile
@@ -300,15 +278,11 @@ rook
 rooster
 salamander
 salmon
-sand dollar
 sandpiper
 sardine
 scorpion
 seahorse
 seal
-sea lion
-sea slug
-sea snail
 shark
 sheep
 shrew
@@ -324,16 +298,12 @@ snake
 snipe
 sole
 sparrow
-sperm whale
 spider
-spider monkey
 spoonbill
 squid
 squirrel
 starfish
 starling
-sting ray
-stink bug
 stoat
 stork
 swallow
@@ -347,24 +317,20 @@ tarsier
 termite
 thrush
 tiger
-tiger shark
 toad
 tortoise
 toucan
-tree frog
 trout
 tuna
 turkey
 turtle
 tyrannosaurus
-vampire bat
 viper
 vole
 vulture
 wallaby
 walrus
 wasp
-water buffalo
 weasel
 whale
 whitefish

--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -55,6 +55,7 @@ func _ready() -> void:
 	_name_generator.add_seed_resource("res://assets/main/editor/creature/animals.txt")
 	_name_generator.add_seed_resource("res://assets/main/editor/creature/american-male-given-names.txt")
 	_name_generator.add_seed_resource("res://assets/main/editor/creature/american-female-given-names.txt")
+	_name_generator.order = 2.7
 	_name_generator.min_length = 5
 	_name_generator.max_length = 11
 	

--- a/project/src/main/markov-model.gd
+++ b/project/src/main/markov-model.gd
@@ -8,8 +8,9 @@ Maintains a list of letter sequences and letters which can follow them.
 var min_length := 3
 var max_length := 15
 
-# the smallest cluster of letters which are guaranteed to stay together.
-var order := 3
+# The smallest cluster of letters which are guaranteed to stay together. A fractional value will randomly alternate
+# between the lower and higher values while generating words.
+var order := 2.5
 
 # Key: Letter cluster, newline-terminated for the word's end
 # Value: Number of times the cluster appeared in the input data
@@ -31,11 +32,16 @@ func add_word(word: String) -> void:
 	if word.length() <= 1:
 		return
 	
-	for i in range(1, word.length() + order + 1):
-		var cluster := word.substr(max(i - order - 1, 0), min(i, order + 1))
-		if i > word.length():
-			cluster += "\n"
-		_add_cluster(cluster)
+	var int_orders := [floor(order)]
+	if floor(order) != ceil(order):
+		int_orders.append(ceil(order))
+	
+	for int_order in int_orders:
+		for i in range(1, word.length() + int_order + 1):
+			var cluster := word.substr(max(i - int_order - 1, 0), min(i, int_order + 1))
+			if i > word.length():
+				cluster += "\n"
+			_add_cluster(cluster)
 
 
 """
@@ -50,7 +56,7 @@ Returns:
 func generate_word() -> String:
 	var word := ""
 	while true:
-		var cluster := word.substr(max(0, word.length() - order - 1), order + 1)
+		var cluster := word.substr(max(0, word.length() - ceil(order) - 1), ceil(order) + 1)
 		cluster = _get_cluster(cluster, word.length() >= min_length)
 		if not cluster:
 			# failure; couldn't find a continuation
@@ -81,7 +87,8 @@ Returns:
 func _get_cluster(cluster_in: String, may_end: bool) -> String:
 	# calculate the total number of connections
 	var total := 0
-	var prefix := cluster_in.substr(max(cluster_in.length() - order, 0))
+	var int_order := floor(order) if randf() > order - floor(order) else ceil(order)
+	var prefix := cluster_in.substr(max(cluster_in.length() - int_order, 0))
 	for cluster in connections.get(prefix):
 		if cluster.ends_with("\n") and not may_end:
 			continue

--- a/project/src/main/name-generator.gd
+++ b/project/src/main/name-generator.gd
@@ -8,7 +8,7 @@ Accepts as input a list of words like 'banana' and 'anabelle', and mixes them in
 var markov_model := MarkovModel.new()
 var min_length: int setget set_min_length
 var max_length: int setget set_max_length
-var order: int setget set_order
+var order: float setget set_order
 
 # Key: Word from the source material
 # Value: true
@@ -38,7 +38,7 @@ func set_max_length(new_max_length: int) -> void:
 	markov_model.max_length = new_max_length
 
 
-func set_order(new_order: int) -> void:
+func set_order(new_order: float) -> void:
 	markov_model.order = new_order
 
 

--- a/project/src/test/puzzle/test-playfield.gd
+++ b/project/src/test/puzzle/test-playfield.gd
@@ -1,5 +1,0 @@
-extends "res://addons/gut/test.gd"
-
-func test_closest_clears() -> void:
-	var result := LineClearer.closest_clears([0, 1, 3, 4, 5, 7], [2, 6, 8, 9, 10])
-	assert_eq([1, 5, 7, 7, 7], result)

--- a/project/src/test/test-markov-model.gd
+++ b/project/src/test/test-markov-model.gd
@@ -7,6 +7,7 @@ var _model
 
 func before_each() -> void:
 	_model = MarkovModel.new()
+	_model.order = 3
 
 
 func test_add_word_order_2() -> void:


### PR DESCRIPTION
A markov order of 2 results in nonsensical names like 'Woodd' because
'ood' and 'odd' are both valid letter clusters. A markov order of '3'
results in predictable names like 'Tarakeet' because the clusters 'ara'
and 'ake' only have a few valid continuations. Randomly alternating
between 2 and 3 mitigates these disadvantages.

Removed multi-word animals. These typically caused animalish names like 'Mistink
Bug' and 'Term Whale'.

Removed test-playfield.gd. It was testing a method which no longer exists.