### PR TITLE
Initial cutscene location logic. Level dialog is no longer on creatures.

### DIFF
--- a/project/assets/main/creatures/primary/boatricia/creature.json
+++ b/project/assets/main/creatures/primary/boatricia/creature.json
@@ -28,22 +28,6 @@
   },
   "chat_selectors": [
     {
-      "level": "boatricia1",
-      "dialog": "level_1",
-      "if_conditions": [
-        "current_level/1"
-      ],
-      "repeat": 0
-    },
-    {
-      "level": "boatricia2",
-      "dialog": "level_2",
-      "if_conditions": [
-        "current_level/2"
-      ],
-      "repeat": 0
-    },
-    {
       "dialog": "hi",
       "repeat": 999999
     },

--- a/project/assets/main/puzzle/levels/cutscenes/boatricia1.json
+++ b/project/assets/main/puzzle/levels/cutscenes/boatricia1.json
@@ -1,0 +1,14 @@
+{
+  "version": "1922",
+  "": [
+    {
+      "who": "Boatricia",
+      "text": "Could you maybe just cook me something small? I'm not very hungry today."
+    },
+    {
+      "who": "#player#",
+      "text": "Okay!",
+      "mood": "smile0"
+    }
+  ]
+}

--- a/project/assets/main/puzzle/levels/cutscenes/boatricia2.json
+++ b/project/assets/main/puzzle/levels/cutscenes/boatricia2.json
@@ -1,0 +1,14 @@
+{
+  "version": "1922",
+  "": [
+    {
+      "who": "Boatricia",
+      "text": "I built up an appetite today! Think you can cook something filling for me and my friends?"
+    },
+    {
+      "who": "#player#",
+      "text": "Sure, no problem!",
+      "mood": "smile0"
+    }
+  ]
+}

--- a/project/assets/main/puzzle/levels/cutscenes/five-customers-no-vegetables.json
+++ b/project/assets/main/puzzle/levels/cutscenes/five-customers-no-vegetables.json
@@ -1,0 +1,14 @@
+{
+  "version": "1922",
+  "": [
+    {
+      "who": "Ebe",
+      "text": "Okay,/ I'll invite my friends too!/ But/ -/-/ no vegetables okay?"
+    },
+    {
+      "who": "Ebe",
+      "text": "I HATE vegetables!/ ./././I hate them so much...",
+      "mood": "rage0"
+    }
+  ]
+}

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-everyone.json
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-everyone.json
@@ -1,0 +1,20 @@
+{
+  "version": "1922",
+  "location": {
+    "location_id": "indoors",
+    "spawn_locations": {
+      "#player#": "kitchen-9",
+      "#sensei#": "kitchen-11",
+      "richie": "kitchen-1",
+      "skins": "kitchen-3",
+      "bones": "kitchen-5",
+      "shirts": "kitchen-7"
+    }
+  },
+  "": [
+    {
+      "who": "Richie",
+      "text": "Okay. Now we can have a cutscene!"
+    }
+  ]
+}

--- a/project/assets/main/puzzle/worlds.json
+++ b/project/assets/main/puzzle/worlds.json
@@ -25,6 +25,7 @@
       "levels": [
         {
           "id": "marsh/hello_everyone",
+          "creature_id": "richie",
           "groups": "marsh/hello"
         },
         {
@@ -107,21 +108,18 @@
         {
           "id": "boatricia1",
           "creature_id": "boatricia",
-          "level_num": 1,
           "locked_until": "group_finished choco_intro",
           "groups": "choco_main"
         },
         {
           "id": "boatricia2",
           "creature_id": "boatricia",
-          "level_num": 2,
           "locked_until": "level_finished boatricia1",
           "groups": "choco_main"
         },
         {
           "id": "five_customers_no_vegetables",
           "creature_id": "ebe",
-          "level_num": 1,
           "locked_until": "group_finished choco_intro",
           "groups": "choco_main"
         },

--- a/project/src/demo/world/CutsceneDemo.tscn
+++ b/project/src/demo/world/CutsceneDemo.tscn
@@ -1,0 +1,143 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=1]
+[ext_resource path="res://src/demo/world/cutscene-demo.gd" type="Script" id=2]
+[ext_resource path="res://src/main/ui/DialogBackdrop.tscn" type="PackedScene" id=3]
+[ext_resource path="res://src/demo/world/cutscene-demo-fatness.gd" type="Script" id=4]
+
+[node name="CutsceneDemo" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -200.0
+margin_top = -30.0
+margin_right = 200.0
+margin_bottom = 30.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Fatness" type="HBoxContainer" parent="VBoxContainer"]
+margin_right = 400.0
+margin_bottom = 28.0
+script = ExtResource( 4 )
+
+[node name="CheckBox" type="CheckBox" parent="VBoxContainer/Fatness"]
+margin_right = 90.0
+margin_bottom = 28.0
+theme = ExtResource( 1 )
+text = "Fatness"
+
+[node name="HSlider" type="HSlider" parent="VBoxContainer/Fatness"]
+margin_left = 94.0
+margin_right = 361.0
+margin_bottom = 28.0
+size_flags_horizontal = 3
+size_flags_vertical = 1
+min_value = 1.0
+max_value = 10.0
+value = 10.0
+tick_count = 10
+ticks_on_borders = true
+
+[node name="Value" type="Label" parent="VBoxContainer/Fatness"]
+margin_left = 365.0
+margin_top = 4.0
+margin_right = 400.0
+margin_bottom = 24.0
+rect_min_size = Vector2( 35, 0 )
+size_flags_horizontal = 0
+theme = ExtResource( 1 )
+text = "10.0"
+align = 1
+
+[node name="Open" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 32.0
+margin_right = 400.0
+margin_bottom = 62.0
+
+[node name="Button" type="Button" parent="VBoxContainer/Open"]
+margin_right = 52.0
+margin_bottom = 30.0
+theme = ExtResource( 1 )
+text = "Open"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="LineEdit" type="LineEdit" parent="VBoxContainer/Open"]
+margin_left = 56.0
+margin_right = 400.0
+margin_bottom = 30.0
+size_flags_horizontal = 3
+theme = ExtResource( 1 )
+text = "marsh/hello_everyone"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="StartButton" type="Button" parent="VBoxContainer"]
+margin_top = 66.0
+margin_right = 400.0
+margin_bottom = 92.0
+theme = ExtResource( 1 )
+text = "Start"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Dialogs" type="Control" parent="."]
+pause_mode = 2
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Backdrop" parent="Dialogs" instance=ExtResource( 3 )]
+color = Color( 0, 0, 0, 0.752941 )
+
+[node name="OpenFile" type="FileDialog" parent="Dialogs"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -320.0
+margin_top = -200.0
+margin_right = 320.0
+margin_bottom = 200.0
+popup_exclusive = true
+window_title = "Open a File"
+mode = 0
+filters = PoolStringArray( "*.json" )
+current_dir = "res://assets/main/puzzle/levels/cutscenes"
+current_path = "res://assets/main/puzzle/levels/cutscenes/"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Error" type="AcceptDialog" parent="Dialogs"]
+margin_right = 250.0
+margin_bottom = 58.0
+popup_exclusive = true
+window_title = "Error"
+dialog_autowrap = true
+[connection signal="pressed" from="VBoxContainer/Fatness/CheckBox" to="VBoxContainer/Fatness" method="_on_CheckBox_pressed"]
+[connection signal="value_changed" from="VBoxContainer/Fatness/HSlider" to="VBoxContainer/Fatness" method="_on_HSlider_value_changed"]
+[connection signal="pressed" from="VBoxContainer/Open/Button" to="." method="_on_OpenButton_pressed"]
+[connection signal="pressed" from="VBoxContainer/StartButton" to="." method="_on_StartButton_pressed"]
+[connection signal="about_to_show" from="Dialogs/OpenFile" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
+[connection signal="file_selected" from="Dialogs/OpenFile" to="." method="_on_OpenFileDialog_file_selected"]
+[connection signal="popup_hide" from="Dialogs/OpenFile" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
+[connection signal="about_to_show" from="Dialogs/Error" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
+[connection signal="popup_hide" from="Dialogs/Error" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]

--- a/project/src/demo/world/cutscene-demo-fatness.gd
+++ b/project/src/demo/world/cutscene-demo-fatness.gd
@@ -1,0 +1,32 @@
+extends HBoxContainer
+"""
+UI control for editing the global 'forced_fatness' field.
+"""
+
+func _ready() -> void:
+	if PlayerData.creature_library.forced_fatness:
+		$CheckBox.pressed = true
+		$HSlider.value = PlayerData.creature_library.forced_fatness
+	else:
+		$CheckBox.pressed = false
+		$HSlider.value = 10.0
+	
+	_refresh()
+
+
+"""
+Updates the UI controls and the global 'forced_fatness' field.
+"""
+func _refresh() -> void:
+	$HSlider.editable = $CheckBox.pressed
+	$Value.text = "%.1f" % [$HSlider.value] if $HSlider.editable else "-"
+	
+	PlayerData.creature_library.forced_fatness = $HSlider.value if $CheckBox.pressed else 0.0
+
+
+func _on_CheckBox_pressed() -> void:
+	_refresh()
+
+
+func _on_HSlider_value_changed(value) -> void:
+	_refresh()

--- a/project/src/demo/world/cutscene-demo.gd
+++ b/project/src/demo/world/cutscene-demo.gd
@@ -1,0 +1,29 @@
+extends Control
+"""
+Demonstrates cutscenes.
+
+The user can select and launch any cutscene, and change how fat the creatures are.
+"""
+
+func _ready() -> void:
+	Breadcrumb.trail = ["res://src/demo/world/CutsceneDemo.tscn"]
+
+
+func _on_StartButton_pressed() -> void:
+	Level.set_launched_level($VBoxContainer/Open/LineEdit.text)
+	Level.push_cutscene_trail(true)
+
+
+func _on_OpenFileDialog_file_selected(path: String) -> void:
+	var full_path: String = $Dialogs/OpenFile.current_path
+	if full_path.begins_with("res://assets/main/puzzle/levels/cutscenes/") and full_path.ends_with(".json"):
+		full_path = full_path.trim_prefix("res://assets/main/puzzle/levels/cutscenes/")
+		full_path = full_path.trim_suffix(".json").replace("-", "_")
+		$VBoxContainer/Open/LineEdit.text = full_path
+	else:
+		$Dialogs/Error.dialog_text = "%s doesn't seem like the path to a cutscene file." % [full_path]
+		$Dialogs/Error.popup_centered()
+
+
+func _on_OpenButton_pressed() -> void:
+	$Dialogs/OpenFile.popup_centered()

--- a/project/src/main/creature-library.gd
+++ b/project/src/main/creature-library.gd
@@ -13,6 +13,9 @@ const GENERIC_FATNESS_COUNT := 150
 # wasn't me"
 const MAX_FILLER_FATNESS := 2.5
 
+# If set, all creatures will have a specific fatness. Used for testing cutscenes.
+var forced_fatness := 0.0
+
 var player_def: CreatureDef
 var sensei_def: CreatureDef
 
@@ -76,6 +79,8 @@ func restore_fatness_state() -> void:
 func has_fatness(creature_id: String) -> bool:
 	if not creature_id:
 		return false
+	if forced_fatness:
+		return true
 	
 	return _fatnesses.has(creature_id)
 
@@ -83,12 +88,17 @@ func has_fatness(creature_id: String) -> bool:
 func get_fatness(creature_id: String) -> float:
 	if not creature_id:
 		return 1.0
+	if forced_fatness:
+		return forced_fatness
 	
 	return _fatnesses[creature_id]
 
 
 func set_fatness(creature_id: String, fatness: float) -> void:
 	if not creature_id:
+		return
+	if forced_fatness:
+		# don't persist the temporary fatness when 'forced_fatness' is set
 		return
 	
 	if creature_id.begins_with("#filler"):

--- a/project/src/main/global.gd
+++ b/project/src/main/global.gd
@@ -15,6 +15,9 @@ const SCENE_OVERWORLD := "res://src/main/world/Overworld.tscn"
 # puzzle where a player drops pieces into a playfield of blocks.
 const SCENE_PUZZLE := "res://src/main/puzzle/Puzzle.tscn"
 
+# cutscene demo; only used during development
+const SCENE_CUTSCENE_DEMO := "res://src/demo/world/CutsceneDemo.tscn"
+
 # weighted distribution of 'fatnesses' in the range [1.0, 10.0]. most creatures are skinny.
 const FATNESSES := [
 	1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,

--- a/project/src/main/puzzle/level/level-settings.gd
+++ b/project/src/main/puzzle/level/level-settings.gd
@@ -158,20 +158,6 @@ func load_from_text(new_id: String, text: String) -> void:
 	from_json_dict(new_id, parse_json(text))
 
 
-"""
-Loads a level based on the creature's chat selectors.
-
-Parameters:
-	'creature': The creature whose level should be loaded.
-	
-	'level_num': Which level should be loaded; '1' is the first level.
-"""
-func load_from_creature(creature: Creature, level_num: int) -> void:
-	var level_ids := creature.get_level_ids()
-	var level_id: String = level_ids[level_num - 1]
-	load_from_resource(level_id)
-
-
 func get_difficulty() -> String:
 	var result: String
 	if difficulty:

--- a/project/src/main/ui/chat/chat-tree.gd
+++ b/project/src/main/ui/chat/chat-tree.gd
@@ -35,6 +35,14 @@ var meta: Dictionary
 # value: array of sequential ChatEvent objects for a particular dialog sequence
 var events: Dictionary = {}
 
+# a specific location where this conversation takes place, if any
+var location_id: String
+
+# spawn locations for different creatures, if this ChatTree represents a cutscene
+# key: creature id
+# value: spawn id
+var spawn_locations: Dictionary = {}
+
 # current position in this dialog tree
 var _position := Position.new()
 
@@ -94,6 +102,9 @@ func from_json_dict(json: Dictionary) -> void:
 					push_warning("Unrecognized dialog data version: '%s'" % [json[key]])
 			"meta":
 				meta = json[key]
+			"location":
+				location_id = json[key].get("location_id", "")
+				spawn_locations = json[key].get("spawn_locations", {})
 			_:
 				for json_chat_event in json[key]:
 					var event := ChatEvent.new()

--- a/project/src/main/ui/level-select/level-buttons.gd
+++ b/project/src/main/ui/level-select/level-buttons.gd
@@ -9,9 +9,6 @@ enum LevelsToInclude {
 	TUTORIALS_ONLY, # only show tutorials; hide regular levels
 }
 
-const ALL_LEVELS := LevelsToInclude.ALL_LEVELS
-const TUTORIALS_ONLY := LevelsToInclude.TUTORIALS_ONLY
-
 # Emitted when the player highlights an unlocked level to show more information.
 signal unlocked_level_selected(level_lock, settings)
 
@@ -20,6 +17,9 @@ signal locked_level_selected(level_lock, settings)
 
 # Emitted when the player highlights the 'overall' button.
 signal overall_selected(world_id, ranks)
+
+const ALL_LEVELS := LevelsToInclude.ALL_LEVELS
+const TUTORIALS_ONLY := LevelsToInclude.TUTORIALS_ONLY
 
 # Levels are arranged into a big rectangle. This is the ratio of the rectangle's width to height.
 const BUTTON_ARRANGEMENT_WIDTH_FACTOR := 1.77778
@@ -194,11 +194,11 @@ func _lowlight_unrelated_buttons(world_id: String) -> void:
 When the player clicks a level button twice, we launch the selected level
 """
 func _on_LevelSelectButton_level_started(settings: LevelSettings) -> void:
-	var level_lock: LevelLock = LevelLibrary.level_lock(settings.id)
-	Level.set_launched_level(settings.id, level_lock.creature_id, level_lock.level_num)
-	if level_lock.creature_id and level_lock.level_num >= 1:
-		Breadcrumb.push_trail(Global.SCENE_OVERWORLD)
-	else:
+	Level.set_launched_level(settings.id)
+	
+	var pushed_cutscene_trail := Level.push_cutscene_trail(true)
+	
+	if not pushed_cutscene_trail:
 		Level.push_level_trail()
 
 

--- a/project/src/main/ui/level-select/level-library.gd
+++ b/project/src/main/ui/level-select/level-library.gd
@@ -50,23 +50,41 @@ func refresh_cleared_levels() -> void:
 
 
 func is_locked(level_id: String) -> bool:
-	return _level_locks[level_id].status in [LevelLock.STATUS_SOFT_LOCK, LevelLock.STATUS_HARD_LOCK]
+	return _level_locks.get(level_id).is_locked() if _level_locks.has(level_id) else false
 
 
 func world_lock(world_id: String) -> WorldLock:
-	return _world_locks[world_id]
+	return _world_locks.get(world_id)
 
 
 func world_lock_for_level(level_id: String) -> WorldLock:
-	return _world_locks_by_level_id[level_id]
+	return _world_locks_by_level_id.get(level_id)
 
 
 func level_lock(level_id: String) -> LevelLock:
-	return _level_locks[level_id]
+	return _level_locks.get(level_id)
 
 
 func level_settings(level_id: String) -> LevelSettings:
-	return _level_settings_by_id[level_id]
+	return _level_settings_by_id.get(level_id)
+
+
+"""
+Returns the first unfinished, unlocked level id for a creature.
+
+This is the level which will be played if the player talks to them on the overworld. Finished levels can be played
+through the cell phone. Locked levels cannot be played; they must be unlocked first.
+"""
+func first_unfinished_level_id_for_creature(creature_id: String) -> String:
+	for world_lock_obj in _world_locks.values():
+		var world_lock: WorldLock = world_lock_obj
+		for level_id in world_lock.level_ids:
+			var level_lock: LevelLock = _level_locks[level_id]
+			if level_lock.creature_id == creature_id and not level_lock.is_locked() \
+					and not PlayerData.level_history.finished_levels.has(level_lock.level_id):
+				return level_lock.level_id
+	
+	return ""
 
 
 """

--- a/project/src/main/ui/level-select/level-lock.gd
+++ b/project/src/main/ui/level-select/level-lock.gd
@@ -33,9 +33,8 @@ const STATUS_HARD_LOCK := LockStatus.HARD_LOCK
 
 var level_id: String
 
-# Some levels activate dialog sequences. These two fields specify which character's dialog should activate.
+# Some levels activate dialog sequences. This field specifies which character's dialog should activate.
 var creature_id: String
-var level_num := -1
 
 # the requirements to unlock this level
 var locked_until_type := ALWAYS_UNLOCKED
@@ -60,7 +59,6 @@ var groups := []
 func from_json_dict(json: Dictionary) -> void:
 	level_id = json.get("id", "")
 	creature_id = json.get("creature_id", "")
-	level_num = json.get("level_num", -1)
 	
 	var locked_until_string: String = json.get("locked_until", "")
 	if locked_until_string:
@@ -74,3 +72,7 @@ func from_json_dict(json: Dictionary) -> void:
 	var groups_string: String = json.get("groups", "")
 	if groups_string:
 		groups = groups_string.split(" ")
+
+
+func is_locked() -> bool:
+	return status in [STATUS_SOFT_LOCK, STATUS_HARD_LOCK]

--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -28,7 +28,7 @@ func _exit_tree() -> void:
 
 func _launch_tutorial() -> void:
 	PlayerData.creature_queue.clear()
-	Level.set_launched_level(Level.BEGINNER_TUTORIAL, Global.SENSEI_ID)
+	Level.set_launched_level(Level.BEGINNER_TUTORIAL)
 	Level.push_level_trail()
 
 

--- a/project/src/main/world/OverworldIndoors.tscn
+++ b/project/src/main/world/OverworldIndoors.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=25 format=2]
+[gd_scene load_steps=26 format=2]
 
 [ext_resource path="res://src/main/world/creature/sensei.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/creature/player.gd" type="Script" id=2]
 [ext_resource path="res://src/main/world/OverworldUi.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/world/overworld-world.gd" type="Script" id=4]
 [ext_resource path="res://src/main/world/restaurant/wall-library.tres" type="TileSet" id=5]
+[ext_resource path="res://src/main/world/Spawn.tscn" type="PackedScene" id=6]
 [ext_resource path="res://src/main/world/restaurant/floor-library.tres" type="TileSet" id=7]
 [ext_resource path="res://src/main/world/environment/WoodTable.tscn" type="PackedScene" id=8]
 [ext_resource path="res://assets/main/world/environment/interior-shadow.png" type="Texture" id=9]
@@ -60,6 +61,7 @@ __meta__ = {
 script = ExtResource( 4 )
 creature_shadows_path = NodePath("Ground/Shadows/Viewport/CreatureShadows")
 chat_icons_path = NodePath("ChatIcons")
+CreaturePackedScene = ExtResource( 19 )
 
 [node name="Ground" type="Node2D" parent="World"]
 z_index = -1
@@ -143,6 +145,7 @@ sensei_spawn_id = "restaurant-sensei"
 [node name="Player" parent="World/Obstacles" instance=ExtResource( 19 )]
 position = Vector2( 158.963, 289.758 )
 script = ExtResource( 2 )
+creature_id = "#player#"
 dna = {
 
 }
@@ -155,16 +158,6 @@ script = ExtResource( 1 )
 [node name="MoveTimer" type="Timer" parent="World/Obstacles/Sensei"]
 wait_time = 0.3
 autostart = true
-
-[node name="Richie" parent="World/Obstacles" groups=[
-"chattables",
-] instance=ExtResource( 19 )]
-position = Vector2( 1765.38, 207.401 )
-creature_id = "richie"
-dna = {
-
-}
-orientation = 1
 
 [node name="WoodPillar" parent="World/Obstacles" instance=ExtResource( 22 )]
 position = Vector2( 498, 9 )
@@ -226,6 +219,35 @@ position = Vector2( 1368, 215 )
 
 [node name="Stool11" parent="World/Obstacles" instance=ExtResource( 13 )]
 position = Vector2( 1368, 155 )
+
+[node name="Spawns" type="Node2D" parent="World"]
+
+[node name="SpawnKitchen1" parent="World/Spawns" instance=ExtResource( 6 )]
+position = Vector2( 1814.38, 40.6189 )
+orientation = 1
+id = "kitchen-1"
+
+[node name="SpawnKitchen3" parent="World/Spawns" instance=ExtResource( 6 )]
+position = Vector2( 1854.82, 142.891 )
+orientation = 1
+id = "kitchen-3"
+
+[node name="SpawnKitchen5" parent="World/Spawns" instance=ExtResource( 6 )]
+position = Vector2( 1885.74, 261.811 )
+orientation = 1
+id = "kitchen-5"
+
+[node name="SpawnKitchen7" parent="World/Spawns" instance=ExtResource( 6 )]
+position = Vector2( 1569.41, 257.055 )
+id = "kitchen-7"
+
+[node name="SpawnKitchen9" parent="World/Spawns" instance=ExtResource( 6 )]
+position = Vector2( 1593.19, 142.891 )
+id = "kitchen-9"
+
+[node name="SpawnKitchen11" parent="World/Spawns" instance=ExtResource( 6 )]
+position = Vector2( 1631.25, 40.6189 )
+id = "kitchen-11"
 
 [node name="ChatIcons" type="Node2D" parent="World"]
 script = ExtResource( 10 )

--- a/project/src/main/world/OverworldObstacles.tscn
+++ b/project/src/main/world/OverworldObstacles.tscn
@@ -43,6 +43,7 @@ impassable_tile_index = 1
 [node name="Player" parent="." instance=ExtResource( 7 )]
 position = Vector2( 150, 150 )
 script = ExtResource( 1 )
+creature_id = "#player#"
 dna = {
 
 }

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -109,6 +109,10 @@ func _physics_process(delta: float) -> void:
 	_maybe_play_bonk_sound(old_non_iso_velocity)
 
 
+func set_collision_disabled(new_collision_disabled: bool) -> void:
+	$CollisionShape2D.disabled = new_collision_disabled
+
+
 func set_suppress_sfx(new_suppress_sfx: bool) -> void:
 	suppress_sfx = new_suppress_sfx
 	$CreatureSfx.suppress_sfx = new_suppress_sfx
@@ -311,18 +315,6 @@ func get_creature_def() -> CreatureDef:
 	return result
 
 
-"""
-Build a list of level ids from the creature's chat selectors.
-"""
-func get_level_ids() -> Array:
-	var level_ids := []
-	for chat_selector_obj in chat_selectors:
-		var chat_selector: Dictionary = chat_selector_obj
-		if chat_selector.has("level") and not level_ids.has(chat_selector["level"]):
-			level_ids.append(chat_selector["level"])
-	return level_ids
-
-
 func refresh_dna() -> void:
 	if is_inside_tree():
 		if dna:
@@ -367,7 +359,12 @@ func _refresh_orientation() -> void:
 
 
 func _refresh_creature_id() -> void:
-	if is_inside_tree():
+	if creature_id == Global.PLAYER_ID:
+		# player's creature_def is loaded in player.gd
+		pass
+	elif not is_inside_tree():
+		pass
+	else:
 		set_creature_def(CreatureLoader.load_creature_def_by_id(creature_id))
 
 

--- a/project/src/main/world/creature/player.gd
+++ b/project/src/main/world/creature/player.gd
@@ -4,13 +4,23 @@ extends Creature
 Script for manipulating the player-controlled character in the overworld.
 """
 
+# If 'true' the player cannot move. Used during cutscenes.
+var input_disabled := false
+
 func _ready() -> void:
 	SceneTransition.connect("fade_out_started", self, "_on_SceneTransition_fade_out_started")
 	set_creature_def(PlayerData.creature_library.player_def)
+	if PlayerData.creature_library.forced_fatness:
+		set_fatness(PlayerData.creature_library.forced_fatness)
+		set_visual_fatness(PlayerData.creature_library.forced_fatness)
+	creature_id = Global.PLAYER_ID
 	ChattableManager.player = self
 
 
 func _unhandled_input(_event: InputEvent) -> void:
+	if input_disabled:
+		return
+	
 	if Utils.walk_pressed_dir(_event) or Utils.walk_released_dir(_event):
 		# calculate the direction the player wants to move
 		set_non_iso_walk_direction(Utils.walk_pressed_dir())

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -14,42 +14,50 @@ onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
 func _ready() -> void:
 	if Global.player_spawn_id:
 		move_creature_to_spawn(ChattableManager.player, Global.player_spawn_id)
-	$Camera.position = ChattableManager.player.position
 	
 	if Global.sensei_spawn_id:
 		move_creature_to_spawn(ChattableManager.sensei, Global.sensei_spawn_id)
 	
 	if Level.launched_level_id:
-		_overworld_ui.cutscene = true
-		
-		# remove all of the creatures from the overworld
-		for node in get_tree().get_nodes_in_group("creatures"):
-			if node != ChattableManager.player and node != ChattableManager.sensei:
-				node.queue_free()
-		
-		# add the cutscene creatures
-		var creature: Creature = CreaturePackedScene.instance()
-		creature.creature_id = Level.launched_creature_id
-		creature.add_to_group("chattables")
-		$Obstacles.add_child(creature)
-		_chat_icons.create_icon(creature)
-		_creature_shadows.create_shadow(creature)
-		
-		# reposition the cutscene creatures, ensuring fat creatures have enough space
-		creature.position = ChattableManager.player.position
-		creature.position += Vector2(creature.chat_extents.x, 0)
-		creature.position += Vector2(ChattableManager.player.chat_extents.x, 0)
-		creature.position += Vector2(60, 0)
-		
-		_schedule_chat(creature)
+		_launch_cutscene()
 	
+	$Camera.position = ChattableManager.player.position
 	ChattableManager.refresh_creatures()
 
 
-func _schedule_chat(creature: Creature) -> void:
+func _launch_cutscene() -> void:
+	_overworld_ui.cutscene = true
+	
+	# remove all of the creatures from the overworld
+	for node in get_tree().get_nodes_in_group("creatures"):
+		if node != ChattableManager.player and node != ChattableManager.sensei:
+			node.queue_free()
+	
+	# add the cutscene creature
+	var cutscene_creature: Creature = _add_creature(Level.launched_creature_id)
+	ChattableManager.player.input_disabled = true
+	
+	# get the location, spawn location data
+	var chat_tree: ChatTree = ChatLibrary.load_chat_events_for_creature(cutscene_creature, Level.launched_level_id)
+	
+	if not chat_tree.spawn_locations:
+		# apply a default position to the cutscene creature
+		cutscene_creature.position = ChattableManager.player.position
+		cutscene_creature.position += Vector2(cutscene_creature.chat_extents.x, 0)
+		cutscene_creature.position += Vector2(ChattableManager.player.chat_extents.x, 0)
+		cutscene_creature.position += Vector2(60, 0)
+	else:
+		for creature_id in chat_tree.spawn_locations:
+			var creature := _find_creature(creature_id)
+			if not creature:
+				creature = _add_creature(creature_id)
+			creature.set_collision_disabled(true)
+			
+			# move the creature to its spawn location
+			move_creature_to_spawn(creature, chat_tree.spawn_locations[creature_id])
+	
 	yield(get_tree(), "idle_frame")
-	var chat_tree := ChatLibrary.load_chat_events_for_creature(creature, Level.launched_level_num)
-	_overworld_ui.start_chat(chat_tree, creature)
+	_overworld_ui.start_chat(chat_tree, cutscene_creature)
 
 
 """
@@ -66,3 +74,30 @@ func move_creature_to_spawn(creature: Creature, spawn_id: String) -> void:
 		target_spawn.move_creature(creature)
 	else:
 		push_warning("Could not locate spawn with id '%s'" % [spawn_id])
+
+
+"""
+Creates a new creature with the specified creature_id and adds it to the scene.
+"""
+func _add_creature(creature_id: String) -> Creature:
+	var creature: Creature = CreaturePackedScene.instance()
+	creature.creature_id = creature_id
+	creature.add_to_group("chattables")
+	$Obstacles.add_child(creature)
+	_chat_icons.create_icon(creature)
+	_creature_shadows.create_shadow(creature)
+	return creature
+
+
+"""
+Locates the creature with the specified creature_id.
+"""
+func _find_creature(creature_id: String) -> Creature:
+	var creature: Creature
+	
+	for creature_node in get_tree().get_nodes_in_group("creatures"):
+		if creature_node.creature_id == creature_id:
+			creature = creature_node
+			break
+	
+	return creature

--- a/project/src/test/ui/chat/test-chat-library.gd
+++ b/project/src/test/ui/chat/test-chat-library.gd
@@ -5,18 +5,6 @@ Unit test for the chat library.
 
 var _chat_selectors := [
 	{
-		"dialog": "level_001",
-		"if_conditions": [
-			"current_level/level_1"
-		]
-	},
-	{
-		"dialog": "level_002",
-		"if_conditions": [
-			"current_level/level_2"
-		]
-	},
-	{
 		"dialog": "greeting_001",
 		"repeat": 999999
 	},
@@ -52,21 +40,6 @@ func before_each() -> void:
 	PlayerData.chat_history.add_history_item("dialog/gurus750/greeting_001")
 	PlayerData.chat_history.add_history_item("dialog/gurus750/notable_001")
 	PlayerData.chat_history.add_history_item("dialog/gurus750/notable_002")
-
-
-func test_level_1() -> void:
-	PlayerData.chat_history.delete_history_item("dialog/gurus750/level_001")
-	PlayerData.chat_history.delete_history_item("dialog/gurus750/level_002")
-	
-	assert_eq(ChatLibrary.choose_dialog_from_chat_selectors(_chat_selectors, _state, _filler_ids), "level_001")
-
-
-func test_level_2() -> void:
-	_state["level_num"] = 2
-	PlayerData.chat_history.delete_history_item("dialog/gurus750/level_001")
-	PlayerData.chat_history.delete_history_item("dialog/gurus750/level_002")
-	
-	assert_eq(ChatLibrary.choose_dialog_from_chat_selectors(_chat_selectors, _state, _filler_ids), "level_002")
 
 
 func test_greeting() -> void:


### PR DESCRIPTION
Cutscenes can take place indoors or outdoors. Added logic for spawning
cutscene characters at different locations.

Level dialog used to be attached to creatures who had specific logic for
'use this dialog for level 1, this dialog for level 2.' This logic is now
implicit, and level dialog is in /assets/main/puzzle/levels/cutscenes

Levels no longer have 'level numbers'. A creature used to have the idea of
their first and second level. This is now implicit based on the contents
of worlds.json and how the levels are organized.

Creature clipping is disabled during cutscene. Very, very, very fat
creatures will inevitably break cutscenes a little but it's better for it
to be cosmetic stuff (creatures clipping or looking funny) and not
functional stuff (creatures spawning out of bounds or not being able to
run somewhere)