### PR TITLE
Fixed layout issues with tall aspect ratios

### DIFF
--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -36,6 +36,7 @@ var _chat_tree_cache: Dictionary
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
 	_update_visible()
+	_refresh_rect_size()
 	get_tree().get_root().connect("size_changed", self, "_on_Viewport_size_changed")
 
 
@@ -151,6 +152,10 @@ func _update_visible() -> void:
 	$Labels/SoutheastLabels/VersionLabel.visible = _show_version and not chatters
 
 
+func _refresh_rect_size() -> void:
+	rect_size = get_viewport_rect().size
+
+
 func _on_ChatUi_pop_out_completed() -> void:
 	PlayerData.chat_history.add_history_item(_current_chat_tree.history_key)
 	
@@ -198,7 +203,7 @@ func _on_SettingsMenu_quit_pressed() -> void:
 
 
 func _on_Viewport_size_changed() -> void:
-	rect_size = get_viewport_rect().size
+	_refresh_rect_size()
 
 
 func _on_CellPhoneButton_pressed() -> void:

--- a/project/src/main/ui/scene-transition-rect.gd
+++ b/project/src/main/ui/scene-transition-rect.gd
@@ -8,6 +8,8 @@ func _ready() -> void:
 	$Tween.connect("tween_all_completed", self, "_on_Tween_tween_all_completed")
 	SceneTransition.connect("fade_out_started", self, "_on_SceneTransition_fade_out_started")
 	SceneTransition.connect("fade_in_started", self, "_on_SceneTransition_fade_in_started")
+	
+	_refresh_rect_size()
 	_initialize_fade()
 
 
@@ -33,8 +35,12 @@ func _launch_fade_tween(new_alpha: float, duration: float) -> void:
 	$Tween.start()
 
 
-func _on_Viewport_size_changed() -> void:
+func _refresh_rect_size() -> void:
 	rect_size = get_viewport_rect().size
+
+
+func _on_Viewport_size_changed() -> void:
+	_refresh_rect_size()
 
 
 func _on_SceneTransition_fade_out_started() -> void:

--- a/project/src/main/world/overworld-bg.gd
+++ b/project/src/main/world/overworld-bg.gd
@@ -5,8 +5,12 @@ Background drawn behind the overworld.
 
 func _ready() -> void:
 	get_tree().get_root().connect("size_changed", self, "_on_Viewport_size_changed")
+	_refresh_rect_size()
+
+
+func _refresh_rect_size() -> void:
 	rect_size = get_viewport_rect().size
 
 
 func _on_Viewport_size_changed() -> void:
-	rect_size = get_viewport_rect().size
+	_refresh_rect_size()


### PR DESCRIPTION
Many UI components had listeners to refresh their screen size when aspect
ratios changed, but they didn't have code to set their screen size
initially. I've moved this functionality into several
'_refresh_screen_size' methods which are called on _ready.