### PR TITLE
Scenarios support chefs, customers. Added customer metabolism

### DIFF
--- a/project/assets/main/creatures/secondary/rhonk.json
+++ b/project/assets/main/creatures/secondary/rhonk.json
@@ -36,5 +36,7 @@
   "chat_selectors": [
 
   ],
-  "fatness": 1
+  "fatness": 1,
+  "weight_gain_scale": 0.25,
+  "metabolism_scale": 4.0
 }

--- a/project/assets/main/puzzle/levels/marsh/hello-everyone.json
+++ b/project/assets/main/puzzle/levels/marsh/hello-everyone.json
@@ -7,6 +7,9 @@
     "type": "time_over",
     "value": "90"
   },
+  "combo_break": [
+    "pieces 999999"
+  ],
   "piece_types": [
     "start_piece_j"
   ],

--- a/project/assets/main/puzzle/worlds.json
+++ b/project/assets/main/puzzle/worlds.json
@@ -26,6 +26,10 @@
         {
           "id": "marsh/hello_everyone",
           "creature_id": "richie",
+          "chef_id": "skins",
+          "customer_ids": [
+            "rhonk"
+          ],
           "groups": "marsh/hello"
         },
         {
@@ -97,114 +101,174 @@
         {
           "id": "placeholder01",
           "creature_id": "ebe",
+          "customer_ids": [
+            "ebe"
+          ],
           "groups": "choco_intro"
         },
         {
           "id": "placeholder02",
           "creature_id": "bort",
+          "customer_ids": [
+            "bort"
+          ],
           "groups": "choco_intro",
           "locked_until": "level_finished placeholder01"
         },
         {
           "id": "boatricia1",
           "creature_id": "boatricia",
+          "customer_ids": [
+            "boatricia"
+          ],
           "locked_until": "group_finished choco_intro",
           "groups": "choco_main"
         },
         {
           "id": "boatricia2",
           "creature_id": "boatricia",
+          "customer_ids": [
+            "boatricia"
+          ],
           "locked_until": "level_finished boatricia1",
           "groups": "choco_main"
         },
         {
           "id": "five_customers_no_vegetables",
           "creature_id": "ebe",
+          "customer_ids": [
+            "ebe"
+          ],
           "locked_until": "group_finished choco_intro",
           "groups": "choco_main"
         },
         {
           "id": "placeholder03",
           "creature_id": "bort",
+          "customer_ids": [
+            "bort"
+          ],
           "locked_until": "group_finished choco_intro",
           "groups": "choco_main"
         },
         {
           "id": "placeholder04",
           "creature_id": "boatricia",
+          "customer_ids": [
+            "boatricia"
+          ],
           "locked_until": "group_finished choco_intro",
           "groups": "choco_main"
         },
         {
           "id": "placeholder05",
           "creature_id": "boatricia",
+          "customer_ids": [
+            "boatricia"
+          ],
           "locked_until": "group_finished choco_intro",
           "groups": "choco_main"
         },
         {
           "id": "placeholder06",
           "creature_id": "ebe",
+          "customer_ids": [
+            "ebe"
+          ],
           "locked_until": "group_finished choco_intro",
           "groups": "choco_main"
         },
         {
           "id": "placeholder07",
           "creature_id": "ebe",
+          "customer_ids": [
+            "ebe"
+          ],
           "locked_until": "group_finished choco_intro",
           "groups": "choco_main"
         },
         {
           "id": "placeholder08",
           "creature_id": "bort",
+          "customer_ids": [
+            "bort"
+          ],
           "locked_until": "group_finished choco_intro",
           "groups": "choco_main"
         },
         {
           "id": "placeholder09",
           "creature_id": "bort",
+          "customer_ids": [
+            "bort"
+          ],
           "locked_until": "group_finished choco_intro",
           "groups": "choco_main"
         },
         {
           "id": "placeholder11",
           "creature_id": "ebe",
+          "customer_ids": [
+            "ebe"
+          ],
           "locked_until": "group_finished choco_intro",
           "groups": "choco_main"
         },
         {
           "id": "placeholder12",
           "creature_id": "boatricia",
+          "customer_ids": [
+            "boatricia"
+          ],
           "locked_until": "group_finished choco_intro",
           "groups": "choco_main"
         },
         {
           "id": "veggie_patty",
           "creature_id": "bort",
+          "customer_ids": [
+            "bort"
+          ],
           "locked_until": "group_finished choco_main 5"
         },
         {
           "id": "placeholder10",
           "creature_id": "bort",
+          "customer_ids": [
+            "bort"
+          ],
           "locked_until": "group_finished choco_main 5"
         },
         {
           "id": "placeholder13",
           "creature_id": "wesker",
+          "customer_ids": [
+            "wesker"
+          ],
           "locked_until": "group_finished choco_main 5"
         },
         {
           "id": "placeholder14",
           "creature_id": "wesker",
+          "customer_ids": [
+            "wesker"
+          ],
           "locked_until": "group_finished choco_main 5"
         },
         {
           "id": "placeholder15",
           "creature_id": "wesker",
+          "customer_ids": [
+            "wesker"
+          ],
           "locked_until": "group_finished choco_main 5"
         },
         {
           "id": "accelerator",
           "creature_id": "wesker",
+          "customer_ids": [
+            "wesker"
+          ],
           "locked_until": "group_finished choco_main 5"
         }
       ]

--- a/project/src/main/puzzle/combo-tracker.gd
+++ b/project/src/main/puzzle/combo-tracker.gd
@@ -86,7 +86,8 @@ func _on_PuzzleScore_after_piece_written() -> void:
 		
 		# check for combo break even if the piece continued the combo.
 		# this is necessary to cover the 'combo_break.pieces = 0' case
-		if combo_break >= Level.settings.combo_break.pieces:
+		if Level.settings.combo_break.pieces != ComboBreakRules.UNLIMITED_PIECES \
+				and combo_break >= Level.settings.combo_break.pieces:
 			break_combo()
 		else:
 			emit_signal("combo_break_changed", combo_break)

--- a/project/src/main/puzzle/level/combo-break-rules.gd
+++ b/project/src/main/puzzle/level/combo-break-rules.gd
@@ -3,6 +3,9 @@ class_name ComboBreakRules
 Things that disrupt the player's combo.
 """
 
+# a magic number for the  'pieces' combo break rule where the combo will never break
+const UNLIMITED_PIECES := 999999
+
 # by default, dropping 2 pieces breaks their combo
 var pieces := 2
 

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -122,8 +122,8 @@ func _feed_creature(fatness_pct: float, food_color: Color) -> void:
 		pass
 	else:
 		var old_fatness: float = customer.get_fatness()
-		var base_score := Creature.fatness_to_score(customer.base_fatness)
-		var target_fatness := Creature.score_to_fatness(base_score + PuzzleScore.get_creature_score())
+		var base_score := customer.fatness_to_score(customer.base_fatness)
+		var target_fatness := customer.score_to_fatness(base_score + PuzzleScore.get_creature_score())
 		customer.set_fatness(lerp(old_fatness, target_fatness, fatness_pct))
 
 	if customer.creature_id == CreatureLibrary.SENSEI_ID:

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -1,6 +1,6 @@
 extends Control
 """
-Showing the player's chef character and active customer in a restaurant scene.
+Showing the chef character and active customer in a restaurant scene.
 
 As the player drops blocks and scores points, the characters animate and react.
 """
@@ -23,10 +23,10 @@ func _ready() -> void:
 	PuzzleScore.connect("topped_out", self, "_on_PuzzleScore_topped_out")
 	PuzzleScore.connect("added_line_score", self, "_on_PuzzleScore_added_line_score")
 	
-	get_player().connect("creature_name_changed", self, "_on_Player_creature_name_changed")
+	get_chef().connect("creature_name_changed", self, "_on_Chef_creature_name_changed")
 	for customer in get_customers():
 		customer.connect("creature_name_changed", self, "_on_Customer_creature_name_changed")
-	_refresh_player_name()
+	_refresh_chef_name()
 	_refresh_customer_name()
 
 
@@ -45,8 +45,8 @@ func get_customer(creature_index: int = -1) -> Creature:
 	return $RestaurantViewport/Scene.get_customer(creature_index)
 
 
-func get_player() -> Creature:
-	return $RestaurantViewport/Scene.get_player()
+func get_chef() -> Creature:
+	return $RestaurantViewport/Scene.get_chef()
 
 
 """
@@ -95,12 +95,12 @@ func _refresh_customer_name() -> void:
 	$CustomerNametag/Panel.refresh_creature(get_customer())
 
 
-func _refresh_player_name() -> void:
-	$RestaurantNametag/Panel.refresh_creature(get_player())
+func _refresh_chef_name() -> void:
+	$RestaurantNametag/Panel.refresh_creature(get_chef())
 
 
-func _on_Player_creature_name_changed() -> void:
-	_refresh_player_name()
+func _on_Chef_creature_name_changed() -> void:
+	_refresh_chef_name()
 
 
 """
@@ -128,11 +128,11 @@ func _on_PuzzleScore_combo_changed(value: int) -> void:
 	# losing your combo doesn't erase the 'recent bonus' value, but decreases it a lot
 	_recent_bonuses = _recent_bonuses.slice(3, _recent_bonuses.size() - 1)
 	if PuzzleScore.game_active:
-		get_player().play_mood(ChatEvent.Mood.DEFAULT)
+		get_chef().play_mood(ChatEvent.Mood.DEFAULT)
 
 
 func _on_PuzzleScore_topped_out() -> void:
-	get_player().play_mood(ChatEvent.Mood.CRY0)
+	get_chef().play_mood(ChatEvent.Mood.CRY0)
 
 
 """
@@ -147,7 +147,7 @@ func _on_PuzzleScore_added_line_score(combo_score: int, box_score: int) -> void:
 		total_bonus += bonus
 	
 	if total_bonus >= 15 * 6:
-		get_player().play_mood(ChatEvent.Mood.SMILE0)
+		get_chef().play_mood(ChatEvent.Mood.SMILE0)
 
 
 """
@@ -164,7 +164,7 @@ func _on_PuzzleScore_game_ended() -> void:
 		PuzzleScore.WON:
 			mood = ChatEvent.Mood.LAUGH1
 	if mood != ChatEvent.Mood.NONE:
-		get_player().play_mood(mood)
+		get_chef().play_mood(mood)
 		_recent_bonuses = []
 
 

--- a/project/src/main/ui/chat/chat-library.gd
+++ b/project/src/main/ui/chat/chat-library.gd
@@ -6,6 +6,9 @@ Dialog is stored as a set of json resources. This class parses those json resour
 into the UI.
 """
 
+# Missing chat tree warnings are currently disabled. Many levels don't have cutscenes.
+const WARN_ON_MISSING_CHAT_TREE := false
+
 """
 Loads a conversation for the specified creature.
 
@@ -32,6 +35,8 @@ func load_chat_events_for_creature(creature: Creature, forced_level_id: String =
 
 """
 Returns the chat tree for the specified creature.
+
+Returns null if the chat tree cannot be found.
 """
 func chat_tree_for_creature_id(creature_id: String, forced_level_id: String = "") -> ChatTree:
 	var creature_def: CreatureDef = PlayerData.creature_library.get_creature_def(creature_id)
@@ -42,6 +47,8 @@ func chat_tree_for_creature_id(creature_id: String, forced_level_id: String = ""
 
 """
 Returns the chat tree for the specified creature.
+
+Returns null if the chat tree cannot be found.
 """
 func chat_tree_for_creature_def(creature_def: CreatureDef, state: Dictionary) -> ChatTree:
 	var creature_id := creature_def.creature_id
@@ -62,7 +69,8 @@ func chat_tree_for_creature_def(creature_def: CreatureDef, state: Dictionary) ->
 	elif FileUtils.file_exists(level_dialog_path):
 		chat_tree = load_chat_events_from_file(level_dialog_path)
 	else:
-		push_warning("Failed to load chat tree '%s' for creature '%s'.\nCould not find file '%s' or '%s'" % \
+		if WARN_ON_MISSING_CHAT_TREE:
+			push_warning("Failed to load chat tree '%s' for creature '%s'.\nCould not find file '%s' or '%s'" % \
 				[chosen_dialog, creature_id, creature_dialog_path, level_dialog_path])
 	
 	return chat_tree

--- a/project/src/main/ui/level-select/level-lock.gd
+++ b/project/src/main/ui/level-select/level-lock.gd
@@ -36,6 +36,10 @@ var level_id: String
 # Some levels activate dialog sequences. This field specifies which character's dialog should activate.
 var creature_id: String
 
+# Some levels involve specific customers or a specific chef.
+var customer_ids: Array
+var chef_id: String
+
 # the requirements to unlock this level
 var locked_until_type := ALWAYS_UNLOCKED
 
@@ -59,6 +63,8 @@ var groups := []
 func from_json_dict(json: Dictionary) -> void:
 	level_id = json.get("id", "")
 	creature_id = json.get("creature_id", "")
+	chef_id = json.get("chef_id", "")
+	customer_ids = json.get("customer_ids", [])
 	
 	var locked_until_string: String = json.get("locked_until", "")
 	if locked_until_string:

--- a/project/src/main/world/creature/creature-def.gd
+++ b/project/src/main/world/creature/creature-def.gd
@@ -68,6 +68,12 @@ var chat_selectors: Array
 # how fat the creature's body is; 5.0 = 5x normal size
 var min_fatness := 1.0
 
+# how fast the creature should gain weight during a puzzle. 4.0x = four times faster than normal.
+var weight_gain_scale := 1.0
+
+# how fast the creature should lose weight between puzzles. 0.25x = four times slower than normal.
+var metabolism_scale := 1.0
+
 func from_json_dict(json: Dictionary) -> void:
 	var version: String = json.get("version")
 	while version != CREATURE_DATA_VERSION:
@@ -97,6 +103,8 @@ func from_json_dict(json: Dictionary) -> void:
 	dialog = json.get("dialog", {})
 	chat_selectors = json.get("chat_selectors", [])
 	min_fatness = json.get("fatness", 1.0)
+	weight_gain_scale = json.get("weight_gain_scale", 1.0)
+	metabolism_scale = json.get("metabolism_scale", 1.0)
 
 
 func to_json_dict() -> Dictionary:
@@ -110,6 +118,8 @@ func to_json_dict() -> Dictionary:
 		"dialog": dialog,
 		"chat_selectors": chat_selectors,
 		"fatness": min_fatness,
+		"weight_gain_scale": weight_gain_scale,
+		"metabolism_scale": metabolism_scale,
 	}
 
 

--- a/project/src/main/world/creature/idle-timer.gd
+++ b/project/src/main/world/creature/idle-timer.gd
@@ -131,5 +131,5 @@ func _on_CreatureVisuals_talking_changed() -> void:
 	_update_state(true)
 
 
-func _on_CreatureVisuals_movement_mode_changed(old_mode: int, new_mode: int) -> void:
+func _on_CreatureVisuals_movement_mode_changed(_old_mode: int, _new_mode: int) -> void:
 	_update_state(true)

--- a/project/src/main/world/letter-projectile.gd
+++ b/project/src/main/world/letter-projectile.gd
@@ -22,7 +22,8 @@ var speed := BASE_SPEED
 """
 Initializes the letter's text, position and angle.
 
-A small amount of noise is applied to the position and angle so that the letters don't move in a perfectly uniform manner.
+A small amount of noise is applied to the position and angle so that the letters don't move in a perfectly uniform
+manner.
 
 Parameters:
 	'init_index': The letter's index. Used to cycle its appearance and behavior.

--- a/project/src/main/world/restaurant/RestaurantScene.tscn
+++ b/project/src/main/world/restaurant/RestaurantScene.tscn
@@ -723,7 +723,7 @@ elevation = 150
 [node name="Seat3" parent="." instance=ExtResource( 2 )]
 position = Vector2( 2380, 585 )
 
-[node name="Player" parent="." instance=ExtResource( 8 )]
+[node name="Chef" parent="." instance=ExtResource( 8 )]
 position = Vector2( 3381.23, 585.763 )
 scale = Vector2( 2.5, 2.5 )
 z_index = 20
@@ -894,6 +894,6 @@ autostart = true
 [connection signal="food_eaten" from="Creature2" to="." method="_on_CreatureVisuals_food_eaten"]
 [connection signal="dna_loaded" from="Creature3" to="DoorChime" method="_on_CreatureVisuals_dna_loaded"]
 [connection signal="food_eaten" from="Creature3" to="." method="_on_CreatureVisuals_food_eaten"]
-[connection signal="dna_loaded" from="Player" to="DoorChime" method="_on_CreatureVisuals_dna_loaded"]
-[connection signal="food_eaten" from="Player" to="." method="_on_CreatureVisuals_food_eaten"]
+[connection signal="dna_loaded" from="Chef" to="DoorChime" method="_on_CreatureVisuals_dna_loaded"]
+[connection signal="food_eaten" from="Chef" to="." method="_on_CreatureVisuals_food_eaten"]
 [connection signal="timeout" from="DoorChime/ChimeTimer" to="DoorChime" method="_on_ChimeTimer_timeout"]

--- a/project/src/main/world/restaurant/chef-camera-mover.gd
+++ b/project/src/main/world/restaurant/chef-camera-mover.gd
@@ -12,5 +12,5 @@ onready var _restaurant_scene: RestaurantScene = get_node(restaurant_scene_path)
 
 func _ready() -> void:
 	play("fat-se")
-	advance(_restaurant_scene.get_player().get_visual_fatness())
+	advance(_restaurant_scene.get_chef().get_visual_fatness())
 	stop()

--- a/project/src/main/world/restaurant/restaurant-scene.gd
+++ b/project/src/main/world/restaurant/restaurant-scene.gd
@@ -19,8 +19,9 @@ func _ready() -> void:
 		_get_seat(i).set_creature(_creatures[i])
 		_get_seat(i).refresh()
 	
-	$Player.set_creature_def(PlayerData.creature_library.player_def)
-	$Player.set_orientation(Creature.SOUTHWEST)
+	var chef_id := Level.launched_chef_id if Level.launched_chef_id else "#player#"
+	$Chef.set_creature_def(PlayerData.creature_library.get_creature_def(chef_id))
+	$Chef.set_orientation(Creature.SOUTHWEST)
 
 
 func set_current_creature_index(new_index: int) -> void:
@@ -51,8 +52,8 @@ func get_fatness(creature_index: int = -1) -> float:
 	return get_customer(creature_index).get_fatness()
 
 
-func get_player() -> Creature:
-	return $Player as Creature
+func get_chef() -> Creature:
+	return $Chef as Creature
 
 
 """


### PR DESCRIPTION
Added customer_ids property to worlds.json, so the level can have a
different character and customer. Not all levels will involve serving the person
you talk to; sometimes you'll talk to employees, or someone will want you to
cater for their friends.

Added weight_gain_scale, metabolism_scale settings. Rhonk gains weight very
slowly and sheds weight very quickly. This is for thematic reasons.

Changed combo_break rule logic so that a value of 999,999 disables combo breaks
entirely. Previously, it was technically possible for someone to break
their combo by dropping 1,000,000 pieces, if they were willing to play the
same level for a week.

combo_break 999,999 rule now includes a special case, just in case the
player actually drops 1,000,000 pieces (!?)

Scenarios can have different chefs, as specified by the optional 'chef_id'
parameter

ChatLibrary.chat_tree_for_creature_id no longer pushes a warning for
non-existent chat trees. Some levels don't have cutscenes currently, and
that's not error or warning-worthy. This can be re-enabled with a flag
later once cutscenes are added.