### PR TITLE
Fixed PackedSprite editor errors, improved singleton logic

### DIFF
--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -12,7 +12,7 @@ func _ready() -> void:
 		Breadcrumb.trail = [Global.SCENE_SPLASH]
 		_launch_tutorial()
 	
-	ResourceCache.substitute_singletons(self)
+	ResourceCache.substitute_singletons()
 	
 	# Fade in music when redirected from a scene with no music, such as the level editor
 	if not MusicPlayer.is_playing_chill_bgm():
@@ -23,7 +23,7 @@ func _ready() -> void:
 
 
 func _exit_tree() -> void:
-	ResourceCache.remove_singletons(self)
+	ResourceCache.remove_singletons()
 
 
 func _launch_tutorial() -> void:

--- a/project/src/main/ui/menu/practice-menu.gd
+++ b/project/src/main/ui/menu/practice-menu.gd
@@ -67,7 +67,7 @@ var levels: Dictionary
 var _rank_lowlights := []
 
 func _ready() -> void:
-	ResourceCache.substitute_singletons(self)
+	ResourceCache.substitute_singletons()
 	
 	# default mode/difficulty if the player hasn't played a level recently
 	var current_mode: String = "Ultra"
@@ -101,7 +101,7 @@ func _ready() -> void:
 
 
 func _exit_tree() -> void:
-	ResourceCache.remove_singletons(self)
+	ResourceCache.remove_singletons()
 
 
 func _refresh() -> void:

--- a/project/src/main/ui/menu/splash-screen.gd
+++ b/project/src/main/ui/menu/splash-screen.gd
@@ -4,7 +4,7 @@ A splash screen which precedes the main menu.
 """
 
 func _ready() -> void:
-	ResourceCache.substitute_singletons(self)
+	ResourceCache.substitute_singletons()
 	
 	if not MusicPlayer.is_playing_chill_bgm():
 		MusicPlayer.play_chill_bgm()
@@ -14,7 +14,7 @@ func _ready() -> void:
 
 
 func _exit_tree() -> void:
-	ResourceCache.remove_singletons(self)
+	ResourceCache.remove_singletons()
 
 
 func _on_Play_pressed() -> void:

--- a/project/src/main/ui/menu/tutorial-menu.gd
+++ b/project/src/main/ui/menu/tutorial-menu.gd
@@ -4,11 +4,11 @@ Scene which lets the player launch tutorials.
 """
 
 func _ready() -> void:
-	ResourceCache.substitute_singletons(self)
+	ResourceCache.substitute_singletons()
 
 
 func _exit_tree() -> void:
-	ResourceCache.remove_singletons(self)
+	ResourceCache.remove_singletons()
 
 
 func _on_BackButton_pressed() -> void:

--- a/project/src/main/ui/wallpaper/Wallpaper.tscn
+++ b/project/src/main/ui/wallpaper/Wallpaper.tscn
@@ -4,7 +4,9 @@
 [ext_resource path="res://src/main/ui/wallpaper/StickerRow.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/ui/wallpaper/wallpaper.gd" type="Script" id=3]
 
-[node name="Wallpaper" type="Control"]
+[node name="Wallpaper" type="Control" groups=[
+"singletons",
+]]
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource( 3 )

--- a/project/src/main/utils.gd
+++ b/project/src/main/utils.gd
@@ -1,3 +1,4 @@
+tool
 class_name Utils
 """
 Contains global utilities.
@@ -230,3 +231,10 @@ static func assign_default_dialog_path(dialog: FileDialog, default_resource_path
 		if not Directory.new().dir_exists(current_path):
 			current_path = OS.get_user_data_dir()
 		dialog.current_path = current_path
+
+
+"""
+Converts an Aseprite json region to a Rect2.
+"""
+static func json_to_rect2(json: Dictionary) -> Rect2:
+	return Rect2(json.x, json.y, json.w, json.h)

--- a/project/src/main/world/creature/creature-visuals.gd
+++ b/project/src/main/world/creature/creature-visuals.gd
@@ -19,6 +19,7 @@ unnecessary textures are loaded.
 signal food_eaten
 
 # emitted when a creature's textures and animations are loaded
+# warning-ignore:unused_signal
 signal dna_loaded
 
 # emitted during the 'run' animation when the creature touches the ground

--- a/project/src/main/world/creature/dna-loader.gd
+++ b/project/src/main/world/creature/dna-loader.gd
@@ -16,7 +16,7 @@ var _pending_shader_keys: Array
 
 onready var _creature_visuals: CreatureVisuals = get_parent()
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	if _pending_shader_keys:
 		# if there are any pending shader keys, we load a few each frame. Setting shader params is slow and setting
 		# too many at once causes frame drops


### PR DESCRIPTION
PackedSprite was throwing errors because it depended on ResourceCache
which was not a tool. ResourceCache shouldn't be a tool because caching
resources in the editor has the potential to cause headaches, as resources
change frequently during development. PackedSprite now has the capability
of loading non-cached resources in the editor.

Improved singleton logic to allow for further singletons. Instead of
specifically saving and loading a wallpaper singleton, ResourceCache now saves
and loads all nodes in the 'singletons' node group.