### PR TITLE
Refactored CreatureDef.min_fatness and breadcrumb pop logic

### DIFF
--- a/project/src/main/breadcrumb.gd
+++ b/project/src/main/breadcrumb.gd
@@ -53,3 +53,8 @@ func _change_scene() -> void:
 			get_tree().change_scene_to(ResourceCache.get_cached_resource(trail.front()))
 		else:
 			get_tree().change_scene(trail.front())
+	else:
+		# player popped the top item off the breadcrumb trail (possibly from something like a demo)
+		# exit to loading screen and load all resources
+		ResourceCache.minimal_resources = false
+		get_tree().change_scene("res://src/main/ui/menu/LoadingScreen.tscn")

--- a/project/src/main/creature-library.gd
+++ b/project/src/main/creature-library.gd
@@ -86,7 +86,7 @@ func reset() -> void:
 	player_def.creature_name = DEFAULT_NAME
 	player_def.creature_short_name = NameUtils.sanitize_short_name(player_def.creature_name)
 	player_def.dna = DEFAULT_DNA.duplicate()
-	player_def.fatness = 1.0
+	player_def.min_fatness = 1.0
 	player_def.chat_theme_def = DEFAULT_CHAT_THEME_DEF.duplicate()
 
 

--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -48,8 +48,6 @@ func _ready() -> void:
 	_name_generator = NameGenerator.new()
 	_name_generator.load_american_animals()
 	
-	Breadcrumb.connect("trail_popped", self, "_on_Breadcrumb_trail_popped")
-	
 	for allele in DnaUtils.BODY_PART_ALLELES:
 		_recent_tweaked_allele_values[allele] = []
 	
@@ -121,6 +119,7 @@ func _mutate_allele(creature: Creature, dna: Dictionary, new_palette: Dictionary
 			while new_fatnesses.has(creature.get_visual_fatness()):
 				new_fatnesses.erase(creature.get_visual_fatness())
 			var new_fatness: float = Utils.rand_value(new_fatnesses)
+			creature.min_fatness = new_fatness
 			creature.set_fatness(new_fatness)
 			creature.set_visual_fatness(new_fatness)
 		"body_rgb":
@@ -262,6 +261,7 @@ func _tweak_creature(creature: Creature, allele: String, color_mode: int) -> voi
 			while new_fatnesses.has(creature.get_visual_fatness()):
 				new_fatnesses.erase(creature.get_visual_fatness())
 			var new_fatness: float = Utils.rand_value(new_fatnesses)
+			creature.min_fatness = new_fatness
 			creature.set_fatness(new_fatness)
 			creature.set_visual_fatness(new_fatness)
 		"body_rgb":
@@ -384,11 +384,6 @@ func _random_highlight_color(color: Color) -> Color:
 	new_color.s = color.s + _rng.randfn(-0.50, 0.20)
 	new_color.v = color.v + _rng.randfn(+0.40, 0.10)
 	return new_color
-
-
-func _on_Breadcrumb_trail_popped(_prev_path: String) -> void:
-	if not Breadcrumb.trail:
-		get_tree().change_scene("res://src/main/ui/menu/LoadingScreen.tscn")
 
 
 func _on_Quit_pressed() -> void:

--- a/project/src/main/editor/puzzle/level-editor.gd
+++ b/project/src/main/editor/puzzle/level-editor.gd
@@ -73,10 +73,6 @@ func _on_Breadcrumb_trail_popped(prev_path: String) -> void:
 	if prev_path == "res://src/main/editor/puzzle/LevelEditor.tscn::test":
 		# player exited the level under test; stop the test
 		_stop_test()
-	elif not Breadcrumb.trail:
-		# player exited the level editor when it was launched standalone; exit to loading screen to avoid jitter
-		ResourceCache.minimal_resources = false
-		get_tree().change_scene("res://src/main/ui/menu/LoadingScreen.tscn")
 
 
 func _on_Quit_pressed() -> void:

--- a/project/src/main/ui/level-select/level-select.gd
+++ b/project/src/main/ui/level-select/level-select.gd
@@ -7,10 +7,6 @@ The level select screen which shows buttons and level info.
 # Virtual property; value is only exposed through getters/setters
 export (LevelSelectModel.LevelsToInclude) var levels_to_include: int setget set_levels_to_include
 
-func _ready() -> void:
-	Breadcrumb.connect("trail_popped", self, "_on_Breadcrumb_trail_popped")
-
-
 """
 Parameters:
 	'new_levels_to_include': An enum in LevelSelectModel.LevelsToInclude which specifies which allows for hiding or
@@ -22,11 +18,6 @@ func set_levels_to_include(new_levels_to_include: int) -> void:
 
 func get_levels_to_include() -> int:
 	return $VBoxContainer/ScrollContainer/MarginContainer/LevelButtons.levels_to_include
-
-
-func _on_Breadcrumb_trail_popped(_prev_path: String) -> void:
-	if not Breadcrumb.trail:
-		get_tree().change_scene("res://src/main/ui/menu/LoadingScreen.tscn")
 
 
 func _on_SettingsMenu_quit_pressed() -> void:

--- a/project/src/main/world/creature/creature-def.gd
+++ b/project/src/main/world/creature/creature-def.gd
@@ -28,7 +28,7 @@ var dialog: Dictionary
 var chat_selectors: Array
 
 # how fat the creature's body is; 5.0 = 5x normal size
-var fatness := 1.0
+var min_fatness := 1.0
 
 func from_json_dict(json: Dictionary) -> void:
 	var version: String = json.get("version")
@@ -58,7 +58,7 @@ func from_json_dict(json: Dictionary) -> void:
 	chat_theme_def = json.get("chat_theme_def", {})
 	dialog = json.get("dialog", {})
 	chat_selectors = json.get("chat_selectors", [])
-	fatness = json.get("fatness", 1.0)
+	min_fatness = json.get("fatness", 1.0)
 
 
 func to_json_dict() -> Dictionary:
@@ -71,5 +71,5 @@ func to_json_dict() -> Dictionary:
 		"chat_theme_def": chat_theme_def,
 		"dialog": dialog,
 		"chat_selectors": chat_selectors,
-		"fatness": fatness,
+		"fatness": min_fatness,
 	}

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -292,7 +292,7 @@ func set_creature_def(new_creature_def: CreatureDef) -> void:
 	creature_short_name = new_creature_def.creature_short_name
 	set_chat_selectors(new_creature_def.chat_selectors)
 	dialog = new_creature_def.dialog
-	min_fatness = new_creature_def.fatness
+	min_fatness = new_creature_def.min_fatness
 	if PlayerData.creature_library.has_fatness(creature_id):
 		set_fatness(PlayerData.creature_library.get_fatness(creature_id))
 	else:
@@ -311,7 +311,7 @@ func get_creature_def() -> CreatureDef:
 	result.creature_short_name = creature_short_name
 	result.dialog = dialog
 	result.chat_theme_def = chat_theme_def
-	result.fatness = get_fatness()
+	result.min_fatness = min_fatness
 	return result
 
 


### PR DESCRIPTION
CreatureDef now defines min_fatness, not fatness. The CreatureDef json still
uses 'fatness' for simplicity and backwards compatibility.

Moved duplicated 'popping top level of breadcrumb trail' logic into
Breadcrumb class. This unfortunately makes Breadcrumb a little more
project-specific, since it depends on ResourceCache and LoadingScreen.