### PR TITLE
Fixed localization bugs: tutorial, fuzzy match

### DIFF
--- a/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
@@ -70,7 +70,7 @@ func _advance_level() -> void:
 	if CurrentLevel.settings.id == "tutorial/basics_0" and _did_build_cake and _did_squish_move:
 		# the player did something crazy; skip the tutorial entirely
 		PuzzleScore.change_level("tutorial/oh_my", false)
-		hud.set_big_message(ChatLibrary.add_mega_pause_charaters(tr("OH, MY!!!")))
+		hud.set_big_message(ChatLibrary.add_mega_lull_characters(tr("OH, MY!!!")))
 		hud.enqueue_pop_out()
 		
 		# force match to end

--- a/project/src/main/ui/settings-language.gd
+++ b/project/src/main/ui/settings-language.gd
@@ -3,6 +3,8 @@ extends HBoxContainer
 UI control for changing the game's language.
 """
 
+const DEFAULT_LOCALE := "en"
+
 onready var _option_button: OptionButton = $OptionButton
 
 func _ready() -> void:
@@ -11,7 +13,44 @@ func _ready() -> void:
 		_option_button.add_item(TranslationServer.get_locale_name(locale))
 	
 	# update the option button's selection to the current locale
-	_option_button.selected = TranslationServer.get_loaded_locales().find(TranslationServer.get_locale())
+	var current_loaded_locale := _current_loaded_locale()
+	if TranslationServer.get_loaded_locales().has(_current_loaded_locale()):
+		_option_button.selected = TranslationServer.get_loaded_locales().find(_current_loaded_locale())
+	else:
+		push_error("Locale '%s' was not in the list of loaded locales" % [current_loaded_locale])
+
+
+"""
+Returns the loaded locale closest to the translation server's locale.
+
+Locale can be of the form 'll_CC', i.e. language code and regional code, e.g. 'en_US', 'en_GB', etc. It might also be
+simply 'll', e.g. 'en'. To find the relevant translation, we look for those with locale starting with the language
+code, and then if any is an exact match for the long form. If not found, we fall back to a near match (another locale
+with same language code).
+
+This logic aligns with the logic in Godot's source code (core/translation.cpp). I could not find anywhere this logic
+or its result was exposed to GDScript.
+"""
+func _current_loaded_locale() -> String:
+	var result: String
+	var translation_server_locale := TranslationServer.get_locale()
+	
+	if TranslationServer.get_loaded_locales().has(translation_server_locale):
+		# found an exact match
+		result = translation_server_locale
+	
+	if not result:
+		# try to find a near match
+		for locale in TranslationServer.get_loaded_locales():
+			if locale.substr(0, 2) == translation_server_locale.substr(0, 2):
+				result = locale
+				break
+	
+	if not result:
+		# no match; default to English
+		result = DEFAULT_LOCALE
+	
+	return result
 
 
 func _on_OptionButton_item_selected(_index: int) -> void:


### PR DESCRIPTION
Fixed 'mega_pause_charaters' typo. This method was renamed to
mega_lull_characters but the reference was not changed. The result was
that triggering the tutorial easter egg would make the tutorial
unfinishable.

Fixed bug where unsupported locale caused menu to be inconsistent.
Specifically, when testing the game my locale was 'en_US' but this did
not match our supported locale of 'en', so it set the selected language
menu item to 'Spanish' even though the game was displayed in english.

The game now matches 'en' to the locale 'en_US', and 'es' to the local
'es_MX' in the settings menu. It does this with an algorithm similar to
the algorithm used by Godot for locale matching.