### PR TITLE
Fix resource leak introduced in CreatureQueue refactoring.

### DIFF
--- a/project/src/main/creature-queue.gd
+++ b/project/src/main/creature-queue.gd
@@ -94,7 +94,8 @@ func _load_secondary_creatures() -> void:
 		if not file:
 			break
 		else:
-			var creature_def := CreatureDef.new().from_json_path("%s/%s" % [dir.get_current_dir(), file.get_file()])
+			var creature_def: CreatureDef = CreatureDef.new()
+			creature_def = creature_def.from_json_path("%s/%s" % [dir.get_current_dir(), file.get_file()])
 			creature_def.creature_id = file.get_file().get_basename()
 			secondary_queue.append(creature_def)
 	dir.list_dir_end()

--- a/project/src/main/editor/creature/dialogs.gd
+++ b/project/src/main/editor/creature/dialogs.gd
@@ -25,7 +25,7 @@ func _on_ImportButton_pressed() -> void:
 Imports the specified creature into the editor.
 """
 func _on_ImportDialog_file_selected(path: String) -> void:
-	var loaded_def := CreatureDef.new().from_json_path(path)
+	var loaded_def: CreatureDef = CreatureDef.new().from_json_path(path)
 	if loaded_def:
 		_creature_editor.set_center_creature_def(loaded_def)
 		_creature_editor.mutate_all_creatures()

--- a/project/src/main/puzzle/tutorial/tutorial-messages.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-messages.gd
@@ -24,7 +24,7 @@ var _instructor_chat_theme: ChatTheme
 var _popped_in: bool
 
 func _ready() -> void:
-	var instructor_creature_def := CreatureDef.new().from_json_path(CreatureLoader.INSTRUCTOR_PATH)
+	var instructor_creature_def: CreatureDef = CreatureDef.new().from_json_path(CreatureLoader.INSTRUCTOR_PATH)
 	_instructor_chat_theme = ChatTheme.new(instructor_creature_def.chat_theme_def)
 	_hide_message()
 

--- a/project/src/main/world/creature/creature-def.gd
+++ b/project/src/main/world/creature/creature-def.gd
@@ -116,10 +116,13 @@ func to_json_dict() -> Dictionary:
 """
 Loads creature data from a json path. Substitutes any missing data.
 
+Note: This method signature should specify a return type of 'CreatureDef', but that causes console errors due to Godot
+#30668 (https://github.com/godotengine/godot/issues/30668).
+
 Returns:
 	The newly loaded creature data, or 'null' if there was a problem loading the json data.
 """
-func from_json_path(path: String) -> CreatureDef:
+func from_json_path(path: String) -> Object:
 	var result := self
 	var creature_def_text: String = FileUtils.get_file_as_text(path)
 	var parsed = parse_json(creature_def_text)

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -192,7 +192,7 @@ func load_creature_def_by_id(id: String) -> CreatureDef:
 			path = INSTRUCTOR_PATH
 		_:
 			path = "res://assets/main/creatures/primary/%s/creature.json" % id
-	return CreatureDef.new().from_json_path(path)
+	return CreatureDef.new().from_json_path(path) as CreatureDef
 
 
 """


### PR DESCRIPTION
CreatureDef cannot have a method returning a CreatureDef or Godot will
throw warnings/errors. See Godot #30668.