### PR TITLE
Instructor can now participate in overworld chats.

### DIFF
--- a/project/assets/main/creatures/primary/richie/creature.json
+++ b/project/assets/main/creatures/primary/richie/creature.json
@@ -38,7 +38,9 @@
 
   },
   "chat_selectors": [
-
+    {
+      "dialog": "pomodoro"
+    }
   ],
   "fatness": 1.4
 }

--- a/project/assets/main/creatures/primary/richie/pomodoro.json
+++ b/project/assets/main/creatures/primary/richie/pomodoro.json
@@ -1,0 +1,68 @@
+{
+  "version": "1922",
+  "" : [
+    {
+      "who": "Richie",
+      "mood": "think0",
+      "text": "I've been reading up on something called the 'Pomodoro Technique' lately!"
+    },
+    {
+      "who": "Richie",
+      "text": "./././'Pomodoro' is a fancy Italian word for sitting on your ass,/ instead of doing any actual work."
+    },
+    {
+      "who": "#instructor#",
+      "mood": "smile0",
+      "text": "Ah,/ I do that already!/ I didn't someone had coined a name for it.",
+      "links": [
+        {"opinion0": "You're both lazy"},
+        {"opinion1": "More like 'Unemployment Technique'"},
+        {"opinion2": "I should study this"},
+        {"opinion3": "I invented that!"}]
+    }
+  ],
+  "opinion0": [
+    {
+      "who": "#player#",
+      "mood": "rage0",
+      "text": "Technique?/ You're both just lazy."
+    },
+    {
+      "who": "#instructor#",
+      "text": "Oh,/ lighten up #player#./ Sounds like someone needs a Pomodoro."
+    }
+  ],
+  "opinion1": [
+    {
+      "who": "#player#",
+      "text": "More like the 'Unemployment Technique'."
+    },
+    {
+      "who": "#instructor#",
+      "text": "Oh, lighten up #player#./ Sounds like someone needs a Pomodoro."
+    }
+  ],
+  "opinion2": [
+    {
+      "who": "#player#",
+      "mood": "think0",
+      "text": "I should study this technique..."
+    },
+    {
+      "who": "#instructor#",
+      "text": "Sure!/ It's good to take a break once in awhile~"
+    }
+  ],
+  "opinion3": [
+    {
+      "who": "#player#",
+      "mood": "laugh0",
+      "text": "I invented that technique!"
+    },
+    {
+      "who": "#instructor#",
+      "mood": "laugh0",
+      "text": "Ha!/ Ha!/ Maybe we can compare notes some time."
+    }
+  ]
+}

--- a/project/project.godot
+++ b/project/project.godot
@@ -244,6 +244,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/puzzle/input-replay.gd"
 }, {
+"base": "Creature",
+"class": "Instructor",
+"language": "GDScript",
+"path": "res://src/main/world/creature/instructor.gd"
+}, {
 "base": "Reference",
 "class": "KeybindSettings",
 "language": "GDScript",
@@ -672,6 +677,7 @@ _global_script_class_icons={
 "HighScoreTable": "",
 "HookableGradeLabel": "",
 "InputReplay": "",
+"Instructor": "",
 "KeybindSettings": "",
 "LeafPoof": "",
 "LevelChunk": "",

--- a/project/src/main/creature-library.gd
+++ b/project/src/main/creature-library.gd
@@ -14,6 +14,7 @@ const GENERIC_FATNESS_COUNT := 150
 const MAX_FILLER_FATNESS := 2.5
 
 var player_def: CreatureDef
+var instructor_def: CreatureDef
 
 # fatnesses by creature id
 var _fatnesses: Dictionary
@@ -50,6 +51,9 @@ func reset() -> void:
 	player_def.dna = CreatureDef.DEFAULT_DNA.duplicate()
 	player_def.min_fatness = 1.0
 	player_def.chat_theme_def = CreatureDef.DEFAULT_CHAT_THEME_DEF.duplicate()
+	
+	if not instructor_def:
+		instructor_def = CreatureLoader.load_creature_def_by_id(Global.CREATURE_ID_INSTRUCTOR)
 
 
 """

--- a/project/src/main/global.gd
+++ b/project/src/main/global.gd
@@ -22,6 +22,7 @@ const FATNESSES := [
 	1.8, 2.3,
 ]
 
+const CREATURE_ID_INSTRUCTOR := "#instructor#"
 const CREATURE_ID_PLAYER := "#player#"
 
 # The factor to multiply by to convert non-isometric coordinates into isometric coordinates

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -117,7 +117,7 @@ Parameters:
 func _feed_creature(fatness_pct: float, food_color: Color) -> void:
 	var customer: Creature = $RestaurantView.get_customer()
 	
-	if customer.creature_id == CreatureLoader.INSTRUCTOR_ID:
+	if customer.creature_id == Global.CREATURE_ID_INSTRUCTOR:
 		# tutorial instructor doesn't gain weight
 		pass
 	else:
@@ -126,7 +126,7 @@ func _feed_creature(fatness_pct: float, food_color: Color) -> void:
 		var target_fatness := Creature.score_to_fatness(base_score + PuzzleScore.get_creature_score())
 		customer.set_fatness(lerp(old_fatness, target_fatness, fatness_pct))
 
-	if customer.creature_id == CreatureLoader.INSTRUCTOR_ID:
+	if customer.creature_id == Global.CREATURE_ID_INSTRUCTOR:
 		# tutorial instructor doesn't become comfortable
 		pass
 	else:

--- a/project/src/main/ui/chat/chat-tree.gd
+++ b/project/src/main/ui/chat/chat-tree.gd
@@ -30,7 +30,9 @@ var history_key: String
 # metadata including whether the chat event is 'filler' or 'notable'
 var meta: Dictionary
 
-# tree of chat events
+# tree of chat event objects
+# key: dialog id (String)
+# value: array of sequential ChatEvent objects for a particular dialog sequence
 var events: Dictionary = {}
 
 # current position in this dialog tree

--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -28,7 +28,7 @@ func _exit_tree() -> void:
 
 func _launch_tutorial() -> void:
 	PlayerData.creature_queue.clear()
-	Level.set_launched_level(Level.BEGINNER_TUTORIAL, CreatureLoader.INSTRUCTOR_ID)
+	Level.set_launched_level(Level.BEGINNER_TUTORIAL, Global.CREATURE_ID_INSTRUCTOR)
 	Level.push_level_trail()
 
 

--- a/project/src/main/world/creature/bort.gd
+++ b/project/src/main/world/creature/bort.gd
@@ -33,7 +33,7 @@ func _on_OverworldUi_chat_started() -> void:
 		$MoveTimer.paused = true
 		set_non_iso_walk_direction(Vector2.ZERO)
 		play_movement_animation("idle")
-		orient_toward(ChattableManager.player)
+		orient_toward(ChattableManager.player.position)
 
 
 """

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -8,9 +8,6 @@ class converts that information into granular information such as 'her Eye/Sprin
 loads resource files specific to each creature.
 """
 
-# the creature id used for the instructor who leads the tutorials
-const INSTRUCTOR_ID := "#instructor#"
-
 # the creature definition path for the instructor who leads tutorials
 const INSTRUCTOR_PATH := "res://assets/main/creatures/instructor/creature.json"
 
@@ -188,7 +185,7 @@ func load_details(dna: Dictionary) -> void:
 func load_creature_def_by_id(id: String) -> CreatureDef:
 	var path: String
 	match id:
-		INSTRUCTOR_ID:
+		Global.CREATURE_ID_INSTRUCTOR:
 			path = INSTRUCTOR_PATH
 		_:
 			path = "res://assets/main/creatures/primary/%s/creature.json" % id

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -208,9 +208,9 @@ func play_mood(mood: int) -> void:
 """
 Orients this creature so they're facing the specified target.
 """
-func orient_toward(target: Node2D) -> void:
+func orient_toward(target_position: Vector2) -> void:
 	# calculate the relative direction of the object this creature should face
-	var direction: Vector2 = Global.from_iso(position.direction_to(target.position))
+	var direction: Vector2 = Global.from_iso(position.direction_to(target_position))
 	var direction_dot := 0.0
 	if direction:
 		direction_dot = direction.normalized().dot(Vector2.RIGHT)

--- a/project/src/main/world/creature/ebe.gd
+++ b/project/src/main/world/creature/ebe.gd
@@ -33,7 +33,7 @@ func _on_OverworldUi_chat_started() -> void:
 		$MoveTimer.paused = true
 		set_non_iso_walk_direction(Vector2.ZERO)
 		play_movement_animation("idle")
-		orient_toward(ChattableManager.player)
+		orient_toward(ChattableManager.player.position)
 
 
 """

--- a/project/src/main/world/creature/instructor.gd
+++ b/project/src/main/world/creature/instructor.gd
@@ -1,3 +1,4 @@
+class_name Instructor
 extends Creature
 """
 Script for manipulating the instructor in the overworld.
@@ -14,12 +15,13 @@ export (NodePath) var player_path: NodePath
 onready var _player: Creature = get_node(player_path)
 
 func _ready() -> void:
-	set_creature_id("#instructor#")
+	set_creature_id(Global.CREATURE_ID_INSTRUCTOR)
 	$MoveTimer.connect("timeout", self, "_on_MoveTimer_timeout")
+	ChattableManager.instructor = self
 
 
 func _on_MoveTimer_timeout() -> void:
-	var player_relative_pos := Global.from_iso(_player.position - position)
+	var player_relative_pos: Vector2 = Global.from_iso(_player.position - position)
 	# the instructor runs at isometric 45 degree angles to mimic the player's inputs
 	var player_angle := stepify(player_relative_pos.normalized().angle(), PI / 4)
 	

--- a/project/src/main/world/overworld-camera.gd
+++ b/project/src/main/world/overworld-camera.gd
@@ -34,15 +34,17 @@ onready var _overworld_ui: OverworldUi = get_node(overworld_ui_path)
 
 func _process(_delta: float) -> void:
 	# calculate the position to zoom in to
-	var bounding_box := Rect2(_player.position, Vector2(0, 0))
+	var close_up_position: Vector2
+	
 	if _overworld_ui.chatters:
 		var max_visual_fatness := 1.0
 		for chatter in _overworld_ui.chatters:
-			bounding_box = bounding_box.expand(chatter.position)
 			if chatter is Creature:
 				max_visual_fatness = max(max_visual_fatness, chatter.get_visual_fatness())
 		zoom_close_up = lerp(ZOOM_CLOSE_UP, ZOOM_DEFAULT, inverse_lerp(1.0, 10.0, max_visual_fatness))
-	close_up_position = bounding_box.position + bounding_box.size * 0.5
+		close_up_position = _overworld_ui.get_center_of_chatters()
+	else:
+		close_up_position = _player.position
 	
 	position = lerp(_player.position, close_up_position, close_up_pct)
 	zoom = lerp(ZOOM_DEFAULT, zoom_close_up, close_up_pct)

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -53,7 +53,7 @@ func _process(_delta: float) -> void:
 func _schedule_chat(creature: Creature) -> void:
 	yield(get_tree(), "idle_frame")
 	var chat_tree := ChatLibrary.load_chat_events_for_creature(creature, Level.launched_level_num)
-	_overworld_ui.start_chat(chat_tree, [creature])
+	_overworld_ui.start_chat(chat_tree, creature)
 
 
 """


### PR DESCRIPTION
Added 'pomodoro' dialog sequence which includes instructor.

Moved INSTRUCTOR_ID constant from creature-loader.gd to global.gd,
alongside CREATURE_ID_PLAYER. Also created a
CreatureLibrary.instructor_def field so that we can quickly grab the
instructor's name.

Minor changes to facing direction of chat participants. Intuitively, I
tried changing the characters to face 'the center of the conversation', but this
often resulted in awkward conversations where the player was facing away from
the character they were talking to.

Closes #744.