### PR TITLE
Minor enhancements, bug fixes and refactorings for puzzles and cutsce…

### DIFF
--- a/project/src/demo/ui/chat/chat-ui-demo.gd
+++ b/project/src/demo/ui/chat/chat-ui-demo.gd
@@ -82,7 +82,7 @@ func _input(event: InputEvent) -> void:
 func _play_chat_tree(filename: String = "") -> void:
 	if filename:
 		_filename = filename
-	var chat_tree := ChatLibrary.load_chat_events_from_file("res://assets/demo/chat/%s.json" % _filename)
+	var chat_tree := ChatLibrary.chat_tree_from_file("res://assets/demo/chat/%s.json" % _filename)
 	if _text_override:
 		chat_tree.get_event().text = _text_override
 	if _choice_override:

--- a/project/src/demo/world/CutsceneDemo.tscn
+++ b/project/src/demo/world/CutsceneDemo.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=1]
 [ext_resource path="res://src/demo/world/cutscene-demo.gd" type="Script" id=2]
 [ext_resource path="res://src/main/ui/DialogBackdrop.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/demo/world/cutscene-demo-fatness.gd" type="Script" id=4]
+[ext_resource path="res://src/demo/world/cutscene-demo-long-names.gd" type="Script" id=5]
 
 [node name="CutsceneDemo" type="Control"]
 anchor_right = 1.0
@@ -26,9 +27,17 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Fatness" type="HBoxContainer" parent="VBoxContainer"]
+[node name="LongNames" type="CheckBox" parent="VBoxContainer"]
 margin_right = 400.0
 margin_bottom = 28.0
+theme = ExtResource( 1 )
+text = "Long Names"
+script = ExtResource( 5 )
+
+[node name="Fatness" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 32.0
+margin_right = 400.0
+margin_bottom = 60.0
 script = ExtResource( 4 )
 
 [node name="CheckBox" type="CheckBox" parent="VBoxContainer/Fatness"]
@@ -61,9 +70,9 @@ text = "10.0"
 align = 1
 
 [node name="Open" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 32.0
+margin_top = 64.0
 margin_right = 400.0
-margin_bottom = 62.0
+margin_bottom = 94.0
 
 [node name="Button" type="Button" parent="VBoxContainer/Open"]
 margin_right = 52.0
@@ -86,9 +95,9 @@ __meta__ = {
 }
 
 [node name="StartButton" type="Button" parent="VBoxContainer"]
-margin_top = 66.0
+margin_top = 98.0
 margin_right = 400.0
-margin_bottom = 92.0
+margin_bottom = 124.0
 theme = ExtResource( 1 )
 text = "Start"
 __meta__ = {
@@ -131,6 +140,7 @@ margin_bottom = 58.0
 popup_exclusive = true
 window_title = "Error"
 dialog_autowrap = true
+[connection signal="toggled" from="VBoxContainer/LongNames" to="VBoxContainer/LongNames" method="_on_toggled"]
 [connection signal="pressed" from="VBoxContainer/Fatness/CheckBox" to="VBoxContainer/Fatness" method="_on_CheckBox_pressed"]
 [connection signal="value_changed" from="VBoxContainer/Fatness/HSlider" to="VBoxContainer/Fatness" method="_on_HSlider_value_changed"]
 [connection signal="pressed" from="VBoxContainer/Open/Button" to="." method="_on_OpenButton_pressed"]

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -161,6 +161,12 @@ func _calculate_food_color(box_ints: Array) -> void:
 		_food_color = Playfield.FOOD_COLORS[box_ints[1]]
 
 
+func _quit_puzzle() -> void:
+	PlayerData.creature_queue.clear()
+	Level.clear_launched_level()
+	Breadcrumb.pop_trail()
+
+
 func _on_Hud_start_button_pressed() -> void:
 	_start_puzzle()
 
@@ -170,9 +176,7 @@ func _on_Hud_settings_button_pressed() -> void:
 
 
 func _on_Hud_back_button_pressed() -> void:
-	PlayerData.creature_queue.clear()
-	Level.clear_launched_level()
-	Breadcrumb.pop_trail()
+	_quit_puzzle()
 
 
 """
@@ -218,6 +222,9 @@ func _on_PuzzleScore_game_ended() -> void:
 			if not PuzzleScore.level_performance.lost and rank_result.seconds_rank < 24: $ApplauseSound.play()
 		_:
 			if not PuzzleScore.level_performance.lost and rank_result.score_rank < 24: $ApplauseSound.play()
+	
+	if PuzzleScore.end_result() in [PuzzleScore.Result.FINISHED, PuzzleScore.Result.WON]:
+		Level.level_state = Level.LevelState.AFTER
 
 
 """
@@ -237,6 +244,4 @@ func _on_SettingsMenu_quit_pressed() -> void:
 			MusicPlayer.stop()
 			MusicPlayer.play_chill_bgm()
 			MusicPlayer.fade_in()
-		PlayerData.creature_queue.clear()
-		Level.clear_launched_level()
-		Breadcrumb.pop_trail()
+		_quit_puzzle()

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -156,12 +156,14 @@ When the game ends, the chef smiles/cries/rages based on how they did.
 func _on_PuzzleScore_game_ended() -> void:
 	var mood: int = ChatEvent.Mood.NONE
 	match PuzzleScore.end_result():
-		PuzzleScore.LOST:
+		PuzzleScore.Result.NONE:
+			pass
+		PuzzleScore.Result.LOST:
 			mood = Utils.rand_value([ChatEvent.Mood.RAGE0, ChatEvent.Mood.RAGE1,
 					ChatEvent.Mood.CRY1, ChatEvent.Mood.THINK1])
-		PuzzleScore.FINISHED:
+		PuzzleScore.Result.FINISHED:
 			mood = ChatEvent.Mood.SMILE0
-		PuzzleScore.WON:
+		PuzzleScore.Result.WON:
 			mood = ChatEvent.Mood.LAUGH1
 	if mood != ChatEvent.Mood.NONE:
 		get_chef().play_mood(mood)

--- a/project/src/main/puzzle/start-end-sfx.gd
+++ b/project/src/main/puzzle/start-end-sfx.gd
@@ -56,10 +56,11 @@ func _on_PuzzleScore_after_level_changed() -> void:
 func _on_PuzzleScore_game_ended() -> void:
 	var sound: AudioStreamPlayer
 	match PuzzleScore.end_result():
-		PuzzleScore.LOST:
+		PuzzleScore.Result.LOST:
 			sound = $GameOverSound
-		PuzzleScore.FINISHED:
+		PuzzleScore.Result.FINISHED:
 			sound = $MatchEndSound
-		PuzzleScore.WON:
+		PuzzleScore.Result.WON:
 			sound = $ExcellentSound
-	sound.play()
+	if sound:
+		sound.play()

--- a/project/src/main/ui/chat/chat-library.gd
+++ b/project/src/main/ui/chat/chat-library.gd
@@ -21,7 +21,7 @@ Parameters:
 	'forced_level_id': (Optional) The current level being chosen. If omitted, the level_id will be calculated based on
 			the first unfinished unlocked level available.
 """
-func load_chat_events_for_creature(creature: Creature, forced_level_id: String = "") -> ChatTree:
+func chat_tree_for_creature(creature: Creature, forced_level_id: String = "") -> ChatTree:
 	var state := _creature_chat_state(creature.creature_id, forced_level_id)
 	var level_id: String = state["level_id"]
 	var chat_tree := chat_tree_for_creature_def(creature.creature_def, state)
@@ -65,13 +65,13 @@ func chat_tree_for_creature_def(creature_def: CreatureDef, state: Dictionary) ->
 		chat_tree.from_json_dict(creature_def.dialog[chosen_dialog])
 		chat_tree.history_key = "dialog/%s/%s" % [creature_id, chosen_dialog]
 	elif FileUtils.file_exists(creature_dialog_path):
-		chat_tree = load_chat_events_from_file(creature_dialog_path)
+		chat_tree = chat_tree_from_file(creature_dialog_path)
 	elif FileUtils.file_exists(level_dialog_path):
-		chat_tree = load_chat_events_from_file(level_dialog_path)
+		chat_tree = chat_tree_from_file(level_dialog_path)
 	else:
 		if WARN_ON_MISSING_CHAT_TREE:
 			push_warning("Failed to load chat tree '%s' for creature '%s'.\nCould not find file '%s' or '%s'" % \
-				[chosen_dialog, creature_id, creature_dialog_path, level_dialog_path])
+					[chosen_dialog, creature_id, creature_dialog_path, level_dialog_path])
 	
 	return chat_tree
 
@@ -100,7 +100,7 @@ func chat_icon_for_creature(creature: Creature) -> int:
 """
 Loads the chat events from the specified json file.
 """
-func load_chat_events_from_file(path: String) -> ChatTree:
+func chat_tree_from_file(path: String) -> ChatTree:
 	var chat_tree := ChatTree.new()
 	var history_key := path
 	history_key = StringUtils.remove_end(history_key, ".json")

--- a/project/src/main/ui/chat/chat-tree.gd
+++ b/project/src/main/ui/chat/chat-tree.gd
@@ -24,6 +24,12 @@ class Position:
 # compatibility. This version number follows a 'ymdh' hex date format which is documented in issue #234.
 const DIALOG_DATA_VERSION := "1922"
 
+# Scene paths corresponding to different ChatTree.location_id values
+const LOCATION_SCENE_PATHS_BY_ID := {
+	"indoors": "res://src/main/world/OverworldIndoors.tscn",
+	"outdoors": "res://src/main/world/Overworld.tscn"
+}
+
 # unique key to identify this conversation in the chat history
 var history_key: String
 
@@ -108,6 +114,10 @@ func can_advance() -> bool:
 		# can advance through the current chat branch
 		can_increment = true
 	return can_increment
+
+
+func cutscene_scene_path() -> String:
+	return LOCATION_SCENE_PATHS_BY_ID.get(location_id, Global.SCENE_OVERWORLD)
 
 
 func from_json_dict(json: Dictionary) -> void:

--- a/project/src/main/ui/menu/practice-menu.gd
+++ b/project/src/main/ui/menu/practice-menu.gd
@@ -151,4 +151,6 @@ func _on_Mode_mode_changed() -> void:
 
 func _on_Start_pressed() -> void:
 	Level.set_launched_level(_get_level().id)
+	# upon completion, practice levels default to 'retry'
+	Level.keep_retrying = true
 	Level.push_level_trail()

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -223,7 +223,9 @@ func _on_ChatUi_pop_out_completed() -> void:
 		if Breadcrumb.trail.size() >= 2 and Breadcrumb.trail[1] == Global.SCENE_CUTSCENE_DEMO:
 			# don't launch the level; go back to CutsceneDemo after playing the cutscene
 			Breadcrumb.pop_trail()
-		elif Level.launched_level_id:
+		elif Level.level_state == Level.LevelState.BEFORE:
+			# pre-level dialog or pre-level cutscene finished playing
+			
 			if cutscene:
 				# remove redundant overworld cutscenes from the breadcrumb trail
 				Breadcrumb.trail.remove(0)

--- a/project/src/main/world/chattable-manager.gd
+++ b/project/src/main/world/chattable-manager.gd
@@ -102,10 +102,10 @@ Returns an array of ChatEvent objects for the dialog sequence which the player s
 func load_chat_events() -> ChatTree:
 	var chat_tree: ChatTree
 	if focused_chattable is Creature:
-		chat_tree = ChatLibrary.load_chat_events_for_creature(focused_chattable)
+		chat_tree = ChatLibrary.chat_tree_for_creature(focused_chattable)
 	elif focused_chattable.has_meta("chat_path"):
 		var chat_path: String = focused_chattable.get_meta("chat_path")
-		chat_tree = ChatLibrary.load_chat_events_from_file(chat_path)
+		chat_tree = ChatLibrary.chat_tree_from_file(chat_path)
 	else:
 		# can't look up chat events without a chat_path; return an empty array
 		push_warning("Chattable %s does not define a 'chat_path' property." % focused_chattable)

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -18,7 +18,7 @@ func _ready() -> void:
 	if Global.sensei_spawn_id:
 		move_creature_to_spawn(ChattableManager.sensei, Global.sensei_spawn_id)
 	
-	if Level.launched_level_id:
+	if Level.level_state != Level.LevelState.NONE:
 		_launch_cutscene()
 	
 	$Camera.position = ChattableManager.player.position
@@ -38,7 +38,14 @@ func _launch_cutscene() -> void:
 	ChattableManager.player.input_disabled = true
 	
 	# get the location, spawn location data
-	var chat_tree: ChatTree = ChatLibrary.load_chat_events_for_creature(cutscene_creature, Level.launched_level_id)
+	var chat_tree: ChatTree
+	match Level.level_state:
+		Level.LevelState.BEFORE:
+			chat_tree = ChatLibrary.chat_tree_for_creature(cutscene_creature, Level.launched_level_id)
+		Level.LevelState.AFTER:
+			chat_tree = ChatLibrary.chat_tree_for_after_level_cutscene()
+		_:
+			push_warning("Unexpected Level.level_state: %s" % [Level.level_state])
 	
 	if not chat_tree.spawn_locations:
 		# apply a default position to the cutscene creature


### PR DESCRIPTION
…nes.

== Enhancements

The 'Start/Back' buttons in a puzzle are now more complex. Upon clearing a
puzzle, these change to 'Retry/Continue' and the continue button is focused to
encourage the player to move on. Practice puzzles are treated differently,
and the retry button is focused instead.

Aborting a puzzle without dropping pieces is no longer recorded as a loss, but
as a 'NONE'. There is no losing sound effect and no delay for the buttons
reappearing.

CutsceneDemo has toggle for long names.

== Bug fixes

Fixed bug where levels were always pausing for 4.2 seconds after
finishing, instead of alternating between 4.2/2.2 seconds depending on the
outcome of the puzzle.

== Refactorings

Moved LOCATION_SCENE_PATHS_BY_ID from level.gd into ChatTree.

Removed PuzzleScore.LOST, PuzzleScore.WON, PuzzleScore.FINISHED
convenience constants. The new PuzzleScore.NONE constant would have been
ambiguous as a convenience constant, so I just removed them all.

Renamed some ChatLibrary methods. ChatLibrary was inconsistent about
refering to things as 'load_' or 'chat_tree' or 'chat_events' but it's now
more consistent.