### PR TITLE
Generic filler creatures get fatter over time.

### DIFF
--- a/project/src/main/creature-library.gd
+++ b/project/src/main/creature-library.gd
@@ -5,6 +5,14 @@ Manages data for all creatures in the world, including the player.
 This includes their appearance, name and weight.
 """
 
+# How many randomly generated filler creatures have their fatness tracked
+const GENERIC_FATNESS_COUNT := 150
+
+# The maximum fatness we'll save for a randomly generated filler creature. We don't want a random creature the player
+# has never seen who weighs 10,000 pounds; it would sort of break immersion as they'd wonder "who fed this person!? it
+# wasn't me"
+const MAX_FILLER_FATNESS := 2.5
+
 # default chat theme when starting a new game
 const DEFAULT_CHAT_THEME_DEF := {
 	"accent_scale": 1.33,
@@ -48,6 +56,27 @@ var _fatnesses: Dictionary
 # fatnesses saved to roll the tile map back to a previous state
 var _saved_fatnesses: Dictionary
 
+# In addition to storing known fatness attributes like "Ebe's weight is 2.5", we store fatnesses for randomly
+# generated filler creatures. We rotate their IDs to avoid edge cases where two creatures have the same ID.
+var _filler_ids: Array
+
+func _init() -> void:
+	_normalize_filler_fatnesses()
+
+
+"""
+Returns a filler ID.
+
+Pushes the filler ID somewhere toward the back of the queue. The position is slightly randomized to prevent cycles
+from emerging.
+"""
+func next_filler_id() -> String:
+	var filler_id: String = _filler_ids.pop_front()
+	# warning-ignore:integer_division
+	_filler_ids.insert(_filler_ids.size() - randi() % (_filler_ids.size() / 2), filler_id)
+	return filler_id
+
+
 func reset() -> void:
 	# default player appearance and name
 	player_def = CreatureDef.new()
@@ -83,6 +112,9 @@ func has_fatness(creature_id: String) -> bool:
 
 
 func get_fatness(creature_id: String) -> float:
+	if not creature_id:
+		return 1.0
+	
 	return _fatnesses[creature_id]
 
 
@@ -90,19 +122,37 @@ func set_fatness(creature_id: String, fatness: float) -> void:
 	if not creature_id:
 		return
 	
+	if creature_id.begins_with("#filler"):
+		fatness = min(fatness, MAX_FILLER_FATNESS)
 	_fatnesses[creature_id] = fatness
 
 
 func to_json_dict() -> Dictionary:
 	return {
-		"#player#": player_def.to_json_dict(),
+		Global.CREATURE_ID_PLAYER: player_def.to_json_dict(),
 		"fatnesses": _fatnesses,
 	}
 
 
 func from_json_dict(json: Dictionary) -> void:
 	reset()
-	if json.has("#player#"):
-		player_def.from_json_dict(json.get("#player#", {}))
+	if json.has(Global.CREATURE_ID_PLAYER):
+		player_def.from_json_dict(json.get(Global.CREATURE_ID_PLAYER, {}))
 	if json.has("fatnesses"):
 		_fatnesses = json.get("fatnesses")
+		_normalize_filler_fatnesses()
+
+
+"""
+Populates the fatness for randomly generated filler creatures.
+"""
+func _normalize_filler_fatnesses() -> void:
+	for i in range(GENERIC_FATNESS_COUNT):
+		var filler_id := "#filler-%03d#" % i
+		_filler_ids.append(filler_id)
+		if not _fatnesses.has(filler_id):
+			# The initial creature generation is biased toward the thin side of things. That way the progression is
+			# more noticable as the generic creatures fatten up.
+			_fatnesses[filler_id] = min(Utils.rand_value(Global.FATNESSES), Utils.rand_value(Global.FATNESSES))
+	
+	_filler_ids.shuffle()

--- a/project/src/main/editor/creature/TweakSizeRow.tscn
+++ b/project/src/main/editor/creature/TweakSizeRow.tscn
@@ -5,7 +5,6 @@
 [ext_resource path="res://assets/main/editor/creature/edit.png" type="Texture" id=3]
 [ext_resource path="res://src/main/editor/creature/tweak-size-row.gd" type="Script" id=4]
 
-
 [node name="Size" type="HBoxContainer"]
 margin_top = 394.0
 margin_right = 306.0

--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -17,13 +17,6 @@ const RANDOM_COLORS := ColorMode.RANDOM_COLORS
 const THEME_COLORS := ColorMode.THEME_COLORS
 const SIMILAR_COLORS := ColorMode.SIMILAR_COLORS
 
-# weighted distribution of 'fatnesses' in the range [1.0, 10.0]. most creatures are skinny.
-const FATNESSES := [
-	1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
-	1.1, 1.2, 1.3, 1.5,
-	1.8, 2.3,
-]
-
 var _rng := RandomNumberGenerator.new()
 var _next_line_color_index := 0
 
@@ -124,7 +117,7 @@ func _mutate_allele(creature: Creature, dna: Dictionary, new_palette: Dictionary
 			creature.creature_name = _name_generator.generate_name()
 			creature.creature_short_name = NameUtils.sanitize_short_name(creature.creature_name)
 		"fatness":
-			var new_fatnesses := FATNESSES.duplicate()
+			var new_fatnesses := Global.FATNESSES.duplicate()
 			while new_fatnesses.has(creature.get_visual_fatness()):
 				new_fatnesses.erase(creature.get_visual_fatness())
 			var new_fatness: float = Utils.rand_value(new_fatnesses)
@@ -259,7 +252,7 @@ func _tweak_creature(creature: Creature, allele: String, color_mode: int) -> voi
 			creature.creature_name = _name_generator.generate_name()
 			creature.creature_short_name = NameUtils.sanitize_short_name(creature.creature_name)
 		"fatness":
-			var new_fatnesses := FATNESSES.duplicate()
+			var new_fatnesses := Global.FATNESSES.duplicate()
 			while new_fatnesses.has(creature.get_visual_fatness()):
 				new_fatnesses.erase(creature.get_visual_fatness())
 			var new_fatness: float = Utils.rand_value(new_fatnesses)

--- a/project/src/main/global.gd
+++ b/project/src/main/global.gd
@@ -15,6 +15,15 @@ const SCENE_OVERWORLD := "res://src/main/world/Overworld.tscn"
 # puzzle where a player drops pieces into a playfield of blocks.
 const SCENE_PUZZLE := "res://src/main/puzzle/Puzzle.tscn"
 
+# weighted distribution of 'fatnesses' in the range [1.0, 10.0]. most creatures are skinny.
+const FATNESSES := [
+	1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+	1.1, 1.2, 1.3, 1.5,
+	1.8, 2.3,
+]
+
+const CREATURE_ID_PLAYER := "#player#"
+
 # The factor to multiply by to convert non-isometric coordinates into isometric coordinates
 const ISO_FACTOR := Vector2(1.0, 0.5)
 

--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -22,7 +22,7 @@ func _ready() -> void:
 
 func _launch_tutorial() -> void:
 	Global.clear_creature_queue()
-	var creature_def := CreatureLoader.load_creature_def_by_id("instructor")
+	var creature_def := CreatureLoader.load_creature_def("res://assets/main/creatures/instructor/creature.json")
 	Global.creature_queue.push_front(creature_def)
 	Scenario.set_launched_scenario(Scenario.BEGINNER_TUTORIAL)
 	Scenario.push_scenario_trail()

--- a/project/src/main/world/chattable-manager.gd
+++ b/project/src/main/world/chattable-manager.gd
@@ -88,7 +88,7 @@ func clear() -> void:
 
 func set_player(new_player: Player) -> void:
 	player = new_player
-	add_chat_theme_def("#player#", player.get_meta("chat_theme_def"))
+	add_chat_theme_def(Global.CREATURE_ID_PLAYER, player.get_meta("chat_theme_def"))
 
 
 """
@@ -136,7 +136,7 @@ dialog line. This function facilitates that.
 """
 func get_chatter(chat_name: String) -> Node2D:
 	var chatter: Node2D
-	if chat_name == "#player#":
+	if chat_name == Global.CREATURE_ID_PLAYER:
 		chatter = player
 	else:
 		for chattable_obj in get_tree().get_nodes_in_group("chattables"):
@@ -178,7 +178,7 @@ Text variables are pound sign delimited: 'Hello #player#'. This matches the synt
 func substitute_variables(string: String, full_name: bool = false) -> String:
 	var result := string
 	if full_name:
-		result = result.replace("#player#", PlayerData.creature_library.player_def.creature_name)
+		result = result.replace(Global.CREATURE_ID_PLAYER, PlayerData.creature_library.player_def.creature_name)
 	else:
-		result = result.replace("#player#", PlayerData.creature_library.player_def.creature_short_name)
+		result = result.replace(Global.CREATURE_ID_PLAYER, PlayerData.creature_library.player_def.creature_short_name)
 	return result

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -86,6 +86,9 @@ func random_def() -> CreatureDef:
 		result.creature_name = _name_generator.generate_name()
 		result.creature_short_name = NameUtils.sanitize_short_name(result.creature_name)
 		result.chat_theme_def = chat_theme_def(result.dna)
+		# set the filler ID, but not the fatness. the fatness attribute in the CreatureDef is the creature's natural
+		# fatness -- not their fatness after being stuffed
+		result.creature_id = PlayerData.creature_library.next_filler_id()
 	return result
 
 


### PR DESCRIPTION
The filler characters weight isn't generated from scratch; it's now
pulled from a pool of 150 filler weights. If the player plays well these
weights will increase, if they play poorly their weights will decrease.

Extracted CREATURE_ID_PLAYER constant.

Moved CreatureEditor.FATNESSES constant into Global, so it can be reused
by CreatureLibrary.