### PR TITLE
Disabled anti-aliasing for body lines. Moved hop/bonk sfx.

### DIFF
--- a/project/src/main/world/creature/Creature.tscn
+++ b/project/src/main/world/creature/Creature.tscn
@@ -606,7 +606,6 @@ __meta__ = {
 }
 
 [node name="CreatureSfx" type="Node2D" parent="."]
-position = Vector2( 512, 912 )
 script = ExtResource( 23 )
 
 [node name="Munch" type="AudioStreamPlayer" parent="CreatureSfx"]
@@ -615,6 +614,18 @@ bus = "Voice Bus"
 [node name="Voice" type="AudioStreamPlayer" parent="CreatureSfx"]
 volume_db = 6.0
 bus = "Voice Bus"
+
+[node name="HopSound" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( -512, -912 )
+stream = ExtResource( 7 )
+volume_db = -4.0
+bus = "Sound Bus"
+
+[node name="BonkSound" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+position = Vector2( -512, -912 )
+stream = ExtResource( 5 )
+volume_db = -4.0
+bus = "Sound Bus"
 
 [node name="HelloTimer" type="Timer" parent="CreatureSfx"]
 one_shot = true
@@ -627,16 +638,6 @@ autostart = true
 shape = SubResource( 2 )
 script = ExtResource( 8 )
 creature_visuals_path = NodePath("../CreatureOutline/Viewport/Visuals")
-
-[node name="HopSound" type="AudioStreamPlayer2D" parent="."]
-stream = ExtResource( 7 )
-volume_db = -4.0
-bus = "Sound Bus"
-
-[node name="BonkSound" type="AudioStreamPlayer2D" parent="."]
-stream = ExtResource( 5 )
-volume_db = -4.0
-bus = "Sound Bus"
 
 [node name="FadeTween" type="Tween" parent="."]
 [connection signal="dna_loaded" from="CreatureOutline/Viewport/Visuals" to="." method="_on_CreatureVisuals_dna_loaded"]

--- a/project/src/main/world/creature/body.gd
+++ b/project/src/main/world/creature/body.gd
@@ -227,7 +227,7 @@ func _draw_body_polygon(points: PoolVector2Array, color: Color) -> void:
 		return
 	
 	var _poly_colors := PoolColorArray([color])
-	draw_polygon(points, _poly_colors, PoolVector2Array(), null, null, true)
+	draw_polygon(points, _poly_colors, PoolVector2Array())
 
 
 """
@@ -240,7 +240,7 @@ func _draw_body_polyline(points: PoolVector2Array, color: Color, line_width: flo
 	
 	if closed:
 		points.append(points[0])
-	draw_polyline(points, color, line_width, true)
+	draw_polyline(points, color, line_width)
 
 
 func _on_CreatureCurve_appearance_changed() -> void:

--- a/project/src/main/world/creature/creature-sfx.gd
+++ b/project/src/main/world/creature/creature-sfx.gd
@@ -1,5 +1,5 @@
 class_name CreatureSfx
-extends Node
+extends Node2D
 """
 Plays creature-related sound effects.
 """

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -110,8 +110,8 @@ onready var _creature_sfx: CreatureSfx = $CreatureSfx
 onready var _collision_shape: CollisionShape2D = $CollisionShape2D
 onready var _fade_tween: Tween = $FadeTween
 
-onready var _bonk_sound: AudioStreamPlayer2D = $BonkSound
-onready var _hop_sound: AudioStreamPlayer2D = $HopSound
+onready var _bonk_sound: AudioStreamPlayer2D = $CreatureSfx/BonkSound
+onready var _hop_sound: AudioStreamPlayer2D = $CreatureSfx/HopSound
 
 func _ready() -> void:
 	_texture_rect.rect_scale = Vector2(TEXTURE_SCALE, TEXTURE_SCALE)


### PR DESCRIPTION
Surprisingly, despite the fact that these body lines and polygons are rarely
drawn, disabling anti-aliasing improves FPS by about 20%.

Moved Hop/Bonk sfx under CreatureSfx node. It makes sense for these sfx
to be siblings.