### PR TITLE
Refactorings: preroll/postroll, StringUtils functions.

### DIFF
--- a/project/src/demo/localization-demo.gd
+++ b/project/src/demo/localization-demo.gd
@@ -47,11 +47,11 @@ func _extract_localizables_from_levels() -> void:
 		_localizables.append(level_settings.description)
 		
 		# extract level's cutscene dialog as localizables
-		if FileUtils.file_exists(ChatLibrary.before_level_cutscene_path(level_id)):
-			var chat_tree := ChatLibrary.chat_tree_from_file(ChatLibrary.before_level_cutscene_path(level_id))
+		if ChatLibrary.has_preroll(level_id):
+			var chat_tree := ChatLibrary.chat_tree_for_preroll(level_id)
 			_extract_localizables_from_chat_tree(chat_tree)
-		if FileUtils.file_exists(ChatLibrary.after_level_cutscene_path(level_id)):
-			var chat_tree := ChatLibrary.chat_tree_from_file(ChatLibrary.after_level_cutscene_path(level_id))
+		if ChatLibrary.has_postroll(level_id):
+			var chat_tree := ChatLibrary.chat_tree_for_postroll(level_id)
 			_extract_localizables_from_chat_tree(chat_tree)
 
 

--- a/project/src/demo/world/cutscene-demo.gd
+++ b/project/src/demo/world/cutscene-demo.gd
@@ -20,7 +20,7 @@ func _on_StartButton_pressed() -> void:
 	elif cutscene_index >= 100 and cutscene_index < 200:
 		# launch 'after level' cutscene
 		Level.level_state = Level.LevelState.AFTER
-		var chat_tree := ChatLibrary.chat_tree_for_after_level_cutscene()
+		var chat_tree := ChatLibrary.chat_tree_for_postroll(Level.launched_level_id)
 		Breadcrumb.push_trail(chat_tree.cutscene_scene_path())
 	else:
 		push_warning("Invalid cutscene path: %s" % [$VBoxContainer/Open/LineEdit.text])

--- a/project/src/main/editor/creature/creature-editor-nametags.gd
+++ b/project/src/main/editor/creature/creature-editor-nametags.gd
@@ -30,7 +30,7 @@ func _ready() -> void:
 When a creature is renamed, the corresponding nametag changes its text and position.
 """
 func _on_Creature_creature_name_changed(creature: Creature, nametag: Panel) -> void:
-	nametag.set_nametag_text(creature.creature_name if creature.creature_name else "(unnamed)")
+	nametag.set_nametag_text(StringUtils.default_if_empty(creature.creature_name, "(unnamed)"))
 	nametag.rect_scale = Vector2(0.6, 0.6) if creature.has_meta("main_creature") else Vector2(0.4, 0.4)
 	nametag.set_bg_color(NAMETAG_HIGHLIGHT if creature.has_meta("main_creature") else NAMETAG_LOWLIGHT)
 	

--- a/project/src/main/old-save.gd
+++ b/project/src/main/old-save.gd
@@ -150,11 +150,11 @@ func _convert_199c(json_save_items: Array) -> Array:
 func _convert_199c_level_id(value: String) -> String:
 	var new_value := value
 	if value.begins_with("tutorial_"):
-		new_value = "tutorial/%s" % [StringUtils.remove_start(value, "tutorial_")]
+		new_value = "tutorial/%s" % [value.trim_prefix("tutorial_")]
 	elif value == "oh_my":
 		new_value = "tutorial/%s" % [value]
 	elif value.begins_with("rank_"):
-		new_value = "rank/%s" % [StringUtils.remove_start(value, "rank_")]
+		new_value = "rank/%s" % [value.trim_prefix("rank_")]
 	elif value.begins_with("sandbox_") \
 			or value.begins_with("sprint_") \
 			or value.begins_with("survival_") \

--- a/project/src/main/puzzle/level/piece-type-rules.gd
+++ b/project/src/main/puzzle/level/piece-type-rules.gd
@@ -31,5 +31,5 @@ func from_json_string_array(json: Array) -> void:
 		elif types_by_json_string.has(json_string):
 			types.append(types_by_json_string[json_string])
 		elif json_string.begins_with("start_") \
-				and types_by_json_string.has(StringUtils.remove_start(json_string, "start_")):
-			start_types.append(types_by_json_string[StringUtils.remove_start(json_string, "start_")])
+				and types_by_json_string.has(json_string.trim_prefix("start_")):
+			start_types.append(types_by_json_string[json_string.trim_prefix("start_")])

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -162,8 +162,8 @@ func _calculate_food_color(box_ints: Array) -> void:
 
 
 func _quit_puzzle() -> void:
-	if Level.level_state == Level.LevelState.AFTER and ChatLibrary.chat_tree_for_after_level_cutscene():
-		var chat_tree := ChatLibrary.chat_tree_for_after_level_cutscene()
+	if Level.level_state == Level.LevelState.AFTER and ChatLibrary.has_postroll(Level.launched_level_id):
+		var chat_tree := ChatLibrary.chat_tree_for_postroll(Level.launched_level_id)
 		# insert cutscene into breadcrumb trail so it will show up after we pop the trail
 		Breadcrumb.trail.insert(1, chat_tree.cutscene_scene_path())
 	else:

--- a/project/src/main/string-utils.gd
+++ b/project/src/main/string-utils.gd
@@ -158,20 +158,7 @@ static func capitalize_words(string: String) -> String:
 Removes a substring only if it is at the beginning of a source string, otherwise returns the source string.
 """
 static func remove_start(string: String, remove: String) -> String:
-	var result := string
-	if string.begins_with(remove):
-		result = string.substr(remove.length())
-	return result
-
-
-"""
-Removes a substring only if it is at the end of a source string, otherwise returns the source string.
-"""
-static func remove_end(string: String, remove: String) -> String:
-	var result := string
-	if string.ends_with(remove):
-		result = string.substr(0, string.length() - remove.length())
-	return result
+	return string.trim_prefix(remove)
 
 
 """
@@ -189,3 +176,10 @@ static func english_number(i: int) -> String:
 			"six", "seven", "eight", "nine", "ten", \
 			"eleven", "twelve", "thirteen", "fourteen", "fifteen", \
 			"sixteen", "seventeen", "eighteen", "nineteen", "twenty"][i];
+
+
+"""
+Returns either the passed in String, or if the String is empty or null, the value of 'default'.
+"""
+static func default_if_empty(s: String, default: String) -> String:
+	return s if s else default

--- a/project/src/main/ui/level-select/level-select-button.gd
+++ b/project/src/main/ui/level-select/level-select-button.gd
@@ -98,7 +98,7 @@ func _refresh_appearance() -> void:
 		LevelSize.MEDIUM: rect_min_size.y = level_column_width * 0.75 + VERTICAL_SPACING * 0.5
 		LevelSize.LONG: rect_min_size.y = level_column_width + VERTICAL_SPACING
 	
-	$Label.text = level_title if level_title else "-"
+	$Label.text = StringUtils.default_if_empty(level_title, "-")
 	
 	var new_bg_color: Color = get("custom_styles/normal").bg_color
 	match $Label.text.hash() % 5:

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -43,9 +43,9 @@ func _launch_cutscene() -> void:
 	var chat_tree: ChatTree
 	match Level.level_state:
 		Level.LevelState.BEFORE:
-			chat_tree = ChatLibrary.chat_tree_for_creature(cutscene_creature, Level.launched_level_id)
+			chat_tree = ChatLibrary.chat_tree_for_preroll(Level.launched_level_id)
 		Level.LevelState.AFTER:
-			chat_tree = ChatLibrary.chat_tree_for_after_level_cutscene()
+			chat_tree = ChatLibrary.chat_tree_for_postroll(Level.launched_level_id)
 		_:
 			push_warning("Unexpected Level.level_state: %s" % [Level.level_state])
 	

--- a/project/src/main/world/restaurant/restaurant-scene.gd
+++ b/project/src/main/world/restaurant/restaurant-scene.gd
@@ -19,7 +19,7 @@ func _ready() -> void:
 		_get_seat(i).set_creature(_creatures[i])
 		_get_seat(i).refresh()
 	
-	var chef_id := Level.launched_chef_id if Level.launched_chef_id else CreatureLibrary.PLAYER_ID
+	var chef_id := StringUtils.default_if_empty(Level.launched_chef_id, CreatureLibrary.PLAYER_ID)
 	$Chef.set_creature_def(PlayerData.creature_library.get_creature_def(chef_id))
 	$Chef.set_orientation(Creature.SOUTHWEST)
 

--- a/project/src/test/test-string-utils.gd
+++ b/project/src/test/test-string-utils.gd
@@ -134,18 +134,6 @@ func test_capitalize() -> void:
 	assert_eq(StringUtils.capitalize_words("HOT DOG"), "Hot Dog")
 
 
-func test_remove_start() -> void:
-	assert_eq(StringUtils.remove_start("www.domain.com", "www."), "domain.com")
-	assert_eq(StringUtils.remove_start("domain.com", "www."), "domain.com")
-	assert_eq(StringUtils.remove_start("www.domain.com", "domain"), "www.domain.com")
-
-
-func test_remove_end() -> void:
-	assert_eq(StringUtils.remove_end("www.domain.com", ".com"), "www.domain")
-	assert_eq(StringUtils.remove_end("www.domain", ".com"), "www.domain")
-	assert_eq(StringUtils.remove_end("www.domain.com", "domain"), "www.domain.com")
-
-
 func test_has_letter() -> void:
 	assert_eq(StringUtils.has_letter("roof action"), true)
 	assert_eq(StringUtils.has_letter("ROOF ACTION"), true)


### PR DESCRIPTION
ChatLibrary now exposes 'has_preroll', 'has_postroll' functions. This
prevents redundant warnings and avoids the need for a warning toggle.

Extracted constants for preroll/postroll cutscene suffixes.

Added StringUtils.default_if_empty function. Replaced StringUtils.remove_start,
StringUtils.remove_end with Godot's trim_prefix, trim_suffix functions.