### PR TITLE
Added cutscene logic for Ebe/Boatricia on overworld.

### DIFF
--- a/project/assets/main/dialog/ebe/creature.json
+++ b/project/assets/main/dialog/ebe/creature.json
@@ -27,123 +27,13 @@
     "accent_texture": 15,
     "color": "feceef"
   },
-  "dialog": {
-    "filler": {
-      "version": "1922",
-      "": [
-        {
-          "who": "Ebe",
-          "text": "Did you want to cook for me,/ or get friend zoned?",
-          "mood": "think0",
-          "links": [
-            {
-              "cook": "I'll cook for you!"
-            },
-            {
-              "hi": "Friend zone me!"
-            },
-            {
-              "bye": "Um, I don't want any of that..."
-            }
-          ]
-        }
-      ],
-      "cook": [
-        {
-          "who": "#player#",
-          "text": "I'll cook for you!",
-          "mood": "smile0",
-          "meta": "scenario_five_customers_no_vegetables"
-        },
-        {
-          "who": "Ebe",
-          "text": "Okay,/ I'll invite my friends too!/ But/ -/-/ no vegetables okay?"
-        },
-        {
-          "who": "Ebe",
-          "text": "I HATE vegetables!/ ./././I hate them so much...",
-          "mood": "rage0"
-        }
-      ],
-      "hi": [
-        {
-          "who": "Ebe",
-          "text": "You tell me you're in love with me,",
-          "mood": "laugh1"
-        },
-        {
-          "who": "Ebe",
-          "text": "...Like you can't take your pretty eyes away from me.",
-          "mood": "laugh0"
-        },
-        {
-          "who": "Ebe",
-          "text": "It's not that I don't wanna stay,",
-          "mood": "rage0"
-        },
-        {
-          "who": "Ebe",
-          "text": "...But every time you come too close I move away.",
-          "mood": "rage1"
-        },
-        {
-          "who": "Ebe",
-          "text": "I wanna believe in everything that you say,/ 'cause it sounds so good...",
-          "mood": "think1"
-        },
-        {
-          "who": "Ebe",
-          "text": "But if you really want me,/ move slow,",
-          "mood": "think0"
-        },
-        {
-          "who": "Ebe",
-          "text": "There's things about me you just have to know.",
-          "mood": "cry0"
-        },
-        {
-          "who": "Ebe",
-          "text": "Sometimes I run.",
-          "mood": "cry1"
-        },
-        {
-          "who": "Ebe",
-          "text": "Sometimes I hide.",
-          "mood": "sweat0"
-        },
-        {
-          "who": "Ebe",
-          "text": "Sometimes I'm scared of you,",
-          "mood": "sweat1"
-        },
-        {
-          "who": "Ebe",
-          "text": "But all I really want is to hold you tight, treat you right,",
-          "mood": "default"
-        },
-        {
-          "who": "Ebe",
-          "text": "Be with you day and night.",
-          "mood": "smile0"
-        },
-        {
-          "who": "Ebe",
-          "text": "Baby,/ all I need is time.",
-          "mood": "smile1"
-        }
-      ],
-      "bye": [
-        {
-          "who": "#player#",
-          "text": "Um,/ I don't want any of that...",
-          "mood": "sweat0"
-        },
-        {
-          "who": "Ebe",
-          "text": "./././",
-          "mood": "sweat0"
-        }
+  "chat_selectors": [
+    {
+      "level": "five_customers_no_vegetables",
+      "dialog": "no_vegetables",
+      "if_conditions": [
+        "current_level/1"
       ]
     }
-  }
+  ]
 }

--- a/project/assets/main/dialog/ebe/filler.json
+++ b/project/assets/main/dialog/ebe/filler.json
@@ -1,0 +1,100 @@
+{
+  "version": "1922",
+  "meta": {
+    "filler": true
+  },
+  "": [
+    {
+      "who": "Ebe",
+      "text": "Did you want to get friend zoned?",
+      "mood": "think0",
+      "links": [
+        {
+          "hi": "Friend zone me!"
+        },
+        {
+          "bye": "Um, I don't think so..."
+        }
+      ]
+    }
+  ],
+  "hi": [
+    {
+      "who": "Ebe",
+      "text": "You tell me you're in love with me,",
+      "mood": "laugh1"
+    },
+    {
+      "who": "Ebe",
+      "text": "...Like you can't take your pretty eyes away from me.",
+      "mood": "laugh0"
+    },
+    {
+      "who": "Ebe",
+      "text": "It's not that I don't wanna stay,",
+      "mood": "rage0"
+    },
+    {
+      "who": "Ebe",
+      "text": "...But every time you come too close I move away.",
+      "mood": "rage1"
+    },
+    {
+      "who": "Ebe",
+      "text": "I wanna believe in everything that you say,/ 'cause it sounds so good...",
+      "mood": "think1"
+    },
+    {
+      "who": "Ebe",
+      "text": "But if you really want me,/ move slow,",
+      "mood": "think0"
+    },
+    {
+      "who": "Ebe",
+      "text": "There's things about me you just have to know.",
+      "mood": "cry0"
+    },
+    {
+      "who": "Ebe",
+      "text": "Sometimes I run.",
+      "mood": "cry1"
+    },
+    {
+      "who": "Ebe",
+      "text": "Sometimes I hide.",
+      "mood": "sweat0"
+    },
+    {
+      "who": "Ebe",
+      "text": "Sometimes I'm scared of you,",
+      "mood": "sweat1"
+    },
+    {
+      "who": "Ebe",
+      "text": "But all I really want is to hold you tight, treat you right,",
+      "mood": "default"
+    },
+    {
+      "who": "Ebe",
+      "text": "Be with you day and night.",
+      "mood": "smile0"
+    },
+    {
+      "who": "Ebe",
+      "text": "Baby,/ all I need is time.",
+      "mood": "smile1"
+    }
+  ],
+  "bye": [
+    {
+      "who": "#player#",
+      "text": "Um,/ maybe later...",
+      "mood": "sweat0"
+    },
+    {
+      "who": "Ebe",
+      "text": "./././",
+      "mood": "sweat0"
+    }
+  ]
+}

--- a/project/assets/main/dialog/ebe/no-vegetables.json
+++ b/project/assets/main/dialog/ebe/no-vegetables.json
@@ -1,0 +1,14 @@
+{
+  "version": "1922",
+  "" : [
+    {
+      "who": "Ebe",
+      "text": "Okay,/ I'll invite my friends too!/ But/ -/-/ no vegetables okay?"
+    },
+    {
+      "who": "Ebe",
+      "text": "I HATE vegetables!/ ./././I hate them so much...",
+      "mood": "rage0"
+    }
+  ]
+}

--- a/project/assets/main/dialog/level-select-1.json
+++ b/project/assets/main/dialog/level-select-1.json
@@ -7,9 +7,6 @@
           "level_1": "(Play level 1)"
         },
         {
-          "level_2": "(Play level 2)"
-        },
-        {
           "chit_chat": "(Chit chat)"
         }
       ]
@@ -18,11 +15,6 @@
   "level_1": [
     {
       "meta": "select_level_1"
-    }
-  ],
-  "level_2": [
-    {
-      "meta": "select_level_2"
     }
   ],
   "chit_chat": [

--- a/project/project.godot
+++ b/project/project.godot
@@ -64,6 +64,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/world/chat-icon.gd"
 }, {
+"base": "Node2D",
+"class": "ChatIcons",
+"language": "GDScript",
+"path": "res://src/main/world/chat-icons.gd"
+}, {
 "base": "RectFitLabel",
 "class": "ChatLineLabel",
 "language": "GDScript",
@@ -148,6 +153,11 @@ _global_script_classes=[ {
 "class": "CreatureShadow",
 "language": "GDScript",
 "path": "res://src/main/world/creature/creature-shadow.gd"
+}, {
+"base": "Node2D",
+"class": "CreatureShadows",
+"language": "GDScript",
+"path": "res://src/main/editor/creature/creature-shadows.gd"
 }, {
 "base": "Node2D",
 "class": "CreatureVisuals",
@@ -541,6 +551,7 @@ _global_script_class_icons={
 "ChatFrame": "",
 "ChatHistory": "",
 "ChatIcon": "",
+"ChatIcons": "",
 "ChatLineLabel": "",
 "ChatLinePanel": "",
 "ChatTheme": "",
@@ -558,6 +569,7 @@ _global_script_class_icons={
 "CreaturePackedSprite": "",
 "CreaturePaletteDemo": "",
 "CreatureShadow": "",
+"CreatureShadows": "",
 "CreatureVisuals": "",
 "DurationCalculator": "",
 "EditorPlayfield": "",

--- a/project/src/main/editor/creature/creature-shadows.gd
+++ b/project/src/main/editor/creature/creature-shadows.gd
@@ -1,3 +1,4 @@
+class_name CreatureShadows
 extends Node2D
 """
 Manages shadows for all creatures in a scene.
@@ -6,10 +7,17 @@ Manages shadows for all creatures in a scene.
 export (PackedScene) var CreatureShadowScene: PackedScene
 
 func _ready() -> void:
-	# create shadows for all creatures in the scene
-	for creature_node in get_tree().get_nodes_in_group("creatures"):
-		var creature: Creature = creature_node
-		var creature_shadow: CreatureShadow = CreatureShadowScene.instance()
-		creature_shadow.shadow_scale = creature.scale * Creature.TEXTURE_SCALE
-		add_child(creature_shadow)
-		creature_shadow.creature_path = creature_shadow.get_path_to(creature)
+	for creature in get_tree().get_nodes_in_group("creatures"):
+		create_shadow(creature)
+
+
+func create_shadow(creature: Creature) -> void:
+	var creature_shadow: CreatureShadow = CreatureShadowScene.instance()
+	creature_shadow.shadow_scale = creature.scale * Creature.TEXTURE_SCALE
+	add_child(creature_shadow)
+	creature_shadow.creature_path = creature_shadow.get_path_to(creature)
+	creature.connect("tree_exited", self, "_on_Creature_tree_exited", [creature_shadow])
+
+
+func _on_Creature_tree_exited(creature_shadow: CreatureShadow) -> void:
+	creature_shadow.queue_free()

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -141,6 +141,7 @@ func _on_Hud_settings_button_pressed() -> void:
 
 
 func _on_Hud_back_button_pressed() -> void:
+	Scenario.clear_launched_scenario()
 	Breadcrumb.pop_trail()
 
 
@@ -175,14 +176,14 @@ func _on_PuzzleScore_game_started() -> void:
 Method invoked when the game ends. Stores the rank result for later.
 """
 func _on_PuzzleScore_game_ended() -> void:
-	if not Scenario.launched_scenario_name:
+	if not Scenario.launched_scenario_id:
 		# null check to avoid errors when launching Puzzle.tscn standalone
 		return
 	
 	$SettingsMenu.quit_text = SettingsMenu.QUIT
 	var rank_result := RankCalculator.new().calculate_rank()
-	PlayerData.scenario_history.add(Scenario.launched_scenario_name, rank_result)
-	PlayerData.scenario_history.prune(Scenario.launched_scenario_name)
+	PlayerData.scenario_history.add(Scenario.launched_scenario_id, rank_result)
+	PlayerData.scenario_history.prune(Scenario.launched_scenario_id)
 	PlayerData.money = int(clamp(PlayerData.money + rank_result.score, 0, 9999999999999999))
 	
 	match Scenario.settings.finish_condition.type:
@@ -205,4 +206,5 @@ func _on_SettingsMenu_quit_pressed() -> void:
 	if $SettingsMenu.quit_text == SettingsMenu.GIVE_UP:
 		PuzzleScore.make_player_lose()
 	else:
+		Scenario.clear_launched_scenario()
 		Breadcrumb.pop_trail()

--- a/project/src/main/puzzle/scenario/scenario-settings.gd
+++ b/project/src/main/puzzle/scenario/scenario-settings.gd
@@ -154,11 +154,11 @@ Loads a scenario based on the creature's chat selectors.
 Parameters:
 	'creature': The creature whose level should be loaded.
 	
-	'level_int': Which level should be loaded; '1' is the first level.
+	'level_num': Which level should be loaded; '1' is the first level.
 """
-func load_from_creature(creature: Creature, level_int: int) -> void:
+func load_from_creature(creature: Creature, level_num: int) -> void:
 	var level_ids := creature.get_level_ids()
-	var level_id: String = level_ids[level_int - 1]
+	var level_id: String = level_ids[level_num - 1]
 	load_from_resource(level_id)
 
 

--- a/project/src/main/puzzle/scenario/scenario.gd
+++ b/project/src/main/puzzle/scenario/scenario.gd
@@ -17,15 +17,49 @@ const BEGINNER_TUTORIAL := "tutorial_beginner_0"
 # The settings for the scenario currently being launched or played
 var settings := ScenarioSettings.new() setget switch_scenario
 
-# The scenario which was initially launched. Some tutorial scenarios transition
+# The scenario which was originally launched. Some tutorial scenarios transition
 # into other scenarios, so this keeps track of the original.
-var launched_scenario_name
+var launched_scenario_id: String
+
+# The creature who launched the scenario. This creature is always the first customer.
+var launched_creature_id: String
+
+# The number of the creature's launched level, '1' being their first level.
+var launched_level_num: int = -1
 
 # 'true' if launching a puzzle from the overworld. This changes the menus and disallows restarting.
 var overworld_puzzle := false
 
+"""
+Unsets all of the 'launched scenario' data.
+
+This ensures the overworld will allow free roam and not try to play a cutscene.
+"""
+func clear_launched_scenario() -> void:
+	set_launched_scenario("", "", -1)
+
+
+"""
+Sets the launched scenario data.
+
+Some tutorial scenarios transition into other scenarios, so this keeps track of the original. These properties also
+used on the overworld to track whether or not it should play a cutscene or allow free roam.
+
+Parameters:
+	'scenario_id': The scenario to launch
+	
+	'creature_id': The creature who shows up in the scenario or participates in the cutscene.
+	
+	'level_num': The number of the creature's launched level, '1' being their first level.
+"""
+func set_launched_scenario(scenario_id: String, creature_id: String = "", level_num: int = -1) -> void:
+	launched_scenario_id = scenario_id
+	launched_creature_id = creature_id
+	launched_level_num = level_num
+
+
 func start_scenario(new_settings: ScenarioSettings) -> void:
-	Scenario.launched_scenario_name = new_settings.id
+	launched_scenario_id = new_settings.id
 	PuzzleScore.reset()
 	switch_scenario(new_settings)
 
@@ -36,17 +70,14 @@ func switch_scenario(new_settings: ScenarioSettings) -> void:
 
 
 """
-Launches a puzzle scene with the specified scenario settings.
-
-Parameters:
-	'scenario_settings': Defines the scenario's difficulty and win condition
-	
-	'overworld_puzzle': True if the player should return to the overworld when the puzzle is done
-	
-	'dna': Creature who should appear in the restaurant.
+Launches a puzzle scene with the previously specified 'launched scenario' settings.
 """
-func push_scenario_trail(scenario_settings: ScenarioSettings, dna: Dictionary = {}) -> void:
+func push_scenario_trail(new_overworld_puzzle: bool) -> void:
+	overworld_puzzle = new_overworld_puzzle
+	var scenario_settings := ScenarioSettings.new()
+	scenario_settings.load_from_resource(launched_scenario_id)
 	start_scenario(scenario_settings)
-	if dna:
-		Global.creature_queue.push_front(dna)
+	if Scenario.launched_creature_id:
+		var creature_def := CreatureLoader.load_creature_def_by_id(Scenario.launched_creature_id)
+		Global.creature_queue.push_front(creature_def.dna)
 	Breadcrumb.push_trail("res://src/main/puzzle/Puzzle.tscn")

--- a/project/src/main/ui/level-select/level-buttons.gd
+++ b/project/src/main/ui/level-select/level-buttons.gd
@@ -30,19 +30,31 @@ var _column_width := COLUMN_WIDTH_SMALL
 var _scenario_settings_by_id: Dictionary
 
 var _duration_calculator := DurationCalculator.new()
+var _level_ids: Array
+var _level_details: Dictionary
 
 func _ready() -> void:
-	var level_ids := [
-		"boatricia1", "boatricia2", "five-customers-no-vegetables", "placeholder01", "placeholder02", "placeholder03",
-		"placeholder04", "placeholder05", "placeholder06", "placeholder07", "placeholder08", "placeholder09",
-		"placeholder10", "placeholder11",
-	]
+	_add_level("boatricia1", "boatricia", 1)
+	_add_level("boatricia2", "boatricia", 2)
+	_add_level("five-customers-no-vegetables", "ebe", 1)
+	_add_level("placeholder01", "ebe")
+	_add_level("placeholder02", "bort")
+	_add_level("placeholder03", "bort")
+	_add_level("placeholder04", "boatricia")
+	_add_level("placeholder05", "boatricia")
+	_add_level("placeholder06", "ebe")
+	_add_level("placeholder07", "ebe")
+	_add_level("placeholder08", "bort")
+	_add_level("placeholder09", "bort")
+	_add_level("placeholder10", "bort")
+	_add_level("placeholder11", "ebe")
+	_add_level("placeholder12")
 	
 	for child in get_children():
 		remove_child(child)
 		child.queue_free()
 	
-	var column_count := ceil(sqrt(level_ids.size() + 1))
+	var column_count := ceil(sqrt(_level_ids.size() + 1))
 	for _i in range(column_count):
 		var vbox_container := VBoxContainer.new()
 		vbox_container.alignment = BoxContainer.ALIGN_END
@@ -51,13 +63,13 @@ func _ready() -> void:
 		_columns.append(vbox_container)
 		add_child(vbox_container)
 	
-	for level_id in level_ids:
+	for level_id in _level_ids:
 		var scenario_settings := ScenarioSettings.new()
 		scenario_settings.load_from_resource(level_id)
 		_scenario_settings_by_id[level_id] = scenario_settings
 	
-	for i in range(level_ids.size()):
-		var level_id: String = level_ids[i]
+	for i in range(_level_ids.size()):
+		var level_id: String = _level_ids[i]
 		var column: VBoxContainer = _columns[(i + 1) % _columns.size()]
 		column.add_child(_level_select_button(level_id))
 	
@@ -107,9 +119,26 @@ func _level_select_button(level_id: String) -> LevelSelectButton:
 	return level_select_button
 
 
+func _add_level(level_id: String, creature_id: String = "", level_num: int = -1) -> void:
+	_level_ids.append(level_id)
+	_level_details[level_id] = {"creature_id": creature_id, "level_num": level_num}
+
+
 func _on_LevelSelectButton_scenario_started(settings: ScenarioSettings) -> void:
-	Scenario.overworld_puzzle = false
-	Scenario.push_scenario_trail(settings)
+	var creature_id := ""
+	if _level_details.has(settings.id):
+		creature_id = _level_details[settings.id].get("creature_id", "")
+	
+	var level_num := -1
+	if _level_details.has(settings.id):
+		level_num = _level_details[settings.id].get("level_num", -1)
+	
+	Scenario.set_launched_scenario(settings.id, creature_id, level_num)
+	
+	if creature_id and level_num >= 1:
+		Breadcrumb.push_trail("res://src/main/world/Overworld.tscn")
+	else:
+		Scenario.push_scenario_trail(true)
 
 
 func _on_LevelSelectButton_focus_entered(settings: ScenarioSettings) -> void:

--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -21,13 +21,12 @@ func _ready() -> void:
 
 
 func _launch_tutorial() -> void:
-	var settings := ScenarioSettings.new()
-	settings.load_from_resource(Scenario.BEGINNER_TUTORIAL)
-	Scenario.overworld_puzzle = false
-	Scenario.push_scenario_trail(settings)
+	Scenario.set_launched_scenario(Scenario.BEGINNER_TUTORIAL)
+	Scenario.push_scenario_trail(false)
 
 
 func _on_PlayStory_pressed() -> void:
+	Scenario.clear_launched_scenario()
 	Breadcrumb.push_trail("res://src/main/world/Overworld.tscn")
 
 

--- a/project/src/main/ui/menu/practice-menu.gd
+++ b/project/src/main/ui/menu/practice-menu.gd
@@ -144,5 +144,5 @@ func _on_Mode_mode_changed() -> void:
 
 
 func _on_Start_pressed() -> void:
-	Scenario.overworld_puzzle = false
-	Scenario.push_scenario_trail(_get_scenario())
+	Scenario.set_launched_scenario(_get_scenario().id)
+	Scenario.push_scenario_trail(false)

--- a/project/src/main/world/Overworld.tscn
+++ b/project/src/main/world/Overworld.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=54 format=2]
+[gd_scene load_steps=55 format=2]
 
 [ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/creature/player.gd" type="Script" id=2]
@@ -50,6 +50,7 @@
 [ext_resource path="res://assets/main/world/creature/3/tail-z1-packed.png" type="Texture" id=48]
 [ext_resource path="res://assets/main/world/creature/3/tail-z0-packed.png" type="Texture" id=49]
 [ext_resource path="res://src/main/world/chat-icons.gd" type="Script" id=50]
+[ext_resource path="res://src/main/world/overworld-world.gd" type="Script" id=51]
 
 [sub_resource type="TileSet" id=1]
 0/name = "block-shadow.png 0"
@@ -88,6 +89,11 @@ __meta__ = {
 }
 
 [node name="World" type="Node" parent="."]
+script = ExtResource( 51 )
+creature_shadows_path = NodePath("Ground/Shadows/Viewport/CreatureShadows")
+chat_icons_path = NodePath("ChatIcons")
+overworld_ui_path = NodePath("../Ui/OverworldUi")
+CreaturePackedScene = ExtResource( 1 )
 
 [node name="Ground" type="Node2D" parent="World"]
 

--- a/project/src/main/world/chat-icons.gd
+++ b/project/src/main/world/chat-icons.gd
@@ -1,3 +1,4 @@
+class_name ChatIcons
 extends Node2D
 """
 Creates and initializes chat icons for all chattables in the scene tree.
@@ -7,6 +8,15 @@ export (PackedScene) var ChatIconScene: PackedScene
 
 func _ready() -> void:
 	for chattable in get_tree().get_nodes_in_group("chattables"):
-		var chat_icon: ChatIcon = ChatIconScene.instance()
-		add_child(chat_icon)
-		chat_icon.initialize(chattable)
+		create_icon(chattable)
+
+
+func create_icon(chattable: Node) -> void:
+	var chat_icon: ChatIcon = ChatIconScene.instance()
+	add_child(chat_icon)
+	chat_icon.initialize(chattable)
+	chattable.connect("tree_exited", self, "_on_Chattable_tree_exited", [chat_icon])
+
+
+func _on_Chattable_tree_exited(chat_icon: ChatIcon) -> void:
+	chat_icon.queue_free()

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -1,0 +1,38 @@
+extends Node
+"""
+Populates/unpopulates the creatures and obstacles on the overworld.
+"""
+
+export (NodePath) var creature_shadows_path: NodePath
+export (NodePath) var chat_icons_path: NodePath
+export (NodePath) var overworld_ui_path: NodePath
+export (PackedScene) var CreaturePackedScene: PackedScene
+
+onready var _creature_shadows: CreatureShadows = get_node(creature_shadows_path)
+onready var _chat_icons: ChatIcons = get_node(chat_icons_path)
+onready var _overworld_ui: OverworldUi = get_node(overworld_ui_path)
+
+func _ready() -> void:
+	if Scenario.launched_scenario_id:
+		_overworld_ui.cutscene = true
+		
+		# remove all of the creatures from the overworld
+		for child in [$Obstacles/Bort, $Obstacles/Ebe, $Obstacles/Boatricia]:
+			child.queue_free()
+		
+		# add the cutscene creatures
+		var creature: Creature = CreaturePackedScene.instance()
+		creature.creature_id = Scenario.launched_creature_id
+		creature.position = Vector2(444, 150)
+		creature.add_to_group("chattables")
+		$Obstacles.add_child(creature)
+		_chat_icons.create_icon(creature)
+		_creature_shadows.create_shadow(creature)
+		
+		_schedule_chat(creature)
+
+
+func _schedule_chat(creature: Creature) -> void:
+	yield(get_tree(), "idle_frame")
+	var chat_tree := ChatLibrary.load_chat_events_for_creature(creature, Scenario.launched_level_num)
+	_overworld_ui.start_chat(chat_tree, [creature])

--- a/project/src/test/ui/chat/test-chat-library.gd
+++ b/project/src/test/ui/chat/test-chat-library.gd
@@ -46,7 +46,7 @@ func before_each() -> void:
 	PlayerData.chat_history.reset()
 	
 	_state["creature_id"] = "gurus750"
-	_state["level_int"] = 1
+	_state["level_num"] = 1
 	_state["notable_chat"] = true
 	
 	PlayerData.chat_history.add_history_item("dialog/gurus750/level-001")
@@ -64,7 +64,7 @@ func test_level_1() -> void:
 
 
 func test_level_2() -> void:
-	_state["level_int"] = 2
+	_state["level_num"] = 2
 	PlayerData.chat_history.delete_history_item("dialog/gurus750/level-001")
 	PlayerData.chat_history.delete_history_item("dialog/gurus750/level-002")
 	


### PR DESCRIPTION
Selecting certain scenarios from the level select screen now plays a
little cutscene.

The 'level select' chat tree now includes an extra 'chit chat' choice,
which is what they'll say on the overworld if they have no level.

launched_scenario_name -> launched_scenario_id. level_int -> level_num

Moved OverworldUi fields related to 'launched scenario', 'launched
creature dna' into Scenario.