### PR TITLE
Enabled vsync. Food NPE fix. Removed wallpaper kludge.

### DIFF
--- a/delint.sh
+++ b/delint.sh
@@ -29,6 +29,7 @@ find ./project/src -name "[a-z]*.tscn"
 
 # project settings which are enabled temporarily, but shouldn't be pushed
 grep "emulate_touch_from_mouse=true" ./project/project.godot 
+grep "window/vsync/use_vsync=false" ./project/project.godot
 
 # check for enabled creature tool scripts; these should be disabled before merging
 grep -lR "^tool #uncomment to view creature in editor" project/src/main/world/creature

--- a/project/project.godot
+++ b/project/project.godot
@@ -924,7 +924,6 @@ gdscript/warnings/return_value_discarded=false
 
 [display]
 
-window/vsync/use_vsync=false
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 
@@ -1121,7 +1120,6 @@ walk_down={
 translations=PoolStringArray( "res://assets/main/locale/en.po", "res://assets/main/locale/es.po" )
 locale_filter=[ 1, [ "en", "es" ] ]
 translation_remaps={
-
 }
 
 [rendering]

--- a/project/src/main/puzzle/food-items.gd
+++ b/project/src/main/puzzle/food-items.gd
@@ -129,6 +129,10 @@ func _on_FoodItem_ready_to_fly(food_item: FoodItem) -> void:
 
 
 func _on_FoodItem_flight_done(food_item: FoodItem) -> void:
+	if not food_item:
+		# food items might be garbage collected before this function is called
+		return
+	
 	if _customer_index == food_item.customer_index:
 		# ensure the customer hasn't been replaced before fattening them
 		_puzzle.feed_creature(food_item.customer, food_item.food_type)

--- a/project/src/main/ui/wallpaper/wallpaper-border.gd
+++ b/project/src/main/ui/wallpaper/wallpaper-border.gd
@@ -20,12 +20,6 @@ export (Vector2) var texture_scale: Vector2 = Vector2(512.0, 512.0) setget set_t
 onready var _texture_rect: TextureRect = $TextureRect
 
 func _ready() -> void:
-	# Bafflingly, removing this mysterious ColorRect makes the TextureRect render incorrectly.
-	var texture_rect_glitch_workaround: ColorRect = ColorRect.new()
-	texture_rect_glitch_workaround.name = "WorkaroundForSomeCrazyGodotBug"
-	texture_rect_glitch_workaround.color = Color.transparent
-	add_child(texture_rect_glitch_workaround)
-	
 	connect("resized", self, "_on_resized")
 	_recalculate_texture_rect_size()
 


### PR DESCRIPTION
Added fix for NPE when food items were deleted at unexpected times

As of Godot 3.3, this wallpaper sprite bug does not appear to be an
issue. Or, it's transient and I can't figure it out. It happened this
morning after the 3.3 upgrade, but after restarting Godot it hasn't
happened again -- even if I remove the invisible textlabel which was the
workaround for older Godot versions.