### PR TITLE
Extracted new Creature.rename() function. Split up main menu script.

### DIFF
--- a/project/src/main/creature-library.gd
+++ b/project/src/main/creature-library.gd
@@ -86,8 +86,7 @@ func reset() -> void:
 	
 	# default player appearance and name
 	var new_player_def := CreatureDef.new()
-	new_player_def.creature_name = CreatureDef.DEFAULT_NAME
-	new_player_def.creature_short_name = NameUtils.sanitize_short_name(new_player_def.creature_name)
+	new_player_def.rename(CreatureDef.DEFAULT_NAME)
 	new_player_def.dna = CreatureDef.DEFAULT_DNA.duplicate()
 	new_player_def.min_fatness = 1.0
 	new_player_def.chat_theme_def = CreatureDef.DEFAULT_CHAT_THEME_DEF.duplicate()

--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -112,9 +112,7 @@ Parameters:
 func _mutate_allele(creature: Creature, dna: Dictionary, new_palette: Dictionary, property: String) -> void:
 	match property:
 		"name":
-			creature.creature_name = _name_generator.generate_name()
-			creature.creature_short_name = NameUtils.sanitize_short_name(creature.creature_name)
-			creature.creature_id = NameUtils.short_name_to_id(creature.creature_short_name)
+			creature.rename(_name_generator.generate_name())
 		"fatness":
 			var new_fatnesses := Global.FATNESSES.duplicate()
 			while new_fatnesses.has(creature.get_visual_fatness()):
@@ -255,9 +253,7 @@ func _tweak_creature(creature: Creature, allele: String, color_mode: int) -> voi
 	
 	match allele:
 		"name":
-			creature.creature_name = _name_generator.generate_name()
-			creature.creature_short_name = NameUtils.sanitize_short_name(creature.creature_name)
-			creature.creature_id = NameUtils.short_name_to_id(creature.creature_short_name)
+			creature.rename(_name_generator.generate_name())
 		"fatness":
 			var new_fatnesses := Global.FATNESSES.duplicate()
 			while new_fatnesses.has(creature.get_visual_fatness()):

--- a/project/src/main/editor/creature/tweak-name-row.gd
+++ b/project/src/main/editor/creature/tweak-name-row.gd
@@ -18,10 +18,7 @@ Update the creature's name and short name.
 """
 func _finish_name_edit(text: String) -> void:
 	var new_name: String = NameUtils.sanitize_name(text)
-	var creature: Creature = _creature_editor.center_creature
-	creature.creature_name = new_name
-	creature.creature_short_name = NameUtils.sanitize_short_name(new_name)
-	creature.creature_id = NameUtils.short_name_to_id(creature.creature_short_name)
+	_creature_editor.center_creature.rename(new_name)
 	_refresh_name_ui()
 
 
@@ -57,13 +54,8 @@ We don't update if the user's typed an invalid name (e.g 'Tom ') because otherwi
 appending punctuation/spaces, as the text box is constantly updated.
 """
 func _on_Edit_text_changed(text: String) -> void:
-	var new_name: String = NameUtils.sanitize_name(text)
-	if new_name == text:
-		var creature := _creature_editor.center_creature
-		creature.creature_name = new_name
-		creature.creature_short_name = NameUtils.sanitize_short_name(new_name)
-		creature.creature_id = NameUtils.short_name_to_id(creature.creature_short_name)
-		_refresh_name_ui()
+	if text == NameUtils.sanitize_name(text):
+		_finish_name_edit(text)
 
 
 func _on_Edit_text_entered(text: String) -> void:
@@ -81,12 +73,8 @@ We don't update if the user's typed an invalid name (e.g 'Tom ') because otherwi
 appending punctuation/spaces, as the text box is constantly updated.
 """
 func _on_ShortName_text_changed(text: String) -> void:
-	var new_name: String = NameUtils.sanitize_short_name(text)
-	if new_name == text:
-		var creature := _creature_editor.center_creature
-		creature.creature_short_name = new_name
-		creature.creature_id = NameUtils.short_name_to_id(creature.creature_short_name)
-		_refresh_name_ui()
+	if text == NameUtils.sanitize_short_name(text):
+		_finish_short_name_edit(text)
 
 
 func _on_ShortName_text_entered(text: String) -> void:

--- a/project/src/main/ui/menu/MainMenu.tscn
+++ b/project/src/main/ui/menu/MainMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://src/main/ui/menu/main-menu.gd" type="Script" id=1]
 [ext_resource path="res://src/main/ui/menu/theme/h3.theme" type="Theme" id=2]
@@ -12,6 +12,8 @@
 [ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=10]
 [ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=11]
 [ext_resource path="res://src/main/ui/menu/main-menu-debug.gd" type="Script" id=12]
+[ext_resource path="res://src/main/ui/menu/main-menu-play.gd" type="Script" id=13]
+[ext_resource path="res://src/main/ui/menu/main-menu-create.gd" type="Script" id=14]
 
 [sub_resource type="DynamicFont" id=1]
 size = 72
@@ -60,6 +62,7 @@ margin_top = 150.0
 margin_bottom = -100.0
 custom_constants/separation = 10
 alignment = 1
+script = ExtResource( 13 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -113,6 +116,7 @@ margin_top = 150.0
 margin_bottom = -100.0
 custom_constants/separation = 10
 alignment = 1
+script = ExtResource( 14 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -181,11 +185,11 @@ __meta__ = {
 [node name="SettingsMenu" parent="." instance=ExtResource( 8 )]
 
 [node name="MusicPopup" parent="." instance=ExtResource( 10 )]
-[connection signal="pressed" from="DropPanel/Play/Story" to="." method="_on_PlayStory_pressed"]
-[connection signal="pressed" from="DropPanel/Play/Practice" to="." method="_on_PlayPractice_pressed"]
-[connection signal="pressed" from="DropPanel/Play/Tutorials" to="." method="_on_Tutorials_pressed"]
-[connection signal="pressed" from="DropPanel/Create/Levels" to="." method="_on_CreateLevels_pressed"]
-[connection signal="pressed" from="DropPanel/Create/Creatures" to="." method="_on_CreateCreatures_pressed"]
+[connection signal="pressed" from="DropPanel/Play/Story" to="DropPanel/Play" method="_on_Story_pressed"]
+[connection signal="pressed" from="DropPanel/Play/Practice" to="DropPanel/Play" method="_on_Practice_pressed"]
+[connection signal="pressed" from="DropPanel/Play/Tutorials" to="DropPanel/Play" method="_on_Tutorials_pressed"]
+[connection signal="pressed" from="DropPanel/Create/Levels" to="DropPanel/Create" method="_on_Levels_pressed"]
+[connection signal="pressed" from="DropPanel/Create/Creatures" to="DropPanel/Create" method="_on_Creatures_pressed"]
 [connection signal="quit_pressed" from="DropPanel/System" to="." method="_on_System_quit_pressed"]
 [connection signal="settings_pressed" from="DropPanel/System" to="SettingsMenu" method="_on_Settings_pressed"]
 [connection signal="pressed" from="DropPanel/Debug/StressTest" to="DropPanel/Debug" method="_on_StressTest_pressed"]

--- a/project/src/main/ui/menu/main-menu-create.gd
+++ b/project/src/main/ui/menu/main-menu-create.gd
@@ -1,0 +1,13 @@
+extends VBoxContainer
+"""
+A panel shown on the main menu which contains various editors.
+"""
+
+func _on_Levels_pressed() -> void:
+	MusicPlayer.stop()
+	Breadcrumb.push_trail("res://src/main/editor/puzzle/LevelEditor.tscn")
+
+
+func _on_Creatures_pressed() -> void:
+	MusicPlayer.stop()
+	Breadcrumb.push_trail("res://src/main/editor/creature/CreatureEditor.tscn")

--- a/project/src/main/ui/menu/main-menu-play.gd
+++ b/project/src/main/ui/menu/main-menu-play.gd
@@ -1,0 +1,17 @@
+extends VBoxContainer
+"""
+A panel shown on the main menu which contains game modes to play.
+"""
+
+func _on_Story_pressed() -> void:
+	PlayerData.creature_queue.clear()
+	CurrentLevel.clear_launched_level()
+	Breadcrumb.push_trail(Global.SCENE_OVERWORLD)
+
+
+func _on_Practice_pressed() -> void:
+	Breadcrumb.push_trail("res://src/main/ui/menu/PracticeMenu.tscn")
+
+
+func _on_Tutorials_pressed() -> void:
+	Breadcrumb.push_trail("res://src/main/ui/menu/TutorialMenu.tscn")

--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -32,33 +32,9 @@ func _launch_tutorial() -> void:
 	CurrentLevel.push_level_trail()
 
 
-func _on_PlayStory_pressed() -> void:
-	PlayerData.creature_queue.clear()
-	CurrentLevel.clear_launched_level()
-	Breadcrumb.push_trail(Global.SCENE_OVERWORLD)
-
-
-func _on_PlayPractice_pressed() -> void:
-	Breadcrumb.push_trail("res://src/main/ui/menu/PracticeMenu.tscn")
-
-
-func _on_CreateLevels_pressed() -> void:
-	MusicPlayer.stop()
-	Breadcrumb.push_trail("res://src/main/editor/puzzle/LevelEditor.tscn")
-
-
-func _on_CreateCreatures_pressed() -> void:
-	MusicPlayer.stop()
-	Breadcrumb.push_trail("res://src/main/editor/creature/CreatureEditor.tscn")
-
-
 func _on_System_quit_pressed() -> void:
 	if OS.has_feature("web"):
 		# don't quit from the web; just go back to splash screen
 		return
 	
 	get_tree().quit()
-
-
-func _on_Tutorials_pressed() -> void:
-	Breadcrumb.push_trail("res://src/main/ui/menu/TutorialMenu.tscn")

--- a/project/src/main/world/creature/creature-def.gd
+++ b/project/src/main/world/creature/creature-def.gd
@@ -152,3 +152,15 @@ func from_json_path(path: String) -> Object:
 	else:
 		result = null
 	return result
+
+
+"""
+Changes the creature's name, and derives a new short name and creature id from their new name.
+
+A creature's name shouldn't change during regular gameplay. This is only for the creature editor and for other randomly
+generated creatures.
+"""
+func rename(new_creature_name: String) -> void:
+	creature_name = new_creature_name
+	creature_short_name = NameUtils.sanitize_short_name(creature_name)
+	creature_id = NameUtils.short_name_to_id(creature_short_name)

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -87,9 +87,7 @@ func random_def() -> CreatureDef:
 	else:
 		result = CreatureDef.new()
 		result.dna = DnaUtils.random_dna()
-		result.creature_name = _name_generator.generate_name()
-		result.creature_short_name = NameUtils.sanitize_short_name(result.creature_name)
-		result.creature_id = NameUtils.short_name_to_id(result.creature_short_name)
+		result.rename(_name_generator.generate_name())
 		result.chat_theme_def = chat_theme_def(result.dna)
 		# set the filler ID, but not the fatness. the fatness attribute in the CreatureDef is the creature's natural
 		# fatness -- not their fatness after being stuffed

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -300,6 +300,18 @@ func feed(food_color: Color) -> void:
 	store_fatness()
 
 
+"""
+Changes the creature's name, and derives a new short name and creature id from their new name.
+
+A creature's name shouldn't change during regular gameplay. This is only for the creature editor and for other randomly
+generated creatures.
+"""
+func rename(new_creature_name: String) -> void:
+	set_creature_name(new_creature_name)
+	creature_short_name = NameUtils.sanitize_short_name(creature_name)
+	creature_id = NameUtils.short_name_to_id(creature_short_name)
+
+
 func restart_idle_timer() -> void:
 	creature_visuals.restart_idle_timer()
 


### PR DESCRIPTION
Lots of code wanted to derive short_names and ids from creature_name, so
this is now a function on Creature and CreatureDef.

Split create and play scripts from main-menu.gd. This seems unnecessarily
modular, but it's consistent with the debug and settings panel.