### PR TITLE
Fixed 'weird chin' bug.

### DIFF
--- a/project/src/main/world/creature/Mouth3Player.tscn
+++ b/project/src/main/world/creature/Mouth3Player.tscn
@@ -76,6 +76,18 @@ tracks/0/keys = {
 "update": 1,
 "values": [ 5, 6, 7, 6, 5 ]
 }
+tracks/1/type = "value"
+tracks/1/path = NodePath("Neck0/HeadBobber/Chin:frame")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0, 4.00001 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ 1, 1 ]
+}
 
 [sub_resource type="Animation" id=4]
 length = 0.6


### PR DESCRIPTION
When the creature yawned while an emote was launched, the chin didn't
reset appropriately. This was because of a missing chin animation key.

Closes #656.