### PR TITLE
Settings tabs. Hide touch settings. Space hard drops.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -900,6 +900,7 @@ hard_drop={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777237,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":3,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"unicode":0,"echo":false,"script":null)
  ]
 }
 soft_drop={

--- a/project/src/main/puzzle/Playfield.tscn
+++ b/project/src/main/puzzle/Playfield.tscn
@@ -208,7 +208,7 @@ margin_bottom = 172.0
 custom_styles/normal = ExtResource( 21 )
 custom_fonts/normal_font = ExtResource( 22 )
 text = "Arrows: Move
-Up/Shift: Hard drop
+Up/Space: Hard drop
 Down: Soft drop
 Z, X: Rotate"
 scroll_active = false
@@ -300,19 +300,19 @@ bus = "Sound Bus"
 
 [node name="BuildSnackBoxSound" type="AudioStreamPlayer" parent="BuildBoxSfx"]
 bus = "Sound Bus"
-[connection signal="before_line_cleared" from="." to="TileMapClip/PlayfieldFx" method="_on_Playfield_before_line_cleared"]
-[connection signal="before_line_cleared" from="." to="TileMapClip/LeafPoofs" method="_on_Playfield_before_line_cleared"]
 [connection signal="before_line_cleared" from="." to="ComboTracker" method="_on_Playfield_before_line_cleared"]
 [connection signal="before_line_cleared" from="." to="LineClearSfx" method="_on_Playfield_before_line_cleared"]
+[connection signal="before_line_cleared" from="." to="TileMapClip/PlayfieldFx" method="_on_Playfield_before_line_cleared"]
+[connection signal="before_line_cleared" from="." to="TileMapClip/LeafPoofs" method="_on_Playfield_before_line_cleared"]
 [connection signal="blocks_prepared" from="." to="LineClearer" method="_on_Playfield_blocks_prepared"]
-[connection signal="box_built" from="." to="TileMapClip/PlayfieldFx" method="_on_Playfield_box_built"]
-[connection signal="box_built" from="." to="BuildBoxSfx" method="_on_Playfield_box_built"]
 [connection signal="box_built" from="." to="ComboTracker" method="_on_Playfield_box_built"]
+[connection signal="box_built" from="." to="BuildBoxSfx" method="_on_Playfield_box_built"]
+[connection signal="box_built" from="." to="TileMapClip/PlayfieldFx" method="_on_Playfield_box_built"]
 [connection signal="line_cleared" from="." to="ComboTracker" method="_on_Playfield_line_cleared"]
 [connection signal="line_erased" from="." to="LineClearSfx" method="_on_Playfield_line_erased"]
 [connection signal="after_boxes_built" from="BoxBuilder" to="." method="_on_BoxBuilder_after_boxes_built"]
-[connection signal="box_built" from="BoxBuilder" to="LineClearer" method="_on_BoxBuilder_box_built"]
 [connection signal="box_built" from="BoxBuilder" to="." method="_on_BoxBuilder_box_built"]
+[connection signal="box_built" from="BoxBuilder" to="LineClearer" method="_on_BoxBuilder_box_built"]
 [connection signal="before_line_cleared" from="LineClearer" to="." method="_on_LineClearer_before_line_cleared"]
 [connection signal="line_cleared" from="LineClearer" to="." method="_on_LineClearer_line_cleared"]
 [connection signal="line_erased" from="LineClearer" to="." method="_on_LineClearer_line_erased"]

--- a/project/src/main/ui/SettingsMenu.tscn
+++ b/project/src/main/ui/SettingsMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=2]
@@ -12,6 +12,37 @@
 [ext_resource path="res://src/main/ui/settings-touch-scheme.gd" type="Script" id=10]
 [ext_resource path="res://src/main/ui/settings-touch-fat-finger.gd" type="Script" id=11]
 [ext_resource path="res://src/main/ui/settings-ghost-piece.gd" type="Script" id=12]
+[ext_resource path="res://src/main/ui/menu/theme/h4-font.tres" type="DynamicFont" id=13]
+
+[sub_resource type="StyleBoxFlat" id=1]
+content_margin_left = 5.0
+content_margin_right = 5.0
+content_margin_top = 5.0
+content_margin_bottom = 5.0
+bg_color = Color( 0.2, 0.176471, 0.176471, 1 )
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_color = Color( 1, 1, 1, 1 )
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+expand_margin_bottom = 2.0
+
+[sub_resource type="StyleBoxFlat" id=2]
+content_margin_left = 5.0
+content_margin_right = 5.0
+content_margin_top = 5.0
+content_margin_bottom = 5.0
+bg_color = Color( 0.2, 0.176471, 0.176471, 1 )
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color( 1, 1, 1, 1 )
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
 
 [node name="SettingsMenu" type="CanvasLayer"]
 pause_mode = 2
@@ -31,7 +62,6 @@ visible = false
 emit_actions = false
 
 [node name="Window" type="Panel" parent="."]
-visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -49,113 +79,103 @@ __meta__ = {
 [node name="UiArea" type="VBoxContainer" parent="Window"]
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = 20.0
-margin_top = 15.0
-margin_right = -20.0
-margin_bottom = -15.0
+margin_left = 5.0
+margin_top = 5.0
+margin_right = -5.0
+margin_bottom = -5.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Center" type="ScrollContainer" parent="Window/UiArea"]
-margin_right = 400.0
-margin_bottom = 286.0
+[node name="TabContainer" type="TabContainer" parent="Window/UiArea"]
+margin_right = 430.0
+margin_bottom = 296.0
 size_flags_vertical = 3
-follow_focus = true
+custom_styles/tab_fg = SubResource( 1 )
+custom_styles/tab_disabled = ExtResource( 2 )
+custom_styles/tab_bg = ExtResource( 2 )
+custom_styles/panel = SubResource( 2 )
+custom_fonts/font = ExtResource( 13 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Settings" type="VBoxContainer" parent="Window/UiArea/Center"]
-margin_right = 400.0
-margin_bottom = 338.0
-size_flags_horizontal = 3
-size_flags_vertical = 3
-custom_constants/separation = 10
-alignment = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
+[node name="Volume" type="VBoxContainer" parent="Window/UiArea/TabContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 5.0
+margin_top = 35.0
+margin_right = -5.0
+margin_bottom = -5.0
 
-[node name="Volume" type="Label" parent="Window/UiArea/Center/Settings"]
-margin_right = 400.0
+[node name="Master" parent="Window/UiArea/TabContainer/Volume" instance=ExtResource( 6 )]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 0.0
+margin_top = 0.0
+margin_right = 420.0
 margin_bottom = 20.0
-theme = ExtResource( 1 )
-text = "Volume"
-align = 1
-valign = 1
 
-[node name="Master" parent="Window/UiArea/Center/Settings" instance=ExtResource( 6 )]
+[node name="Music" parent="Window/UiArea/TabContainer/Volume" instance=ExtResource( 6 )]
 anchor_left = 0.0
 anchor_top = 0.0
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_left = 0.0
-margin_top = 30.0
-margin_right = 400.0
-margin_bottom = 50.0
-
-[node name="Music" parent="Window/UiArea/Center/Settings" instance=ExtResource( 6 )]
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 0.0
-margin_top = 60.0
-margin_right = 400.0
-margin_bottom = 80.0
+margin_top = 24.0
+margin_right = 420.0
+margin_bottom = 44.0
 volume_type = 1
 
-[node name="Sounds" parent="Window/UiArea/Center/Settings" instance=ExtResource( 6 )]
+[node name="Sounds" parent="Window/UiArea/TabContainer/Volume" instance=ExtResource( 6 )]
 anchor_left = 0.0
 anchor_top = 0.0
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_left = 0.0
-margin_top = 90.0
-margin_right = 400.0
-margin_bottom = 110.0
+margin_top = 48.0
+margin_right = 420.0
+margin_bottom = 68.0
 volume_type = 2
 
-[node name="Voices" parent="Window/UiArea/Center/Settings" instance=ExtResource( 6 )]
+[node name="Voices" parent="Window/UiArea/TabContainer/Volume" instance=ExtResource( 6 )]
 anchor_left = 0.0
 anchor_top = 0.0
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_left = 0.0
-margin_top = 120.0
-margin_right = 400.0
-margin_bottom = 140.0
+margin_top = 72.0
+margin_right = 420.0
+margin_bottom = 92.0
 volume_type = 3
 
-[node name="Gameplay" type="Label" parent="Window/UiArea/Center/Settings"]
-margin_top = 150.0
-margin_right = 400.0
-margin_bottom = 170.0
-theme = ExtResource( 1 )
-text = "Gameplay"
-align = 1
-valign = 1
+[node name="Gameplay" type="VBoxContainer" parent="Window/UiArea/TabContainer"]
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 5.0
+margin_top = 35.0
+margin_right = -5.0
+margin_bottom = -5.0
 
-[node name="GhostPiece" type="Control" parent="Window/UiArea/Center/Settings"]
-margin_top = 180.0
-margin_right = 400.0
-margin_bottom = 206.0
+[node name="GhostPiece" type="HBoxContainer" parent="Window/UiArea/TabContainer/Gameplay"]
+margin_right = 420.0
+margin_bottom = 28.0
 rect_min_size = Vector2( 400, 26 )
 size_flags_horizontal = 3
 theme = ExtResource( 1 )
+custom_constants/separation = 20
 script = ExtResource( 12 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Label" type="Label" parent="Window/UiArea/Center/Settings/GhostPiece"]
-anchor_bottom = 1.0
-margin_right = 66.0
+[node name="Label" type="Label" parent="Window/UiArea/TabContainer/Gameplay/GhostPiece"]
+margin_right = 160.0
+margin_bottom = 28.0
 rect_min_size = Vector2( 120, 28 )
 size_flags_horizontal = 3
 size_flags_vertical = 5
-size_flags_stretch_ratio = 0.5
+size_flags_stretch_ratio = 0.74
 text = "Ghost Piece"
 align = 2
 valign = 1
@@ -163,41 +183,46 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="OptionButton" type="CheckBox" parent="Window/UiArea/Center/Settings/GhostPiece"]
-margin_left = 133.0
-margin_right = 293.0
+[node name="OptionButton" type="CheckBox" parent="Window/UiArea/TabContainer/Gameplay/GhostPiece"]
+margin_left = 180.0
+margin_right = 420.0
 margin_bottom = 28.0
 rect_min_size = Vector2( 160, 26 )
-size_flags_horizontal = 0
+size_flags_horizontal = 3
 size_flags_vertical = 4
+size_flags_stretch_ratio = 1.1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Touch" type="Label" parent="Window/UiArea/Center/Settings"]
-margin_top = 216.0
-margin_right = 400.0
-margin_bottom = 236.0
-theme = ExtResource( 1 )
-text = "Touch"
-align = 1
-valign = 1
+[node name="Touch" type="VBoxContainer" parent="Window/UiArea/TabContainer"]
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 5.0
+margin_top = 35.0
+margin_right = -5.0
+margin_bottom = -5.0
 
-[node name="Size" type="Control" parent="Window/UiArea/Center/Settings"]
-margin_top = 246.0
-margin_right = 400.0
-margin_bottom = 266.0
+[node name="Size" type="HBoxContainer" parent="Window/UiArea/TabContainer/Touch"]
+margin_right = 420.0
+margin_bottom = 20.0
 rect_min_size = Vector2( 400, 20 )
 size_flags_horizontal = 3
 theme = ExtResource( 1 )
+custom_constants/separation = 20
 script = ExtResource( 8 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Label" type="Label" parent="Window/UiArea/Center/Settings/Size"]
-anchor_bottom = 1.0
-margin_right = 36.0
+[node name="Spacer1" type="Control" parent="Window/UiArea/TabContainer/Touch/Size"]
+margin_right = 20.0
+margin_bottom = 20.0
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.1
+
+[node name="Label" type="Label" parent="Window/UiArea/TabContainer/Touch/Size"]
+margin_left = 40.0
+margin_right = 160.0
+margin_bottom = 20.0
 rect_min_size = Vector2( 120, 0 )
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.5
@@ -207,11 +232,11 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Control" type="HBoxContainer" parent="Window/UiArea/Center/Settings/Size"]
-anchor_left = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = -267.0
+[node name="Control" type="HBoxContainer" parent="Window/UiArea/TabContainer/Touch/Size"]
+margin_left = 180.0
+margin_right = 379.0
+margin_bottom = 20.0
+rect_min_size = Vector2( 140, 20 )
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_constants/separation = 10
@@ -219,12 +244,12 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="HSlider" type="HSlider" parent="Window/UiArea/Center/Settings/Size/Control"]
+[node name="HSlider" type="HSlider" parent="Window/UiArea/TabContainer/Touch/Size/Control"]
 margin_top = 2.0
-margin_right = 160.0
+margin_right = 149.0
 margin_bottom = 18.0
-rect_min_size = Vector2( 160, 0 )
-size_flags_horizontal = 0
+rect_min_size = Vector2( 80, 16 )
+size_flags_horizontal = 3
 size_flags_vertical = 4
 max_value = 11.0
 value = 1.0
@@ -233,32 +258,38 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Text" type="Label" parent="Window/UiArea/Center/Settings/Size/Control"]
-margin_left = 170.0
-margin_right = 218.0
+[node name="Text" type="Label" parent="Window/UiArea/TabContainer/Touch/Size/Control"]
+margin_left = 159.0
+margin_right = 219.0
 margin_bottom = 20.0
+rect_min_size = Vector2( 60, 0 )
 theme = ExtResource( 1 )
 text = "1.00x"
 
-[node name="Scheme" type="Control" parent="Window/UiArea/Center/Settings"]
-margin_top = 276.0
-margin_right = 400.0
-margin_bottom = 302.0
+[node name="Spacer2" type="Control" parent="Window/UiArea/TabContainer/Touch/Size"]
+margin_left = 399.0
+margin_right = 420.0
+margin_bottom = 20.0
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.1
+
+[node name="Scheme" type="HBoxContainer" parent="Window/UiArea/TabContainer/Touch"]
+margin_top = 24.0
+margin_right = 420.0
+margin_bottom = 50.0
 rect_min_size = Vector2( 400, 26 )
 size_flags_horizontal = 3
 theme = ExtResource( 1 )
+custom_constants/separation = 20
 script = ExtResource( 10 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Label" type="Label" parent="Window/UiArea/Center/Settings/Scheme"]
-anchor_bottom = 1.0
-margin_right = 66.0
+[node name="Label" type="Label" parent="Window/UiArea/TabContainer/Touch/Scheme"]
+margin_right = 160.0
+margin_bottom = 26.0
 rect_min_size = Vector2( 120, 0 )
 size_flags_horizontal = 3
 size_flags_vertical = 5
-size_flags_stretch_ratio = 0.5
+size_flags_stretch_ratio = 0.74
 text = "Scheme"
 align = 2
 valign = 1
@@ -266,37 +297,35 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="OptionButton" type="OptionButton" parent="Window/UiArea/Center/Settings/Scheme"]
-margin_left = 133.0
-margin_top = 2.0
-margin_right = 293.0
-margin_bottom = 18.0
+[node name="OptionButton" type="OptionButton" parent="Window/UiArea/TabContainer/Touch/Scheme"]
+margin_left = 180.0
+margin_right = 340.0
+margin_bottom = 26.0
 rect_min_size = Vector2( 160, 0 )
-size_flags_horizontal = 0
+size_flags_horizontal = 2
 size_flags_vertical = 4
+size_flags_stretch_ratio = 1.1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="FatFinger" type="Control" parent="Window/UiArea/Center/Settings"]
-margin_top = 312.0
-margin_right = 400.0
-margin_bottom = 338.0
+[node name="FatFinger" type="HBoxContainer" parent="Window/UiArea/TabContainer/Touch"]
+margin_top = 54.0
+margin_right = 420.0
+margin_bottom = 80.0
 rect_min_size = Vector2( 400, 26 )
 size_flags_horizontal = 3
 theme = ExtResource( 1 )
+custom_constants/separation = 20
 script = ExtResource( 11 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Label" type="Label" parent="Window/UiArea/Center/Settings/FatFinger"]
-anchor_bottom = 1.0
-margin_right = 66.0
+[node name="Label" type="Label" parent="Window/UiArea/TabContainer/Touch/FatFinger"]
+margin_right = 160.0
+margin_bottom = 26.0
 rect_min_size = Vector2( 120, 0 )
 size_flags_horizontal = 3
 size_flags_vertical = 5
-size_flags_stretch_ratio = 0.5
+size_flags_stretch_ratio = 0.74
 text = "Fat Finger"
 align = 2
 valign = 1
@@ -304,32 +333,36 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="OptionButton" type="OptionButton" parent="Window/UiArea/Center/Settings/FatFinger"]
-margin_left = 133.0
-margin_top = 2.0
-margin_right = 293.0
-margin_bottom = 18.0
+[node name="OptionButton" type="OptionButton" parent="Window/UiArea/TabContainer/Touch/FatFinger"]
+margin_left = 180.0
+margin_right = 340.0
+margin_bottom = 26.0
 rect_min_size = Vector2( 160, 0 )
-size_flags_horizontal = 0
+size_flags_horizontal = 2
 size_flags_vertical = 4
+size_flags_stretch_ratio = 1.1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Bottom" type="Control" parent="Window/UiArea"]
-margin_top = 290.0
-margin_right = 400.0
-margin_bottom = 330.0
-rect_min_size = Vector2( 0, 40 )
+margin_top = 300.0
+margin_right = 430.0
+margin_bottom = 350.0
+rect_min_size = Vector2( 0, 50 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Ok" type="Button" parent="Window/UiArea/Bottom"]
-margin_left = 140.0
-margin_top = 4.0
-margin_right = 260.0
-margin_bottom = 44.0
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -60.0
+margin_top = -20.0
+margin_right = 60.0
+margin_bottom = 20.0
 rect_min_size = Vector2( 120, 40 )
 size_flags_horizontal = 4
 size_flags_vertical = 4
@@ -345,10 +378,12 @@ __meta__ = {
 action = "ui_cancel"
 
 [node name="Quit" type="Button" parent="Window/UiArea/Bottom"]
-anchor_top = 1.0
-anchor_bottom = 1.0
-margin_top = -30.0
-margin_right = 80.0
+anchor_top = 0.5
+anchor_bottom = 0.5
+margin_left = 10.0
+margin_top = -15.0
+margin_right = 90.0
+margin_bottom = 15.0
 rect_min_size = Vector2( 80, 30 )
 size_flags_horizontal = 4
 size_flags_vertical = 4
@@ -358,9 +393,9 @@ text = "Quit"
 __meta__ = {
 "_edit_use_anchors_": false
 }
-[connection signal="toggled" from="Window/UiArea/Center/Settings/GhostPiece/OptionButton" to="Window/UiArea/Center/Settings/GhostPiece" method="_on_OptionButton_toggled"]
-[connection signal="value_changed" from="Window/UiArea/Center/Settings/Size/Control/HSlider" to="Window/UiArea/Center/Settings/Size" method="_on_HSlider_value_changed"]
-[connection signal="item_selected" from="Window/UiArea/Center/Settings/Scheme/OptionButton" to="Window/UiArea/Center/Settings/Scheme" method="_on_OptionButton_item_selected"]
-[connection signal="item_selected" from="Window/UiArea/Center/Settings/FatFinger/OptionButton" to="Window/UiArea/Center/Settings/FatFinger" method="_on_OptionButton_item_selected"]
+[connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/GhostPiece/OptionButton" to="Window/UiArea/TabContainer/Gameplay/GhostPiece" method="_on_OptionButton_toggled"]
+[connection signal="value_changed" from="Window/UiArea/TabContainer/Touch/Size/Control/HSlider" to="Window/UiArea/TabContainer/Touch/Size" method="_on_HSlider_value_changed"]
+[connection signal="item_selected" from="Window/UiArea/TabContainer/Touch/Scheme/OptionButton" to="Window/UiArea/TabContainer/Touch/Scheme" method="_on_OptionButton_item_selected"]
+[connection signal="item_selected" from="Window/UiArea/TabContainer/Touch/FatFinger/OptionButton" to="Window/UiArea/TabContainer/Touch/FatFinger" method="_on_OptionButton_item_selected"]
 [connection signal="pressed" from="Window/UiArea/Bottom/Ok" to="." method="_on_Ok_pressed"]
 [connection signal="pressed" from="Window/UiArea/Bottom/Quit" to="." method="_on_Quit_pressed"]

--- a/project/src/main/ui/VolumeSetting.tscn
+++ b/project/src/main/ui/VolumeSetting.tscn
@@ -5,7 +5,7 @@
 [ext_resource path="res://assets/main/puzzle/squish.wav" type="AudioStream" id=3]
 [ext_resource path="res://assets/main/world/creature/combo-voice-00.wav" type="AudioStream" id=4]
 
-[node name="Setting" type="Control"]
+[node name="Setting" type="HBoxContainer"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -14,17 +14,23 @@ margin_left = -200.0
 margin_top = -10.0
 margin_right = 200.0
 margin_bottom = 10.0
-rect_min_size = Vector2( 400, 20 )
-size_flags_horizontal = 3
 theme = ExtResource( 1 )
+custom_constants/separation = 20
 script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[node name="Spacer1" type="Control" parent="."]
+margin_right = 18.0
+margin_bottom = 20.0
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.1
+
 [node name="Label" type="Label" parent="."]
-anchor_bottom = 1.0
-margin_right = 50.0
+margin_left = 38.0
+margin_right = 158.0
+margin_bottom = 20.0
 rect_min_size = Vector2( 120, 0 )
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.5
@@ -35,11 +41,10 @@ __meta__ = {
 }
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
-anchor_left = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = -267.0
-rect_min_size = Vector2( 240, 0 )
+margin_left = 178.0
+margin_right = 361.0
+margin_bottom = 20.0
+rect_min_size = Vector2( 140, 20 )
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_constants/separation = 10
@@ -49,10 +54,10 @@ __meta__ = {
 
 [node name="HSlider" type="HSlider" parent="HBoxContainer"]
 margin_top = 2.0
-margin_right = 160.0
+margin_right = 113.0
 margin_bottom = 18.0
-rect_min_size = Vector2( 160, 0 )
-size_flags_horizontal = 0
+rect_min_size = Vector2( 80, 0 )
+size_flags_horizontal = 3
 size_flags_vertical = 4
 max_value = 1.0
 step = 0.01
@@ -62,11 +67,18 @@ __meta__ = {
 }
 
 [node name="Percent" type="Label" parent="HBoxContainer"]
-margin_left = 170.0
-margin_right = 230.0
+margin_left = 123.0
+margin_right = 183.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 60, 0 )
 text = "100%"
+
+[node name="Spacer2" type="Control" parent="."]
+margin_left = 381.0
+margin_right = 400.0
+margin_bottom = 20.0
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.1
 
 [node name="SampleTimer" type="Timer" parent="."]
 wait_time = 0.5
@@ -80,5 +92,3 @@ bus = "Sound Bus"
 stream = ExtResource( 4 )
 volume_db = 6.0
 bus = "Voice Bus"
-[connection signal="value_changed" from="HBoxContainer/HSlider" to="." method="_on_HSlider_value_changed"]
-[connection signal="timeout" from="SampleTimer" to="." method="_on_SampleTimer_timeout"]

--- a/project/src/main/ui/menu/settings-menu.gd
+++ b/project/src/main/ui/menu/settings-menu.gd
@@ -23,6 +23,10 @@ var _old_focus_owner: Control
 func _ready() -> void:
 	# starts invisible
 	hide()
+	
+	if not OS.has_touchscreen_ui_hint():
+		# hide 'touch' settings if touch is not enabled
+		$Window/UiArea/TabContainer/Touch.queue_free()
 
 
 func set_quit_text(new_quit_text: String) -> void:

--- a/project/src/main/ui/volume-setting-control.gd
+++ b/project/src/main/ui/volume-setting-control.gd
@@ -9,12 +9,15 @@ Updates the player's stored settings, and also updates the audio server.
 export (VolumeSettings.VolumeType) var volume_type: int setget set_volume_type
 
 func _ready() -> void:
+	$HBoxContainer/HSlider.value = PlayerData.volume_settings.get_bus_volume_linear(volume_type)
 	_refresh_setting_label()
 	_refresh_percent_label()
-	$HBoxContainer/HSlider.value = PlayerData.volume_settings.get_bus_volume_linear(volume_type)
 	
 	# don't play sample sounds during initialization
 	$SampleTimer.stop()
+	
+	$HBoxContainer/HSlider.connect("value_changed", self, "_on_HSlider_value_changed")
+	$SampleTimer.connect("timeout", self, "_on_SampleTimer_timeout")
 
 
 func set_volume_type(new_volume_type: int) -> void:

--- a/project/src/main/world/Overworld.tscn
+++ b/project/src/main/world/Overworld.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=77 format=2]
+[gd_scene load_steps=80 format=2]
 
 [ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/creature/player.gd" type="Script" id=2]
@@ -65,8 +65,33 @@
 [ext_resource path="res://assets/main/ui/touch/close-pressed.png" type="Texture" id=63]
 [ext_resource path="res://src/main/ui/level-select/LevelSelectPanel.tscn" type="PackedScene" id=64]
 [ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=65]
+[ext_resource path="res://assets/main/world/environment/marsh-block-sheet.png" type="Texture" id=66]
+[ext_resource path="res://src/main/world/overworld-corner-map.gd" type="Script" id=67]
 
 [sub_resource type="TileSet" id=1]
+0/name = "marsh-block-sheet.png 0"
+0/texture = ExtResource( 66 )
+0/tex_offset = Vector2( 0, 20 )
+0/modulate = Color( 1, 1, 1, 1 )
+0/region = Rect2( 0, 0, 740, 848 )
+0/tile_mode = 2
+0/autotile/icon_coordinate = Vector2( 0, 0 )
+0/autotile/tile_size = Vector2( 148, 212 )
+0/autotile/spacing = 0
+0/autotile/occluder_map = [  ]
+0/autotile/navpoly_map = [  ]
+0/autotile/priority_map = [  ]
+0/autotile/z_index_map = [  ]
+0/occluder_offset = Vector2( 0, 0 )
+0/navigation_offset = Vector2( 0, 0 )
+0/shape_offset = Vector2( 0, 0 )
+0/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+0/shape_one_way = false
+0/shape_one_way_margin = 0.0
+0/shapes = [  ]
+0/z_index = 0
+
+[sub_resource type="TileSet" id=2]
 0/name = "block-shadow.png 0"
 0/texture = ExtResource( 19 )
 0/tex_offset = Vector2( 0, 20 )
@@ -82,35 +107,35 @@
 0/shapes = [  ]
 0/z_index = 0
 
-[sub_resource type="ViewportTexture" id=2]
+[sub_resource type="ViewportTexture" id=3]
 viewport_path = NodePath("World/Ground/Shadows/Viewport")
 
-[sub_resource type="RectangleShape2D" id=3]
+[sub_resource type="RectangleShape2D" id=4]
 extents = Vector2( 28, 14 )
 
-[sub_resource type="InputEventAction" id=4]
+[sub_resource type="InputEventAction" id=5]
 action = "phone"
 
-[sub_resource type="ShortCut" id=5]
-shortcut = SubResource( 4 )
+[sub_resource type="ShortCut" id=6]
+shortcut = SubResource( 5 )
 
-[sub_resource type="InputEventAction" id=6]
+[sub_resource type="InputEventAction" id=7]
 action = "ui_cancel"
 
-[sub_resource type="ShortCut" id=7]
-shortcut = SubResource( 6 )
+[sub_resource type="ShortCut" id=8]
+shortcut = SubResource( 7 )
 
-[sub_resource type="InputEventAction" id=8]
+[sub_resource type="InputEventAction" id=9]
 action = "interact"
 
-[sub_resource type="ShortCut" id=9]
-shortcut = SubResource( 8 )
+[sub_resource type="ShortCut" id=10]
+shortcut = SubResource( 9 )
 
-[sub_resource type="InputEventAction" id=10]
+[sub_resource type="InputEventAction" id=11]
 action = "ui_cancel"
 
-[sub_resource type="ShortCut" id=11]
-shortcut = SubResource( 10 )
+[sub_resource type="ShortCut" id=12]
+shortcut = SubResource( 11 )
 
 [node name="Overworld" type="Node"]
 
@@ -143,7 +168,16 @@ cell_size = Vector2( 128, 64 )
 cell_tile_origin = 1
 centered_textures = true
 format = 1
-tile_data = PoolIntArray( -327677, 1, 0, -327676, 1, 0, -327675, 1, 0, -327667, 1, 0, -327666, 1, 0, -327665, 1, 0, -262144, 1, 0, -262143, 0, 0, -262142, 0, 0, -262141, 0, 0, -262140, 0, 0, -262139, 0, 0, -262138, 0, 0, -262137, 0, 0, -262136, 0, 0, -262135, 0, 0, -262134, 0, 0, -262133, 0, 0, -262132, 0, 0, -262131, 0, 0, -262130, 0, 0, -262129, 1, 0, -196608, 1, 0, -196607, 0, 0, -196606, 0, 0, -196605, 22, 0, -196604, 22, 0, -196603, 22, 0, -196602, 22, 0, -196601, 22, 0, -196600, 22, 0, -196599, 22, 0, -196598, 22, 0, -196597, 22, 0, -196596, 22, 0, -196595, 0, 0, -196594, 0, 0, -196593, 1, 0, -131072, 1, 0, -131071, 0, 0, -131070, 22, 0, -131069, 22, 0, -131068, 22, 0, -131067, 0, 0, -131066, 22, 0, -131065, 0, 0, -131064, 22, 0, -131063, 0, 0, -131062, 22, 0, -131061, 0, 0, -131060, 22, 0, -131059, 22, 0, -131058, 0, 0, -131057, 1, 0, -65536, 1, 0, -65535, 0, 0, -65534, 22, 0, -65533, 0, 0, -65532, 0, 0, -65531, 0, 0, -65530, 0, 0, -65529, 21, 2, -65528, 0, 0, -65527, 0, 0, -65526, 0, 0, -65525, 0, 0, -65524, 0, 0, -65523, 22, 0, -65522, 0, 0, -65521, 1, 0, 0, 1, 0, 1, 0, 0, 2, 22, 0, 3, 21, 65539, 4, 21, 131073, 5, 21, 131073, 6, 21, 131073, 7, 21, 131075, 8, 0, 0, 9, 0, 0, 10, 0, 0, 11, 0, 0, 12, 0, 0, 13, 22, 0, 14, 0, 0, 15, 1, 0, 65536, 1, 0, 65537, 0, 0, 65538, 22, 0, 65539, 0, 0, 65540, 0, 0, 65541, 0, 0, 65542, 0, 0, 65543, 21, 65540, 65544, 21, 131073, 65545, 21, 131073, 65546, 21, 65538, 65547, 0, 0, 65548, 0, 0, 65549, 22, 0, 65550, 0, 0, 65551, 1, 0, 131072, 1, 0, 131073, 0, 0, 131074, 22, 0, 131075, 0, 0, 131076, 0, 0, 131077, 0, 0, 131078, 0, 0, 131079, 0, 0, 131080, 0, 0, 131081, 0, 0, 131082, 21, 65540, 131083, 21, 65536, 131084, 0, 0, 131085, 22, 0, 131086, 0, 0, 131087, 1, 0, 196608, 1, 0, 196609, 0, 0, 196610, 22, 0, 196611, 22, 0, 196612, 0, 0, 196613, 22, 0, 196614, 21, 0, 196615, 22, 0, 196616, 0, 0, 196617, 22, 0, 196618, 0, 0, 196619, 22, 0, 196620, 22, 0, 196621, 22, 0, 196622, 0, 0, 196623, 1, 0, 262144, 1, 0, 262145, 0, 0, 262146, 0, 0, 262147, 22, 0, 262148, 22, 0, 262149, 22, 0, 262150, 22, 0, 262151, 22, 0, 262152, 22, 0, 262153, 22, 0, 262154, 22, 0, 262155, 22, 0, 262156, 22, 0, 262157, 0, 0, 262158, 0, 0, 262159, 1, 0, 327680, 1, 0, 327681, 0, 0, 327682, 0, 0, 327683, 0, 0, 327684, 0, 0, 327685, 0, 0, 327686, 0, 0, 327687, 0, 0, 327688, 0, 0, 327689, 0, 0, 327690, 0, 0, 327691, 0, 0, 327692, 0, 0, 327693, 0, 0, 327694, 0, 0, 327695, 1, 0, 393216, 1, 0, 393217, 1, 0, 393218, 1, 0, 393219, 1, 0, 393220, 1, 0, 393221, 1, 0, 393222, 1, 0, 393223, 1, 0, 393224, 1, 0, 393225, 1, 0, 393226, 1, 0, 393227, 1, 0, 393228, 1, 0, 393231, 1, 0 )
+tile_data = PoolIntArray( -327677, 1, 0, -327676, 1, 0, -327675, 1, 0, -327667, 1, 0, -327666, 1, 0, -327665, 1, 0, -262144, 1, 0, -262143, 0, 131072, -262142, 0, 131076, -262141, 0, 131074, -262140, 0, 131074, -262139, 0, 131074, -262138, 0, 131074, -262137, 0, 131074, -262136, 0, 131074, -262135, 0, 131074, -262134, 0, 131074, -262133, 0, 131074, -262132, 0, 131074, -262131, 0, 131076, -262130, 0, 65537, -262129, 1, 0, -196608, 1, 0, -196607, 0, 131073, -196606, 0, 65536, -196605, 22, 0, -196604, 22, 0, -196603, 22, 0, -196602, 22, 0, -196601, 22, 0, -196600, 22, 0, -196599, 22, 0, -196598, 22, 0, -196597, 22, 0, -196596, 22, 0, -196595, 0, 65540, -196594, 0, 65538, -196593, 1, 0, -131072, 1, 0, -131071, 0, 3, -131070, 22, 0, -131069, 22, 0, -131068, 22, 0, -131067, 0, 2, -131066, 22, 0, -131065, 0, 0, -131064, 22, 0, -131063, 0, 2, -131062, 22, 0, -131061, 0, 2, -131060, 22, 0, -131059, 22, 0, -131058, 0, 3, -131057, 1, 0, -65536, 1, 0, -65535, 0, 3, -65534, 22, 0, -65533, 0, 65539, -65532, 0, 131074, -65531, 0, 131075, -65530, 0, 4, -65529, 21, 2, -65528, 0, 131072, -65527, 0, 196608, -65526, 0, 131076, -65525, 0, 196608, -65524, 0, 65537, -65523, 22, 0, -65522, 0, 3, -65521, 1, 0, 0, 1, 0, 1, 0, 3, 2, 22, 0, 3, 21, 65539, 4, 21, 131073, 5, 21, 131074, 6, 21, 131073, 7, 21, 131075, 8, 0, 65540, 9, 0, 131075, 10, 0, 131075, 11, 0, 196608, 12, 0, 65538, 13, 22, 0, 14, 0, 3, 15, 1, 0, 65536, 1, 0, 65537, 0, 3, 65538, 22, 0, 65539, 0, 131072, 65540, 0, 131076, 65541, 0, 131076, 65542, 0, 65537, 65543, 21, 65540, 65544, 21, 131074, 65545, 21, 131074, 65546, 21, 65538, 65547, 0, 65540, 65548, 0, 65538, 65549, 22, 0, 65550, 0, 3, 65551, 1, 0, 131072, 1, 0, 131073, 0, 3, 131074, 22, 0, 131075, 0, 65540, 131076, 0, 196608, 131077, 0, 131075, 131078, 0, 131075, 131079, 0, 131074, 131080, 0, 131076, 131081, 0, 4, 131082, 21, 65540, 131083, 21, 65536, 131084, 0, 1, 131085, 22, 0, 131086, 0, 3, 131087, 1, 0, 131091, 0, 2, 196608, 1, 0, 196609, 0, 3, 196610, 22, 0, 196611, 22, 0, 196612, 0, 1, 196613, 22, 0, 196614, 21, 0, 196615, 22, 0, 196616, 0, 1, 196617, 22, 0, 196618, 0, 0, 196619, 22, 0, 196620, 22, 0, 196621, 22, 0, 196622, 0, 3, 196623, 1, 0, 196626, 0, 131072, 196627, 0, 196608, 196628, 0, 65537, 262144, 1, 0, 262145, 0, 131073, 262146, 0, 65537, 262147, 22, 0, 262148, 22, 0, 262149, 22, 0, 262150, 22, 0, 262151, 22, 0, 262152, 22, 0, 262153, 22, 0, 262154, 22, 0, 262155, 22, 0, 262156, 22, 0, 262157, 0, 131072, 262158, 0, 65538, 262159, 1, 0, 262162, 0, 65540, 262163, 0, 196608, 262164, 0, 65536, 327680, 1, 0, 327681, 0, 65540, 327682, 0, 131075, 327683, 0, 131074, 327684, 0, 131074, 327685, 0, 131074, 327686, 0, 131074, 327687, 0, 131074, 327688, 0, 131074, 327689, 0, 131074, 327690, 0, 131074, 327691, 0, 131074, 327692, 0, 131074, 327693, 0, 131075, 327694, 0, 65536, 327695, 1, 0, 327699, 0, 1, 393216, 1, 0, 393217, 1, 0, 393218, 1, 0, 393219, 1, 0, 393220, 1, 0, 393221, 1, 0, 393222, 1, 0, 393223, 1, 0, 393224, 1, 0, 393225, 1, 0, 393226, 1, 0, 393227, 1, 0, 393228, 1, 0, 393231, 1, 0, 458753, 0, 131072, 458754, 0, 131074, 458755, 0, 131076, 458756, 0, 65537, 524289, 0, 3, 524291, 0, 131073, 524292, 0, 65538, 524297, 0, 2, 589825, 0, 3, 589827, 0, 131073, 589828, 0, 196608, 589829, 0, 131076, 589830, 0, 65537, 589833, 0, 131073, 589834, 0, 131076, 589835, 0, 131074, 589836, 0, 4, 655361, 0, 131073, 655362, 0, 131076, 655363, 0, 196608, 655364, 0, 196608, 655365, 0, 196608, 655366, 0, 65538, 655368, 0, 65539, 655369, 0, 131075, 655370, 0, 65538, 720897, 0, 65540, 720898, 0, 196608, 720899, 0, 196608, 720900, 0, 196608, 720901, 0, 196608, 720902, 0, 65538, 720906, 0, 3, 720908, 0, 131072, 720909, 0, 131076, 720910, 0, 65537, 786434, 0, 131073, 786435, 0, 196608, 786436, 0, 196608, 786437, 0, 196608, 786438, 0, 65538, 786442, 0, 1, 786444, 0, 131073, 786445, 0, 196608, 786446, 0, 65538, 851970, 0, 65540, 851971, 0, 131075, 851972, 0, 131075, 851973, 0, 131075, 851974, 0, 65536, 851980, 0, 65540, 851981, 0, 131075, 851982, 0, 65536 )
+
+[node name="CornerMap" type="TileMap" parent="World/Ground/GroundMap"]
+mode = 1
+tile_set = SubResource( 1 )
+cell_size = Vector2( 128, 64 )
+cell_tile_origin = 1
+centered_textures = true
+format = 1
+script = ExtResource( 67 )
 
 [node name="Shadows" type="Node2D" parent="World/Ground"]
 
@@ -154,7 +188,7 @@ transparent_bg = true
 [node name="ObstacleShadows" type="TileMap" parent="World/Ground/Shadows/Viewport"]
 scale = Vector2( 2.5, 2.5 )
 mode = 1
-tile_set = SubResource( 1 )
+tile_set = SubResource( 2 )
 cell_size = Vector2( 128, 64 )
 cell_tile_origin = 1
 centered_textures = true
@@ -172,7 +206,7 @@ margin_right = 1024.0
 margin_bottom = 600.0
 rect_min_size = Vector2( 1024, 600 )
 rect_scale = Vector2( 0.4, 0.4 )
-texture = SubResource( 2 )
+texture = SubResource( 3 )
 flip_v = true
 script = ExtResource( 22 )
 __meta__ = {
@@ -189,7 +223,7 @@ cell_tile_origin = 1
 cell_y_sort = true
 centered_textures = true
 format = 1
-tile_data = PoolIntArray( -262143, 0, 0, -262142, 0, 0, -262141, 0, 0, -262140, 0, 0, -262139, 0, 0, -262138, 0, 0, -262137, 0, 0, -262136, 0, 0, -262135, 0, 0, -262134, 0, 0, -262133, 0, 0, -262132, 0, 0, -262131, 0, 0, -262130, 0, 0, -196607, 0, 0, -196606, 0, 0, -196595, 0, 0, -196594, 0, 0, -131071, 0, 0, -131058, 0, 0, -65535, 0, 0, -65522, 0, 0, 1, 0, 0, 14, 0, 0, 65537, 0, 0, 65542, 0, 0, 65550, 0, 0, 131073, 0, 0, 131086, 0, 0, 196609, 0, 0, 196622, 0, 0, 262145, 0, 0, 262146, 0, 0, 262157, 0, 0, 262158, 0, 0, 327681, 0, 0, 327682, 0, 0, 327683, 0, 0, 327684, 0, 0, 327685, 0, 0, 327686, 0, 0, 327687, 0, 0, 327688, 0, 0, 327689, 0, 0, 327690, 0, 0, 327691, 0, 0, 327692, 0, 0, 327693, 0, 0, 327694, 0, 0 )
+tile_data = PoolIntArray( 65542, 0, 0 )
 
 [node name="GrassTufts" type="YSort" parent="World/Obstacles"]
 script = ExtResource( 16 )
@@ -397,7 +431,7 @@ scale = Vector2( 0.539476, 0.539476 )
 texture = ExtResource( 13 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="World/Obstacles/GlowySphere"]
-shape = SubResource( 3 )
+shape = SubResource( 4 )
 
 [node name="ChatIcons" type="Node2D" parent="World"]
 script = ExtResource( 50 )
@@ -528,7 +562,7 @@ margin_left = 292.0
 margin_right = 392.0
 margin_bottom = 100.0
 size_flags_horizontal = 0
-shortcut = SubResource( 5 )
+shortcut = SubResource( 6 )
 icon = ExtResource( 60 )
 expand_icon = true
 normal_icon = ExtResource( 60 )
@@ -540,7 +574,7 @@ anchor_bottom = 0.0
 margin_left = 402.0
 margin_right = 502.0
 margin_bottom = 100.0
-shortcut = SubResource( 7 )
+shortcut = SubResource( 8 )
 icon = ExtResource( 56 )
 expand_icon = true
 normal_icon = ExtResource( 56 )
@@ -568,7 +602,7 @@ anchor_bottom = 0.0
 margin_left = 402.0
 margin_right = 502.0
 margin_bottom = 100.0
-shortcut = SubResource( 9 )
+shortcut = SubResource( 10 )
 icon = ExtResource( 55 )
 expand_icon = true
 normal_icon = ExtResource( 55 )
@@ -627,7 +661,7 @@ margin_left = 292.0
 margin_right = 392.0
 margin_bottom = 100.0
 size_flags_horizontal = 0
-shortcut = SubResource( 11 )
+shortcut = SubResource( 12 )
 icon = ExtResource( 62 )
 expand_icon = true
 normal_icon = ExtResource( 62 )


### PR DESCRIPTION
The settings panel is going to allow custom keyboard controls, but this
will occupy a lot of visual real estate. A tabbed UI will prevent the
settings panel from being too busy.

Closes #643.

'Touch' settings are now hidden if touch isn't enabled.

Players expect space bar to hard drop, based on other similar games.

VolumeSetting signals are now connected in GDScript, instead of through
configuration. Signals connected through configuration frequently get
disconnected.