### PR TITLE
Chat refactorings. PuzzleConnect/PuzzleCornerMap.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -114,11 +114,6 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/puzzle/combo-tracker.gd"
 }, {
-"base": "Reference",
-"class": "Connect",
-"language": "GDScript",
-"path": "res://src/main/connect.gd"
-}, {
 "base": "KinematicBody2D",
 "class": "Creature",
 "language": "GDScript",
@@ -470,6 +465,11 @@ _global_script_classes=[ {
 "path": "res://src/main/puzzle/puzzle-areas.gd"
 }, {
 "base": "Reference",
+"class": "PuzzleConnect",
+"language": "GDScript",
+"path": "res://src/main/puzzle-connect.gd"
+}, {
+"base": "Reference",
 "class": "PuzzlePerformance",
 "language": "GDScript",
 "path": "res://src/main/puzzle/puzzle-performance.gd"
@@ -656,7 +656,6 @@ _global_script_class_icons={
 "ComboBreakRules": "",
 "ComboCounter": "",
 "ComboTracker": "",
-"Connect": "",
 "Creature": "",
 "CreatureCurve": "",
 "CreatureDef": "",
@@ -727,6 +726,7 @@ _global_script_class_icons={
 "Playfield": "",
 "Puzzle": "",
 "PuzzleAreas": "",
+"PuzzleConnect": "",
 "PuzzlePerformance": "",
 "PuzzleTileMap": "",
 "RankCalculator": "",

--- a/project/src/main/puzzle-connect.gd
+++ b/project/src/main/puzzle-connect.gd
@@ -1,9 +1,13 @@
-class_name Connect
+class_name PuzzleConnect
 """
-Map integers such as '14' to autotile coordinates such as 'LEFT | RIGHT | DOWN'
+Map integers such as '14' to puzzle autotile coordinates such as 'LEFT | RIGHT | DOWN'
+
+This is useful for tiles which are arranged so that the X coordinates of the tiles correspond to the directions they're
+connected. This type of tilemap is used for puzzle pieces.
 """
 
-# constants used when drawing tiles which are connected to other tiles
+# Constants used when drawing tiles which are connected to other tiles. These serve a similar purpose to the
+# TileSet.BIND_TOP constants, but with smaller values.
 const UP := 1
 const DOWN := 2
 const LEFT := 4

--- a/project/src/main/puzzle/PuzzleTileMap.tscn
+++ b/project/src/main/puzzle/PuzzleTileMap.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource path="res://assets/main/puzzle/blocks/blocks-corners.png" type="Texture" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleTileSet.tres" type="TileSet" id=2]
-[ext_resource path="res://src/main/puzzle/piece/CornerMap.tscn" type="PackedScene" id=3]
+[ext_resource path="res://src/main/puzzle/piece/PuzzleCornerMap.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/puzzle/piece/shadow-map.gd" type="Script" id=4]
 [ext_resource path="res://src/main/puzzle/puzzle-tile-map.gd" type="Script" id=5]
 [ext_resource path="res://assets/main/puzzle/blocks/blocks-boxes-shadows.png" type="Texture" id=6]

--- a/project/src/main/puzzle/box-builder.gd
+++ b/project/src/main/puzzle/box-builder.gd
@@ -177,14 +177,14 @@ func _process_box(end_x: int, end_y: int, width: int, height: int) -> bool:
 	var start_x := end_x - (width - 1)
 	var start_y := end_y - (height - 1)
 	for x in range(start_x, end_x + 1):
-		if Connect.is_u(_tile_map.get_cell_autotile_coord(x, start_y).x):
+		if PuzzleConnect.is_u(_tile_map.get_cell_autotile_coord(x, start_y).x):
 			return false
-		if Connect.is_d(_tile_map.get_cell_autotile_coord(x, end_y).x):
+		if PuzzleConnect.is_d(_tile_map.get_cell_autotile_coord(x, end_y).x):
 			return false
 	for y in range(start_y, end_y + 1):
-		if Connect.is_l(_tile_map.get_cell_autotile_coord(start_x, y).x):
+		if PuzzleConnect.is_l(_tile_map.get_cell_autotile_coord(start_x, y).x):
 			return false
-		if Connect.is_r(_tile_map.get_cell_autotile_coord(end_x, y).x):
+		if PuzzleConnect.is_r(_tile_map.get_cell_autotile_coord(end_x, y).x):
 			return false
 	
 	# calculate the ingredient string for the box

--- a/project/src/main/puzzle/line-clearer.gd
+++ b/project/src/main/puzzle/line-clearer.gd
@@ -225,11 +225,11 @@ func _box_ints(y: int) -> Array:
 		var right_autotile_coord := _tile_map.get_cell_autotile_coord(x + 1, y)
 		if _tile_map.get_cell(x, y) == 1:
 			var should_count: bool = false
-			if (Connect.is_l(autotile_coord.x) and Connect.is_r(autotile_coord.x)):
+			if (PuzzleConnect.is_l(autotile_coord.x) and PuzzleConnect.is_r(autotile_coord.x)):
 				# wide boxes count multiple times to reward difficult horizontal builds
 				should_count = true
-			elif not Connect.is_l(autotile_coord.x) and \
-					(not Connect.is_r(autotile_coord.x) or not Connect.is_r(right_autotile_coord.x)):
+			elif not PuzzleConnect.is_l(autotile_coord.x) and \
+					(not PuzzleConnect.is_r(autotile_coord.x) or not PuzzleConnect.is_r(right_autotile_coord.x)):
 				# narrow boxes (1 wide, 2 wide) still count
 				should_count = true
 			if should_count:

--- a/project/src/main/puzzle/piece/PuzzleCornerMap.tscn
+++ b/project/src/main/puzzle/piece/PuzzleCornerMap.tscn
@@ -1,8 +1,7 @@
 [gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://assets/main/puzzle/blocks/blocks-corners.png" type="Texture" id=1]
-[ext_resource path="res://src/main/puzzle/piece/corner-map.gd" type="Script" id=2]
-
+[ext_resource path="res://src/main/puzzle/piece/puzzle-corner-map.gd" type="Script" id=2]
 
 [sub_resource type="TileSet" id=1]
 0/name = "blocks-corners.png 2"

--- a/project/src/main/puzzle/piece/puzzle-corner-map.gd
+++ b/project/src/main/puzzle/piece/puzzle-corner-map.gd
@@ -4,6 +4,9 @@ Tile map which covers the corners of another tilemap.
 
 Without this tile map, a simple 16-tile autotiling would result in tiny holes at the corners of a filled in area. This
 tile map fills in the holes.
+
+This tilemap assumes tiles are arranged so that the X coordinates of the tiles correspond to the directions they're
+connected. This type of tilemap is used for puzzle pieces.
 """
 
 onready var _parent_map: TileMap = get_parent()
@@ -20,16 +23,20 @@ func _process(_delta: float) -> void:
 				# vegetable cell?
 				continue
 			# check for corner connected up and left
-			if Connect.is_u(pacx) and Connect.is_l(pacx) and not Connect.is_u(_pacx(cell + Vector2.LEFT)):
+			if PuzzleConnect.is_u(pacx) and PuzzleConnect.is_l(pacx) \
+					and not PuzzleConnect.is_u(_pacx(cell + Vector2.LEFT)):
 				set_cell(cell.x * 2, cell.y * 2, 0, false, false, false, Vector2(0, pacy * 2))
 			# check for corner connected up and right
-			if Connect.is_u(pacx) and Connect.is_r(pacx) and not Connect.is_u(_pacx(cell + Vector2.RIGHT)):
+			if PuzzleConnect.is_u(pacx) and PuzzleConnect.is_r(pacx) \
+					and not PuzzleConnect.is_u(_pacx(cell + Vector2.RIGHT)):
 				set_cell(cell.x * 2 + 1, cell.y * 2, 0, false, false, false, Vector2(1, pacy * 2))
 			# check for corner connected down and left
-			if Connect.is_d(pacx) and Connect.is_l(pacx) and not Connect.is_d(_pacx(cell + Vector2.LEFT)):
+			if PuzzleConnect.is_d(pacx) and PuzzleConnect.is_l(pacx) \
+					and not PuzzleConnect.is_d(_pacx(cell + Vector2.LEFT)):
 				set_cell(cell.x * 2, cell.y * 2 + 1, 0, false, false, false, Vector2(0, pacy * 2 + 1))
 			# check for corner connected down and right
-			if Connect.is_d(pacx) and Connect.is_r(pacx) and not Connect.is_d(_pacx(cell + Vector2.RIGHT)):
+			if PuzzleConnect.is_d(pacx) and PuzzleConnect.is_r(pacx) \
+					and not PuzzleConnect.is_d(_pacx(cell + Vector2.RIGHT)):
 				set_cell(cell.x * 2 + 1, cell.y * 2 + 1, 0, false, false, false, Vector2(1, pacy * 2 + 1))
 		dirty = false
 

--- a/project/src/main/puzzle/puzzle-tile-map.gd
+++ b/project/src/main/puzzle/puzzle-tile-map.gd
@@ -94,13 +94,13 @@ func build_box(rect: Rect2, color_int: int) -> void:
 	
 	# top/bottom edge
 	for curr_x in range(rect.position.x, rect.end.x):
-		_disconnect_block(Vector2(curr_x, rect.position.y), Connect.UP)
-		_disconnect_block(Vector2(curr_x, rect.end.y - 1), Connect.DOWN)
+		_disconnect_block(Vector2(curr_x, rect.position.y), PuzzleConnect.UP)
+		_disconnect_block(Vector2(curr_x, rect.end.y - 1), PuzzleConnect.DOWN)
 	
 	# left/right edge
 	for curr_y in range(rect.position.y, rect.end.y):
-		_disconnect_block(Vector2(rect.position.x, curr_y), Connect.LEFT)
-		_disconnect_block(Vector2(rect.end.x - 1, curr_y), Connect.RIGHT)
+		_disconnect_block(Vector2(rect.position.x, curr_y), PuzzleConnect.LEFT)
+		_disconnect_block(Vector2(rect.end.x - 1, curr_y), PuzzleConnect.RIGHT)
 
 
 """
@@ -229,13 +229,13 @@ func _convert_piece_to_veg(pos: Vector2) -> void:
 	set_block(pos, TILE_VEG, Vector2(randi() % 18, vegetable_type))
 	
 	# recurse to neighboring connected cells
-	if get_cellv(pos + Vector2.UP) == 0 and Connect.is_u(old_autotile_coord.x):
+	if get_cellv(pos + Vector2.UP) == 0 and PuzzleConnect.is_u(old_autotile_coord.x):
 		_convert_piece_to_veg(pos + Vector2.UP)
-	if get_cellv(pos + Vector2.DOWN) == 0 and Connect.is_d(old_autotile_coord.x):
+	if get_cellv(pos + Vector2.DOWN) == 0 and PuzzleConnect.is_d(old_autotile_coord.x):
 		_convert_piece_to_veg(pos + Vector2.DOWN)
-	if get_cellv(pos + Vector2.LEFT) == 0 and Connect.is_l(old_autotile_coord.x):
+	if get_cellv(pos + Vector2.LEFT) == 0 and PuzzleConnect.is_l(old_autotile_coord.x):
 		_convert_piece_to_veg(pos + Vector2.LEFT)
-	if get_cellv(pos + Vector2.RIGHT) == 0 and Connect.is_r(old_autotile_coord.x):
+	if get_cellv(pos + Vector2.RIGHT) == 0 and PuzzleConnect.is_r(old_autotile_coord.x):
 		_convert_piece_to_veg(pos + Vector2.RIGHT)
 
 
@@ -251,9 +251,9 @@ bottom of a bread box looks like a delicious frosted snack and the player can te
 """
 func _disconnect_box(pos: Vector2) -> void:
 	if get_cellv(pos + Vector2.UP) == TILE_BOX:
-		_disconnect_block(pos + Vector2.UP, Connect.DOWN)
+		_disconnect_block(pos + Vector2.UP, PuzzleConnect.DOWN)
 	if get_cellv(pos + Vector2.DOWN) == TILE_BOX:
-		_disconnect_block(pos + Vector2.DOWN, Connect.UP)
+		_disconnect_block(pos + Vector2.DOWN, PuzzleConnect.UP)
 
 
 """
@@ -267,7 +267,7 @@ func _disconnect_block(pos: Vector2, dir_mask: int = 15) -> void:
 		# empty cell; nothing to disconnect
 		return
 	var autotile_coord := get_cell_autotile_coord(pos.x, pos.y)
-	autotile_coord.x = Connect.unset_dirs(autotile_coord.x, dir_mask)
+	autotile_coord.x = PuzzleConnect.unset_dirs(autotile_coord.x, dir_mask)
 	set_block(pos, get_cellv(pos), autotile_coord)
 
 

--- a/project/src/main/puzzle/squish-map.gd
+++ b/project/src/main/puzzle/squish-map.gd
@@ -34,13 +34,13 @@ func _process(delta: float) -> void:
 				continue
 			var color_x := 0
 			if row > 0 and is_cell_blocked(cell_pos + Vector2.UP):
-				color_x = Connect.set_u(color_x)
+				color_x = PuzzleConnect.set_u(color_x)
 			if row < ROW_COUNT - 1 and is_cell_blocked(cell_pos + Vector2.DOWN):
-				color_x = Connect.set_d(color_x)
+				color_x = PuzzleConnect.set_d(color_x)
 			if col > 0 and is_cell_blocked(cell_pos + Vector2.LEFT):
-				color_x = Connect.set_l(color_x)
+				color_x = PuzzleConnect.set_l(color_x)
 			if col < COL_COUNT - 1 and is_cell_blocked(cell_pos + Vector2.RIGHT):
-				color_x = Connect.set_r(color_x)
+				color_x = PuzzleConnect.set_r(color_x)
 			set_block(cell_pos, 0, Vector2(color_x, _color_y))
 	
 	squish_seconds_remaining -= delta

--- a/project/src/main/puzzle/star-seeds.gd
+++ b/project/src/main/puzzle/star-seeds.gd
@@ -66,13 +66,13 @@ func _prepare_wobblers_for_level() -> void:
 			if cell_contents != PuzzleTileMap.TILE_BOX:
 				continue
 			var autotile_coord := _puzzle_tile_map.get_cell_autotile_coord(x, y)
-			if Connect.is_u(autotile_coord.x) or Connect.is_l(autotile_coord.x):
+			if PuzzleConnect.is_u(autotile_coord.x) or PuzzleConnect.is_l(autotile_coord.x):
 				continue
 			# upper left corner...
 			var rect := Rect2(x, y, 1, 1)
-			while(Connect.is_r(_puzzle_tile_map.get_cell_autotile_coord(rect.end.x - 1, y).x)):
+			while(PuzzleConnect.is_r(_puzzle_tile_map.get_cell_autotile_coord(rect.end.x - 1, y).x)):
 				rect.size.x += 1
-			while(Connect.is_d(_puzzle_tile_map.get_cell_autotile_coord(rect.end.x - 1, rect.end.y - 1).x)):
+			while(PuzzleConnect.is_d(_puzzle_tile_map.get_cell_autotile_coord(rect.end.x - 1, rect.end.y - 1).x)):
 				rect.size.y += 1
 			_add_wobblers_for_box(rect, autotile_coord.y)
 

--- a/project/src/main/ui/chat/chat-history.gd
+++ b/project/src/main/ui/chat/chat-history.gd
@@ -6,6 +6,13 @@ Keeps track of which conversations the player's had and how long ago they've had
 """
 
 """
+Constant for the age of conversations we've never had. This is a large number so that evaluating 'have we had this
+conversation recently?' will work without requiring a third branch to handle the case where we haven't had a
+conversation before.
+"""
+const CHAT_AGE_NEVER := 99999999
+
+"""
 Tracks which conversations the player has had with each creature. The value is a per-creature index which starts from
 0 and increments with each conversation with that creature.
 
@@ -73,11 +80,10 @@ func get_chat_age(history_key: String) -> int:
 	var chat_prefix := StringUtils.substring_before_last(history_key, "/")
 	
 	var chat_count: int = chat_counts.get(chat_prefix, 0)
-	var chat_time: int = chat_history.get(history_key, -1)
 	
-	var result := -1
-	if chat_count > 0 and chat_time != -1:
-		result = chat_count - chat_time - 1
+	var result := CHAT_AGE_NEVER
+	if chat_count > 0 and chat_history.has(history_key):
+		result = chat_count - chat_history.get(history_key) - 1
 	return result
 
 


### PR DESCRIPTION
Changed 'never had this conversation' logic to return 99999999 instead of
-1. Returning a very large number lines up with the rest of the logic so
that we don't need a third branch.

Extracted common 'creature chat state' logic a little. More work could be
done here but this is a start.

PuzzleConnect and PuzzleCornerMap were originally developed as generic class,
but after becoming aware of autotiling and TileSet.BIND_TOP constants, these are
more specialized than I thought. I've renamed and commented them to make that
more apparent.