### PR TITLE
ChatIcons are generated for all chattables. Lowered squirrel chat icons.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -59,7 +59,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/ui/chat/chat-history.gd"
 }, {
-"base": "Sprite",
+"base": "Node2D",
 "class": "ChatIcon",
 "language": "GDScript",
 "path": "res://src/main/world/chat-icon.gd"

--- a/project/src/main/world/ChatIcon.tscn
+++ b/project/src/main/world/ChatIcon.tscn
@@ -9,7 +9,7 @@ length = 1.8
 loop = true
 step = 0.05
 tracks/0/type = "value"
-tracks/0/path = NodePath(".:scale")
+tracks/0/path = NodePath("Sprite:scale")
 tracks/0/interp = 2
 tracks/0/loop_wrap = true
 tracks/0/imported = false
@@ -21,13 +21,14 @@ tracks/0/keys = {
 "values": [ Vector2( 0.085, 0.085 ), Vector2( 0.1, 0.1 ), Vector2( 0.1, 0.1 ), Vector2( 0.085, 0.085 ), Vector2( 0.085, 0.085 ) ]
 }
 
-[node name="ChatIcon" type="Sprite"]
+[node name="ChatIcon" type="Node2D"]
+script = ExtResource( 2 )
+
+[node name="Sprite" type="Sprite" parent="."]
 position = Vector2( 64, -52 )
 scale = Vector2( 0.085, 0.085 )
 texture = ExtResource( 1 )
 hframes = 6
-script = ExtResource( 2 )
-bubble_type = 1
 
 [node name="PulsePlayer" type="AnimationPlayer" parent="."]
 autoplay = "pulse"

--- a/project/src/main/world/Overworld.tscn
+++ b/project/src/main/world/Overworld.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=53 format=2]
+[gd_scene load_steps=54 format=2]
 
 [ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/creature/player.gd" type="Script" id=2]
@@ -49,6 +49,7 @@
 [ext_resource path="res://assets/main/world/creature/2/nose-packed.png" type="Texture" id=47]
 [ext_resource path="res://assets/main/world/creature/3/tail-z1-packed.png" type="Texture" id=48]
 [ext_resource path="res://assets/main/world/creature/3/tail-z0-packed.png" type="Texture" id=49]
+[ext_resource path="res://src/main/world/chat-icons.gd" type="Script" id=50]
 
 [sub_resource type="TileSet" id=1]
 0/name = "block-shadow.png 0"
@@ -154,35 +155,39 @@ dna = {
 
 }
 
-[node name="Bort" parent="World/Obstacles" instance=ExtResource( 1 )]
+[node name="Bort" parent="World/Obstacles" groups=[
+"chattables",
+] instance=ExtResource( 1 )]
 position = Vector2( 313.439, 344.721 )
 script = ExtResource( 26 )
 creature_id = "bort"
 dna = {
 
 }
-chat_bubble_type = 1
 overworld_ui_path = NodePath("../../../Ui/OverworldUi")
 
 [node name="MoveTimer" type="Timer" parent="World/Obstacles/Bort"]
 wait_time = 1.6
 autostart = true
 
-[node name="Ebe" parent="World/Obstacles" instance=ExtResource( 1 )]
+[node name="Ebe" parent="World/Obstacles" groups=[
+"chattables",
+] instance=ExtResource( 1 )]
 position = Vector2( 444.163, 149.951 )
 script = ExtResource( 24 )
 creature_id = "ebe"
 dna = {
 
 }
-chat_bubble_type = 1
 overworld_ui_path = NodePath("../../../Ui/OverworldUi")
 
 [node name="MoveTimer" type="Timer" parent="World/Obstacles/Ebe"]
 wait_time = 0.9
 autostart = true
 
-[node name="Boatricia" parent="World/Obstacles" instance=ExtResource( 1 )]
+[node name="Boatricia" parent="World/Obstacles" groups=[
+"chattables",
+] instance=ExtResource( 1 )]
 position = Vector2( 652.587, 320.111 )
 creature_id = "boatricia"
 dna = {
@@ -327,15 +332,16 @@ dna = {
 "shader:TailZ1:red": Color( 0.0431373, 0.270588, 0.65098, 1 ),
 "tail": "3"
 }
-chat_bubble_type = 1
 
-[node name="GlowySphere" type="KinematicBody2D" parent="World/Obstacles"]
+[node name="GlowySphere" type="KinematicBody2D" parent="World/Obstacles" groups=[
+"chattables",
+]]
 position = Vector2( 731.162, 206.052 )
 script = ExtResource( 11 )
 
-[node name="ChatIcon" parent="World/Obstacles/GlowySphere" instance=ExtResource( 12 )]
-bubble_type = 2
-right_side = false
+[node name="ChatIconHook" type="RemoteTransform2D" parent="World/Obstacles/GlowySphere"]
+update_rotation = false
+update_scale = false
 
 [node name="Sprite" type="Sprite" parent="World/Obstacles/GlowySphere"]
 position = Vector2( 0, -32 )
@@ -344,6 +350,10 @@ texture = ExtResource( 13 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="World/Obstacles/GlowySphere"]
 shape = SubResource( 3 )
+
+[node name="ChatIcons" type="Node2D" parent="World"]
+script = ExtResource( 50 )
+ChatIconScene = ExtResource( 12 )
 
 [node name="Camera" type="Camera2D" parent="World"]
 position = Vector2( 150, 150 )

--- a/project/src/main/world/chat-icons.gd
+++ b/project/src/main/world/chat-icons.gd
@@ -1,0 +1,12 @@
+extends Node2D
+"""
+Creates and initializes chat icons for all chattables in the scene tree.
+"""
+
+export (PackedScene) var ChatIconScene: PackedScene
+
+func _ready() -> void:
+	for chattable in get_tree().get_nodes_in_group("chattables"):
+		var chat_icon: ChatIcon = ChatIconScene.instance()
+		add_child(chat_icon)
+		chat_icon.initialize(chattable)

--- a/project/src/main/world/creature/Creature.tscn
+++ b/project/src/main/world/creature/Creature.tscn
@@ -1,9 +1,7 @@
-[gd_scene load_steps=33 format=2]
+[gd_scene load_steps=32 format=2]
 
 [ext_resource path="res://src/main/world/creature/CreatureVisuals.tscn" type="PackedScene" id=1]
-[ext_resource path="res://src/main/world/creature/creature-chat-icon.gd" type="Script" id=2]
 [ext_resource path="res://src/main/world/creature/creature.gd" type="Script" id=3]
-[ext_resource path="res://src/main/world/ChatIcon.tscn" type="PackedScene" id=4]
 [ext_resource path="res://assets/main/world/creature/move-bonk.wav" type="AudioStream" id=5]
 [ext_resource path="res://src/main/viewport-outline-material.tres" type="Material" id=6]
 [ext_resource path="res://assets/main/world/creature/move-hop.wav" type="AudioStream" id=7]
@@ -30,6 +28,7 @@
 [ext_resource path="res://assets/main/world/creature/2/cheek-z0-packed.png" type="Texture" id=28]
 [ext_resource path="res://assets/main/world/creature/2/cheek-z2-packed.png" type="Texture" id=29]
 [ext_resource path="res://assets/main/world/creature/4/head-packed.png" type="Texture" id=30]
+[ext_resource path="res://src/main/world/creature/creature-chat-icon-hook.gd" type="Script" id=31]
 
 [sub_resource type="ViewportTexture" id=1]
 flags = 5
@@ -328,9 +327,10 @@ dna = {
 update_rotation = false
 update_scale = false
 
-[node name="ChatIcon" parent="." instance=ExtResource( 4 )]
-script = ExtResource( 2 )
-bubble_type = 0
+[node name="ChatIconHook" type="RemoteTransform2D" parent="."]
+update_rotation = false
+update_scale = false
+script = ExtResource( 31 )
 creature_visuals_path = NodePath("../CreatureOutline/Viewport/Visuals")
 
 [node name="CreatureOutline" type="Node2D" parent="."]

--- a/project/src/main/world/creature/CreatureVisuals.tscn
+++ b/project/src/main/world/creature/CreatureVisuals.tscn
@@ -81,7 +81,7 @@ shader_param/black = Color( 0, 0, 0, 1 )
 shader_param/shadow_texture = SubResource( 6 )
 shader_param/color_texture = SubResource( 5 )
 
-[sub_resource type="ShaderMaterial" id=9]
+[sub_resource type="ShaderMaterial" id=8]
 resource_local_to_scene = true
 shader = ExtResource( 1 )
 shader_param/red = Color( 0, 0, 0, 1 )
@@ -89,20 +89,20 @@ shader_param/green = Color( 0, 0, 0, 1 )
 shader_param/blue = Color( 0, 0, 0, 1 )
 shader_param/black = Color( 0, 0, 0, 1 )
 
-[sub_resource type="CanvasItemMaterial" id=10]
+[sub_resource type="CanvasItemMaterial" id=9]
 particles_animation = true
 particles_anim_h_frames = 2
 particles_anim_v_frames = 2
 particles_anim_loop = false
 
-[sub_resource type="Gradient" id=11]
+[sub_resource type="Gradient" id=10]
 offsets = PoolRealArray( 0, 0.255924, 0.796209, 0.976303 )
 colors = PoolColorArray( 1, 1, 1, 0, 1, 1, 1, 0.752941, 1, 1, 1, 0.501961, 1, 1, 1, 0 )
 
-[sub_resource type="GradientTexture" id=12]
-gradient = SubResource( 11 )
+[sub_resource type="GradientTexture" id=11]
+gradient = SubResource( 10 )
 
-[sub_resource type="ParticlesMaterial" id=13]
+[sub_resource type="ParticlesMaterial" id=12]
 resource_local_to_scene = true
 emission_shape = 1
 emission_sphere_radius = 50.0
@@ -115,7 +115,15 @@ orbit_velocity = 0.0
 orbit_velocity_random = 0.0
 damping = 50.0
 scale = 0.7
-color_ramp = SubResource( 12 )
+color_ramp = SubResource( 11 )
+
+[sub_resource type="ShaderMaterial" id=13]
+resource_local_to_scene = true
+shader = ExtResource( 1 )
+shader_param/red = Color( 0, 0, 0, 1 )
+shader_param/green = Color( 0, 0, 0, 1 )
+shader_param/blue = Color( 0, 0, 0, 1 )
+shader_param/black = Color( 0, 0, 0, 1 )
 
 [sub_resource type="ShaderMaterial" id=14]
 resource_local_to_scene = true
@@ -240,27 +248,19 @@ shader_param/black = Color( 0, 0, 0, 1 )
 [sub_resource type="ShaderMaterial" id=29]
 resource_local_to_scene = true
 shader = ExtResource( 1 )
-shader_param/red = Color( 0, 0, 0, 1 )
-shader_param/green = Color( 0, 0, 0, 1 )
-shader_param/blue = Color( 0, 0, 0, 1 )
-shader_param/black = Color( 0, 0, 0, 1 )
-
-[sub_resource type="ShaderMaterial" id=30]
-resource_local_to_scene = true
-shader = ExtResource( 1 )
 shader_param/red = Color( 1, 1, 1, 1 )
 shader_param/green = null
 shader_param/blue = null
 shader_param/black = Color( 0, 0, 0, 1 )
 
-[sub_resource type="Gradient" id=31]
+[sub_resource type="Gradient" id=30]
 offsets = PoolRealArray( 0.00473934, 0.390947 )
 colors = PoolColorArray( 1, 1, 1, 0.752941, 1, 1, 1, 0 )
 
-[sub_resource type="GradientTexture" id=32]
-gradient = SubResource( 31 )
+[sub_resource type="GradientTexture" id=31]
+gradient = SubResource( 30 )
 
-[sub_resource type="ParticlesMaterial" id=33]
+[sub_resource type="ParticlesMaterial" id=32]
 emission_shape = 1
 emission_sphere_radius = 120.0
 flag_disable_z = true
@@ -270,9 +270,9 @@ initial_velocity = -800.0
 orbit_velocity = 0.0
 orbit_velocity_random = 0.0
 scale = 1.7
-color_ramp = SubResource( 32 )
+color_ramp = SubResource( 31 )
 
-[sub_resource type="ParticlesMaterial" id=34]
+[sub_resource type="ParticlesMaterial" id=33]
 emission_shape = 1
 emission_sphere_radius = 45.0
 flag_disable_z = true
@@ -284,12 +284,12 @@ orbit_velocity = 0.0
 orbit_velocity_random = 0.0
 damping = 50.0
 scale = 0.7
-color_ramp = SubResource( 12 )
+color_ramp = SubResource( 11 )
 
-[sub_resource type="CanvasItemMaterial" id=35]
+[sub_resource type="CanvasItemMaterial" id=34]
 resource_local_to_scene = true
 
-[sub_resource type="ShaderMaterial" id=36]
+[sub_resource type="ShaderMaterial" id=35]
 resource_local_to_scene = true
 shader = ExtResource( 1 )
 shader_param/red = Color( 1, 1, 1, 1 )
@@ -297,7 +297,7 @@ shader_param/green = Color( 1, 1, 0.24, 1 )
 shader_param/blue = Color( 0, 0, 0, 1 )
 shader_param/black = Color( 0, 0, 0, 1 )
 
-[sub_resource type="ShaderMaterial" id=37]
+[sub_resource type="ShaderMaterial" id=36]
 resource_local_to_scene = true
 shader = ExtResource( 1 )
 shader_param/red = Color( 0, 0, 0, 1 )
@@ -365,7 +365,7 @@ script = ExtResource( 6 )
 texture = ExtResource( 49 )
 frame_data = "res://assets/main/world/creature/1/arm-z0-packed.json"
 rect_size = Vector2( 512, 512 )
-frame = 1
+frame = 3
 offset = Vector2( 0, -119 )
 invisible_while_sprinting = true
 
@@ -377,7 +377,7 @@ script = ExtResource( 6 )
 texture = ExtResource( 58 )
 frame_data = "res://assets/main/world/creature/1/leg-z0-packed.json"
 rect_size = Vector2( 512, 512 )
-frame = 1
+frame = 3
 offset = Vector2( 0, -119 )
 invisible_while_sprinting = true
 
@@ -391,7 +391,6 @@ texture = ExtResource( 51 )
 frame_data = "res://assets/main/world/creature/1/sprint-z0-packed.json"
 rect_size = Vector2( 512, 512 )
 frame = 6
-centered = true
 offset = Vector2( 0, -119 )
 
 [node name="TailZ0" type="Node2D" parent="."]
@@ -446,9 +445,9 @@ material = SubResource( 7 )
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = -580.0
-margin_top = -850.0
+margin_top = -848.0
 margin_right = 620.0
-margin_bottom = 350.0
+margin_bottom = 352.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -462,13 +461,13 @@ render_target_update_mode = 3
 
 [node name="NearLeg" type="Node2D" parent="."]
 light_mask = 2
-material = SubResource( 9 )
+material = SubResource( 8 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 6 )
 texture = ExtResource( 57 )
 frame_data = "res://assets/main/world/creature/1/leg-z1-packed.json"
 rect_size = Vector2( 512, 512 )
-frame = 1
+frame = 3
 offset = Vector2( 0, -119 )
 invisible_while_sprinting = true
 
@@ -480,26 +479,26 @@ script = ExtResource( 6 )
 texture = ExtResource( 52 )
 frame_data = "res://assets/main/world/creature/1/arm-z1-packed.json"
 rect_size = Vector2( 512, 512 )
-frame = 1
+frame = 3
 offset = Vector2( 0, -119 )
 invisible_while_sprinting = true
 
 [node name="BodySweat" type="Particles2D" parent="."]
-material = SubResource( 10 )
+material = SubResource( 9 )
 position = Vector2( -10, -50 )
 scale = Vector2( 1, 0.9 )
 emitting = false
 amount = 3
 lifetime = 3.6
 randomness = 1.0
-process_material = SubResource( 13 )
+process_material = SubResource( 12 )
 texture = ExtResource( 44 )
 script = ExtResource( 46 )
 creature_visuals_path = NodePath("..")
 
 [node name="Collar" type="Node2D" parent="."]
 light_mask = 2
-material = SubResource( 14 )
+material = SubResource( 13 )
 position = Vector2( 0, -100 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 6 )
@@ -513,7 +512,7 @@ __meta__ = {
 
 [node name="HeadBobber" type="Sprite" parent="Neck0"]
 light_mask = 2
-position = Vector2( 0, -100 )
+position = Vector2( 0, -99 )
 scale = Vector2( 0.418, 0.418 )
 hframes = 3
 frame = 1
@@ -521,11 +520,12 @@ script = ExtResource( 9 )
 __meta__ = {
 "_editor_description_": "Neck1 offsets the head's position as the creature bobs their head up and down"
 }
+head_bob_mode = 0
 
 [node name="HairZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 15 )
+material = SubResource( 14 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
 rect_size = Vector2( 512, 512 )
@@ -534,7 +534,7 @@ frame = 1
 [node name="EarZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 16 )
+material = SubResource( 15 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
 rect_size = Vector2( 512, 512 )
@@ -543,7 +543,7 @@ frame = 1
 [node name="HornZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 17 )
+material = SubResource( 16 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
 rect_size = Vector2( 512, 512 )
@@ -552,7 +552,7 @@ frame = 1
 [node name="CheekZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 18 )
+material = SubResource( 17 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
 rect_size = Vector2( 512, 512 )
@@ -561,7 +561,7 @@ frame = 1
 [node name="Head" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 19 )
+material = SubResource( 18 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
 rect_size = Vector2( 512, 512 )
@@ -570,7 +570,7 @@ frame = 1
 [node name="Chin" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 20 )
+material = SubResource( 19 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 2 )
 texture = ExtResource( 56 )
@@ -581,7 +581,7 @@ frame = 1
 [node name="EarZ1" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 16 )
+material = SubResource( 15 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
 rect_size = Vector2( 512, 512 )
@@ -590,7 +590,7 @@ frame = 1
 [node name="CheekZ1" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 21 )
+material = SubResource( 20 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
 rect_size = Vector2( 512, 512 )
@@ -599,7 +599,7 @@ frame = 1
 [node name="EarZ2" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 22 )
+material = SubResource( 21 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
 rect_size = Vector2( 512, 512 )
@@ -608,7 +608,7 @@ frame = 1
 [node name="Mouth" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 23 )
+material = SubResource( 22 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 2 )
 rect_size = Vector2( 512, 512 )
@@ -617,7 +617,7 @@ frame = 1
 [node name="EyeZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 24 )
+material = SubResource( 23 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 2 )
 rect_size = Vector2( 512, 512 )
@@ -626,7 +626,7 @@ frame = 1
 [node name="EmoteEyeZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 24 )
+material = SubResource( 23 )
 position = Vector2( 0, 256 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 2 )
@@ -650,7 +650,7 @@ offset = Vector2( 0, -119 )
 [node name="HairZ1" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 25 )
+material = SubResource( 24 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
 rect_size = Vector2( 512, 512 )
@@ -659,7 +659,7 @@ frame = 1
 [node name="HornZ1" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 26 )
+material = SubResource( 25 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
 rect_size = Vector2( 512, 512 )
@@ -668,7 +668,7 @@ frame = 1
 [node name="Nose" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 27 )
+material = SubResource( 26 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
 rect_size = Vector2( 512, 512 )
@@ -677,7 +677,7 @@ frame = 1
 [node name="EyeZ1" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 24 )
+material = SubResource( 23 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 2 )
 rect_size = Vector2( 512, 512 )
@@ -686,7 +686,7 @@ frame = 1
 [node name="CheekZ2" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 28 )
+material = SubResource( 27 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
 rect_size = Vector2( 512, 512 )
@@ -695,7 +695,7 @@ frame = 1
 [node name="HairZ2" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 29 )
+material = SubResource( 28 )
 scale = Vector2( 2, 2 )
 z_index = 1
 script = ExtResource( 6 )
@@ -704,7 +704,7 @@ frame = 1
 
 [node name="EmoteEyeZ1" type="Node2D" parent="Neck0/HeadBobber"]
 light_mask = 2
-material = SubResource( 30 )
+material = SubResource( 29 )
 position = Vector2( 0, 256 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 2 )
@@ -745,20 +745,20 @@ offset = Vector2( 0, -119 )
 z_index = 1
 emitting = false
 local_coords = false
-process_material = SubResource( 33 )
+process_material = SubResource( 32 )
 texture = ExtResource( 42 )
 script = ExtResource( 43 )
 creature_visuals_path = NodePath("../../..")
 
 [node name="SweatDrops" type="Particles2D" parent="Neck0/HeadBobber"]
-material = SubResource( 10 )
+material = SubResource( 9 )
 position = Vector2( 6, -60 )
 scale = Vector2( 2.8, 2.4 )
 emitting = false
 amount = 3
 lifetime = 3.6
 randomness = 1.0
-process_material = SubResource( 34 )
+process_material = SubResource( 33 )
 texture = ExtResource( 44 )
 script = ExtResource( 45 )
 creature_visuals_path = NodePath("../../..")
@@ -766,7 +766,7 @@ creature_visuals_path = NodePath("../../..")
 [node name="EmoteGlow" type="Sprite" parent="Neck0/HeadBobber"]
 modulate = Color( 1, 1, 1, 0 )
 light_mask = 2
-material = SubResource( 35 )
+material = SubResource( 34 )
 position = Vector2( 25.3166, 262.374 )
 scale = Vector2( 2, 2 )
 texture = ExtResource( 4 )
@@ -778,7 +778,7 @@ __meta__ = {
 [node name="EmoteBrain" type="Node2D" parent="Neck0/HeadBobber"]
 modulate = Color( 1, 1, 1, 0 )
 light_mask = 2
-material = SubResource( 36 )
+material = SubResource( 35 )
 position = Vector2( 255.118, 133.989 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 2 )
@@ -803,7 +803,7 @@ offset = Vector2( 0, -119 )
 [node name="EmoteBody" type="Node2D" parent="."]
 modulate = Color( 1, 1, 1, 0 )
 light_mask = 2
-material = SubResource( 37 )
+material = SubResource( 36 )
 position = Vector2( -169.545, 19.486 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 2 )
@@ -841,42 +841,42 @@ root_node = NodePath("../..")
 root_node = NodePath("../..")
 creature_visuals_path = NodePath("../..")
 [connection signal="dna_loaded" from="." to="Animations/IdleTimer" method="_on_CreatureVisuals_dna_loaded"]
-[connection signal="movement_mode_changed" from="." to="NearLeg" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ2" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ1" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ2" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Nose" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="FarLeg" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ0" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="NearArm" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Collar" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="FarArm" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Sprint" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ1" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Nose" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ2" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ2" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ0" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ1" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="orientation_changed" from="." to="NearLeg" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprint" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="NearArm" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ0" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ0" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="NearLeg" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Collar" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ2" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ1" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ2" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Nose" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="FarLeg" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ0" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="NearArm" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Collar" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="FarArm" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ1" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Nose" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ2" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ2" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ0" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ1" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="NearArm" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="NearLeg" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Collar" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="idle_animation_started" from="Animations/IdleTimer" to="Animations/EmotePlayer" method="_on_IdleTimer_idle_animation_started"]
 [connection signal="idle_animation_stopped" from="Animations/IdleTimer" to="Animations/EmotePlayer" method="_on_IdleTimer_idle_animation_stopped"]

--- a/project/src/main/world/creature/creature-chat-icon-hook.gd
+++ b/project/src/main/world/creature/creature-chat-icon-hook.gd
@@ -1,6 +1,6 @@
-extends ChatIcon
+extends RemoteTransform2D
 """
-A visual icon which appears next to something the player can interact with.
+Defines the position so that chat icons appear next to the creature's head.
 """
 
 export (NodePath) var creature_visuals_path: NodePath
@@ -18,7 +18,7 @@ Reposition the icon next to the creature's head.
 If we don't reposition the icon, it gets lost behind creatures that are fat.
 """
 func _refresh_target_position() -> void:
-	set_target_position(_creature_visuals.get_node("Neck0").position * 0.4)
+	position = _creature_visuals.get_node("Neck0").position * _creature_visuals.scale.y * 0.4
 
 
 func _on_CreatureVisuals_head_moved() -> void:

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -43,9 +43,6 @@ export (bool) var suppress_sfx: bool = false setget set_suppress_sfx
 export (int) var elevation: int setget set_elevation
 
 # virtual property; value is only exposed through getters/setters
-export (ChatIcon.BubbleType) var chat_bubble_type: int setget set_chat_bubble_type, get_chat_bubble_type
-
-# virtual property; value is only exposed through getters/setters
 var creature_def: CreatureDef setget set_creature_def, get_creature_def
 
 # dictionaries containing metadata for which dialog sequences should be launched in which order
@@ -96,14 +93,6 @@ func _physics_process(delta: float) -> void:
 	var old_non_iso_velocity := _non_iso_velocity
 	set_iso_velocity(move_and_slide(_iso_velocity))
 	_maybe_play_bonk_sound(old_non_iso_velocity)
-
-
-func set_chat_bubble_type(new_chat_bubble_type: int) -> void:
-	$ChatIcon.set_bubble_type(new_chat_bubble_type)
-
-
-func get_chat_bubble_type() -> int:
-	return $ChatIcon.bubble_type
 
 
 func set_suppress_sfx(new_suppress_sfx: bool) -> void:
@@ -304,6 +293,20 @@ func refresh_dna() -> void:
 		creature_visuals.dna = dna
 		if dna.has("line_rgb"):
 			$CreatureOutline/TextureRect.material.set_shader_param("black", Color(dna.line_rgb))
+
+
+"""
+Workaround for Godot #21789 to make get_class return class_name
+"""
+func get_class() -> String:
+	return "Creature"
+
+
+"""
+Workaround for Godot #21789 to make is_class match class_name
+"""
+func is_class(name: String) -> bool:
+	return name == "Creature" or .is_class(name)
 
 
 func _refresh_creature_id() -> void:

--- a/project/src/main/world/glowy-sphere.gd
+++ b/project/src/main/world/glowy-sphere.gd
@@ -5,3 +5,4 @@ Script for showing a placeholder chattable object in the overworld.
 
 func _ready() -> void:
 	set_meta("chat_path", "res://assets/main/dialog/glowy-sphere.json")
+	set_meta("chat_bubble_type", ChatIcon.THOUGHT)


### PR DESCRIPTION
Creatures no longer have a chat icon -- instead, a separate ChatIcons node
generates chat icons for all creatures, and anything else that is in the
chattables group. Instead of customizing the chat icon by changing the
chat icon's properties, nodes can define metadata which affects their chat
icon appearance, such as the 'chat_bubble_type' metadata

This is a slightly cleaner design as scaling/rotating a creature won't
mess with their chat icon, and we don't need to worry about chat icons
being hidden by the environment.

These chat icons can't go in the UI layer because they're positioned using
RemoteTransform2D. But they're in a Node2D separate from the creatures and the
environment.

Lowered chat bubbles for small squirrel creatures. Their heads are lower,
so the chat icons should be lower as well.