### PR TITLE
Fixed bugs related to overworld input, buttons, focus

### DIFF
--- a/project/src/main/ui/chat/ChatChoices.tscn
+++ b/project/src/main/ui/chat/ChatChoices.tscn
@@ -38,6 +38,10 @@ margin_right = 138.0
 margin_bottom = 234.0
 choice_text = "I wouldn't choose this one!"
 
+[node name="EnableInputTimer" type="Timer" parent="."]
+wait_time = 0.8
+one_shot = true
+
 [node name="PopSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 4 )
 volume_db = -6.0

--- a/project/src/main/ui/chat/ChatUi.tscn
+++ b/project/src/main/ui/chat/ChatUi.tscn
@@ -49,6 +49,7 @@ __meta__ = {
 [connection signal="all_text_shown" from="ChatFrame" to="." method="_on_ChatFrame_all_text_shown"]
 [connection signal="pop_out_completed" from="ChatFrame" to="." method="_on_ChatFrame_pop_out_completed"]
 [connection signal="chat_choice_chosen" from="ChatChoices" to="ChatAdvancer" method="_on_ChatChoices_chat_choice_chosen"]
+[connection signal="chat_choice_chosen" from="ChatChoices" to="." method="_on_ChatChoices_chat_choice_chosen"]
 [connection signal="chat_choice_chosen" from="ChatChoices" to="TouchTranslator" method="_on_ChatChoices_chat_choice_chosen"]
 [connection signal="chat_event_shown" from="ChatAdvancer" to="." method="_on_ChatAdvancer_chat_event_shown"]
 [connection signal="chat_finished" from="ChatAdvancer" to="ChatFrame" method="_on_ChatAdvancer_chat_finished"]

--- a/project/src/main/ui/chat/chat-choices.gd
+++ b/project/src/main/ui/chat/chat-choices.gd
@@ -72,6 +72,9 @@ func show_choices(choices: Array, moods: Array, new_columns: int = 0) -> void:
 	_refresh_child_buttons()
 	
 	if choices:
+		# briefly disable input to prevent the player from mashing through chat choices accidentally
+		$EnableInputTimer.start()
+		
 		# wait for old chat choices to be deleted before grabbing focus
 		yield(get_tree(), "idle_frame")
 		for button in get_tree().get_nodes_in_group("chat_choices"):
@@ -166,6 +169,10 @@ Makes all the chat choice buttons disappear and emits a signal with the player's
 The chat choice buttons remain as children of this node so they can be animated away.
 """
 func _on_ChatChoiceButton_pressed() -> void:
+	if not $EnableInputTimer.is_stopped():
+		# don't let the player mash through chat choices accidentally
+		return
+	
 	var old_buttons := get_tree().get_nodes_in_group("chat_choices")
 
 	# determine the currently selected choice

--- a/project/src/main/ui/chat/chat-ui.gd
+++ b/project/src/main/ui/chat/chat-ui.gd
@@ -8,6 +8,7 @@ signal chat_event_played(chat_event)
 
 # emitted when we present the player with a dialog choice
 signal showed_choices
+signal chat_choice_chosen(choice_index)
 signal pop_out_completed
 
 # how long the player needs to hold the button to skip all dialog
@@ -147,3 +148,7 @@ func _on_ChatFrame_all_text_shown() -> void:
 
 func _on_ChatFrame_pop_out_completed() -> void:
 	emit_signal("pop_out_completed")
+
+
+func _on_ChatChoices_chat_choice_chosen(choice_index: int) -> void:
+	emit_signal("chat_choice_chosen", choice_index)

--- a/project/src/main/world/OverworldTouchButtons.tscn
+++ b/project/src/main/world/OverworldTouchButtons.tscn
@@ -7,6 +7,7 @@
 modulate = Color( 1, 1, 1, 0.627451 )
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 2
 script = ExtResource( 3 )
 __meta__ = {
 "_edit_use_anchors_": false

--- a/project/src/main/world/OverworldUi.tscn
+++ b/project/src/main/world/OverworldUi.tscn
@@ -161,6 +161,7 @@ margin_bottom = 1.99976
 modulate = Color( 1, 1, 1, 0.627451 )
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 2
 script = ExtResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -186,12 +187,14 @@ anchor_bottom = 0.0
 margin_left = 292.0
 margin_right = 392.0
 margin_bottom = 100.0
+focus_mode = 0
 size_flags_horizontal = 0
 custom_styles/hover = SubResource( 1 )
 custom_styles/pressed = SubResource( 2 )
 custom_styles/focus = SubResource( 3 )
 custom_styles/disabled = SubResource( 4 )
 custom_styles/normal = SubResource( 5 )
+enabled_focus_mode = 0
 shortcut = SubResource( 7 )
 icon = ExtResource( 33 )
 expand_icon = true
@@ -204,11 +207,13 @@ anchor_bottom = 0.0
 margin_left = 402.0
 margin_right = 502.0
 margin_bottom = 100.0
+focus_mode = 0
 custom_styles/hover = SubResource( 1 )
 custom_styles/pressed = SubResource( 2 )
 custom_styles/focus = SubResource( 3 )
 custom_styles/disabled = SubResource( 4 )
 custom_styles/normal = SubResource( 5 )
+enabled_focus_mode = 0
 shortcut = SubResource( 9 )
 icon = ExtResource( 25 )
 expand_icon = true
@@ -237,11 +242,13 @@ anchor_bottom = 0.0
 margin_left = 402.0
 margin_right = 502.0
 margin_bottom = 100.0
+focus_mode = 0
 custom_styles/hover = SubResource( 1 )
 custom_styles/pressed = SubResource( 2 )
 custom_styles/focus = SubResource( 3 )
 custom_styles/disabled = SubResource( 4 )
 custom_styles/normal = SubResource( 5 )
+enabled_focus_mode = 0
 shortcut = SubResource( 11 )
 icon = ExtResource( 23 )
 expand_icon = true
@@ -327,10 +334,12 @@ custom_styles/normal = SubResource( 5 )
 disabled = true
 
 [node name="MusicPopup" parent="Control" instance=ExtResource( 16 )]
+mouse_filter = 2
 
 [node name="SceneTransitionRect" parent="Control" instance=ExtResource( 15 )]
 anchor_right = 1.0
 anchor_bottom = 1.0
+[connection signal="chat_choice_chosen" from="Control/ChatUi" to="." method="_on_ChatUi_chat_choice_chosen"]
 [connection signal="chat_event_played" from="Control/ChatUi" to="." method="_on_ChatUi_chat_event_played"]
 [connection signal="pop_out_completed" from="Control/ChatUi" to="." method="_on_ChatUi_pop_out_completed"]
 [connection signal="showed_choices" from="Control/ChatUi" to="." method="_on_ChatUi_showed_choices"]
@@ -338,13 +347,17 @@ anchor_bottom = 1.0
 [connection signal="pressed" from="Control/Buttons/Northeast/SettingsButton" to="." method="_on_SettingsButton_pressed"]
 [connection signal="pressed" from="Control/Buttons/Southeast/TalkButton" to="." method="_on_TalkButton_pressed"]
 [connection signal="cheat_detected" from="Control/CheatCodeDetector" to="Control/Labels/SoutheastLabels/FpsLabel" method="_on_CheatCodeDetector_cheat_detected"]
+[connection signal="hide" from="Control/SettingsMenu" to="." method="_on_SettingsMenu_hide"]
 [connection signal="hide" from="Control/SettingsMenu" to="Control/TouchButtons" method="_on_Menu_hide"]
 [connection signal="hide" from="Control/SettingsMenu" to="Control/Buttons" method="_on_Menu_hide"]
 [connection signal="quit_pressed" from="Control/SettingsMenu" to="." method="_on_SettingsMenu_quit_pressed"]
+[connection signal="show" from="Control/SettingsMenu" to="." method="_on_SettingsMenu_show"]
 [connection signal="show" from="Control/SettingsMenu" to="Control/TouchButtons" method="_on_Menu_show"]
 [connection signal="show" from="Control/SettingsMenu" to="Control/Buttons" method="_on_Menu_show"]
+[connection signal="hide" from="Control/CellPhoneMenu" to="." method="_on_CellPhoneMenu_hide"]
 [connection signal="hide" from="Control/CellPhoneMenu" to="Control/TouchButtons" method="_on_Menu_hide"]
 [connection signal="hide" from="Control/CellPhoneMenu" to="Control/Buttons" method="_on_Menu_hide"]
+[connection signal="show" from="Control/CellPhoneMenu" to="." method="_on_CellPhoneMenu_show"]
 [connection signal="show" from="Control/CellPhoneMenu" to="Control/TouchButtons" method="_on_Menu_show"]
 [connection signal="show" from="Control/CellPhoneMenu" to="Control/Buttons" method="_on_Menu_show"]
 [connection signal="pressed" from="Control/CellPhoneMenu/Buttons/Northeast/BackButton" to="Control/CellPhoneMenu" method="_on_BackButton_pressed"]

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -397,9 +397,9 @@ func _refresh_creature_id() -> void:
 	elif not is_inside_tree():
 		pass
 	else:
-		var creature_def: CreatureDef = PlayerData.creature_library.get_creature_def(creature_id)
-		if creature_def:
-			set_creature_def(creature_def)
+		var new_creature_def: CreatureDef = PlayerData.creature_library.get_creature_def(creature_id)
+		if new_creature_def:
+			set_creature_def(new_creature_def)
 
 
 func _apply_friction() -> void:

--- a/project/src/main/world/creature/player.gd
+++ b/project/src/main/world/creature/player.gd
@@ -7,6 +7,9 @@ Script for manipulating the player-controlled character in the overworld.
 # If 'true' the player cannot move. Used during cutscenes.
 var input_disabled := false
 
+# if 'true' the ui has focus, and the player shouldn't move.
+var ui_has_focus := false setget set_ui_has_focus
+
 func _ready() -> void:
 	SceneTransition.connect("fade_out_started", self, "_on_SceneTransition_fade_out_started")
 	
@@ -19,13 +22,20 @@ func _ready() -> void:
 
 
 func _unhandled_input(_event: InputEvent) -> void:
-	if input_disabled:
+	if input_disabled or ui_has_focus:
 		return
 	
 	if Utils.walk_pressed_dir(_event) or Utils.walk_released_dir(_event):
 		# calculate the direction the player wants to move
 		set_non_iso_walk_direction(Utils.walk_pressed_dir())
 		get_tree().set_input_as_handled()
+
+
+func set_ui_has_focus(new_ui_has_focus: bool) -> void:
+	ui_has_focus = new_ui_has_focus
+	if ui_has_focus and non_iso_walk_direction:
+		# if the player is moving when something grabs focus, stop their movement
+		set_non_iso_walk_direction(Vector2(0, 0))
 
 
 """

--- a/project/src/main/world/overworld-buttons.gd
+++ b/project/src/main/world/overworld-buttons.gd
@@ -3,7 +3,11 @@ extends Control
 Manages the buttons for the overworld.
 """
 
+onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
+
 func _ready() -> void:
+	_overworld_ui.connect("chat_started", self, "_on_OverworldUi_chat_started")
+	_overworld_ui.connect("chat_ended", self, "_on_OverworldUi_chat_ended")
 	for button in [$Northeast/SettingsButton, $Northeast/PhoneButton, $Southeast/TalkButton]:
 		button.connect("resized", self, "_on_Button_resized", [button])
 	yield(get_tree(), "idle_frame")

--- a/project/src/main/world/overworld-touch-buttons.gd
+++ b/project/src/main/world/overworld-touch-buttons.gd
@@ -3,8 +3,12 @@ extends Control
 Touchscreen buttons displayed for the overworld.
 """
 
+onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
+
 func _ready() -> void:
 	if OS.has_touchscreen_ui_hint():
+		_overworld_ui.connect("chat_started", self, "_on_OverworldUi_chat_started")
+		_overworld_ui.connect("chat_ended", self, "_on_OverworldUi_chat_ended")
 		PlayerData.touch_settings.connect("settings_changed", self, "_on_TouchSettings_settings_changed")
 		_refresh_button_positions()
 		show()


### PR DESCRIPTION
Added 0.8s delay before chat choices can be picked. This avoids an issue where
the player could accidentally choose something while mashing through dialog.

Closes #799.

Restored signals for OverworldButtons, OverworldTouchButtons. Disconnecting
these signals kept the UI buttons visible during conversations and cutscenes,
allowing the player to quit or select levels while cutscenes were playing.

Closes #800. Closes #801.

Disable player input and halt their movement when the UI has focus. This
fixes some weird behavior. One example is if you were moving and a
conversation popped up, you'd keep running in that direction. Another
example is when the cell phone menu was popped up, you could navigate the
menu with the arrow keys, but if you navigated to a corner button you
could also move your character towards that corner. Conditionally
disabling player input required adding a few new signals related to the
Overworld UI.