### PR TITLE
Fixed bug with editing creatures who'd eaten.

### DIFF
--- a/project/src/main/editor/creature/CreatureEditor.tscn
+++ b/project/src/main/editor/creature/CreatureEditor.tscn
@@ -258,6 +258,7 @@ dna = {
 "tail": "1"
 }
 suppress_sfx = true
+suppress_fatness = true
 
 [node name="NeCreature" parent="World/Creatures" instance=ExtResource( 1 )]
 position = Vector2( 384, 244 )
@@ -426,6 +427,7 @@ dna = {
 "tail": "1"
 }
 suppress_sfx = true
+suppress_fatness = true
 
 [node name="ECreature" parent="World/Creatures" instance=ExtResource( 1 )]
 position = Vector2( 464, 384 )
@@ -598,6 +600,7 @@ dna = {
 "tail": "1"
 }
 suppress_sfx = true
+suppress_fatness = true
 
 [node name="WCreature" parent="World/Creatures" instance=ExtResource( 1 )]
 position = Vector2( 84, 384 )
@@ -768,6 +771,7 @@ dna = {
 "tail": "1"
 }
 suppress_sfx = true
+suppress_fatness = true
 
 [node name="CenterCreature" parent="World/Creatures" instance=ExtResource( 1 )]
 position = Vector2( 260, 400 )
@@ -944,6 +948,7 @@ dna = {
 "tail": "1"
 }
 suppress_sfx = true
+suppress_fatness = true
 
 [node name="SwCreature" parent="World/Creatures" instance=ExtResource( 1 )]
 position = Vector2( 164, 524 )
@@ -1112,6 +1117,7 @@ dna = {
 "tail": "1"
 }
 suppress_sfx = true
+suppress_fatness = true
 
 [node name="SeCreature" parent="World/Creatures" instance=ExtResource( 1 )]
 position = Vector2( 384, 524 )
@@ -1280,6 +1286,7 @@ dna = {
 "tail": "1"
 }
 suppress_sfx = true
+suppress_fatness = true
 
 [node name="Ui" type="CanvasLayer" parent="."]
 

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -43,6 +43,10 @@ export (String) var creature_id: String setget set_creature_id
 export (Dictionary) var dna: Dictionary setget set_dna
 export (bool) var suppress_sfx: bool = false setget set_suppress_sfx
 
+# if 'true' the creature will only use the fatness in the creature definition,
+# ignoring any accrued fatness from puzzles
+export (bool) var suppress_fatness: bool = false
+
 # how high the creature's torso is from the floor, such as when they're sitting on a stool or standing up
 export (int) var elevation: int setget set_elevation
 
@@ -341,7 +345,7 @@ func set_creature_def(new_creature_def: CreatureDef) -> void:
 	min_fatness = new_creature_def.min_fatness
 	weight_gain_scale = new_creature_def.weight_gain_scale
 	metabolism_scale = new_creature_def.metabolism_scale
-	if PlayerData.creature_library.has_fatness(creature_id):
+	if PlayerData.creature_library.has_fatness(creature_id) and not suppress_fatness:
 		set_fatness(PlayerData.creature_library.get_fatness(creature_id))
 	else:
 		set_fatness(min_fatness)


### PR DESCRIPTION
Creatures who had eaten showed up in the creature editor as very fat,
and would grow and shrink. The creature editor now ignores any extra
fatness from food they've eaten.

Closes #856.