### PR TITLE
PackedSprite no longer redraws after redundant setter calls.

### DIFF
--- a/project/src/main/gameplay-settings.gd
+++ b/project/src/main/gameplay-settings.gd
@@ -29,4 +29,4 @@ func to_json_dict() -> Dictionary:
 
 
 func from_json_dict(json: Dictionary) -> void:
-	ghost_piece = json.get("ghost_piece", true)
+	set_ghost_piece(json.get("ghost_piece", true))

--- a/project/src/main/packed-sprite.gd
+++ b/project/src/main/packed-sprite.gd
@@ -60,22 +60,30 @@ func get_frame_count() -> int:
 
 
 func set_rect_size(new_rect_size: Vector2) -> void:
+	if rect_size == new_rect_size:
+		return
 	rect_size = new_rect_size
 	update()
 
 
 func set_frame(new_frame: int) -> void:
+	if frame == new_frame:
+		return
 	frame = new_frame
 	update()
 	emit_signal("frame_changed")
 
 
 func set_centered(new_centered: bool) -> void:
+	if centered == new_centered:
+		return
 	centered = new_centered
 	update()
 
 
 func set_offset(new_offset: Vector2) -> void:
+	if offset == new_offset:
+		return
 	offset = new_offset
 	update()
 


### PR DESCRIPTION
set_frame() frequently gets called with the current frame, triggering
unnecessary calls to update() and _draw(). PackedSprite now ignores
these redundant calls, granting a 6% increase in performance when
drawing large numbers of creatures.

GameplaySettings.from_json_dict now correctly emits a ghost_piece_changed
signal.