### PR TITLE
Fixed rendering issues with very, very wide aspect ratios.

### DIFF
--- a/project/src/main/world/Overworld.tscn
+++ b/project/src/main/world/Overworld.tscn
@@ -75,7 +75,7 @@ __meta__ = {
 
 [node name="World" type="Node" parent="."]
 script = ExtResource( 51 )
-creature_shadows_path = NodePath("Ground/Shadows/Viewport/CreatureShadows")
+creature_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/CreatureShadows")
 chat_icons_path = NodePath("ChatIcons")
 CreaturePackedScene = ExtResource( 1 )
 
@@ -93,8 +93,9 @@ size = Vector2( 1024, 600 )
 transparent_bg = true
 usage = 0
 
-[node name="ObstacleMapShadows" type="TileMap" parent="World/Ground/Shadows/Viewport"]
-scale = Vector2( 2.5, 2.5 )
+[node name="ViewportRoot" type="Node2D" parent="World/Ground/Shadows/Viewport"]
+
+[node name="ObstacleMapShadows" type="TileMap" parent="World/Ground/Shadows/Viewport/ViewportRoot"]
 mode = 1
 tile_set = SubResource( 1 )
 cell_size = Vector2( 128, 64 )
@@ -103,16 +104,14 @@ centered_textures = true
 format = 1
 tile_data = PoolIntArray( -131070, 0, 0, -65534, 0, 0, 2, 0, 0, 65538, 0, 0, 131074, 0, 0, 196610, 0, 0 )
 script = ExtResource( 20 )
-obstacle_map_path = NodePath("../../../../Obstacles/ObstacleMap")
+obstacle_map_path = NodePath("../../../../../Obstacles/ObstacleMap")
 cell_shadow_mapping = {
 2: Rect2( -5, -2, 11, 5 )
 }
 
-[node name="CreatureShadows" parent="World/Ground/Shadows/Viewport" instance=ExtResource( 18 )]
-scale = Vector2( 2.5, 2.5 )
+[node name="CreatureShadows" parent="World/Ground/Shadows/Viewport/ViewportRoot" instance=ExtResource( 18 )]
 
-[node name="ShadowCasterShadows" type="Node2D" parent="World/Ground/Shadows/Viewport"]
-scale = Vector2( 2.5, 2.5 )
+[node name="ShadowCasterShadows" type="Node2D" parent="World/Ground/Shadows/Viewport/ViewportRoot"]
 script = ExtResource( 72 )
 OvalShadowScene = ExtResource( 73 )
 
@@ -121,17 +120,12 @@ modulate = Color( 1, 1, 1, 0.501961 )
 margin_right = 1024.0
 margin_bottom = 600.0
 rect_min_size = Vector2( 1024, 600 )
-rect_scale = Vector2( 0.4, 0.4 )
 texture = SubResource( 2 )
 flip_v = true
 script = ExtResource( 22 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
-
-[node name="Timer" type="Timer" parent="World/Ground"]
-one_shot = true
-autostart = true
 
 [node name="Obstacles" type="YSort" parent="World"]
 
@@ -154,9 +148,6 @@ creature_id = "#player#"
 dna = {
 
 }
-suppress_sfx = false
-elevation = 0
-orientation = 0
 
 [node name="Bort" parent="World/Obstacles" groups=[
 "chattables",

--- a/project/src/main/world/OverworldIndoors.tscn
+++ b/project/src/main/world/OverworldIndoors.tscn
@@ -83,7 +83,7 @@ __meta__ = {
 
 [node name="World" type="Node" parent="."]
 script = ExtResource( 4 )
-creature_shadows_path = NodePath("Ground/Shadows/Viewport/CreatureShadows")
+creature_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/CreatureShadows")
 chat_icons_path = NodePath("ChatIcons")
 CreaturePackedScene = ExtResource( 19 )
 
@@ -106,8 +106,9 @@ size = Vector2( 1024, 600 )
 transparent_bg = true
 usage = 0
 
-[node name="ObstacleMapShadows" type="TileMap" parent="World/Ground/Shadows/Viewport"]
-scale = Vector2( 1.25, 1.25 )
+[node name="ViewportRoot" type="Node2D" parent="World/Ground/Shadows/Viewport"]
+
+[node name="ObstacleMapShadows" type="TileMap" parent="World/Ground/Shadows/Viewport/ViewportRoot"]
 tile_set = SubResource( 1 )
 cell_size = Vector2( 128, 64 )
 cell_tile_origin = 1
@@ -115,7 +116,7 @@ centered_textures = true
 format = 1
 tile_data = PoolIntArray( -131070, 0, 0, -65536, 0, 0, -65535, 0, 0, 1, 0, 0, 131067, 0, 0, 131072, 0, 0, 196608, 0, 0, 589827, 0, 0, 655360, 0, 0 )
 script = ExtResource( 38 )
-obstacle_map_path = NodePath("../../../../../../OverworldIndoors/World/Obstacles/ObstacleMap")
+obstacle_map_path = NodePath("../../../../../Obstacles/ObstacleMap")
 cell_shadow_mapping = {
 3: Rect2( -1, 0, 3, 1 ),
 4: Rect2( -1, 0, 3, 1 ),
@@ -124,11 +125,9 @@ cell_shadow_mapping = {
 7: Rect2( -1, 0, 3, 1 )
 }
 
-[node name="CreatureShadows" parent="World/Ground/Shadows/Viewport" instance=ExtResource( 18 )]
-scale = Vector2( 2.5, 2.5 )
+[node name="CreatureShadows" parent="World/Ground/Shadows/Viewport/ViewportRoot" instance=ExtResource( 18 )]
 
-[node name="ShadowCasterShadows" type="Node2D" parent="World/Ground/Shadows/Viewport"]
-scale = Vector2( 2.5, 2.5 )
+[node name="ShadowCasterShadows" type="Node2D" parent="World/Ground/Shadows/Viewport/ViewportRoot"]
 script = ExtResource( 34 )
 OvalShadowScene = ExtResource( 30 )
 

--- a/project/src/main/world/screwport-texrect.gd
+++ b/project/src/main/world/screwport-texrect.gd
@@ -12,6 +12,9 @@ so simple.
 # the viewport in our viewport texture
 var _viewport: Viewport
 
+# the root node of the viewport which we can rescale
+var _viewport_root: Node2D
+
 func _ready() -> void:
 	if not texture or not texture.is_class("ViewportTexture") or not texture.viewport_path:
 		push_error("ViewportTexture with Viewport must be set.")
@@ -20,23 +23,50 @@ func _ready() -> void:
 	get_tree().get_root().connect("size_changed", self, "_on_Viewport_size_changed")
 	_viewport = get_tree().current_scene.get_node(texture.viewport_path)
 	_viewport.connect("size_changed", self, "_on_Viewport_size_changed")
-	_refresh_viewport_size()
+	_viewport_root = _viewport.get_node("ViewportRoot")
+	
+	_rescale_and_reposition_viewport()
 
 
 func _process(_delta: float) -> void:
 	if not _viewport:
 		return
+	
+	_reposition_viewport()
 
+
+"""
+Rescales our target viewport based on our parent viewport.
+
+Our parent viewport changes its size and scale based on the window size. When the window is resized, our parent
+viewport often adopts nonsensical sizes like (70,400, 123) which cause problems if we try and reuse them for our target
+viewport. So we rescale the target viewport's boundaries based on our parent's viewport transform to prevent throwing
+errors or causing memory issues.
+"""
+func _rescale_and_reposition_viewport() -> void:
+	# Adjust the viewport and texture size to match the scaled viewport size.
+	# This should match OS.get_window_size() if we're being rendered in the main viewport.
+	_viewport.size = get_viewport_rect().size * get_viewport_transform().get_scale()
+	rect_size = _viewport.size
+	
+	# If our parent viewport is very large, we scale the items in the target viewport large, but rescale the texture
+	# itself to be small. This cancels out so that items render at an appropriate size.
+	_viewport_root.scale = get_viewport_transform().get_scale()
+	rect_scale = Vector2(1.0, 1.0) / _viewport_root.scale
+	
+	# Immediately update our position. This prevents a drifting effect when resizing the window.
+	_reposition_viewport()
+
+
+"""
+Updates the texture position and viewport origin to remain centered on the screen.
+"""
+func _reposition_viewport() -> void:
 	# align ourselves with the upper-left corner of the screen
 	rect_position -= get_global_transform_with_canvas().origin
 	# align the viewport with our new position
 	_viewport.canvas_transform.origin = -rect_position / rect_scale
 
 
-func _refresh_viewport_size() -> void:
-	_viewport.size = get_viewport_rect().size / rect_scale
-	rect_size = _viewport.size
-
-
 func _on_Viewport_size_changed() -> void:
-	_refresh_viewport_size()
+	_rescale_and_reposition_viewport()


### PR DESCRIPTION
When the window had a very small aspect ratio like 1:30,
ScrewportTexRect used to resize itself to a very wide size such as
(15,000, 30) which caused rendering problems. It now consistently
resizes itself to the size of the screen, adjusting the scale of the
items in the viewport to compensate.

Closes #733.