### PR TITLE
Fix ghost piece toggle bug, splash fade bug.

### DIFF
--- a/project/src/main/gameplay-settings.gd
+++ b/project/src/main/gameplay-settings.gd
@@ -3,8 +3,17 @@ class_name GameplaySettings
 Manages settings which control the gameplay.
 """
 
+signal ghost_piece_changed(value)
+
 # 'true' if a ghost piece should be shown during the puzzle sections.
-var ghost_piece := true
+var ghost_piece := true setget set_ghost_piece
+
+func set_ghost_piece(new_ghost_piece: bool) -> void:
+	if ghost_piece == new_ghost_piece:
+		return
+	ghost_piece = new_ghost_piece
+	emit_signal("ghost_piece_changed", new_ghost_piece)
+
 
 """
 Resets the gameplay settings to their default values.

--- a/project/src/main/puzzle/piece/ghost-mover.gd
+++ b/project/src/main/puzzle/piece/ghost-mover.gd
@@ -5,8 +5,30 @@ Moves the ghost piece when the piece or playfield changes.
 
 export (NodePath) var tile_map_path: NodePath
 
+# Stores the offset used when drawing the ghost piece.
+#
+# We calculate and store this even if the ghost piece is disabled. This allows us to properly handle enabling and
+# disabling the ghost piece during a puzzle.
+var _ghost_shadow_offset := Vector2.ZERO
+
 onready var _tile_map: PuzzleTileMap = get_node(tile_map_path)
 
-func _on_Dropper_hard_drop_target_pos_changed(piece: ActivePiece, hard_drop_target_pos: Vector2) -> void:
+func _ready() -> void:
+	PlayerData.gameplay_settings.connect("ghost_piece_changed", self, "_on_GameplaySettings_ghost_piece_changed")
+	_refresh_ghost_piece()
+
+
+func _refresh_ghost_piece() -> void:
 	if PlayerData.gameplay_settings.ghost_piece:
-		_tile_map.set_ghost_shadow_offset(hard_drop_target_pos - piece.pos)
+		_tile_map.set_ghost_shadow_offset(_ghost_shadow_offset)
+	else:
+		_tile_map.set_ghost_shadow_offset(Vector2.ZERO)
+
+
+func _on_Dropper_hard_drop_target_pos_changed(piece: ActivePiece, hard_drop_target_pos: Vector2) -> void:
+	_ghost_shadow_offset = hard_drop_target_pos - piece.pos
+	_refresh_ghost_piece()
+
+
+func _on_GameplaySettings_ghost_piece_changed(_value: bool) -> void:
+	_refresh_ghost_piece()

--- a/project/src/main/ui/scene-transition.gd
+++ b/project/src/main/ui/scene-transition.gd
@@ -31,6 +31,9 @@ Parameters:
 """
 func push_trail(path: String, skip_transition: bool = false) -> void:
 	if skip_transition or not get_tree().get_nodes_in_group("scene_transition_covers"):
+		# explicitly assign fading to false in case the user clicks a button while still fading in
+		fading = false
+		
 		Breadcrumb.push_trail(path)
 	else:
 		_fade_out("push_trail", [path])


### PR DESCRIPTION
Toggling the ghost piece in the middle of a puzzle caused some unusual
behavior. The shadow offset would retain the value for the most recent
shadow piece. So the ghost piece stuck around, it was just in a silly
place. We now enable/disable the ghost piece correctly and respond to
the player changing their settings mid-puzzle.

Closes #853.

Fixed a bug where clicking 'Play' while the splash screen was still
fading in resulted in all the subsequent menus fading in and out as
well.