### PR TITLE
Fix ObjectDB leaks introduced in 507ea7b

### DIFF
--- a/project/src/main/puzzle/tutorial/skill-tally-item.gd
+++ b/project/src/main/puzzle/tutorial/skill-tally-item.gd
@@ -68,16 +68,6 @@ func increment() -> void:
 
 
 """
-Duplicates the SkillTallyItem, reconnecting all playfield and piece manager signals in the new node.
-"""
-func duplicate(flags: int = 15) -> Node:
-	var result: SkillTallyItem = .duplicate(flags)
-	# reconnect signals from piece manager and playfield
-	result.puzzle = puzzle
-	return result
-
-
-"""
 Initializes this node when the puzzle field is assigned.
 
 Connects the signals in 'signal_names' to the appropriate nodes.

--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -20,5 +20,7 @@ func _ready() -> void:
 	piece_manager = puzzle.get_piece_manager()
 	
 	for skill_tally_item in $SkillTallyItems.get_children():
-		skill_tally_item.puzzle = hud.puzzle
-		hud.add_skill_tally_item(skill_tally_item.duplicate())
+		if skill_tally_item is SkillTallyItem:
+			var new_item: SkillTallyItem = skill_tally_item.duplicate()
+			new_item.puzzle = hud.puzzle
+			hud.add_skill_tally_item(new_item)


### PR DESCRIPTION
For some reason, the old duplicate() implementation I had causes ObjectDB
leaks even when the method is renamed, and even when it is never invoked.
It is very strange.