### PR TITLE
DNA refactoring, PackedScene replacements

### DIFF
--- a/project/src/demo/ui/chat/mood-demo.gd
+++ b/project/src/demo/ui/chat/mood-demo.gd
@@ -29,7 +29,7 @@ func _input(event: InputEvent) -> void:
 			KEY_F: $Creature.creature_visuals.play_idle_animation("idle-ear-wiggle1")
 	else:
 		match(Utils.key_scancode(event)):
-			KEY_BRACELEFT, KEY_BRACERIGHT: $Creature.dna = DnaUtils.fill_dna(DnaUtils.random_creature_palette())
+			KEY_BRACELEFT, KEY_BRACERIGHT: $Creature.dna = DnaUtils.random_dna()
 			KEY_1: $Creature.play_mood(ChatEvent.Mood.DEFAULT)
 			KEY_Q: $Creature.play_mood(ChatEvent.Mood.SMILE0)
 			KEY_W: $Creature.play_mood(ChatEvent.Mood.SMILE1)

--- a/project/src/main/editor/puzzle/LevelEditor.tscn
+++ b/project/src/main/editor/puzzle/LevelEditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=2]
+[gd_scene load_steps=20 format=2]
 
 [ext_resource path="res://src/main/puzzle/PuzzleTileMap.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/editor/puzzle/editor-json.gd" type="Script" id=2]
@@ -16,6 +16,7 @@
 [ext_resource path="res://assets/main/ui/touch/rotate-cw.png" type="Texture" id=14]
 [ext_resource path="res://src/main/ui/DialogBackdrop.tscn" type="PackedScene" id=15]
 [ext_resource path="res://src/main/editor/puzzle/dialogs.gd" type="Script" id=16]
+[ext_resource path="res://src/main/puzzle/Puzzle.tscn" type="PackedScene" id=17]
 
 [sub_resource type="ShaderMaterial" id=1]
 resource_local_to_scene = true
@@ -41,6 +42,7 @@ script = ExtResource( 8 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+PuzzleScene = ExtResource( 17 )
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
 anchor_right = 1.0

--- a/project/src/main/editor/puzzle/level-editor.gd
+++ b/project/src/main/editor/puzzle/level-editor.gd
@@ -9,10 +9,10 @@ Full instructions are available at https://github.com/Poobslag/turbofat/wiki/lev
 # default to an empty level; players may be confused if it's not empty
 const DEFAULT_LEVEL := "ultra_normal"
 
+export (PackedScene) var PuzzleScene: PackedScene
+
 # level scene currently being tested
 var _test_scene: Node
-
-onready var PuzzleScene := preload("res://src/main/puzzle/Puzzle.tscn")
 
 onready var level_name := $HBoxContainer/SideButtons/LevelName
 onready var _level_json := $HBoxContainer/SideButtons/Json

--- a/project/src/main/puzzle/FrostingViewports.tscn
+++ b/project/src/main/puzzle/FrostingViewports.tscn
@@ -1,12 +1,14 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://src/main/puzzle/frosting-viewports.gd" type="Script" id=1]
+[ext_resource path="res://src/main/puzzle/FrostingGlob.tscn" type="PackedScene" id=2]
 
 [node name="FrostingViewports" type="Control"]
 script = ExtResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+FrostingGlobScene = ExtResource( 2 )
 
 [node name="Viewport" type="Viewport" parent="."]
 size = Vector2( 324, 544 )

--- a/project/src/main/puzzle/Playfield.tscn
+++ b/project/src/main/puzzle/Playfield.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=40 format=2]
+[gd_scene load_steps=41 format=2]
 
 [ext_resource path="res://src/main/puzzle/playfield.gd" type="Script" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleTileMap.tscn" type="PackedScene" id=2]
@@ -22,6 +22,7 @@
 [ext_resource path="res://src/main/puzzle/flat-mix.shader" type="Shader" id=20]
 [ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=21]
 [ext_resource path="res://src/main/ui/blogger-sans-medium-18.tres" type="DynamicFont" id=22]
+[ext_resource path="res://src/main/puzzle/LeafPoof.tscn" type="PackedScene" id=23]
 [ext_resource path="res://assets/main/puzzle/playfield-bg.png" type="Texture" id=37]
 [ext_resource path="res://src/main/puzzle/combo-tracker.gd" type="Script" id=61]
 [ext_resource path="res://assets/main/fuzzy-circle-128.png" type="Texture" id=62]
@@ -182,6 +183,7 @@ __meta__ = {
 position = Vector2( 0, -96 )
 z_index = 5
 script = ExtResource( 5 )
+LeafPoofScene = ExtResource( 23 )
 puzzle_tile_map_path = NodePath("../TileMap")
 
 [node name="ShadowTexture" type="TextureRect" parent="."]
@@ -300,8 +302,8 @@ bus = "Sound Bus"
 bus = "Sound Bus"
 [connection signal="before_line_cleared" from="." to="TileMapClip/PlayfieldFx" method="_on_Playfield_before_line_cleared"]
 [connection signal="before_line_cleared" from="." to="TileMapClip/LeafPoofs" method="_on_Playfield_before_line_cleared"]
-[connection signal="before_line_cleared" from="." to="LineClearSfx" method="_on_Playfield_before_line_cleared"]
 [connection signal="before_line_cleared" from="." to="ComboTracker" method="_on_Playfield_before_line_cleared"]
+[connection signal="before_line_cleared" from="." to="LineClearSfx" method="_on_Playfield_before_line_cleared"]
 [connection signal="blocks_prepared" from="." to="LineClearer" method="_on_Playfield_blocks_prepared"]
 [connection signal="box_built" from="." to="TileMapClip/PlayfieldFx" method="_on_Playfield_box_built"]
 [connection signal="box_built" from="." to="BuildBoxSfx" method="_on_Playfield_box_built"]

--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=70 format=2]
+[gd_scene load_steps=75 format=2]
 
 [ext_resource path="res://src/main/ui/menu/theme/h3.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/tutorial/TutorialHud.tscn" type="PackedScene" id=2]
@@ -32,12 +32,17 @@
 [ext_resource path="res://src/main/puzzle/topout-tracker.gd" type="Script" id=30]
 [ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=31]
 [ext_resource path="res://src/main/puzzle/combo-counters.gd" type="Script" id=32]
+[ext_resource path="res://src/main/puzzle/Seed.tscn" type="PackedScene" id=33]
+[ext_resource path="res://src/main/puzzle/Star.tscn" type="PackedScene" id=34]
+[ext_resource path="res://src/main/puzzle/FrostingGlob.tscn" type="PackedScene" id=35]
 [ext_resource path="res://src/main/ui/font-fit-label.gd" type="Script" id=36]
+[ext_resource path="res://src/main/puzzle/FoodItem.tscn" type="PackedScene" id=37]
 [ext_resource path="res://assets/main/ui/go.wav" type="AudioStream" id=38]
 [ext_resource path="res://assets/main/ui/ready.wav" type="AudioStream" id=39]
 [ext_resource path="res://assets/main/puzzle/wood-backdrop.png" type="Texture" id=40]
 [ext_resource path="res://assets/main/puzzle/playfield-walls.png" type="Texture" id=41]
 [ext_resource path="res://assets/main/puzzle/chalkboard.png" type="Texture" id=42]
+[ext_resource path="res://src/main/puzzle/ComboCounter.tscn" type="PackedScene" id=43]
 [ext_resource path="res://assets/main/world/chef/gameover-voice4.wav" type="AudioStream" id=44]
 [ext_resource path="res://assets/main/world/chef/gameover-voice3.wav" type="AudioStream" id=45]
 [ext_resource path="res://assets/main/world/chef/gameover-voice0.wav" type="AudioStream" id=46]
@@ -169,6 +174,8 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 _puzzle_tile_map_path = NodePath("../Playfield/TileMapClip/TileMap")
+StarScene = ExtResource( 34 )
+SeedScene = ExtResource( 33 )
 
 [node name="PieceManager" parent="." instance=ExtResource( 9 )]
 playfield_path = NodePath("../Playfield")
@@ -188,6 +195,7 @@ margin_bottom = 576.5
 script = ExtResource( 16 )
 glob_min_scale = 1.2
 glob_max_scale = 2.5
+FrostingGlobScene = ExtResource( 35 )
 
 [node name="Walls" type="TextureRect" parent="."]
 material = SubResource( 5 )
@@ -209,6 +217,7 @@ script = ExtResource( 24 )
 puzzle_tile_map_path = NodePath("../Playfield/TileMapClip/TileMap")
 playfield_path = NodePath("../Playfield")
 next_piece_displays_path = NodePath("../NextPieceDisplays")
+FrostingGlobScene = ExtResource( 35 )
 
 [node name="GlobViewports" type="Node" parent="FrostingGlobs"]
 
@@ -247,6 +256,7 @@ __meta__ = {
 z_index = 3
 script = ExtResource( 20 )
 playfield_path = NodePath("../Playfield")
+FoodScene = ExtResource( 37 )
 
 [node name="Viewport" type="Viewport" parent="FoodItems"]
 size = Vector2( 1024, 600 )
@@ -269,6 +279,7 @@ z_index = 3
 script = ExtResource( 32 )
 piece_manager_path = NodePath("../PieceManager")
 playfield_path = NodePath("../Playfield")
+ComboCounterScene = ExtResource( 43 )
 
 [node name="Hud" type="CanvasLayer" parent="."]
 
@@ -487,12 +498,12 @@ codes = [ "delays" ]
 
 [node name="PuzzleMusicManager" type="Node" parent="."]
 script = ExtResource( 19 )
-[connection signal="before_line_cleared" from="Playfield" to="StarSeeds" method="_on_Playfield_before_line_cleared"]
 [connection signal="before_line_cleared" from="Playfield" to="FrostingGlobs" method="_on_Playfield_before_line_cleared"]
 [connection signal="before_line_cleared" from="Playfield" to="ComboCounters" method="_on_Playfield_before_line_cleared"]
+[connection signal="before_line_cleared" from="Playfield" to="StarSeeds" method="_on_Playfield_before_line_cleared"]
 [connection signal="blocks_prepared" from="Playfield" to="StarSeeds" method="_on_Playfield_blocks_prepared"]
-[connection signal="box_built" from="Playfield" to="StarSeeds" method="_on_Playfield_box_built"]
 [connection signal="box_built" from="Playfield" to="FrostingGlobs" method="_on_Playfield_box_built"]
+[connection signal="box_built" from="Playfield" to="StarSeeds" method="_on_Playfield_box_built"]
 [connection signal="line_cleared" from="Playfield" to="." method="_on_Playfield_line_cleared"]
 [connection signal="line_erased" from="Playfield" to="StarSeeds" method="_on_Playfield_line_erased"]
 [connection signal="lines_deleted" from="Playfield" to="StarSeeds" method="_on_Playfield_lines_deleted"]

--- a/project/src/main/puzzle/combo-counters.gd
+++ b/project/src/main/puzzle/combo-counters.gd
@@ -5,6 +5,7 @@ Combo indicators which appear when the player clears a line in puzzle mode.
 
 export (NodePath) var piece_manager_path: NodePath
 export (NodePath) var playfield_path: NodePath
+export (PackedScene) var ComboCounterScene: PackedScene
 
 # Stores the x position of the previous combo counter to ensure consecutive counters aren't vertically aligned
 var _previous_cell_x := -1
@@ -14,7 +15,6 @@ var _previous_cell_x := -1
 # value: average x position of the piece's blocks in that row
 var _piece_x_by_y: Dictionary
 
-onready var ComboCounterScene := preload("res://src/main/puzzle/ComboCounter.tscn")
 onready var _piece_manager: PieceManager = get_node(piece_manager_path)
 onready var _playfield: Playfield = get_node(playfield_path)
 

--- a/project/src/main/puzzle/food-items.gd
+++ b/project/src/main/puzzle/food-items.gd
@@ -4,8 +4,7 @@ Food items which appear when the player clears boxes in puzzle mode.
 """
 
 export (NodePath) var playfield_path: NodePath
-
-onready var FoodScene := preload("res://src/main/puzzle/FoodItem.tscn")
+export (PackedScene) var FoodScene: PackedScene
 
 onready var _playfield: Playfield = get_node(playfield_path)
 onready var _puzzle_tile_map := _playfield.tile_map

--- a/project/src/main/puzzle/frosting-globs.gd
+++ b/project/src/main/puzzle/frosting-globs.gd
@@ -16,8 +16,8 @@ signal hit_next_pieces(glob)
 export (NodePath) var puzzle_tile_map_path: NodePath
 export (NodePath) var playfield_path: NodePath
 export (NodePath) var next_piece_displays_path: NodePath
+export (PackedScene) var FrostingGlobScene: PackedScene
 
-onready var FrostingGlobScene := preload("res://src/main/puzzle/FrostingGlob.tscn")
 onready var _puzzle_tile_map: PuzzleTileMap = get_node(puzzle_tile_map_path)
 onready var _puzzle_areas: PuzzleAreas
 

--- a/project/src/main/puzzle/frosting-viewports.gd
+++ b/project/src/main/puzzle/frosting-viewports.gd
@@ -10,7 +10,7 @@ export (float) var glob_min_scale := 1.0
 # the maximum smear size for globs which are smeared quickly.
 export (float) var glob_max_scale := 1.0
 
-onready var FrostingGlobScene := preload("res://src/main/puzzle/FrostingGlob.tscn")
+export (PackedScene) var FrostingGlobScene: PackedScene
 
 func _ready() -> void:
 	$Viewport.size = rect_size

--- a/project/src/main/puzzle/leaf-poofs.gd
+++ b/project/src/main/puzzle/leaf-poofs.gd
@@ -6,7 +6,7 @@ Any occupied cell which isn't used in a box risks spawning a leaf poof. The more
 the chance of a poof.
 """
 
-onready var LeafPoofScene := preload("res://src/main/puzzle/LeafPoof.tscn")
+export (PackedScene) var LeafPoofScene: PackedScene
 
 export (NodePath) var puzzle_tile_map_path: NodePath
 

--- a/project/src/main/puzzle/piece/piece-mover.gd
+++ b/project/src/main/puzzle/piece/piece-mover.gd
@@ -109,8 +109,8 @@ func apply_move_input(piece: ActivePiece) -> void:
 	# piece towards an obstruction. We trigger DAS if the piece already moved successfully, or they're pressing the
 	# direction but DAS hasn't yet activated.
 	#
-	# Otherwise, there are some unusual levels where, for example, 'O' pieces in a 3-column well will get
-	# instant DAS to the right (where they're blocked) but not to the left (where they can move)
+	# Otherwise, there are some unusual situations 'O' pieces in a central 3-column well will get instant DAS to the
+	# right (where they're blocked) but not to the left (where they can move)
 	if input.is_left_pressed() and not piece.can_move_to(piece.pos + Vector2.LEFT, piece.orientation):
 		input.set_left_das_active()
 	if input.is_right_pressed() and not piece.can_move_to(piece.pos + Vector2.RIGHT, piece.orientation):

--- a/project/src/main/puzzle/star-seeds.gd
+++ b/project/src/main/puzzle/star-seeds.gd
@@ -46,8 +46,9 @@ export (NodePath) var _puzzle_tile_map_path: NodePath
 # value: Wobbler node contained within that cell
 var _wobblers_by_cell: Dictionary
 
-onready var StarScene := preload("res://src/main/puzzle/Star.tscn")
-onready var SeedScene := preload("res://src/main/puzzle/Seed.tscn")
+export (PackedScene) var StarScene: PackedScene
+export (PackedScene) var SeedScene: PackedScene
+
 onready var _puzzle_tile_map: PuzzleTileMap = get_node(_puzzle_tile_map_path)
 
 func _ready() -> void:

--- a/project/src/main/puzzle/wobbler.gd
+++ b/project/src/main/puzzle/wobbler.gd
@@ -16,12 +16,6 @@ export (float) var avg_pulse_amount := 0.2
 # How many seconds the sprite should take to shrink to minimum/maximum scale
 export (float) var avg_pulse_period := 3.0
 
-# Slightly randomize inputs so each object is slightly unique
-onready var _spin_amount := avg_spin_amount * rand_range(0.8, 1.2)
-onready var _spin_period := avg_spin_period * rand_range(0.8, 1.2)
-onready var _pulse_amount := avg_pulse_amount * rand_range(0.8, 1.2)
-onready var _pulse_period := avg_pulse_period * rand_range(0.8, 1.2)
-
 # The unmodified scale/rotation before pulsing/spinning
 var base_scale := Vector2(1.0, 1.0) setget set_base_scale
 var base_rotation := 0.0 setget set_base_rotation
@@ -31,6 +25,12 @@ var food_type := 0
 
 # Stars/seeds pulse and rotate. This field is used to calculate the pulse/rotation amount
 var _total_time := 0.0
+
+# Slightly randomize inputs so each object is slightly unique
+onready var _spin_amount := avg_spin_amount * rand_range(0.8, 1.2)
+onready var _spin_period := avg_spin_period * rand_range(0.8, 1.2)
+onready var _pulse_amount := avg_pulse_amount * rand_range(0.8, 1.2)
+onready var _pulse_period := avg_pulse_period * rand_range(0.8, 1.2)
 
 func _ready() -> void:
 	frame = randi() % (hframes * vframes)

--- a/project/src/main/utils.gd
+++ b/project/src/main/utils.gd
@@ -179,8 +179,8 @@ static func find_closest(values: Array, target: float) -> int:
 """
 If the specified key does not exist, this method associates it with the given value.
 """
-static func put_if_absent(dna: Dictionary, key: String, value) -> void:
-	dna[key] = dna.get(key, value)
+static func put_if_absent(dict: Dictionary, key: String, value) -> void:
+	dict[key] = dict.get(key, value)
 
 
 static func remove_all(values: Array, value) -> Array:

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -89,7 +89,7 @@ func random_def() -> CreatureDef:
 		result = PlayerData.creature_queue.pop_secondary_creature()
 	else:
 		result = CreatureDef.new()
-		result.dna = DnaUtils.random_creature_palette()
+		result.dna = DnaUtils.random_dna()
 		result.creature_name = _name_generator.generate_name()
 		result.creature_short_name = NameUtils.sanitize_short_name(result.creature_name)
 		result.chat_theme_def = chat_theme_def(result.dna)

--- a/project/src/main/world/creature/creature-visuals.gd
+++ b/project/src/main/world/creature/creature-visuals.gd
@@ -207,7 +207,7 @@ Generates a creature with a random appearance.
 func random_creature(value: bool = true) -> void:
 	if not value:
 		return
-	var new_dna: Dictionary = DnaUtils.fill_dna(DnaUtils.random_creature_palette())
+	var new_dna: Dictionary = DnaUtils.random_dna()
 	set_dna(new_dna)
 
 

--- a/project/src/main/world/creature/dna-utils.gd
+++ b/project/src/main/world/creature/dna-utils.gd
@@ -348,24 +348,30 @@ Otherwise, missing values will be left empty, leading to invisible body parts or
 func fill_dna(dna: Dictionary) -> Dictionary:
 	# duplicate the dna so that we don't modify the original
 	var result := dna.duplicate()
-	Utils.put_if_absent(result, "line_rgb", "6c4331")
-	Utils.put_if_absent(result, "body_rgb", "b23823")
-	Utils.put_if_absent(result, "belly_rgb", "ffa86d")
-	Utils.put_if_absent(result, "cloth_rgb", "282828")
-	Utils.put_if_absent(result, "glass_rgb", "282828")
-	Utils.put_if_absent(result, "plastic_rgb", "282828")
-	Utils.put_if_absent(result, "hair_rgb", "f1e398")
-	Utils.put_if_absent(result, "eye_rgb", "282828 dedede")
-	Utils.put_if_absent(result, "horn_rgb", "f1e398")
+	
+	var new_palette: Dictionary = DnaUtils.random_creature_palette()
+	for allele in COLOR_ALLELES:
+		Utils.put_if_absent(result, allele, new_palette[allele])
 	
 	if ResourceCache.minimal_resources:
 		# avoid loading unnecessary resources for things like the level editor
 		pass
 	else:
-		for allele in BODY_PART_ALLELES:
+		var alleles := BODY_PART_ALLELES.duplicate()
+		alleles.shuffle()
+		for allele in alleles:
 			Utils.put_if_absent(result, allele, Utils.weighted_rand_value(allele_weights(result, allele)))
 		Utils.put_if_absent(result, "emote-eye", "0" if result.get("eye", "0") == "0" else "1")
 	return result
+
+
+"""
+Returns a dna dictionary containing sensible random values.
+
+This includes an aesthetically pleasing palette and body parts that look good together.
+"""
+func random_dna() -> Dictionary:
+	return fill_dna({})
 
 
 """


### PR DESCRIPTION
Added a DnaUtils.random_dna() method; this is a trivial method but many
places wanted a random creature so now it's in one place

Alleles are now shuffled before DnaUtils picks them. This avoids any sort
of 'pecking order' where one allele trumps another allele when they
conflict. Otherwise we could have a subtle preference where noses are more
common than beaks, or vice-versa

DnaUtils.fill_dna now fills color alleles with a random palette, instead
of a fixed palette

Replaced '.tscn' strings with PackedScene exports. Using PackedScene exports
allows Godot to keep these scenes hooked up during move/rename operations.