### PR TITLE
Refactored combos, restaurant nametags, dna loader.

### DIFF
--- a/project/src/main/puzzle/combo-counters.gd
+++ b/project/src/main/puzzle/combo-counters.gd
@@ -47,7 +47,7 @@ func _on_PuzzleScore_before_piece_written() -> void:
 When a line is cleared we add a new combo counter.
 """
 func _on_Playfield_before_line_cleared(y: int, _total_lines: int, _remaining_lines: int, _box_ints: Array) -> void:
-	if PuzzleScore.get_creature_line_clears() < 3:
+	if PuzzleScore.combo < 3:
 		# no combo counters below 3x
 		return
 	
@@ -75,5 +75,5 @@ func _on_Playfield_before_line_cleared(y: int, _total_lines: int, _remaining_lin
 	combo_counter.position = _playfield.tile_map.map_to_world(target_cell + Vector2(0, -3))
 	combo_counter.position += _playfield.tile_map.cell_size * Vector2(0.5, 0.5)
 	combo_counter.position *= _playfield.tile_map.scale
-	combo_counter.combo = PuzzleScore.get_creature_line_clears()
+	combo_counter.combo = PuzzleScore.combo
 	add_child(combo_counter)

--- a/project/src/main/puzzle/combo-tracker.gd
+++ b/project/src/main/puzzle/combo-tracker.gd
@@ -6,14 +6,10 @@ Keeps track of the player's combo.
 Increments the combo when the player does well, breaks the combo when the player messes up.
 """
 
-signal combo_changed(value)
 signal combo_break_changed(value)
 
 # bonus points which are awarded as the player continues a combo
 const COMBO_SCORE_ARR = [0, 0, 5, 5, 10, 10, 15, 15, 20]
-
-# number of lines the player has cleared without dropping their combo
-var combo := 0 setget set_combo
 
 # The number of pieces the player has dropped without clearing a line or making a box.
 var combo_break := 0 setget set_combo_break
@@ -31,36 +27,28 @@ func _ready() -> void:
 	Level.connect("settings_changed", self, "_on_Level_settings_changed")
 
 
-func set_combo(new_combo: int) -> void:
-	combo = new_combo
-	emit_signal("combo_changed", new_combo)
-
-
 func set_combo_break(new_combo_break: int) -> void:
 	combo_break = new_combo_break
 	emit_signal("combo_break_changed", combo_break)
 
 
 func break_combo() -> void:
-	if combo >= 20:
+	if PuzzleScore.combo >= 20:
 		$Fanfare3.play()
-	elif combo >= 10:
+	elif PuzzleScore.combo >= 10:
 		$Fanfare2.play()
-	elif combo >= 5:
+	elif PuzzleScore.combo >= 5:
 		$Fanfare1.play()
 	
-	if PuzzleScore.get_creature_line_clears() > 0:
+	if PuzzleScore.combo > 0:
 		PuzzleScore.end_combo()
-	combo = 0
-	emit_signal("combo_changed", combo)
+	PuzzleScore.combo = 0
 	emit_signal("combo_break_changed", combo_break)
 
 
 func _reset() -> void:
-	combo = 0
 	combo_break = 0
-	emit_signal("combo_changed", combo)
-	emit_signal("combo_break_changed", combo)
+	emit_signal("combo_break_changed", combo_break)
 
 
 func _on_PuzzleScore_game_prepared() -> void:
@@ -115,8 +103,7 @@ func _on_PuzzleScore_game_ended() -> void:
 Increments the combo and score for the specified line clear.
 """
 func _on_Playfield_before_line_cleared(_y: int, _total_lines: int, _remaining_lines: int, box_ints: Array) -> void:
-	combo += 1
-	var combo_score: int = COMBO_SCORE_ARR[clamp(combo - 1, 0, COMBO_SCORE_ARR.size() - 1)]
+	var combo_score: int = COMBO_SCORE_ARR[clamp(PuzzleScore.combo, 0, COMBO_SCORE_ARR.size() - 1)]
 	var box_score := 0
 	for box_int in box_ints:
 		if PuzzleTileMap.is_snack_box(box_int):
@@ -126,4 +113,3 @@ func _on_Playfield_before_line_cleared(_y: int, _total_lines: int, _remaining_li
 		else:
 			box_score += Level.settings.score.veg_points
 	PuzzleScore.add_line_score(combo_score, box_score)
-	emit_signal("combo_changed", combo)

--- a/project/src/main/puzzle/line-clear-sfx.gd
+++ b/project/src/main/puzzle/line-clear-sfx.gd
@@ -49,8 +49,6 @@ onready var _line_erase_sounds := [$LineEraseSound1, $LineEraseSound2, $LineEras
 
 onready var _veg_erase_sounds := [$VegEraseSound1, $VegEraseSound2, $VegEraseSound3]
 
-onready var _combo_tracker: ComboTracker = $"../ComboTracker"
-
 func _play_thump_sound(_y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
 	var sound_index := clamp(total_lines - remaining_lines - 1, 0, _line_erase_sounds.size() - 1)
 	var sound: AudioStreamPlayer
@@ -71,13 +69,13 @@ a repeating list where the repetition is concealed using a shepard tone.
 """
 func _play_combo_sound(_y: int, _total_lines: int, _remaining_lines: int, _box_ints: Array) -> void:
 	var sound: AudioStream
-	if _combo_tracker.combo <= 0:
+	if PuzzleScore.combo <= 0:
 		# lines were cleared from top out or another unusual case. don't play combo sounds
 		pass
-	elif _combo_tracker.combo < _combo_sounds.size():
-		sound = _combo_sounds[_combo_tracker.combo - 1]
+	elif PuzzleScore.combo < _combo_sounds.size():
+		sound = _combo_sounds[PuzzleScore.combo - 1]
 	else:
-		sound = _combo_endless_sounds[(_combo_tracker.combo - 1 - _combo_sounds.size()) % _combo_endless_sounds.size()]
+		sound = _combo_endless_sounds[(PuzzleScore.combo - 1 - _combo_sounds.size()) % _combo_endless_sounds.size()]
 	if sound:
 		$ComboSound.stream = sound
 		$ComboSound.play()

--- a/project/src/main/puzzle/playfield-fx.gd
+++ b/project/src/main/puzzle/playfield-fx.gd
@@ -82,7 +82,7 @@ onready var _combo_tracker: ComboTracker = get_node(combo_tracker_path)
 func _ready() -> void:
 	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
 	_combo_tracker.connect("combo_break_changed", self, "_on_ComboTracker_combo_break_changed")
-	_combo_tracker.connect("combo_changed", self, "_on_ComboTracker_combo_changed")
+	PuzzleScore.connect("combo_changed", self, "_on_PuzzleScore_combo_changed")
 	_init_tile_set()
 	_init_color_tile_indexes()
 	reset()
@@ -244,7 +244,7 @@ func _on_ComboTracker_combo_break_changed(_value: int) -> void:
 	_refresh_tile_maps()
 
 
-func _on_ComboTracker_combo_changed(value: int) -> void:
+func _on_PuzzleScore_combo_changed(value: int) -> void:
 	_calculate_brightness(value)
 	_start_glow_tween()
 	_refresh_tile_maps()

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -119,10 +119,6 @@ func break_combo() -> void:
 	$ComboTracker.break_combo()
 
 
-func set_combo(new_combo: int) -> void:
-	$ComboTracker.combo = new_combo
-
-
 """
 Resets the playfield to the level's initial state.
 """

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -132,7 +132,7 @@ func _feed_creature(fatness_pct: float, food_color: Color) -> void:
 	else:
 		var comfort := 0.0
 		# ate five things; comfortable
-		comfort += clamp(inverse_lerp(5, 15, PuzzleScore.get_creature_line_clears()), 0.0, 1.0)
+		comfort += clamp(inverse_lerp(5, 15, PuzzleScore.combo), 0.0, 1.0)
 		# starting to overeat; less comfortable
 		comfort -= clamp(inverse_lerp(400, 600, PuzzleScore.get_creature_score()), 0.0, 1.0)
 		# overate; uncomfortable
@@ -194,7 +194,7 @@ func _on_Playfield_line_cleared(_y: int, total_lines: int, remaining_lines: int,
 	
 	# Calculate whether or not the creature should say something positive about the combo.
 	# They say something after clearing [6, 12, 18, 24...] lines.
-	if remaining_lines == 0 and $Playfield/ComboTracker.combo >= 6 and total_lines > $Playfield/ComboTracker.combo % 6:
+	if remaining_lines == 0 and PuzzleScore.combo >= 6 and total_lines > PuzzleScore.combo % 6:
 		yield(get_tree().create_timer(0.5), "timeout")
 		$RestaurantView.get_customer().play_combo_voice()
 

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -19,7 +19,7 @@ func _ready() -> void:
 	
 	PuzzleScore.connect("game_ended", self, "_on_PuzzleScore_game_ended")
 	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
-	PuzzleScore.connect("combo_ended", self, "_on_PuzzleScore_combo_ended")
+	PuzzleScore.connect("combo_changed", self, "_on_PuzzleScore_combo_changed")
 	PuzzleScore.connect("topped_out", self, "_on_PuzzleScore_topped_out")
 	PuzzleScore.connect("added_line_score", self, "_on_PuzzleScore_added_line_score")
 	
@@ -92,18 +92,11 @@ func start_suppress_sfx_timer() -> void:
 
 
 func _refresh_customer_name() -> void:
-	_refresh_nametag($CustomerNametag/Panel, get_customer())
+	$CustomerNametag/Panel.refresh_creature(get_customer())
 
 
 func _refresh_player_name() -> void:
-	_refresh_nametag($RestaurantNametag/Panel, get_player())
-
-
-func _refresh_nametag(nametag: NametagPanel, creature: Creature) -> void:
-	nametag.set_nametag_text(creature.creature_name)
-	var chat_theme := ChatTheme.new(creature.chat_theme_def)
-	nametag.set_bg_color(chat_theme.border_color)
-	nametag.set_font_color(chat_theme.nametag_font_color)
+	$RestaurantNametag/Panel.refresh_creature(get_player())
 
 
 func _on_Player_creature_name_changed() -> void:
@@ -118,7 +111,14 @@ func _on_PuzzleScore_game_prepared() -> void:
 		scroll_to_new_creature()
 
 
-func _on_PuzzleScore_combo_ended() -> void:
+"""
+Cycle out the customer when the combo resets to 0.
+"""
+func _on_PuzzleScore_combo_changed(value: int) -> void:
+	if value > 0:
+		# if the combo is not resetting, we ignore the change
+		return
+	
 	if PuzzleScore.no_more_customers:
 		pass
 	elif PuzzleScore.game_active:

--- a/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
@@ -28,7 +28,7 @@ var _combo_diagram := preload("res://assets/main/puzzle/tutorial/combo-diagram.p
 func _ready() -> void:
 	PuzzleScore.connect("after_game_prepared", self, "_on_PuzzleScore_after_game_prepared")
 	PuzzleScore.connect("after_level_changed", self, "_on_PuzzleScore_after_level_changed")
-	PuzzleScore.connect("combo_ended", self, "_on_PuzzleScore_combo_ended")
+	PuzzleScore.connect("combo_changed", self, "_on_PuzzleScore_combo_changed")
 	
 	playfield.connect("after_piece_written", self, "_on_Playfield_after_piece_written")
 	playfield.connect("line_cleared", self, "_on_Playfield_line_cleared")
@@ -108,13 +108,11 @@ Parameters:
 	'goal': (Optional) The combo needed to complete the tutorial section
 """
 func _set_combo_state(start: int, goal: int = 0) -> void:
+	PuzzleScore.set_combo(start)
 	if goal:
 		hud.skill_tally_item("Combo").value = start
 		hud.skill_tally_item("Combo").max_value = goal
 		hud.skill_tally_item("Combo").update_label()
-	
-	playfield.set_combo(start)
-	PuzzleScore.set_creature_line_clears(start)
 
 
 """
@@ -250,8 +248,9 @@ func _on_Playfield_box_built(_rect: Rect2, color: int) -> void:
 		hud.skill_tally_item("CakeBox").increment()
 
 
-func _on_PuzzleScore_combo_ended() -> void:
-	_did_end_combo = true
+func _on_PuzzleScore_combo_changed(value: int) -> void:
+	if value == 0:
+		_did_end_combo = true
 
 
 func _on_PuzzleScore_after_game_prepared() -> void:

--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -58,5 +58,4 @@ Each tutorial section should have a fresh start; we don't want them to receive a
 fanfare at the start of a section.
 """
 func _on_PuzzleScore_before_level_changed(_new_level_id: String) -> void:
-	playfield.set_combo(0)
-	PuzzleScore.set_creature_line_clears(0)
+	PuzzleScore.set_combo(0)

--- a/project/src/main/ui/chat/chat-nametag-panel.gd
+++ b/project/src/main/ui/chat/chat-nametag-panel.gd
@@ -15,9 +15,7 @@ func show_label(chat_theme: ChatTheme, nametag_right: bool) -> void:
 	if nametag_size == ChatTheme.NAMETAG_OFF:
 		return
 	
-	set_bg_color(chat_theme.border_color)
-	set_font_color(chat_theme.nametag_font_color)
-	
+	refresh_chat_theme(chat_theme)
 	rect_position.y = 2 - rect_size.y
 	if nametag_right:
 		rect_position.x = get_parent().rect_size.x - rect_size.x - 12

--- a/project/src/main/ui/nametag-panel.gd
+++ b/project/src/main/ui/nametag-panel.gd
@@ -18,6 +18,16 @@ onready var _labels := {
 	ChatTheme.NAMETAG_XXL: $ExtraExtraLarge,
 }
 
+func refresh_creature(creature: Creature) -> void:
+	set_nametag_text(creature.creature_name)
+	refresh_chat_theme(ChatTheme.new(creature.chat_theme_def))
+
+
+func refresh_chat_theme(chat_theme: ChatTheme) -> void:
+	set_bg_color(chat_theme.border_color)
+	set_font_color(chat_theme.nametag_font_color)
+
+
 """
 Assigns the name label's text and updates our nametag_size field to the smallest name label which fit.
 """

--- a/project/src/main/world/creature/CreatureVisuals.tscn
+++ b/project/src/main/world/creature/CreatureVisuals.tscn
@@ -352,7 +352,6 @@ texture = ExtResource( 51 )
 frame_data = "res://assets/main/world/creature/1/sprint-z0-packed.json"
 rect_size = Vector2( 512, 512 )
 frame = 6
-centered = true
 offset = Vector2( 0, -119 )
 
 [node name="TailZ0" type="Node2D" parent="."]
@@ -491,9 +490,6 @@ script = ExtResource( 9 )
 __meta__ = {
 "_editor_description_": "Neck1 offsets the head's position as the creature bobs their head up and down"
 }
-head_bob_mode = 1
-head_motion_pixels = 2.0
-head_motion_seconds = 6.5
 
 [node name="AccessoryZ0" type="Node2D" parent="Neck0/HeadBobber"]
 show_behind_parent = true
@@ -823,9 +819,6 @@ script = ExtResource( 8 )
 
 [node name="Animations" type="Node" parent="."]
 script = ExtResource( 5 )
-emote_eye_frame = 0
-eye_frame = 0
-emote_arm_frame = 0
 creature_visuals_path = NodePath("..")
 
 [node name="IdleTimer" type="Timer" parent="Animations"]
@@ -845,50 +838,50 @@ root_node = NodePath("../..")
 root_node = NodePath("../..")
 creature_visuals_path = NodePath("../..")
 [connection signal="dna_loaded" from="." to="Animations/IdleTimer" method="_on_CreatureVisuals_dna_loaded"]
-[connection signal="movement_mode_changed" from="." to="FarArm" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Sprint" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="FarLeg" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ2" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ2" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/AccessoryZ2" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/AccessoryZ0" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ0" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ0" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="NearArm" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Sprint" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="FarArm" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="FarLeg" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="NearLeg" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Bellybutton" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Collar" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Nose" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/AccessoryZ1" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ1" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ0" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Collar" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ0" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="NearLeg" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/AccessoryZ0" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Bellybutton" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/CheekZ2" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ1" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/HairZ2" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/AccessoryZ1" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/Nose" method="_on_CreatureVisuals_movement_mode_changed"]
-[connection signal="movement_mode_changed" from="." to="Neck0/HeadBobber/AccessoryZ2" method="_on_CreatureVisuals_movement_mode_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ2" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ2" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/AccessoryZ2" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/AccessoryZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="NearArm" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="FarArm" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="FarLeg" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="NearArm" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="NearLeg" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Bellybutton" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Collar" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Nose" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/AccessoryZ1" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ1" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ1" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ0" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ0" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Collar" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ0" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Head" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="NearLeg" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/AccessoryZ0" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Bellybutton" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/EarZ2" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/CheekZ2" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ1" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HairZ2" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/AccessoryZ1" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Nose" method="_on_CreatureVisuals_orientation_changed"]
-[connection signal="orientation_changed" from="." to="Neck0/HeadBobber/AccessoryZ2" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="idle_animation_started" from="Animations/IdleTimer" to="Animations/EmotePlayer" method="_on_IdleTimer_idle_animation_started"]
 [connection signal="idle_animation_stopped" from="Animations/IdleTimer" to="Animations/EmotePlayer" method="_on_IdleTimer_idle_animation_stopped"]

--- a/project/src/main/world/creature/creature-visuals.gd
+++ b/project/src/main/world/creature/creature-visuals.gd
@@ -19,7 +19,6 @@ unnecessary textures are loaded.
 signal food_eaten
 
 # emitted when a creature's textures and animations are loaded
-# warning-ignore:unused_signal
 signal dna_loaded
 
 # emitted during the 'run' animation when the creature touches the ground
@@ -104,6 +103,7 @@ var mouth_player
 func _ready() -> void:
 	# Update creature's appearance based on their behavior and orientation
 	set_orientation(orientation)
+	$DnaLoader.connect("dna_loaded", self, "_on_DnaLoader_dna_loaded")
 
 
 func _process(delta: float) -> void:
@@ -423,3 +423,7 @@ func _compute_orientation(direction: Vector2) -> int:
 		# convert the float orientation [-2.0, 2.0] to an int orientation [0, 3]
 		new_orientation = wrapi(int(round(unrounded_orientation)), 0, 4)
 	return new_orientation
+
+
+func _on_DnaLoader_dna_loaded() -> void:
+	emit_signal("dna_loaded")

--- a/project/src/main/world/creature/dna-loader.gd
+++ b/project/src/main/world/creature/dna-loader.gd
@@ -7,6 +7,9 @@ This needs to be separate from the CreatureVisuals node because it must continue
 creature editor will have strange behavior, particularly in its color picker.
 """
 
+# emitted when a creature's textures and animations are loaded
+signal dna_loaded
+
 # The maximum amount of microseconds to spend setting shader params in each frame. This is capped to avoid frame drops.
 const MAX_SHADER_USEC_PER_FRAME := 240
 
@@ -143,7 +146,7 @@ func load_dna() -> void:
 	
 	# initialize creature curves, and reset the mouth/eye frame to avoid a strange transition frame
 	_creature_visuals.reset_frames()
-	_creature_visuals.emit_signal("dna_loaded")
+	emit_signal("dna_loaded")
 
 
 """

--- a/project/src/main/world/restaurant/RestaurantView.tscn
+++ b/project/src/main/world/restaurant/RestaurantView.tscn
@@ -215,6 +215,6 @@ margin_bottom = 367.0
 margin_left = -60.0
 margin_right = 60.0
 custom_styles/panel = SubResource( 4 )
-[connection signal="current_creature_index_changed" from="RestaurantViewport/Scene" to="CustomerCameraMover" method="_on_RestaurantScene_current_creature_index_changed"]
 [connection signal="current_creature_index_changed" from="RestaurantViewport/Scene" to="." method="_on_RestaurantScene_current_creature_index_changed"]
+[connection signal="current_creature_index_changed" from="RestaurantViewport/Scene" to="CustomerCameraMover" method="_on_RestaurantScene_current_creature_index_changed"]
 [connection signal="food_eaten" from="RestaurantViewport/Scene" to="CustomerCameraMover" method="_on_RestaurantScene_food_eaten"]


### PR DESCRIPTION
Combined ComboTracker.combo and PuzzleScore.creature_line_clears. We were
storing this information in two places before. It's now stored in PuzzleScore's
new combo field.

Pushed logic for refreshing nametag appearance into NametagPanel to keep
RestaurantView smaller.

DnaLoader no longer emits a signal on CreatureVisuals. Nodes should emit
their own signals, even if it's technically a little less efficient in
this case.