### PR TITLE
Added jitter fix. Split DnaLoader from CreatureVisuals.

### DIFF
--- a/delint.sh
+++ b/delint.sh
@@ -19,8 +19,8 @@ grep -R -n "var [^:]* = " --include="*.gd" ./project/src \
   | grep -v "chat-event.gd:74" \
   | grep -v "level-settings.gd:182" \
   | grep -v "level-settings.gd:184" \
-  | grep -v "creature-visuals.gd.*var property_value =" \
-  | grep -v "creature-visuals.gd.*var shader_value ="
+  | grep -v "dna-loader.gd.*var property_value =" \
+  | grep -v "dna-loader.gd.*var shader_value ="
 
 find ./project/src -name "*.TMP"
 find ./project/src -name "*.gd~"

--- a/project/src/demo/ui/chat/MoodDemo.tscn
+++ b/project/src/demo/ui/chat/MoodDemo.tscn
@@ -43,7 +43,6 @@ __meta__ = {
 [node name="Creature" parent="." instance=ExtResource( 1 )]
 position = Vector2( 512, 420 )
 scale = Vector2( 3, 3 )
-creature_id = ""
 dna = {
 "accessory": "0",
 "belly": "1",
@@ -222,5 +221,3 @@ dna = {
 "shader:TailZ1:red": Color( 0.0431373, 0.270588, 0.65098, 1 ),
 "tail": "1"
 }
-suppress_sfx = false
-elevation = 0

--- a/project/src/main/world/creature/CreatureVisuals.tscn
+++ b/project/src/main/world/creature/CreatureVisuals.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=61 format=2]
+[gd_scene load_steps=62 format=2]
 
 [ext_resource path="res://src/main/world/rgb-palette.shader" type="Shader" id=1]
 [ext_resource path="res://src/main/packed-sprite.gd" type="Script" id=2]
@@ -7,6 +7,7 @@
 [ext_resource path="res://src/main/world/creature/creature-animations.gd" type="Script" id=5]
 [ext_resource path="res://src/main/world/creature/creature-packed-sprite.gd" type="Script" id=6]
 [ext_resource path="res://assets/main/world/creature/1/neck-blend-packed.png" type="Texture" id=7]
+[ext_resource path="res://src/main/world/creature/dna-loader.gd" type="Script" id=8]
 [ext_resource path="res://src/main/world/creature/head-bobber.gd" type="Script" id=9]
 [ext_resource path="res://assets/main/world/creature/1/emote-brain-packed.png" type="Texture" id=10]
 [ext_resource path="res://assets/main/world/creature/1/emote-arm-z1-packed.png" type="Texture" id=14]
@@ -71,20 +72,20 @@ shader_param/black = Color( 0, 0, 0, 1 )
 shader_param/shadow_texture = SubResource( 5 )
 shader_param/color_texture = SubResource( 4 )
 
-[sub_resource type="CanvasItemMaterial" id=8]
+[sub_resource type="CanvasItemMaterial" id=7]
 particles_animation = true
 particles_anim_h_frames = 2
 particles_anim_v_frames = 2
 particles_anim_loop = false
 
-[sub_resource type="Gradient" id=9]
+[sub_resource type="Gradient" id=8]
 offsets = PoolRealArray( 0, 0.255924, 0.796209, 0.976303 )
 colors = PoolColorArray( 1, 1, 1, 0, 1, 1, 1, 0.752941, 1, 1, 1, 0.501961, 1, 1, 1, 0 )
 
-[sub_resource type="GradientTexture" id=10]
-gradient = SubResource( 9 )
+[sub_resource type="GradientTexture" id=9]
+gradient = SubResource( 8 )
 
-[sub_resource type="ParticlesMaterial" id=11]
+[sub_resource type="ParticlesMaterial" id=10]
 resource_local_to_scene = true
 emission_shape = 1
 emission_sphere_radius = 50.0
@@ -97,7 +98,15 @@ orbit_velocity = 0.0
 orbit_velocity_random = 0.0
 damping = 50.0
 scale = 0.7
-color_ramp = SubResource( 10 )
+color_ramp = SubResource( 9 )
+
+[sub_resource type="ShaderMaterial" id=11]
+resource_local_to_scene = true
+shader = ExtResource( 1 )
+shader_param/red = Color( 0, 0, 0, 1 )
+shader_param/green = Color( 0, 0, 0, 1 )
+shader_param/blue = Color( 0, 0, 0, 1 )
+shader_param/black = Color( 0, 0, 0, 1 )
 
 [sub_resource type="ShaderMaterial" id=12]
 resource_local_to_scene = true
@@ -112,7 +121,7 @@ resource_local_to_scene = true
 shader = ExtResource( 1 )
 shader_param/red = Color( 0, 0, 0, 1 )
 shader_param/green = Color( 0, 0, 0, 1 )
-shader_param/blue = Color( 0, 0, 0, 1 )
+shader_param/blue = Color( 1, 1, 1, 1 )
 shader_param/black = Color( 0, 0, 0, 1 )
 
 [sub_resource type="ShaderMaterial" id=14]
@@ -120,7 +129,7 @@ resource_local_to_scene = true
 shader = ExtResource( 1 )
 shader_param/red = Color( 0, 0, 0, 1 )
 shader_param/green = Color( 0, 0, 0, 1 )
-shader_param/blue = Color( 1, 1, 1, 1 )
+shader_param/blue = Color( 0, 0, 0, 1 )
 shader_param/black = Color( 0, 0, 0, 1 )
 
 [sub_resource type="ShaderMaterial" id=15]
@@ -167,7 +176,7 @@ shader_param/black = Color( 0, 0, 0, 1 )
 resource_local_to_scene = true
 shader = ExtResource( 1 )
 shader_param/red = Color( 0, 0, 0, 1 )
-shader_param/green = Color( 0, 0, 0, 1 )
+shader_param/green = Color( 0.952941, 0.572549, 0.454902, 1 )
 shader_param/blue = Color( 0, 0, 0, 1 )
 shader_param/black = Color( 0, 0, 0, 1 )
 
@@ -175,19 +184,11 @@ shader_param/black = Color( 0, 0, 0, 1 )
 resource_local_to_scene = true
 shader = ExtResource( 1 )
 shader_param/red = Color( 0, 0, 0, 1 )
-shader_param/green = Color( 0.952941, 0.572549, 0.454902, 1 )
-shader_param/blue = Color( 0, 0, 0, 1 )
-shader_param/black = Color( 0, 0, 0, 1 )
-
-[sub_resource type="ShaderMaterial" id=22]
-resource_local_to_scene = true
-shader = ExtResource( 1 )
-shader_param/red = Color( 0, 0, 0, 1 )
 shader_param/green = Color( 0, 0, 0, 1 )
 shader_param/blue = Color( 0, 0, 0, 1 )
 shader_param/black = Color( 0, 0, 0, 1 )
 
-[sub_resource type="ShaderMaterial" id=23]
+[sub_resource type="ShaderMaterial" id=22]
 resource_local_to_scene = true
 shader = ExtResource( 1 )
 shader_param/red = Color( 1, 1, 1, 1 )
@@ -195,7 +196,7 @@ shader_param/green = Color( 0, 0, 0, 1 )
 shader_param/blue = Color( 0, 0, 0, 1 )
 shader_param/black = Color( 0, 0, 0, 1 )
 
-[sub_resource type="ShaderMaterial" id=24]
+[sub_resource type="ShaderMaterial" id=23]
 resource_local_to_scene = true
 shader = ExtResource( 1 )
 shader_param/red = Color( 0, 0, 0, 1 )
@@ -203,14 +204,14 @@ shader_param/green = Color( 0, 0, 0, 1 )
 shader_param/blue = Color( 0, 0, 0, 1 )
 shader_param/black = Color( 0, 0, 0, 1 )
 
-[sub_resource type="Gradient" id=25]
+[sub_resource type="Gradient" id=24]
 offsets = PoolRealArray( 0.00473934, 0.390947 )
 colors = PoolColorArray( 1, 1, 1, 0.752941, 1, 1, 1, 0 )
 
-[sub_resource type="GradientTexture" id=26]
-gradient = SubResource( 25 )
+[sub_resource type="GradientTexture" id=25]
+gradient = SubResource( 24 )
 
-[sub_resource type="ParticlesMaterial" id=27]
+[sub_resource type="ParticlesMaterial" id=26]
 emission_shape = 1
 emission_sphere_radius = 120.0
 flag_disable_z = true
@@ -220,9 +221,9 @@ initial_velocity = -800.0
 orbit_velocity = 0.0
 orbit_velocity_random = 0.0
 scale = 1.7
-color_ramp = SubResource( 26 )
+color_ramp = SubResource( 25 )
 
-[sub_resource type="ParticlesMaterial" id=28]
+[sub_resource type="ParticlesMaterial" id=27]
 emission_shape = 1
 emission_sphere_radius = 45.0
 flag_disable_z = true
@@ -234,12 +235,12 @@ orbit_velocity = 0.0
 orbit_velocity_random = 0.0
 damping = 50.0
 scale = 0.7
-color_ramp = SubResource( 10 )
+color_ramp = SubResource( 9 )
 
-[sub_resource type="CanvasItemMaterial" id=29]
+[sub_resource type="CanvasItemMaterial" id=28]
 resource_local_to_scene = true
 
-[sub_resource type="ShaderMaterial" id=30]
+[sub_resource type="ShaderMaterial" id=29]
 resource_local_to_scene = true
 shader = ExtResource( 1 )
 shader_param/red = Color( 1, 1, 1, 1 )
@@ -247,7 +248,7 @@ shader_param/green = Color( 1, 1, 0.24, 1 )
 shader_param/blue = Color( 0, 0, 0, 1 )
 shader_param/black = Color( 0, 0, 0, 1 )
 
-[sub_resource type="ShaderMaterial" id=31]
+[sub_resource type="ShaderMaterial" id=30]
 resource_local_to_scene = true
 shader = ExtResource( 1 )
 shader_param/red = Color( 0, 0, 0, 1 )
@@ -326,7 +327,6 @@ texture = ExtResource( 49 )
 frame_data = "res://assets/main/world/creature/1/arm-z0-packed.json"
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
 offset = Vector2( 0, -119 )
 invisible_while_sprinting = true
 
@@ -339,7 +339,6 @@ texture = ExtResource( 58 )
 frame_data = "res://assets/main/world/creature/1/leg-z0-packed.json"
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
 offset = Vector2( 0, -119 )
 invisible_while_sprinting = true
 
@@ -353,7 +352,6 @@ texture = ExtResource( 51 )
 frame_data = "res://assets/main/world/creature/1/sprint-z0-packed.json"
 rect_size = Vector2( 512, 512 )
 frame = 6
-centered = true
 offset = Vector2( 0, -119 )
 
 [node name="TailZ0" type="Node2D" parent="."]
@@ -361,11 +359,8 @@ light_mask = 2
 material = SubResource( 3 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 2 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
 offset = Vector2( 0, -119 )
 
 [node name="BodyShadows" type="ViewportContainer" parent="."]
@@ -434,7 +429,6 @@ texture = ExtResource( 57 )
 frame_data = "res://assets/main/world/creature/1/leg-z1-packed.json"
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
 offset = Vector2( 0, -119 )
 invisible_while_sprinting = true
 
@@ -447,49 +441,39 @@ texture = ExtResource( 52 )
 frame_data = "res://assets/main/world/creature/1/arm-z1-packed.json"
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
 offset = Vector2( 0, -119 )
 invisible_while_sprinting = true
 
 [node name="BodySweat" type="Particles2D" parent="."]
-material = SubResource( 8 )
+material = SubResource( 7 )
 position = Vector2( -10, -50 )
 scale = Vector2( 1, 0.9 )
 emitting = false
 amount = 3
 lifetime = 3.6
 randomness = 1.0
-process_material = SubResource( 11 )
+process_material = SubResource( 10 )
 texture = ExtResource( 44 )
 script = ExtResource( 46 )
 creature_visuals_path = NodePath("..")
 
 [node name="Bellybutton" type="Node2D" parent="."]
 light_mask = 2
-material = SubResource( 12 )
+material = SubResource( 11 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
 offset = Vector2( 0, -119 )
-invisible_while_sprinting = false
 
 [node name="Collar" type="Node2D" parent="."]
 light_mask = 2
-material = SubResource( 13 )
+material = SubResource( 12 )
 position = Vector2( 0, -100 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="Neck0" type="Sprite" parent="."]
 __meta__ = {
@@ -506,173 +490,116 @@ script = ExtResource( 9 )
 __meta__ = {
 "_editor_description_": "Neck1 offsets the head's position as the creature bobs their head up and down"
 }
-head_bob_mode = 1
-head_motion_pixels = 2.0
-head_motion_seconds = 6.5
 
 [node name="AccessoryZ0" type="Node2D" parent="Neck0/HeadBobber"]
+show_behind_parent = true
+light_mask = 2
+material = SubResource( 13 )
+scale = Vector2( 2, 2 )
+script = ExtResource( 6 )
+rect_size = Vector2( 512, 512 )
+frame = 1
+
+[node name="HairZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 14 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
-[node name="HairZ0" type="Node2D" parent="Neck0/HeadBobber"]
+[node name="EarZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 15 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
-[node name="EarZ0" type="Node2D" parent="Neck0/HeadBobber"]
+[node name="HornZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 16 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
-[node name="HornZ0" type="Node2D" parent="Neck0/HeadBobber"]
+[node name="CheekZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 17 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
-[node name="CheekZ0" type="Node2D" parent="Neck0/HeadBobber"]
+[node name="Head" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 18 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
-
-[node name="Head" type="Node2D" parent="Neck0/HeadBobber"]
-show_behind_parent = true
-light_mask = 2
-material = SubResource( 19 )
-scale = Vector2( 2, 2 )
-script = ExtResource( 6 )
-texture = null
-frame_data = ""
-rect_size = Vector2( 512, 512 )
-frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="Chin" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 20 )
+material = SubResource( 19 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 2 )
 texture = ExtResource( 56 )
 frame_data = "res://assets/main/world/creature/1/chin-packed.json"
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
 
 [node name="EarZ1" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 16 )
+material = SubResource( 15 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="CheekZ1" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 18 )
+material = SubResource( 17 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="Mouth" type="Node2D" parent="Neck0/HeadBobber"]
+show_behind_parent = true
+light_mask = 2
+material = SubResource( 20 )
+scale = Vector2( 2, 2 )
+script = ExtResource( 2 )
+rect_size = Vector2( 512, 512 )
+frame = 1
+
+[node name="EyeZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 21 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 2 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-
-[node name="EyeZ0" type="Node2D" parent="Neck0/HeadBobber"]
-show_behind_parent = true
-light_mask = 2
-material = SubResource( 22 )
-scale = Vector2( 2, 2 )
-script = ExtResource( 2 )
-texture = null
-frame_data = ""
-rect_size = Vector2( 512, 512 )
-frame = 1
-centered = true
-offset = Vector2( 0, 0 )
 
 [node name="EmoteEyeZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 23 )
+material = SubResource( 22 )
 position = Vector2( 0, 256 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 2 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
-frame = 0
-centered = true
 offset = Vector2( 0, -119 )
 
 [node name="EmoteArmZ0" type="Node2D" parent="Neck0/HeadBobber"]
@@ -685,161 +612,106 @@ script = ExtResource( 2 )
 texture = ExtResource( 25 )
 frame_data = "res://assets/main/world/creature/1/emote-arm-z0-packed.json"
 rect_size = Vector2( 512, 512 )
-frame = 0
-centered = true
 offset = Vector2( 0, -119 )
 
 [node name="AccessoryZ1" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 14 )
+material = SubResource( 13 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="HairZ1" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 15 )
+material = SubResource( 14 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
 [node name="HornZ1" type="Node2D" parent="Neck0/HeadBobber"]
-show_behind_parent = true
-light_mask = 2
-material = SubResource( 17 )
-scale = Vector2( 2, 2 )
-script = ExtResource( 6 )
-texture = null
-frame_data = ""
-rect_size = Vector2( 512, 512 )
-frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
-
-[node name="Nose" type="Node2D" parent="Neck0/HeadBobber"]
-show_behind_parent = true
-light_mask = 2
-material = SubResource( 24 )
-scale = Vector2( 2, 2 )
-script = ExtResource( 6 )
-texture = null
-frame_data = ""
-rect_size = Vector2( 512, 512 )
-frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
-
-[node name="EyeZ1" type="Node2D" parent="Neck0/HeadBobber"]
-show_behind_parent = true
-light_mask = 2
-material = SubResource( 22 )
-scale = Vector2( 2, 2 )
-script = ExtResource( 2 )
-texture = null
-frame_data = ""
-rect_size = Vector2( 512, 512 )
-frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-
-[node name="EmoteEyeZ1" type="Node2D" parent="Neck0/HeadBobber"]
-show_behind_parent = true
-light_mask = 2
-material = SubResource( 23 )
-position = Vector2( 0, 256 )
-scale = Vector2( 2, 2 )
-script = ExtResource( 2 )
-texture = null
-frame_data = ""
-rect_size = Vector2( 512, 512 )
-frame = 0
-centered = true
-offset = Vector2( 0, -119 )
-
-[node name="EarZ2" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 16 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
-[node name="CheekZ2" type="Node2D" parent="Neck0/HeadBobber"]
+[node name="Nose" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
-material = SubResource( 18 )
+material = SubResource( 23 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
-[node name="HairZ2" type="Node2D" parent="Neck0/HeadBobber"]
+[node name="EyeZ1" type="Node2D" parent="Neck0/HeadBobber"]
+show_behind_parent = true
+light_mask = 2
+material = SubResource( 21 )
+scale = Vector2( 2, 2 )
+script = ExtResource( 2 )
+rect_size = Vector2( 512, 512 )
+frame = 1
+
+[node name="EmoteEyeZ1" type="Node2D" parent="Neck0/HeadBobber"]
+show_behind_parent = true
+light_mask = 2
+material = SubResource( 22 )
+position = Vector2( 0, 256 )
+scale = Vector2( 2, 2 )
+script = ExtResource( 2 )
+rect_size = Vector2( 512, 512 )
+offset = Vector2( 0, -119 )
+
+[node name="EarZ2" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 15 )
 scale = Vector2( 2, 2 )
-z_index = 1
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
 
-[node name="AccessoryZ2" type="Node2D" parent="Neck0/HeadBobber"]
+[node name="CheekZ2" type="Node2D" parent="Neck0/HeadBobber"]
+show_behind_parent = true
+light_mask = 2
+material = SubResource( 17 )
+scale = Vector2( 2, 2 )
+script = ExtResource( 6 )
+rect_size = Vector2( 512, 512 )
+frame = 1
+
+[node name="HairZ2" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 material = SubResource( 14 )
 scale = Vector2( 2, 2 )
+z_index = 1
 script = ExtResource( 6 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
-offset = Vector2( 0, 0 )
-invisible_while_sprinting = false
+
+[node name="AccessoryZ2" type="Node2D" parent="Neck0/HeadBobber"]
+show_behind_parent = true
+light_mask = 2
+material = SubResource( 13 )
+scale = Vector2( 2, 2 )
+script = ExtResource( 6 )
+rect_size = Vector2( 512, 512 )
+frame = 1
 
 [node name="Food" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
 light_mask = 2
 scale = Vector2( 2, 2 )
 script = ExtResource( 2 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
-frame = 0
-centered = true
-offset = Vector2( 0, 0 )
 
 [node name="FoodLaser" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -848,12 +720,7 @@ position = Vector2( 1024, 0 )
 scale = Vector2( 2, 2 )
 z_index = 1
 script = ExtResource( 2 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
-frame = 0
-centered = true
-offset = Vector2( 0, 0 )
 
 [node name="EmoteArmZ1" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -865,28 +732,26 @@ script = ExtResource( 2 )
 texture = ExtResource( 14 )
 frame_data = "res://assets/main/world/creature/1/emote-arm-z1-packed.json"
 rect_size = Vector2( 512, 512 )
-frame = 0
-centered = true
 offset = Vector2( 0, -119 )
 
 [node name="SweatSquirts" type="Particles2D" parent="Neck0/HeadBobber"]
 z_index = 1
 emitting = false
 local_coords = false
-process_material = SubResource( 27 )
+process_material = SubResource( 26 )
 texture = ExtResource( 42 )
 script = ExtResource( 43 )
 creature_visuals_path = NodePath("../../..")
 
 [node name="SweatDrops" type="Particles2D" parent="Neck0/HeadBobber"]
-material = SubResource( 8 )
+material = SubResource( 7 )
 position = Vector2( 6, -60 )
 scale = Vector2( 2.8, 2.4 )
 emitting = false
 amount = 3
 lifetime = 3.6
 randomness = 1.0
-process_material = SubResource( 28 )
+process_material = SubResource( 27 )
 texture = ExtResource( 44 )
 script = ExtResource( 45 )
 creature_visuals_path = NodePath("../../..")
@@ -894,7 +759,7 @@ creature_visuals_path = NodePath("../../..")
 [node name="EmoteGlow" type="Sprite" parent="Neck0/HeadBobber"]
 modulate = Color( 1, 1, 1, 0 )
 light_mask = 2
-material = SubResource( 29 )
+material = SubResource( 28 )
 position = Vector2( 25.3166, 262.374 )
 scale = Vector2( 2, 2 )
 texture = ExtResource( 4 )
@@ -906,7 +771,7 @@ __meta__ = {
 [node name="EmoteBrain" type="Node2D" parent="Neck0/HeadBobber"]
 modulate = Color( 1, 1, 1, 0 )
 light_mask = 2
-material = SubResource( 30 )
+material = SubResource( 29 )
 position = Vector2( -18.259, -54.299 )
 scale = Vector2( 2, 2 )
 script = ExtResource( 2 )
@@ -914,7 +779,6 @@ texture = ExtResource( 10 )
 frame_data = "res://assets/main/world/creature/1/emote-brain-packed.json"
 rect_size = Vector2( 256, 256 )
 frame = 6
-centered = true
 offset = Vector2( 0, -119 )
 
 [node name="EmoteHead" type="Node2D" parent="Neck0/HeadBobber"]
@@ -927,21 +791,17 @@ texture = ExtResource( 21 )
 frame_data = "res://assets/main/world/creature/1/emote-head-packed.json"
 rect_size = Vector2( 512, 256 )
 frame = 1
-centered = true
 offset = Vector2( 0, -119 )
 
 [node name="EmoteBody" type="Node2D" parent="."]
 modulate = Color( 1, 1, 1, 0 )
 light_mask = 2
-material = SubResource( 31 )
+material = SubResource( 30 )
 position = Vector2( -169.545, 19.486 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 2 )
 texture = ExtResource( 15 )
 frame_data = "res://assets/main/world/creature/1/emote-body-packed.json"
-rect_size = Vector2( 100, 100 )
-frame = 0
-centered = true
 offset = Vector2( 0, -119 )
 
 [node name="TailZ1" type="Node2D" parent="."]
@@ -949,12 +809,13 @@ light_mask = 2
 material = SubResource( 3 )
 scale = Vector2( 0.836, 0.836 )
 script = ExtResource( 2 )
-texture = null
-frame_data = ""
 rect_size = Vector2( 512, 512 )
 frame = 1
-centered = true
 offset = Vector2( 0, -119 )
+
+[node name="DnaLoader" type="Node" parent="."]
+pause_mode = 2
+script = ExtResource( 8 )
 
 [node name="Animations" type="Node" parent="."]
 script = ExtResource( 5 )
@@ -977,44 +838,44 @@ root_node = NodePath("../..")
 root_node = NodePath("../..")
 creature_visuals_path = NodePath("../..")
 [connection signal="dna_loaded" from="." to="Animations/IdleTimer" method="_on_CreatureVisuals_dna_loaded"]
+[connection signal="movement_mode_changed" from="." to="Sprint" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="FarArm" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="FarLeg" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Sprint" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Collar" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="NearArm" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ1" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Bellybutton" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ0" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="NearLeg" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ0" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="NearLeg" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ1" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ2" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Nose" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ1" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="NearArm" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ0" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ2" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Nose" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ2" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="orientation_changed" from="." to="FarArm" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="FarLeg" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Collar" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="NearArm" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ1" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Bellybutton" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ0" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="NearLeg" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ0" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="NearLeg" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ1" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ2" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Nose" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ1" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="NearArm" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ2" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Nose" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ2" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="idle_animation_started" from="Animations/IdleTimer" to="Animations/EmotePlayer" method="_on_IdleTimer_idle_animation_started"]
 [connection signal="idle_animation_stopped" from="Animations/IdleTimer" to="Animations/EmotePlayer" method="_on_IdleTimer_idle_animation_stopped"]

--- a/project/src/main/world/creature/dna-loader.gd
+++ b/project/src/main/world/creature/dna-loader.gd
@@ -1,0 +1,171 @@
+extends Node
+"""
+Assigns and unassigns textures and animations based on a creature's dna.
+
+This needs to be separate from the CreatureVisuals node because it must continue running while paused. Otherwise the
+creature editor will have strange behavior, particularly in its color picker.
+"""
+
+# The maximum amount of microseconds to spend setting shader params in each frame. This is capped to avoid frame drops.
+const MAX_SHADER_USEC_PER_FRAME := 240
+
+# Array of string shader keys from the dna which haven't yet been loaded. Instead of loading these up front, we load
+# these gradually over time. Setting shader params is slow and setting too many at once causes frame drops.
+var _pending_shader_keys: Array
+
+onready var _creature_visuals: CreatureVisuals = get_parent()
+
+func _process(delta: float) -> void:
+	if _pending_shader_keys:
+		# if there are any pending shader keys, we load a few each frame. Setting shader params is slow and setting
+		# too many at once causes frame drops
+		var start_ticks_usec := OS.get_ticks_usec()
+		while OS.get_ticks_usec() - start_ticks_usec < MAX_SHADER_USEC_PER_FRAME and _pending_shader_keys:
+			var key: String = _pending_shader_keys.pop_front()
+			var node_path: String = key.split(":")[1]
+			var shader_param: String = key.split(":")[2]
+			var shader_value = _creature_visuals.dna[key]
+			if _creature_visuals.has_node(node_path):
+				_creature_visuals.get_node(node_path).material.set_shader_param(shader_param, shader_value)
+
+
+"""
+Unassigns the textures and animations for the creature.
+
+Different body parts have different animations and textures. Before changing the creature's appearance, any old
+textures and animations need to be stopped and removed, and any signals disconnected. This method handles all of that.
+"""
+func unload_dna() -> void:
+	_creature_visuals.get_node("Animations/EmotePlayer").unemote_immediate()
+	for node_path in [
+		"Bellybutton",
+		"Collar",
+		"FarArm",
+		"FarLeg",
+		"NearArm",
+		"NearLeg",
+		"Sprint",
+		"TailZ0",
+		"TailZ1",
+		"Neck0/HeadBobber/AccessoryZ0",
+		"Neck0/HeadBobber/AccessoryZ1",
+		"Neck0/HeadBobber/AccessoryZ2",
+		"Neck0/HeadBobber/CheekZ0",
+		"Neck0/HeadBobber/CheekZ1",
+		"Neck0/HeadBobber/CheekZ2",
+		"Neck0/HeadBobber/Chin",
+		"Neck0/HeadBobber/EarZ0",
+		"Neck0/HeadBobber/EarZ1",
+		"Neck0/HeadBobber/EarZ2",
+		"Neck0/HeadBobber/EmoteEyeZ0",
+		"Neck0/HeadBobber/EmoteEyeZ1",
+		"Neck0/HeadBobber/EyeZ0",
+		"Neck0/HeadBobber/EyeZ1",
+		"Neck0/HeadBobber/Food",
+		"Neck0/HeadBobber/FoodLaser",
+		"Neck0/HeadBobber/HairZ0",
+		"Neck0/HeadBobber/HairZ1",
+		"Neck0/HeadBobber/HairZ2",
+		"Neck0/HeadBobber/Head",
+		"Neck0/HeadBobber/HornZ0",
+		"Neck0/HeadBobber/HornZ1",
+		"Neck0/HeadBobber/Mouth",
+		"Neck0/HeadBobber/Nose",
+	]:
+		if _creature_visuals.has_node(node_path):
+			var packed_sprite: PackedSprite = _creature_visuals.get_node(node_path)
+			packed_sprite.texture = null
+			packed_sprite.frame_data = ""
+			if packed_sprite.material:
+				packed_sprite.material.set_shader_param("red", Color.black)
+				packed_sprite.material.set_shader_param("green", Color.black)
+				packed_sprite.material.set_shader_param("blue", Color.black)
+				packed_sprite.material.set_shader_param("black", Color.black)
+	
+	_creature_visuals.get_node("Body").rect_position = Vector2(-580, -850)
+	_creature_visuals.get_node("Neck0/HeadBobber").position = Vector2(0, -100)
+	_creature_visuals.scale = Vector2(1.00, 1.00)
+	
+	_remove_dna_node("Animations/MouthPlayer")
+	_remove_dna_node("Animations/EarPlayer")
+	_remove_dna_node("Animations/FatSpriteMover")
+	_remove_dna_node("Body/Viewport/Body")
+	_remove_dna_node("BellyColors/Viewport/Body")
+	_remove_dna_node("BodyShadows/Viewport/Body")
+
+
+"""
+Assigns the textures and animations based on the creature's dna.
+
+This method assumes that any existing animations and connections have been disconnected.
+"""
+func load_dna() -> void:
+	if _creature_visuals.dna.has("mouth"):
+		_add_dna_node(CreatureLoader.new_mouth_player(_creature_visuals.dna.mouth), "mouth",
+				_creature_visuals.dna.mouth, _creature_visuals.get_node("Animations"))
+	
+	if _creature_visuals.dna.has("ear"):
+		_add_dna_node(CreatureLoader.new_ear_player(_creature_visuals.dna.ear), "ear",
+				_creature_visuals.dna.ear, _creature_visuals.get_node("Animations"))
+	
+	if _creature_visuals.dna.has("body"):
+		_add_dna_node(CreatureLoader.new_body(_creature_visuals.dna.body), "body",
+				_creature_visuals.dna.body, _creature_visuals.get_node("Body/Viewport"))
+		_add_dna_node(CreatureLoader.new_body_colors(_creature_visuals.dna.body), "body colors",
+				_creature_visuals.dna.body, _creature_visuals.get_node("BellyColors/Viewport"))
+		_add_dna_node(CreatureLoader.new_body_shadows(_creature_visuals.dna.body), "body shadows",
+				_creature_visuals.dna.body, _creature_visuals.get_node("BodyShadows/Viewport"))
+		_add_dna_node(CreatureLoader.new_fat_sprite_mover(_creature_visuals.dna.body), "fat sprite mover",
+				_creature_visuals.dna.body, _creature_visuals.get_node("Animations"))
+	
+	if _creature_visuals.get_node("Animations").has_node("MouthPlayer"):
+		_creature_visuals.mouth_player = _creature_visuals.get_node("Animations").get_node("MouthPlayer")
+	
+	for key in _creature_visuals.dna.keys():
+		if key.find("property:") == 0:
+			var node_path: String = key.split(":")[1]
+			var property_name: String = key.split(":")[2]
+			var property_value = _creature_visuals.dna[key]
+			if node_path == "BellyColors/Viewport/Body" and property_name == "belly":
+				# set_belly requires an int, not a string
+				property_value = int(property_value)
+			if _creature_visuals.has_node(node_path):
+				_creature_visuals.get_node(node_path).set(property_name, property_value)
+	
+	_pending_shader_keys.clear()
+	for key in _creature_visuals.dna.keys():
+		if key.find("shader:") == 0:
+			_pending_shader_keys.append(key)
+	
+	_creature_visuals.scale = Vector2(0.60, 0.60) if _creature_visuals.dna.get("body") == "2" else Vector2(1.00, 1.00)
+	_creature_visuals.visible = true
+	
+	# initialize creature curves, and reset the mouth/eye frame to avoid a strange transition frame
+	_creature_visuals.reset_frames()
+	_creature_visuals.emit_signal("dna_loaded")
+
+
+"""
+Removes a 'dna node', one which swaps out based on the creature's DNA.
+"""
+func _remove_dna_node(path: NodePath) -> void:
+	if not _creature_visuals.has_node(path):
+		return
+	
+	var node := _creature_visuals.get_node(path)
+	# These nodes must be immediately removed to avoid name conflicts with the nodes which replace them.
+	node.get_parent().remove_child(node)
+	node.queue_free()
+
+
+"""
+Adds a 'dna node', one which swaps out based on the creature's DNA.
+"""
+func _add_dna_node(node: Node, key_message: String, value_message: String, parent: Node = self) -> void:
+	if not node:
+		push_warning("Invalid %s: %s" % [key_message, value_message])
+		return
+	
+	parent.add_child(node)
+	node.owner = _creature_visuals
+	node.creature_visuals_path = node.get_path_to(_creature_visuals)


### PR DESCRIPTION
Jitter seems to mostly stem from editing too many shader parameters in one
frame; this is now spread out over multiple frames.

DnaLoader is now separate because it needs to have pausing disabled; otherwise
creature colors don't update properly when using the color pickers in the
creature editor.

Note: I initially attempted an approach where instead of loading shader
parameters gradually, I loaded all DNA properties gradually. This
introduced problems because the code would try to animate partially-loaded
textures, and required stuff like mutexes and new signals to keep track of
whether the DNA was unloaded, partially loaded, or fully loaded. It was a
big mess, but if you want to pursue this in the future you can see my work
in 59e1f6e.