### PR TITLE
Fix bug where dialog bubbles didn't appear on the correct side.

### DIFF
--- a/project/src/main/ui/chat/chat-ui.gd
+++ b/project/src/main/ui/chat/chat-ui.gd
@@ -94,11 +94,11 @@ func _on_ChatAdvancer_chat_event_shown(chat_event: ChatEvent) -> void:
 		$ChatChoices.hide_choices()
 	
 	# reposition the nametags for whether the characters are on the left or right side
-	var chatter := ChattableManager.get_chatter(chat_event["who"])
+	var creature := ChattableManager.get_creature_by_id(chat_event["who"])
 	var nametag_right := false
 	var squished := false
-	if chatter and chatter.has_method("get_orientation"):
-		var orientation: int = chatter.get_orientation()
+	if creature:
+		var orientation: int = creature.orientation
 		if orientation in [Creature.NORTHEAST, Creature.SOUTHEAST]:
 			# If we're facing right, we're on the left side. Put the nametag on the left.
 			nametag_right = false

--- a/project/src/main/world/chattable-manager.gd
+++ b/project/src/main/world/chattable-manager.gd
@@ -159,26 +159,6 @@ func is_focus_enabled() -> bool:
 
 
 """
-Returns the overworld object which has the specified 'chat name'.
-
-During dialog sequences, we sometimes need to know which overworld object corresponds to the person saying the current
-dialog line. This function facilitates that.
-"""
-func get_chatter(chat_id: String) -> Node2D:
-	var chatter: Node2D
-	if chat_id == CreatureLibrary.PLAYER_ID:
-		chatter = player
-	else:
-		for chattable_obj in get_tree().get_nodes_in_group("chattables"):
-			var chattable: Node = chattable_obj
-			if chattable.is_class("Node2D") and chattable.has_meta("chat_id") \
-					and chattable.get_meta("chat_id") == chat_id:
-				chatter = chattable
-				break
-	return chatter
-
-
-"""
 Substitutes variables in player-visible text.
 
 Text variables are pound sign delimited: 'Hello #player#'. This matches the syntax of Tracery.


### PR DESCRIPTION
The logic for dialog bubbles appearing on one side or the other was broken
in 9c4c4b2f when the get_orientation function was removed. The code didn't
throw errors because ChatUi tried to invoked this function leniently using
reflection, instead of enforcing the chatter's class.

ChatUi now assumes all chatters are creatures.