### PR TITLE
Bug fixes: mid-chat exit, repeat chat zoom, music popup

### DIFF
--- a/project/src/main/ui/chat/chat-tree.gd
+++ b/project/src/main/ui/chat/chat-tree.gd
@@ -96,6 +96,20 @@ func advance(link_index := -1) -> bool:
 	return did_increment
 
 
+"""
+Returns 'true' if the chat position can be advanced deeper into the tree.
+"""
+func can_advance() -> bool:
+	var can_increment := false
+	if get_event().links and events.has(get_event().links[-1]):
+		# can reset to beginning of a new chat branch
+		can_increment = true
+	elif _position.index + 1 < events[_position.key].size():
+		# can advance through the current chat branch
+		can_increment = true
+	return can_increment
+
+
 func from_json_dict(json: Dictionary) -> void:
 	for key in json.keys():
 		match key:

--- a/project/src/main/ui/music-popup-tween.gd
+++ b/project/src/main/ui/music-popup-tween.gd
@@ -3,13 +3,36 @@ extends Tween
 Makes the music popup appear and disappear.
 """
 
+enum PopupState {
+	NONE,
+	POPPING_IN,
+	POPPING_OUT
+}
+
 # the how long it takes the popup to slide in or out of view
 const TWEEN_DURATION := 0.2
 
 # the duration that the popup remains visible
 const POPUP_DURATION := 4.0
 
+# the music panel's y coordinate when popped in and when popped out
+const POP_IN_Y := 32
+const POP_OUT_Y := 0
+
+# tracks whether the popup is currently popping in or out
+var _popup_state: int = PopupState.NONE
+
 onready var _music_panel := get_node("../Panel")
+
+func _ready() -> void:
+	connect("tween_all_completed", self, "_on_tween_all_completed")
+
+
+func _enter_tree() -> void:
+	# wait a frame for the Timer to be added to the scene tree before restoring its state.
+	# we use a one-shot listener method instead of a yield statement to avoid 'class instance is gone' errors.
+	get_tree().connect("idle_frame", self, "_restore_tween_and_timer_state")
+
 
 """
 Makes the music popup appear, and then hides it after a few seconds.
@@ -27,12 +50,62 @@ func pop_in_and_out(pop_in_delay: float) -> void:
 
 
 func _pop_in() -> void:
+	# Calculate the tween duration.
+	# This is usually TWEEN_DURATION, but can be shorter if the popup is partially popped in.
+	var pop_in_amount := inverse_lerp(POP_OUT_Y, POP_IN_Y, _music_panel.rect_position.y)
+	var tween_duration := TWEEN_DURATION * (1.0 - pop_in_amount)
+	
+	_popup_state = PopupState.POPPING_IN
 	remove_all()
-	interpolate_property(_music_panel, "rect_position:y", _music_panel.rect_position.y, 32, TWEEN_DURATION)
+	interpolate_property(_music_panel, "rect_position:y", _music_panel.rect_position.y, POP_IN_Y, tween_duration)
 	start()
 
 
 func _pop_out() -> void:
+	# Calculate the tween duration.
+	# This is usually TWEEN_DURATION, but can be shorter if the popup is partially popped out.
+	var pop_in_amount := inverse_lerp(POP_OUT_Y, POP_IN_Y, _music_panel.rect_position.y)
+	var tween_duration := TWEEN_DURATION * pop_in_amount
+	
+	_popup_state = PopupState.POPPING_OUT
 	remove_all()
-	interpolate_property(_music_panel, "rect_position:y", _music_panel.rect_position.y, 0, TWEEN_DURATION)
+	interpolate_property(_music_panel, "rect_position:y", _music_panel.rect_position.y, POP_OUT_Y, tween_duration)
 	start()
+
+
+"""
+Restores the MusicPopupTween and Timer to the state before they exited the tree.
+
+The MusicPopup is a singleton so that it maintains its position as the player navigates menus. However, timers and
+tweens stop running when they exit the scene tree. This method restores the timers and tweens so that they're running
+again.
+"""
+func _restore_tween_and_timer_state() -> void:
+	# disconnect our one-shot method
+	get_tree().disconnect("idle_frame", self, "_restore_tween_and_timer_state")
+	
+	match _popup_state:
+		PopupState.POPPING_IN:
+			# PopupTween was interrupted while popping in.
+			# Pop in, wait a few seconds and then pop out.
+			pop_in_and_out(0.0)
+		
+		PopupState.POPPING_OUT:
+			# PopupTween was interrupted while popping out.
+			# Finish popping out.
+			_pop_out()
+		
+		PopupState.NONE:
+			if _music_panel and _music_panel.rect_position.y > POP_OUT_Y:
+				# PopupTween was interrupted while popped in.
+				# Wait a few seconds and then pop out.
+				$Timer.start(POPUP_DURATION)
+				yield($Timer, "timeout")
+				_pop_out()
+			else:
+				# PopupTween was not interrupted.
+				pass
+
+
+func _on_tween_all_completed() -> void:
+	_popup_state = PopupState.NONE

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -144,7 +144,11 @@ Quick one-line chats don't interrupt the player or zoom the camera in; the playe
 running. That's why we call them 'drive by chats'.
 """
 func is_drive_by_chat() -> bool:
-	return _current_chat_tree.events.size() <= 1 and _current_chat_tree.events.get("", []).size() <= 1
+	return not _current_chat_tree.can_advance()
+
+
+func is_chatting() -> bool:
+	return not chatters.empty()
 
 
 """

--- a/project/src/main/world/overworld-exit.gd
+++ b/project/src/main/world/overworld-exit.gd
@@ -31,6 +31,8 @@ var _player_overlapping := false
 # 'true' if the player stepped on this exit arrow and is exiting
 var _player_exiting := false
 
+onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
+
 func _ready() -> void:
 	SceneTransition.connect("fade_out_ended", self, "_on_SceneTransition_fade_out_ended")
 	connect("body_entered", self, "_on_body_entered")
@@ -42,6 +44,9 @@ func _ready() -> void:
 func _physics_process(_delta: float) -> void:
 	if Engine.is_editor_hint() or not ChattableManager.player:
 		# don't try to change scenes in the editor
+		return
+	if _overworld_ui.is_chatting():
+		# don't change scenes while chatting
 		return
 	
 	if _player_overlapping and not SceneTransition.fading:


### PR DESCRIPTION
Overworld exits are now disabled while a conversation is going on. This
fixes a bug where talking to a creature and then walking into a restaurant
mid-conversation caused some strange behavior.

Closes #804.

Talking to a creature you've spoken to already no longer zooms the camera
in for the one-line dialog summary.

Closes #775.

If the music popup was half-way popped in and out during a scene change,
it froze in that half-popped state. The MusicPopupTween now tracks its
state and restores its tweens and timers when it re-enters the scene tree.

Closes #764.