### PR TITLE
Fixed 'fade out' tutorial bug, back button bug.

### DIFF
--- a/project/src/main/puzzle/puzzle-messages.gd
+++ b/project/src/main/puzzle/puzzle-messages.gd
@@ -60,6 +60,9 @@ func _on_Settings_pressed() -> void:
 
 
 func _on_Back_pressed() -> void:
+	# disconnect signal to prevent the back button from changing its label
+	CurrentLevel.disconnect("level_state_changed", self, "_on_Level_level_state_changed")
+	
 	emit_signal("back_button_pressed")
 
 

--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -7,11 +7,6 @@ Includes buttons for starting a new game, launching the level editor, and exitin
 """
 
 func _ready() -> void:
-	if not PlayerData.level_history.finished_levels.has(LevelLibrary.BEGINNER_TUTORIAL):
-		# if the player fails/quits the first tutorial, they're redirected to the splash screen
-		Breadcrumb.trail = [Global.SCENE_SPLASH]
-		_launch_tutorial()
-	
 	ResourceCache.substitute_singletons()
 	
 	# Fade in music when redirected from a scene with no music, such as the level editor
@@ -24,12 +19,6 @@ func _ready() -> void:
 
 func _exit_tree() -> void:
 	ResourceCache.remove_singletons()
-
-
-func _launch_tutorial() -> void:
-	PlayerData.creature_queue.clear()
-	CurrentLevel.set_launched_level(LevelLibrary.BEGINNER_TUTORIAL)
-	CurrentLevel.push_level_trail()
 
 
 func _on_System_quit_pressed() -> void:

--- a/project/src/main/ui/menu/splash-screen.gd
+++ b/project/src/main/ui/menu/splash-screen.gd
@@ -21,8 +21,17 @@ func _exit_tree() -> void:
 	ResourceCache.remove_singletons()
 
 
+func _launch_tutorial() -> void:
+	PlayerData.creature_queue.clear()
+	CurrentLevel.set_launched_level(LevelLibrary.BEGINNER_TUTORIAL)
+	CurrentLevel.push_level_trail()
+
+
 func _on_Play_pressed() -> void:
-	SceneTransition.push_trail(Global.SCENE_MAIN_MENU, true)
+	if not PlayerData.level_history.finished_levels.has(LevelLibrary.BEGINNER_TUTORIAL):
+		_launch_tutorial()
+	else:
+		SceneTransition.push_trail(Global.SCENE_MAIN_MENU, true)
 
 
 func _on_System_quit_pressed() -> void:


### PR DESCRIPTION
Before, the game would briefly show the main menu when launching the
first tutorial. Now, splash screen goes to the tutorial directly.

Before, the 'Back' button would briefly change to 'Continue' when you
clicked it upon finishing a tutorial. It no longer changes.