### PR TITLE
Cleaned up minor issues discovered during cutscene logic.

### DIFF
--- a/project/src/main/global.gd
+++ b/project/src/main/global.gd
@@ -3,14 +3,27 @@ extends Node
 Contains variables for preserving state when loading different scenes.
 """
 
+# splash screen which precedes the main menu.
+const SCENE_SPLASH := "res://src/main/ui/menu/SplashScreen.tscn"
+
+# menu the user sees after starting the game.
+const SCENE_MAIN_MENU := "res://src/main/ui/menu/MainMenu.tscn"
+
+# overworld which the player character can run around on and talk to other creatures.
+const SCENE_OVERWORLD := "res://src/main/world/Overworld.tscn"
+
+# puzzle where a player drops pieces into a playfield of blocks.
+const SCENE_PUZZLE := "res://src/main/puzzle/Puzzle.tscn"
+
 # The factor to multiply by to convert non-isometric coordinates into isometric coordinates
 const ISO_FACTOR := Vector2(1.0, 0.5)
 
 # Target number of creature greetings (hello, goodbye) per minute
 const GREETINGS_PER_MINUTE := 3.0
 
-# The creatures who will show up during the next puzzle. The first creature in the queue will show up first.
+# The creatures who will show up during the next puzzle.
 var creature_queue := []
+var creature_queue_index: int
 
 # Stores all of the benchmarks which have been started
 var _benchmark_start_times := Dictionary()
@@ -75,3 +88,8 @@ func should_chat() -> bool:
 	else:
 		should_chat = false
 	return should_chat
+
+
+func clear_creature_queue() -> void:
+	Global.creature_queue = []
+	Global.creature_queue_index = 0

--- a/project/src/main/puzzle/puzzle-messages.gd
+++ b/project/src/main/puzzle/puzzle-messages.gd
@@ -17,9 +17,6 @@ func _ready() -> void:
 	$MessageLabel.hide()
 	# grab focus so the player can start a new game or navigate with the keyboard
 	$Buttons/Start.grab_focus()
-	
-	if Scenario.overworld_puzzle:
-		$Buttons/Back.text = "Quit"
 
 
 func is_settings_button_visible() -> bool:
@@ -94,17 +91,14 @@ func _on_PuzzleScore_after_game_ended() -> void:
 	$Buttons/Settings.show()
 	$Buttons/Back.show()
 	$Buttons/Start.show()
-	if Scenario.overworld_puzzle:
-		# player can't restart a level if a creature asked them to do it, for thematic reasons
-		$Buttons/Start.hide()
 	if Scenario.settings.other.tutorial or Scenario.settings.other.after_tutorial:
 		if not PuzzleScore.scenario_performance.lost:
 			# if they won, make them exit; hide the start button
 			$Buttons/Start.hide()
 			
 			# don't redirect them back to the splash screen, send them to the main menu
-			if Breadcrumb.trail[1] == "res://src/main/ui/menu/SplashScreen.tscn":
-				Breadcrumb.trail.insert(1, "res://src/main/ui/menu/MainMenu.tscn")
+			if Breadcrumb.trail[1] == Global.SCENE_SPLASH:
+				Breadcrumb.trail.insert(1, Global.SCENE_MAIN_MENU)
 	
 	if $Buttons/Start.is_visible_in_tree():
 		# grab focus so the player can retry or navigate with the keyboard

--- a/project/src/main/puzzle/puzzle-score.gd
+++ b/project/src/main/puzzle/puzzle-score.gd
@@ -196,7 +196,7 @@ func reset() -> void:
 	bonus_score = 0
 	scenario_performance = PuzzlePerformance.new()
 	level_index = 0
-	no_more_customers = false
+	no_more_customers = Scenario.settings.other.tutorial
 	
 	emit_signal("score_changed")
 	emit_signal("level_index_changed", 0)

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -45,10 +45,11 @@ properties.
 """
 func summon_creature(creature_index: int = -1) -> void:
 	var dna: Dictionary
-	if Global.creature_queue.empty():
-		dna = CreatureLoader.random_def()
+	if Global.creature_queue_index < Global.creature_queue.size():
+		dna = Global.creature_queue[Global.creature_queue_index]
+		Global.creature_queue_index += 1
 	else:
-		dna = Global.creature_queue.pop_front()
+		dna = CreatureLoader.random_def()
 	$RestaurantViewport/Scene.summon_creature(dna, creature_index)
 
 
@@ -66,11 +67,19 @@ func scroll_to_new_creature(new_creature_index: int = -1) -> void:
 
 
 """
+Temporarily suppresses 'hello' and 'door chime' sounds.
+"""
+func start_suppress_sfx_timer() -> void:
+	for i in range(3):
+		get_customer(i).start_suppress_sfx_timer()
+	$RestaurantViewport/Scene.start_suppress_sfx_timer()
+
+
+"""
 If they ended the previous game while serving a creature, we scroll to a new one
 """
 func _on_PuzzleScore_game_prepared() -> void:
-	if get_customer().get_fatness() > 1 and not Scenario.settings.other.tutorial:
-		# don't scroll if we're doing a tutorial; the tutorial will scroll back to the instructor if necessary.
+	if get_customer().feed_count > 0:
 		scroll_to_new_creature()
 
 

--- a/project/src/main/puzzle/scenario/scenario-history.gd
+++ b/project/src/main/puzzle/scenario/scenario-history.gd
@@ -38,6 +38,22 @@ func results(scenario_id: String) -> Array:
 
 
 """
+Returns a player's best performance for a specific scenario.
+
+Parameters:
+	'scenario_id': The id of the scenario to evaluate
+	
+	'daily': (Optional) If true, only performances with today's date are included
+"""
+func best_result(scenario_id: String, daily: bool = false) -> RankResult:
+	var best_result: RankResult
+	var best_results := best_results(scenario_id, daily)
+	if best_results:
+		best_result = best_results[0]
+	return best_result
+
+
+"""
 Returns a player's best performances for a specific scenario.
 
 Parameters:

--- a/project/src/main/puzzle/scenario/scenario.gd
+++ b/project/src/main/puzzle/scenario/scenario.gd
@@ -27,9 +27,6 @@ var launched_creature_id: String
 # The number of the creature's launched level, '1' being their first level.
 var launched_level_num: int = -1
 
-# 'true' if launching a puzzle from the overworld. This changes the menus and disallows restarting.
-var overworld_puzzle := false
-
 """
 Unsets all of the 'launched scenario' data.
 
@@ -72,12 +69,11 @@ func switch_scenario(new_settings: ScenarioSettings) -> void:
 """
 Launches a puzzle scene with the previously specified 'launched scenario' settings.
 """
-func push_scenario_trail(new_overworld_puzzle: bool) -> void:
-	overworld_puzzle = new_overworld_puzzle
+func push_scenario_trail() -> void:
 	var scenario_settings := ScenarioSettings.new()
 	scenario_settings.load_from_resource(launched_scenario_id)
 	start_scenario(scenario_settings)
 	if Scenario.launched_creature_id:
 		var creature_def := CreatureLoader.load_creature_def_by_id(Scenario.launched_creature_id)
 		Global.creature_queue.push_front(creature_def.dna)
-	Breadcrumb.push_trail("res://src/main/puzzle/Puzzle.tscn")
+	Breadcrumb.push_trail(Global.SCENE_PUZZLE)

--- a/project/src/main/puzzle/tutorial/tutorial-hud.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-hud.gd
@@ -244,10 +244,6 @@ func _flash() -> void:
 
 
 func _on_PuzzleScore_game_prepared() -> void:
-	if Scenario.settings.other.tutorial:
-		# summon the instructor. this is redundant for the first attempt of a tutorial, but necessary when retrying
-		_puzzle.summon_instructor()
-	
 	_lines_cleared = 0
 	_boxes_built = 0
 	_squish_moves = 0

--- a/project/src/main/ui/chat/chat-library.gd
+++ b/project/src/main/ui/chat/chat-library.gd
@@ -27,7 +27,7 @@ func load_chat_events_for_creature(creature: Creature, level_num: int = -1, chit
 		state["level_num"] = level_num
 	
 	var chat_tree: ChatTree
-	if chit_chat or level_num != -1:
+	if chit_chat or level_num != -1 or not creature.get_level_ids():
 		# returning dialog for the creature
 		var chosen_dialog := choose_dialog_from_chat_selectors(creature.chat_selectors, state)
 		if creature.dialog.has(chosen_dialog):

--- a/project/src/main/ui/level-select/level-buttons.gd
+++ b/project/src/main/ui/level-select/level-buttons.gd
@@ -136,9 +136,9 @@ func _on_LevelSelectButton_scenario_started(settings: ScenarioSettings) -> void:
 	Scenario.set_launched_scenario(settings.id, creature_id, level_num)
 	
 	if creature_id and level_num >= 1:
-		Breadcrumb.push_trail("res://src/main/world/Overworld.tscn")
+		Breadcrumb.push_trail(Global.SCENE_OVERWORLD)
 	else:
-		Scenario.push_scenario_trail(true)
+		Scenario.push_scenario_trail()
 
 
 func _on_LevelSelectButton_focus_entered(settings: ScenarioSettings) -> void:
@@ -150,11 +150,10 @@ func _on_OverallButton_focus_entered() -> void:
 	var ranks := []
 	for settings_obj in _scenario_settings_by_id.values():
 		var settings: ScenarioSettings = settings_obj
-		var best_results := PlayerData.scenario_history.best_results(settings.id)
+		var best_result := PlayerData.scenario_history.best_result(settings.id)
 		var rank := 999.0
-		if best_results:
-			var result: RankResult = best_results[0]
-			rank = result.seconds_rank if result.compare == "-seconds" else result.score_rank
+		if best_result:
+			rank = best_result.seconds_rank if best_result.compare == "-seconds" else best_result.score_rank
 		ranks.append(rank)
 	
 	emit_signal("overall_selected", ranks)

--- a/project/src/main/ui/level-select/level-info-panel.gd
+++ b/project/src/main/ui/level-select/level-info-panel.gd
@@ -43,15 +43,13 @@ func _on_LevelButtons_level_selected(settings: ScenarioSettings) -> void:
 	text += "Duration: %s\n" % [duration_string]
 	
 	var prev_result := PlayerData.scenario_history.prev_result(settings.id)
-	var best_results := PlayerData.scenario_history.best_results(settings.id)
 	if prev_result:
 		text += "New: %s\n" % [PoolStringArray(HighScoreTable.rank_result_row(prev_result)).join("   ")]
 	else:
 		text += "\n"
-	if best_results:
-		text += "Top: %s" % [PoolStringArray(HighScoreTable.rank_result_row(best_results[0])).join("   ")]
-	else:
-		text += ""
+	var best_result := PlayerData.scenario_history.best_result(settings.id)
+	if best_result:
+		text += "Top: %s" % [PoolStringArray(HighScoreTable.rank_result_row(best_result)).join("   ")]
 	$MarginContainer/Label.text = text
 
 

--- a/project/src/main/ui/menu/loading-screen.gd
+++ b/project/src/main/ui/menu/loading-screen.gd
@@ -13,4 +13,4 @@ func _process(_delta: float) -> void:
 
 
 func _on_ResourceCache_finished_loading() -> void:
-	Breadcrumb.push_trail("res://src/main/ui/menu/SplashScreen.tscn")
+	Breadcrumb.push_trail(Global.SCENE_SPLASH)

--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -1,15 +1,15 @@
 class_name MainMenu
 extends Control
 """
-The menu the user sees when they start the game.
+The menu the user sees after starting the game.
 
-Includes buttons starting a new game, launching the level editor, and exiting the game.
+Includes buttons for starting a new game, launching the level editor, and exiting the game.
 """
 
 func _ready() -> void:
 	if not PlayerData.scenario_history.finished_scenarios.has(Scenario.BEGINNER_TUTORIAL):
 		# if the player fails/quits the first tutorial, they're redirected to the splash screen
-		Breadcrumb.trail = ["res://src/main/ui/menu/SplashScreen.tscn"]
+		Breadcrumb.trail = [Global.SCENE_SPLASH]
 		_launch_tutorial()
 	
 	# Fade in music when redirected from a scene with no music, such as the level editor
@@ -21,13 +21,17 @@ func _ready() -> void:
 
 
 func _launch_tutorial() -> void:
+	Global.clear_creature_queue()
+	var creature_def := CreatureLoader.load_creature_def_by_id("instructor")
+	Global.creature_queue.push_front(creature_def.dna)
 	Scenario.set_launched_scenario(Scenario.BEGINNER_TUTORIAL)
-	Scenario.push_scenario_trail(false)
+	Scenario.push_scenario_trail()
 
 
 func _on_PlayStory_pressed() -> void:
+	Global.clear_creature_queue()
 	Scenario.clear_launched_scenario()
-	Breadcrumb.push_trail("res://src/main/world/Overworld.tscn")
+	Breadcrumb.push_trail(Global.SCENE_OVERWORLD)
 
 
 func _on_PlayPractice_pressed() -> void:

--- a/project/src/main/ui/menu/practice-menu.gd
+++ b/project/src/main/ui/menu/practice-menu.gd
@@ -145,4 +145,4 @@ func _on_Mode_mode_changed() -> void:
 
 func _on_Start_pressed() -> void:
 	Scenario.set_launched_scenario(_get_scenario().id)
-	Scenario.push_scenario_trail(false)
+	Scenario.push_scenario_trail()

--- a/project/src/main/ui/menu/splash-screen.gd
+++ b/project/src/main/ui/menu/splash-screen.gd
@@ -12,7 +12,7 @@ func _ready() -> void:
 
 
 func _on_Play_pressed() -> void:
-	Breadcrumb.push_trail("res://src/main/ui/menu/MainMenu.tscn")
+	Breadcrumb.push_trail(Global.SCENE_MAIN_MENU)
 
 
 func _on_System_quit_pressed() -> void:

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -121,7 +121,7 @@ func _process_select_level_meta_item(level_num: int = -1) -> void:
 		
 		if level_num >= 1:
 			var level_ids := creature.get_level_ids()
-			var scenario_id: String = level_ids[Scenario.launched_level_num - 1]
+			var scenario_id: String = level_ids[level_num - 1]
 			Scenario.set_launched_scenario(scenario_id, creature.creature_id, level_num)
 
 
@@ -146,11 +146,11 @@ func _on_ChatUi_pop_out_completed() -> void:
 		
 		if Scenario.launched_scenario_id:
 			ChattableManager.clear()
-			Scenario.push_scenario_trail(cutscene)
+			Scenario.push_scenario_trail()
 			
 			if cutscene:
 				# upon completing a puzzle, return to the level select screen
-				Breadcrumb.trail.erase("res://src/main/world/Overworld.tscn")
+				Breadcrumb.trail.erase(Global.SCENE_OVERWORLD)
 
 
 func _on_ChatUi_chat_event_played(chat_event: ChatEvent) -> void:

--- a/project/src/main/world/Overworld.tscn
+++ b/project/src/main/world/Overworld.tscn
@@ -93,6 +93,7 @@ script = ExtResource( 51 )
 creature_shadows_path = NodePath("Ground/Shadows/Viewport/CreatureShadows")
 chat_icons_path = NodePath("ChatIcons")
 overworld_ui_path = NodePath("../Ui/OverworldUi")
+player_path = NodePath("Obstacles/Player")
 CreaturePackedScene = ExtResource( 1 )
 
 [node name="Ground" type="Node2D" parent="World"]

--- a/project/src/main/world/creature/Creature.tscn
+++ b/project/src/main/world/creature/Creature.tscn
@@ -533,12 +533,11 @@ bus = "Sound Bus"
 stream = ExtResource( 5 )
 volume_db = -4.0
 bus = "Sound Bus"
-[connection signal="dna_loaded" from="CreatureOutline/Viewport/Visuals" to="." method="_on_CreatureVisuals_dna_loaded"]
 [connection signal="dna_loaded" from="CreatureOutline/Viewport/Visuals" to="CreatureSfx" method="_on_CreatureVisuals_dna_loaded"]
-[connection signal="food_eaten" from="CreatureOutline/Viewport/Visuals" to="." method="_on_CreatureVisuals_food_eaten"]
+[connection signal="dna_loaded" from="CreatureOutline/Viewport/Visuals" to="." method="_on_CreatureVisuals_dna_loaded"]
 [connection signal="food_eaten" from="CreatureOutline/Viewport/Visuals" to="CreatureSfx" method="_on_CreatureVisuals_food_eaten"]
+[connection signal="food_eaten" from="CreatureOutline/Viewport/Visuals" to="." method="_on_CreatureVisuals_food_eaten"]
 [connection signal="landed" from="CreatureOutline/Viewport/Visuals" to="." method="_on_CreatureVisuals_landed"]
 [connection signal="movement_mode_changed" from="CreatureOutline/Viewport/Visuals" to="." method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="visual_fatness_changed" from="CreatureOutline/Viewport/Visuals" to="." method="_on_CreatureVisuals_visual_fatness_changed"]
 [connection signal="timeout" from="CreatureSfx/HelloTimer" to="CreatureSfx" method="_on_HelloTimer_timeout"]
-[connection signal="extents_changed" from="CollisionShape2D" to="." method="_on_CollisionShape2D_extents_changed"]

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -6,11 +6,13 @@ Populates/unpopulates the creatures and obstacles on the overworld.
 export (NodePath) var creature_shadows_path: NodePath
 export (NodePath) var chat_icons_path: NodePath
 export (NodePath) var overworld_ui_path: NodePath
+export (NodePath) var player_path: NodePath
 export (PackedScene) var CreaturePackedScene: PackedScene
 
 onready var _creature_shadows: CreatureShadows = get_node(creature_shadows_path)
 onready var _chat_icons: ChatIcons = get_node(chat_icons_path)
 onready var _overworld_ui: OverworldUi = get_node(overworld_ui_path)
+onready var _player: Creature = get_node(player_path)
 
 func _ready() -> void:
 	if Scenario.launched_scenario_id:
@@ -23,11 +25,16 @@ func _ready() -> void:
 		# add the cutscene creatures
 		var creature: Creature = CreaturePackedScene.instance()
 		creature.creature_id = Scenario.launched_creature_id
-		creature.position = Vector2(444, 150)
 		creature.add_to_group("chattables")
 		$Obstacles.add_child(creature)
 		_chat_icons.create_icon(creature)
 		_creature_shadows.create_shadow(creature)
+		
+		# reposition the cutscene creatures, ensuring fat creatures have enough space
+		creature.position = _player.position
+		creature.position += Vector2(creature.chat_extents.x, 0)
+		creature.position += Vector2(_player.chat_extents.x, 0)
+		creature.position += Vector2(60, 0)
 		
 		_schedule_chat(creature)
 

--- a/project/src/main/world/restaurant/RestaurantScene.tscn
+++ b/project/src/main/world/restaurant/RestaurantScene.tscn
@@ -883,7 +883,6 @@ bus = "Sound Bus"
 script = ExtResource( 3 )
 
 [node name="ChimeTimer" type="Timer" parent="DoorChime"]
-wait_time = 0.5
 one_shot = true
 
 [node name="SuppressSfxTimer" type="Timer" parent="DoorChime"]

--- a/project/src/main/world/restaurant/door-chime.gd
+++ b/project/src/main/world/restaurant/door-chime.gd
@@ -17,6 +17,13 @@ func play_door_chime() -> void:
 	play()
 
 
+"""
+Temporarily suppresses door chime sounds.
+"""
+func start_suppress_sfx_timer() -> void:
+	$SuppressSfxTimer.start(1.0)
+
+
 func _on_CreatureVisuals_dna_loaded() -> void:
 	if not $SuppressSfxTimer.is_stopped():
 		# suppress door chime at the start of a scenario

--- a/project/src/main/world/restaurant/restaurant-scene.gd
+++ b/project/src/main/world/restaurant/restaurant-scene.gd
@@ -65,6 +65,13 @@ func get_customer(creature_index: int = -1) -> Creature:
 
 
 """
+Temporarily suppresses 'hello' and 'door chime' sounds.
+"""
+func start_suppress_sfx_timer() -> void:
+	$DoorChime.start_suppress_sfx_timer()
+
+
+"""
 Returns the seat with the specified optional index. Defaults to the seat of the creature being fed.
 """
 func _get_seat(seat_index: int = -1) -> Control:


### PR DESCRIPTION
Creatures are closer together during cutscenes, especially skinny
creatures.

Extracted 'SCENE_' constants into Global.

Can always restart puzzles, original creature shows up. Thematically it's
interesting to say 'you only get one chance' but this will frustrate players,
and there's no compelling gameplay reason to forbid players from retrying a
level.

Rewrote tutorial to use creature queue instead of custom logic.

Instead of checking 'is the fatness 1.0' to see if a creature has been
fed, it checks a custom 'feed_count' variable. Some creatures will
eventually be >1.0 fatness by default, so this logic is more robust.

Suppress sound effects when restarting level; restarting shouldn't play
chime and 'hello' sounds.

Fixed bug where quitting a puzzle while 'upbeat' music was playing caused
it to play on the main menu.