### PR TITLE
Fixed bugs in overworld dialog, limbs

### DIFF
--- a/project/assets/main/creatures/primary/boatricia/creature.json
+++ b/project/assets/main/creatures/primary/boatricia/creature.json
@@ -32,14 +32,16 @@
       "dialog": "level_1",
       "if_conditions": [
         "current_level/1"
-      ]
+      ],
+      "repeat": 0
     },
     {
       "level": "boatricia2",
       "dialog": "level_2",
       "if_conditions": [
         "current_level/2"
-      ]
+      ],
+      "repeat": 0
     },
     {
       "dialog": "hi",

--- a/project/assets/main/creatures/primary/ebe/creature.json
+++ b/project/assets/main/creatures/primary/ebe/creature.json
@@ -33,7 +33,8 @@
       "dialog": "no_vegetables",
       "if_conditions": [
         "current_level/1"
-      ]
+      ],
+      "repeat": 0
     }
   ]
 }

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -165,16 +165,16 @@ func _process_select_level_meta_item(level_num: int = -1) -> void:
 		push_warning("No creature_chatters found for select_level")
 	else:
 		var creature: Creature = creature_chatters[0]
-		if not _chat_tree_cache.has(creature.creature_id):
-			var chit_chat: bool = level_num < 1
+		var chit_chat: bool = level_num < 1
+		if not _chat_tree_cache.has(creature) or not chit_chat:
 			_next_chat_tree = ChatLibrary.load_chat_events_for_creature(creature, level_num, chit_chat)
 			if _next_chat_tree.meta.get("filler", false):
 				PlayerData.chat_history.increment_filler_count(creature.creature_id)
 			if _next_chat_tree.meta.get("notable", false):
 				PlayerData.chat_history.reset_filler_count(creature.creature_id)
-			_chat_tree_cache[creature.creature_id] = _next_chat_tree
+			_chat_tree_cache[creature] = _next_chat_tree
 		
-		_next_chat_tree = _chat_tree_cache[creature.creature_id]
+		_next_chat_tree = _chat_tree_cache[creature]
 		
 		if level_num >= 1:
 			var level_ids := creature.get_level_ids()

--- a/project/src/main/world/chattable-manager.gd
+++ b/project/src/main/world/chattable-manager.gd
@@ -32,13 +32,6 @@ var _focus_enabled := true setget set_focus_enabled, is_focus_enabled
 # value: Creature object corresponding to the chatter name 
 var _creatures_by_chatter_name := {}
 
-func _ready() -> void:
-	for creature_obj in get_tree().get_nodes_in_group("creatures"):
-		var creature: Creature = creature_obj
-		_refresh_creature_name(creature)
-		creature.connect("creature_name_changed", self, "_on_Creature_creature_name_changed", [creature])
-
-
 func _physics_process(_delta: float) -> void:
 	var min_distance := MAX_INTERACT_DISTANCE
 	var new_focus: Node2D
@@ -72,6 +65,18 @@ func _physics_process(_delta: float) -> void:
 	if new_focus != _focused:
 		_focused = new_focus
 		emit_signal("focus_changed")
+
+
+"""
+Refreshes our state based on the creatures in the scene, and reconnects some signals.
+"""
+func refresh_creatures() -> void:
+	_creatures_by_chatter_name.clear()
+	for creature_obj in get_tree().get_nodes_in_group("creatures"):
+		var creature: Creature = creature_obj
+		_refresh_creature_name(creature)
+		if not creature.is_connected("creature_name_changed", self, "_on_Creature_creature_name_changed"):
+			creature.connect("creature_name_changed", self, "_on_Creature_creature_name_changed", [creature])
 
 
 """

--- a/project/src/main/world/creature/creature-visuals.gd
+++ b/project/src/main/world/creature/creature-visuals.gd
@@ -250,6 +250,11 @@ func set_orientation(new_orientation: int) -> void:
 		# orientation by making it something nonsensical
 		old_orientation = -1
 	
+	if $Animations/MovementPlayer.current_animation == "idle-nw" and new_orientation in [SOUTHEAST, SOUTHWEST]:
+		$Animations/MovementPlayer.play("idle-se")
+	elif $Animations/MovementPlayer.current_animation == "idle-se" and new_orientation in [NORTHEAST, NORTHWEST]:
+		$Animations/MovementPlayer.play("idle-nw")
+	
 	emit_signal("orientation_changed", old_orientation, new_orientation)
 
 

--- a/project/src/main/world/overworld-camera.gd
+++ b/project/src/main/world/overworld-camera.gd
@@ -34,8 +34,6 @@ onready var _overworld_ui: OverworldUi = get_node(overworld_ui_path)
 
 func _process(_delta: float) -> void:
 	# calculate the position to zoom in to
-	var close_up_position: Vector2
-	
 	if _overworld_ui.chatters:
 		var max_visual_fatness := 1.0
 		for chatter in _overworld_ui.chatters:
@@ -43,8 +41,6 @@ func _process(_delta: float) -> void:
 				max_visual_fatness = max(max_visual_fatness, chatter.get_visual_fatness())
 		zoom_close_up = lerp(ZOOM_CLOSE_UP, ZOOM_DEFAULT, inverse_lerp(1.0, 10.0, max_visual_fatness))
 		close_up_position = _overworld_ui.get_center_of_chatters()
-	else:
-		close_up_position = _player.position
 	
 	position = lerp(_player.position, close_up_position, close_up_pct)
 	zoom = lerp(ZOOM_DEFAULT, zoom_close_up, close_up_pct)

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -38,6 +38,7 @@ func _ready() -> void:
 		
 		_schedule_chat(creature)
 	
+	ChattableManager.refresh_creatures()
 	get_tree().get_root().connect("size_changed", self, "_on_Viewport_size_changed")
 	_refresh_goop_control_size()
 


### PR DESCRIPTION
Fixed bug with the wrong dialog showing on the overworld when you selected
the 'level 1'/'level 2'/'chit chat' options.

Fixed bug with facial expressions no longer working.

These two bugs were caused because ChattableManager was loading all of the
creatures on _ready(), but it's an autoload node which will only be loaded
once. This meant it would work OK if Overworld.tscn was loaded directly,
but didn't work when the game was launched normally through the title
screen.

Closes #750.

Fixed bug where arms/legs pointed the wrong way if you talked to a character
walking backwards. This is because the 'idle-nw' animation overrode the newly
set arm and leg frames.

Closes #751.