### PR TITLE
Rewrote piece shuffling algorithm to be more reliable.

### DIFF
--- a/project/src/test/puzzle/piece/test-piece-queue.gd
+++ b/project/src/test/puzzle/piece/test-piece-queue.gd
@@ -1,0 +1,24 @@
+extends "res://addons/gut/test.gd"
+"""
+Unit test for the queue of upcoming pieces.
+"""
+
+func test_empty() -> void:
+	assert_eq([0], PieceQueue.non_adjacent_indexes([], 3))
+
+
+func test_nothing_matches() -> void:
+	assert_eq([0, 1, 2, 3], PieceQueue.non_adjacent_indexes([1, 1, 1], 2))
+
+
+func test_many_matches() -> void:
+	assert_eq([0, 3, 6], PieceQueue.non_adjacent_indexes([1, 2, 1, 1, 2, 1], 2))
+
+
+func test_from_index() -> void:
+	assert_eq([3, 4], PieceQueue.non_adjacent_indexes([1, 2, 1, 1], 2, 3))
+	assert_eq([4], PieceQueue.non_adjacent_indexes([1, 2, 1, 1], 2, 4))
+
+
+func test_no_possibilities() -> void:
+	assert_eq([], PieceQueue.non_adjacent_indexes([2, 1, 2], 2))


### PR DESCRIPTION
The old algorithm shuffled pieces up to 48 times and hoped that one of the
random arrangements resulted in having no back-to-back pieces. But it was
random, and even though the most I ever saw it take was 15-20 tries, it
could theoretically have bad luck and fail to come up with an arrangement.

The new algorithm finds a location for each piece deterministically, and
is more reliable. It will only fail if it's impossible to find an
arrangement (e.g a custom level with a piece queue with 3 T pieces and an
O piece)