### PR TITLE
Rewrote chat logic to key off of creature_id

### DIFF
--- a/project/assets/demo/chat/dialog-blank.json
+++ b/project/assets/demo/chat/dialog-blank.json
@@ -2,7 +2,7 @@
   "version": "1922",
   "": [
     {
-      "who": "Lorum",
+      "who": "lorum",
       "links": [
         {
           "yes": "Yes, that's right."
@@ -19,7 +19,7 @@
       "mood": "smile0"
     },
     {
-      "who": "Lorum",
+      "who": "lorum",
       "text": "I agree! Sed do eiusmod."
     }
   ],
@@ -30,7 +30,7 @@
       "mood": "rage0"
     },
     {
-      "who": "Lorum"
+      "who": "lorum"
     }
   ]
 }

--- a/project/assets/demo/chat/dialog-choices2.json
+++ b/project/assets/demo/chat/dialog-choices2.json
@@ -2,7 +2,7 @@
   "version": "1922",
   "": [
     {
-      "who": "Lorum",
+      "who": "lorum",
       "text": "Lorem ipsum dolor sit amet? What do you think?",
       "links": [
         {
@@ -21,7 +21,7 @@
       "mood": "smile0"
     },
     {
-      "who": "Lorum",
+      "who": "lorum",
       "text": "I agree! Sed do eiusmod."
     }
   ],
@@ -32,7 +32,7 @@
       "mood": "rage0"
     },
     {
-      "who": "Lorum",
+      "who": "lorum",
       "text": "But... but sed do eiusmod!"
     }
   ]

--- a/project/assets/demo/chat/dialog-choices3.json
+++ b/project/assets/demo/chat/dialog-choices3.json
@@ -2,7 +2,7 @@
   "version": "1922",
   "": [
     {
-      "who": "Lorum",
+      "who": "lorum",
       "text": "Lorem ipsum dolor sit amet? How many?",
       "links": [
         {
@@ -24,7 +24,7 @@
       "mood": "sweat0"
     },
     {
-      "who": "Lorum",
+      "who": "lorum",
       "text": "Here is your sed do eiusmod."
     }
   ],
@@ -35,7 +35,7 @@
       "mood": "think0"
     },
     {
-      "who": "Lorum",
+      "who": "lorum",
       "text": "Here, two sed do eiusmods."
     }
   ],
@@ -46,7 +46,7 @@
       "mood": "smile1"
     },
     {
-      "who": "Lorum",
+      "who": "lorum",
       "text": "I only have three sed do eiusmods, but I'll get you more later."
     }
   ]

--- a/project/assets/demo/chat/dialog-choices7.json
+++ b/project/assets/demo/chat/dialog-choices7.json
@@ -2,7 +2,7 @@
   "version": "1922",
   "": [
     {
-      "who": "Lorum",
+      "who": "lorum",
       "text": "Lorem ipsum dolor sit amet? How many?",
       "links": ["one", "two", "three", "four", "five", "six", "seven"]
     }
@@ -14,7 +14,7 @@
       "mood": "smile0"
     },
     {
-      "who": "Lorum",
+      "who": "lorum",
       "text": "Here is your sed do eiusmod."
     }
   ],
@@ -25,7 +25,7 @@
       "mood": "smile1"
     },
     {
-      "who": "Lorum",
+      "who": "lorum",
       "text": "Here are your sed do eiusmods."
     }
   ],
@@ -36,7 +36,7 @@
       "mood": "laugh0"
     },
     {
-      "who": "Lorum",
+      "who": "lorum",
       "text": "Here are your sed do eiusmods."
     }
   ],
@@ -46,7 +46,7 @@
       "text": "Four."
     },
     {
-      "who": "Lorum",
+      "who": "lorum",
       "text": "Here are your sed do eiusmods."
     }
   ],
@@ -57,7 +57,7 @@
       "mood": "laugh1"
     },
     {
-      "who": "Lorum",
+      "who": "lorum",
       "text": "Here are your sed do eiusmods."
     }
   ],
@@ -68,7 +68,7 @@
       "mood": "think0"
     },
     {
-      "who": "Lorum",
+      "who": "lorum",
       "text": "Here are your sed do eiusmods."
     }
   ],
@@ -79,7 +79,7 @@
       "mood": "think1"
     },
     {
-      "who": "Lorum",
+      "who": "lorum",
       "text": "Here are your sed do eiusmods."
     }
   ]

--- a/project/assets/demo/chat/dialog-unbranched.json
+++ b/project/assets/demo/chat/dialog-unbranched.json
@@ -1,43 +1,43 @@
 [
   {
     "version": "1922",
-    "who": "Lorum",
+    "who": "lorum",
     "text": "Apple ipsum dolor sit amet"
   },
   {
-    "who": "Lorum",
+    "who": "lorum",
     "text": "Apricot ipsum dolor sit amet"
   },
   {
-    "who": "Lorum",
+    "who": "lorum",
     "text": "Banana ipsum dolor sit amet"
   },
   {
-    "who": "Lorum",
+    "who": "lorum",
     "text": "Canteloupe ipsum dolor sit amet"
   },
   {
-    "who": "Lorum",
+    "who": "lorum",
     "text": "Cherry ipsum dolor sit amet"
   },
   {
-    "who": "Lorum",
+    "who": "lorum",
     "text": "Grape ipsum dolor sit amet"
   },
   {
-    "who": "Lorum",
+    "who": "lorum",
     "text": "Grapefruit ipsum dolor sit amet"
   },
   {
-    "who": "Lorum",
+    "who": "lorum",
     "text": "Guava ipsum dolor sit amet"
   },
   {
-    "who": "Lorum",
+    "who": "lorum",
     "text": "Lemon ipsum dolor sit amet"
   },
   {
-    "who": "Lorum",
+    "who": "lorum",
     "text": "Lime ipsum dolor sit amet"
   }
 ]

--- a/project/assets/main/creatures/primary/boatricia/filler-000.json
+++ b/project/assets/main/creatures/primary/boatricia/filler-000.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Boatricia",
+      "who": "boatricia",
       "text": "./././I don't have anything to say right now!"
     }
   ]

--- a/project/assets/main/creatures/primary/boatricia/hi.json
+++ b/project/assets/main/creatures/primary/boatricia/hi.json
@@ -2,7 +2,7 @@
   "version": "1922",
   "": [
     {
-      "who": "Boatricia",
+      "who": "boatricia",
       "text": "Oh!/ I remember you from before./ I'm Boatricia,/ I'm sort of new here and trying to make some friends.",
       "mood": "smile0"
     },
@@ -16,7 +16,7 @@
       "mood": "think0"
     },
     {
-      "who": "Boatricia",
+      "who": "boatricia",
       "text": "Oh! Well aren't you sweet~",
       "mood": "smile1"
     }

--- a/project/assets/main/creatures/primary/boatricia/level-1.json
+++ b/project/assets/main/creatures/primary/boatricia/level-1.json
@@ -2,7 +2,7 @@
   "version": "1922",
   "": [
     {
-      "who": "Boatricia",
+      "who": "boatricia",
       "text": "Could you maybe just cook me something small? I'm not very hungry today."
     },
     {

--- a/project/assets/main/creatures/primary/boatricia/level-2.json
+++ b/project/assets/main/creatures/primary/boatricia/level-2.json
@@ -2,7 +2,7 @@
   "version": "1922",
   "": [
     {
-      "who": "Boatricia",
+      "who": "boatricia",
       "text": "I built up an appetite today! Think you can cook something filling for me and my friends?"
     },
     {

--- a/project/assets/main/creatures/primary/boatricia/life-is-so-short.json
+++ b/project/assets/main/creatures/primary/boatricia/life-is-so-short.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Boatricia",
+      "who": "boatricia",
       "mood": "think0",
       "text": "Life is so short./././"
     },

--- a/project/assets/main/creatures/primary/boatricia/my-maid-died.json
+++ b/project/assets/main/creatures/primary/boatricia/my-maid-died.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Boatricia",
+      "who": "boatricia",
       "mood": "cry0",
       "text": "My maid died!"
     },

--- a/project/assets/main/creatures/primary/bones/filler-000.json
+++ b/project/assets/main/creatures/primary/bones/filler-000.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Bones",
+      "who": "bones",
       "mood": "smile0",
       "text": "Bork!/ Give me a call if you need anything,/ boss!"
     }

--- a/project/assets/main/creatures/primary/bones/filler-001.json
+++ b/project/assets/main/creatures/primary/bones/filler-001.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Bones",
+      "who": "bones",
       "text": "When I was a kid,/ buying a new video game every week seemed like an impossible dream!/ ./././But games are actually pretty cheap."
     }
   ]

--- a/project/assets/main/creatures/primary/bones/filler-002.json
+++ b/project/assets/main/creatures/primary/bones/filler-002.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Bones",
+      "who": "bones",
       "text": "It's hard forcing yourself into a healthy routine at first,/ bork!/ But eventually you don't even think about it."
     }
   ]

--- a/project/assets/main/creatures/primary/bort/creature.json
+++ b/project/assets/main/creatures/primary/bort/creature.json
@@ -31,7 +31,7 @@
       "version": "1922",
       "": [
         {
-          "who": "Bort",
+          "who": "bort",
           "text": "Wow!/ ./././You finally did it?/ Does this count as our first conversation!?",
           "mood": "think0",
           "links": [
@@ -54,7 +54,7 @@
           "mood": "smile0"
         },
         {
-          "who": "Bort",
+          "who": "bort",
           "text": "Congratulations!/ Wow!",
           "mood": "smile0",
           "links": [
@@ -69,7 +69,7 @@
           "mood": "think0"
         },
         {
-          "who": "Bort",
+          "who": "bort",
           "text": "Congratulations!/ Wow!",
           "mood": "smile0",
           "links": [
@@ -84,7 +84,7 @@
           "mood": "cry0"
         },
         {
-          "who": "Bort",
+          "who": "bort",
           "text": "Aww, don't be like that! This is looking great.",
           "mood": "smile0",
           "links": [
@@ -94,7 +94,7 @@
       ],
       "nice": [
         {
-          "who": "Bort",
+          "who": "bort",
           "text": "./././I can't wait to see what you do next!"
         }
       ]

--- a/project/assets/main/creatures/primary/ebe/filler-000.json
+++ b/project/assets/main/creatures/primary/ebe/filler-000.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "Did you want to get friend zoned?",
       "mood": "think0",
       "links": [
@@ -20,67 +20,67 @@
   ],
   "hi": [
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "You tell me you're in love with me,",
       "mood": "laugh1"
     },
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "...Like you can't take your pretty eyes away from me.",
       "mood": "laugh0"
     },
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "It's not that I don't wanna stay,",
       "mood": "rage0"
     },
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "...But every time you come too close I move away.",
       "mood": "rage1"
     },
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "I wanna believe in everything that you say,/ 'cause it sounds so good...",
       "mood": "think1"
     },
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "But if you really want me,/ move slow,",
       "mood": "think0"
     },
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "There's things about me you just have to know.",
       "mood": "cry0"
     },
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "Sometimes I run.",
       "mood": "cry1"
     },
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "Sometimes I hide.",
       "mood": "sweat0"
     },
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "Sometimes I'm scared of you,",
       "mood": "sweat1"
     },
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "But all I really want is to hold you tight, treat you right,",
       "mood": "default"
     },
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "Be with you day and night.",
       "mood": "smile0"
     },
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "Baby,/ all I need is time.",
       "mood": "smile1"
     }
@@ -92,7 +92,7 @@
       "mood": "sweat0"
     },
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "./././",
       "mood": "sweat0"
     }

--- a/project/assets/main/creatures/primary/ebe/no-vegetables.json
+++ b/project/assets/main/creatures/primary/ebe/no-vegetables.json
@@ -2,11 +2,11 @@
   "version": "1922",
   "": [
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "Okay,/ I'll invite my friends too!/ But/ -/-/ no vegetables okay?"
     },
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "I HATE vegetables!/ ./././I hate them so much...",
       "mood": "rage0"
     }

--- a/project/assets/main/creatures/primary/gordo/creature.json
+++ b/project/assets/main/creatures/primary/gordo/creature.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "gordo",
   "name": "Gordo",
   "short_name": "Gordo",
   "dna": {

--- a/project/assets/main/creatures/primary/richie/filler-000.json
+++ b/project/assets/main/creatures/primary/richie/filler-000.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Richie",
+      "who": "richie",
       "text": "Hey relax!/ We got everything under control."
     }
   ]

--- a/project/assets/main/creatures/primary/richie/filler-001.json
+++ b/project/assets/main/creatures/primary/richie/filler-001.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Richie",
+      "who": "richie",
       "text": "You know,/ a liquor license might help us bring in more customers."
     }
   ]

--- a/project/assets/main/creatures/primary/richie/filler-002.json
+++ b/project/assets/main/creatures/primary/richie/filler-002.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Richie",
+      "who": "richie",
       "mood": "think0",
       "text": "You ever think of shortening the restaurant to just \"Turbo's\"?/ I'm just sayin'././."
     }

--- a/project/assets/main/creatures/primary/richie/pomodoro.json
+++ b/project/assets/main/creatures/primary/richie/pomodoro.json
@@ -2,12 +2,12 @@
   "version": "1922",
   "": [
     {
-      "who": "Richie",
+      "who": "richie",
       "mood": "think0",
       "text": "I've been reading up on something called the 'Pomodoro Technique' lately!"
     },
     {
-      "who": "Richie",
+      "who": "richie",
       "text": "./././'Pomodoro' is a fancy Italian word for sitting on your ass,/ instead of doing any actual work."
     },
     {

--- a/project/assets/main/creatures/primary/shirts/filler-000.json
+++ b/project/assets/main/creatures/primary/shirts/filler-000.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Shirts",
+      "who": "shirts",
       "mood": "think0",
       "text": "./././I usually figure if people don't talk to me it's 'cause they like,/ don't want to talk./ But don't be afraid to hit me up."
     }

--- a/project/assets/main/creatures/primary/shirts/filler-001.json
+++ b/project/assets/main/creatures/primary/shirts/filler-001.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Shirts",
+      "who": "shirts",
       "text": "Online gaming's sorta nice because people just assume I'm a guy./ ./././It's just annoying when everyone's on voice chat."
     }
   ]

--- a/project/assets/main/creatures/primary/shirts/filler-002.json
+++ b/project/assets/main/creatures/primary/shirts/filler-002.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Shirts",
+      "who": "shirts",
       "text": "Can you do me a favor and act like we're having a conversation?/ Just for a few seconds./ ./././A little longer./././ Okay,/ thanks."
     }
   ]

--- a/project/assets/main/creatures/primary/skins/filler-000.json
+++ b/project/assets/main/creatures/primary/skins/filler-000.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Skins",
+      "who": "skins",
       "mood": "smile0",
       "text": "I'm always ready for more training!/ Just call me on my cell./ Mowr!"
     }

--- a/project/assets/main/creatures/primary/skins/filler-001.json
+++ b/project/assets/main/creatures/primary/skins/filler-001.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Skins",
+      "who": "skins",
       "text": "You should come mountain biking some time!/ It's not as dangerous as you think."
     }
   ]

--- a/project/assets/main/creatures/primary/skins/filler-002.json
+++ b/project/assets/main/creatures/primary/skins/filler-002.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Skins",
+      "who": "skins",
       "text": "My phone's been acting slow lately/. ./././They do that on purpose so you'll by a new one./ It's so annoying!"
     }
   ]

--- a/project/assets/main/creatures/primary/wesker/filler-000.json
+++ b/project/assets/main/creatures/primary/wesker/filler-000.json
@@ -5,7 +5,7 @@
   },
   "": [
     {
-      "who": "Wesker",
+      "who": "wesker",
       "text": "./././I don't have anything to say right now!"
     }
   ]

--- a/project/assets/main/creatures/secondary/alber.json
+++ b/project/assets/main/creatures/secondary/alber.json
@@ -1,6 +1,6 @@
 {
   "version": "187d",
-  "id": "",
+  "id": "alber",
   "name": "Alber",
   "short_name": "Alber",
   "dna": {

--- a/project/assets/main/creatures/secondary/alexander.json
+++ b/project/assets/main/creatures/secondary/alexander.json
@@ -1,6 +1,6 @@
 {
   "version": "187d",
-  "id": "",
+  "id": "alexander",
   "name": "Alexander",
   "short_name": "Alexander",
   "dna": {

--- a/project/assets/main/creatures/secondary/beats.json
+++ b/project/assets/main/creatures/secondary/beats.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "beats",
   "name": "Beats",
   "short_name": "Beats",
   "dna": {

--- a/project/assets/main/creatures/secondary/bundles.json
+++ b/project/assets/main/creatures/secondary/bundles.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "bundles",
   "name": "Bundles",
   "short_name": "Bundles",
   "dna": {

--- a/project/assets/main/creatures/secondary/cast.json
+++ b/project/assets/main/creatures/secondary/cast.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "cast",
   "name": "Cast",
   "short_name": "Cast",
   "dna": {

--- a/project/assets/main/creatures/secondary/chelle.json
+++ b/project/assets/main/creatures/secondary/chelle.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "chelle",
   "name": "Chelle",
   "short_name": "Chelle",
   "dna": {

--- a/project/assets/main/creatures/secondary/darry.json
+++ b/project/assets/main/creatures/secondary/darry.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "darry",
   "name": "Darry",
   "short_name": "Darry",
   "dna": {

--- a/project/assets/main/creatures/secondary/dingold.json
+++ b/project/assets/main/creatures/secondary/dingold.json
@@ -1,6 +1,6 @@
 {
   "version": "187d",
-  "id": "",
+  "id": "dingold",
   "name": "Dingold",
   "short_name": "Dingold",
   "dna": {

--- a/project/assets/main/creatures/secondary/dreadhark.json
+++ b/project/assets/main/creatures/secondary/dreadhark.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "dreadhark",
   "name": "Dreadhark",
   "short_name": "Dreadhark",
   "dna": {

--- a/project/assets/main/creatures/secondary/eech.json
+++ b/project/assets/main/creatures/secondary/eech.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "eech",
   "name": "Eech",
   "short_name": "Eech",
   "dna": {

--- a/project/assets/main/creatures/secondary/eeeroy.json
+++ b/project/assets/main/creatures/secondary/eeeroy.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "eeeroy",
   "name": "Eeeroy",
   "short_name": "Eeeroy",
   "dna": {

--- a/project/assets/main/creatures/secondary/flutter.json
+++ b/project/assets/main/creatures/secondary/flutter.json
@@ -1,6 +1,6 @@
 {
   "version": "19a3",
-  "id": "",
+  "id": "flutter",
   "name": "Flutter",
   "short_name": "Flutter",
   "dna": {

--- a/project/assets/main/creatures/secondary/gall.json
+++ b/project/assets/main/creatures/secondary/gall.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "gall",
   "name": "Gall",
   "short_name": "Gall",
   "dna": {

--- a/project/assets/main/creatures/secondary/goris.json
+++ b/project/assets/main/creatures/secondary/goris.json
@@ -1,6 +1,6 @@
 {
   "version": "187d",
-  "id": "",
+  "id": "goris",
   "name": "Goris",
   "short_name": "Goris",
   "dna": {

--- a/project/assets/main/creatures/secondary/i-n-cognito.json
+++ b/project/assets/main/creatures/secondary/i-n-cognito.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "i_n_cognito",
   "name": "I. N. Cognito",
   "short_name": "I. N. Cognito",
   "dna": {

--- a/project/assets/main/creatures/secondary/jayton.json
+++ b/project/assets/main/creatures/secondary/jayton.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "jayton",
   "name": "Jayton",
   "short_name": "Jayton",
   "dna": {

--- a/project/assets/main/creatures/secondary/lango.json
+++ b/project/assets/main/creatures/secondary/lango.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "lango",
   "name": "Lango",
   "short_name": "Lango",
   "dna": {

--- a/project/assets/main/creatures/secondary/leentil.json
+++ b/project/assets/main/creatures/secondary/leentil.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "leentil",
   "name": "Leentil",
   "short_name": "Leentil",
   "dna": {

--- a/project/assets/main/creatures/secondary/lisk.json
+++ b/project/assets/main/creatures/secondary/lisk.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "lisk",
   "name": "Lisk",
   "short_name": "Lisk",
   "dna": {

--- a/project/assets/main/creatures/secondary/logana.json
+++ b/project/assets/main/creatures/secondary/logana.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "logana",
   "name": "Logana",
   "short_name": "Logana",
   "dna": {

--- a/project/assets/main/creatures/secondary/magpird.json
+++ b/project/assets/main/creatures/secondary/magpird.json
@@ -1,6 +1,6 @@
 {
   "version": "187d",
-  "id": "",
+  "id": "magpird",
   "name": "Magpird",
   "short_name": "Magpird",
   "dna": {

--- a/project/assets/main/creatures/secondary/mewow.json
+++ b/project/assets/main/creatures/secondary/mewow.json
@@ -1,6 +1,6 @@
 {
   "version": "187d",
-  "id": "",
+  "id": "mewow",
   "name": "Mewow",
   "short_name": "Mewow",
   "dna": {

--- a/project/assets/main/creatures/secondary/miteby.json
+++ b/project/assets/main/creatures/secondary/miteby.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "miteby",
   "name": "Miteby",
   "short_name": "Miteby",
   "dna": {

--- a/project/assets/main/creatures/secondary/mocha.json
+++ b/project/assets/main/creatures/secondary/mocha.json
@@ -1,6 +1,6 @@
 {
   "version": "187d",
-  "id": "",
+  "id": "mocha",
   "name": "Mocha",
   "short_name": "Mocha",
   "dna": {

--- a/project/assets/main/creatures/secondary/nard.json
+++ b/project/assets/main/creatures/secondary/nard.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "nard",
   "name": "Nard",
   "short_name": "Nard",
   "dna": {

--- a/project/assets/main/creatures/secondary/nardine.json
+++ b/project/assets/main/creatures/secondary/nardine.json
@@ -1,6 +1,6 @@
 {
   "version": "187d",
-  "id": "",
+  "id": "nardine",
   "name": "Nardine",
   "short_name": "Nardine",
   "dna": {

--- a/project/assets/main/creatures/secondary/nictor.json
+++ b/project/assets/main/creatures/secondary/nictor.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "nictor",
   "name": "Nictor",
   "short_name": "Nictor",
   "dna": {

--- a/project/assets/main/creatures/secondary/pairet.json
+++ b/project/assets/main/creatures/secondary/pairet.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "pairet",
   "name": "Pairet",
   "short_name": "Pairet",
   "dna": {

--- a/project/assets/main/creatures/secondary/pandon.json
+++ b/project/assets/main/creatures/secondary/pandon.json
@@ -1,6 +1,6 @@
 {
   "version": "187d",
-  "id": "",
+  "id": "pandon",
   "name": "Pandon",
   "short_name": "Pandon",
   "dna": {

--- a/project/assets/main/creatures/secondary/pipedro.json
+++ b/project/assets/main/creatures/secondary/pipedro.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "pipedro",
   "name": "Pipedro",
   "short_name": "Pipedro",
   "dna": {

--- a/project/assets/main/creatures/secondary/ranpo.json
+++ b/project/assets/main/creatures/secondary/ranpo.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "ranpo",
   "name": "Ranpo",
   "short_name": "Ranpo",
   "dna": {

--- a/project/assets/main/creatures/secondary/rex.json
+++ b/project/assets/main/creatures/secondary/rex.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "rex",
   "name": "Rex",
   "short_name": "Rex",
   "dna": {

--- a/project/assets/main/creatures/secondary/rhinosaur.json
+++ b/project/assets/main/creatures/secondary/rhinosaur.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "rhinosaur",
   "name": "Rhinosaur",
   "short_name": "Rhinosaur",
   "dna": {

--- a/project/assets/main/creatures/secondary/rhonk.json
+++ b/project/assets/main/creatures/secondary/rhonk.json
@@ -1,6 +1,6 @@
 {
   "version": "187d",
-  "id": "",
+  "id": "rhonk",
   "name": "Rhonk",
   "short_name": "Rhonk",
   "dna": {

--- a/project/assets/main/creatures/secondary/rice.json
+++ b/project/assets/main/creatures/secondary/rice.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "rice",
   "name": "Rice",
   "short_name": "Rice",
   "dna": {

--- a/project/assets/main/creatures/secondary/ricket.json
+++ b/project/assets/main/creatures/secondary/ricket.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "ricket",
   "name": "Ricket",
   "short_name": "Ricket",
   "dna": {

--- a/project/assets/main/creatures/secondary/sandrew.json
+++ b/project/assets/main/creatures/secondary/sandrew.json
@@ -1,6 +1,6 @@
 {
   "version": "187d",
-  "id": "",
+  "id": "sandrew",
   "name": "Sandrew",
   "short_name": "Sandrew",
   "dna": {

--- a/project/assets/main/creatures/secondary/snorz.json
+++ b/project/assets/main/creatures/secondary/snorz.json
@@ -1,6 +1,6 @@
 {
   "version": "187d",
-  "id": "",
+  "id": "snorz",
   "name": "Snorz",
   "short_name": "Snorz",
   "dna": {

--- a/project/assets/main/creatures/secondary/spood.json
+++ b/project/assets/main/creatures/secondary/spood.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "spood",
   "name": "Spood",
   "short_name": "Spood",
   "dna": {

--- a/project/assets/main/creatures/secondary/squawkapus.json
+++ b/project/assets/main/creatures/secondary/squawkapus.json
@@ -1,6 +1,6 @@
 {
   "version": "19a3",
-  "id": "",
+  "id": "squawkapus",
   "name": "Sir Clarnacle Squawkapus George Rufus Branley VIII",
   "short_name": "Squawkapus",
   "dna": {

--- a/project/assets/main/creatures/secondary/stunker.json
+++ b/project/assets/main/creatures/secondary/stunker.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "stunker",
   "name": "Stunker",
   "short_name": "Stunker",
   "dna": {

--- a/project/assets/main/creatures/secondary/terpion.json
+++ b/project/assets/main/creatures/secondary/terpion.json
@@ -1,6 +1,6 @@
 {
   "version": "170e",
-  "id": "",
+  "id": "terpion",
   "name": "Terpion",
   "dna": {
     "line_rgb": "6c4331",

--- a/project/assets/main/creatures/secondary/vile.json
+++ b/project/assets/main/creatures/secondary/vile.json
@@ -1,6 +1,6 @@
 {
   "version": "19dd",
-  "id": "",
+  "id": "vile",
   "name": "Vile",
   "short_name": "Vile",
   "dna": {

--- a/project/assets/main/puzzle/levels/cutscenes/boatricia1.json
+++ b/project/assets/main/puzzle/levels/cutscenes/boatricia1.json
@@ -2,7 +2,7 @@
   "version": "1922",
   "": [
     {
-      "who": "Boatricia",
+      "who": "boatricia",
       "text": "Could you maybe just cook me something small? I'm not very hungry today."
     },
     {

--- a/project/assets/main/puzzle/levels/cutscenes/boatricia2.json
+++ b/project/assets/main/puzzle/levels/cutscenes/boatricia2.json
@@ -2,7 +2,7 @@
   "version": "1922",
   "": [
     {
-      "who": "Boatricia",
+      "who": "boatricia",
       "text": "I built up an appetite today! Think you can cook something filling for me and my friends?"
     },
     {

--- a/project/assets/main/puzzle/levels/cutscenes/five-customers-no-vegetables.json
+++ b/project/assets/main/puzzle/levels/cutscenes/five-customers-no-vegetables.json
@@ -2,11 +2,11 @@
   "version": "1922",
   "": [
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "Okay,/ I'll invite my friends too!/ But/ -/-/ no vegetables okay?"
     },
     {
-      "who": "Ebe",
+      "who": "ebe",
       "text": "I HATE vegetables!/ ./././I hate them so much...",
       "mood": "rage0"
     }

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-everyone.json
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-everyone.json
@@ -13,7 +13,7 @@
   },
   "": [
     {
-      "who": "Richie",
+      "who": "richie",
       "text": "Okay. Now we can have a cutscene!"
     }
   ]

--- a/project/project.godot
+++ b/project/project.godot
@@ -570,6 +570,11 @@ _global_script_classes=[ {
 "path": "res://src/main/ui/wallpaper/sticker-row.gd"
 }, {
 "base": "Reference",
+"class": "StringTransformer",
+"language": "GDScript",
+"path": "res://src/main/string-transformer.gd"
+}, {
+"base": "Reference",
 "class": "StringUtils",
 "language": "GDScript",
 "path": "res://src/main/string-utils.gd"
@@ -747,6 +752,7 @@ _global_script_class_icons={
 "StateMachine": "",
 "Sticker": "",
 "StickerRow": "",
+"StringTransformer": "",
 "StringUtils": "",
 "SwipeContainer": "",
 "TouchSettings": "",

--- a/project/src/demo/ui/chat/chat-frame-demo.gd
+++ b/project/src/demo/ui/chat/chat-frame-demo.gd
@@ -13,7 +13,7 @@ Keys:
 	[P]: Print the json accent definition
 	[R]: Generate a random accent definition
 	[S]: Swap the accent's colors
-	[Shift]: Squish the window to the side
+	[Z]: Squish the window to the side
 """
 
 const TEXTS := [
@@ -32,7 +32,7 @@ const TEXTS := [
 		+ " magna aliqua. Ut enim ad minim",
 ]
 
-const WHOS := [
+const NAMES := [
 	"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore" \
 		+ " magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea" \
 		+ " commodo consequat.",
@@ -62,7 +62,7 @@ const SCALES := [
 ]
 
 # these fields store the results of the user's input
-var _who_index := 4
+var _name_index := 4
 var _text_index := 4
 
 var _color_index := 0
@@ -82,7 +82,7 @@ func _input(event: InputEvent) -> void:
 	match Utils.key_scancode(event):
 		KEY_0, KEY_1, KEY_2, KEY_3, KEY_4, KEY_5, KEY_6, KEY_7, KEY_8, KEY_9:
 			if Input.is_key_pressed(KEY_SHIFT):
-				_who_index = Utils.key_num(event)
+				_name_index = Utils.key_num(event)
 			else:
 				_text_index = Utils.key_num(event)
 			_play_chat_event()
@@ -129,7 +129,7 @@ func _input(event: InputEvent) -> void:
 			if _scale_index > 0:
 				_scale_index -= 1
 				_play_chat_event()
-		KEY_SHIFT:
+		KEY_Z:
 			_squished = !_squished
 			_play_chat_event()
 
@@ -138,8 +138,12 @@ func _input(event: InputEvent) -> void:
 Configures the chat window's appearance based on the user's input.
 """
 func _play_chat_event() -> void:
+	var creature_def := CreatureDef.new()
+	creature_def.creature_name = NAMES[_name_index]
+	PlayerData.creature_library.set_creature_def("lorum", creature_def)
+	
 	var chat_event := ChatEvent.new()
-	chat_event.who = WHOS[_who_index]
+	chat_event.who = "lorum"
 	chat_event.text = TEXTS[_text_index]
 	chat_event.chat_theme_def = _get_chat_theme_def()
 	$ChatFrame.play_chat_event(chat_event, _nametag_right, _squished)

--- a/project/src/demo/ui/chat/chat-ui-demo.gd
+++ b/project/src/demo/ui/chat/chat-ui-demo.gd
@@ -47,7 +47,10 @@ var _text_override := ""
 var _choice_override := ""
 
 func _ready() -> void:
-	ChattableManager.add_chat_theme_def("Lorum", {})
+	var creature_def := CreatureDef.new()
+	creature_def.creature_name = "Lorum"
+	PlayerData.creature_library.set_creature_def("lorum", creature_def)
+
 	_play_chat_tree("dialog-unbranched")
 
 

--- a/project/src/demo/world/CutsceneDemo.tscn
+++ b/project/src/demo/world/CutsceneDemo.tscn
@@ -105,7 +105,6 @@ __meta__ = {
 }
 
 [node name="Backdrop" parent="Dialogs" instance=ExtResource( 3 )]
-color = Color( 0, 0, 0, 0.752941 )
 
 [node name="OpenFile" type="FileDialog" parent="Dialogs"]
 anchor_left = 0.5

--- a/project/src/demo/world/cutscene-demo-fatness.gd
+++ b/project/src/demo/world/cutscene-demo-fatness.gd
@@ -28,5 +28,5 @@ func _on_CheckBox_pressed() -> void:
 	_refresh()
 
 
-func _on_HSlider_value_changed(value) -> void:
+func _on_HSlider_value_changed(_value: float) -> void:
 	_refresh()

--- a/project/src/demo/world/cutscene-demo.gd
+++ b/project/src/demo/world/cutscene-demo.gd
@@ -14,7 +14,7 @@ func _on_StartButton_pressed() -> void:
 	Level.push_cutscene_trail(true)
 
 
-func _on_OpenFileDialog_file_selected(path: String) -> void:
+func _on_OpenFileDialog_file_selected(_path: String) -> void:
 	var full_path: String = $Dialogs/OpenFile.current_path
 	if full_path.begins_with("res://assets/main/puzzle/levels/cutscenes/") and full_path.ends_with(".json"):
 		full_path = full_path.trim_prefix("res://assets/main/puzzle/levels/cutscenes/")

--- a/project/src/main/creature-library.gd
+++ b/project/src/main/creature-library.gd
@@ -5,6 +5,10 @@ Manages data for all creatures in the world, including the player.
 This includes their appearance, name and weight.
 """
 
+# unique creature ids
+const SENSEI_ID := "#sensei#"
+const PLAYER_ID := "#player#"
+
 # How many randomly generated filler creatures have their fatness tracked
 const GENERIC_FATNESS_COUNT := 150
 
@@ -16,8 +20,9 @@ const MAX_FILLER_FATNESS := 2.5
 # If set, all creatures will have a specific fatness. Used for testing cutscenes.
 var forced_fatness := 0.0
 
-var player_def: CreatureDef
-var sensei_def: CreatureDef
+# Virtual properties; values are only exposed through getters/setters
+var player_def: CreatureDef setget set_player_def, get_player_def
+var sensei_def: CreatureDef setget set_sensei_def,get_sensei_def
 
 # fatnesses by creature id
 var _fatnesses: Dictionary
@@ -28,6 +33,16 @@ var _saved_fatnesses: Dictionary
 # In addition to storing known fatness attributes like "Ebe's weight is 2.5", we store fatnesses for randomly
 # generated filler creatures. We rotate their IDs to avoid edge cases where two creatures have the same ID.
 var _filler_ids: Array
+
+# Cached creature definitions. This includes all primary and creature json definitions loaded from static json files,
+# as well as the player and sensei's definitions.
+#
+# This is a transient field which is populated on startup, but is not saved anywhere. As its contents not written to
+# disk, it should not be modified with the intent of permanently changing a creature's appearance.
+#
+# key: creature_id
+# value: CreatureDef instance with the specified id
+var _creature_defs_by_id: Dictionary
 
 func _init() -> void:
 	_normalize_filler_fatnesses()
@@ -46,17 +61,48 @@ func next_filler_id() -> String:
 	return filler_id
 
 
+func set_player_def(new_player_def: CreatureDef) -> void:
+	_creature_defs_by_id[PLAYER_ID] = new_player_def
+
+
+func get_player_def() -> CreatureDef:
+	return _creature_defs_by_id.get(PLAYER_ID)
+
+
+func set_sensei_def(new_sensei_def: CreatureDef) -> void:
+	_creature_defs_by_id[SENSEI_ID] = new_sensei_def
+
+
+func get_sensei_def() -> CreatureDef:
+	return _creature_defs_by_id.get(SENSEI_ID)
+
+
 func reset() -> void:
-	# default player appearance and name
-	player_def = CreatureDef.new()
-	player_def.creature_name = CreatureDef.DEFAULT_NAME
-	player_def.creature_short_name = NameUtils.sanitize_short_name(player_def.creature_name)
-	player_def.dna = CreatureDef.DEFAULT_DNA.duplicate()
-	player_def.min_fatness = 1.0
-	player_def.chat_theme_def = CreatureDef.DEFAULT_CHAT_THEME_DEF.duplicate()
+	_creature_defs_by_id.clear()
 	
-	if not sensei_def:
-		sensei_def = CreatureLoader.load_creature_def_by_id(Global.SENSEI_ID)
+	# default player appearance and name
+	var new_player_def := CreatureDef.new()
+	new_player_def.creature_name = CreatureDef.DEFAULT_NAME
+	new_player_def.creature_short_name = NameUtils.sanitize_short_name(new_player_def.creature_name)
+	new_player_def.dna = CreatureDef.DEFAULT_DNA.duplicate()
+	new_player_def.min_fatness = 1.0
+	new_player_def.chat_theme_def = CreatureDef.DEFAULT_CHAT_THEME_DEF.duplicate()
+	set_player_def(new_player_def)
+	
+	var creature_def_paths := []
+	# append sensei path
+	creature_def_paths.append(CreatureLoader.SENSEI_PATH)
+	
+	# append primary paths
+	creature_def_paths += _file_paths("res://assets/main/creatures/primary", "/creature.json")
+	
+	# append secondary paths
+	creature_def_paths += _file_paths("res://assets/main/creatures/secondary")
+	
+	# store load and creature_defs in _creature_defs_by_id
+	for path in creature_def_paths:
+		var creature_def := CreatureDef.new().from_json_path(path)
+		_creature_defs_by_id[creature_def.creature_id] = creature_def
 
 
 """
@@ -108,18 +154,28 @@ func set_fatness(creature_id: String, fatness: float) -> void:
 
 func to_json_dict() -> Dictionary:
 	return {
-		Global.PLAYER_ID: player_def.to_json_dict(),
+		PLAYER_ID: get_player_def().to_json_dict(),
 		"fatnesses": _fatnesses,
 	}
 
 
 func from_json_dict(json: Dictionary) -> void:
 	reset()
-	if json.has(Global.PLAYER_ID):
-		player_def.from_json_dict(json.get(Global.PLAYER_ID, {}))
+	if json.has(PLAYER_ID):
+		var new_player_def := CreatureDef.new()
+		new_player_def.from_json_dict(json.get(PLAYER_ID, {}))
+		set_player_def(new_player_def)
 	if json.has("fatnesses"):
 		_fatnesses = json.get("fatnesses")
 		_normalize_filler_fatnesses()
+
+
+func get_creature_def(creature_id: String) -> CreatureDef:
+	return _creature_defs_by_id.get(creature_id)
+
+
+func set_creature_def(creature_id: String, creature_def: CreatureDef) -> void:
+	_creature_defs_by_id[creature_id] = creature_def
 
 
 """
@@ -135,3 +191,28 @@ func _normalize_filler_fatnesses() -> void:
 			_fatnesses[filler_id] = min(Utils.rand_value(Global.FATNESSES), Utils.rand_value(Global.FATNESSES))
 	
 	_filler_ids.shuffle()
+
+
+"""
+Returns a list of file paths in the specified directory.
+
+This only returns the directory's immediate children, and does not perform a tree traversal.
+
+Parameters:
+	'dir_path': The path of the directory to scan
+	
+	'file_suffix': (Optional) A suffix to append to each returned file path.
+"""
+func _file_paths(dir_path: String, file_suffix: String = "") -> Array:
+	var result := []
+	var dir := Directory.new()
+	dir.open(dir_path)
+	dir.list_dir_begin(true, true)
+	while true:
+		var file := dir.get_next()
+		if file:
+			result.append(("%s/%s" % [dir.get_current_dir(), file.get_file()]) + file_suffix)
+		else:
+			break
+	dir.list_dir_end()
+	return result

--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -114,6 +114,7 @@ func _mutate_allele(creature: Creature, dna: Dictionary, new_palette: Dictionary
 		"name":
 			creature.creature_name = _name_generator.generate_name()
 			creature.creature_short_name = NameUtils.sanitize_short_name(creature.creature_name)
+			creature.creature_id = NameUtils.short_name_to_id(creature.creature_short_name)
 		"fatness":
 			var new_fatnesses := Global.FATNESSES.duplicate()
 			while new_fatnesses.has(creature.get_visual_fatness()):
@@ -256,6 +257,7 @@ func _tweak_creature(creature: Creature, allele: String, color_mode: int) -> voi
 		"name":
 			creature.creature_name = _name_generator.generate_name()
 			creature.creature_short_name = NameUtils.sanitize_short_name(creature.creature_name)
+			creature.creature_id = NameUtils.short_name_to_id(creature.creature_short_name)
 		"fatness":
 			var new_fatnesses := Global.FATNESSES.duplicate()
 			while new_fatnesses.has(creature.get_visual_fatness()):

--- a/project/src/main/editor/creature/tweak-name-row.gd
+++ b/project/src/main/editor/creature/tweak-name-row.gd
@@ -18,8 +18,10 @@ Update the creature's name and short name.
 """
 func _finish_name_edit(text: String) -> void:
 	var new_name: String = NameUtils.sanitize_name(text)
-	_creature_editor.center_creature.creature_name = new_name
-	_creature_editor.center_creature.creature_short_name = NameUtils.sanitize_short_name(new_name)
+	var creature: Creature = _creature_editor.center_creature
+	creature.creature_name = new_name
+	creature.creature_short_name = NameUtils.sanitize_short_name(new_name)
+	creature.creature_id = NameUtils.short_name_to_id(creature.creature_short_name)
 	_refresh_name_ui()
 
 
@@ -28,7 +30,9 @@ Update the creature's short name.
 """
 func _finish_short_name_edit(text: String) -> void:
 	var new_name: String = NameUtils.sanitize_short_name(text)
-	_creature_editor.center_creature.creature_short_name = new_name
+	var creature: Creature = _creature_editor.center_creature
+	creature.creature_short_name = new_name
+	creature.creature_id = NameUtils.short_name_to_id(creature.creature_short_name)
 	_refresh_name_ui()
 
 
@@ -55,8 +59,10 @@ appending punctuation/spaces, as the text box is constantly updated.
 func _on_Edit_text_changed(text: String) -> void:
 	var new_name: String = NameUtils.sanitize_name(text)
 	if new_name == text:
-		_creature_editor.center_creature.creature_name = new_name
-		_creature_editor.center_creature.creature_short_name = NameUtils.sanitize_short_name(new_name)
+		var creature := _creature_editor.center_creature
+		creature.creature_name = new_name
+		creature.creature_short_name = NameUtils.sanitize_short_name(new_name)
+		creature.creature_id = NameUtils.short_name_to_id(creature.creature_short_name)
 		_refresh_name_ui()
 
 
@@ -77,7 +83,9 @@ appending punctuation/spaces, as the text box is constantly updated.
 func _on_ShortName_text_changed(text: String) -> void:
 	var new_name: String = NameUtils.sanitize_short_name(text)
 	if new_name == text:
-		_creature_editor.center_creature.creature_short_name = new_name
+		var creature := _creature_editor.center_creature
+		creature.creature_short_name = new_name
+		creature.creature_id = NameUtils.short_name_to_id(creature.creature_short_name)
 		_refresh_name_ui()
 
 

--- a/project/src/main/global.gd
+++ b/project/src/main/global.gd
@@ -25,10 +25,6 @@ const FATNESSES := [
 	1.8, 2.3,
 ]
 
-# unique creature ids
-const SENSEI_ID := "#sensei#"
-const PLAYER_ID := "#player#"
-
 # The factor to multiply by to convert non-isometric coordinates into isometric coordinates
 const ISO_FACTOR := Vector2(1.0, 0.5)
 

--- a/project/src/main/name-utils.gd
+++ b/project/src/main/name-utils.gd
@@ -150,3 +150,34 @@ static func shorten_name(name: String) -> String:
 		result += suffixes[randi() % suffixes.length()]
 	
 	return result
+
+
+"""
+Converts a short name like 'Dr. Smiles' into a creature ID like 'dr_smiles'.
+
+The creature editor converts creature IDs to snake case and strips any diacritical marks or upper ascii. The game
+should work fine even if the IDs have upper ascii and spaces, they'll just be more annoying to type in.
+"""
+static func short_name_to_id(short_name: String) -> String:
+	var transformer := StringTransformer.new(short_name)
+	
+	# convert to lowercase
+	transformer.transformed = transformer.transformed.to_lower()
+	
+	# convert characters with diacritical marks to undecorated latin letters
+	transformer.sub("[àáâãäå]", "a")
+	transformer.sub("[æ]", "ae")
+	transformer.sub("[ç]", "c")
+	transformer.sub("[èéêë]", "e")
+	transformer.sub("[ìíîï]", "i")
+	transformer.sub("[ðòóôõö]", "o")
+	transformer.sub("[ñ]", "n")
+	transformer.sub("[š]", "s")
+	transformer.sub("[ùúûü]", "u")
+	transformer.sub("[ýÿ]", "y")
+	transformer.sub("[ž]", "z")
+	
+	# strip special characters and punctuation
+	transformer.sub("[^a-zA-Z0-9]+", "_")
+	
+	return transformer.transformed

--- a/project/src/main/old-save.gd
+++ b/project/src/main/old-save.gd
@@ -9,25 +9,6 @@ consider dropping backwards compatibility for older versions.
 # Filename for v0.0517 data. Can be changed for tests
 var player_data_filename_0517 := "user://turbofat.save"
 
-class StringTransformer:
-	"""
-	Applies a series of regex transformations.
-	"""
-	
-	var _regex := RegEx.new()
-	var transformed: String
-	
-	func _init(s: String) -> void:
-		transformed = s
-	
-	"""
-	Apply a regex transformation.
-	"""
-	func sub(pattern: String, replacement: String) -> void:
-		_regex.compile(pattern)
-		transformed = _regex.sub(transformed, replacement, true)
-
-
 """
 Returns 'true' if the player has an old save file but no new save file.
 

--- a/project/src/main/puzzle/level/level.gd
+++ b/project/src/main/puzzle/level/level.gd
@@ -110,6 +110,6 @@ func push_level_trail() -> void:
 	
 	start_level(level_settings)
 	if Level.launched_creature_id:
-		var creature_def := CreatureLoader.load_creature_def_by_id(Level.launched_creature_id)
+		var creature_def: CreatureDef = PlayerData.creature_library.get_creature_def(Level.launched_creature_id)
 		PlayerData.creature_queue.primary_queue.push_front(creature_def)
 	Breadcrumb.push_trail(Global.SCENE_PUZZLE)

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -117,7 +117,7 @@ Parameters:
 func _feed_creature(fatness_pct: float, food_color: Color) -> void:
 	var customer: Creature = $RestaurantView.get_customer()
 	
-	if customer.creature_id == Global.SENSEI_ID:
+	if customer.creature_id == CreatureLibrary.SENSEI_ID:
 		# tutorial sensei doesn't gain weight
 		pass
 	else:
@@ -126,7 +126,7 @@ func _feed_creature(fatness_pct: float, food_color: Color) -> void:
 		var target_fatness := Creature.score_to_fatness(base_score + PuzzleScore.get_creature_score())
 		customer.set_fatness(lerp(old_fatness, target_fatness, fatness_pct))
 
-	if customer.creature_id == Global.SENSEI_ID:
+	if customer.creature_id == CreatureLibrary.SENSEI_ID:
 		# tutorial sensei doesn't become comfortable
 		pass
 	else:

--- a/project/src/main/string-transformer.gd
+++ b/project/src/main/string-transformer.gd
@@ -1,0 +1,24 @@
+class_name StringTransformer
+"""
+Applies a series of regex transformations.
+"""
+
+# the transformed string
+var transformed: String
+
+# the regex instance which performs the transformations
+var _regex := RegEx.new()
+
+"""
+Parameters:
+	's': The string to be transformed.
+"""
+func _init(s: String) -> void:
+	transformed = s
+
+"""
+Apply a regex transformation.
+"""
+func sub(pattern: String, replacement: String) -> void:
+	_regex.compile(pattern)
+	transformed = _regex.sub(transformed, replacement, true)

--- a/project/src/main/ui/chat/chat-event.gd
+++ b/project/src/main/ui/chat/chat-event.gd
@@ -59,12 +59,12 @@ func from_json_dict(json: Dictionary) -> void:
 	_parse_meta(json)
 	
 	if json.has("who"):
-		chat_theme_def = ChattableManager.get_chat_theme_def(who)
+		chat_theme_def = PlayerData.creature_library.get_creature_def(who).chat_theme_def
 	else:
 		# Dialog with no speaker; decorate it as a thought bubble
 		if text:
 			text = "(%s)" % text
-		chat_theme_def = ChattableManager.get_chat_theme_def("#player#")
+		chat_theme_def = PlayerData.creature_library.get_creature_def("#player#").chat_theme_def
 
 
 """

--- a/project/src/main/ui/chat/chat-frame.gd
+++ b/project/src/main/ui/chat/chat-frame.gd
@@ -71,7 +71,8 @@ func play_chat_event(chat_event: ChatEvent, nametag_right: bool, squished: bool)
 	
 	# set the text and calculate how big of a frame we need
 	var chat_line_size: int = $ChatLineLabel.show_message(chat_event.text, 0.5)
-	$ChatLinePanel/NametagPanel.set_nametag_text(chat_event.who)
+	var creature_def := PlayerData.creature_library.get_creature_def(chat_event.who)
+	$ChatLinePanel/NametagPanel.set_nametag_text(creature_def.creature_name)
 	
 	# update the UI's appearance
 	$ChatLineLabel.update_appearance(chat_theme)

--- a/project/src/main/ui/chat/chat-library.gd
+++ b/project/src/main/ui/chat/chat-library.gd
@@ -34,7 +34,7 @@ func load_chat_events_for_creature(creature: Creature, forced_level_id: String =
 Returns the chat tree for the specified creature.
 """
 func chat_tree_for_creature_id(creature_id: String, forced_level_id: String = "") -> ChatTree:
-	var creature_def: CreatureDef = CreatureLoader.load_creature_def_by_id(creature_id)
+	var creature_def: CreatureDef = PlayerData.creature_library.get_creature_def(creature_id)
 	var state := _creature_chat_state(creature_id, forced_level_id)
 	
 	return chat_tree_for_creature_def(creature_def, state)

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -48,16 +48,16 @@ func start_chat(new_chat_tree: ChatTree, target: Node2D) -> void:
 	_current_chat_tree = new_chat_tree
 	
 	var new_chatters := [ChattableManager.player, target]
-	var chatter_names := {}
+	var chatter_ids := {}
 	for chat_events_obj in new_chat_tree.events.values():
 		var chat_events: Array = chat_events_obj
 		for chat_event_obj in chat_events:
 			var chat_event: ChatEvent = chat_event_obj
-			chatter_names[chat_event.who] = true
+			chatter_ids[chat_event.who] = true
 	
-	for chatter_name_obj in chatter_names:
-		var chatter_name: String = chatter_name_obj
-		var chatter := ChattableManager.get_creature_by_chatter_name(chatter_name)
+	for chatter_id_obj in chatter_ids:
+		var chatter_id: String = chatter_id_obj
+		var chatter := ChattableManager.get_creature_by_id(chatter_id)
 		if chatter and not new_chatters.has(chatter):
 			new_chatters.append(chatter)
 	
@@ -190,7 +190,7 @@ func _on_ChatUi_chat_event_played(chat_event: ChatEvent) -> void:
 	make_chatters_face_eachother()
 	
 	# update the chatter's mood
-	var chatter := ChattableManager.get_creature_by_chatter_name(chat_event.who)
+	var chatter := ChattableManager.get_creature_by_id(chat_event.who)
 	if chatter and chatter.has_method("play_mood"):
 		chatter.call("play_mood", chat_event.mood)
 

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -89,6 +89,7 @@ func random_def() -> CreatureDef:
 		result.dna = DnaUtils.random_dna()
 		result.creature_name = _name_generator.generate_name()
 		result.creature_short_name = NameUtils.sanitize_short_name(result.creature_name)
+		result.creature_id = NameUtils.short_name_to_id(result.creature_short_name)
 		result.chat_theme_def = chat_theme_def(result.dna)
 		# set the filler ID, but not the fatness. the fatness attribute in the CreatureDef is the creature's natural
 		# fatness -- not their fatness after being stuffed
@@ -180,16 +181,6 @@ func load_details(dna: Dictionary) -> void:
 	_load_head(dna)
 	_load_body(dna)
 	_load_colors(dna)
-
-
-func load_creature_def_by_id(id: String) -> CreatureDef:
-	var path: String
-	match id:
-		Global.SENSEI_ID:
-			path = SENSEI_PATH
-		_:
-			path = "res://assets/main/creatures/primary/%s/creature.json" % id
-	return CreatureDef.new().from_json_path(path) as CreatureDef
 
 
 """

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -173,12 +173,12 @@ func set_chat_selectors(new_chat_selectors: Array) -> void:
 
 func set_creature_id(new_creature_id: String) -> void:
 	creature_id = new_creature_id
+	set_meta("chat_id", creature_id)
 	_refresh_creature_id()
 
 
 func set_creature_name(new_creature_name: String) -> void:
 	creature_name = new_creature_name
-	set_meta("chat_name", creature_name)
 	emit_signal("creature_name_changed")
 
 
@@ -360,13 +360,15 @@ func _refresh_orientation() -> void:
 
 
 func _refresh_creature_id() -> void:
-	if creature_id == Global.PLAYER_ID:
+	if creature_id == CreatureLibrary.PLAYER_ID:
 		# player's creature_def is loaded in player.gd
 		pass
 	elif not is_inside_tree():
 		pass
 	else:
-		set_creature_def(CreatureLoader.load_creature_def_by_id(creature_id))
+		var creature_def: CreatureDef = PlayerData.creature_library.get_creature_def(creature_id)
+		if creature_def:
+			set_creature_def(creature_def)
 
 
 func _apply_friction() -> void:

--- a/project/src/main/world/creature/player.gd
+++ b/project/src/main/world/creature/player.gd
@@ -9,11 +9,12 @@ var input_disabled := false
 
 func _ready() -> void:
 	SceneTransition.connect("fade_out_started", self, "_on_SceneTransition_fade_out_started")
+	
 	set_creature_def(PlayerData.creature_library.player_def)
 	if PlayerData.creature_library.forced_fatness:
 		set_fatness(PlayerData.creature_library.forced_fatness)
 		set_visual_fatness(PlayerData.creature_library.forced_fatness)
-	creature_id = Global.PLAYER_ID
+	creature_id = CreatureLibrary.PLAYER_ID
 	ChattableManager.player = self
 
 

--- a/project/src/main/world/creature/sensei.gd
+++ b/project/src/main/world/creature/sensei.gd
@@ -11,7 +11,7 @@ const TOO_CLOSE_THRESHOLD := 140.0
 const TOO_FAR_THRESHOLD := 280.0
 
 func _ready() -> void:
-	set_creature_id(Global.SENSEI_ID)
+	set_creature_id(CreatureLibrary.SENSEI_ID)
 	$MoveTimer.connect("timeout", self, "_on_MoveTimer_timeout")
 	ChattableManager.sensei = self
 

--- a/project/src/test/test-name-utils.gd
+++ b/project/src/test/test-name-utils.gd
@@ -48,3 +48,15 @@ func test_sanitize_short_name() -> void:
 	
 	# one huge mess of consonants
 	assert_eq(NameUtils.sanitize_short_name("Crwdmbrrssnsydstncbrshcvr"), "Crwdm")
+
+
+func test_short_name_to_id() -> void:
+	assert_eq(NameUtils.short_name_to_id(""), "")
+	
+	# ids should be snake_case and only include underscores, letters, and numbers
+	assert_eq(NameUtils.short_name_to_id("SPOIL633"), "spoil633")
+	assert_eq(NameUtils.short_name_to_id("spoil-633"), "spoil_633")
+	assert_eq(NameUtils.short_name_to_id("húsbóndi"), "husbondi")
+	assert_eq(NameUtils.short_name_to_id("Dr. Smiles"), "dr_smiles")
+	assert_eq(NameUtils.short_name_to_id("ŽÁLGÕ"), "zalgo")
+	assert_eq(NameUtils.short_name_to_id("_-spoil-_-633-?"), "_spoil_633_")


### PR DESCRIPTION
Chat logic used to key off of creature_name, and query the creatures in
the current scene. This caused problems:

1. CutsceneDemo did not have an actual environment, but loaded chat trees
to find metadata. This triggered the caching of 'there is no creature
named John' causing warnings and blank chat themes.

2. Multiple creatures might have the same name, particularly if the player
chooses a common name. The old code avoided this by caching some creatures
by name (Richie, Boatricia) and other creatures by id (#player#, #sensei#)

The new code keys off of creature_id, and queries the cached creature
definitions in CreatureLibrary. This is available in scenes without an
environment, avoiding the aformentioned bugs.

Assigned creature IDs for creature def json files. Now that we're looking up
creatures by their IDs, these ID fields need to be set or they're not retrieved
properly.

CreatureEditor assigns creature_id field.

Extracted StringTransformer from OldSave for reuse in other scripts.

Moved PLAYER_ID, SENSEI_ID into CreatureLibrary.