### PR TITLE
Extracted LevelLibrary. Fixed possible 'inaccessible tutorial' bug.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -259,6 +259,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/puzzle/leaf-poof.gd"
 }, {
+"base": "Control",
+"class": "LevelButtons",
+"language": "GDScript",
+"path": "res://src/main/ui/level-select/level-buttons.gd"
+}, {
 "base": "Reference",
 "class": "LevelChunk",
 "language": "GDScript",
@@ -288,11 +293,6 @@ _global_script_classes=[ {
 "class": "LevelSelectButton",
 "language": "GDScript",
 "path": "res://src/main/ui/level-select/level-select-button.gd"
-}, {
-"base": "Reference",
-"class": "LevelSelectModel",
-"language": "GDScript",
-"path": "res://src/main/ui/level-select/level-select-model.gd"
 }, {
 "base": "Reference",
 "class": "LevelSettings",
@@ -680,13 +680,13 @@ _global_script_class_icons={
 "Instructor": "",
 "KeybindSettings": "",
 "LeafPoof": "",
+"LevelButtons": "",
 "LevelChunk": "",
 "LevelChunkControl": "",
 "LevelEditor": "",
 "LevelHistory": "",
 "LevelLock": "",
 "LevelSelectButton": "",
-"LevelSelectModel": "",
 "LevelSettings": "",
 "LineClearer": "",
 "LockAlleleButton": "",
@@ -769,6 +769,7 @@ default_bus_layout="res://src/main/ui/default_bus_layout.tres"
 
 [autoload]
 
+LevelLibrary="*res://src/main/ui/level-select/level-library.gd"
 Breadcrumb="*res://src/main/breadcrumb.gd"
 ChatLibrary="*res://src/main/ui/chat/chat-library.gd"
 ChattableManager="*res://src/main/world/chattable-manager.gd"
@@ -778,6 +779,7 @@ DnaUtils="*res://src/main/world/creature/dna-utils.gd"
 Global="*res://src/main/global.gd"
 MilestoneManager="*res://src/main/puzzle/milestone-manager.gd"
 MusicPlayer="*res://src/main/music/MusicPlayer.tscn"
+Level="*res://src/main/puzzle/level/level.gd"
 Pauser="*res://src/main/pauser.gd"
 PieceSpeeds="*res://src/main/puzzle/piece/piece-speeds.gd"
 PieceTypes="*res://src/main/puzzle/piece/piece-types.gd"
@@ -785,7 +787,6 @@ PlayerData="*res://src/main/player-data.gd"
 PlayerSave="*res://src/main/player-save.gd"
 PuzzleScore="*res://src/main/puzzle/puzzle-score.gd"
 ResourceCache="*res://src/main/ResourceCache.tscn"
-Level="*res://src/main/puzzle/level/level.gd"
 
 [debug]
 

--- a/project/src/main/player-data.gd
+++ b/project/src/main/player-data.gd
@@ -7,6 +7,9 @@ This data includes how well they've done on each level and how much money they'v
 
 signal money_changed(value)
 
+# emitted when the player beats a level, or when the level history is reset or reloaded
+signal level_history_changed
+
 var level_history := LevelHistory.new()
 var chat_history := ChatHistory.new()
 
@@ -33,6 +36,8 @@ func reset() -> void:
 	touch_settings.reset()
 	keybind_settings.reset()
 	money = 0
+	
+	emit_signal("level_history_changed")
 
 
 func set_money(new_money: int) -> void:

--- a/project/src/main/player-save.gd
+++ b/project/src/main/player-save.gd
@@ -148,6 +148,9 @@ func _load_player_data_from_file(filename: String) -> bool:
 		save_item.from_json_dict(json_save_item_obj)
 		_load_line(save_item.type, save_item.key, save_item.value)
 	
+	# emit a signal indicating the level history was loaded
+	PlayerData.emit_signal("level_history_changed")
+	
 	return true
 
 

--- a/project/src/main/puzzle/level/level-settings.gd
+++ b/project/src/main/puzzle/level/level-settings.gd
@@ -210,7 +210,7 @@ func _get_max_speed_id() -> String:
 	for milestone_obj in speed_ups:
 		var milestone: Milestone = milestone_obj
 		var speed_id: String = milestone.get_meta("speed")
-		var speed_id_index := PieceSpeeds.speed_ids.find(speed_id)
+		var speed_id_index: int = PieceSpeeds.speed_ids.find(speed_id)
 		if speed_id_index > max_speed_id_index:
 			max_speed_id_index = speed_id_index
 			max_speed_id = speed_id

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -210,6 +210,7 @@ func _on_PuzzleScore_game_ended() -> void:
 	var rank_result := RankCalculator.new().calculate_rank()
 	PlayerData.level_history.add(Level.launched_level_id, rank_result)
 	PlayerData.level_history.prune(Level.launched_level_id)
+	PlayerData.emit_signal("level_history_changed")
 	PlayerData.money = int(clamp(PlayerData.money + rank_result.score, 0, 9999999999999999))
 	
 	match Level.settings.finish_condition.type:

--- a/project/src/main/ui/level-select/level-select.gd
+++ b/project/src/main/ui/level-select/level-select.gd
@@ -5,11 +5,11 @@ The level select screen which shows buttons and level info.
 
 # Allows for hiding/showing certain levels.
 # Virtual property; value is only exposed through getters/setters
-export (LevelSelectModel.LevelsToInclude) var levels_to_include: int setget set_levels_to_include
+export (LevelButtons.LevelsToInclude) var levels_to_include: int setget set_levels_to_include
 
 """
 Parameters:
-	'new_levels_to_include': An enum in LevelSelectModel.LevelsToInclude which specifies which allows for hiding or
+	'new_levels_to_include': An enum in LevelButtons.LevelsToInclude which specifies which allows for hiding or
 			showing certain levels.
 """
 func set_levels_to_include(new_levels_to_include: int) -> void:


### PR DESCRIPTION
Other classes and logic need to know things like 'which levels does the
player have unlocked' outside of the level select UI, and it makes sense
for this to be a singleton node so we don't need to reload the JSON
everywhere.

Fixed potential tutorial bug. There was some logic setting the tutorial world to
LevelLock.STATUS_CLEARED (1) if all levels in the tutorial were complete.
However, tutorial worlds don't use this particular enum, and it resulted in the
tutorials being marked as LockStatus.LOCK (1) instead.