### PR TITLE
Added creature stress test. FPS displayed as integer.

### DIFF
--- a/project/src/main/ui/CreatureStressTest.tscn
+++ b/project/src/main/ui/CreatureStressTest.tscn
@@ -1,0 +1,105 @@
+[gd_scene load_steps=6 format=2]
+
+[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=1]
+[ext_resource path="res://src/main/ui/creature-stress-test.gd" type="Script" id=2]
+[ext_resource path="res://src/main/ui/FpsLabel.tscn" type="PackedScene" id=3]
+[ext_resource path="res://src/main/ui/menu/theme/h2.theme" type="Theme" id=4]
+[ext_resource path="res://src/main/ui/menu/theme/h3.theme" type="Theme" id=5]
+
+[node name="CreatureStressTest" type="Node"]
+script = ExtResource( 2 )
+CreaturePackedScene = ExtResource( 1 )
+
+[node name="Creatures" type="Node2D" parent="."]
+
+[node name="Ui" type="Control" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Control" type="VBoxContainer" parent="Ui"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -75.0
+margin_top = -148.0
+margin_right = 75.0
+margin_bottom = 247.0
+rect_min_size = Vector2( 150, 200 )
+custom_constants/separation = 10
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="PlusTen" type="Button" parent="Ui/Control"]
+margin_right = 150.0
+margin_bottom = 51.0
+theme = ExtResource( 4 )
+text = "+10"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="PlusOne" type="Button" parent="Ui/Control"]
+margin_top = 61.0
+margin_right = 150.0
+margin_bottom = 112.0
+theme = ExtResource( 4 )
+text = "+1"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="CreatureCount" type="Label" parent="Ui/Control"]
+margin_top = 122.0
+margin_right = 150.0
+margin_bottom = 167.0
+theme = ExtResource( 4 )
+text = "2"
+align = 1
+
+[node name="MinusOne" type="Button" parent="Ui/Control"]
+margin_top = 177.0
+margin_right = 150.0
+margin_bottom = 228.0
+theme = ExtResource( 4 )
+text = "-1"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="MinusTen" type="Button" parent="Ui/Control"]
+margin_top = 238.0
+margin_right = 150.0
+margin_bottom = 289.0
+theme = ExtResource( 4 )
+text = "-10"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Spacer" type="Control" parent="Ui/Control"]
+margin_top = 299.0
+margin_right = 150.0
+margin_bottom = 349.0
+rect_min_size = Vector2( 0, 50 )
+
+[node name="QuitButton" type="Button" parent="Ui/Control"]
+margin_top = 359.0
+margin_right = 150.0
+margin_bottom = 395.0
+theme = ExtResource( 5 )
+text = "Quit"
+
+[node name="FpsLabel" parent="Ui" instance=ExtResource( 3 )]
+margin_top = -30.0
+margin_right = -10.0002
+margin_bottom = 0.0
+[connection signal="pressed" from="Ui/Control/PlusTen" to="." method="_on_CreatureButton_pressed" binds= [ 10 ]]
+[connection signal="pressed" from="Ui/Control/PlusOne" to="." method="_on_CreatureButton_pressed" binds= [ 1 ]]
+[connection signal="pressed" from="Ui/Control/MinusOne" to="." method="_on_CreatureButton_pressed" binds= [ -1 ]]
+[connection signal="pressed" from="Ui/Control/MinusTen" to="." method="_on_CreatureButton_pressed" binds= [ -10 ]]
+[connection signal="pressed" from="Ui/Control/QuitButton" to="." method="_on_QuitButton_pressed"]

--- a/project/src/main/ui/creature-stress-test.gd
+++ b/project/src/main/ui/creature-stress-test.gd
@@ -1,0 +1,94 @@
+extends Node
+"""
+Shows the impact of creatures on FPS.
+
+As of February 2021, adding more creatures results in a massive performance performance degradation. This stress test
+lets us objectively measure how far performance degrades with each new creature, to quantify bottlenecks and potential
+performance improvements.
+"""
+
+const INITIAL_CREATURE_COUNT := 5
+
+# We use a predictable set of creature IDs so that unusual creatures will not impact the results
+const CREATURE_IDS := [
+	"alexander", "beats", "dingold", "goris", "logana", "pipedro",
+	"rhinosaur", "snorz", "squawkapus", "stunker", "terpion", "vile",
+]
+
+export (PackedScene) var CreaturePackedScene: PackedScene
+
+func _ready() -> void:
+	# We use a predictable fatness value so that the player's performance in the game will not impact the results
+	PlayerData.creature_library.forced_fatness = 1.0
+	
+	_add_creatures(INITIAL_CREATURE_COUNT)
+	_refresh_creature_count()
+
+
+"""
+Adds creatures to the scene.
+
+The creatures are selected sequentially using a predetermined set of creature IDs.
+
+Parameters:
+	'count': The number of creatures to add.
+"""
+func _add_creatures(count: int) -> void:
+	for _i in range(0, count):
+		var creature: Creature = CreaturePackedScene.instance()
+		
+		var creature_index := $Creatures.get_child_count()
+		creature.creature_id = CREATURE_IDS[creature_index % CREATURE_IDS.size()]
+		creature.orientation = Utils.rand_value([CreatureVisuals.SOUTHWEST, CreatureVisuals.SOUTHEAST])
+		
+		var target_rect := Rect2(0, 0, 1024, 768).grow(-100)
+		creature.position.x = rand_range(target_rect.position.x, target_rect.end.x)
+		creature.position.y = rand_range(target_rect.position.y, target_rect.end.y)
+		
+		$Creatures.add_child(creature)
+		_refresh_creature_count()
+
+
+"""
+Removes creatures from the scene.
+
+The creatures are removed in FILO order.
+
+Parameters:
+	'count': The number of creatures to add.
+"""
+func _remove_creatures(count: int) -> void:
+	for _i in range(0, count):
+		if $Creatures.get_child_count() == 0:
+			break
+		
+		var creature: Creature = $Creatures.get_children().back()
+		creature.queue_free()
+		$Creatures.remove_child(creature)
+		_refresh_creature_count()
+
+
+"""
+Updates the 'creature count' label.
+"""
+func _refresh_creature_count() -> void:
+	$Ui/Control/CreatureCount.text = str($Creatures.get_child_count())
+
+
+"""
+When the player presses a button, we add or remove creatures from the scene.
+
+Parameters:
+	'creature_delta': The number of creatures to add if positive, or to remove if negative.
+"""
+func _on_CreatureButton_pressed(creature_delta: int) -> void:
+	if creature_delta > 0:
+		_add_creatures(creature_delta)
+	elif creature_delta < 0:
+		_remove_creatures(-creature_delta)
+
+
+func _on_QuitButton_pressed() -> void:
+	# Restore 'forced_fatness' to its original value
+	PlayerData.creature_library.forced_fatness = 0.0
+	Breadcrumb.pop_trail()

--- a/project/src/main/ui/fps-label.gd
+++ b/project/src/main/ui/fps-label.gd
@@ -4,7 +4,7 @@ Renders the current frames-per-second to the screen, '60.00 fps'
 """
 
 func _process(_delta: float) -> void:
-	text = "%.2f fps" % Engine.get_frames_per_second()
+	text = "%d fps" % Engine.get_frames_per_second()
 
 
 func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDetector) -> void:

--- a/project/src/main/ui/menu/MainMenu.tscn
+++ b/project/src/main/ui/menu/MainMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://src/main/ui/menu/main-menu.gd" type="Script" id=1]
 [ext_resource path="res://src/main/ui/menu/theme/h3.theme" type="Theme" id=2]
@@ -10,6 +10,8 @@
 [ext_resource path="res://src/main/ui/SettingsMenu.tscn" type="PackedScene" id=8]
 [ext_resource path="res://src/main/ui/menu/theme/h2-font-outline.tres" type="DynamicFont" id=9]
 [ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=10]
+[ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=11]
+[ext_resource path="res://src/main/ui/menu/main-menu-debug.gd" type="Script" id=12]
 
 [sub_resource type="DynamicFont" id=1]
 size = 72
@@ -70,7 +72,7 @@ custom_fonts/font = ExtResource( 9 )
 text = "Play"
 align = 1
 
-[node name="2d" type="Button" parent="DropPanel/Play"]
+[node name="Story" type="Button" parent="DropPanel/Play"]
 margin_left = 134.0
 margin_top = 72.0
 margin_right = 327.0
@@ -150,16 +152,41 @@ margin_top = -100.0
 alignment = 1
 quit_on_cancel = false
 
+[node name="Debug" type="VBoxContainer" parent="DropPanel"]
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -136.0
+margin_top = -48.0
+margin_right = -19.9999
+margin_bottom = -20.0
+script = ExtResource( 12 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="StressTest" type="Button" parent="DropPanel/Debug"]
+margin_right = 116.0
+margin_bottom = 28.0
+rect_min_size = Vector2( 116, 28 )
+theme = ExtResource( 11 )
+text = "Stress Test"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
 [node name="VersionLabel" parent="." instance=ExtResource( 7 )]
 
 [node name="SettingsMenu" parent="." instance=ExtResource( 8 )]
 
 [node name="MusicPopup" parent="." instance=ExtResource( 10 )]
-[connection signal="pressed" from="DropPanel/Play/2d" to="." method="_on_PlayStory_pressed"]
+[connection signal="pressed" from="DropPanel/Play/Story" to="." method="_on_PlayStory_pressed"]
 [connection signal="pressed" from="DropPanel/Play/Practice" to="." method="_on_PlayPractice_pressed"]
 [connection signal="pressed" from="DropPanel/Play/Tutorials" to="." method="_on_Tutorials_pressed"]
 [connection signal="pressed" from="DropPanel/Create/Levels" to="." method="_on_CreateLevels_pressed"]
 [connection signal="pressed" from="DropPanel/Create/Creatures" to="." method="_on_CreateCreatures_pressed"]
 [connection signal="quit_pressed" from="DropPanel/System" to="." method="_on_System_quit_pressed"]
 [connection signal="settings_pressed" from="DropPanel/System" to="SettingsMenu" method="_on_Settings_pressed"]
+[connection signal="pressed" from="DropPanel/Debug/StressTest" to="DropPanel/Debug" method="_on_StressTest_pressed"]
 [connection signal="quit_pressed" from="SettingsMenu" to="DropPanel/System" method="_on_Quit_pressed"]

--- a/project/src/main/ui/menu/main-menu-debug.gd
+++ b/project/src/main/ui/menu/main-menu-debug.gd
@@ -1,0 +1,14 @@
+extends VBoxContainer
+"""
+A panel shown on the main menu containing developer tools.
+
+The panel only appears in debug builds of the game.
+"""
+
+func _ready() -> void:
+	# only show debug panel for debug builds
+	visible = OS.is_debug_build()
+
+
+func _on_StressTest_pressed() -> void:
+	Breadcrumb.push_trail("res://src/main/ui/CreatureStressTest.tscn")


### PR DESCRIPTION
Added creature stress test which allows developers to measure the
performance impact of adding more and more creatures. This stress test
can be launched from the main menu in debug builds.

get_frames_per_second returns a float, but it is always an integer
value. It was unnecessary to always show '60.00 fps' so now this is
instead shown as '60'