### PR TITLE
Creatures maintain their weight. Fixed camera listener bug.

### DIFF
--- a/project/src/main/creature-library.gd
+++ b/project/src/main/creature-library.gd
@@ -41,6 +41,12 @@ const DEFAULT_NAME := "Spira"
 
 var player_def: CreatureDef
 
+# fatnesses by creature id
+var _fatnesses: Dictionary
+
+# fatnesses saved to roll the tile map back to a previous state
+var _saved_fatnesses: Dictionary
+
 func reset() -> void:
 	# default player appearance and name
 	player_def = CreatureDef.new()
@@ -51,9 +57,45 @@ func reset() -> void:
 	player_def.chat_theme_def = DEFAULT_CHAT_THEME_DEF.duplicate()
 
 
+"""
+Saves the current fatness state so that we can roll back later.
+"""
+func save_fatness_state() -> void:
+	_saved_fatnesses = _fatnesses.duplicate()
+
+
+"""
+Restores the previously saved fatness state.
+
+This prevents a creature from gaining weight when retrying a level over and over.
+Thematically, we're turning back time.
+"""
+func restore_fatness_state() -> void:
+	_fatnesses = _saved_fatnesses.duplicate()
+
+
+func has_fatness(creature_id: String) -> bool:
+	if not creature_id:
+		return false
+	
+	return _fatnesses.has(creature_id)
+
+
+func get_fatness(creature_id: String) -> float:
+	return _fatnesses[creature_id]
+
+
+func set_fatness(creature_id: String, fatness: float) -> void:
+	if not creature_id:
+		return
+	
+	_fatnesses[creature_id] = fatness
+
+
 func to_json_dict() -> Dictionary:
 	return {
 		"#player#": player_def.to_json_dict(),
+		"fatnesses": _fatnesses,
 	}
 
 
@@ -61,3 +103,5 @@ func from_json_dict(json: Dictionary) -> void:
 	reset()
 	if json.has("#player#"):
 		player_def.from_json_dict(json.get("#player#", {}))
+	if json.has("fatnesses"):
+		_fatnesses = json.get("fatnesses")

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -192,7 +192,7 @@ func load_details(dna: Dictionary) -> void:
 
 
 func load_creature_def_by_id(id: String) -> CreatureDef:
-	return load_creature_def("res://assets/main/primary/%s/creature.json" % id)
+	return load_creature_def("res://assets/main/creatures/primary/%s/creature.json" % id)
 
 
 func load_creature_def(path: String) -> CreatureDef:
@@ -225,7 +225,9 @@ func _load_secondary_creatures() -> void:
 		if not file:
 			break
 		else:
-			_secondary_creature_queue.append(load_creature_def("%s/%s" % [dir.get_current_dir(), file.get_file()]))
+			var creature_def := load_creature_def("%s/%s" % [dir.get_current_dir(), file.get_file()])
+			creature_def.creature_id = file.get_file().get_basename()
+			_secondary_creature_queue.append(creature_def)
 	dir.list_dir_end()
 	_secondary_creature_queue.shuffle()
 

--- a/project/src/main/world/restaurant/customer-camera-mover.gd
+++ b/project/src/main/world/restaurant/customer-camera-mover.gd
@@ -24,7 +24,7 @@ onready var _customer_camera: Camera2D = get_node(customer_camera_path)
 func _ready() -> void:
 	var customers := _restaurant_scene.get_customers()
 	for i in range(0, customers.size()):
-		customers[i].connect("visual_fatness_changed", self, "_on_Creature_visual_fatness_changed", [0])
+		customers[i].connect("visual_fatness_changed", self, "_on_Creature_visual_fatness_changed", [i])
 	_refresh_target_camera_position()
 	_customer_camera.position = target_camera_position
 


### PR DESCRIPTION
Overworld creatures like Bort, Ebe and Boatricia appear fat on the
overworld and during puzzles if they eat too much. Secondary creatures
like Pandon, Mocha and Nardine maintain their weight from puzzle to puzzle
as well.

Fixed camera listener bug introduced in a0d9389e. Instead of registering a
listener on all three creatures, it was only being registered on the
first.