### PR TITLE
Fixed bug when starting a chat after using an exit

### DIFF
--- a/project/src/main/world/chattable-manager.gd
+++ b/project/src/main/world/chattable-manager.gd
@@ -31,6 +31,7 @@ var _creatures_by_id := {}
 
 func _ready() -> void:
 	Breadcrumb.connect("before_scene_changed", self, "_on_Breadcrumb_before_scene_changed")
+	SceneTransition.connect("fade_out_started", self, "_on_SceneTransition_fade_out_started")
 
 
 func _physics_process(_delta: float) -> void:
@@ -205,3 +206,12 @@ func _on_Breadcrumb_before_scene_changed() -> void:
 	player = null
 	sensei = null
 	focused_chattable = null
+	_focus_enabled = true
+	_creatures_by_id.clear()
+
+
+"""
+We prevent the player from interacting with objects during scene transitions.
+"""
+func _on_SceneTransition_fade_out_started() -> void:
+	set_focus_enabled(false)

--- a/project/src/main/world/creature/creature-animations.gd
+++ b/project/src/main/world/creature/creature-animations.gd
@@ -188,7 +188,7 @@ func _refresh_creature_visuals_path() -> void:
 	_tail_z1 = _creature_visuals.get_node("TailZ1")
 
 
-func _on_CreatureVisuals_orientation_changed(old_orientation: int, new_orientation: int) -> void:
+func _on_CreatureVisuals_orientation_changed(_old_orientation: int, new_orientation: int) -> void:
 	if _movement_player.current_animation == "idle-nw" and CreatureOrientation.oriented_south(new_orientation):
 		_movement_player.play("idle-se")
 	elif _movement_player.current_animation == "idle-se" and CreatureOrientation.oriented_north(new_orientation):


### PR DESCRIPTION
There was a bug where if you stepped on an exit and started a chat, the
game wouldn't let you talk to anyone. This exposed two problems.

1. ChattableManager wasn't fully resetting its state when exiting a
   scene. I've modified it to flush the 'focus_enabled' and
   'creatures_by_id' properties the same way it flushes the others.

2. ChattableManager wasn't preventing chat interactions during scene
   changes. I've connected it to a signal so that scene transitions
   block the player from interacting with stuff.

Closes #834.