### PR TITLE
Scenarios can now impose a piece limit.

### DIFF
--- a/project/assets/main/puzzle/levels/accelerator.json
+++ b/project/assets/main/puzzle/levels/accelerator.json
@@ -1,0 +1,30 @@
+{
+  "version": "19c5",
+  "start_speed": "2",
+  "title": "Accelerator",
+  "description": "Hurry up and finish before things get out of control!",
+  "finish_condition": {
+    "type": "score",
+    "value": "800"
+  },
+  "speed_ups": [
+    {"type": "pieces", "value": "4", "speed": "1"},
+    {"type": "pieces", "value": "8", "speed": "2"},
+    {"type": "pieces", "value": "12", "speed": "3"},
+    {"type": "pieces", "value": "16", "speed": "4"},
+
+    {"type": "pieces", "value": "40", "speed": "5"},
+    {"type": "pieces", "value": "44", "speed": "6"},
+    {"type": "pieces", "value": "48", "speed": "7"},
+    {"type": "pieces", "value": "52", "speed": "8"},
+    {"type": "pieces", "value": "56", "speed": "9"},
+
+    {"type": "pieces", "value": "80", "speed": "A1"},
+    {"type": "pieces", "value": "84", "speed": "A2"},
+    {"type": "pieces", "value": "88", "speed": "A3"},
+    {"type": "pieces", "value": "92", "speed": "A4"},
+    {"type": "pieces", "value": "96", "speed": "A5"},
+
+    {"type": "pieces", "value": "120", "speed": "AA"}
+  ]
+}

--- a/project/assets/main/puzzle/levels/veggie-patty.json
+++ b/project/assets/main/puzzle/levels/veggie-patty.json
@@ -1,0 +1,89 @@
+{
+  "version": "19c5",
+  "start_speed": "4",
+  "title": "Veggie Patty",
+  "description": "Twice the pace and half the space? ...This is a recipe for disaster!",
+  "finish_condition": {
+    "type": "pieces",
+    "value": "80"
+  },
+  "lose_condition": [
+    "top_out 1"
+  ],
+  "blocks_start": {
+    "tiles": [
+      {
+        "pos": "0 11",
+        "tile": "2 2 2"
+      },
+      {
+        "pos": "1 11",
+        "tile": "2 12 2"
+      },
+      {
+        "pos": "4 11",
+        "tile": "2 17 3"
+      },
+      {
+        "pos": "5 11",
+        "tile": "2 9 0"
+      },
+      {
+        "pos": "6 11",
+        "tile": "2 6 3"
+      },
+      {
+        "pos": "0 12",
+        "tile": "2 7 2"
+      },
+      {
+        "pos": "1 12",
+        "tile": "2 3 2"
+      },
+      {
+        "pos": "2 12",
+        "tile": "2 6 3"
+      },
+      {
+        "pos": "3 12",
+        "tile": "2 16 1"
+      },
+      {
+        "pos": "5 12",
+        "tile": "2 5 1"
+      },
+      {
+        "pos": "6 12",
+        "tile": "2 14 1"
+      },
+      {
+        "pos": "7 12",
+        "tile": "2 0 3"
+      },
+      {
+        "pos": "8 12",
+        "tile": "2 7 0"
+      },
+      {
+        "pos": "2 13",
+        "tile": "2 2 0"
+      },
+      {
+        "pos": "3 13",
+        "tile": "2 10 3"
+      },
+      {
+        "pos": "4 13",
+        "tile": "2 8 2"
+      },
+      {
+        "pos": "7 13",
+        "tile": "2 5 1"
+      },
+      {
+        "pos": "8 13",
+        "tile": "2 14 2"
+      }
+    ]
+  }
+}

--- a/project/assets/main/puzzle/worlds.json
+++ b/project/assets/main/puzzle/worlds.json
@@ -102,6 +102,11 @@
           "groups": "choco_main"
         },
         {
+          "id": "veggie_patty",
+          "creature_id": "bort",
+          "locked_until": "group_finished choco_main 5"
+        },
+        {
           "id": "placeholder10",
           "creature_id": "bort",
           "locked_until": "group_finished choco_main 5"
@@ -123,6 +128,10 @@
         },
         {
           "id": "placeholder15",
+          "creature_id": "wesker"
+        },
+        {
+          "id": "accelerator",
           "creature_id": "wesker"
         }
       ]

--- a/project/src/main/editor/puzzle/level-editor.gd
+++ b/project/src/main/editor/puzzle/level-editor.gd
@@ -6,7 +6,7 @@ A graphical level editor which lets players create, load and save levels.
 Full instructions are available at https://github.com/Poobslag/turbofat/wiki/level-editor
 """
 
-const DEFAULT_LEVEL := "ultra-normal"
+const DEFAULT_LEVEL := "veggie_patty"
 
 # level scene currently being tested
 var _test_scene: Node

--- a/project/src/main/puzzle/duration-calculator.gd
+++ b/project/src/main/puzzle/duration-calculator.gd
@@ -44,6 +44,8 @@ func duration(settings: LevelSettings) -> float:
 			result = _duration_for_lines(settings, lines)
 		Milestone.LINES:
 			result = _duration_for_lines(settings, settings.finish_condition.value)
+		Milestone.PIECES:
+			result = _duration_for_lines(settings, settings.finish_condition.value * 2)
 		Milestone.TIME_OVER:
 			result = settings.finish_condition.value
 		Milestone.CUSTOMERS:

--- a/project/src/main/puzzle/level/milestone.gd
+++ b/project/src/main/puzzle/level/milestone.gd
@@ -10,6 +10,7 @@ enum MilestoneType {
 	NONE,
 	CUSTOMERS,
 	LINES,
+	PIECES,
 	SCORE,
 	TIME_OVER,
 	TIME_UNDER,
@@ -18,6 +19,7 @@ enum MilestoneType {
 const NONE := MilestoneType.NONE
 const CUSTOMERS := MilestoneType.CUSTOMERS
 const LINES := MilestoneType.LINES
+const PIECES := MilestoneType.PIECES
 const SCORE := MilestoneType.SCORE
 const TIME_OVER := MilestoneType.TIME_OVER
 const TIME_UNDER := MilestoneType.TIME_UNDER
@@ -27,6 +29,7 @@ const JSON_MILESTONE_TYPES := {
 	"none": MilestoneType.NONE,
 	"customers": MilestoneType.CUSTOMERS,
 	"lines": MilestoneType.LINES,
+	"pieces": MilestoneType.PIECES,
 	"score": MilestoneType.SCORE,
 	"time_over": MilestoneType.TIME_OVER,
 	"time_under": MilestoneType.TIME_UNDER,

--- a/project/src/main/puzzle/milestone-hud.gd
+++ b/project/src/main/puzzle/milestone-hud.gd
@@ -26,6 +26,8 @@ func _ready() -> void:
 			$Desc.text = "Customers"
 		Milestone.LINES:
 			$Desc.text = "Lines"
+		Milestone.PIECES:
+			$Desc.text = "Pieces"
 		Milestone.SCORE:
 			$Desc.text = "Money"
 		Milestone.TIME_OVER:
@@ -60,7 +62,7 @@ func update_milebar_text() -> void:
 	match milestone.type:
 		Milestone.NONE:
 			$Value.text = "-"
-		Milestone.CUSTOMERS, Milestone.LINES:
+		Milestone.CUSTOMERS, Milestone.LINES, Milestone.PIECES:
 			$Value.text = StringUtils.comma_sep(remaining)
 		Milestone.SCORE:
 			$Value.text = "¥%s" % StringUtils.comma_sep(remaining)

--- a/project/src/main/puzzle/piece/NextPieceDisplay.tscn
+++ b/project/src/main/puzzle/piece/NextPieceDisplay.tscn
@@ -1,9 +1,16 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://src/main/puzzle/piece/next-piece-display.gd" type="Script" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleTileMap.tscn" type="PackedScene" id=2]
+[ext_resource path="res://src/main/puzzle/flat-mix.shader" type="Shader" id=3]
+
+[sub_resource type="ShaderMaterial" id=1]
+resource_local_to_scene = true
+shader = ExtResource( 3 )
+shader_param/mix_color = Color( 1, 1, 1, 0 )
 
 [node name="NextPieceDisplay" type="Node2D"]
 script = ExtResource( 1 )
 
 [node name="TileMap" parent="." instance=ExtResource( 2 )]
+material = SubResource( 1 )

--- a/project/src/main/puzzle/piece/next-piece-display.gd
+++ b/project/src/main/puzzle/piece/next-piece-display.gd
@@ -24,16 +24,17 @@ func initialize(piece_queue: PieceQueue, piece_index: int) -> void:
 func _process(_delta: float) -> void:
 	var next_piece := _piece_queue.get_next_piece(_piece_index)
 	if next_piece != _displayed_piece:
-		var bounding_box := Rect2(next_piece.get_cell_position(UNROTATED, 0), Vector2(1.0, 1.0))
-		# update the tile map with the new piece type
 		$TileMap.clear()
-		for i in range(next_piece.pos_arr[0].size()):
-			var block_pos := next_piece.get_cell_position(UNROTATED, i)
-			var block_color := next_piece.get_cell_color(UNROTATED, i)
-			$TileMap.set_block(block_pos, 0, block_color)
-			bounding_box = bounding_box.expand(next_piece.get_cell_position(UNROTATED, i))
-			bounding_box = bounding_box.expand(next_piece.get_cell_position(UNROTATED, i) + Vector2(1, 1))
-		$TileMap/CornerMap.dirty = true
-		_displayed_piece = next_piece
-		$TileMap.position = $TileMap.cell_size \
-				* (Vector2(1.5, 1.5) - (bounding_box.position + bounding_box.size / 2.0)) / 2.0
+		if next_piece != PieceTypes.piece_null:
+			var bounding_box := Rect2(next_piece.get_cell_position(UNROTATED, 0), Vector2(1.0, 1.0))
+			# update the tile map with the new piece type
+			for i in range(next_piece.pos_arr[0].size()):
+				var block_pos := next_piece.get_cell_position(UNROTATED, i)
+				var block_color := next_piece.get_cell_color(UNROTATED, i)
+				$TileMap.set_block(block_pos, 0, block_color)
+				bounding_box = bounding_box.expand(next_piece.get_cell_position(UNROTATED, i))
+				bounding_box = bounding_box.expand(next_piece.get_cell_position(UNROTATED, i) + Vector2(1, 1))
+			$TileMap/CornerMap.dirty = true
+			_displayed_piece = next_piece
+			$TileMap.position = $TileMap.cell_size \
+					* (Vector2(1.5, 1.5) - (bounding_box.position + bounding_box.size / 2.0)) / 2.0

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -106,10 +106,13 @@ func write_piece(pos: Vector2, orientation: int, type: PieceType, death_piece :=
 		$BoxBuilder.process_boxes()
 		$LineClearer.schedule_full_row_line_clears()
 	
+	PuzzleScore.before_piece_written()
+	
 	if $BoxBuilder.remaining_box_build_frames == 0 and $LineClearer.remaining_line_erase_frames == 0:
 		# If any boxes are being built or lines are being cleared, we emit the
 		# signal later. Otherwise we emit it now.
 		emit_signal("after_piece_written")
+		PuzzleScore.after_piece_written()
 
 
 func break_combo() -> void:
@@ -146,6 +149,7 @@ func _on_BoxBuilder_after_boxes_built() -> void:
 		$LineClearer.set_physics_process(true)
 	else:
 		emit_signal("after_piece_written")
+		PuzzleScore.after_piece_written()
 
 
 func _on_LineClearer_before_line_cleared(y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
@@ -163,6 +167,7 @@ func _on_LineClearer_line_cleared(y: int, total_lines: int, remaining_lines: int
 func _on_LineClearer_lines_deleted(lines: Array) -> void:
 	emit_signal("lines_deleted", lines)
 	emit_signal("after_piece_written")
+	PuzzleScore.after_piece_written()
 
 
 func _on_FrostingGlobs_hit_playfield(glob: Node) -> void:

--- a/project/src/main/puzzle/puzzle-performance.gd
+++ b/project/src/main/puzzle/puzzle-performance.gd
@@ -10,6 +10,9 @@ var seconds := 0.0
 # raw number of cleared lines, not including bonus points
 var lines := 0
 
+# number of pieces placed
+var pieces := 0
+
 # bonus points awarded for clearing boxes
 var box_score := 0
 

--- a/project/src/main/puzzle/puzzle-score.gd
+++ b/project/src/main/puzzle/puzzle-score.gd
@@ -31,6 +31,13 @@ signal after_game_ended
 signal speed_index_changed(value)
 
 signal added_line_score(combo_score, box_score)
+
+# emitted on the frame that the player drops and locks a new piece
+signal before_piece_written
+
+# emitted after the piece is written, and all boxes are made, and all lines are cleared
+signal after_piece_written
+
 signal score_changed
 
 signal combo_ended
@@ -253,6 +260,15 @@ func end_result() -> int:
 		return WON
 	else:
 		return FINISHED
+
+
+func before_piece_written() -> void:
+	level_performance.pieces += 1
+	emit_signal("before_piece_written")
+
+
+func after_piece_written() -> void:
+	emit_signal("after_piece_written")
 
 
 func _prepare_game() -> void:

--- a/project/src/main/puzzle/rank-result.gd
+++ b/project/src/main/puzzle/rank-result.gd
@@ -21,6 +21,10 @@ var speed_rank := WORST_RANK
 var lines := 0
 var lines_rank := WORST_RANK
 
+# number of pieces placed
+var pieces := 0
+var pieces_rank := WORST_RANK
+
 # points awarded for lines left over at the end
 var leftover_score := 0
 
@@ -63,6 +67,8 @@ func to_json_dict() -> Dictionary:
 		"leftover_score": leftover_score,
 		"lines": lines,
 		"lines_rank": lines_rank,
+		"pieces": pieces,
+		"pieces_rank": pieces_rank,
 		"lost": lost,
 		"score": score,
 		"score_rank": score_rank,
@@ -87,6 +93,8 @@ func from_json_dict(json: Dictionary) -> void:
 	leftover_score = json.get("leftover_score", 0)
 	lines = int(json.get("lines", "0"))
 	lines_rank = float(json.get("lines_rank", "999"))
+	pieces = int(json.get("lines", "0"))
+	pieces_rank = float(json.get("lines_rank", "999"))
 	lost = bool(json.get("lost", true))
 	score = int(json.get("score", "0"))
 	score_rank = float(json.get("score_rank", "999"))

--- a/project/src/main/puzzle/results-hud.gd
+++ b/project/src/main/puzzle/results-hud.gd
@@ -85,6 +85,12 @@ func _append_grade_information(rank_result: RankResult, _creature_scores: Array,
 		if not Level.settings.rank.unranked:
 			text += " (%s)" % RankCalculator.grade(rank_result.speed_rank)
 		text += "\n"
+	elif finish_condition_type == Milestone.PIECES:
+		text += "Pieces: %d" % rank_result.pieces
+		text += topped_out
+		if not Level.settings.rank.unranked:
+			text += " (%s)" % RankCalculator.grade(rank_result.pieces_rank)
+		text += "\n"
 	else:
 		text += "Lines: %d" % rank_result.lines
 		text += topped_out

--- a/project/src/test/puzzle/test-rank-calculator.gd
+++ b/project/src/test/puzzle/test-rank-calculator.gd
@@ -108,6 +108,13 @@ func test_calculate_rank_marathon_300_fail() -> void:
 	assert_eq(rank.score_rank, 999.0)
 
 
+func test_calculate_pieces_rank() -> void:
+	Level.settings.set_finish_condition(Milestone.PIECES, 80)
+	PuzzleScore.level_performance.pieces = 40
+	var rank := _rank_calculator.calculate_rank()
+	assert_eq(RankCalculator.grade(rank.pieces_rank), "S")
+
+
 func test_calculate_rank_sprint_120() -> void:
 	Level.settings.set_start_speed("A0")
 	Level.settings.set_finish_condition(Milestone.TIME_OVER, 120)


### PR DESCRIPTION
New levels, 'veggie patty', 'accelerator'.

We now perform 'speed ups' before line clears, because it sounds better
for speedups caused by a piece milestone. Otherwise the sound effects play when
the player drops a piece, except when they clear lines, and then there's a
delay, which is jarring.

We still perform 'level finishes' after line clears, because otherwise the
player won't earn the points from their final line clear.

For this reason MilestoneManager now performs most level checks after line
clears, instead of checking for them every frame. This also required some
minor tweaks to signals in LineClearer and PuzzleScore.

For levels with limited pieces, the next piece queue runs out.