### PR TITLE
Level triggers. New levels with 'annoying rotation'.

### DIFF
--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-everyone-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-everyone-100.chat
@@ -14,7 +14,7 @@ s: So how was that?
 [very-good] I think you killed it!
 [good] That was pretty good!
 [bad] ...
-[very-bad] Well... I wouldn't eat it.
+[very-bad] That was terrible! Are you kidding me?
 
 [very-good]
 p1: ^__^ Wow, I think you killed it! You have some real talent.
@@ -34,22 +34,28 @@ s: .__.; ... ... ...
 [sensei-answers-insult]
 
 [very-bad]
-p1: /._. Well... I wouldn't eat it. Did you have any cooking experience before this?
+p1: >__< That was terrible! Are you kidding me? ...Did you have any cooking experience before this?
 s: ._.; Uhh I mean like, Richie's been helping me figure out the kitchen stuff. ...Did I mess something up?
 [sensei-answers-insult]
 
 [sensei-answers-praise]
-s1: /._. Hmm. Yes! Pretty good. Your rhythm's ahhh... a little off though!
-s: My... my rhythm?
-s1: Yes!/ That food should be coming out like pap-/pap-/pap-/pap-/pap!/ Right now you're more like pappap,// pappa/ pap.
-s1: You don't want to give them any break. Eating should become an unconscious reflex to them, like blinking!
+s1: /._. Hmm. Yes! Pretty good. Your technique is ahhh... a little off though!
+s: My... my technique?
+s1: You should focus on the piece of food you're cooking. You don't need to flip all those other pieces beforehand.
+s: @_@ But I have to keep them flipped the same way! Otherwise it makes my head all muddy.
+s1: Well, flipping them slows you down.
+s1: That food should be coming out like pap-/pap-/pap-/pap-/pap!/ Right now you're more like pappap,// pappa/ pap.
+s1: You don't want to give your customers any break. Eating should become an unconscious reflex to them, like blinking!
 [oh-okay]
 
 [sensei-answers-insult]
-s1: /._. What I think #player# is trying to say is your rhythm is ahhh... a little off.
-s: My... my rhythm?
-s1: Yes!/ That food should be coming out like pap-/pap-/pap-/pap-/pap!/ Right now you're more like pappap,// pappa/ pap.
-s1: You don't want to give them any break. Eating should become an unconscious reflex to them, like blinking!
+s1: /._. What I think #player# is trying to say is your technique is ahhh... a little strange.
+s: My... my technique?
+s1: You should focus on the piece of food you're cooking. You don't need to flip all those other pieces beforehand.
+s: @_@ But I have to keep them flipped the same way! Otherwise it makes my head all muddy.
+s1: Well, flipping them slows you down.
+s1: That food should be coming out like pap-/pap-/pap-/pap-/pap!/ Right now you're more like pappap,// pappa/ pap.
+s1: You don't want to give your customers any break. Eating should become an unconscious reflex to them, like blinking!
 [oh-okay]
 
 [oh-okay]

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-skins-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-skins-100.chat
@@ -8,10 +8,12 @@ player, p1, kitchen-5
 sensei, s1, kitchen-3
 skins, s, kitchen-7
 
-s1: /._. Hmm... just like before.
-p1: <_< Yeah...
-s: ._.; Mowr... Any tips?
-p1: I don't know, I'm kind of at a loss on this one. #sensei#? Why isn't it working?
-p1: /._. Was it their technique or... were they too slow? They didn't seem slow to me.
-s1: Ahh well. Their cooking skills are improving, so... Maybe it's just a matter of time.
-s1: ^y^ The customers will come back, and next time they'll stay longer! So, let's be patient.
+s1: /._. Hmm... so, do you remember that thing I said not to do?
+s: ._.; ...
+s1: <_< That thing that you're still doing?
+s: .__.; Mawr...
+s1: <__< You're still doing that thing.
+s: u__u I know, I know! I'm trying, I really am! ...I'll practice more, I promise.
+p1: It's okay, we're not angry. We're just, umm...
+p1: ^_^ ...Just, just keep practicing. You'll get there.
+s: u_u Thanks, mowwr...

--- a/project/assets/main/puzzle/levels/marsh/goodbye-skins.json
+++ b/project/assets/main/puzzle/levels/marsh/goodbye-skins.json
@@ -1,159 +1,157 @@
 {
   "version": "19c5",
-  "start_speed": "5",
+  "start_speed": "3",
   "title": "Goodbye Skins!",
-  "description": "Goodbye Skins! ...I'll miss you the most of all!",
+  "description": "Well, I guess Skins gave up rotating entirely. ...Or did he?",
   "finish_condition": {
     "type": "time_over",
-    "value": "90"
+    "value": "120"
   },
+  "rank": [
+    "box_factor 0.8"
+  ],
   "lose_condition": [
-    "top_out 1"
+    "top_out 9"
   ],
   "piece_types": [
-    "start_piece_j"
+    "start_piece_p"
   ],
-  "speed_ups": [
-    {
-      "type": "time_over",
-      "value": "30",
-      "speed": "7"
-    },
-    {
-      "type": "time_over",
-      "value": "60",
-      "speed": "9"
-    }
+  "other": [
+    "suppress_piece_rotation rotation_and_signals"
   ],
   "blocks_start": {
     "tiles": [
       {
-        "pos": "0 14",
-        "tile": "1 10 3"
+        "pos": "6 11",
+        "tile": "0 8 3"
       },
       {
-        "pos": "1 14",
-        "tile": "1 14 3"
+        "pos": "7 11",
+        "tile": "0 12 3"
       },
       {
-        "pos": "2 14",
-        "tile": "1 6 3"
+        "pos": "8 11",
+        "tile": "0 6 3"
       },
       {
-        "pos": "0 15",
-        "tile": "1 11 3"
+        "pos": "8 12",
+        "tile": "0 3 3"
       },
       {
-        "pos": "1 15",
-        "tile": "1 15 3"
+        "pos": "8 13",
+        "tile": "0 1 3"
       },
       {
-        "pos": "2 15",
-        "tile": "1 7 3"
+        "pos": "6 14",
+        "tile": "0 8 3"
       },
       {
-        "pos": "3 15",
-        "tile": "0 10 1"
+        "pos": "7 14",
+        "tile": "0 12 3"
       },
       {
-        "pos": "4 15",
-        "tile": "0 6 1"
+        "pos": "8 14",
+        "tile": "0 6 3"
       },
       {
-        "pos": "0 16",
-        "tile": "1 9 3"
+        "pos": "6 15",
+        "tile": "0 10 0"
       },
       {
-        "pos": "1 16",
-        "tile": "1 13 3"
+        "pos": "7 15",
+        "tile": "0 6 0"
       },
       {
-        "pos": "2 16",
-        "tile": "1 5 3"
-      },
-      {
-        "pos": "3 16",
-        "tile": "0 9 1"
-      },
-      {
-        "pos": "4 16",
-        "tile": "0 13 1"
+        "pos": "8 15",
+        "tile": "0 3 3"
       },
       {
         "pos": "5 16",
-        "tile": "0 4 1"
+        "tile": "0 8 0"
       },
       {
-        "pos": "0 17",
-        "tile": "1 10 0"
+        "pos": "6 16",
+        "tile": "0 13 0"
       },
       {
-        "pos": "1 17",
-        "tile": "1 14 0"
+        "pos": "7 16",
+        "tile": "0 5 0"
       },
       {
-        "pos": "2 17",
-        "tile": "1 6 0"
-      },
-      {
-        "pos": "3 17",
-        "tile": "1 10 2"
+        "pos": "8 16",
+        "tile": "0 1 3"
       },
       {
         "pos": "4 17",
-        "tile": "1 14 2"
+        "tile": "1 10 4"
       },
       {
         "pos": "5 17",
-        "tile": "1 6 2"
+        "tile": "1 14 4"
+      },
+      {
+        "pos": "6 17",
+        "tile": "1 14 4"
+      },
+      {
+        "pos": "7 17",
+        "tile": "1 14 4"
+      },
+      {
+        "pos": "8 17",
+        "tile": "1 6 4"
       },
       {
         "pos": "0 18",
-        "tile": "1 11 0"
-      },
-      {
-        "pos": "1 18",
-        "tile": "1 15 0"
-      },
-      {
-        "pos": "2 18",
-        "tile": "1 7 0"
-      },
-      {
-        "pos": "3 18",
-        "tile": "1 11 2"
+        "tile": "2 13 2"
       },
       {
         "pos": "4 18",
-        "tile": "1 15 2"
+        "tile": "1 11 4"
       },
       {
         "pos": "5 18",
-        "tile": "1 7 2"
+        "tile": "1 15 4"
+      },
+      {
+        "pos": "6 18",
+        "tile": "1 15 4"
+      },
+      {
+        "pos": "7 18",
+        "tile": "1 15 4"
+      },
+      {
+        "pos": "8 18",
+        "tile": "1 7 4"
       },
       {
         "pos": "0 19",
-        "tile": "1 9 0"
-      },
-      {
-        "pos": "1 19",
-        "tile": "1 13 0"
+        "tile": "2 15 2"
       },
       {
         "pos": "2 19",
-        "tile": "1 5 0"
-      },
-      {
-        "pos": "3 19",
-        "tile": "1 9 2"
+        "tile": "2 6 3"
       },
       {
         "pos": "4 19",
-        "tile": "1 13 2"
+        "tile": "1 9 4"
       },
       {
         "pos": "5 19",
-        "tile": "1 5 2"
+        "tile": "1 13 4"
+      },
+      {
+        "pos": "6 19",
+        "tile": "1 13 4"
+      },
+      {
+        "pos": "7 19",
+        "tile": "1 13 4"
+      },
+      {
+        "pos": "8 19",
+        "tile": "1 5 4"
       }
     ]
   }

--- a/project/assets/main/puzzle/levels/marsh/hello-everyone.json
+++ b/project/assets/main/puzzle/levels/marsh/hello-everyone.json
@@ -2,7 +2,7 @@
   "version": "19c5",
   "start_speed": "1",
   "title": "Hello Everyone!",
-  "description": "Let's meet the employees of our Merrymellow Marsh location!",
+  "description": "Let's meet our Merrymellow Marsh area employees! Surely they won't rotate pieces incompetently.",
   "finish_condition": {
     "type": "time_over",
     "value": "90"
@@ -12,6 +12,26 @@
   ],
   "piece_types": [
     "start_piece_j"
+  ],
+  "lose_condition": [
+    "top_out 9"
+  ],
+  "rank": [
+    "extra_seconds_per_piece", "0.4"
+  ],
+  "triggers": [
+    {
+      "phases": ["rotated_right", "initial_rotated_right"],
+      "effect": "rotate_next_pieces right"
+    },
+    {
+      "phases": ["rotated_left", "initial_rotated_left"],
+      "effect": "rotate_next_pieces left"
+    },
+    {
+      "phases": ["rotated_twice", "initial_rotated_twice"],
+      "effect": "rotate_next_pieces twice"
+    }
   ],
   "blocks_start": {
     "tiles": [

--- a/project/assets/main/puzzle/levels/marsh/hello-skins.json
+++ b/project/assets/main/puzzle/levels/marsh/hello-skins.json
@@ -1,148 +1,134 @@
 {
   "version": "19c5",
-  "start_speed": "4",
+  "start_speed": "1",
   "title": "Hello Skins!",
-  "description": "Let's get to know Skins a little better.",
+  "description": "Skins, you really shouldn't rotate the upcoming pieces! It hurts my head a little.",
   "finish_condition": {
-    "type": "score",
-    "value": "400"
+    "type": "time_over",
+    "value": "120"
   },
-  "piece_types": [
-    "start_piece_p"
+  "lose_condition": [
+    "top_out 9"
+  ],
+  "rank": [
+    "extra_seconds_per_piece", "0.4"
+  ],
+  "triggers": [
+    {
+      "phases": [
+        "rotated_right",
+        "initial_rotated_right"
+      ],
+      "effect": "rotate_next_pieces right"
+    },
+    {
+      "phases": [
+        "rotated_left",
+        "initial_rotated_left"
+      ],
+      "effect": "rotate_next_pieces left"
+    },
+    {
+      "phases": [
+        "rotated_twice",
+        "initial_rotated_twice"
+      ],
+      "effect": "rotate_next_pieces twice"
+    }
+  ],
+  "speed_ups": [
+    {
+      "type": "time_over",
+      "value": "30",
+      "speed": "3"
+    },
+    {
+      "type": "time_over",
+      "value": "60",
+      "speed": "5"
+    }
   ],
   "blocks_start": {
     "tiles": [
       {
-        "pos": "6 11",
-        "tile": "0 8 3"
+        "pos": "2 16",
+        "tile": "2 5 2"
       },
       {
-        "pos": "7 11",
-        "tile": "0 12 3"
+        "pos": "3 16",
+        "tile": "1 10 5"
       },
       {
-        "pos": "8 11",
-        "tile": "0 6 3"
-      },
-      {
-        "pos": "8 12",
-        "tile": "0 3 3"
-      },
-      {
-        "pos": "8 13",
-        "tile": "0 1 3"
-      },
-      {
-        "pos": "6 14",
-        "tile": "0 8 3"
-      },
-      {
-        "pos": "7 14",
-        "tile": "0 12 3"
-      },
-      {
-        "pos": "8 14",
-        "tile": "0 6 3"
-      },
-      {
-        "pos": "6 15",
-        "tile": "0 10 0"
-      },
-      {
-        "pos": "7 15",
-        "tile": "0 6 0"
-      },
-      {
-        "pos": "8 15",
-        "tile": "0 3 3"
+        "pos": "4 16",
+        "tile": "1 14 5"
       },
       {
         "pos": "5 16",
-        "tile": "0 8 0"
+        "tile": "1 6 5"
       },
       {
         "pos": "6 16",
-        "tile": "0 13 0"
+        "tile": "2 16 3"
       },
       {
-        "pos": "7 16",
-        "tile": "0 5 0"
-      },
-      {
-        "pos": "8 16",
-        "tile": "0 1 3"
+        "pos": "3 17",
+        "tile": "1 11 5"
       },
       {
         "pos": "4 17",
-        "tile": "1 10 4"
+        "tile": "1 15 5"
       },
       {
         "pos": "5 17",
-        "tile": "1 14 4"
+        "tile": "1 7 5"
       },
       {
         "pos": "6 17",
-        "tile": "1 14 4"
+        "tile": "2 0 3"
       },
       {
         "pos": "7 17",
-        "tile": "1 14 4"
+        "tile": "2 3 1"
       },
       {
-        "pos": "8 17",
-        "tile": "1 6 4"
-      },
-      {
-        "pos": "0 18",
-        "tile": "2 13 2"
-      },
-      {
-        "pos": "4 18",
-        "tile": "1 11 4"
-      },
-      {
-        "pos": "5 18",
-        "tile": "1 15 4"
-      },
-      {
-        "pos": "6 18",
-        "tile": "1 15 4"
-      },
-      {
-        "pos": "7 18",
-        "tile": "1 15 4"
-      },
-      {
-        "pos": "8 18",
-        "tile": "1 7 4"
-      },
-      {
-        "pos": "0 19",
-        "tile": "2 15 2"
-      },
-      {
-        "pos": "2 19",
+        "pos": "1 18",
         "tile": "2 6 3"
       },
       {
+        "pos": "2 18",
+        "tile": "2 12 3"
+      },
+      {
+        "pos": "3 18",
+        "tile": "1 11 5"
+      },
+      {
+        "pos": "4 18",
+        "tile": "1 15 5"
+      },
+      {
+        "pos": "5 18",
+        "tile": "1 7 5"
+      },
+      {
+        "pos": "2 19",
+        "tile": "2 5 0"
+      },
+      {
+        "pos": "3 19",
+        "tile": "1 9 5"
+      },
+      {
         "pos": "4 19",
-        "tile": "1 9 4"
+        "tile": "1 13 5"
       },
       {
         "pos": "5 19",
-        "tile": "1 13 4"
+        "tile": "1 5 5"
       },
       {
         "pos": "6 19",
-        "tile": "1 13 4"
-      },
-      {
-        "pos": "7 19",
-        "tile": "1 13 4"
-      },
-      {
-        "pos": "8 19",
-        "tile": "1 5 4"
+        "tile": "2 15 3"
       }
     ]
   }

--- a/project/assets/main/puzzle/levels/marsh/pulling-for-skins.json
+++ b/project/assets/main/puzzle/levels/marsh/pulling-for-skins.json
@@ -2,303 +2,65 @@
   "version": "19c5",
   "start_speed": "3",
   "title": "Pulling for Skins",
-  "description": "C'mon Skins, you can do this! We believe in you!",
+  "description": "Skins doesn't rotate as many of the upcoming pieces. ...This is progress?",
   "finish_condition": {
     "type": "time_over",
-    "value": "90"
+    "value": "150"
   },
   "rank": [
-    "box_factor 0.5",
-    "combo_factor 0.5"
+    "extra_seconds_per_piece", "0.6",
+    "box_factor 0.8"
+  ],
+  "piece_types": [
+    "start_piece_v"
   ],
   "lose_condition": [
-    "top_out 1"
+    "top_out 9"
+  ],
+  "triggers": [
+    {
+      "phases": [
+        "rotated_right",
+        "initial_rotated_right"
+      ],
+      "effect": "rotate_next_pieces right 0 0"
+    },
+    {
+      "phases": [
+        "rotated_left",
+        "initial_rotated_left"
+      ],
+      "effect": "rotate_next_pieces left 0 0"
+    },
+    {
+      "phases": [
+        "rotated_twice",
+        "initial_rotated_twice"
+      ],
+      "effect": "rotate_next_pieces twice 0 0"
+    }
+  ],
+  "other": [
+    "suppress_piece_rotation",
+    "suppress_piece_initial_rotation"
   ],
   "blocks_start": {
     "tiles": [
       {
-        "pos": "0 10",
-        "tile": "1 10 1"
-      },
-      {
-        "pos": "1 10",
-        "tile": "1 14 1"
-      },
-      {
-        "pos": "2 10",
-        "tile": "1 6 1"
-      },
-      {
-        "pos": "4 10",
-        "tile": "2 8 1"
-      },
-      {
-        "pos": "5 10",
-        "tile": "2 3 0"
-      },
-      {
-        "pos": "6 10",
-        "tile": "2 6 1"
-      },
-      {
-        "pos": "7 10",
-        "tile": "2 7 0"
-      },
-      {
-        "pos": "0 11",
-        "tile": "1 9 1"
-      },
-      {
-        "pos": "1 11",
-        "tile": "1 13 1"
-      },
-      {
-        "pos": "2 11",
-        "tile": "1 5 1"
-      },
-      {
-        "pos": "3 11",
-        "tile": "2 3 0"
-      },
-      {
-        "pos": "4 11",
-        "tile": "2 0 3"
-      },
-      {
-        "pos": "5 11",
-        "tile": "2 5 0"
-      },
-      {
-        "pos": "7 11",
-        "tile": "2 12 0"
-      },
-      {
-        "pos": "0 12",
-        "tile": "2 1 0"
-      },
-      {
-        "pos": "1 12",
-        "tile": "2 5 0"
-      },
-      {
-        "pos": "3 12",
-        "tile": "1 8 2"
-      },
-      {
-        "pos": "4 12",
-        "tile": "1 12 2"
-      },
-      {
-        "pos": "5 12",
-        "tile": "1 4 2"
-      },
-      {
-        "pos": "7 12",
-        "tile": "2 14 2"
-      },
-      {
-        "pos": "8 12",
-        "tile": "2 10 3"
-      },
-      {
-        "pos": "1 13",
-        "tile": "2 9 3"
-      },
-      {
-        "pos": "3 13",
-        "tile": "2 1 0"
-      },
-      {
-        "pos": "4 13",
-        "tile": "2 5 0"
-      },
-      {
-        "pos": "5 13",
-        "tile": "2 1 0"
-      },
-      {
-        "pos": "6 13",
-        "tile": "1 10 3"
-      },
-      {
-        "pos": "7 13",
-        "tile": "1 14 3"
-      },
-      {
-        "pos": "8 13",
-        "tile": "1 6 3"
-      },
-      {
-        "pos": "1 14",
-        "tile": "2 15 3"
-      },
-      {
-        "pos": "2 14",
-        "tile": "2 16 2"
-      },
-      {
-        "pos": "3 14",
-        "tile": "2 1 0"
-      },
-      {
-        "pos": "5 14",
-        "tile": "2 17 0"
-      },
-      {
-        "pos": "6 14",
-        "tile": "1 9 3"
-      },
-      {
-        "pos": "7 14",
-        "tile": "1 13 3"
-      },
-      {
-        "pos": "8 14",
-        "tile": "1 5 3"
-      },
-      {
-        "pos": "0 15",
-        "tile": "1 8 4"
-      },
-      {
-        "pos": "1 15",
-        "tile": "1 12 4"
-      },
-      {
-        "pos": "2 15",
-        "tile": "1 4 4"
-      },
-      {
-        "pos": "3 15",
-        "tile": "2 2 2"
-      },
-      {
-        "pos": "5 15",
-        "tile": "2 9 2"
-      },
-      {
-        "pos": "6 15",
-        "tile": "2 11 3"
-      },
-      {
-        "pos": "8 15",
-        "tile": "2 2 3"
-      },
-      {
-        "pos": "0 16",
-        "tile": "2 0 0"
-      },
-      {
-        "pos": "2 16",
-        "tile": "2 12 0"
-      },
-      {
-        "pos": "3 16",
-        "tile": "1 8 4"
-      },
-      {
-        "pos": "4 16",
-        "tile": "1 12 4"
-      },
-      {
-        "pos": "5 16",
-        "tile": "1 4 4"
-      },
-      {
-        "pos": "6 16",
-        "tile": "2 14 0"
-      },
-      {
-        "pos": "8 16",
-        "tile": "2 5 0"
-      },
-      {
-        "pos": "0 17",
-        "tile": "2 1 0"
-      },
-      {
-        "pos": "2 17",
-        "tile": "2 7 1"
-      },
-      {
-        "pos": "3 17",
-        "tile": "2 14 1"
-      },
-      {
-        "pos": "4 17",
-        "tile": "2 8 0"
-      },
-      {
-        "pos": "6 17",
-        "tile": "1 10 4"
-      },
-      {
-        "pos": "7 17",
-        "tile": "1 14 4"
-      },
-      {
-        "pos": "8 17",
-        "tile": "1 6 4"
-      },
-      {
-        "pos": "0 18",
-        "tile": "1 10 4"
-      },
-      {
-        "pos": "1 18",
-        "tile": "1 14 4"
-      },
-      {
-        "pos": "2 18",
-        "tile": "1 6 4"
-      },
-      {
-        "pos": "4 18",
-        "tile": "2 1 1"
-      },
-      {
-        "pos": "6 18",
-        "tile": "1 11 4"
-      },
-      {
         "pos": "7 18",
-        "tile": "1 15 4"
+        "tile": "0 10 3"
       },
       {
         "pos": "8 18",
-        "tile": "1 7 4"
-      },
-      {
-        "pos": "0 19",
-        "tile": "1 9 4"
-      },
-      {
-        "pos": "1 19",
-        "tile": "1 13 4"
-      },
-      {
-        "pos": "2 19",
-        "tile": "1 5 4"
-      },
-      {
-        "pos": "4 19",
-        "tile": "2 13 2"
-      },
-      {
-        "pos": "5 19",
-        "tile": "2 9 3"
-      },
-      {
-        "pos": "6 19",
-        "tile": "1 9 4"
+        "tile": "0 6 3"
       },
       {
         "pos": "7 19",
-        "tile": "1 13 4"
+        "tile": "0 9 3"
       },
       {
         "pos": "8 19",
-        "tile": "1 5 4"
+        "tile": "0 5 3"
       }
     ]
   }

--- a/project/assets/main/puzzle/worlds.json
+++ b/project/assets/main/puzzle/worlds.json
@@ -79,6 +79,7 @@
         },
         {
           "id": "marsh/pulling_for_skins",
+          "chef_id": "skins",
           "groups": "marsh/pulling_for",
           "locked_until": "level_finished marsh/pulling_for_everyone"
         },
@@ -98,6 +99,7 @@
         },
         {
           "id": "marsh/goodbye_skins",
+          "chef_id": "skins",
           "groups": "marsh/goodbye",
           "locked_until": "level_finished marsh/lets_all_get_merry"
         },

--- a/project/assets/test/turbofat-245b.json
+++ b/project/assets/test/turbofat-245b.json
@@ -1,0 +1,201 @@
+[
+  {
+    "type": "version",
+    "value": "245b"
+  },
+  {
+    "type": "level_history",
+    "key": "marsh/hello_everyone",
+    "value": [
+      {
+        "box_score": 285,
+        "box_score_per_line": 8.636364,
+        "box_score_per_line_rank": 17.011836,
+        "combo_score": 560,
+        "combo_score_per_line": 20,
+        "combo_score_per_line_rank": 0,
+        "compare": "+score",
+        "leftover_score": 216,
+        "lines": 33,
+        "lines_rank": 8.217941,
+        "pieces": 33,
+        "pieces_rank": 8.217941,
+        "lost": false,
+        "score": 1094,
+        "score_rank": 3.49,
+        "seconds": 90.000005,
+        "seconds_rank": 999,
+        "speed": 21.999999,
+        "speed_rank": 8.217942,
+        "success": false,
+        "timestamp": {
+          "year": 2021,
+          "month": 4,
+          "day": 23,
+          "weekday": 5,
+          "dst": false,
+          "hour": 8,
+          "minute": 54,
+          "second": 44
+        },
+        "top_out_count": 0
+      }
+    ]
+  },
+  {
+    "type": "level_history",
+    "key": "marsh/hello_skins",
+    "value": [
+      {
+        "box_score": 0,
+        "box_score_per_line": 0,
+        "box_score_per_line_rank": 999,
+        "combo_score": 0,
+        "combo_score_per_line": 0,
+        "combo_score_per_line_rank": 999,
+        "compare": "-seconds",
+        "leftover_score": 0,
+        "lines": 0,
+        "lines_rank": 999,
+        "pieces": 0,
+        "pieces_rank": 999,
+        "lost": true,
+        "score": 0,
+        "score_rank": 999,
+        "seconds": 7.9,
+        "seconds_rank": 999,
+        "speed": 0,
+        "speed_rank": 999,
+        "success": false,
+        "timestamp": {
+          "year": 2021,
+          "month": 4,
+          "day": 25,
+          "weekday": 0,
+          "dst": false,
+          "hour": 10,
+          "minute": 25,
+          "second": 14
+        },
+        "top_out_count": 0
+      }
+    ]
+  },
+  {
+    "type": "level_history",
+    "key": "marsh/pulling_for_everyone",
+    "value": [
+      {
+        "box_score": 265,
+        "box_score_per_line": 15.588235,
+        "box_score_per_line_rank": 0,
+        "combo_score": 145,
+        "combo_score_per_line": 12.083333,
+        "combo_score_per_line_rank": 12.300069,
+        "compare": "-seconds",
+        "leftover_score": 139,
+        "lines": 17,
+        "lines_rank": 0,
+        "pieces": 17,
+        "pieces_rank": 0,
+        "lost": false,
+        "score": 566,
+        "score_rank": 999,
+        "seconds": 33.083335,
+        "seconds_rank": 1.64,
+        "speed": 30.831232,
+        "speed_rank": 0,
+        "success": false,
+        "timestamp": {
+          "year": 2020,
+          "month": 11,
+          "day": 9,
+          "weekday": 1,
+          "dst": false,
+          "hour": 17,
+          "minute": 29,
+          "second": 14
+        },
+        "top_out_count": 0
+      }
+    ]
+  },
+  {
+    "type": "level_history",
+    "key": "marsh/pulling_for_skins",
+    "value": [
+      {
+        "box_score": 70,
+        "box_score_per_line": 10,
+        "box_score_per_line_rank": 0,
+        "combo_score": 30,
+        "combo_score_per_line": 13.333333,
+        "combo_score_per_line_rank": 0,
+        "compare": "+score",
+        "leftover_score": 0,
+        "lines": 7,
+        "lines_rank": 62.715793,
+        "pieces": 7,
+        "pieces_rank": 62.715793,
+        "lost": true,
+        "score": 107,
+        "score_rank": 30.99,
+        "seconds": 25.633335,
+        "seconds_rank": 999,
+        "speed": 16.384915,
+        "speed_rank": 19.436632,
+        "success": false,
+        "timestamp": {
+          "year": 2021,
+          "month": 4,
+          "day": 25,
+          "weekday": 0,
+          "dst": false,
+          "hour": 11,
+          "minute": 19,
+          "second": 50
+        },
+        "top_out_count": 0
+      }
+    ]
+  },
+  {
+    "type": "level_history",
+    "key": "marsh/goodbye_skins",
+    "value": [
+      {
+        "box_score": 595,
+        "box_score_per_line": 12.142857,
+        "box_score_per_line_rank": 5.82443,
+        "combo_score": 480,
+        "combo_score_per_line": 10.909091,
+        "combo_score_per_line_rank": 15.656382,
+        "compare": "+score",
+        "leftover_score": 223,
+        "lines": 49,
+        "lines_rank": 0,
+        "pieces": 49,
+        "pieces_rank": 0,
+        "lost": false,
+        "score": 1347,
+        "score_rank": 0.76,
+        "seconds": 90.000005,
+        "seconds_rank": 999,
+        "speed": 32.666664,
+        "speed_rank": 0,
+        "success": false,
+        "timestamp": {
+          "year": 2020,
+          "month": 11,
+          "day": 9,
+          "weekday": 1,
+          "dst": false,
+          "hour": 17,
+          "minute": 42,
+          "second": 30
+        },
+        "top_out_count": 0
+      }
+    ]
+  }
+]

--- a/project/project.godot
+++ b/project/project.godot
@@ -349,6 +349,21 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/puzzle/level/level-settings.gd"
 }, {
+"base": "Reference",
+"class": "LevelTrigger",
+"language": "GDScript",
+"path": "res://src/main/puzzle/level/level-trigger.gd"
+}, {
+"base": "Reference",
+"class": "LevelTriggerEffect",
+"language": "GDScript",
+"path": "res://src/main/puzzle/level/level-trigger-effect.gd"
+}, {
+"base": "Reference",
+"class": "LevelTriggers",
+"language": "GDScript",
+"path": "res://src/main/puzzle/level/level-triggers.gd"
+}, {
 "base": "Node",
 "class": "LineClearer",
 "language": "GDScript",
@@ -429,6 +444,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/nearest-sorter.gd"
 }, {
+"base": "Reference",
+"class": "NextPiece",
+"language": "GDScript",
+"path": "res://src/main/puzzle/piece/next-piece.gd"
+}, {
 "base": "Node2D",
 "class": "NextPieceDisplay",
 "language": "GDScript",
@@ -493,11 +513,6 @@ _global_script_classes=[ {
 "class": "PiecePhysics",
 "language": "GDScript",
 "path": "res://src/main/puzzle/piece/piece-physics.gd"
-}, {
-"base": "Node",
-"class": "PieceQueue",
-"language": "GDScript",
-"path": "res://src/main/puzzle/piece/piece-queue.gd"
 }, {
 "base": "Reference",
 "class": "PieceSpeed",
@@ -803,6 +818,9 @@ _global_script_class_icons={
 "LevelLock": "",
 "LevelSelectButton": "",
 "LevelSettings": "",
+"LevelTrigger": "",
+"LevelTriggerEffect": "",
+"LevelTriggers": "",
 "LineClearer": "",
 "LockAlleleButton": "",
 "LoseConditionRules": "",
@@ -819,6 +837,7 @@ _global_script_class_icons={
 "NameUtils": "",
 "NametagPanel": "",
 "NearestSorter": "",
+"NextPiece": "",
 "NextPieceDisplay": "",
 "NextPieceDisplays": "",
 "OldSave": "",
@@ -832,7 +851,6 @@ _global_script_class_icons={
 "PieceManager": "",
 "PieceMover": "",
 "PiecePhysics": "",
-"PieceQueue": "",
 "PieceSpeed": "",
 "PieceSquisher": "",
 "PieceStates": "",
@@ -896,6 +914,7 @@ default_bus_layout="res://src/main/ui/default_bus_layout.tres"
 [autoload]
 
 Global="*res://src/main/global.gd"
+LevelTriggerEffects="*res://src/main/puzzle/level/level-trigger-effects.gd"
 PieceSpeeds="*res://src/main/puzzle/piece/piece-speeds.gd"
 PieceTypes="*res://src/main/puzzle/piece/piece-types.gd"
 Breadcrumb="*res://src/main/breadcrumb.gd"
@@ -911,6 +930,7 @@ MilestoneManager="*res://src/main/puzzle/milestone-manager.gd"
 MusicPlayer="*res://src/main/music/MusicPlayer.tscn"
 MusicTransition="*res://src/main/music/music-transition.gd"
 Pauser="*res://src/main/pauser.gd"
+PieceQueue="*res://src/main/puzzle/piece/piece-queue.gd"
 PlayerData="*res://src/main/player-data.gd"
 PlayerSave="*res://src/main/player-save.gd"
 PuzzleScore="*res://src/main/puzzle/puzzle-score.gd"

--- a/project/src/main/player-save.gd
+++ b/project/src/main/player-save.gd
@@ -7,7 +7,7 @@ This data includes how well they've done on each level and how much money they'v
 
 # Current version for saved player data. Should be updated if and only if the player format changes.
 # This version number follows a 'ymdh' hex date format which is documented in issue #234.
-const PLAYER_DATA_VERSION := "245b"
+const PLAYER_DATA_VERSION := "24cc"
 
 var rolling_backups := RollingBackups.new()
 

--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -372,7 +372,6 @@ SeedScene = ExtResource( 33 )
 
 [node name="PieceManager" parent="." instance=ExtResource( 9 )]
 playfield_path = NodePath("../Playfield")
-next_piece_displays_path = NodePath("../NextPieceDisplays")
 
 [node name="NextPieceDisplays" parent="." instance=ExtResource( 64 )]
 margin_left = 688.0
@@ -646,9 +645,10 @@ codes = [ "delays", "bigfps" ]
 script = ExtResource( 19 )
 
 [node name="SceneTransitionCover" parent="." instance=ExtResource( 50 )]
+
 [connection signal="before_line_cleared" from="Playfield" to="StarSeeds" method="_on_Playfield_before_line_cleared"]
-[connection signal="before_line_cleared" from="Playfield" to="FrostingGlobs" method="_on_Playfield_before_line_cleared"]
 [connection signal="before_line_cleared" from="Playfield" to="ComboCounters" method="_on_Playfield_before_line_cleared"]
+[connection signal="before_line_cleared" from="Playfield" to="FrostingGlobs" method="_on_Playfield_before_line_cleared"]
 [connection signal="blocks_prepared" from="Playfield" to="StarSeeds" method="_on_Playfield_blocks_prepared"]
 [connection signal="box_built" from="Playfield" to="StarSeeds" method="_on_Playfield_box_built"]
 [connection signal="box_built" from="Playfield" to="FrostingGlobs" method="_on_Playfield_box_built"]
@@ -660,10 +660,10 @@ script = ExtResource( 19 )
 [connection signal="squish_moved" from="PieceManager" to="FrostingGlobs" method="_on_PieceManager_squish_moved"]
 [connection signal="customer_changed" from="RestaurantView" to="FoodItems" method="_on_RestaurantView_customer_changed"]
 [connection signal="hit_next_pieces" from="FrostingGlobs" to="FrostingSfx" method="_on_FrostingGlobs_hit_next_pieces"]
-[connection signal="hit_playfield" from="FrostingGlobs" to="Playfield" method="_on_FrostingGlobs_hit_playfield"]
 [connection signal="hit_playfield" from="FrostingGlobs" to="FrostingSfx" method="_on_FrostingGlobs_hit_playfield"]
-[connection signal="hit_wall" from="FrostingGlobs" to="WallGlobViewports" method="_on_FrostingGlobs_hit_wall"]
+[connection signal="hit_playfield" from="FrostingGlobs" to="Playfield" method="_on_FrostingGlobs_hit_playfield"]
 [connection signal="hit_wall" from="FrostingGlobs" to="FrostingSfx" method="_on_FrostingGlobs_hit_wall"]
+[connection signal="hit_wall" from="FrostingGlobs" to="WallGlobViewports" method="_on_FrostingGlobs_hit_wall"]
 [connection signal="timeout" from="FoodItems/FoodFlightTimer" to="FoodItems" method="_on_FoodFlightTimer_timeout"]
 [connection signal="back_button_pressed" from="Hud/HudUi/PuzzleMessages" to="." method="_on_Hud_back_button_pressed"]
 [connection signal="settings_button_pressed" from="Hud/HudUi/PuzzleMessages" to="." method="_on_Hud_settings_button_pressed"]
@@ -671,5 +671,5 @@ script = ExtResource( 19 )
 [connection signal="hide" from="SettingsMenu" to="Hud/TouchButtons" method="_on_Menu_hide"]
 [connection signal="quit_pressed" from="SettingsMenu" to="." method="_on_SettingsMenu_quit_pressed"]
 [connection signal="show" from="SettingsMenu" to="Hud/TouchButtons" method="_on_Menu_show"]
-[connection signal="cheat_detected" from="CheatCodeDetector" to="Hud/HudUi/PuzzleTrace" method="_on_CheatCodeDetector_cheat_detected"]
 [connection signal="cheat_detected" from="CheatCodeDetector" to="Hud/FpsLabel" method="_on_CheatCodeDetector_cheat_detected"]
+[connection signal="cheat_detected" from="CheatCodeDetector" to="Hud/HudUi/PuzzleTrace" method="_on_CheatCodeDetector_cheat_detected"]

--- a/project/src/main/puzzle/duration-calculator.gd
+++ b/project/src/main/puzzle/duration-calculator.gd
@@ -63,11 +63,13 @@ Returns the estimated time to clear the specified number of lines.
 """
 func _duration_for_lines(settings: LevelSettings, lines: float) -> float:
 	var min_frames_per_line := RankCalculator.min_frames_per_line(PieceSpeeds.speed(settings.difficulty))
-	var lines_per_minute := 60 * 60 / min_frames_per_line
-	lines_per_minute *= pow(RankCalculator.RDF_SPEED, _rank(settings))
+	var min_lines_per_frame := 1 / min_frames_per_line
+	var master_lines_per_second := 60 * min_lines_per_frame + 2 * settings.rank.extra_seconds_per_piece
+	var master_lines_per_minute := 60 * master_lines_per_second
+	master_lines_per_minute *= pow(RankCalculator.RDF_SPEED, _rank(settings))
 	# minimum 8.0 lines per minute; novices don't play THAT slowly
-	lines_per_minute = max(MIN_LINES_PER_MINUTE, lines_per_minute)
-	return 60 * lines / lines_per_minute
+	master_lines_per_minute = max(MIN_LINES_PER_MINUTE, master_lines_per_minute)
+	return 60 * lines / master_lines_per_minute
 
 
 """

--- a/project/src/main/puzzle/level/level-settings.gd
+++ b/project/src/main/puzzle/level/level-settings.gd
@@ -26,6 +26,9 @@ var finish_condition := Milestone.new()
 # Sequence of puzzle inputs to be replayed for things such as tutorials.
 var input_replay := InputReplay.new()
 
+# Triggers which cause strange things to happen during a level.
+var triggers := LevelTriggers.new()
+
 # Array of Milestone objects representing the requirements to speed up. This mostly applies to 'Marathon Mode' where
 # clearing lines makes you speed up.
 var speed_ups := []
@@ -148,6 +151,8 @@ func from_json_dict(new_id: String, json: Dictionary) -> void:
 		success_condition.from_json_dict(json["success_condition"])
 	if json.has("input_replay"):
 		input_replay.from_json_string_array(json["input_replay"])
+	if json.has("triggers"):
+		triggers.from_json_array(json["triggers"])
 
 
 func load_from_resource(new_id: String) -> void:

--- a/project/src/main/puzzle/level/level-trigger-effect.gd
+++ b/project/src/main/puzzle/level/level-trigger-effect.gd
@@ -1,0 +1,27 @@
+class_name LevelTriggerEffect
+"""
+An abstract class describing the effect of a level trigger.
+
+A LevelTriggerEffect might subtract points from the player's score, rotate a piece or turn the playfield invisible.
+"""
+
+"""
+Executes this level trigger effect.
+
+Parameters:
+	'params': Parameters specific to this level trigger's phase. For example, a phase which involves clearing lines
+		could pass in parameters specifying which lines were cleared.
+"""
+func run(_params: Array = []) -> void:
+	pass
+
+
+"""
+Populates this level trigger with the specified string parameters.
+
+Parameters:
+	'new_config': An array of string parameters parsed from json. For example, a level trigger effect which rotates the
+		piece could pass in parameters specifying the direction to rotate.
+"""
+func set_config(_new_config: Array = []) -> void:
+	pass

--- a/project/src/main/puzzle/level/level-trigger-effects.gd
+++ b/project/src/main/puzzle/level/level-trigger-effects.gd
@@ -1,0 +1,67 @@
+extends Node
+"""
+A library of level trigger effects.
+
+These effects are each mapped to a unique string so that they can be referenced from json.
+"""
+
+"""
+Rotates one or more pieces in the piece queue.
+"""
+class RotateNextPiecesEffect extends LevelTriggerEffect:
+	enum Rotation {
+		NONE, RIGHT, LEFT, TWICE
+	}
+	
+	# an enum in Rotation corresponding to the direction to rotate
+	var rotate_dir: int
+	
+	# The first piece index in the queue to rotate, inclusive
+	var next_piece_from_index: int = 0
+	
+	# The last piece index in the queue to rotate, inclusive
+	var next_piece_to_index: int = 999999
+	
+	"""
+	Updates the effect's configuration.
+	
+	This effect's configuration accepts the following parameters:
+	
+	[0]: (Optional) The direction to rotate, 'right', 'left', 'twice' or 'none'. Defaults to 'none'.
+	[1]: (Optional) The first piece index in the queue to rotate. Defaults to 0.
+	[2]: (Optional) The last piece index in the queue to rotate. Defaults to 999999.
+	
+	Example: ["right", "0", "0"]
+	"""
+	func set_config(new_config: Array = []) -> void:
+		if new_config.size() >= 1:
+			match(new_config[0]):
+				"none": rotate_dir = Rotation.NONE
+				"right": rotate_dir = Rotation.RIGHT
+				"left": rotate_dir = Rotation.LEFT
+				"twice": rotate_dir = Rotation.TWICE
+		
+		if new_config.size() >= 2:
+			next_piece_from_index = new_config[1].to_int()
+		
+		if new_config.size() >= 3:
+			next_piece_to_index = new_config[2].to_int()
+	
+	
+	"""
+	Rotates one or more pieces in the piece queue.
+	"""
+	func run(_params: Array = []) -> void:
+		for i in range(next_piece_from_index, next_piece_to_index + 1):
+			if i >= PieceQueue.pieces.size():
+				break
+			var next_piece: NextPiece = PieceQueue.pieces[i]
+			match rotate_dir:
+				Rotation.RIGHT: next_piece.orientation = next_piece.get_cw_orientation()
+				Rotation.LEFT: next_piece.orientation = next_piece.get_ccw_orientation()
+				Rotation.TWICE: next_piece.orientation = next_piece.get_flip_orientation()
+
+
+var effects_by_string := {
+	"rotate_next_pieces": RotateNextPiecesEffect,
+}

--- a/project/src/main/puzzle/level/level-trigger.gd
+++ b/project/src/main/puzzle/level/level-trigger.gd
@@ -1,0 +1,82 @@
+class_name LevelTrigger
+"""
+A trigger which causes strange things to happen during a level.
+
+A level can contain any number of triggers, and each trigger makes something happen at a specific time. For example, a
+trigger might rotate the pieces in the piece queue every 2 seconds, or a trigger might toggle the playfield invisible
+every time the player places a piece.
+"""
+
+# phases when a level trigger can fire
+enum LevelTriggerPhase {
+	ROTATED_RIGHT,
+	ROTATED_LEFT,
+	ROTATED_TWICE,
+	INITIAL_ROTATED_RIGHT,
+	INITIAL_ROTATED_LEFT,
+	INITIAL_ROTATED_TWICE,
+}
+
+const ROTATED_RIGHT := LevelTriggerPhase.ROTATED_RIGHT
+const ROTATED_LEFT := LevelTriggerPhase.ROTATED_LEFT
+const ROTATED_TWICE := LevelTriggerPhase.ROTATED_TWICE
+const INITIAL_ROTATED_RIGHT := LevelTriggerPhase.INITIAL_ROTATED_RIGHT
+const INITIAL_ROTATED_LEFT := LevelTriggerPhase.INITIAL_ROTATED_LEFT
+const INITIAL_ROTATED_TWICE := LevelTriggerPhase.INITIAL_ROTATED_TWICE
+
+# key: json string corresponding to a phase
+# value: an enum from LevelTriggerPhase
+const PHASE_INTS_BY_STRING := {
+	"rotated_right": ROTATED_RIGHT,
+	"rotated_left": ROTATED_LEFT,
+	"rotated_twice": ROTATED_TWICE,
+	"initial_rotated_right": INITIAL_ROTATED_RIGHT,
+	"initial_rotated_left": INITIAL_ROTATED_LEFT,
+	"initial_rotated_twice": INITIAL_ROTATED_TWICE,
+}
+
+# key: an enum from LevelTriggerPhase
+# value: 'true' if this trigger should fire during that phase
+var phases := {}
+
+# the effect caused by this level trigger
+var effect: LevelTriggerEffect
+
+"""
+Enables this trigger for the specified phase.
+
+Parameters:
+	'phase': an enum from LevelTriggerPhase corresponding to the new phase.
+"""
+func add_phase(phase: int) -> void:
+	phases[phase] = true
+
+
+"""
+Executes this level trigger's effect.
+
+Parameters:
+	'params': Parameters specific to this level trigger's phase. For example, a phase which involves clearing lines
+		could pass in parameters specifying which lines were cleared.
+"""
+func run(params: Array = []) -> void:
+	effect.run(params)
+
+
+func from_json_dict(json: Dictionary) -> void:
+	for phase_string in json.get("phases", []):
+		if not PHASE_INTS_BY_STRING.has(phase_string):
+			push_warning("Unrecognized phase: %s" % [phase_string])
+			continue
+		
+		add_phase(PHASE_INTS_BY_STRING.get(phase_string))
+	
+	var effect_string: String = json.get("effect")
+	var effect_key: String = StringUtils.substring_before(effect_string, " ")
+	var effect_config: Array = StringUtils.substring_after(effect_string, " ").split(" ")
+	if not LevelTriggerEffects.effects_by_string.has(effect_key):
+		push_warning("Unrecognized effect: %s" % [effect_key])
+	var effect_script: GDScript = LevelTriggerEffects.effects_by_string.get(effect_key)
+	effect = effect_script.new()
+	if effect_config:
+		effect.set_config(effect_config)

--- a/project/src/main/puzzle/level/level-triggers.gd
+++ b/project/src/main/puzzle/level/level-triggers.gd
@@ -1,0 +1,39 @@
+class_name LevelTriggers
+"""
+Triggers which cause strange things to happen during a level.
+
+A level can contain any number of triggers, and each trigger makes something happen at a specific time. For example, a
+trigger might rotate the pieces in the piece queue every 2 seconds, or a trigger might toggle the playfield invisible
+every time the player places a piece.
+"""
+
+# key: An enum from LevelTrigger.LevelTriggerPhase
+# value: An array of LevelTriggers which should happen during that phase
+var _triggers := {}
+
+"""
+Runs all triggers for the specified phase.
+
+Parameters:
+	'phase': An enum from LevelTrigger.LevelTriggerPhase corresponding to the triggers to run.
+"""
+func run_triggers(phase: int) -> void:
+	if not _triggers.has(phase):
+		return
+	
+	for trigger in _triggers.get(phase, []):
+		trigger.run()
+
+
+func from_json_array(json: Array) -> void:
+	for trigger_json in json:
+		var trigger := LevelTrigger.new()
+		trigger.from_json_dict(trigger_json)
+		_add_trigger(trigger)
+
+
+func _add_trigger(trigger: LevelTrigger) -> void:
+	for phase in trigger.phases:
+		if not _triggers.has(phase):
+			_triggers[phase] = []
+		_triggers[phase].append(trigger)

--- a/project/src/main/puzzle/level/other-rules.gd
+++ b/project/src/main/puzzle/level/other-rules.gd
@@ -3,6 +3,12 @@ class_name OtherRules
 Rules which are unique enough that it doesn't make sense to put them in their own groups.
 """
 
+enum SuppressPieceRotation {
+	NONE, # piece rotation is not suppressed
+	ROTATION, # piece rotation is suppressed, but rotation signals still fire for things like sfx
+	ROTATION_AND_SIGNALS # piece rotation is suppressed, no rotation signals fire for things like sfx
+}
+
 # 'true' for levels which follow tutorial levels
 var after_tutorial := false
 
@@ -14,6 +20,12 @@ var enhance_combo_fx := false
 
 # 'true' for non-interactive tutorial levels which don't let the player do anything
 var non_interactive := false
+
+# an enum from SuppressPieceRotation for whether pieces can rotate
+var suppress_piece_rotation: int = SuppressPieceRotation.NONE
+
+# an enum from SuppressPieceRotation for whether pieces can be initially rotated by holding a rotate key
+var suppress_piece_initial_rotation: int = SuppressPieceRotation.NONE
 
 # When the player first launches the game and does the tutorial, we skip the start button and countdown.
 var skip_intro := false
@@ -30,5 +42,15 @@ func from_json_string_array(json: Array) -> void:
 	if rules.has("enhance_combo_fx"): enhance_combo_fx = true
 	if rules.has("no_clear_on_finish"): clear_on_finish = false
 	if rules.has("non_interactive"): non_interactive = true
+	if rules.has("suppress_piece_rotation"):
+		match(rules.string_value()):
+			# rules.string_value() returns '1' if there are no parameters specified
+			"1", "rotation": suppress_piece_rotation = SuppressPieceRotation.ROTATION
+			"rotation_and_signals": suppress_piece_rotation = SuppressPieceRotation.ROTATION_AND_SIGNALS
+	if rules.has("suppress_piece_initial_rotation"):
+		match(rules.string_value()):
+			# rules.string_value() returns '1' if there are no parameters specified
+			"1", "rotation": suppress_piece_initial_rotation = SuppressPieceRotation.ROTATION
+			"rotation_and_signals": suppress_piece_initial_rotation = SuppressPieceRotation.ROTATION_AND_SIGNALS
 	if rules.has("start_level"): start_level = rules.string_value()
 	if rules.has("tutorial"): tutorial = true

--- a/project/src/main/puzzle/level/rank-rules.gd
+++ b/project/src/main/puzzle/level/rank-rules.gd
@@ -11,6 +11,9 @@ var box_factor := 1.0
 # needs 3x the usual combo points per line to get a good rank
 var combo_factor := 1.0
 
+# extra time it takes an expert to move the piece where it belongs
+var extra_seconds_per_piece := 0.0
+
 # expected combo per customer
 var customer_combo := 0
 
@@ -41,3 +44,4 @@ func from_json_string_array(json: Array) -> void:
 	if rules.has("success_bonus"): success_bonus = rules.float_value()
 	if rules.has("top_out_penalty"): top_out_penalty = rules.int_value()
 	if rules.has("unranked"): unranked = true
+	if rules.has("extra_seconds_per_piece"): extra_seconds_per_piece = rules.float_value()

--- a/project/src/main/puzzle/piece/NextPieceDisplays.tscn
+++ b/project/src/main/puzzle/piece/NextPieceDisplays.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://src/main/puzzle/piece/next-piece-displays.gd" type="Script" id=1]
 [ext_resource path="res://src/main/puzzle/piece/NextPieceDisplay.tscn" type="PackedScene" id=2]
 [ext_resource path="res://assets/main/puzzle/next-piece-bg.png" type="Texture" id=3]
-[ext_resource path="res://src/main/puzzle/piece/piece-queue.gd" type="Script" id=4]
 
 [node name="NextPieceDisplays" type="Control"]
 margin_right = 64.0
@@ -58,6 +57,3 @@ color = Color( 0, 0, 0, 0.627451 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
-
-[node name="PieceQueue" type="Node" parent="."]
-script = ExtResource( 4 )

--- a/project/src/main/puzzle/piece/next-piece-display.gd
+++ b/project/src/main/puzzle/piece/next-piece-display.gd
@@ -10,33 +10,33 @@ const UNROTATED := PieceType.Orientation.UNROTATED
 # how far into the future this display should look; 0 = show the next piece, 10 = show the 11th piece
 var _piece_index := 0
 
-# currently displayed piece type
-var _displayed_piece
-
-# queue of upcoming randomized pieces
-var _piece_queue: PieceQueue
+var _displayed_piece: NextPiece
+var _displayed_orientation: int
 
 onready var _tile_map: PuzzleTileMap = $TileMap
 
-func initialize(piece_queue: PieceQueue, piece_index: int) -> void:
-	_piece_queue = piece_queue
+func initialize(piece_index: int) -> void:
 	_piece_index = piece_index
 
 
 func _process(_delta: float) -> void:
-	var next_piece := _piece_queue.get_next_piece(_piece_index)
-	if next_piece != _displayed_piece:
+	var next_piece: NextPiece = PieceQueue.get_next_piece(_piece_index)
+	if next_piece != _displayed_piece or next_piece.orientation != _displayed_orientation:
 		_tile_map.clear()
 		if next_piece != PieceTypes.piece_null:
-			var bounding_box := Rect2(next_piece.get_cell_position(UNROTATED, 0), Vector2(1.0, 1.0))
+			var bounding_box := Rect2( \
+					next_piece.type.get_cell_position(next_piece.orientation, 0), Vector2(1.0, 1.0))
 			# update the tile map with the new piece type
-			for i in range(next_piece.pos_arr[0].size()):
-				var block_pos := next_piece.get_cell_position(UNROTATED, i)
-				var block_color := next_piece.get_cell_color(UNROTATED, i)
+			for i in range(next_piece.type.pos_arr[0].size()):
+				var block_pos := next_piece.type.get_cell_position(next_piece.orientation, i)
+				var block_color := next_piece.type.get_cell_color(next_piece.orientation, i)
 				_tile_map.set_block(block_pos, 0, block_color)
-				bounding_box = bounding_box.expand(next_piece.get_cell_position(UNROTATED, i))
-				bounding_box = bounding_box.expand(next_piece.get_cell_position(UNROTATED, i) + Vector2(1, 1))
+				bounding_box = bounding_box.expand( \
+						next_piece.type.get_cell_position(next_piece.orientation, i))
+				bounding_box = bounding_box.expand( \
+						next_piece.type.get_cell_position(next_piece.orientation, i) + Vector2(1, 1))
 			_tile_map.position = _tile_map.cell_size \
 					* (Vector2(1.5, 1.5) - (bounding_box.position + bounding_box.size / 2.0)) / 2.0
 		_tile_map.corner_map.dirty = true
 		_displayed_piece = next_piece
+		_displayed_orientation = next_piece.orientation

--- a/project/src/main/puzzle/piece/next-piece-displays.gd
+++ b/project/src/main/puzzle/piece/next-piece-displays.gd
@@ -19,18 +19,11 @@ func _ready() -> void:
 
 
 """
-Pops the next piece off the queue.
-"""
-func pop_next_piece() -> PieceType:
-	return $PieceQueue.pop_next_piece()
-
-
-"""
 Adds a new next piece display.
 """
 func _add_display(piece_index: int, x: float, y: float, scale: float) -> void:
 	var new_display: NextPieceDisplay = NextPieceDisplayScene.instance()
-	new_display.initialize($PieceQueue, piece_index)
+	new_display.initialize(piece_index)
 	new_display.scale = Vector2(scale, scale)
 	new_display.position = Vector2(x, y)
 	new_display.hide()

--- a/project/src/main/puzzle/piece/next-piece.gd
+++ b/project/src/main/puzzle/piece/next-piece.gd
@@ -1,0 +1,37 @@
+class_name NextPiece
+"""
+Contains the settings and state for an upcoming piece.
+"""
+
+# Piece shape, color, kick information
+var type: PieceType
+
+# The current orientation. For most pieces, orientation will range from
+# [0, 1, 2, 3] for [unrotated, clockwise, flipped, counterclockwise].
+#
+# Pieces in the next queue are typically unrotated.
+var orientation := 0
+
+"""
+Returns the orientation the piece will be in if it rotates clockwise.
+"""
+func get_cw_orientation() -> int:
+	return wrapi(orientation + 1, 0, type.pos_arr.size())
+
+
+"""
+Returns the orientation the piece will be in if it rotates counter-clockwise.
+"""
+func get_ccw_orientation() -> int:
+	return wrapi(orientation - 1, 0, type.pos_arr.size())
+
+
+"""
+Returns the orientation the piece will be in if it rotates 180 degrees.
+"""
+func get_flip_orientation() -> int:
+	return wrapi(orientation + 2, 0, type.pos_arr.size())
+
+
+func _to_string() -> String:
+	return type.to_string()

--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -36,7 +36,6 @@ signal lock_started
 signal tiles_changed(tile_map)
 
 export (NodePath) var playfield_path: NodePath
-export (NodePath) var next_piece_displays_path: NodePath
 
 # settings and state for the currently active piece.
 var piece: ActivePiece
@@ -50,7 +49,6 @@ var drawn_piece_orientation: int
 onready var tile_map: PuzzleTileMap = $TileMap
 onready var input: PieceInput = $Input
 
-onready var _next_piece_displays: NextPieceDisplays = get_node(next_piece_displays_path)
 onready var _physics: PiecePhysics = $Physics
 onready var _playfield: Playfield = get_node(playfield_path)
 onready var _states: PieceStates = $States
@@ -118,8 +116,9 @@ Spawns a new piece at the top of the _playfield.
 Returns 'true' if the piece was spawned successfully, or 'false' if the player topped out.
 """
 func spawn_piece() -> bool:
-	var piece_type := _next_piece_displays.pop_next_piece()
-	piece = ActivePiece.new(piece_type, funcref(_playfield.tile_map, "is_cell_blocked"))
+	var next_piece := PieceQueue.pop_next_piece()
+	piece = ActivePiece.new(next_piece.type, funcref(_playfield.tile_map, "is_cell_blocked"))
+	piece.orientation = next_piece.orientation
 	var success := _physics.spawn_piece(piece)
 	emit_signal("piece_spawned")
 	emit_signal("piece_changed", piece)

--- a/project/src/main/puzzle/piece/piece-physics.gd
+++ b/project/src/main/puzzle/piece/piece-physics.gd
@@ -24,6 +24,14 @@ Returns 'true' if the piece was spawned successfully, or 'false' if the player t
 """
 func spawn_piece(piece: ActivePiece) -> bool:
 	rotator.apply_initial_rotate_input(piece)
+	
+	# relocate piece to the top of the playfield
+	var highest_pos := 3
+	for pos_arr_item in piece.get_pos_arr():
+		if pos_arr_item.y < highest_pos:
+			highest_pos = pos_arr_item.y
+	piece.pos.y -= highest_pos
+	
 	mover.apply_initial_move_input(piece)
 	
 	var success := true

--- a/project/src/main/puzzle/piece/piece-rotator.gd
+++ b/project/src/main/puzzle/piece/piece-rotator.gd
@@ -3,8 +3,11 @@ extends Node
 Handles horizontal movement for the player's active piece.
 """
 
+# warning-ignore:unused_signal
 signal initial_rotated_left
+# warning-ignore:unused_signal
 signal initial_rotated_right
+# warning-ignore:unused_signal
 signal initial_rotated_twice
 
 # warning-ignore:unused_signal
@@ -22,26 +25,44 @@ func apply_initial_rotate_input(piece: ActivePiece) -> void:
 	if not input.is_cw_pressed() and not input.is_ccw_pressed():
 		return
 	
-	if input.is_cw_pressed() and input.is_ccw_pressed():
-		input.set_cw_input_as_handled()
-		input.set_ccw_input_as_handled()
-		piece.orientation = piece.get_flip_orientation()
-		emit_signal("initial_rotated_twice")
-	elif input.is_cw_pressed():
-		input.set_cw_input_as_handled()
-		piece.orientation = piece.get_cw_orientation()
-		emit_signal("initial_rotated_right")
-	elif input.is_ccw_pressed():
-		input.set_ccw_input_as_handled()
-		piece.orientation = piece.get_ccw_orientation()
-		emit_signal("initial_rotated_left")
+	var rotation_signal: String
 	
-	# relocate rotated piece to the top of the playfield
-	var highest_pos := 3
-	for pos_arr_item in piece.get_pos_arr():
-		if pos_arr_item.y < highest_pos:
-			highest_pos = pos_arr_item.y
-	piece.pos.y -= highest_pos
+	if input.is_cw_pressed() and input.is_ccw_pressed():
+		rotation_signal = "initial_rotated_twice"
+	elif input.is_cw_pressed():
+		rotation_signal = "initial_rotated_right"
+	elif input.is_ccw_pressed():
+		rotation_signal = "initial_rotated_left"
+	
+	match rotation_signal:
+		"initial_rotated_left":
+			input.set_ccw_input_as_handled()
+			piece.target_orientation = piece.get_ccw_orientation()
+		"initial_rotated_right":
+			input.set_cw_input_as_handled()
+			piece.target_orientation = piece.get_cw_orientation()
+		"initial_rotated_twice":
+			input.set_cw_input_as_handled()
+			input.set_ccw_input_as_handled()
+			piece.target_orientation = piece.get_flip_orientation()
+	
+	if rotation_signal:
+		match CurrentLevel.settings.other.suppress_piece_initial_rotation:
+			OtherRules.SuppressPieceRotation.ROTATION_AND_SIGNALS:
+				# 'suppress piece initial rotation and signals' is enabled; do nothing
+				pass
+			OtherRules.SuppressPieceRotation.ROTATION:
+				# 'suppress piece initial rotation' is enabled; emit rotation signals but don't rotate
+				emit_signal(rotation_signal)
+			_:
+				# rotate the piece and emit rotation signals
+				piece.move_to_target()
+				emit_signal(rotation_signal)
+	
+	match rotation_signal:
+		"initial_rotated_left": CurrentLevel.settings.triggers.run_triggers(LevelTrigger.INITIAL_ROTATED_LEFT)
+		"initial_rotated_right": CurrentLevel.settings.triggers.run_triggers(LevelTrigger.INITIAL_ROTATED_RIGHT)
+		"initial_rotated_twice": CurrentLevel.settings.triggers.run_triggers(LevelTrigger.INITIAL_ROTATED_TWICE)
 
 
 func apply_rotate_input(piece: ActivePiece) -> void:
@@ -70,13 +91,30 @@ func apply_rotate_input(piece: ActivePiece) -> void:
 		
 		if piece.target_pos.y < piece.pos.y and not piece.can_floor_kick():
 			# tried to flip but we don't have any floor kicks for it
-			pass
-		elif piece.can_move_to_target():
-			piece.move_to_target()
-			if rotation_signal:
-				emit_signal(rotation_signal)
-			if piece.pos.y < old_piece_y:
-				piece.floor_kicks += 1
+			rotation_signal = ""
+		elif not piece.can_move_to_target():
+			rotation_signal = ""
+		
+		if rotation_signal:
+			match CurrentLevel.settings.other.suppress_piece_rotation:
+				OtherRules.SuppressPieceRotation.ROTATION_AND_SIGNALS:
+					# 'suppress piece rotation and signals' is enabled; do nothing
+					pass
+				OtherRules.SuppressPieceRotation.ROTATION:
+					# 'suppress piece rotation' is enabled; emit rotation signals but don't rotate
+					emit_signal(rotation_signal)
+				_:
+					# rotate the piece and emit rotation signals
+					piece.move_to_target()
+					emit_signal(rotation_signal)
+		
+		if piece.pos.y < old_piece_y:
+			piece.floor_kicks += 1
+		
+		match rotation_signal:
+			"rotated_left": CurrentLevel.settings.triggers.run_triggers(LevelTrigger.ROTATED_LEFT)
+			"rotated_right": CurrentLevel.settings.triggers.run_triggers(LevelTrigger.ROTATED_RIGHT)
+			"rotated_twice": CurrentLevel.settings.triggers.run_triggers(LevelTrigger.ROTATED_TWICE)
 
 
 """

--- a/project/src/main/puzzle/piece/piece-types.gd
+++ b/project/src/main/puzzle/piece/piece-types.gd
@@ -114,11 +114,15 @@ var piece_l := PieceType.new("l",
 	)
 
 var piece_o := PieceType.new("o",
-		# shape data, two states so that the rotate button has an effect
+		# shape data, four states so that the rotate button has an effect and can distinguish cw/ccw rotation
 		[[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)],
+		[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)],
+		[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)],
 		[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)]],
 		# color data
 		[[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)],
+		[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)],
+		[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)],
 		[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)]],
 		KICKS_NONE,
 		[Vector2(0, 0), Vector2(0, 0), Vector2(0, 0), Vector2(0, 0)]

--- a/project/src/test/puzzle/piece/test-piece-queue.gd
+++ b/project/src/test/puzzle/piece/test-piece-queue.gd
@@ -3,22 +3,53 @@ extends "res://addons/gut/test.gd"
 Unit test for the queue of upcoming pieces.
 """
 
+var _piece_dict := {
+	"j": PieceTypes.piece_j,
+	"l": PieceTypes.piece_l,
+	"o": PieceTypes.piece_o,
+	"p": PieceTypes.piece_p,
+	"q": PieceTypes.piece_q,
+	"t": PieceTypes.piece_t,
+	"u": PieceTypes.piece_u,
+	"v": PieceTypes.piece_v
+}
+
 func test_empty() -> void:
-	assert_eq([0], PieceQueue.non_adjacent_indexes([], 3))
+	assert_eq([0], non_adjacent_indexes([], "p"))
 
 
 func test_nothing_matches() -> void:
-	assert_eq([0, 1, 2, 3], PieceQueue.non_adjacent_indexes([1, 1, 1], 2))
+	assert_eq([0, 1, 2, 3], non_adjacent_indexes(["l", "l", "l"], "o"))
 
 
 func test_many_matches() -> void:
-	assert_eq([0, 3, 6], PieceQueue.non_adjacent_indexes([1, 2, 1, 1, 2, 1], 2))
+	assert_eq([0, 3, 6], non_adjacent_indexes(["l", "o", "l", "l", "o", "l"], "o"))
 
 
 func test_from_index() -> void:
-	assert_eq([3, 4], PieceQueue.non_adjacent_indexes([1, 2, 1, 1], 2, 3))
-	assert_eq([4], PieceQueue.non_adjacent_indexes([1, 2, 1, 1], 2, 4))
+	assert_eq([3, 4], non_adjacent_indexes(["l", "o", "l", "l"], "o", 3))
+	assert_eq([4], non_adjacent_indexes(["l", "o", "l", "l"], "o", 4))
 
 
 func test_no_possibilities() -> void:
-	assert_eq([], PieceQueue.non_adjacent_indexes([2, 1, 2], 2))
+	assert_eq([], non_adjacent_indexes(["o", "l", "o"], "o"))
+
+
+"""
+Convenience function which converts strings into appropriate piece parameters.
+
+Parameters:
+	'piece_strings': An array of strings like 't' and 'o' corresponding to piece shapes.
+	
+	'piece_type_string': A string like 't' or 'o' corresponding to a piece type.
+	
+	'from_index': The lowest position to check in the piece queue.
+"""
+func non_adjacent_indexes(piece_strings: Array, piece_type_string: String, from_index: int = 0) -> Array:
+	var pieces := []
+	for piece_string in piece_strings:
+		var next_piece := NextPiece.new()
+		next_piece.type = _piece_dict.get(piece_string)
+		pieces.append(next_piece)
+	var piece_type: PieceType = _piece_dict.get(piece_type_string)
+	return PieceQueue.non_adjacent_indexes(pieces, piece_type, from_index)

--- a/project/src/test/puzzle/test-rank-calculator.gd
+++ b/project/src/test/puzzle/test-rank-calculator.gd
@@ -17,35 +17,35 @@ func before_each() -> void:
 	PuzzleScore.level_performance = PuzzlePerformance.new()
 
 
-func test_max_lpm_slow_marathon() -> void:
+func test_master_lpm_slow_marathon() -> void:
 	CurrentLevel.settings.set_start_speed("0")
-	assert_almost_eq(_rank_calculator._max_lpm(), 30.77, 0.1)
+	assert_almost_eq(_rank_calculator._master_lpm(), 30.77, 0.1)
 
 
-func test_max_lpm_medium_marathon() -> void:
+func test_master_lpm_medium_marathon() -> void:
 	CurrentLevel.settings.set_start_speed("A0")
-	assert_almost_eq(_rank_calculator._max_lpm(), 35.64, 0.1)
+	assert_almost_eq(_rank_calculator._master_lpm(), 35.64, 0.1)
 
 
-func test_max_lpm_fast_marathon() -> void:
+func test_master_lpm_fast_marathon() -> void:
 	CurrentLevel.settings.set_start_speed("F0")
-	assert_almost_eq(_rank_calculator._max_lpm(), 68.90, 0.1)
+	assert_almost_eq(_rank_calculator._master_lpm(), 68.90, 0.1)
 
 
-func test_max_lpm_mixed_marathon() -> void:
+func test_master_lpm_mixed_marathon() -> void:
 	CurrentLevel.settings.set_start_speed("0")
 	CurrentLevel.settings.add_speed_up(Milestone.LINES, 30, "A0")
 	CurrentLevel.settings.add_speed_up(Milestone.LINES, 60, "F0")
 	CurrentLevel.settings.set_finish_condition(Milestone.LINES, 100)
-	assert_almost_eq(_rank_calculator._max_lpm(), 46.23, 0.1)
+	assert_almost_eq(_rank_calculator._master_lpm(), 46.23, 0.1)
 
 
-func test_max_lpm_mixed_sprint() -> void:
+func test_master_lpm_mixed_sprint() -> void:
 	CurrentLevel.settings.set_start_speed("0")
 	CurrentLevel.settings.add_speed_up(Milestone.TIME_OVER, 30, "A0")
 	CurrentLevel.settings.add_speed_up(Milestone.TIME_OVER, 60, "F0")
 	CurrentLevel.settings.set_finish_condition(Milestone.TIME_OVER, 90)
-	assert_almost_eq(_rank_calculator._max_lpm(), 50.98, 0.1)
+	assert_almost_eq(_rank_calculator._master_lpm(), 50.98, 0.1)
 
 
 func test_calculate_rank_marathon_300_master() -> void:
@@ -356,3 +356,19 @@ func test_unranked_loss() -> void:
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank.seconds_rank), "-")
 	assert_eq(RankCalculator.grade(rank.score_rank), "-")
+
+
+func test_extra_seconds_per_piece() -> void:
+	CurrentLevel.settings.set_finish_condition(Milestone.TIME_OVER, 180)
+	PuzzleScore.level_performance.seconds = 180
+	PuzzleScore.level_performance.lines = 60
+	PuzzleScore.level_performance.score = 1160
+	var rank1 := _rank_calculator.calculate_rank()
+	assert_eq(RankCalculator.grade(rank1.speed_rank), "S+")
+	assert_eq(RankCalculator.grade(rank1.score_rank), "S+")
+	
+	# with the 'extra_seconds_per_piece' setting enabled, the player gets a better grade
+	CurrentLevel.settings.rank.extra_seconds_per_piece = 1.2
+	var rank2 = _rank_calculator.calculate_rank()
+	assert_eq(RankCalculator.grade(rank2.speed_rank), "M")
+	assert_eq(RankCalculator.grade(rank2.score_rank), "SSS")

--- a/project/src/test/test-backwards-compatible.gd
+++ b/project/src/test/test-backwards-compatible.gd
@@ -55,6 +55,12 @@ func load_1b3c_data() -> void:
 	PlayerSave.load_player_data()
 
 
+func load_245b_data() -> void:
+	var dir := Directory.new()
+	dir.copy("res://assets/test/turbofat-245b.json", "user://%s" % TEMP_FILENAME)
+	PlayerSave.load_player_data()
+
+
 func test_0517_lost_true() -> void:
 	load_0517_data()
 	
@@ -184,3 +190,14 @@ func test_1b3c() -> void:
 	var history_marathon: RankResult = PlayerData.level_history.results("practice/marathon_hard")[0]
 	assert_eq(history_marathon.lost, false)
 	assert_eq(history_marathon.score, 5115)
+
+
+func test_245b() -> void:
+	load_245b_data()
+	
+	# some levels were made much harder/different, and their scores should be invalidated
+	assert_true(PlayerData.level_history.level_names().has("marsh/pulling_for_everyone"))
+	assert_false(PlayerData.level_history.level_names().has("marsh/hello_everyone"))
+	assert_false(PlayerData.level_history.level_names().has("marsh/hello_skins"))
+	assert_false(PlayerData.level_history.level_names().has("marsh/pulling_for_skins"))
+	assert_false(PlayerData.level_history.level_names().has("marsh/goodbye_skins"))


### PR DESCRIPTION
PieceQueue is an autoload singleton which stores NextPieces instead of
PieceTypes. This allows the rotation of pieces in the next queue.

Refactored PieceRotator for symmetry. PieceRotator now splits up logic into
'before stuff rotates' and 'after stuff rotates' which may help for future
levels. While there is no 'pre_rotate_left' phase, it's now trivial to add
one.

Skins's levels now follow a logical progression where they start by
rotating everything, and end by rotating nothing. Updated the save data
version and purged scores for the affected levels.

New 'extra seconds per piece' field. This is necessary for annoying
levels where moving/rotating the pieces is harder than usual.