### PR TITLE
Fixed bug where chat_selectors were no longer populated properly

### DIFF
--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -307,10 +307,11 @@ func get_creature_def() -> CreatureDef:
 	var result := CreatureDef.new()
 	result.creature_id = creature_id
 	result.dna = DnaUtils.trim_dna(dna)
+	result.chat_theme_def = chat_theme_def
 	result.creature_name = creature_name
 	result.creature_short_name = creature_short_name
+	result.chat_selectors = chat_selectors
 	result.dialog = dialog
-	result.chat_theme_def = chat_theme_def
 	result.min_fatness = min_fatness
 	return result
 


### PR DESCRIPTION
d06c8a83 introduced a Creature.chat_selectors field, but did not populate
it appropriately in get_creature_def(). As a result the most recent chat
refactoring broke the chat selector logic, meaning special dialog would
never show up.