### PR TITLE
Added error dialog when saving/loading files in HTML5.

### DIFF
--- a/project/src/main/editor/creature/CreatureEditor.tscn
+++ b/project/src/main/editor/creature/CreatureEditor.tscn
@@ -1765,11 +1765,11 @@ current_dir = "/workspace/turbofat/project"
 current_path = "/workspace/turbofat/project/"
 
 [node name="Error" type="AcceptDialog" parent="Ui/Dialogs"]
-margin_right = 83.0
+margin_right = 250.0
 margin_bottom = 58.0
 popup_exclusive = true
 window_title = "Error"
-dialog_text = "Error importing creature."
+dialog_autowrap = true
 
 [node name="SettingsMenu" parent="." instance=ExtResource( 13 )]
 [connection signal="creature_clicked" from="Ui/CreatureSelector" to="." method="_on_CreatureSelector_creature_clicked"]

--- a/project/src/main/editor/creature/dialogs.gd
+++ b/project/src/main/editor/creature/dialogs.gd
@@ -7,7 +7,16 @@ export (NodePath) var creature_editor_path: NodePath
 
 onready var _creature_editor: CreatureEditor = get_node(creature_editor_path)
 
+func _show_import_export_not_supported_error() -> void:
+	$Error.dialog_text = "Import/export isn't supported over the web. Sorry!"
+	$Error.popup_centered()
+
+
 func _on_ImportButton_pressed() -> void:
+	if OS.has_feature("web"):
+		_show_import_export_not_supported_error()
+		return
+	
 	$Import.popup_centered()
 
 
@@ -20,10 +29,15 @@ func _on_ImportDialog_file_selected(path: String) -> void:
 		_creature_editor.center_creature.creature_def = loaded_def
 		_creature_editor.mutate_all_creatures()
 	else:
+		$Error.dialog_text = "Error importing creature."
 		$Error.popup_centered()
 
 
 func _on_ExportButton_pressed() -> void:
+	if OS.has_feature("web"):
+		_show_import_export_not_supported_error()
+		return
+	
 	var exported_creature: Creature = _creature_editor.center_creature
 	var sanitized_creature_name := StringUtils.sanitize_file_root(exported_creature.creature_short_name)
 	$Export.current_file = "%s.json" % sanitized_creature_name

--- a/project/src/main/editor/puzzle/LevelEditor.tscn
+++ b/project/src/main/editor/puzzle/LevelEditor.tscn
@@ -395,8 +395,9 @@ __meta__ = {
 
 [node name="Dialogs" type="Control" parent="."]
 pause_mode = 2
-margin_right = 40.0
-margin_bottom = 40.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
 script = ExtResource( 16 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -462,6 +463,13 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[node name="Error" type="AcceptDialog" parent="Dialogs"]
+margin_right = 250.0
+margin_bottom = 58.0
+popup_exclusive = true
+window_title = "Error"
+dialog_autowrap = true
+
 [node name="SettingsMenu" parent="." instance=ExtResource( 9 )]
 [connection signal="tile_map_changed" from="HBoxContainer/TabContainer/Playfield/CenterPanel/Playfield" to="HBoxContainer/SideButtons/Json" method="_on_Playfield_tile_map_changed"]
 [connection signal="pressed" from="HBoxContainer/SideButtons/OpenFile" to="Dialogs" method="_on_OpenFile_pressed"]
@@ -480,4 +488,6 @@ __meta__ = {
 [connection signal="about_to_show" from="Dialogs/SaveDialog" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
 [connection signal="file_selected" from="Dialogs/SaveDialog" to="Dialogs" method="_on_SaveDialog_file_selected"]
 [connection signal="popup_hide" from="Dialogs/SaveDialog" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
+[connection signal="about_to_show" from="Dialogs/Error" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
+[connection signal="popup_hide" from="Dialogs/Error" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
 [connection signal="quit_pressed" from="SettingsMenu" to="." method="_on_Quit_pressed"]

--- a/project/src/main/editor/puzzle/dialogs.gd
+++ b/project/src/main/editor/puzzle/dialogs.gd
@@ -5,6 +5,11 @@ Shows popup dialogs for the level editor.
 
 onready var _level_editor: LevelEditor = get_parent()
 
+func _show_save_load_not_supported_error() -> void:
+	$Error.dialog_text = "Saving/loading files isn't supported over the web. Sorry!"
+	$Error.popup_centered()
+
+
 func _on_OpenResourceDialog_file_selected(path: String) -> void:
 	_level_editor.load_scenario(path)
 
@@ -18,6 +23,10 @@ func _on_SaveDialog_file_selected(path: String) -> void:
 
 
 func _on_OpenFile_pressed() -> void:
+	if OS.has_feature("web"):
+		_show_save_load_not_supported_error()
+		return
+	
 	$OpenFileDialog.popup_centered()
 
 
@@ -26,6 +35,10 @@ func _on_OpenResource_pressed() -> void:
 
 
 func _on_Save_pressed() -> void:
+	if OS.has_feature("web"):
+		_show_save_load_not_supported_error()
+		return
+	
 	var file_root := StringUtils.sanitize_file_root(_level_editor.scenario_name.text)
 	$SaveDialog.current_file = ScenarioSettings.scenario_filename(file_root)
 	$SaveDialog.popup_centered()

--- a/project/src/main/ui/DialogBackdrop.tscn
+++ b/project/src/main/ui/DialogBackdrop.tscn
@@ -4,8 +4,8 @@
 
 [node name="Backdrop" type="ColorRect"]
 visible = false
-margin_right = 1024.0
-margin_bottom = 600.0
+anchor_right = 1.0
+anchor_bottom = 1.0
 color = Color( 0, 0, 0, 0.752941 )
 script = ExtResource( 1 )
 __meta__ = {


### PR DESCRIPTION
While HTML5 supports saving/loading files, it only gives you access to a
user sandbox and doesn't let you access any files on the filesystem. This
makes saving/loading pretty useless. We now pop up an error.

Closes #580.

Fixed issue where DialogBackdrop didn't reach the edges of the screen if
the screen was resized.