### PR TITLE
Smoother zooming to avoid camera jitter.

### DIFF
--- a/project/src/main/world/overworld-camera.gd
+++ b/project/src/main/world/overworld-camera.gd
@@ -60,7 +60,7 @@ func set_close_up(new_close_up: bool) -> void:
 	close_up = new_close_up
 	$Tween.remove_all()
 	$Tween.interpolate_property(self, "close_up_pct", close_up_pct, 1.0 if close_up else 0.0,
-			ZOOM_DURATION, Tween.TRANS_QUAD, Tween.EASE_OUT)
+			ZOOM_DURATION, Tween.TRANS_SINE, Tween.EASE_IN_OUT)
 	$Tween.start()
 
 


### PR DESCRIPTION
When the camera zoomed out there were a few frames of jitter. This may
reflect an inherent flaw in our texture zooming logic, but for now it's
unnoticable if the camera zoom eases in and out, instead of only easing in
one direction.

Closes #741.