### PR TITLE
Sensei weight gain. Creature fading. Noise renames. Warnings.

### DIFF
--- a/project/assets/main/creatures/sensei/creature.json
+++ b/project/assets/main/creatures/sensei/creature.json
@@ -29,5 +29,6 @@
     "accent_texture": 6,
     "color": "a854cb",
     "dark": false
-  }
+  },
+  "weight_gain_scale": 0.0
 }

--- a/project/src/main/puzzle/frame-drops-label.gd
+++ b/project/src/main/puzzle/frame-drops-label.gd
@@ -34,7 +34,7 @@ func _ready() -> void:
 	_refresh_text()
 
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	_expected_visual_msec += _seconds_per_frame * 1000
 	_actual_visual_msec = OS.get_system_time_msecs()
 	
@@ -46,7 +46,7 @@ func _process(delta: float) -> void:
 		_refresh_text()
 
 
-func _physics_process(delta: float) -> void:
+func _physics_process(_delta: float) -> void:
 	_expected_physics_msec += _seconds_per_frame * 1000
 	_actual_physics_msec = OS.get_system_time_msecs()
 	

--- a/project/src/main/puzzle/piece/piece-queue.gd
+++ b/project/src/main/puzzle/piece/piece-queue.gd
@@ -217,10 +217,10 @@ func _move_duplicate_piece(from_index: int, min_to_index: int) -> int:
 """
 Returns 'true' if the specified array has the same piece back-to-back.
 """
-func _has_duplicate_pieces(pieces: Array) -> bool:
+func _has_duplicate_pieces(in_pieces: Array) -> bool:
 	var result := false
-	for i in range(pieces.size() - 1):
-		if pieces[i].type == pieces[i + 1].type:
+	for i in range(in_pieces.size() - 1):
+		if in_pieces[i].type == in_pieces[i + 1].type:
 			result = true
 			break
 	return result
@@ -273,9 +273,10 @@ Parameters:
 	
 	'from_index': The lowest position to check in the piece queue.
 """
-static func non_adjacent_indexes(pieces: Array, piece_type: PieceType, from_index: int = 0) -> Array:
+static func non_adjacent_indexes(in_pieces: Array, piece_type: PieceType, from_index: int = 0) -> Array:
 	var result := []
-	for i in range(from_index, pieces.size() + 1):
-		if (i == 0 or piece_type != pieces[i - 1].type) and (i >= pieces.size() or piece_type != pieces[i].type):
+	for i in range(from_index, in_pieces.size() + 1):
+		if (i == 0 or piece_type != in_pieces[i - 1].type) \
+				and (i >= in_pieces.size() or piece_type != in_pieces[i].type):
 			result.append(i)
 	return result

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -92,19 +92,8 @@ Parameters:
 	'food_type': An enum from FoodType corresponding to the food to show
 """
 func feed_creature(customer: Creature, food_type: int) -> void:
-	if customer.creature_id == CreatureLibrary.SENSEI_ID:
-		# tutorial sensei doesn't become comfortable
-		pass
-	else:
-		var comfort := 0.0
-		# ate five things; comfortable
-		comfort += clamp(inverse_lerp(5, 15, PuzzleScore.combo), 0.0, 1.0)
-		# starting to overeat; less comfortable
-		comfort -= clamp(inverse_lerp(400, 600, PuzzleScore.get_creature_score()), 0.0, 1.0)
-		# overate; uncomfortable
-		comfort -= clamp(inverse_lerp(600, 1200, PuzzleScore.get_creature_score()), 0.0, 1.0)
-		customer.set_comfort(comfort)
-	
+	var new_comfort := customer.score_to_comfort(PuzzleScore.combo, PuzzleScore.get_creature_score())
+	customer.set_comfort(new_comfort)
 	customer.feed(food_type)
 
 

--- a/project/src/main/puzzle/rainbow-metaball.shader
+++ b/project/src/main/puzzle/rainbow-metaball.shader
@@ -25,7 +25,7 @@ vec3 hsv2rgb_smooth(in vec3 c) {
 	return c.z * mix(vec3(1.0), rgb, c.y);
 }
 
-float perlin_noise(in vec2 p) {
+float get_noise_2d(in vec2 p) {
 	return textureLod(noise, p * 0.125, 2.0).x;
 }
 
@@ -47,10 +47,10 @@ float stepify_hue(in float f_in) {
 void fragment() {
 	vec4 color = texture(TEXTURE, UV);
 	
-	vec2 uv2 = UV + perlin_noise(0.6 * vec2(UV.x + 38.913 + TIME * 0.010, UV.y + 81.975 + TIME * DISTORTION_SPEED));
+	vec2 uv2 = UV + get_noise_2d(0.6 * vec2(UV.x + 38.913 + TIME * 0.010, UV.y + 81.975 + TIME * DISTORTION_SPEED));
 	uv2 = uv2 + vec2(TIME * SCROLL_SPEED, 0.0);
 	
-	float f = perlin_noise(2.0 * uv2);
+	float f = get_noise_2d(2.0 * uv2);
 	f = (f + TIME * CYCLE_SPEED) * 2.0;
 	f = stepify_hue(f);
 	

--- a/project/src/main/puzzle/texture-metaball.shader
+++ b/project/src/main/puzzle/texture-metaball.shader
@@ -39,7 +39,7 @@ vec3 hsv2rgb_smooth(in vec3 c) {
 	return c.z * mix(vec3(1.0), rgb, c.y);
 }
 
-float perlin_noise(in vec2 p) {
+float get_noise_2d(in vec2 p) {
 	return textureLod(noise, p * 0.125, 2.0).x;
 }
 
@@ -72,9 +72,9 @@ void fragment() {
 	frosting_color.a = smoothstep(0.76, 0.80, frosting_color.a);
 	
 	// calculate rainbow metaball color
-	vec2 uv2 = UV + perlin_noise(0.6 * vec2(UV.x + 38.913 + TIME * 0.010, UV.y + 81.975 + TIME * DISTORTION_SPEED));
+	vec2 uv2 = UV + get_noise_2d(0.6 * vec2(UV.x + 38.913 + TIME * 0.010, UV.y + 81.975 + TIME * DISTORTION_SPEED));
 	uv2 = uv2 + vec2(TIME * SCROLL_SPEED, 0.0);
-	float f = perlin_noise(2.0 * uv2);
+	float f = get_noise_2d(2.0 * uv2);
 	f = (f + TIME * CYCLE_SPEED) * 2.0;
 	f = stepify_hue(f);
 	rainbow_color.rgb = hsv2rgb_smooth(vec3(f, 1.0, 1.0));

--- a/project/src/main/world/goop-ground.shader
+++ b/project/src/main/world/goop-ground.shader
@@ -49,17 +49,17 @@ void vertex() {
 }
 
 // returns a number evenly distributed in the range [0.0, 1.0) based on simplex noise
-float noise(vec2 p) {
+float get_noise_2d(vec2 p) {
 	return textureLod(noise_texture, p, 2.0).r;
 }
 
 vec4 goop_color() {
 	vec2 uv0 = local * SQUASH_FACTOR / vec2(textureSize(noise_texture, 0));
 	vec2 uv1 = uv0 + vec2(38.913, 81.975) + time * SCROLL_SPEED;
-	vec2 uv2 = uv0 * vec2(4.0, 4.0) + noise(1.2 * uv1) + vec2(time * DISTORTION_SPEED, 0.0);
+	vec2 uv2 = uv0 * vec2(4.0, 4.0) + get_noise_2d(1.2 * uv1) + vec2(time * DISTORTION_SPEED, 0.0);
 
 	// calculate a number evenly distributed in the range [0.0, 1.0) based on noise
-	float f = noise(0.3 * uv2 / vec2(8.0, 8.0));
+	float f = get_noise_2d(0.3 * uv2 / vec2(8.0, 8.0));
 	f = fract((f + time * CYCLE_SPEED) * 8.0);
 
 	// stepify the number into a wave_amount; when wave_amount is near 1.0 we mix in the wave_color


### PR DESCRIPTION
Removed/relocated specialized sensei weight gain logic. Sensei's lack of weight
gain is now handled by the 'weight_gain_scale' field. Other creatures
can be configured to not gain weight as well.

Creatures now fade in during scene transitions. This hides visual
artifacts as their body parts load.

Renamed 'perlin_noise' function to 'get_noise_2d'. We no longer use perlin
noise, and instead use OpenSimplexNoise, so the old name was inaccurate.
'get_noise_2d' is a function in noise_texture so it seems like a consistent
name choice.

Resolved warnings. Prefixed shadowed parameters with 'in_' prefix.