### PR TITLE
Overworld refactorings; OverworldUi scene, simpler paths.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -389,7 +389,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/world/environment/oval-shadow.gd"
 }, {
-"base": "Control",
+"base": "Reference",
 "class": "OverworldUi",
 "language": "GDScript",
 "path": "res://src/main/ui/overworld-ui.gd"

--- a/project/src/main/breadcrumb.gd
+++ b/project/src/main/breadcrumb.gd
@@ -14,6 +14,9 @@ Parameters:
 """
 signal trail_popped(prev_path)
 
+# Emitted before this class changes the running scene.
+signal before_scene_changed
+
 var trail := []
 
 """
@@ -62,6 +65,7 @@ func replace_trail(path: String) -> void:
 Changes the running scene to the one at the front of the breadcrumb trail.
 """
 func _change_scene() -> void:
+	emit_signal("before_scene_changed")
 	if trail:
 		if ResourceCache.has_cached_resource(trail.front()):
 			get_tree().change_scene_to(ResourceCache.get_cached_resource(trail.front()))

--- a/project/src/main/global.gd
+++ b/project/src/main/global.gd
@@ -101,3 +101,8 @@ func should_chat() -> bool:
 	else:
 		should_chat = false
 	return should_chat
+
+
+func get_overworld_ui() -> OverworldUi:
+	var nodes := get_tree().get_nodes_in_group("overworld_ui")
+	return nodes[0]

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -1,5 +1,5 @@
 class_name OverworldUi
-extends Control
+extends CanvasLayer
 """
 UI elements for the overworld.
 
@@ -69,7 +69,7 @@ func start_chat(new_chat_tree: ChatTree, target: Node2D) -> void:
 	
 	# reset state variables
 	_next_chat_tree = null
-	$ChatUi.play_chat_tree(_current_chat_tree)
+	$Control/ChatUi.play_chat_tree(_current_chat_tree)
 
 
 func set_show_version(new_show_version: bool) -> void:
@@ -148,12 +148,12 @@ func is_drive_by_chat() -> bool:
 Updates the different UI components to be visible/invisible based on the UI's current state.
 """
 func _update_visible() -> void:
-	$ChatUi.visible = true if chatters else false
-	$Labels/SoutheastLabels/VersionLabel.visible = _show_version and not chatters
+	$Control/ChatUi.visible = true if chatters else false
+	$Control/Labels/SoutheastLabels/VersionLabel.visible = _show_version and not chatters
 
 
 func _refresh_rect_size() -> void:
-	rect_size = get_viewport_rect().size
+	$Control.rect_size = $Control.get_viewport_rect().size
 
 
 func _on_ChatUi_pop_out_completed() -> void:
@@ -163,7 +163,7 @@ func _on_ChatUi_pop_out_completed() -> void:
 		_current_chat_tree = _next_chat_tree
 		# don't reset launched_level; this is currently set by the first of a series of chat trees
 		_next_chat_tree = null
-		$ChatUi.play_chat_tree(_current_chat_tree)
+		$Control/ChatUi.play_chat_tree(_current_chat_tree)
 	else:
 		# unset mood
 		for chatter in chatters:
@@ -176,7 +176,6 @@ func _on_ChatUi_pop_out_completed() -> void:
 		emit_signal("chat_ended")
 		
 		if Level.launched_level_id:
-			ChattableManager.clear()
 			Level.push_level_trail()
 			
 			if cutscene:
@@ -198,7 +197,6 @@ func _on_ChatUi_showed_choices() -> void:
 
 
 func _on_SettingsMenu_quit_pressed() -> void:
-	ChattableManager.clear()
 	Breadcrumb.pop_trail()
 
 
@@ -207,11 +205,11 @@ func _on_Viewport_size_changed() -> void:
 
 
 func _on_CellPhoneButton_pressed() -> void:
-	$CellPhoneMenu.show()
+	$Control/CellPhoneMenu.show()
 
 
 func _on_SettingsButton_pressed() -> void:
-	$SettingsMenu.show()
+	$Control/SettingsMenu.show()
 
 
 func _on_TalkButton_pressed() -> void:

--- a/project/src/main/ui/scene-transition-rect.gd
+++ b/project/src/main/ui/scene-transition-rect.gd
@@ -4,12 +4,10 @@ Covers the screen during scene transitions.
 """
 
 func _ready() -> void:
-	get_tree().get_root().connect("size_changed", self, "_on_Viewport_size_changed")
 	$Tween.connect("tween_all_completed", self, "_on_Tween_tween_all_completed")
 	SceneTransition.connect("fade_out_started", self, "_on_SceneTransition_fade_out_started")
 	SceneTransition.connect("fade_in_started", self, "_on_SceneTransition_fade_in_started")
 	
-	_refresh_rect_size()
 	_initialize_fade()
 
 
@@ -33,14 +31,6 @@ func _launch_fade_tween(new_alpha: float, duration: float) -> void:
 	$Tween.remove_all()
 	$Tween.interpolate_property(self, "modulate", modulate, Utils.to_transparent(modulate, new_alpha), duration)
 	$Tween.start()
-
-
-func _refresh_rect_size() -> void:
-	rect_size = get_viewport_rect().size
-
-
-func _on_Viewport_size_changed() -> void:
-	_refresh_rect_size()
 
 
 func _on_SceneTransition_fade_out_started() -> void:

--- a/project/src/main/world/Overworld.tscn
+++ b/project/src/main/world/Overworld.tscn
@@ -1,42 +1,19 @@
-[gd_scene load_steps=57 format=2]
+[gd_scene load_steps=26 format=2]
 
 [ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/OverworldObstacles.tscn" type="PackedScene" id=2]
-[ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=3]
-[ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=4]
-[ext_resource path="res://src/main/ui/MoneyLabel.tscn" type="PackedScene" id=5]
-[ext_resource path="res://src/main/ui/SettingsMenu.tscn" type="PackedScene" id=6]
-[ext_resource path="res://src/main/ui/FpsLabel.tscn" type="PackedScene" id=7]
-[ext_resource path="res://src/main/ui/VersionLabel.tscn" type="PackedScene" id=8]
-[ext_resource path="res://src/main/ui/chat/ChatUi.tscn" type="PackedScene" id=9]
-[ext_resource path="res://src/main/ui/overworld-ui.gd" type="Script" id=10]
-[ext_resource path="res://src/main/ui/SceneTransitionRect.tscn" type="PackedScene" id=11]
 [ext_resource path="res://src/main/world/ChatIcon.tscn" type="PackedScene" id=12]
 [ext_resource path="res://src/main/world/goop-ground.gd" type="Script" id=13]
 [ext_resource path="res://src/main/world/GroundMap.tscn" type="PackedScene" id=14]
+[ext_resource path="res://src/main/world/OverworldUi.tscn" type="PackedScene" id=15]
 [ext_resource path="res://src/main/world/creature/CreatureShadows.tscn" type="PackedScene" id=18]
 [ext_resource path="res://assets/main/world/environment/block-shadow.png" type="Texture" id=19]
 [ext_resource path="res://src/main/world/environment/obstacle-map-shadows.gd" type="Script" id=20]
 [ext_resource path="res://src/main/world/overworld-camera.gd" type="Script" id=21]
 [ext_resource path="res://src/main/world/screwport-texrect.gd" type="Script" id=22]
-[ext_resource path="res://src/main/world/OverworldTouchButtons.tscn" type="PackedScene" id=23]
 [ext_resource path="res://src/main/world/overworld-bg.gd" type="Script" id=25]
 [ext_resource path="res://src/main/world/chat-icons.gd" type="Script" id=50]
 [ext_resource path="res://src/main/world/overworld-world.gd" type="Script" id=51]
-[ext_resource path="res://src/main/world/phone-menu.gd" type="Script" id=52]
-[ext_resource path="res://src/main/world/overworld-buttons.gd" type="Script" id=53]
-[ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=54]
-[ext_resource path="res://assets/main/ui/touch/interact.png" type="Texture" id=55]
-[ext_resource path="res://assets/main/ui/touch/menu.png" type="Texture" id=56]
-[ext_resource path="res://assets/main/ui/touch/menu-pressed.png" type="Texture" id=57]
-[ext_resource path="res://src/main/ui/ImageButton.tscn" type="PackedScene" id=58]
-[ext_resource path="res://assets/main/ui/touch/interact-pressed.png" type="Texture" id=59]
-[ext_resource path="res://assets/main/ui/touch/phone.png" type="Texture" id=60]
-[ext_resource path="res://assets/main/ui/touch/phone-pressed.png" type="Texture" id=61]
-[ext_resource path="res://assets/main/ui/touch/close.png" type="Texture" id=62]
-[ext_resource path="res://assets/main/ui/touch/close-pressed.png" type="Texture" id=63]
-[ext_resource path="res://src/main/ui/level-select/LevelSelectPanel.tscn" type="PackedScene" id=64]
-[ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=65]
 [ext_resource path="res://src/main/world/environment/isometric-goo.shader" type="Shader" id=66]
 [ext_resource path="res://assets/main/world/rgb-texture.shader" type="Shader" id=67]
 [ext_resource path="res://assets/main/world/environment/marsh-block-texture.png" type="Texture" id=69]
@@ -88,30 +65,6 @@ viewport_path = NodePath("World/Ground/Viewport")
 [sub_resource type="ViewportTexture" id=6]
 viewport_path = NodePath("World/Ground/Shadows/Viewport")
 
-[sub_resource type="InputEventAction" id=7]
-action = "phone"
-
-[sub_resource type="ShortCut" id=8]
-shortcut = SubResource( 7 )
-
-[sub_resource type="InputEventAction" id=9]
-action = "ui_cancel"
-
-[sub_resource type="ShortCut" id=10]
-shortcut = SubResource( 9 )
-
-[sub_resource type="InputEventAction" id=11]
-action = "interact"
-
-[sub_resource type="ShortCut" id=12]
-shortcut = SubResource( 11 )
-
-[sub_resource type="InputEventAction" id=13]
-action = "ui_cancel"
-
-[sub_resource type="ShortCut" id=14]
-shortcut = SubResource( 13 )
-
 [node name="Overworld" type="Node"]
 
 [node name="Bg" type="CanvasLayer" parent="."]
@@ -130,8 +83,6 @@ __meta__ = {
 script = ExtResource( 51 )
 creature_shadows_path = NodePath("Ground/Shadows/Viewport/CreatureShadows")
 chat_icons_path = NodePath("ChatIcons")
-overworld_ui_path = NodePath("../Ui/OverworldUi")
-player_path = NodePath("Obstacles/Player")
 CreaturePackedScene = ExtResource( 1 )
 
 [node name="Ground" type="Node2D" parent="World"]
@@ -217,273 +168,13 @@ __meta__ = {
 [node name="ChatIcons" type="Node2D" parent="World"]
 script = ExtResource( 50 )
 ChatIconScene = ExtResource( 12 )
-overworld_ui_path = NodePath("../../Ui/OverworldUi")
 
 [node name="Camera" type="Camera2D" parent="World"]
 position = Vector2( 150, 150 )
 current = true
 smoothing_enabled = true
 script = ExtResource( 21 )
-player_path = NodePath("../Obstacles/Player")
-overworld_ui_path = NodePath("../../Ui/OverworldUi")
 
 [node name="Tween" type="Tween" parent="World/Camera"]
 
-[node name="Ui" type="CanvasLayer" parent="."]
-
-[node name="OverworldUi" type="Control" parent="Ui"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-script = ExtResource( 10 )
-__meta__ = {
-"_edit_group_": true,
-"_edit_lock_": true,
-"_edit_use_anchors_": false
-}
-
-[node name="Labels" type="Control" parent="Ui/OverworldUi"]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -512.0
-margin_top = -300.0
-margin_right = 512.0
-margin_bottom = 300.0
-rect_min_size = Vector2( 1024, 600 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="SoutheastLabels" type="VBoxContainer" parent="Ui/OverworldUi/Labels"]
-anchor_left = 1.0
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = -502.0
-margin_top = -290.0
-margin_right = -10.0
-margin_bottom = -10.0
-theme = ExtResource( 3 )
-alignment = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="FpsLabel" parent="Ui/OverworldUi/Labels/SoutheastLabels" instance=ExtResource( 7 )]
-visible = false
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 0.0
-margin_top = 236.0
-margin_right = 492.0
-margin_bottom = 256.0
-
-[node name="VersionLabel" parent="Ui/OverworldUi/Labels/SoutheastLabels" instance=ExtResource( 8 )]
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 0.0
-margin_top = 260.0
-margin_right = 492.0
-margin_bottom = 280.0
-
-[node name="NorthwestLabels" type="VBoxContainer" parent="Ui/OverworldUi/Labels"]
-margin_left = 10.0
-margin_top = 10.0
-margin_right = 512.0
-margin_bottom = 300.0
-theme = ExtResource( 3 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="MoneyLabel" parent="Ui/OverworldUi/Labels/NorthwestLabels" instance=ExtResource( 5 )]
-margin_left = 0.0
-margin_top = 0.0
-margin_right = 502.0
-margin_bottom = 32.0
-compact = true
-
-[node name="ChatUi" parent="Ui/OverworldUi" instance=ExtResource( 9 )]
-visible = false
-margin_bottom = 1.99976
-
-[node name="TouchButtons" parent="Ui/OverworldUi" instance=ExtResource( 23 )]
-
-[node name="Buttons" type="Control" parent="Ui/OverworldUi"]
-modulate = Color( 1, 1, 1, 0.627451 )
-anchor_right = 1.0
-anchor_bottom = 1.0
-script = ExtResource( 53 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Northeast" type="HBoxContainer" parent="Ui/OverworldUi/Buttons"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -512.0
-margin_top = 10.0
-margin_right = -10.0
-margin_bottom = 110.0
-rect_min_size = Vector2( 100, 100 )
-custom_constants/separation = 10
-alignment = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="PhoneButton" parent="Ui/OverworldUi/Buttons/Northeast" instance=ExtResource( 58 )]
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 292.0
-margin_right = 392.0
-margin_bottom = 100.0
-size_flags_horizontal = 0
-shortcut = SubResource( 8 )
-icon = ExtResource( 60 )
-expand_icon = true
-normal_icon = ExtResource( 60 )
-pressed_icon = ExtResource( 61 )
-
-[node name="SettingsButton" parent="Ui/OverworldUi/Buttons/Northeast" instance=ExtResource( 58 )]
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 402.0
-margin_right = 502.0
-margin_bottom = 100.0
-shortcut = SubResource( 10 )
-icon = ExtResource( 56 )
-expand_icon = true
-normal_icon = ExtResource( 56 )
-pressed_icon = ExtResource( 57 )
-
-[node name="Southeast" type="HBoxContainer" parent="Ui/OverworldUi/Buttons"]
-anchor_left = 1.0
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = -512.0
-margin_top = -160.0
-margin_right = -10.0
-margin_bottom = -60.0
-rect_min_size = Vector2( 100, 100 )
-custom_constants/separation = 10
-alignment = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="TalkButton" parent="Ui/OverworldUi/Buttons/Southeast" instance=ExtResource( 58 )]
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 402.0
-margin_right = 502.0
-margin_bottom = 100.0
-shortcut = SubResource( 12 )
-icon = ExtResource( 55 )
-expand_icon = true
-normal_icon = ExtResource( 55 )
-pressed_icon = ExtResource( 59 )
-
-[node name="CheatCodeDetector" parent="Ui/OverworldUi" instance=ExtResource( 4 )]
-codes = [ "bigfps" ]
-
-[node name="SettingsMenu" parent="Ui/OverworldUi" instance=ExtResource( 6 )]
-quit_text = "Save + Quit"
-
-[node name="CellPhoneMenu" type="CanvasLayer" parent="Ui/OverworldUi"]
-script = ExtResource( 52 )
-
-[node name="Bg" type="ColorRect" parent="Ui/OverworldUi/CellPhoneMenu"]
-visible = false
-anchor_right = 1.0
-anchor_bottom = 1.0
-color = Color( 0, 0, 0, 0.752941 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="LevelSelect" parent="Ui/OverworldUi/CellPhoneMenu" instance=ExtResource( 64 )]
-visible = false
-
-[node name="Buttons" type="Control" parent="Ui/OverworldUi/CellPhoneMenu"]
-visible = false
-modulate = Color( 1, 1, 1, 0.627451 )
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Northeast" type="HBoxContainer" parent="Ui/OverworldUi/CellPhoneMenu/Buttons"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -512.0
-margin_top = 10.0
-margin_right = -10.0
-margin_bottom = 110.0
-rect_min_size = Vector2( 100, 100 )
-mouse_filter = 2
-custom_constants/separation = 10
-alignment = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="BackButton" parent="Ui/OverworldUi/CellPhoneMenu/Buttons/Northeast" instance=ExtResource( 58 )]
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 292.0
-margin_right = 392.0
-margin_bottom = 100.0
-size_flags_horizontal = 0
-shortcut = SubResource( 14 )
-icon = ExtResource( 62 )
-expand_icon = true
-normal_icon = ExtResource( 62 )
-pressed_icon = ExtResource( 63 )
-
-[node name="ShortcutHelper" parent="Ui/OverworldUi/CellPhoneMenu/Buttons/Northeast/BackButton" instance=ExtResource( 54 )]
-action = "phone"
-
-[node name="Spacer" parent="Ui/OverworldUi/CellPhoneMenu/Buttons/Northeast" instance=ExtResource( 58 )]
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 402.0
-margin_right = 502.0
-margin_bottom = 100.0
-mouse_filter = 2
-disabled = true
-
-[node name="MusicPopup" parent="Ui/OverworldUi" instance=ExtResource( 65 )]
-
-[node name="SceneTransitionRect" parent="Ui" instance=ExtResource( 11 )]
-[connection signal="chat_ended" from="Ui/OverworldUi" to="World/Camera" method="_on_OverworldUi_chat_ended"]
-[connection signal="chat_ended" from="Ui/OverworldUi" to="Ui/OverworldUi/Buttons" method="_on_OverworldUi_chat_ended"]
-[connection signal="chat_ended" from="Ui/OverworldUi" to="Ui/OverworldUi/TouchButtons" method="_on_OverworldUi_chat_ended"]
-[connection signal="chat_started" from="Ui/OverworldUi" to="World/Camera" method="_on_OverworldUi_chat_started"]
-[connection signal="chat_started" from="Ui/OverworldUi" to="Ui/OverworldUi/Buttons" method="_on_OverworldUi_chat_started"]
-[connection signal="chat_started" from="Ui/OverworldUi" to="Ui/OverworldUi/TouchButtons" method="_on_OverworldUi_chat_started"]
-[connection signal="chat_event_played" from="Ui/OverworldUi/ChatUi" to="Ui/OverworldUi" method="_on_ChatUi_chat_event_played"]
-[connection signal="pop_out_completed" from="Ui/OverworldUi/ChatUi" to="Ui/OverworldUi" method="_on_ChatUi_pop_out_completed"]
-[connection signal="showed_choices" from="Ui/OverworldUi/ChatUi" to="Ui/OverworldUi" method="_on_ChatUi_showed_choices"]
-[connection signal="pressed" from="Ui/OverworldUi/Buttons/Northeast/PhoneButton" to="Ui/OverworldUi" method="_on_CellPhoneButton_pressed"]
-[connection signal="pressed" from="Ui/OverworldUi/Buttons/Northeast/SettingsButton" to="Ui/OverworldUi" method="_on_SettingsButton_pressed"]
-[connection signal="pressed" from="Ui/OverworldUi/Buttons/Southeast/TalkButton" to="Ui/OverworldUi" method="_on_TalkButton_pressed"]
-[connection signal="cheat_detected" from="Ui/OverworldUi/CheatCodeDetector" to="Ui/OverworldUi/Labels/SoutheastLabels/FpsLabel" method="_on_CheatCodeDetector_cheat_detected"]
-[connection signal="hide" from="Ui/OverworldUi/SettingsMenu" to="Ui/OverworldUi/Buttons" method="_on_Menu_hide"]
-[connection signal="hide" from="Ui/OverworldUi/SettingsMenu" to="Ui/OverworldUi/TouchButtons" method="_on_Menu_hide"]
-[connection signal="quit_pressed" from="Ui/OverworldUi/SettingsMenu" to="Ui/OverworldUi" method="_on_SettingsMenu_quit_pressed"]
-[connection signal="show" from="Ui/OverworldUi/SettingsMenu" to="Ui/OverworldUi/Buttons" method="_on_Menu_show"]
-[connection signal="show" from="Ui/OverworldUi/SettingsMenu" to="Ui/OverworldUi/TouchButtons" method="_on_Menu_show"]
-[connection signal="hide" from="Ui/OverworldUi/CellPhoneMenu" to="Ui/OverworldUi/Buttons" method="_on_Menu_hide"]
-[connection signal="hide" from="Ui/OverworldUi/CellPhoneMenu" to="Ui/OverworldUi/TouchButtons" method="_on_Menu_hide"]
-[connection signal="show" from="Ui/OverworldUi/CellPhoneMenu" to="Ui/OverworldUi/Buttons" method="_on_Menu_show"]
-[connection signal="show" from="Ui/OverworldUi/CellPhoneMenu" to="Ui/OverworldUi/TouchButtons" method="_on_Menu_show"]
-[connection signal="pressed" from="Ui/OverworldUi/CellPhoneMenu/Buttons/Northeast/BackButton" to="Ui/OverworldUi/CellPhoneMenu" method="_on_BackButton_pressed"]
+[node name="Ui" parent="." instance=ExtResource( 15 )]

--- a/project/src/main/world/OverworldIndoors.tscn
+++ b/project/src/main/world/OverworldIndoors.tscn
@@ -1,50 +1,27 @@
-[gd_scene load_steps=56 format=2]
+[gd_scene load_steps=25 format=2]
 
 [ext_resource path="res://src/main/world/creature/sensei.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/creature/player.gd" type="Script" id=2]
-[ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=3]
+[ext_resource path="res://src/main/world/OverworldUi.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/world/overworld-world.gd" type="Script" id=4]
 [ext_resource path="res://src/main/world/restaurant/wall-library.tres" type="TileSet" id=5]
-[ext_resource path="res://src/main/ui/overworld-ui.gd" type="Script" id=6]
 [ext_resource path="res://src/main/world/restaurant/floor-library.tres" type="TileSet" id=7]
 [ext_resource path="res://src/main/world/environment/WoodTable.tscn" type="PackedScene" id=8]
 [ext_resource path="res://assets/main/world/environment/interior-shadow.png" type="Texture" id=9]
 [ext_resource path="res://src/main/world/chat-icons.gd" type="Script" id=10]
-[ext_resource path="res://assets/main/ui/touch/menu.png" type="Texture" id=11]
-[ext_resource path="res://assets/main/ui/touch/menu-pressed.png" type="Texture" id=12]
 [ext_resource path="res://src/main/world/environment/Stool.tscn" type="PackedScene" id=13]
-[ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=14]
-[ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=15]
 [ext_resource path="res://src/main/world/ChatIcon.tscn" type="PackedScene" id=16]
-[ext_resource path="res://src/main/ui/SettingsMenu.tscn" type="PackedScene" id=17]
 [ext_resource path="res://src/main/world/creature/CreatureShadows.tscn" type="PackedScene" id=18]
 [ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=19]
 [ext_resource path="res://src/main/world/OverworldExit.tscn" type="PackedScene" id=20]
-[ext_resource path="res://src/main/ui/SceneTransitionRect.tscn" type="PackedScene" id=21]
 [ext_resource path="res://src/main/world/environment/WoodPillar.tscn" type="PackedScene" id=22]
-[ext_resource path="res://src/main/ui/FpsLabel.tscn" type="PackedScene" id=24]
-[ext_resource path="res://src/main/ui/VersionLabel.tscn" type="PackedScene" id=25]
-[ext_resource path="res://src/main/ui/MoneyLabel.tscn" type="PackedScene" id=26]
-[ext_resource path="res://src/main/ui/chat/ChatUi.tscn" type="PackedScene" id=27]
-[ext_resource path="res://src/main/world/OverworldTouchButtons.tscn" type="PackedScene" id=28]
-[ext_resource path="res://src/main/ui/ImageButton.tscn" type="PackedScene" id=29]
 [ext_resource path="res://src/main/world/environment/OvalShadow.tscn" type="PackedScene" id=30]
-[ext_resource path="res://src/main/ui/level-select/LevelSelectPanel.tscn" type="PackedScene" id=31]
-[ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=32]
 [ext_resource path="res://src/main/world/obstacle-map.gd" type="Script" id=33]
 [ext_resource path="res://src/main/world/shadow-caster-shadows.gd" type="Script" id=34]
-[ext_resource path="res://assets/main/ui/touch/interact.png" type="Texture" id=35]
-[ext_resource path="res://assets/main/ui/touch/interact-pressed.png" type="Texture" id=36]
 [ext_resource path="res://src/main/world/environment/obstacle-map-shadows.gd" type="Script" id=38]
 [ext_resource path="res://src/main/world/overworld-camera.gd" type="Script" id=39]
 [ext_resource path="res://src/main/world/screwport-texrect.gd" type="Script" id=40]
 [ext_resource path="res://src/main/world/overworld-bg.gd" type="Script" id=41]
-[ext_resource path="res://src/main/world/phone-menu.gd" type="Script" id=42]
-[ext_resource path="res://src/main/world/overworld-buttons.gd" type="Script" id=43]
-[ext_resource path="res://assets/main/ui/touch/close.png" type="Texture" id=46]
-[ext_resource path="res://assets/main/ui/touch/phone-pressed.png" type="Texture" id=47]
-[ext_resource path="res://assets/main/ui/touch/phone.png" type="Texture" id=48]
-[ext_resource path="res://assets/main/ui/touch/close-pressed.png" type="Texture" id=49]
 
 [sub_resource type="TileSet" id=1]
 0/name = "interior-shadow.png 0"
@@ -65,30 +42,6 @@
 [sub_resource type="ViewportTexture" id=2]
 viewport_path = NodePath("World/Ground/Shadows/Viewport")
 
-[sub_resource type="InputEventAction" id=3]
-action = "phone"
-
-[sub_resource type="ShortCut" id=4]
-shortcut = SubResource( 3 )
-
-[sub_resource type="InputEventAction" id=5]
-action = "ui_cancel"
-
-[sub_resource type="ShortCut" id=6]
-shortcut = SubResource( 5 )
-
-[sub_resource type="InputEventAction" id=7]
-action = "interact"
-
-[sub_resource type="ShortCut" id=8]
-shortcut = SubResource( 7 )
-
-[sub_resource type="InputEventAction" id=9]
-action = "ui_cancel"
-
-[sub_resource type="ShortCut" id=10]
-shortcut = SubResource( 9 )
-
 [node name="OverworldIndoors" type="Node"]
 
 [node name="Bg" type="CanvasLayer" parent="."]
@@ -107,8 +60,6 @@ __meta__ = {
 script = ExtResource( 4 )
 creature_shadows_path = NodePath("Ground/Shadows/Viewport/CreatureShadows")
 chat_icons_path = NodePath("ChatIcons")
-overworld_ui_path = NodePath("../Ui/OverworldUi")
-player_path = NodePath("Obstacles/Player")
 
 [node name="Ground" type="Node2D" parent="World"]
 z_index = -1
@@ -200,7 +151,6 @@ orientation = 3
 [node name="Sensei" parent="World/Obstacles" instance=ExtResource( 19 )]
 position = Vector2( 45.1765, 205.713 )
 script = ExtResource( 1 )
-player_path = NodePath("../../../../OverworldIndoors/World/Obstacles/Player")
 
 [node name="MoveTimer" type="Timer" parent="World/Obstacles/Sensei"]
 wait_time = 0.3
@@ -280,274 +230,13 @@ position = Vector2( 1368, 155 )
 [node name="ChatIcons" type="Node2D" parent="World"]
 script = ExtResource( 10 )
 ChatIconScene = ExtResource( 16 )
-overworld_ui_path = NodePath("../../../OverworldIndoors/Ui/OverworldUi")
 
 [node name="Camera" type="Camera2D" parent="World"]
 position = Vector2( 150, 150 )
 current = true
 smoothing_enabled = true
 script = ExtResource( 39 )
-player_path = NodePath("../../../OverworldIndoors/World/Obstacles/Player")
-overworld_ui_path = NodePath("../../../OverworldIndoors/Ui/OverworldUi")
 
 [node name="Tween" type="Tween" parent="World/Camera"]
 
-[node name="Ui" type="CanvasLayer" parent="."]
-
-[node name="OverworldUi" type="Control" parent="Ui"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-script = ExtResource( 6 )
-__meta__ = {
-"_edit_group_": true,
-"_edit_lock_": true,
-"_edit_use_anchors_": false
-}
-
-[node name="Labels" type="Control" parent="Ui/OverworldUi"]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -512.0
-margin_top = -300.0
-margin_right = 512.0
-margin_bottom = 300.0
-rect_min_size = Vector2( 1024, 600 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="SoutheastLabels" type="VBoxContainer" parent="Ui/OverworldUi/Labels"]
-anchor_left = 1.0
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = -502.0
-margin_top = -290.0
-margin_right = -10.0
-margin_bottom = -10.0
-theme = ExtResource( 3 )
-alignment = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="FpsLabel" parent="Ui/OverworldUi/Labels/SoutheastLabels" instance=ExtResource( 24 )]
-visible = false
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 0.0
-margin_top = 236.0
-margin_right = 492.0
-margin_bottom = 256.0
-
-[node name="VersionLabel" parent="Ui/OverworldUi/Labels/SoutheastLabels" instance=ExtResource( 25 )]
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 0.0
-margin_top = 260.0
-margin_right = 492.0
-margin_bottom = 280.0
-
-[node name="NorthwestLabels" type="VBoxContainer" parent="Ui/OverworldUi/Labels"]
-margin_left = 10.0
-margin_top = 10.0
-margin_right = 512.0
-margin_bottom = 300.0
-theme = ExtResource( 3 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="MoneyLabel" parent="Ui/OverworldUi/Labels/NorthwestLabels" instance=ExtResource( 26 )]
-margin_left = 0.0
-margin_top = 0.0
-margin_right = 502.0
-margin_bottom = 32.0
-compact = true
-
-[node name="ChatUi" parent="Ui/OverworldUi" instance=ExtResource( 27 )]
-visible = false
-margin_bottom = 1.99976
-
-[node name="TouchButtons" parent="Ui/OverworldUi" instance=ExtResource( 28 )]
-
-[node name="Buttons" type="Control" parent="Ui/OverworldUi"]
-modulate = Color( 1, 1, 1, 0.627451 )
-anchor_right = 1.0
-anchor_bottom = 1.0
-script = ExtResource( 43 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Northeast" type="HBoxContainer" parent="Ui/OverworldUi/Buttons"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -512.0
-margin_top = 10.0
-margin_right = -10.0
-margin_bottom = 110.0
-rect_min_size = Vector2( 100, 100 )
-custom_constants/separation = 10
-alignment = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="PhoneButton" parent="Ui/OverworldUi/Buttons/Northeast" instance=ExtResource( 29 )]
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 292.0
-margin_right = 392.0
-margin_bottom = 100.0
-size_flags_horizontal = 0
-shortcut = SubResource( 4 )
-icon = ExtResource( 48 )
-expand_icon = true
-normal_icon = ExtResource( 48 )
-pressed_icon = ExtResource( 47 )
-
-[node name="SettingsButton" parent="Ui/OverworldUi/Buttons/Northeast" instance=ExtResource( 29 )]
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 402.0
-margin_right = 502.0
-margin_bottom = 100.0
-shortcut = SubResource( 6 )
-icon = ExtResource( 11 )
-expand_icon = true
-normal_icon = ExtResource( 11 )
-pressed_icon = ExtResource( 12 )
-
-[node name="Southeast" type="HBoxContainer" parent="Ui/OverworldUi/Buttons"]
-anchor_left = 1.0
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = -512.0
-margin_top = -160.0
-margin_right = -10.0
-margin_bottom = -60.0
-rect_min_size = Vector2( 100, 100 )
-custom_constants/separation = 10
-alignment = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="TalkButton" parent="Ui/OverworldUi/Buttons/Southeast" instance=ExtResource( 29 )]
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 402.0
-margin_right = 502.0
-margin_bottom = 100.0
-shortcut = SubResource( 8 )
-icon = ExtResource( 35 )
-expand_icon = true
-normal_icon = ExtResource( 35 )
-pressed_icon = ExtResource( 36 )
-
-[node name="CheatCodeDetector" parent="Ui/OverworldUi" instance=ExtResource( 15 )]
-codes = [ "bigfps" ]
-
-[node name="SettingsMenu" parent="Ui/OverworldUi" instance=ExtResource( 17 )]
-quit_text = "Save + Quit"
-
-[node name="CellPhoneMenu" type="CanvasLayer" parent="Ui/OverworldUi"]
-script = ExtResource( 42 )
-
-[node name="Bg" type="ColorRect" parent="Ui/OverworldUi/CellPhoneMenu"]
-visible = false
-anchor_right = 1.0
-anchor_bottom = 1.0
-color = Color( 0, 0, 0, 0.752941 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="LevelSelect" parent="Ui/OverworldUi/CellPhoneMenu" instance=ExtResource( 31 )]
-visible = false
-
-[node name="Buttons" type="Control" parent="Ui/OverworldUi/CellPhoneMenu"]
-visible = false
-modulate = Color( 1, 1, 1, 0.627451 )
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Northeast" type="HBoxContainer" parent="Ui/OverworldUi/CellPhoneMenu/Buttons"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -512.0
-margin_top = 10.0
-margin_right = -10.0
-margin_bottom = 110.0
-rect_min_size = Vector2( 100, 100 )
-mouse_filter = 2
-custom_constants/separation = 10
-alignment = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="BackButton" parent="Ui/OverworldUi/CellPhoneMenu/Buttons/Northeast" instance=ExtResource( 29 )]
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 292.0
-margin_right = 392.0
-margin_bottom = 100.0
-size_flags_horizontal = 0
-shortcut = SubResource( 10 )
-icon = ExtResource( 46 )
-expand_icon = true
-normal_icon = ExtResource( 46 )
-pressed_icon = ExtResource( 49 )
-
-[node name="ShortcutHelper" parent="Ui/OverworldUi/CellPhoneMenu/Buttons/Northeast/BackButton" instance=ExtResource( 14 )]
-action = "phone"
-
-[node name="Spacer" parent="Ui/OverworldUi/CellPhoneMenu/Buttons/Northeast" instance=ExtResource( 29 )]
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 402.0
-margin_right = 502.0
-margin_bottom = 100.0
-mouse_filter = 2
-disabled = true
-
-[node name="MusicPopup" parent="Ui/OverworldUi" instance=ExtResource( 32 )]
-
-[node name="SceneTransitionRect" parent="Ui" instance=ExtResource( 21 )]
-[connection signal="chat_ended" from="Ui/OverworldUi" to="World/Camera" method="_on_OverworldUi_chat_ended"]
-[connection signal="chat_ended" from="Ui/OverworldUi" to="Ui/OverworldUi/TouchButtons" method="_on_OverworldUi_chat_ended"]
-[connection signal="chat_ended" from="Ui/OverworldUi" to="Ui/OverworldUi/Buttons" method="_on_OverworldUi_chat_ended"]
-[connection signal="chat_started" from="Ui/OverworldUi" to="World/Camera" method="_on_OverworldUi_chat_started"]
-[connection signal="chat_started" from="Ui/OverworldUi" to="Ui/OverworldUi/TouchButtons" method="_on_OverworldUi_chat_started"]
-[connection signal="chat_started" from="Ui/OverworldUi" to="Ui/OverworldUi/Buttons" method="_on_OverworldUi_chat_started"]
-[connection signal="showed_chat_choices" from="Ui/OverworldUi" to="World/Obstacles/Player" method="_on_OverworldUi_showed_chat_choices"]
-[connection signal="chat_event_played" from="Ui/OverworldUi/ChatUi" to="Ui/OverworldUi" method="_on_ChatUi_chat_event_played"]
-[connection signal="pop_out_completed" from="Ui/OverworldUi/ChatUi" to="Ui/OverworldUi" method="_on_ChatUi_pop_out_completed"]
-[connection signal="showed_choices" from="Ui/OverworldUi/ChatUi" to="Ui/OverworldUi" method="_on_ChatUi_showed_choices"]
-[connection signal="pressed" from="Ui/OverworldUi/Buttons/Northeast/PhoneButton" to="Ui/OverworldUi" method="_on_CellPhoneButton_pressed"]
-[connection signal="pressed" from="Ui/OverworldUi/Buttons/Northeast/SettingsButton" to="Ui/OverworldUi" method="_on_SettingsButton_pressed"]
-[connection signal="pressed" from="Ui/OverworldUi/Buttons/Southeast/TalkButton" to="Ui/OverworldUi" method="_on_TalkButton_pressed"]
-[connection signal="cheat_detected" from="Ui/OverworldUi/CheatCodeDetector" to="Ui/OverworldUi/Labels/SoutheastLabels/FpsLabel" method="_on_CheatCodeDetector_cheat_detected"]
-[connection signal="hide" from="Ui/OverworldUi/SettingsMenu" to="Ui/OverworldUi/TouchButtons" method="_on_Menu_hide"]
-[connection signal="hide" from="Ui/OverworldUi/SettingsMenu" to="Ui/OverworldUi/Buttons" method="_on_Menu_hide"]
-[connection signal="quit_pressed" from="Ui/OverworldUi/SettingsMenu" to="Ui/OverworldUi" method="_on_SettingsMenu_quit_pressed"]
-[connection signal="show" from="Ui/OverworldUi/SettingsMenu" to="Ui/OverworldUi/TouchButtons" method="_on_Menu_show"]
-[connection signal="show" from="Ui/OverworldUi/SettingsMenu" to="Ui/OverworldUi/Buttons" method="_on_Menu_show"]
-[connection signal="hide" from="Ui/OverworldUi/CellPhoneMenu" to="Ui/OverworldUi/TouchButtons" method="_on_Menu_hide"]
-[connection signal="hide" from="Ui/OverworldUi/CellPhoneMenu" to="Ui/OverworldUi/Buttons" method="_on_Menu_hide"]
-[connection signal="show" from="Ui/OverworldUi/CellPhoneMenu" to="Ui/OverworldUi/TouchButtons" method="_on_Menu_show"]
-[connection signal="show" from="Ui/OverworldUi/CellPhoneMenu" to="Ui/OverworldUi/Buttons" method="_on_Menu_show"]
-[connection signal="pressed" from="Ui/OverworldUi/CellPhoneMenu/Buttons/Northeast/BackButton" to="Ui/OverworldUi/CellPhoneMenu" method="_on_BackButton_pressed"]
+[node name="Ui" parent="." instance=ExtResource( 3 )]

--- a/project/src/main/world/OverworldObstacles.tscn
+++ b/project/src/main/world/OverworldObstacles.tscn
@@ -63,7 +63,6 @@ creature_id = "bort"
 dna = {
 
 }
-overworld_ui_path = NodePath("../../../Ui/OverworldUi")
 
 [node name="MoveTimer" type="Timer" parent="Bort"]
 wait_time = 1.6
@@ -78,7 +77,6 @@ creature_id = "ebe"
 dna = {
 
 }
-overworld_ui_path = NodePath("../../../Ui/OverworldUi")
 
 [node name="MoveTimer" type="Timer" parent="Ebe"]
 wait_time = 0.9
@@ -100,7 +98,6 @@ script = ExtResource( 2 )
 dna = {
 
 }
-player_path = NodePath("../Player")
 
 [node name="MoveTimer" type="Timer" parent="Sensei"]
 wait_time = 0.3

--- a/project/src/main/world/OverworldUi.tscn
+++ b/project/src/main/world/OverworldUi.tscn
@@ -1,0 +1,350 @@
+[gd_scene load_steps=39 format=2]
+
+[ext_resource path="res://src/main/world/overworld-buttons.gd" type="Script" id=1]
+[ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=2]
+[ext_resource path="res://src/main/ui/overworld-ui.gd" type="Script" id=3]
+[ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=10]
+[ext_resource path="res://src/main/ui/level-select/LevelSelectPanel.tscn" type="PackedScene" id=11]
+[ext_resource path="res://src/main/world/OverworldTouchButtons.tscn" type="PackedScene" id=12]
+[ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=13]
+[ext_resource path="res://src/main/ui/SettingsMenu.tscn" type="PackedScene" id=14]
+[ext_resource path="res://src/main/ui/SceneTransitionRect.tscn" type="PackedScene" id=15]
+[ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=16]
+[ext_resource path="res://src/main/ui/ImageButton.tscn" type="PackedScene" id=17]
+[ext_resource path="res://src/main/ui/chat/ChatUi.tscn" type="PackedScene" id=18]
+[ext_resource path="res://src/main/ui/FpsLabel.tscn" type="PackedScene" id=19]
+[ext_resource path="res://src/main/ui/VersionLabel.tscn" type="PackedScene" id=20]
+[ext_resource path="res://src/main/ui/MoneyLabel.tscn" type="PackedScene" id=21]
+[ext_resource path="res://assets/main/ui/touch/interact-pressed.png" type="Texture" id=22]
+[ext_resource path="res://assets/main/ui/touch/interact.png" type="Texture" id=23]
+[ext_resource path="res://assets/main/ui/touch/menu-pressed.png" type="Texture" id=24]
+[ext_resource path="res://assets/main/ui/touch/menu.png" type="Texture" id=25]
+[ext_resource path="res://src/main/world/phone-menu.gd" type="Script" id=28]
+[ext_resource path="res://assets/main/ui/touch/phone.png" type="Texture" id=33]
+[ext_resource path="res://assets/main/ui/touch/phone-pressed.png" type="Texture" id=34]
+[ext_resource path="res://assets/main/ui/touch/close.png" type="Texture" id=35]
+[ext_resource path="res://assets/main/ui/touch/close-pressed.png" type="Texture" id=36]
+
+[sub_resource type="StyleBoxEmpty" id=1]
+
+[sub_resource type="StyleBoxEmpty" id=2]
+
+[sub_resource type="StyleBoxEmpty" id=3]
+
+[sub_resource type="StyleBoxEmpty" id=4]
+
+[sub_resource type="StyleBoxEmpty" id=5]
+
+[sub_resource type="InputEventAction" id=6]
+action = "phone"
+
+[sub_resource type="ShortCut" id=7]
+shortcut = SubResource( 6 )
+
+[sub_resource type="InputEventAction" id=8]
+action = "ui_cancel"
+
+[sub_resource type="ShortCut" id=9]
+shortcut = SubResource( 8 )
+
+[sub_resource type="InputEventAction" id=10]
+action = "interact"
+
+[sub_resource type="ShortCut" id=11]
+shortcut = SubResource( 10 )
+
+[sub_resource type="StyleBoxFlat" id=12]
+content_margin_left = 5.0
+content_margin_right = 5.0
+content_margin_top = 5.0
+content_margin_bottom = 5.0
+bg_color = Color( 0.1, 0.094, 0.094, 1 )
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color( 1, 1, 1, 1 )
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+
+[sub_resource type="InputEventAction" id=13]
+action = "ui_cancel"
+
+[sub_resource type="ShortCut" id=14]
+shortcut = SubResource( 13 )
+
+[node name="OverworldUi" type="CanvasLayer" groups=[
+"overworld_ui",
+]]
+script = ExtResource( 3 )
+
+[node name="Control" type="Control" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+__meta__ = {
+"_edit_group_": true,
+"_edit_lock_": true,
+"_edit_use_anchors_": false
+}
+
+[node name="Labels" type="Control" parent="Control"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -512.0
+margin_top = -300.0
+margin_right = 512.0
+margin_bottom = 300.0
+rect_min_size = Vector2( 1024, 600 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="SoutheastLabels" type="VBoxContainer" parent="Control/Labels"]
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -502.0
+margin_top = -290.0
+margin_right = -10.0
+margin_bottom = -10.0
+theme = ExtResource( 2 )
+alignment = 2
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="FpsLabel" parent="Control/Labels/SoutheastLabels" instance=ExtResource( 19 )]
+visible = false
+margin_top = 236.0
+margin_right = 492.0
+margin_bottom = 256.0
+
+[node name="VersionLabel" parent="Control/Labels/SoutheastLabels" instance=ExtResource( 20 )]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 0.0
+margin_top = 260.0
+margin_right = 492.0
+margin_bottom = 280.0
+
+[node name="NorthwestLabels" type="VBoxContainer" parent="Control/Labels"]
+margin_left = 10.0
+margin_top = 10.0
+margin_right = 512.0
+margin_bottom = 300.0
+theme = ExtResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="MoneyLabel" parent="Control/Labels/NorthwestLabels" instance=ExtResource( 21 )]
+margin_left = 0.0
+margin_top = 0.0
+margin_right = 502.0
+margin_bottom = 32.0
+compact = true
+
+[node name="ChatUi" parent="Control" instance=ExtResource( 18 )]
+visible = false
+margin_bottom = 1.99976
+
+[node name="TouchButtons" parent="Control" instance=ExtResource( 12 )]
+
+[node name="Buttons" type="Control" parent="Control"]
+modulate = Color( 1, 1, 1, 0.627451 )
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Northeast" type="HBoxContainer" parent="Control/Buttons"]
+anchor_left = 1.0
+anchor_right = 1.0
+margin_left = -512.0
+margin_top = 10.0
+margin_right = -10.0
+margin_bottom = 110.0
+rect_min_size = Vector2( 100, 100 )
+custom_constants/separation = 10
+alignment = 2
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="PhoneButton" parent="Control/Buttons/Northeast" instance=ExtResource( 17 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 292.0
+margin_right = 392.0
+margin_bottom = 100.0
+size_flags_horizontal = 0
+custom_styles/hover = SubResource( 1 )
+custom_styles/pressed = SubResource( 2 )
+custom_styles/focus = SubResource( 3 )
+custom_styles/disabled = SubResource( 4 )
+custom_styles/normal = SubResource( 5 )
+shortcut = SubResource( 7 )
+icon = ExtResource( 33 )
+expand_icon = true
+normal_icon = ExtResource( 33 )
+pressed_icon = ExtResource( 34 )
+
+[node name="SettingsButton" parent="Control/Buttons/Northeast" instance=ExtResource( 17 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 402.0
+margin_right = 502.0
+margin_bottom = 100.0
+custom_styles/hover = SubResource( 1 )
+custom_styles/pressed = SubResource( 2 )
+custom_styles/focus = SubResource( 3 )
+custom_styles/disabled = SubResource( 4 )
+custom_styles/normal = SubResource( 5 )
+shortcut = SubResource( 9 )
+icon = ExtResource( 25 )
+expand_icon = true
+normal_icon = ExtResource( 25 )
+pressed_icon = ExtResource( 24 )
+
+[node name="Southeast" type="HBoxContainer" parent="Control/Buttons"]
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -512.0
+margin_top = -160.0
+margin_right = -10.0
+margin_bottom = -60.0
+rect_min_size = Vector2( 100, 100 )
+custom_constants/separation = 10
+alignment = 2
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="TalkButton" parent="Control/Buttons/Southeast" instance=ExtResource( 17 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 402.0
+margin_right = 502.0
+margin_bottom = 100.0
+custom_styles/hover = SubResource( 1 )
+custom_styles/pressed = SubResource( 2 )
+custom_styles/focus = SubResource( 3 )
+custom_styles/disabled = SubResource( 4 )
+custom_styles/normal = SubResource( 5 )
+shortcut = SubResource( 11 )
+icon = ExtResource( 23 )
+expand_icon = true
+normal_icon = ExtResource( 23 )
+pressed_icon = ExtResource( 22 )
+
+[node name="CheatCodeDetector" parent="Control" instance=ExtResource( 10 )]
+codes = [ "bigfps" ]
+
+[node name="SettingsMenu" parent="Control" instance=ExtResource( 14 )]
+quit_text = "Save + Quit"
+
+[node name="CellPhoneMenu" type="CanvasLayer" parent="Control"]
+script = ExtResource( 28 )
+
+[node name="Bg" type="ColorRect" parent="Control/CellPhoneMenu"]
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color( 0, 0, 0, 0.752941 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="LevelSelect" parent="Control/CellPhoneMenu" instance=ExtResource( 11 )]
+visible = false
+custom_styles/panel = SubResource( 12 )
+
+[node name="Buttons" type="Control" parent="Control/CellPhoneMenu"]
+visible = false
+modulate = Color( 1, 1, 1, 0.627451 )
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Northeast" type="HBoxContainer" parent="Control/CellPhoneMenu/Buttons"]
+anchor_left = 1.0
+anchor_right = 1.0
+margin_left = -512.0
+margin_top = 10.0
+margin_right = -10.0
+margin_bottom = 110.0
+rect_min_size = Vector2( 100, 100 )
+mouse_filter = 2
+custom_constants/separation = 10
+alignment = 2
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="BackButton" parent="Control/CellPhoneMenu/Buttons/Northeast" instance=ExtResource( 17 )]
+margin_left = 292.0
+margin_right = 392.0
+margin_bottom = 100.0
+size_flags_horizontal = 0
+custom_styles/hover = SubResource( 1 )
+custom_styles/pressed = SubResource( 2 )
+custom_styles/focus = SubResource( 3 )
+custom_styles/disabled = SubResource( 4 )
+custom_styles/normal = SubResource( 5 )
+shortcut = SubResource( 14 )
+icon = ExtResource( 35 )
+expand_icon = true
+normal_icon = ExtResource( 35 )
+pressed_icon = ExtResource( 36 )
+
+[node name="ShortcutHelper" parent="Control/CellPhoneMenu/Buttons/Northeast/BackButton" instance=ExtResource( 13 )]
+action = "phone"
+
+[node name="Spacer" parent="Control/CellPhoneMenu/Buttons/Northeast" instance=ExtResource( 17 )]
+margin_left = 402.0
+margin_right = 502.0
+margin_bottom = 100.0
+mouse_filter = 2
+custom_styles/hover = SubResource( 1 )
+custom_styles/pressed = SubResource( 2 )
+custom_styles/focus = SubResource( 3 )
+custom_styles/disabled = SubResource( 4 )
+custom_styles/normal = SubResource( 5 )
+disabled = true
+
+[node name="MusicPopup" parent="Control" instance=ExtResource( 16 )]
+
+[node name="SceneTransitionRect" parent="Control" instance=ExtResource( 15 )]
+anchor_right = 1.0
+anchor_bottom = 1.0
+[connection signal="chat_event_played" from="Control/ChatUi" to="." method="_on_ChatUi_chat_event_played"]
+[connection signal="pop_out_completed" from="Control/ChatUi" to="." method="_on_ChatUi_pop_out_completed"]
+[connection signal="showed_choices" from="Control/ChatUi" to="." method="_on_ChatUi_showed_choices"]
+[connection signal="pressed" from="Control/Buttons/Northeast/PhoneButton" to="." method="_on_CellPhoneButton_pressed"]
+[connection signal="pressed" from="Control/Buttons/Northeast/SettingsButton" to="." method="_on_SettingsButton_pressed"]
+[connection signal="pressed" from="Control/Buttons/Southeast/TalkButton" to="." method="_on_TalkButton_pressed"]
+[connection signal="cheat_detected" from="Control/CheatCodeDetector" to="Control/Labels/SoutheastLabels/FpsLabel" method="_on_CheatCodeDetector_cheat_detected"]
+[connection signal="hide" from="Control/SettingsMenu" to="Control/TouchButtons" method="_on_Menu_hide"]
+[connection signal="hide" from="Control/SettingsMenu" to="Control/Buttons" method="_on_Menu_hide"]
+[connection signal="quit_pressed" from="Control/SettingsMenu" to="." method="_on_SettingsMenu_quit_pressed"]
+[connection signal="show" from="Control/SettingsMenu" to="Control/TouchButtons" method="_on_Menu_show"]
+[connection signal="show" from="Control/SettingsMenu" to="Control/Buttons" method="_on_Menu_show"]
+[connection signal="hide" from="Control/CellPhoneMenu" to="Control/TouchButtons" method="_on_Menu_hide"]
+[connection signal="hide" from="Control/CellPhoneMenu" to="Control/Buttons" method="_on_Menu_hide"]
+[connection signal="show" from="Control/CellPhoneMenu" to="Control/TouchButtons" method="_on_Menu_show"]
+[connection signal="show" from="Control/CellPhoneMenu" to="Control/Buttons" method="_on_Menu_show"]
+[connection signal="pressed" from="Control/CellPhoneMenu/Buttons/Northeast/BackButton" to="Control/CellPhoneMenu" method="_on_BackButton_pressed"]

--- a/project/src/main/world/chat-icons.gd
+++ b/project/src/main/world/chat-icons.gd
@@ -5,13 +5,12 @@ Creates and initializes chat icons for all chattables in the scene tree.
 """
 
 export (PackedScene) var ChatIconScene: PackedScene
-export (NodePath) var overworld_ui_path: NodePath
 
 # key: Node2D in the 'chattable' node group
 # value: ChatIcon instance
 var _chat_icon_by_chattable: Dictionary
 
-onready var overworld_ui: OverworldUi = get_node(overworld_ui_path)
+onready var overworld_ui: OverworldUi = Global.get_overworld_ui()
 
 func _ready() -> void:
 	overworld_ui.connect("chat_cached", self, "_on_OverworldUi_chat_cached")

--- a/project/src/main/world/chattable-manager.gd
+++ b/project/src/main/world/chattable-manager.gd
@@ -32,6 +32,10 @@ var _focus_enabled := true setget set_focus_enabled, is_focus_enabled
 # value: Creature object corresponding to the chatter name 
 var _creatures_by_chatter_name := {}
 
+func _ready() -> void:
+	Breadcrumb.connect("before_scene_changed", self, "_on_Breadcrumb_before_scene_changed")
+
+
 func _physics_process(_delta: float) -> void:
 	var min_distance := MAX_INTERACT_DISTANCE
 	var new_focused_chattable: Node2D
@@ -111,17 +115,6 @@ func load_chat_events() -> ChatTree:
 		# can't look up chat events without a chat_path; return an empty array
 		push_warning("Chattable %s does not define a 'chat_path' property." % focused_chattable)
 	return chat_tree
-
-
-"""
-Purges all node instances from the manager.
-
-Because ChattableManager is a singleton, node instances must be purged before changing scenes. Otherwise it's
-possible for an invisible object from a previous scene to receive focus.
-"""
-func clear() -> void:
-	player = null
-	focused_chattable = null
 
 
 func set_player(new_player: Player) -> void:
@@ -255,3 +248,15 @@ func _refresh_creature_name(creature: Creature) -> void:
 
 func _on_Creature_creature_name_changed(creature: Creature) -> void:
 	_refresh_creature_name(creature)
+
+
+"""
+Purges all node instances from the manager.
+
+Because ChattableManager is a singleton, node instances must be purged before changing scenes. Otherwise it's
+possible for an invisible object from a previous scene to receive focus.
+"""
+func _on_Breadcrumb_before_scene_changed() -> void:
+	player = null
+	sensei = null
+	focused_chattable = null

--- a/project/src/main/world/creature/bort.gd
+++ b/project/src/main/world/creature/bort.gd
@@ -5,9 +5,7 @@ Script which controls a character 'Bort' on the overworld.
 Makes him run back and forth.
 """
 
-export (NodePath) var overworld_ui_path: NodePath
-
-onready var _overworld_ui: OverworldUi = get_node(overworld_ui_path)
+onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
 
 func _ready() -> void:
 	_overworld_ui.connect("chat_started", self, "_on_OverworldUi_chat_started")

--- a/project/src/main/world/creature/ebe.gd
+++ b/project/src/main/world/creature/ebe.gd
@@ -5,9 +5,7 @@ Script which controls a character 'Ebe' on the overworld.
 Makes her run back and forth.
 """
 
-export (NodePath) var overworld_ui_path: NodePath
-
-onready var _overworld_ui: OverworldUi = get_node(overworld_ui_path)
+onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
 
 func _ready() -> void:
 	_overworld_ui.connect("chat_started", self, "_on_OverworldUi_chat_started")

--- a/project/src/main/world/creature/sensei.gd
+++ b/project/src/main/world/creature/sensei.gd
@@ -10,10 +10,6 @@ The sensei follows the player around.
 const TOO_CLOSE_THRESHOLD := 140.0
 const TOO_FAR_THRESHOLD := 280.0
 
-export (NodePath) var player_path: NodePath
-
-onready var _player: Creature = get_node(player_path)
-
 func _ready() -> void:
 	set_creature_id(Global.SENSEI_ID)
 	$MoveTimer.connect("timeout", self, "_on_MoveTimer_timeout")
@@ -21,7 +17,7 @@ func _ready() -> void:
 
 
 func _on_MoveTimer_timeout() -> void:
-	var player_relative_pos: Vector2 = Global.from_iso(_player.position - position)
+	var player_relative_pos: Vector2 = Global.from_iso(ChattableManager.player.position - position)
 	# the sensei runs at isometric 45 degree angles to mimic the player's inputs
 	var player_angle := stepify(player_relative_pos.normalized().angle(), PI / 4)
 	

--- a/project/src/main/world/overworld-camera.gd
+++ b/project/src/main/world/overworld-camera.gd
@@ -14,9 +14,6 @@ const ZOOM_DEFAULT := Vector2(1.0, 1.0)
 # how far from the camera center the player needs to be before the camera zooms out
 const AUTO_ZOOM_OUT_DISTANCE := 100.0
 
-export (NodePath) var player_path: NodePath
-export (NodePath) var overworld_ui_path: NodePath
-
 # 'true' if the camera should currently be zoomed in for a conversation
 var close_up: bool setget set_close_up
 
@@ -29,8 +26,12 @@ var close_up_position: Vector2
 # zoom amount for the current conversation; we don't zoom in as much if the creature is fat
 var zoom_close_up := ZOOM_CLOSE_UP
 
-onready var _player: Player = get_node(player_path)
-onready var _overworld_ui: OverworldUi = get_node(overworld_ui_path)
+onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
+
+func _ready() -> void:
+	_overworld_ui.connect("chat_started", self, "_on_OverworldUi_chat_started")
+	_overworld_ui.connect("chat_ended", self, "_on_OverworldUi_chat_ended")
+
 
 func _process(_delta: float) -> void:
 	# calculate the position to zoom in to
@@ -42,10 +43,10 @@ func _process(_delta: float) -> void:
 		zoom_close_up = lerp(ZOOM_CLOSE_UP, ZOOM_DEFAULT, inverse_lerp(1.0, 10.0, max_visual_fatness))
 		close_up_position = _overworld_ui.get_center_of_chatters()
 	
-	position = lerp(_player.position, close_up_position, close_up_pct)
+	position = lerp(ChattableManager.player.position, close_up_position, close_up_pct)
 	zoom = lerp(ZOOM_DEFAULT, zoom_close_up, close_up_pct)
 	
-	if close_up and _player.position.distance_to(close_up_position) > AUTO_ZOOM_OUT_DISTANCE:
+	if close_up and ChattableManager.player.position.distance_to(close_up_position) > AUTO_ZOOM_OUT_DISTANCE:
 		# player left the chat area; zoom back out
 		set_close_up(false)
 

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -5,14 +5,11 @@ Populates/unpopulates the creatures and obstacles on the overworld.
 
 export (NodePath) var creature_shadows_path: NodePath
 export (NodePath) var chat_icons_path: NodePath
-export (NodePath) var overworld_ui_path: NodePath
-export (NodePath) var player_path: NodePath
 export (PackedScene) var CreaturePackedScene: PackedScene
 
 onready var _creature_shadows: CreatureShadows = get_node(creature_shadows_path)
 onready var _chat_icons: ChatIcons = get_node(chat_icons_path)
-onready var _overworld_ui: OverworldUi = get_node(overworld_ui_path)
-onready var _player: Creature = get_node(player_path)
+onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
 
 func _ready() -> void:
 	if Global.player_spawn_id:
@@ -39,9 +36,9 @@ func _ready() -> void:
 		_creature_shadows.create_shadow(creature)
 		
 		# reposition the cutscene creatures, ensuring fat creatures have enough space
-		creature.position = _player.position
+		creature.position = ChattableManager.player.position
 		creature.position += Vector2(creature.chat_extents.x, 0)
-		creature.position += Vector2(_player.chat_extents.x, 0)
+		creature.position += Vector2(ChattableManager.player.chat_extents.x, 0)
 		creature.position += Vector2(60, 0)
 		
 		_schedule_chat(creature)


### PR DESCRIPTION
Nodes now use OverworldUi dependency instead of OverworldUiLayer dependency.
This dependency is referenced with a global utility function
(Global.get_overworld_ui) instead of complex relative paths (../../../Ui)

ChattableManager.clear() is now handled with a breadcrumb listener. Ideally this
would be with a scene_changed signal on the node tree, but the node tree does
not provide signals like that.

Fixed oversight where sensei was not purged from ChattableManager.