### PR TITLE
Fixed bug with empty next pieces.

### DIFF
--- a/project/src/main/puzzle/piece/next-piece-display.gd
+++ b/project/src/main/puzzle/piece/next-piece-display.gd
@@ -34,7 +34,7 @@ func _process(_delta: float) -> void:
 				$TileMap.set_block(block_pos, 0, block_color)
 				bounding_box = bounding_box.expand(next_piece.get_cell_position(UNROTATED, i))
 				bounding_box = bounding_box.expand(next_piece.get_cell_position(UNROTATED, i) + Vector2(1, 1))
-			$TileMap/CornerMap.dirty = true
-			_displayed_piece = next_piece
 			$TileMap.position = $TileMap.cell_size \
 					* (Vector2(1.5, 1.5) - (bounding_box.position + bounding_box.size / 2.0)) / 2.0
+		$TileMap/CornerMap.dirty = true
+		_displayed_piece = next_piece


### PR DESCRIPTION
The next piece displays only refreshed their '_displayed_piece' field for
non-empty cases, resulting in a small chance that an empty piece wouldn't
refresh. This resulted in a temporary gap in the next piece queue.