### PR TITLE
Smaller overworld viewports.

### DIFF
--- a/project/src/main/world/Overworld.tscn
+++ b/project/src/main/world/Overworld.tscn
@@ -91,7 +91,7 @@ z_index = -1
 script = ExtResource( 13 )
 
 [node name="GoopViewport" type="Viewport" parent="World/Ground"]
-size = Vector2( 2560, 1500 )
+size = Vector2( 1024, 600 )
 usage = 0
 render_target_update_mode = 3
 
@@ -105,18 +105,18 @@ __meta__ = {
 }
 
 [node name="Viewport" type="Viewport" parent="World/Ground"]
-size = Vector2( 2560, 1500 )
+size = Vector2( 1024, 600 )
 transparent_bg = true
 usage = 0
 
 [node name="GroundMap" parent="World/Ground/Viewport" instance=ExtResource( 14 )]
+scale = Vector2( 1, 1 )
 
 [node name="ScrewportTexrect" type="TextureRect" parent="World/Ground"]
 material = SubResource( 3 )
 margin_right = 1024.0
 margin_bottom = 600.0
 rect_min_size = Vector2( 1024, 600 )
-rect_scale = Vector2( 0.4, 0.4 )
 texture = SubResource( 4 )
 flip_v = true
 script = ExtResource( 22 )

--- a/project/src/main/world/OverworldUi.tscn
+++ b/project/src/main/world/OverworldUi.tscn
@@ -120,6 +120,11 @@ __meta__ = {
 
 [node name="FpsLabel" parent="Control/Labels/SoutheastLabels" instance=ExtResource( 19 )]
 visible = false
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 0.0
 margin_top = 236.0
 margin_right = 492.0
 margin_bottom = 256.0


### PR DESCRIPTION
The viewports used to be huge and scaled down, which looked nicer at
higher resolutions. But it makes the game run much slower, especially on
mobile devices.