### PR TITLE
Cutscene camera improvements.

### DIFF
--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-everyone.json
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-everyone.json
@@ -7,8 +7,7 @@
       "#sensei#": "!kitchen-11",
       "richie": "!kitchen-1",
       "skins": "kitchen-3",
-      "bones": "kitchen-5",
-      "shirts": "kitchen-7"
+      "bones": "kitchen-5"
     }
   },
   "": [

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -85,8 +85,9 @@ func is_show_version() -> bool:
 Turn the the active chat participants towards each other, and make them face the camera.
 """
 func make_chatters_face_eachother() -> void:
-	var center_of_non_player_chatters := get_center_of_chatters(
+	var chatter_bounding_box := get_chatter_bounding_box(
 			[], [ChattableManager.player, ChattableManager.sensei])
+	var center_of_non_player_chatters := chatter_bounding_box.position + chatter_bounding_box.size * 0.5
 	
 	for chatter in chatters:
 		if chatter == ChattableManager.player:
@@ -108,7 +109,7 @@ func make_chatters_face_eachother() -> void:
 
 
 """
-Calculates the center of the characters involved in the current conversation.
+Calculates the bounding box of the characters involved in the current conversation.
 
 Parameters:
 	'include': (Optional) characters in the current conversation will only be included if they are in this list.
@@ -116,10 +117,10 @@ Parameters:
 	'exclude': (Optional) Characters in the current conversation will be excluded if they are in this list.
 
 Returns:
-	The center of the smallest rectangle including all characters in the current conversation. If no characters meet
-	this criteria, this returns an zero-size rectangle at (0, 0).
+	The smallest rectangle including all characters in the current conversation. If no characters meet this criteria,
+	this returns an zero-size rectangle at (0, 0).
 """
-func get_center_of_chatters(include: Array = [], exclude: Array = []) -> Vector2:
+func get_chatter_bounding_box(include: Array = [], exclude: Array = []) -> Rect2:
 	var bounding_box: Rect2
 	
 	for chatter in chatters:
@@ -133,7 +134,7 @@ func get_center_of_chatters(include: Array = [], exclude: Array = []) -> Vector2
 			bounding_box = bounding_box.expand(chatter.position)
 		else:
 			bounding_box = Rect2(chatter.position, Vector2.ZERO)
-	return bounding_box.position + bounding_box.size * 0.5
+	return bounding_box
 
 
 """
@@ -143,7 +144,7 @@ Quick one-line chats don't interrupt the player or zoom the camera in; the playe
 running. That's why we call them 'drive by chats'.
 """
 func is_drive_by_chat() -> bool:
-	return _current_chat_tree.events.size() == 1
+	return _current_chat_tree.events.size() <= 1 and _current_chat_tree.events.get("", []).size() <= 1
 
 
 """

--- a/project/src/main/world/overworld-camera.gd
+++ b/project/src/main/world/overworld-camera.gd
@@ -3,6 +3,13 @@ extends Camera2D
 Overworld camera. Follows the main character and zooms in during conversations.
 """
 
+# how far from the camera center the player needs to be before the camera zooms out
+const AUTO_ZOOM_OUT_DISTANCE := 100.0
+
+# amount of empty space around characters
+const CAMERA_BOUNDARY := 160
+
+# amount of time spent zooming in and out
 const ZOOM_DURATION := 1.0
 
 # maximum zoom amount for conversations
@@ -10,9 +17,6 @@ const ZOOM_CLOSE_UP := Vector2(0.5, 0.5)
 
 # zoom amount when running around
 const ZOOM_DEFAULT := Vector2(1.0, 1.0)
-
-# how far from the camera center the player needs to be before the camera zooms out
-const AUTO_ZOOM_OUT_DISTANCE := 100.0
 
 # 'true' if the camera should currently be zoomed in for a conversation
 var close_up: bool setget set_close_up
@@ -22,11 +26,15 @@ var close_up_pct := 0.0
 
 # the position to zoom in to. the midpoint of the smallest rectangle containing all chatters
 var close_up_position: Vector2
+var close_up_bounding_box: Rect2
 
 # zoom amount for the current conversation; we don't zoom in as much if the creature is fat
 var zoom_close_up := ZOOM_CLOSE_UP
 
 onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
+
+onready var _project_resolution := Vector2(ProjectSettings.get_setting("display/window/size/width"), \
+		ProjectSettings.get_setting("display/window/size/height"))
 
 func _ready() -> void:
 	_overworld_ui.connect("chat_started", self, "_on_OverworldUi_chat_started")
@@ -44,14 +52,24 @@ func _process(_delta: float) -> void:
 		for chatter in _overworld_ui.chatters:
 			if chatter is Creature:
 				max_visual_fatness = max(max_visual_fatness, chatter.get_visual_fatness())
-		zoom_close_up = lerp(ZOOM_CLOSE_UP, ZOOM_DEFAULT, inverse_lerp(1.0, 10.0, max_visual_fatness))
-		close_up_position = _overworld_ui.get_center_of_chatters()
+		
+		var new_close_up_bounding_box := _overworld_ui.get_chatter_bounding_box()
+		if new_close_up_bounding_box != close_up_bounding_box:
+			close_up_bounding_box = new_close_up_bounding_box
+			close_up_bounding_box = close_up_bounding_box.grow(CAMERA_BOUNDARY)
+			close_up_position = close_up_bounding_box.position + close_up_bounding_box.size * 0.5
+			
+			zoom_close_up.x = max(close_up_bounding_box.size.x / _project_resolution.x, \
+					close_up_bounding_box.size.y / _project_resolution.y)
+			zoom_close_up.x = clamp(zoom_close_up.x, 0.5, 1.0)
+			zoom_close_up.y = zoom_close_up.x
 	
 	zoom = lerp(ZOOM_DEFAULT, zoom_close_up, close_up_pct)
-	
 	position = lerp(ChattableManager.player.position, close_up_position, close_up_pct)
-	if close_up and ChattableManager.player.position.distance_to(close_up_position) > AUTO_ZOOM_OUT_DISTANCE:
-		# player left the chat area; zoom back out
+	
+	if not _overworld_ui.cutscene and close_up \
+			and ChattableManager.player.position.distance_to(close_up_position) > AUTO_ZOOM_OUT_DISTANCE:
+		 # player left the chat area; zoom back out
 		set_close_up(false)
 
 


### PR DESCRIPTION
Camera zooms out further if characters are further apart. The old camera
behavior zoomed in too much which would clip characters off the top and
bottom of the screen.

Changed 'get_center_of_chatters' to 'get_chatter_bounding_box'. The
OverworldCamera needs to zoom out more if characters are further apart,
so it needs a rectangle and not just a coordinate.

Removed Shirts from 'hello everyone' scene.