### PR TITLE
Fixed inky mouths, long unit test lines

### DIFF
--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -14,6 +14,9 @@ const MAX_FATNESS := 10.0
 # How long it takes a creature to grow to a new size
 const GROWTH_SECONDS := 0.12
 
+# The color inside a creature's mouth.
+const PINK_INSIDE_COLOR := Color("f39274")
+
 # AnimationPlayer scenes with animations for each type of mouth
 var _mouth_player_scenes := {
 	"1": preload("res://src/main/world/creature/Mouth1Player.tscn"),
@@ -316,7 +319,7 @@ func _load_colors(dna: Dictionary) -> void:
 	_set_krgb(dna, "Neck0/HeadBobber/Chin", line_color, chin_skin_color)
 	
 	var mouth_skin_color := belly_color if dna.get("head") in ["2", "3", "5"] else body_color
-	_set_krgb(dna, "Neck0/HeadBobber/Mouth", line_color, mouth_skin_color)
+	_set_krgb(dna, "Neck0/HeadBobber/Mouth", line_color, mouth_skin_color, PINK_INSIDE_COLOR)
 	
 	var nose_skin_color := belly_color if dna.get("head") in ["2", "3"] else body_color
 	_set_krgb(dna, "Neck0/HeadBobber/Nose", line_color, nose_skin_color)

--- a/project/src/test/test-rolling-backups.gd
+++ b/project/src/test/test-rolling-backups.gd
@@ -5,75 +5,76 @@ Unit test demonstrating the rolling backup behavior.
 
 const TEMP_FILENAME := "test837.save"
 
-var _rolling_backups := RollingBackups.new()
+var _backups := RollingBackups.new()
 
 func before_each() -> void:
-	_rolling_backups.current_filename = "user://%s" % TEMP_FILENAME
+	_backups.current_filename = "user://%s" % TEMP_FILENAME
 
 
 func after_each() -> void:
 	var dir := Directory.new()
-	dir.remove(_rolling_backups.rolling_filename(RollingBackups.CURRENT))
-	dir.remove(_rolling_backups.rolling_filename(RollingBackups.THIS_HOUR))
-	dir.remove(_rolling_backups.rolling_filename(RollingBackups.PREV_HOUR))
-	dir.remove(_rolling_backups.rolling_filename(RollingBackups.THIS_DAY))
-	dir.remove(_rolling_backups.rolling_filename(RollingBackups.PREV_DAY))
-	dir.remove(_rolling_backups.rolling_filename(RollingBackups.THIS_WEEK))
-	dir.remove(_rolling_backups.rolling_filename(RollingBackups.PREV_WEEK))
+	dir.remove(_backups.rolling_filename(RollingBackups.CURRENT))
+	dir.remove(_backups.rolling_filename(RollingBackups.THIS_HOUR))
+	dir.remove(_backups.rolling_filename(RollingBackups.PREV_HOUR))
+	dir.remove(_backups.rolling_filename(RollingBackups.THIS_DAY))
+	dir.remove(_backups.rolling_filename(RollingBackups.PREV_DAY))
+	dir.remove(_backups.rolling_filename(RollingBackups.THIS_WEEK))
+	dir.remove(_backups.rolling_filename(RollingBackups.PREV_WEEK))
 
 
 func test_rolling_filename() -> void:
-	assert_eq(_rolling_backups.rolling_filename(RollingBackups.CURRENT), "user://test837.save")
-	assert_eq(_rolling_backups.rolling_filename(RollingBackups.THIS_HOUR), "user://test837.this-hour.save.bak")
-	assert_eq(_rolling_backups.rolling_filename(RollingBackups.PREV_HOUR), "user://test837.prev-hour.save.bak")
-	assert_eq(_rolling_backups.rolling_filename(RollingBackups.THIS_DAY), "user://test837.this-day.save.bak")
-	assert_eq(_rolling_backups.rolling_filename(RollingBackups.PREV_DAY), "user://test837.prev-day.save.bak")
-	assert_eq(_rolling_backups.rolling_filename(RollingBackups.THIS_WEEK), "user://test837.this-week.save.bak")
-	assert_eq(_rolling_backups.rolling_filename(RollingBackups.PREV_WEEK), "user://test837.prev-week.save.bak")
+	assert_eq(_backups.rolling_filename(RollingBackups.CURRENT), "user://test837.save")
+	assert_eq(_backups.rolling_filename(RollingBackups.THIS_HOUR), "user://test837.this-hour.save.bak")
+	assert_eq(_backups.rolling_filename(RollingBackups.PREV_HOUR), "user://test837.prev-hour.save.bak")
+	assert_eq(_backups.rolling_filename(RollingBackups.THIS_DAY), "user://test837.this-day.save.bak")
+	assert_eq(_backups.rolling_filename(RollingBackups.PREV_DAY), "user://test837.prev-day.save.bak")
+	assert_eq(_backups.rolling_filename(RollingBackups.THIS_WEEK), "user://test837.this-week.save.bak")
+	assert_eq(_backups.rolling_filename(RollingBackups.PREV_WEEK), "user://test837.prev-week.save.bak")
 
 
 func test_corrupt_filename() -> void:
-	assert_eq(_rolling_backups.corrupt_filename("user://test837.save"), "user://test837.save.corrupt")
-	assert_eq(_rolling_backups.corrupt_filename("user://test837.this-day.save.bak"), "user://test837.this-day.save.corrupt")
+	assert_eq(_backups.corrupt_filename("user://test837.save"), "user://test837.save.corrupt")
+	assert_eq(_backups.corrupt_filename("user://test837.this-day.save.bak"),
+			"user://test837.this-day.save.corrupt")
 	
 	# invalid input should produce non-harmful output
-	assert_eq(_rolling_backups.corrupt_filename("abcd"), "abcd.save.corrupt")
+	assert_eq(_backups.corrupt_filename("abcd"), "abcd.save.corrupt")
 
 
 func test_rotate_backups_none_exist() -> void:
-	FileUtils.write_file(_rolling_backups.current_filename, "")
-	_rolling_backups.rotate_backups()
+	FileUtils.write_file(_backups.current_filename, "")
+	_backups.rotate_backups()
 	var file := File.new()
 	
 	# current save still exists
-	assert_true(file.file_exists(_rolling_backups.rolling_filename(RollingBackups.CURRENT)), "RollingBackups.CURRENT")
+	assert_true(file.file_exists(_backups.rolling_filename(RollingBackups.CURRENT)), "RollingBackups.CURRENT")
 	
 	# newest backups were created
-	assert_true(file.file_exists(_rolling_backups.rolling_filename(RollingBackups.THIS_HOUR)), "RollingBackups.THIS_HOUR")
-	assert_true(file.file_exists(_rolling_backups.rolling_filename(RollingBackups.THIS_DAY)), "RollingBackups.THIS_DAY")
-	assert_true(file.file_exists(_rolling_backups.rolling_filename(RollingBackups.THIS_WEEK)), "RollingBackups.THIS_WEEK")
+	assert_true(file.file_exists(_backups.rolling_filename(RollingBackups.THIS_HOUR)), "RollingBackups.THIS_HOUR")
+	assert_true(file.file_exists(_backups.rolling_filename(RollingBackups.THIS_DAY)), "RollingBackups.THIS_DAY")
+	assert_true(file.file_exists(_backups.rolling_filename(RollingBackups.THIS_WEEK)), "RollingBackups.THIS_WEEK")
 	
 	# old backups weren't created yet
-	assert_false(file.file_exists(_rolling_backups.rolling_filename(RollingBackups.PREV_HOUR)), "RollingBackups.PREV_HOUR")
-	assert_false(file.file_exists(_rolling_backups.rolling_filename(RollingBackups.PREV_DAY)), "RollingBackups.PREV_DAY")
-	assert_false(file.file_exists(_rolling_backups.rolling_filename(RollingBackups.PREV_WEEK)), "RollingBackups.PREV_WEEK")
+	assert_false(file.file_exists(_backups.rolling_filename(RollingBackups.PREV_HOUR)), "RollingBackups.PREV_HOUR")
+	assert_false(file.file_exists(_backups.rolling_filename(RollingBackups.PREV_DAY)), "RollingBackups.PREV_DAY")
+	assert_false(file.file_exists(_backups.rolling_filename(RollingBackups.PREV_WEEK)), "RollingBackups.PREV_WEEK")
 
 
 """
 Don't overwrite the 'this_xxx' backups if they already exist
 """
 func test_rotate_backups_dont_overwrite_thisxxx() -> void:
-	FileUtils.write_file(_rolling_backups.current_filename, "new-920")
-	FileUtils.write_file(_rolling_backups.rolling_filename(RollingBackups.THIS_HOUR), "old-920")
-	_rolling_backups.rotate_backups()
+	FileUtils.write_file(_backups.current_filename, "new-920")
+	FileUtils.write_file(_backups.rolling_filename(RollingBackups.THIS_HOUR), "old-920")
+	_backups.rotate_backups()
 	
-	assert_eq(FileUtils.get_file_as_text(_rolling_backups.rolling_filename(RollingBackups.THIS_HOUR)), "old-920")
+	assert_eq(FileUtils.get_file_as_text(_backups.rolling_filename(RollingBackups.THIS_HOUR)), "old-920")
 
 
 """
 Move the 'this_xxx' backups out of the way if they're old
 """
 func test_move_backups() -> void:
-	FileUtils.write_file(_rolling_backups.rolling_filename(RollingBackups.THIS_HOUR), "")
+	FileUtils.write_file(_backups.rolling_filename(RollingBackups.THIS_HOUR), "")
 	var file: File = File.new()
 	file.close()


### PR DESCRIPTION
Inky mouths were a side effect of creature refactorings in a24a01ef. Mouths used
to be a specific pink color which was defined in CreatureVisuals.tscn.
I've moved this pink color into CreatureLoader so it won't be overwritten
as easily.

Fixed long lines in 'test-rolling-backups.gd'