### PR TITLE
Refactored creature queue, tutorial combos, dead code

### DIFF
--- a/project/assets/main/creatures/secondary/lango.json
+++ b/project/assets/main/creatures/secondary/lango.json
@@ -18,7 +18,7 @@
     "nose": "2",
     "tail": "1",
     "accessory": "0",
-    "line_rgb": "41281e",
+    "line_rgb": "6d3510",
     "body_rgb": "a24f18",
     "belly_rgb": "ded1ae",
     "cloth_rgb": "ffa2ec",

--- a/project/assets/main/puzzle/levels/tutorial-basics-0.json
+++ b/project/assets/main/puzzle/levels/tutorial-basics-0.json
@@ -198,9 +198,6 @@
       }
     ]
   },
-  "combo_break": [
-    "pieces 0"
-  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial-basics-1.json
+++ b/project/assets/main/puzzle/levels/tutorial-basics-1.json
@@ -96,9 +96,6 @@
       }
     ]
   },
-  "combo_break": [
-    "pieces 0"
-  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial-basics-2.json
+++ b/project/assets/main/puzzle/levels/tutorial-basics-2.json
@@ -216,9 +216,6 @@
       }
     ]
   },
-  "combo_break": [
-    "pieces 0"
-  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial-basics-3.json
+++ b/project/assets/main/puzzle/levels/tutorial-basics-3.json
@@ -228,9 +228,6 @@
       }
     ]
   },
-  "combo_break": [
-    "pieces 0"
-  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial-squish-0.json
+++ b/project/assets/main/puzzle/levels/tutorial-squish-0.json
@@ -300,9 +300,6 @@
       }
     ]
   },
-  "combo_break": [
-    "pieces 0"
-  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial-squish-1.json
+++ b/project/assets/main/puzzle/levels/tutorial-squish-1.json
@@ -1,9 +1,6 @@
 {
   "version": "19c5",
   "start_speed": "T",
-  "combo_break": [
-    "pieces 0"
-  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial-squish-2.json
+++ b/project/assets/main/puzzle/levels/tutorial-squish-2.json
@@ -188,9 +188,6 @@
   "piece_types": [
     "piece_p"
   ],
-  "combo_break": [
-    "pieces 0"
-  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial-squish-3.json
+++ b/project/assets/main/puzzle/levels/tutorial-squish-3.json
@@ -216,9 +216,6 @@
   "piece_types": [
     "piece_v"
   ],
-  "combo_break": [
-    "pieces 0"
-  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial-squish-4.json
+++ b/project/assets/main/puzzle/levels/tutorial-squish-4.json
@@ -184,9 +184,6 @@
   "piece_types": [
     "piece_u"
   ],
-  "combo_break": [
-    "pieces 0"
-  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial-squish-5.json
+++ b/project/assets/main/puzzle/levels/tutorial-squish-5.json
@@ -230,9 +230,6 @@
     "piece_t",
     "piece_u"
   ],
-  "combo_break": [
-    "pieces 0"
-  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial-squish-6.json
+++ b/project/assets/main/puzzle/levels/tutorial-squish-6.json
@@ -254,9 +254,6 @@
     "piece_t",
     "piece_u"
   ],
-  "combo_break": [
-    "pieces 0"
-  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/project.godot
+++ b/project/project.godot
@@ -154,6 +154,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/demo/world/creature/creature-palette-demo.gd"
 }, {
+"base": "Reference",
+"class": "CreatureQueue",
+"language": "GDScript",
+"path": "res://src/main/creature-queue.gd"
+}, {
 "base": "Node2D",
 "class": "CreatureShadow",
 "language": "GDScript",
@@ -639,6 +644,7 @@ _global_script_class_icons={
 "CreatureLibrary": "",
 "CreaturePackedSprite": "",
 "CreaturePaletteDemo": "",
+"CreatureQueue": "",
 "CreatureShadow": "",
 "CreatureShadows": "",
 "CreatureVisuals": "",

--- a/project/src/main/creature-library.gd
+++ b/project/src/main/creature-library.gd
@@ -13,44 +13,6 @@ const GENERIC_FATNESS_COUNT := 150
 # wasn't me"
 const MAX_FILLER_FATNESS := 2.5
 
-# default chat theme when starting a new game
-const DEFAULT_CHAT_THEME_DEF := {
-	"accent_scale": 1.33,
-	"accent_swapped": true,
-	"accent_texture": 13,
-	"color": "b23823"
-}
-
-# default creature appearance when starting a new game
-const DEFAULT_DNA := {
-	"accessory": "0",
-	"belly": "1",
-	"belly_rgb": "c9442a",
-	"bellybutton": "0",
-	"body": "1",
-	"body_rgb": "b23823",
-	"cheek": "3",
-	"cloth_rgb": "282828",
-	"collar": "0",
-	"ear": "1",
-	"eye": "1",
-	"eye_rgb": "282828 dedede",
-	"glass_rgb": "282828",
-	"hair": "0",
-	"hair_rgb": "f1e398",
-	"head": "1",
-	"horn": "1",
-	"horn_rgb": "f1e398",
-	"line_rgb": "6c4331",
-	"mouth": "2",
-	"nose": "0",
-	"plastic_rgb": "282828",
-	"tail": "0",
-}
-
-# default name when starting a new game
-const DEFAULT_NAME := "Spira"
-
 var player_def: CreatureDef
 
 # fatnesses by creature id
@@ -83,11 +45,11 @@ func next_filler_id() -> String:
 func reset() -> void:
 	# default player appearance and name
 	player_def = CreatureDef.new()
-	player_def.creature_name = DEFAULT_NAME
+	player_def.creature_name = CreatureDef.DEFAULT_NAME
 	player_def.creature_short_name = NameUtils.sanitize_short_name(player_def.creature_name)
-	player_def.dna = DEFAULT_DNA.duplicate()
+	player_def.dna = CreatureDef.DEFAULT_DNA.duplicate()
 	player_def.min_fatness = 1.0
-	player_def.chat_theme_def = DEFAULT_CHAT_THEME_DEF.duplicate()
+	player_def.chat_theme_def = CreatureDef.DEFAULT_CHAT_THEME_DEF.duplicate()
 
 
 """

--- a/project/src/main/creature-queue.gd
+++ b/project/src/main/creature-queue.gd
@@ -1,0 +1,101 @@
+class_name CreatureQueue
+"""
+Queue of creatures who appear when the player solves puzzles.
+
+This includes a 'primary queue' of creatures guaranteed to show up at the start of a puzzle, and a 'secondary queue'
+of creatures who randomly show up during a puzzle.
+"""
+
+# Queue of creatures who show up at the start of a puzzle.
+var primary_queue := []
+var primary_index: int
+
+# Queue of creatures who randomly show up during a puzzle.
+var secondary_queue: Array
+var secondary_index := 0
+
+func _init() -> void:
+	_load_secondary_creatures()
+
+
+"""
+Returns 'true' if the primary creature queue has any creatures left.
+"""
+func has_primary_creature() -> bool:
+	return primary_index < primary_queue.size()
+
+
+"""
+Returns the next creature in the primary creature queue, and advances the queue.
+"""
+func pop_primary_creature() -> CreatureDef:
+	var creature_def: CreatureDef
+	if has_primary_creature():
+		creature_def = PlayerData.creature_queue.primary_queue[PlayerData.creature_queue.primary_index]
+		PlayerData.creature_queue.primary_index += 1
+	return creature_def
+
+
+"""
+Returns 'true' if the secondary creature queue has any creatures left.
+"""
+func has_secondary_creature() -> bool:
+	return secondary_index < secondary_queue.size()
+
+
+"""
+Returns the next creature in the secondary creature queue, and advances the queue.
+"""
+func pop_secondary_creature() -> CreatureDef:
+	var creature_def: CreatureDef
+	if has_secondary_creature():
+		creature_def = PlayerData.creature_queue.secondary_queue[PlayerData.creature_queue.secondary_index]
+		# don't loop back through the queue; we don't want the same customer showing up twice during a puzzle
+		PlayerData.creature_queue.secondary_index += 1
+	return creature_def
+
+
+"""
+Empties the queue of creatures who will show up at the start of the next puzzle.
+
+Also rotates the secondary creatures so the same creatures don't show up over and over.
+"""
+func clear() -> void:
+	primary_queue = []
+	primary_index = 0
+	reset_secondary_creature_queue()
+
+
+"""
+Resets the queue of secondary creatures; recognizable characters who show up now and then, but don't have any dialog or
+levels
+
+This resets the queue_index to 0, and moves the beginning of the queue to the end.
+"""
+func reset_secondary_creature_queue() -> void:
+	if secondary_queue and secondary_index > 0:
+		var new_queue := []
+		new_queue += secondary_queue.slice(
+				secondary_index, secondary_queue.size() - 1)
+		new_queue += secondary_queue.slice(0, secondary_index - 1)
+		secondary_queue = new_queue
+		secondary_index = 0
+
+
+"""
+Loads all secondary creature data from a directory of json files.
+"""
+func _load_secondary_creatures() -> void:
+	var dir := Directory.new()
+	dir.open("res://assets/main/creatures/secondary")
+	dir.list_dir_begin(true, true)
+	while true:
+		var file := dir.get_next()
+		if not file:
+			break
+		else:
+			var creature_def := CreatureDef.new().from_json_path("%s/%s" % [dir.get_current_dir(), file.get_file()])
+			creature_def.creature_id = file.get_file().get_basename()
+			secondary_queue.append(creature_def)
+	dir.list_dir_end()
+	secondary_queue.shuffle()

--- a/project/src/main/editor/creature/dialogs.gd
+++ b/project/src/main/editor/creature/dialogs.gd
@@ -25,7 +25,7 @@ func _on_ImportButton_pressed() -> void:
 Imports the specified creature into the editor.
 """
 func _on_ImportDialog_file_selected(path: String) -> void:
-	var loaded_def := CreatureLoader.load_creature_def(path)
+	var loaded_def := CreatureDef.new().from_json_path(path)
 	if loaded_def:
 		_creature_editor.set_center_creature_def(loaded_def)
 		_creature_editor.mutate_all_creatures()

--- a/project/src/main/global.gd
+++ b/project/src/main/global.gd
@@ -30,10 +30,6 @@ const ISO_FACTOR := Vector2(1.0, 0.5)
 # Target number of creature greetings (hello, goodbye) per minute
 const GREETINGS_PER_MINUTE := 3.0
 
-# The creatures who will show up during the next puzzle.
-var creature_queue := []
-var creature_queue_index: int
-
 # Stores all of the benchmarks which have been started
 var _benchmark_start_times := Dictionary()
 
@@ -97,9 +93,3 @@ func should_chat() -> bool:
 	else:
 		should_chat = false
 	return should_chat
-
-
-func clear_creature_queue() -> void:
-	Global.creature_queue = []
-	Global.creature_queue_index = 0
-	CreatureLoader.reset_secondary_creature_queue()

--- a/project/src/main/player-data.gd
+++ b/project/src/main/player-data.gd
@@ -11,6 +11,7 @@ var level_history := LevelHistory.new()
 var chat_history := ChatHistory.new()
 
 var creature_library := CreatureLibrary.new()
+var creature_queue := CreatureQueue.new()
 
 var gameplay_settings := GameplaySettings.new()
 var volume_settings := VolumeSettings.new()

--- a/project/src/main/puzzle/level/level.gd
+++ b/project/src/main/puzzle/level/level.gd
@@ -82,5 +82,5 @@ func push_level_trail() -> void:
 	start_level(level_settings)
 	if Level.launched_creature_id:
 		var creature_def := CreatureLoader.load_creature_def_by_id(Level.launched_creature_id)
-		Global.creature_queue.push_front(creature_def)
+		PlayerData.creature_queue.primary_queue.push_front(creature_def)
 	Breadcrumb.push_trail(Global.SCENE_PUZZLE)

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -22,8 +22,8 @@ func _ready() -> void:
 	PuzzleScore.connect("after_game_ended", self, "_on_PuzzleScore_after_game_ended")
 	$Playfield/TileMapClip/TileMap/Viewport/ShadowMap.piece_tile_map = $PieceManager/TileMap
 	
-	Global.creature_queue_index = 0
-	CreatureLoader.reset_secondary_creature_queue()
+	PlayerData.creature_queue.primary_index = 0
+	PlayerData.creature_queue.reset_secondary_creature_queue()
 	for i in range(3):
 		$RestaurantView.summon_creature(i)
 	
@@ -88,12 +88,12 @@ func _start_puzzle() -> void:
 	
 	if _start_button_click_count > 1:
 		# restart puzzle; reset customers
-		CreatureLoader.reset_secondary_creature_queue()
-		if Global.creature_queue:
+		PlayerData.creature_queue.reset_secondary_creature_queue()
+		if PlayerData.creature_queue.primary_queue:
 			# Reset fatness. Playing the same puzzle over and over shouldn't
 			# make a creature super fat. Thematically, we're turning back time.
 			PlayerData.creature_library.restore_fatness_state()
-		Global.creature_queue_index = 0
+		PlayerData.creature_queue.primary_index = 0
 		$RestaurantView.start_suppress_sfx_timer()
 		for i in range(3):
 			$RestaurantView.summon_creature(i)
@@ -175,7 +175,7 @@ func _on_Hud_settings_button_pressed() -> void:
 
 
 func _on_Hud_back_button_pressed() -> void:
-	Global.clear_creature_queue()
+	PlayerData.creature_queue.clear()
 	Level.clear_launched_level()
 	Breadcrumb.pop_trail()
 
@@ -245,6 +245,6 @@ func _on_SettingsMenu_quit_pressed() -> void:
 			MusicPlayer.stop()
 			MusicPlayer.play_chill_bgm()
 			MusicPlayer.fade_in()
-		Global.clear_creature_queue()
+		PlayerData.creature_queue.clear()
 		Level.clear_launched_level()
 		Breadcrumb.pop_trail()

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -62,9 +62,8 @@ properties.
 """
 func summon_creature(creature_index: int = -1) -> void:
 	var creature_def := CreatureDef.new()
-	if Global.creature_queue_index < Global.creature_queue.size():
-		creature_def = Global.creature_queue[Global.creature_queue_index]
-		Global.creature_queue_index += 1
+	if PlayerData.creature_queue.has_primary_creature():
+		creature_def = PlayerData.creature_queue.pop_primary_creature()
 	else:
 		creature_def = CreatureLoader.random_def()
 	$RestaurantViewport/Scene.summon_creature(creature_def, creature_index)

--- a/project/src/main/puzzle/tutorial/tutorial-messages.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-messages.gd
@@ -24,8 +24,8 @@ var _instructor_chat_theme: ChatTheme
 var _popped_in: bool
 
 func _ready() -> void:
-	var _instructor_creature_def := CreatureLoader.load_creature_def(CreatureLoader.INSTRUCTOR_PATH)
-	_instructor_chat_theme = ChatTheme.new(_instructor_creature_def.chat_theme_def)
+	var instructor_creature_def := CreatureDef.new().from_json_path(CreatureLoader.INSTRUCTOR_PATH)
+	_instructor_chat_theme = ChatTheme.new(instructor_creature_def.chat_theme_def)
 	_hide_message()
 
 

--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -17,6 +17,8 @@ func _ready() -> void:
 	playfield = puzzle.get_playfield()
 	piece_manager = puzzle.get_piece_manager()
 	
+	PuzzleScore.connect("before_level_changed", self, "_on_PuzzleScore_before_level_changed")
+	
 	for skill_tally_item in $SkillTallyItems.get_children():
 		if skill_tally_item is SkillTallyItem:
 			var new_item: SkillTallyItem = skill_tally_item.duplicate()
@@ -47,3 +49,14 @@ func hide_completed_skill_tally_items() -> void:
 		var skill_tally_item: SkillTallyItem = skill_tally_item_obj
 		if skill_tally_item.is_complete():
 			skill_tally_item.visible = false
+
+
+"""
+Reset the player's combo between puzzle sections.
+
+Each tutorial section should have a fresh start; we don't want them to receive a discouraging 'you broke your combo'
+fanfare at the start of a section.
+"""
+func _on_PuzzleScore_before_level_changed(_new_level_id: String) -> void:
+	playfield.set_combo(0)
+	PuzzleScore.set_creature_line_clears(0)

--- a/project/src/main/ui/level-select/hookable-grade-label.gd
+++ b/project/src/main/ui/level-select/hookable-grade-label.gd
@@ -97,10 +97,8 @@ func _refresh_status_icon(lock_status: int) -> void:
 			$StatusIcon.texture = _locked_texture
 			$StatusIcon.modulate = Color("666666")
 			outline_color = Color("808080")
-		LevelLock.STATUS_HARD_LOCK:
-			$StatusIcon.texture = _locked_texture
-			$StatusIcon.modulate = Color("444444")
-			outline_color = Color("808080")
+		_:
+			push_warning("Unexpected lock status: %s" % [lock_status])
 	$StatusIcon.material.set("shader_param/black", outline_color)
 
 

--- a/project/src/main/ui/level-select/level-description-panel.gd
+++ b/project/src/main/ui/level-select/level-description-panel.gd
@@ -56,9 +56,6 @@ func _on_LevelButtons_locked_level_selected(level_lock: LevelLock, settings: Lev
 			var level_count := StringUtils.english_number(level_lock.keys_needed)
 			text += "Clear %s more levels to unlock this. You can do it!" % [level_count]
 			text = text.replace("one more levels", "one more level")
-		LevelLock.STATUS_HARD_LOCK:
-			text += "You can't unlock this level yet."
-			text += "\n\n...Go unlock some other levels first. Patience is key!"
 		_:
 			push_warning("Unexpected lock status: %s" % [level_lock.status])
 	

--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -27,13 +27,13 @@ func _exit_tree() -> void:
 
 
 func _launch_tutorial() -> void:
-	Global.clear_creature_queue()
+	PlayerData.creature_queue.clear()
 	Level.set_launched_level(Level.BEGINNER_TUTORIAL, CreatureLoader.INSTRUCTOR_ID)
 	Level.push_level_trail()
 
 
 func _on_PlayStory_pressed() -> void:
-	Global.clear_creature_queue()
+	PlayerData.creature_queue.clear()
 	Level.clear_launched_level()
 	Breadcrumb.push_trail(Global.SCENE_OVERWORLD)
 

--- a/project/src/main/world/creature/creature-def.gd
+++ b/project/src/main/world/creature/creature-def.gd
@@ -5,6 +5,44 @@ Stores information about a creature such as their name, appearance, and dialog.
 
 const CREATURE_DATA_VERSION := "19dd"
 
+# default chat theme when starting a new game
+const DEFAULT_CHAT_THEME_DEF := {
+	"accent_scale": 1.33,
+	"accent_swapped": true,
+	"accent_texture": 13,
+	"color": "b23823"
+}
+
+# default creature appearance when starting a new game
+const DEFAULT_DNA := {
+	"accessory": "0",
+	"belly": "1",
+	"belly_rgb": "c9442a",
+	"bellybutton": "0",
+	"body": "1",
+	"body_rgb": "b23823",
+	"cheek": "3",
+	"cloth_rgb": "282828",
+	"collar": "0",
+	"ear": "1",
+	"eye": "1",
+	"eye_rgb": "282828 dedede",
+	"glass_rgb": "282828",
+	"hair": "0",
+	"hair_rgb": "f1e398",
+	"head": "1",
+	"horn": "1",
+	"horn_rgb": "f1e398",
+	"line_rgb": "6c4331",
+	"mouth": "2",
+	"nose": "0",
+	"plastic_rgb": "282828",
+	"tail": "0",
+}
+
+# default name when starting a new game
+const DEFAULT_NAME := "Spira"
+
 # creature's id, e.g 'boatricia'
 var creature_id: String
 
@@ -73,3 +111,31 @@ func to_json_dict() -> Dictionary:
 		"chat_selectors": chat_selectors,
 		"fatness": min_fatness,
 	}
+
+
+"""
+Loads creature data from a json path. Substitutes any missing data.
+
+Returns:
+	The newly loaded creature data, or 'null' if there was a problem loading the json data.
+"""
+func from_json_path(path: String) -> CreatureDef:
+	var result := self
+	var creature_def_text: String = FileUtils.get_file_as_text(path)
+	var parsed = parse_json(creature_def_text)
+	if typeof(parsed) == TYPE_DICTIONARY:
+		var json_creature_def: Dictionary = parsed
+		from_json_dict(json_creature_def)
+		
+		# populate default values when importing incomplete json
+		for allele in DnaUtils.ALLELES:
+			Utils.put_if_absent(dna, allele, DEFAULT_DNA[allele])
+		if not creature_name:
+			creature_name = DEFAULT_NAME
+		if not creature_short_name:
+			creature_short_name = DEFAULT_NAME
+		if not chat_theme_def:
+			chat_theme_def = DEFAULT_CHAT_THEME_DEF.duplicate()
+	else:
+		result = null
+	return result


### PR DESCRIPTION
Extracted new CreatureQueue class. This logic used to be spread between
Global and CreatureLoader, but is now collected in a single class. Also
moved some creature constants and initialization logic into CreatureDef.
This was necessary to avoid circular references while refactoring.

Tutorials now reset combo when the player clears a section. This lets us remove the 'don't build combos' flag from the tutorial level data. This also lets the player build combos on tutorial sections which should be more intuitive.

Removed redundant 'how to render hard locked levels' logic. Hard locked
levels were once rendered, but they're not anymore.