### PR TITLE
Fixed bug in music transitions where two songs could play

### DIFF
--- a/project/src/main/music/music-player.gd
+++ b/project/src/main/music/music-player.gd
@@ -22,7 +22,7 @@ var current_bgm: CheckpointSong
 # value: desired volume_db for playing music
 var _max_volume_db_by_bgm := {}
 
-var all_bgms
+var all_bgms: Array
 
 onready var _chill_bgms := [
 		$ChubHub, $DessertCourse, $HarderButter,
@@ -109,9 +109,9 @@ func play_bgm(new_bgm: CheckpointSong, from_position: float = -1.0) -> void:
 	if old_bgm == new_bgm:
 		return
 	
+	if current_bgm:
+		stop()
 	current_bgm = new_bgm
-	if old_bgm:
-		old_bgm.stop()
 	current_bgm.volume_db = _max_volume_db_by_bgm[current_bgm.name]
 	current_bgm.play(from_position)
 	emit_signal("current_bgm_changed", current_bgm)

--- a/project/src/main/music/music-transition.gd
+++ b/project/src/main/music/music-transition.gd
@@ -13,6 +13,10 @@ func _ready() -> void:
 	SceneTransition.connect("fade_in_started", self, "_on_SceneTransition_fade_in_started")
 
 
+func is_fading_in_bgm() -> bool:
+	return true if _faded_bgm else false
+
+
 """
 When the scene fades back in, we un-fade any music we previously faded out.
 """
@@ -21,6 +25,9 @@ func _on_SceneTransition_fade_in_started() -> void:
 		# If we faded the music out, we fade it back in
 		MusicPlayer.play_bgm(_faded_bgm, _faded_bgm.get_playback_position())
 		MusicPlayer.fade_in(SceneTransition.SCREEN_FADE_IN_DURATION * 1.5)
+		
+		# reset _faded_bgm to avoid fading the same song in twice
+		_faded_bgm = null
 
 
 """

--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -15,7 +15,7 @@ func _ready() -> void:
 	ResourceCache.substitute_singletons()
 	
 	# Fade in music when redirected from a scene with no music, such as the level editor
-	if not MusicPlayer.is_playing_chill_bgm():
+	if not MusicPlayer.is_playing_chill_bgm() and not MusicTransition.is_fading_in_bgm():
 		MusicPlayer.play_chill_bgm()
 		MusicPlayer.fade_in()
 	

--- a/project/src/main/ui/menu/splash-screen.gd
+++ b/project/src/main/ui/menu/splash-screen.gd
@@ -6,7 +6,7 @@ A splash screen which precedes the main menu.
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
 	
-	if not MusicPlayer.is_playing_chill_bgm():
+	if not MusicPlayer.is_playing_chill_bgm() and not MusicTransition.is_fading_in_bgm():
 		MusicPlayer.play_chill_bgm()
 	$DropPanel/PlayHolder/Play.grab_focus()
 	if PlayerSave.corrupt_filenames:


### PR DESCRIPTION
The music fade in/fade out logic introduced in c3074853 conflicted with
the logic in MainMenu.tscn for playing music. Sometimes both scripts
would try to play music at once.

I fixed this in a few places. MusicPlayer now stops any existing 'fade
in' tween when playing a new song. MusicTransition will no longer try to
fade in a song more than once. Scenes which play music now check
MusicTransition for a conflict. Any one of these would have been
sufficient to address the bug, but they all could cause problems.