### PR TITLE
Scenario.name -> id. Minor refactorings, JSON syntax fixes.

### DIFF
--- a/project/assets/main/dialog/boatricia/level-1.json
+++ b/project/assets/main/dialog/boatricia/level-1.json
@@ -3,7 +3,7 @@
   "" : [
     {
       "who": "Boatricia",
-      "text": "Could you maybe just cook me something small? I'm not very hungry today.",
+      "text": "Could you maybe just cook me something small? I'm not very hungry today."
     },
     {
       "who": "#player#",

--- a/project/assets/main/dialog/boatricia/level-2.json
+++ b/project/assets/main/dialog/boatricia/level-2.json
@@ -3,8 +3,7 @@
   "" : [
     {
       "who": "Boatricia",
-      "text": "I built up an appetite today! Think you can cook something filling for me and my friends?",
-      "meta": "scenario_boatricia2"
+      "text": "I built up an appetite today! Think you can cook something filling for me and my friends?"
     },
     {
       "who": "#player#",

--- a/project/src/main/editor/creature/reroll-ui.gd
+++ b/project/src/main/editor/creature/reroll-ui.gd
@@ -29,5 +29,5 @@ func _refresh_percent_label() -> void:
 	$Button.text = "Reroll (%d%%)" % int($HSlider.value * 100)
 
 
-func _on_HSlider_value_changed(value: float) -> void:
+func _on_HSlider_value_changed(_value: float) -> void:
 	_refresh_percent_label()

--- a/project/src/main/puzzle/combo-tracker.gd
+++ b/project/src/main/puzzle/combo-tracker.gd
@@ -90,7 +90,7 @@ func _on_PuzzleScore_game_ended() -> void:
 """
 Increments the combo and score for the specified line clear.
 """
-func _on_Playfield_before_line_cleared(_y, _total_lines, _remaining_lines, box_ints) -> void:
+func _on_Playfield_before_line_cleared(_y: int, _total_lines: int, _remaining_lines: int, box_ints: Array) -> void:
 	combo += 1
 	var combo_score: int = COMBO_SCORE_ARR[clamp(combo - 1, 0, COMBO_SCORE_ARR.size() - 1)]
 	var box_score := 0

--- a/project/src/main/puzzle/rank-calculator.gd
+++ b/project/src/main/puzzle/rank-calculator.gd
@@ -17,7 +17,7 @@ const RDF_COMBO_SCORE_PER_LINE := 0.970
 # theoretical player to meet all three statistics simultaneously.
 const MASTER_BOX_SCORE := 14.5
 const MASTER_COMBO_SCORE := 17.575
-const MASTER_COMBO := 22
+const MASTER_CUSTOMER_COMBO := 22
 const MASTER_LEFTOVER_LINES := 12
 
 # The number of extra unnecessary frames a perfect player will spend moving their piece.
@@ -123,7 +123,7 @@ func _max_lpm() -> float:
 			var level_up: Milestone = Scenario.settings.level_ups[i + 1]
 			match level_up.type:
 				Milestone.CUSTOMERS:
-					level_lines = MASTER_COMBO
+					level_lines = MASTER_CUSTOMER_COMBO
 				Milestone.LINES:
 					level_lines = level_up.value
 				Milestone.TIME_OVER:
@@ -198,7 +198,7 @@ func _populate_rank_fields(rank_result: RankResult, lenient: bool) -> void:
 		Milestone.NONE:
 			target_lines = 999999
 		Milestone.CUSTOMERS:
-			target_lines = MASTER_COMBO * finish_condition.value
+			target_lines = MASTER_CUSTOMER_COMBO * finish_condition.value
 		Milestone.LINES:
 			target_lines = int(finish_condition.get_meta("lenient_value")) if lenient else finish_condition.value
 		Milestone.SCORE:

--- a/project/src/main/puzzle/results-hud.gd
+++ b/project/src/main/puzzle/results-hud.gd
@@ -135,7 +135,7 @@ func _on_PuzzleScore_game_prepared() -> void:
 
 
 func _on_PuzzleScore_after_game_ended() -> void:
-	var rank_result: RankResult = PlayerData.scenario_history.prev_result(Scenario.settings.name)
+	var rank_result: RankResult = PlayerData.scenario_history.prev_result(Scenario.settings.id)
 	if not rank_result or Scenario.settings.rank.skip_results:
 		return
 	

--- a/project/src/main/puzzle/scenario/scenario-history.gd
+++ b/project/src/main/puzzle/scenario/scenario-history.gd
@@ -33,26 +33,23 @@ func reset() -> void:
 """
 Returns a player's performances for a specific scenario.
 """
-func results(scenario: String) -> Array:
-	return rank_results.get(scenario, [])
+func results(scenario_id: String) -> Array:
+	return rank_results.get(scenario_id, [])
 
 
 """
 Returns a player's best performances for a specific scenario.
 
 Parameters:
-	'scenario': The name of the scenario to evaluate
+	'scenario_id': The id of the scenario to evaluate
 	
-	'daily': If true, only performances with today's date are included
-	
-	'property': (Optional) The property evaluated to determine which of the player's RankResults was the best, such
-		as 'score' or 'seconds'. Defaults to 'score'.
+	'daily': (Optional) If true, only performances with today's date are included
 """
-func best_results(scenario: String, daily: bool) -> Array:
-	if not rank_results.has(scenario):
+func best_results(scenario_id: String, daily: bool = false) -> Array:
+	if not rank_results.has(scenario_id):
 		return []
 	
-	var results: Array = rank_results[scenario].duplicate()
+	var results: Array = rank_results[scenario_id].duplicate()
 	if daily:
 		# only include items with today's date
 		var now := OS.get_datetime()
@@ -76,10 +73,10 @@ func best_results(scenario: String, daily: bool) -> Array:
 	return results.slice(0, min(results.size() - 1, max_size - 1))
 
 
-func prev_result(scenario: String) -> RankResult:
-	if not rank_results.has(scenario) or rank_results[scenario].empty():
+func prev_result(scenario_id: String) -> RankResult:
+	if not rank_results.has(scenario_id) or rank_results[scenario_id].empty():
 		return null
-	return rank_results[scenario][0]
+	return rank_results[scenario_id][0]
 
 
 """
@@ -87,37 +84,37 @@ Records the current scenario performance to the player's history.
 
 'add' should be followed by 'prune' to ensure the history does not grow too large.
 """
-func add(scenario: String, rank_result: RankResult) -> void:
-	if not scenario:
-		# can't store history without a scenario name
+func add(scenario_id: String, rank_result: RankResult) -> void:
+	if not scenario_id:
+		# can't store history without a scenario id
 		return
 	
-	if not rank_results.has(scenario):
-		rank_results[scenario] = []
-	rank_results[scenario].push_front(rank_result)
-	if rank_result.success and not successful_scenarios.has(scenario):
-		successful_scenarios[scenario] = OS.get_datetime()
-	if not rank_result.lost and not successful_scenarios.has(scenario):
-		finished_scenarios[scenario] = OS.get_datetime()
+	if not rank_results.has(scenario_id):
+		rank_results[scenario_id] = []
+	rank_results[scenario_id].push_front(rank_result)
+	if rank_result.success and not successful_scenarios.has(scenario_id):
+		successful_scenarios[scenario_id] = OS.get_datetime()
+	if not rank_result.lost and not successful_scenarios.has(scenario_id):
+		finished_scenarios[scenario_id] = OS.get_datetime()
 
 
-func has(scenario: String) -> bool:
-	return rank_results.has(scenario) and rank_results.get(scenario).size() >= 1
+func has(scenario_id: String) -> bool:
+	return rank_results.has(scenario_id) and rank_results.get(scenario_id).size() >= 1
 
 
 """
 Prunes the history down to only the best daily results, best all-time results, and the most recent result.
 """
-func prune(scenario: String) -> void:
-	if not has(scenario):
+func prune(scenario_id: String) -> void:
+	if not has(scenario_id):
 		return
 	
 	# collect the best scores, but reinsert the newest score at index 0 for prev_result()
 	var best: Dictionary = {}
-	for result in best_results(scenario, false) + best_results(scenario, true):
+	for result in best_results(scenario_id, false) + best_results(scenario_id, true):
 		best[result] = ""
-	best.erase(rank_results[scenario][0])
-	rank_results[scenario] = [rank_results[scenario][0]] + best.keys()
+	best.erase(rank_results[scenario_id][0])
+	rank_results[scenario_id] = [rank_results[scenario_id][0]] + best.keys()
 
 
 func _compare_by_low_seconds(a: RankResult, b: RankResult) -> bool:

--- a/project/src/main/puzzle/scenario/scenario-settings.gd
+++ b/project/src/main/puzzle/scenario/scenario-settings.gd
@@ -23,16 +23,16 @@ var combo_break := ComboBreakRules.new()
 # used for limits such as serving 5 creatures or clearing 10 lines. 
 var finish_condition := Milestone.new()
 
-# The requirements to level up and make the game harder. This mostly applies to 'Marathon Mode' where clearing lines
-# makes you level up.
+# Array of Milestone objects representing the requirements to level up. This mostly applies to 'Marathon Mode' where
+# clearing lines makes you level up.
 var level_ups := []
 
 # How the player loses. The player usually loses if they top out a certain number of times, but some scenarios might
 # have different rules.
 var lose_condition := LoseConditionRules.new()
 
-# The scenario name, used internally for saving/loading data.
-var name := ""
+# The scenario id used for saving/loading data.
+var id := ""
 
 # Rules which are unique enough that it doesn't make sense to put them in their own groups.
 var other := OtherRules.new()
@@ -70,7 +70,7 @@ func reset() -> void:
 	level_ups.clear()
 	success_condition = Milestone.new()
 	finish_condition = Milestone.new()
-	name = ""
+	id = ""
 
 
 func set_start_level(new_start_level: String) -> void:
@@ -102,10 +102,10 @@ func set_success_condition(type: int, value: int) -> void:
 Populates this object with json data.
 
 Parameters:
-	'new_name': The scenario name used for saving statistics.
+	'new_id': The scenario id used for saving statistics.
 """
-func from_json_dict(new_name: String, json: Dictionary) -> void:
-	name = new_name
+func from_json_dict(new_id: String, json: Dictionary) -> void:
+	id = new_id
 	if json.get("version") != SCENARIO_DATA_VERSION:
 		push_warning("Unrecognized scenario data version: '%s'" % json.get("version"))
 	
@@ -137,12 +137,12 @@ func from_json_dict(new_name: String, json: Dictionary) -> void:
 		success_condition.from_json_dict(json["success_condition"])
 
 
-func load_from_resource(new_name: String) -> void:
-	load_from_text(new_name, FileUtils.get_file_as_text(scenario_path(new_name)))
+func load_from_resource(new_id: String) -> void:
+	load_from_text(new_id, FileUtils.get_file_as_text(scenario_path(new_id)))
 
 
-func load_from_text(new_name: String, text: String) -> void:
-	from_json_dict(new_name, parse_json(text))
+func load_from_text(new_id: String, text: String) -> void:
+	from_json_dict(new_id, parse_json(text))
 
 
 """
@@ -154,9 +154,9 @@ Parameters:
 	'level_int': Which level should be loaded; '1' is the first level.
 """
 func load_from_creature(creature: Creature, level_int: int) -> void:
-	var level_names := creature.get_level_names()
-	var level_name: String = level_names[level_int - 1]
-	load_from_resource(level_name)
+	var level_ids := creature.get_level_ids()
+	var level_id: String = level_ids[level_int - 1]
+	load_from_resource(level_id)
 
 
 static func scenario_path(scenario_name: String) -> String:

--- a/project/src/main/puzzle/scenario/scenario.gd
+++ b/project/src/main/puzzle/scenario/scenario.gd
@@ -25,7 +25,7 @@ var launched_scenario_name
 var overworld_puzzle := false
 
 func start_scenario(new_settings: ScenarioSettings) -> void:
-	Scenario.launched_scenario_name = new_settings.name
+	Scenario.launched_scenario_name = new_settings.id
 	PuzzleScore.reset()
 	switch_scenario(new_settings)
 

--- a/project/src/main/puzzle/tutorial/tutorial-hud.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-hud.gd
@@ -32,7 +32,7 @@ func _ready() -> void:
 		skill_tally_item.set_puzzle(_puzzle)
 	refresh()
 	
-	if Scenario.settings.name.begins_with("tutorial_beginner"):
+	if Scenario.settings.id.begins_with("tutorial_beginner"):
 		_puzzle.hide_start_button()
 		_puzzle.hide_back_button()
 		yield(get_tree().create_timer(0.40), "timeout")
@@ -54,7 +54,7 @@ func refresh() -> void:
 	for item in $SkillTallyItems/GridContainer.get_children():
 		item.visible = false
 	
-	if Scenario.settings.name.begins_with("tutorial_beginner"):
+	if Scenario.settings.id.begins_with("tutorial_beginner"):
 		# prepare for the 'tutorial_beginner' tutorial
 		if not _playfield.is_connected("box_built", self, "_on_Playfield_box_built"):
 			_playfield.connect("box_built", self, "_on_Playfield_box_built")
@@ -118,7 +118,7 @@ func _handle_line_clear_message() -> void:
 
 func _handle_squish_move_message() -> void:
 	if _did_squish_move and _squish_moves == 1:
-		match Scenario.settings.name:
+		match Scenario.settings.id:
 			"tutorial_beginner_0", "tutorial_beginner_1":
 				append_message("Oh my,/ you're not supposed to know how to do that!\n\n..."
 						+ "But yes,/ squish moves can help you out of a jam.")
@@ -131,7 +131,7 @@ func _handle_squish_move_message() -> void:
 
 func _handle_build_box_message() -> void:
 	if _did_build_box and _boxes_built == 1:
-		match Scenario.settings.name:
+		match Scenario.settings.id:
 			"tutorial_beginner_0":
 				append_message("Oh my,/ you're not supposed to know how to do that!\n\n"
 						+ "...But yes,/ those boxes earn $15 when you clear them./"
@@ -144,7 +144,7 @@ func _handle_build_box_message() -> void:
 
 
 func _handle_snack_stack_message() -> void:
-	if Scenario.settings.name == "tutorial_beginner_3" and _did_build_box and _did_squish_move:
+	if Scenario.settings.id == "tutorial_beginner_3" and _did_build_box and _did_squish_move:
 		_snack_stacks += 1
 		$SkillTallyItems/GridContainer/SnackStack.increment()
 		if _snack_stacks == 1:
@@ -162,7 +162,7 @@ func _on_Playfield_after_piece_written() -> void:
 	_handle_build_box_message()
 	_handle_snack_stack_message()
 	
-	match Scenario.settings.name:
+	match Scenario.settings.id:
 		"tutorial_beginner_0":
 			if _lines_cleared >= 2: _advance_scenario()
 		"tutorial_beginner_1":
@@ -183,7 +183,7 @@ func _advance_scenario() -> void:
 	# clear out any text to ensure we don't end up pages behind, if the player is fast
 	$Message.hide_text()
 	
-	if Scenario.settings.name == "tutorial_beginner_0" and _did_build_cake and _did_squish_move:
+	if Scenario.settings.id == "tutorial_beginner_0" and _did_build_cake and _did_squish_move:
 		# the player did something crazy; skip the tutorial entirely
 		_change_scenario("oh_my")
 		append_big_message("O/H/,/// M/Y/!/!/!")

--- a/project/src/main/ui/chat/chat-library.gd
+++ b/project/src/main/ui/chat/chat-library.gd
@@ -27,11 +27,11 @@ func load_chat_events_for_creature(creature: Creature, level_int: int = -1) -> C
 		state["level_int"] = 1
 	
 	var chat_tree: ChatTree
-	var level_names := creature.get_level_names()
-	if level_names.size() == 2 and level_int == -1:
+	var level_ids := creature.get_level_ids()
+	if level_ids.size() == 2 and level_int == -1:
 		# talking to a creature with two or more levels results in a selection menu (for now)
 		chat_tree = load_chat_events_from_file("res://assets/main/dialog/level-select-2.json")
-	elif level_names.size() <= 2:
+	elif level_ids.size() <= 2:
 		var chosen_dialog := choose_dialog_from_chat_selectors(creature.chat_selectors, state)
 		if creature.dialog.has(chosen_dialog):
 			chat_tree = ChatTree.new()
@@ -41,7 +41,7 @@ func load_chat_events_for_creature(creature: Creature, level_int: int = -1) -> C
 			var path := "res://assets/main/dialog/%s/%s.json" % [creature.creature_id, chosen_dialog.replace("_", "-")]
 			chat_tree = load_chat_events_from_file(path)
 	else:
-		push_warning("Unexpected level names count: %s" % level_names.size())
+		push_warning("Unexpected level ids count: %s" % level_ids.size())
 	return chat_tree
 
 

--- a/project/src/main/ui/chat/chat-ui.gd
+++ b/project/src/main/ui/chat/chat-ui.gd
@@ -121,8 +121,8 @@ func _on_ChatAdvancer_chat_event_shown(chat_event: ChatEvent) -> void:
 	$ChatFrame.visible = true if chat_event.text else false
 	if not chat_event.text:
 		# emitting the 'all_text_shown' signal while other nodes are still receiving the current 'chat_event_shown'
-		# signal introduces complications, so we pause for a fraction of a second
-		yield(get_tree().create_timer(0.0001), "timeout")
+		# signal introduces complications, so we wait until the next frame
+		yield(get_tree(), "idle_frame")
 		$ChatFrame.emit_signal("all_text_shown")
 		if not $ChatAdvancer.should_prompt():
 			$ChatAdvancer.advance()

--- a/project/src/main/ui/high-score-table.gd
+++ b/project/src/main/ui/high-score-table.gd
@@ -48,10 +48,10 @@ func _add_rows() -> void:
 	if not _scenario:
 		return
 	
-	for best_result_obj in PlayerData.scenario_history.best_results(_scenario.name, daily):
+	for best_result_obj in PlayerData.scenario_history.best_results(_scenario.id, daily):
 		var best_result: RankResult = best_result_obj
 		var row := []
-		
+
 		# append timestamp
 		if daily:
 			row.append("%02d:%02d" % [
@@ -64,10 +64,10 @@ func _add_rows() -> void:
 					best_result.timestamp["month"],
 					best_result.timestamp["day"],
 				])
-		
+
 		# append lines
 		row.append(StringUtils.comma_sep(best_result.lines))
-		
+
 		# append score/time and grade
 		if best_result.compare == "-seconds":
 			var seconds_string := StringUtils.format_duration(best_result.seconds)
@@ -81,7 +81,7 @@ func _add_rows() -> void:
 				score_string += "*"
 			row.append(score_string)
 			row.append(RankCalculator.grade(best_result.score_rank))
-		
+
 		_add_row(row)
 
 

--- a/project/src/main/ui/menu/practice-menu.gd
+++ b/project/src/main/ui/menu/practice-menu.gd
@@ -75,16 +75,16 @@ func _ready() -> void:
 		var category: Array = category_obj
 		var mode: String = category[0]
 		var difficulty: String = category[1]
-		var scenario_name: String = category[2]
+		var scenario_id: String = category[2]
 		if not mode_difficulties.has(mode):
 			mode_difficulties[mode] = []
 		mode_difficulties[mode].append(difficulty)
 		
 		var settings: ScenarioSettings = ScenarioSettings.new()
-		settings.load_from_resource(scenario_name)
+		settings.load_from_resource(scenario_id)
 		scenarios["%s %s" % [mode, difficulty]] = settings
 		
-		if scenario_name == Scenario.settings.name:
+		if scenario_id == Scenario.settings.id:
 			# if they've just played a practice mode scenario, we default to that scenario
 			current_mode = mode
 			current_difficulty = difficulty
@@ -120,7 +120,7 @@ func _calculate_lowlights() -> void:
 	
 	for difficulty in mode_difficulties[_get_mode()]:
 		var scenario: ScenarioSettings = scenarios["%s %s" % [_get_mode(), difficulty]]
-		_rank_lowlights.append(not PlayerData.scenario_history.successful_scenarios.has(scenario.name))
+		_rank_lowlights.append(not PlayerData.scenario_history.successful_scenarios.has(scenario.id))
 
 
 func _get_mode() -> String:

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -275,15 +275,15 @@ func get_creature_def() -> CreatureDef:
 
 
 """
-Build a list of level names from the creature's chat selectors.
+Build a list of level ids from the creature's chat selectors.
 """
-func get_level_names() -> Array:
-	var level_names := []
+func get_level_ids() -> Array:
+	var level_ids := []
 	for chat_selector_obj in chat_selectors:
 		var chat_selector: Dictionary = chat_selector_obj
 		if chat_selector.has("level"):
-			level_names.append(chat_selector["level"])
-	return level_names
+			level_ids.append(chat_selector["level"])
+	return level_ids
 
 
 func refresh_dna() -> void:


### PR DESCRIPTION
Changed scenario.name to scenario.id, to disambiguate between IDs like
'tutorial_beginner' and titles like 'Easy does it!'. ...Both of these
things could be construed as names, so I'm going to call one an 'ID' and
one a 'title'.

Minor refactorings; renames, warnings.

Boatricia's JSON data had some dangling commas.