### PR TITLE
Fixed HTML5 quit button.

### DIFF
--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -53,6 +53,10 @@ func _on_CreateCreatures_pressed() -> void:
 
 
 func _on_System_quit_pressed() -> void:
+	if OS.has_feature("web"):
+		# don't quit from the web; just go back to splash screen
+		return
+	
 	get_tree().quit()
 
 

--- a/project/src/main/ui/menu/splash-screen.gd
+++ b/project/src/main/ui/menu/splash-screen.gd
@@ -11,6 +11,10 @@ func _ready() -> void:
 	$DropPanel/PlayHolder/Play.grab_focus()
 	if PlayerSave.corrupt_filenames:
 		$BadSaveDataControl.popup()
+	
+	if OS.has_feature("web"):
+		# don't quit from the web. it just blacks out the window, which isn't useful or user friendly
+		$DropPanel/System/Quit.hide()
 
 
 func _exit_tree() -> void:


### PR DESCRIPTION
Main quit button quits to splash screen. Splash screen quit button no
longer exists. The player can close the browser window to quit.

Closes #700.