### PR TITLE
New 'hello' cutscenes.

### DIFF
--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-bones-100.json
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-bones-100.json
@@ -1,0 +1,109 @@
+{
+  "version": "1922",
+  "location": {
+    "location_id": "outdoors",
+    "spawn_locations": {
+      "#player#": "restaurant-1",
+      "#sensei#": "restaurant-4",
+      "bones": "restaurant-8"
+    }
+  },
+  "": [
+    {
+      "who": "#player#",
+      "text": "Well that was./././ good!"
+    },
+    {
+      "who": "bones",
+      "text": "Just good?",
+      "mood": "awkward0"
+    },
+    {
+      "who": "#player#",
+      "text": "I mean the combos aren't working!/ It's./././ I don't think it's your fault,/ don't take it personally.",
+      "mood": "awkward0"
+    },
+    {
+      "who": "#player#",
+      "text": "You're./././ You're doing good./ ./././You're a good boy.",
+      "mood": "smile0"
+    },
+    {
+      "who": "bones",
+      "text": "Groarf.",
+      "mood": "cry0"
+    },
+    {
+      "who": "#player#",
+      "text": "C'mon,/ let's like./././ let's get drinks or something,/ blow off some steam!/ You did./././ good today.",
+      "mood": "laugh0"
+    },
+    {
+      "who": "bones",
+      "text": "Ohhh./ Actually,/ I really gotta work out tonight./ I already missed two nights this week./ I can't miss a third night.",
+      "mood": "think0",
+      "links": [
+        {
+          "you-need-exercise": "Yeah, you're looking a little chunky"
+        },
+        {
+          "yay-exercise": "That's some good discipline!"
+        },
+        {
+          "boo-exercise": "Well, can we hang out tomorrow?"
+        }
+      ]
+    }
+  ],
+  "you-need-exercise": [
+    {
+      "who": "#player#",
+      "text": "Heh yeah,/ I thought you were looking a little chunky around the middle.",
+      "mood": "think0"
+    },
+    {
+      "who": "bones",
+      "text": "W-what!?!",
+      "mood": "sweat1"
+    },
+    {
+      "who": "#player#",
+      "text": "Ha ha,/ go exercise.",
+      "mood": "laugh1"
+    },
+    {
+      "who": "bones",
+      "text": "Y-/yeah,/ bye!",
+      "mood": "sweat0"
+    }
+  ],
+  "yay-exercise": [
+    {
+      "who": "#player#",
+      "text": "Oh good for you,/ that's some good discipline!/ ./././See you around.",
+      "mood": "smile0"
+    },
+    {
+      "who": "bones",
+      "text": "Bye!",
+      "mood": "smile0"
+    }
+  ],
+  "boo-exercise": [
+    {
+      "who": "#player#",
+      "text": "How about tomorrow then?/ ./././Can we hang out tomorrow?",
+      "mood": "sweat0"
+    },
+    {
+      "who": "bones",
+      "text": "Uhhh,/ I gotta go./ See you around!",
+      "meta": "creature-exit bones"
+    },
+    {
+      "who": "#player#",
+      "text": "Oh!/ Goodbye!",
+      "mood": "awkward0"
+    }
+  ]
+}

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-shirts-000.json
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-shirts-000.json
@@ -1,0 +1,55 @@
+{
+  "version": "1922",
+  "location": {
+    "location_id": "indoors",
+    "spawn_locations": {
+      "#player#": "entrance-10",
+      "#sensei#": "entrance-7",
+      "shirts": "entrance-2"
+    }
+  },
+  "": [
+    {
+      "who": "shirts",
+      "text": "Oh hey what's up./ I heard you guys came the other day when I wasn't here./ So did I miss like anything./././ important?"
+    },
+    {
+      "who": "#sensei#",
+      "text": "Ahh, nothing important./ We're still trying to figure out why this location isn't attracting more customers."
+    },
+    {
+      "who": "#player#",
+      "text": "Yeah,/ Skins and Bones showed us their cooking skills. ./././They seem nice!",
+      "mood": "smile0"
+    },
+    {
+      "who": "shirts",
+      "text": "Hah./ Yeah they DO seem nice.",
+      "mood": "awkward1"
+    },
+    {
+      "who": "#player#",
+      "text": "Yeah!/ ./././Umm,/ wait what?/ ./././I feel like there's something you're not telling me.",
+      "mood": "think0"
+    },
+    {
+      "who": "shirts",
+      "text": "Hah hah./ Yeah that's alright,/ you'll figure it out.",
+      "mood": "sigh0"
+    },
+    {
+      "who": "#player#",
+      "text": "Umm... Alright. Sounds fun. Anywaaay...",
+      "mood": "awkward0"
+    },
+    {
+      "who": "#player#",
+      "text": "Why don't you show us your skills in the kitchen!/ Let's focus on some combos today,/ if you know about those."
+    },
+    {
+      "who": "shirts",
+      "text": "Yeah yeah!/ Combos./ Sure thing.",
+      "mood": "smile0"
+    }
+  ]
+}

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-skins-100.json
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-skins-100.json
@@ -1,0 +1,46 @@
+{
+  "version": "1922",
+  "location": {
+    "location_id": "indoors",
+    "spawn_locations": {
+      "#player#": "kitchen-5",
+      "#sensei#": "kitchen-3",
+      "skins": "kitchen-7"
+    }
+  },
+  "": [
+    {
+      "who": "#sensei#",
+      "text": "Hmm./././ just like before.",
+      "mood": "think0"
+    },
+    {
+      "who": "#player#",
+      "text": "Yeah...",
+      "mood": "awkward0"
+    },
+    {
+      "who": "skins",
+      "text": "Mowr./././ Any tips?",
+      "mood": "sweat0"
+    },
+    {
+      "who": "#player#",
+      "text": "I don't know,/ I'm kind of at a loss on this one./ #sensei#?/ Why isn't it working?"
+    },
+    {
+      "who": "#player#",
+      "text": "Was it their technique or./././ were they too slow?/ They didn't seem slow to me.",
+      "mood": "think0"
+    },
+    {
+      "who": "#sensei#",
+      "text": "Ahh well./ Their cooking skills are improving,/ so./././ Maybe it's just a matter of time."
+    },
+    {
+      "who": "#sensei#",
+      "text": "The customers will come back,/ and next time they'll stay longer! So,/ let's be patient.",
+      "mood": "yes0"
+    }
+  ]
+}

--- a/project/assets/main/puzzle/worlds.json
+++ b/project/assets/main/puzzle/worlds.json
@@ -44,17 +44,23 @@
         {
           "id": "marsh/hello_bones",
           "groups": "marsh/hello",
-          "locked_until": "level_finished marsh/hello_everyone"
+          "locked_until": "level_finished marsh/hello_everyone",
+          "creature_id": "bones",
+          "chef_id": "bones"
         },
         {
           "id": "marsh/hello_shirts",
           "groups": "marsh/hello",
-          "locked_until": "level_finished marsh/hello_everyone"
+          "locked_until": "level_finished marsh/hello_everyone",
+          "creature_id": "shirts",
+          "chef_id": "shirts"
         },
         {
           "id": "marsh/hello_skins",
           "groups": "marsh/hello",
-          "locked_until": "level_finished marsh/hello_everyone"
+          "locked_until": "level_finished marsh/hello_everyone",
+          "creature_id": "skins",
+          "chef_id": "skins"
         },
         {
           "id": "marsh/pulling_for_everyone",

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -191,7 +191,7 @@ func _focused_chattable_chat_tree() -> ChatTree:
 	
 	if not _chat_tree_cache.has(focused_chattable):
 		var chat_tree := ChattableManager.load_chat_events()
-		if focused_chattable is Creature:
+		if chat_tree and focused_chattable is Creature:
 			if chat_tree.meta.get("filler", false):
 				PlayerData.chat_history.increment_filler_count(focused_chattable.creature_id)
 			if chat_tree.meta.get("notable", false):
@@ -246,6 +246,10 @@ func _on_ChatUi_chat_event_played(chat_event: ChatEvent) -> void:
 			var creature_id := StringUtils.substring_after(meta_item, "creature-enter ")
 			var entering_creature := ChattableManager.get_creature_by_id(creature_id)
 			entering_creature.fade_in()
+		if meta_item.begins_with("creature-exit "):
+			var creature_id := StringUtils.substring_after(meta_item, "creature-exit ")
+			var exiting_creature := ChattableManager.get_creature_by_id(creature_id)
+			exiting_creature.fade_out()
 	
 	# update the chatter's mood
 	var chatter := ChattableManager.get_creature_by_id(chat_event.who)
@@ -300,9 +304,13 @@ func _on_TalkButton_pressed() -> void:
 		# launch a cutscene if necessary
 		pushed_cutscene_trail = Level.push_cutscene_trail()
 	
-	if not pushed_cutscene_trail:
+	if chat_tree and not pushed_cutscene_trail:
 		# if no cutscene was launched, start a chat
 		start_chat(chat_tree, ChattableManager.focused_chattable)
+	
+	if not chat_tree and not pushed_cutscene_trail:
+		# if no chat was launched, start a level
+		Level.push_level_trail()
 
 
 func _on_CellPhoneMenu_show() -> void:

--- a/project/src/main/world/OverworldIndoors.tscn
+++ b/project/src/main/world/OverworldIndoors.tscn
@@ -216,6 +216,24 @@ position = Vector2( 1368, 155 )
 
 [node name="Spawns" type="Node2D" parent="World"]
 
+[node name="SpawnEntrance2" parent="World/Spawns" instance=ExtResource( 6 )]
+position = Vector2( 342.245, 52.3916 )
+orientation = 1
+id = "entrance-2"
+
+[node name="SpawnEntrance5" parent="World/Spawns" instance=ExtResource( 6 )]
+position = Vector2( 394.38, 152.458 )
+orientation = 1
+id = "entrance-5"
+
+[node name="SpawnEntrance7" parent="World/Spawns" instance=ExtResource( 6 )]
+position = Vector2( 126.975, 170.117 )
+id = "entrance-7"
+
+[node name="SpawnEntrance10" parent="World/Spawns" instance=ExtResource( 6 )]
+position = Vector2( 179.111, 52.3916 )
+id = "entrance-10"
+
 [node name="SpawnKitchen1" parent="World/Spawns" instance=ExtResource( 6 )]
 position = Vector2( 1814.38, 40.6189 )
 orientation = 1

--- a/project/src/main/world/OverworldObstacles.tscn
+++ b/project/src/main/world/OverworldObstacles.tscn
@@ -185,11 +185,29 @@ chat_path = "res://assets/main/dialog/marsh-crystal.json"
 
 [node name="ChatIconHook" type="RemoteTransform2D" parent="MarshCrystal"]
 
-[node name="Spawn1" parent="." instance=ExtResource( 16 )]
+[node name="SpawnRestaurant1" parent="." instance=ExtResource( 16 )]
+position = Vector2( 1288.39, 655.857 )
+orientation = 1
+id = "restaurant-1"
+
+[node name="SpawnRestaurant4" parent="." instance=ExtResource( 16 )]
+position = Vector2( 1337.78, 744.532 )
+orientation = 1
+id = "restaurant-4"
+
+[node name="SpawnRestaurant8" parent="." instance=ExtResource( 16 )]
+position = Vector2( 1111.04, 758.001 )
+id = "restaurant-8"
+
+[node name="SpawnRestaurant11" parent="." instance=ExtResource( 16 )]
+position = Vector2( 1146.96, 656.98 )
+id = "restaurant-11"
+
+[node name="SpawnRestaurantPlayer" parent="." instance=ExtResource( 16 )]
 position = Vector2( 1019, 648 )
 orientation = 1
 id = "restaurant-player"
 
-[node name="Spawn2" parent="." instance=ExtResource( 16 )]
+[node name="SpawnRestaurantSensei" parent="." instance=ExtResource( 16 )]
 position = Vector2( 1192, 676 )
 id = "restaurant-sensei"

--- a/project/src/main/world/chattable-manager.gd
+++ b/project/src/main/world/chattable-manager.gd
@@ -147,8 +147,12 @@ anything.
 func set_focus_enabled(new_focus_enabled: bool) -> void:
 	_focus_enabled = new_focus_enabled
 	
+	var old_focused_chattable := focused_chattable
 	if not _focus_enabled:
 		set_focused_chattable(null)
+	
+	if old_focused_chattable == focused_chattable:
+		emit_signal("focus_changed")
 
 
 """

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -28,9 +28,11 @@ func _ready() -> void:
 func _launch_cutscene() -> void:
 	_overworld_ui.cutscene = true
 	
-	# remove all of the creatures from the overworld
+	# remove all of the creatures from the overworld except for the player and sensei
 	for node in get_tree().get_nodes_in_group("creatures"):
 		if node != ChattableManager.player and node != ChattableManager.sensei:
+			# remove it immediately so we don't find it in the tree later
+			node.get_parent().remove_child(node)
 			node.queue_free()
 	
 	# add the cutscene creature


### PR DESCRIPTION
Added 'creature-exit' cutscene metadata

Cutscene logic removes creatures from the tree to avoid a scenario
where a creature like 'bones' in a cutscene had queue_free() called, and
then the freed creature was manipulated in the cutscene.

Fixed bug with overworld camera where it would recalculate the bounding
box every frame, because the new enlarged bounding box didn't match the
calculated box.

Fixed bugs with intro-less scenarios, visible cutscene bubbles

'set_focus_enabled' emits signals appropriately

Removed orphaned import files.

Fixed crash/name when talking to crystal.