### PR TITLE
FileDialogs default to better paths.

### DIFF
--- a/license/asset-license.txt
+++ b/license/asset-license.txt
@@ -44,8 +44,8 @@ project/assets/main/puzzle/move.wav "\Cooking_Game_16bit\Cooking_Game_16bit\Ingr
 project/assets/main/puzzle/presquish.wav "Foley Rubber Glove 1" by Epidemic Sound
 project/assets/main/puzzle/rotate0.wav "\Cooking_Game_16bit\Cooking_Game_16bit\Ingredient_Pickup\Cooking_Game_Ingredient_Pickup_Water_03.wav"
 project/assets/main/puzzle/rotate1.wav "\Cooking_Game_16bit\Cooking_Game_16bit\Ingredient_Pickup\Cooking_Game_Ingredient_Pickup_Water_03.wav"
-project/assets/main/puzzle/scenario/tutorial-section-complete.wav "\GameBurp - 2000 Game Sound FX Collection (WAV)\SUCCESS - CHIMES - (55)\SUCCESS CHIME Bells Sparkle Tune Short 06.wav"
-project/assets/main/puzzle/scenario/tutorial-task-complete.wav "\GameBurp - 2000 Game Sound FX Collection (WAV)\SUCCESS - CHIMES - (55)\SUCCESS CHIME Bells Sparkle Tune Short 05.wav"
+project/assets/main/puzzle/tutorial/tutorial-section-complete.wav "\GameBurp - 2000 Game Sound FX Collection (WAV)\SUCCESS - CHIMES - (55)\SUCCESS CHIME Bells Sparkle Tune Short 06.wav"
+project/assets/main/puzzle/tutorial/tutorial-task-complete.wav "\GameBurp - 2000 Game Sound FX Collection (WAV)\SUCCESS - CHIMES - (55)\SUCCESS CHIME Bells Sparkle Tune Short 05.wav"
 project/assets/main/puzzle/smash.wav "\Cooking_Game_16bit\Cooking_Game_16bit\Ingredient_Pickup\Cooking_Game_Ingredient_Pickup_Squish_04.wav"
 project/assets/main/puzzle/veg-erase.wav "\Cooking_Game_16bit\Cooking_Game_16bit\Cooking_Actions\Organic_Actions\Cooking_Game_Actions_Squish_Vegetable_02.wav" 
 project/assets/main/ui/chat/emote-*.wav "Developed using Jonathan Murphy's TS-808 emulator, licensed under the Creative Commons Attribution-Noncommercial-NoDerivative Works 3.0 Australia License. Consider donating at http://tactilesounds.blogspot.com/"

--- a/project/src/main/editor/creature/CreatureEditor.tscn
+++ b/project/src/main/editor/creature/CreatureEditor.tscn
@@ -1792,8 +1792,9 @@ window_title = "Open a File"
 mode = 0
 access = 2
 filters = PoolStringArray( "*.json" )
-current_dir = "/workspace/turbofat/project"
-current_path = "/workspace/turbofat/project/"
+current_dir = "/"
+current_file = "509e7c82-9399-425a-9f15-9370c2b3de8b"
+current_path = "/509e7c82-9399-425a-9f15-9370c2b3de8b"
 
 [node name="Export" type="FileDialog" parent="Ui/Dialogs"]
 anchor_left = 0.5
@@ -1807,8 +1808,9 @@ margin_bottom = 480.0
 popup_exclusive = true
 window_title = "Export Creature"
 access = 2
-current_dir = "/workspace/turbofat/project"
-current_path = "/workspace/turbofat/project/"
+current_dir = "/"
+current_file = "509e7c82-9399-425a-9f15-9370c2b3de8b"
+current_path = "/509e7c82-9399-425a-9f15-9370c2b3de8b"
 
 [node name="Error" type="AcceptDialog" parent="Ui/Dialogs"]
 margin_right = 250.0

--- a/project/src/main/editor/creature/dialogs.gd
+++ b/project/src/main/editor/creature/dialogs.gd
@@ -17,6 +17,7 @@ func _on_ImportButton_pressed() -> void:
 		_show_import_export_not_supported_error()
 		return
 	
+	Utils.assign_default_dialog_path($Import, "res://assets/main/creatures/secondary/")
 	$Import.popup_centered()
 
 
@@ -38,6 +39,7 @@ func _on_ExportButton_pressed() -> void:
 		_show_import_export_not_supported_error()
 		return
 	
+	Utils.assign_default_dialog_path($Export, "res://assets/main/creatures/secondary/")
 	var exported_creature: Creature = _creature_editor.center_creature
 	var sanitized_creature_name := StringUtils.sanitize_file_root(exported_creature.creature_short_name)
 	$Export.current_file = "%s.json" % sanitized_creature_name

--- a/project/src/main/editor/puzzle/LevelEditor.tscn
+++ b/project/src/main/editor/puzzle/LevelEditor.tscn
@@ -405,7 +405,7 @@ __meta__ = {
 
 [node name="Backdrop" parent="Dialogs" instance=ExtResource( 15 )]
 
-[node name="OpenFileDialog" type="FileDialog" parent="Dialogs"]
+[node name="OpenFile" type="FileDialog" parent="Dialogs"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -419,14 +419,14 @@ window_title = "Open a File"
 mode = 0
 access = 2
 filters = PoolStringArray( "*.json" )
-current_dir = "/workspace/turbofat"
-current_file = "boatricia.json"
-current_path = "/workspace/turbofat/boatricia.json"
+current_dir = "/"
+current_file = "509e7c82-9399-425a-9f15-9370c2b3de8b"
+current_path = "/509e7c82-9399-425a-9f15-9370c2b3de8b"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="OpenResourceDialog" type="FileDialog" parent="Dialogs"]
+[node name="OpenResource" type="FileDialog" parent="Dialogs"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -445,7 +445,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="SaveDialog" type="FileDialog" parent="Dialogs"]
+[node name="Save" type="FileDialog" parent="Dialogs"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -456,9 +456,9 @@ margin_right = 792.0
 margin_bottom = 480.0
 popup_exclusive = true
 access = 2
-current_dir = "/workspace/turbofat"
-current_file = "boatricia.json"
-current_path = "/workspace/turbofat/boatricia.json"
+current_dir = "/"
+current_file = "509e7c82-9399-425a-9f15-9370c2b3de8b"
+current_path = "/509e7c82-9399-425a-9f15-9370c2b3de8b"
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -479,15 +479,15 @@ dialog_autowrap = true
 [connection signal="text_changed" from="HBoxContainer/SideButtons/Json" to="HBoxContainer/SideButtons/Json" method="_on_text_changed"]
 [connection signal="pressed" from="HBoxContainer/SideButtons/Settings" to="SettingsMenu" method="_on_Settings_pressed"]
 [connection signal="pressed" from="HBoxContainer/SideButtons/Quit" to="." method="_on_Quit_pressed"]
-[connection signal="about_to_show" from="Dialogs/OpenFileDialog" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
-[connection signal="file_selected" from="Dialogs/OpenFileDialog" to="Dialogs" method="_on_OpenFileDialog_file_selected"]
-[connection signal="popup_hide" from="Dialogs/OpenFileDialog" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
-[connection signal="about_to_show" from="Dialogs/OpenResourceDialog" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
-[connection signal="file_selected" from="Dialogs/OpenResourceDialog" to="Dialogs" method="_on_OpenResourceDialog_file_selected"]
-[connection signal="popup_hide" from="Dialogs/OpenResourceDialog" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
-[connection signal="about_to_show" from="Dialogs/SaveDialog" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
-[connection signal="file_selected" from="Dialogs/SaveDialog" to="Dialogs" method="_on_SaveDialog_file_selected"]
-[connection signal="popup_hide" from="Dialogs/SaveDialog" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
+[connection signal="about_to_show" from="Dialogs/OpenFile" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
+[connection signal="file_selected" from="Dialogs/OpenFile" to="Dialogs" method="_on_OpenFile_file_selected"]
+[connection signal="popup_hide" from="Dialogs/OpenFile" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
+[connection signal="about_to_show" from="Dialogs/OpenResource" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
+[connection signal="file_selected" from="Dialogs/OpenResource" to="Dialogs" method="_on_OpenResource_file_selected"]
+[connection signal="popup_hide" from="Dialogs/OpenResource" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
+[connection signal="about_to_show" from="Dialogs/Save" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
+[connection signal="file_selected" from="Dialogs/Save" to="Dialogs" method="_on_Save_file_selected"]
+[connection signal="popup_hide" from="Dialogs/Save" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
 [connection signal="about_to_show" from="Dialogs/Error" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
 [connection signal="popup_hide" from="Dialogs/Error" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
 [connection signal="quit_pressed" from="SettingsMenu" to="." method="_on_Quit_pressed"]

--- a/project/src/main/editor/puzzle/dialogs.gd
+++ b/project/src/main/editor/puzzle/dialogs.gd
@@ -10,15 +10,15 @@ func _show_save_load_not_supported_error() -> void:
 	$Error.popup_centered()
 
 
-func _on_OpenResourceDialog_file_selected(path: String) -> void:
+func _on_OpenResource_file_selected(path: String) -> void:
 	_level_editor.load_scenario(path)
 
 
-func _on_OpenFileDialog_file_selected(path: String) -> void:
+func _on_OpenFile_file_selected(path: String) -> void:
 	_level_editor.load_scenario(path)
 
 
-func _on_SaveDialog_file_selected(path: String) -> void:
+func _on_Save_file_selected(path: String) -> void:
 	_level_editor.save_scenario(path)
 
 
@@ -27,11 +27,12 @@ func _on_OpenFile_pressed() -> void:
 		_show_save_load_not_supported_error()
 		return
 	
-	$OpenFileDialog.popup_centered()
+	Utils.assign_default_dialog_path($OpenFile, "res://assets/main/puzzle/scenario/")
+	$OpenFile.popup_centered()
 
 
 func _on_OpenResource_pressed() -> void:
-	$OpenResourceDialog.popup_centered()
+	$OpenResource.popup_centered()
 
 
 func _on_Save_pressed() -> void:
@@ -39,6 +40,7 @@ func _on_Save_pressed() -> void:
 		_show_save_load_not_supported_error()
 		return
 	
+	Utils.assign_default_dialog_path($Save, "res://assets/main/puzzle/scenario/")
 	var file_root := StringUtils.sanitize_file_root(_level_editor.scenario_name.text)
-	$SaveDialog.current_file = ScenarioSettings.scenario_filename(file_root)
-	$SaveDialog.popup_centered()
+	$Save.current_file = ScenarioSettings.scenario_filename(file_root)
+	$Save.popup_centered()

--- a/project/src/main/file-utils.gd
+++ b/project/src/main/file-utils.gd
@@ -5,6 +5,7 @@ Utility class for file operations.
 Many of these were adopted from the Gut library.
 """
 
+
 static func file_exists(path: String) -> bool:
 	var f := File.new()
 	var exists := f.file_exists(path)

--- a/project/src/main/utils.gd
+++ b/project/src/main/utils.gd
@@ -212,3 +212,21 @@ static func subtract(a: Array, b: Array) -> Array:
 		else:
 			result.append(item)
 	return result
+
+
+"""
+Assigns a default path for a FileDialog.
+
+At runtime, this will default to the user's data directory. During development, this will default to a resource path
+for convenience when authoring Turbo Fat's creature's/scenarios.
+
+Note: We only want to assign the path the first time, but we can't check 'is the path empty' because an empty path is a
+valid choice -- a user can navigate to the root directory. So instead of checking 'is the path empty' we check 'is the
+path this specific UUID' since that's something the user will never navigate to accidentally.
+"""
+static func assign_default_dialog_path(dialog: FileDialog, default_resource_path: String) -> void:
+	if dialog.current_path == "/509e7c82-9399-425a-9f15-9370c2b3de8b":
+		var current_path := ProjectSettings.globalize_path(default_resource_path)
+		if not Directory.new().dir_exists(current_path):
+			current_path = OS.get_user_data_dir()
+		dialog.current_path = current_path


### PR DESCRIPTION
With the old behavior, I had '/workspace/turbofat/project' hard-coded in
these FileDialogs which worked OK on my computer, but would just default
to 'C:\' on other people's computers.

I've changed the file dialogs to locate specific resource paths if
available (if you're running the game in the Godot editor) and, if
unavailable, it'll default to the user's data directory. (I would rather
default to something like 'My Documents' but this appears to be
unsupported.)

Renamed LevelEditor dialog nodes to avoid redundancy in paths like
'Dialogs/OpenFileDialog'.

Fixed some asset license paths.