### PR TITLE
PieceType.rotate_piece, underscores_to_hyphens, PuzzleTileMapReader

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -580,6 +580,11 @@ _global_script_classes=[ {
 "path": "res://src/main/puzzle/puzzle-tile-map.gd"
 }, {
 "base": "Reference",
+"class": "PuzzleTileMapReader",
+"language": "GDScript",
+"path": "res://src/main/puzzle/puzzle-tile-map-reader.gd"
+}, {
+"base": "Reference",
 "class": "RankCalculator",
 "language": "GDScript",
 "path": "res://src/main/puzzle/rank-calculator.gd"
@@ -864,6 +869,7 @@ _global_script_class_icons={
 "PuzzleConnect": "",
 "PuzzlePerformance": "",
 "PuzzleTileMap": "",
+"PuzzleTileMapReader": "",
 "RankCalculator": "",
 "RankResult": "",
 "RankRules": "",

--- a/project/src/demo/world/cutscene-demo.gd
+++ b/project/src/demo/world/cutscene-demo.gd
@@ -31,7 +31,8 @@ func _on_OpenFileDialog_file_selected(_path: String) -> void:
 	if full_path.begins_with("res://assets/main/puzzle/levels/cutscenes/") \
 			and full_path.ends_with(ChatLibrary.CHAT_EXTENSION):
 		full_path = full_path.trim_prefix("res://assets/main/puzzle/levels/cutscenes/")
-		full_path = full_path.trim_suffix(".chat").replace("-", "_")
+		full_path = full_path.trim_suffix(".chat")
+		full_path = StringUtils.hyphens_to_underscores(full_path)
 		$VBoxContainer/Open/LineEdit.text = full_path
 	else:
 		$Dialogs/Error.dialog_text = "%s doesn't seem like the path to a cutscene file." % [full_path]

--- a/project/src/main/creature-library.gd
+++ b/project/src/main/creature-library.gd
@@ -27,7 +27,7 @@ var sensei_def: CreatureDef setget set_sensei_def,get_sensei_def
 # fatnesses by creature id
 var _fatnesses: Dictionary
 
-# fatnesses saved to roll the tile map back to a previous state
+# fatnesses saved to roll the tilemap back to a previous state
 var _saved_fatnesses: Dictionary
 
 # In addition to storing known fatness attributes like "Ebe's weight is 2.5", we store fatnesses for randomly

--- a/project/src/main/editor/puzzle/editor-json.gd
+++ b/project/src/main/editor/puzzle/editor-json.gd
@@ -34,24 +34,16 @@ func can_parse_json() -> bool:
 
 
 """
-Refreshes the tile map based on our json text.
+Refreshes the tilemap based on our json text.
 """
 func refresh_tile_map() -> void:
 	if can_parse_json():
 		_tile_map.clear()
-		for json_tile in _json_tiles:
-			var json_pos_arr: PoolStringArray = json_tile.get("pos", "").split(" ")
-			var json_tile_arr: PoolStringArray = json_tile.get("tile", "").split(" ")
-			if json_pos_arr.size() < 2 or json_tile_arr.size() < 3:
-				continue
-			var pos := Vector2(int(json_pos_arr[0]), int(json_pos_arr[1]))
-			var tile := int(json_tile_arr[0])
-			var autotile_coord := Vector2(int(json_tile_arr[1]), int(json_tile_arr[2]))
-			_tile_map.set_block(pos, tile, autotile_coord)
+		PuzzleTileMapReader.read(_json_tiles, funcref(_tile_map, "set_block"))
 
 
 """
-Refreshes our json text based on the tile map.
+Refreshes our json text based on the tilemap.
 """
 func refresh_json() -> void:
 	if can_parse_json():

--- a/project/src/main/editor/puzzle/editor-playfield.gd
+++ b/project/src/main/editor/puzzle/editor-playfield.gd
@@ -6,7 +6,7 @@ Playfield for use in the level editor.
 This script provides drag/drop logic and other things specific to the level editor.
 """
 
-# emitted when the player changes the tile map's contents. This signal is not emitted when set_cell is called, to
+# emitted when the player changes the tilemap's contents. This signal is not emitted when set_cell is called, to
 # prevent infinite recursion when populated by editor-json.gd.
 signal tile_map_changed
 var dragging_right_mouse := false

--- a/project/src/main/editor/puzzle/level-chunk-control.gd
+++ b/project/src/main/editor/puzzle/level-chunk-control.gd
@@ -20,7 +20,7 @@ func get_drag_data(_pos: Vector2) -> Object:
 
 
 """
-Calculates the extents of the tile map's used cells.
+Calculates the extents of the tilemap's used cells.
 """
 func _tile_map_extents() -> Rect2:
 	var extents := Rect2(Vector2.ZERO, Vector2.ZERO)
@@ -32,14 +32,14 @@ func _tile_map_extents() -> Rect2:
 
 
 """
-Overridden by child classes, which use this method to populate the contents of the tile map.
+Overridden by child classes, which use this method to populate the contents of the tilemap.
 """
 func _refresh_tile_map() -> void:
 	pass
 
 
 """
-Refreshes the scale to ensure the contents of the tile map fit inside an item in the palette.
+Refreshes the scale to ensure the contents of the tilemap fit inside an item in the palette.
 """
 func _refresh_scale() -> void:
 	var extents := _tile_map_extents()

--- a/project/src/main/editor/puzzle/piece-chunk.gd
+++ b/project/src/main/editor/puzzle/piece-chunk.gd
@@ -21,7 +21,7 @@ var _editor_pieces := {
 }
 
 var _orientation := 0
-var _piece: PieceType = PieceTypes.piece_j
+var _type: PieceType = PieceTypes.piece_j
 
 func _ready() -> void:
 	$"../../Buttons/RotateButton".connect("pressed", self, "_on_RotateButton_pressed")
@@ -29,7 +29,7 @@ func _ready() -> void:
 
 func set_editor_piece(new_editor_piece: int) -> void:
 	editor_piece = new_editor_piece
-	_piece = _editor_pieces[editor_piece]
+	_type = _editor_pieces[editor_piece]
 	_refresh_tile_map()
 	_refresh_scale()
 
@@ -39,8 +39,8 @@ Calculates the extents of the piece's used cells.
 """
 func _piece_extents() -> Rect2:
 	var extents := Rect2(Vector2.ZERO, Vector2.ZERO)
-	extents.position = _piece.get_cell_position(_orientation, 0)
-	for pos in _piece.pos_arr[_orientation]:
+	extents.position = _type.get_cell_position(_orientation, 0)
+	for pos in _type.pos_arr[_orientation]:
 		extents = extents.expand(pos)
 	return extents
 
@@ -48,11 +48,11 @@ func _piece_extents() -> Rect2:
 func _refresh_tile_map() -> void:
 	var _extents := _piece_extents()
 	$TileMap.clear()
-	for i in range(_piece.pos_arr[_orientation].size()):
-		var target_pos := _piece.get_cell_position(_orientation, i) - _extents.position
-		$TileMap.set_block(target_pos, 0, _piece.color_arr[_orientation][i])
+	for i in range(_type.pos_arr[_orientation].size()):
+		var target_pos := _type.get_cell_position(_orientation, i) - _extents.position
+		$TileMap.set_block(target_pos, 0, _type.color_arr[_orientation][i])
 
 
 func _on_RotateButton_pressed() -> void:
-	_orientation = (_orientation + 1) % _piece.pos_arr.size()
+	_orientation = _type.get_cw_orientation(_orientation)
 	_refresh_tile_map()

--- a/project/src/main/old-save.gd
+++ b/project/src/main/old-save.gd
@@ -197,8 +197,8 @@ func _convert_1922(json_save_items: Array) -> Array:
 	for json_save_item_obj in json_save_items:
 		var save_item: SaveItem = SaveItem.new()
 		save_item.from_json_dict(json_save_item_obj)
-		save_item.type = save_item.type.replace("-", "_")
-		save_item.key = save_item.key.replace("-", "_")
+		save_item.type = StringUtils.hyphens_to_underscores(save_item.type)
+		save_item.key = StringUtils.hyphens_to_underscores(save_item.key)
 		if typeof(save_item.value) == TYPE_DICTIONARY:
 			_replace_key_hyphens_with_underscores(save_item.value)
 		
@@ -228,8 +228,8 @@ func _convert_1682(json_save_items: Array) -> Array:
 	for json_save_item_obj in json_save_items:
 		var save_item: SaveItem = SaveItem.new()
 		save_item.from_json_dict(json_save_item_obj)
-		save_item.type = save_item.type.replace("-", "_")
-		save_item.key = save_item.key.replace("-", "_")
+		save_item.type = StringUtils.hyphens_to_underscores(save_item.type)
+		save_item.key = StringUtils.hyphens_to_underscores(save_item.key)
 		if typeof(save_item.value) == TYPE_DICTIONARY:
 			_replace_key_hyphens_with_underscores(save_item.value)
 		
@@ -246,7 +246,7 @@ func _convert_1682(json_save_items: Array) -> Array:
 func _replace_key_hyphens_with_underscores(dict: Dictionary) -> void:
 	for key in dict.keys():
 		if key.find("-") != -1:
-			dict[key.replace("-", "_")] = dict[key]
+			dict[StringUtils.hyphens_to_underscores(key)] = dict[key]
 			dict.erase(key)
 
 

--- a/project/src/main/puzzle/level/blocks-start-rules.gd
+++ b/project/src/main/puzzle/level/blocks-start-rules.gd
@@ -3,22 +3,31 @@ class_name BlocksStartRules
 Blocks/boxes which begin on the playfield.
 """
 
+# Vector2 array with the positions of all cells containing a tile
 var used_cells := []
+
+# key: (Vector2) positions of cells containing a tile
+# value: (int) tile indexes of each cell
 var tiles := {}
+
+# key: (Vector2) positions of cells containing a tile
+# value: (Vector2) coordinate of the autotile variation in the tileset
 var autotile_coords := {}
 
 func from_json_dict(json: Dictionary) -> void:
-	for json_tile in json.get("tiles", []):
-		var json_pos_arr: PoolStringArray = json_tile.get("pos", "").split(" ")
-		var json_tile_arr: PoolStringArray = json_tile.get("tile", "").split(" ")
-		if json_pos_arr.size() < 2 or json_tile_arr.size() < 3:
-			continue
-		var pos := Vector2(int(json_pos_arr[0]), int(json_pos_arr[1]))
-		var tile := int(json_tile_arr[0])
-		var autotile_coord := Vector2(int(json_tile_arr[1]), int(json_tile_arr[2]))
-		set_block(pos, tile, autotile_coord)
+	PuzzleTileMapReader.read(json.get("tiles", []), funcref(self, "set_block"))
 
 
+"""
+Defines a block which will begin on the playfield.
+
+Parameters:
+	'pos': Position of the cell
+	
+	'tile': Tile index of the cell
+	
+	'autotile_coord': Coordinate of the autotile variation in the tileset
+"""
 func set_block(pos: Vector2, tile: int, autotile_coord: Vector2) -> void:
 	used_cells.append(pos)
 	tiles[pos] = tile

--- a/project/src/main/puzzle/level/level-settings.gd
+++ b/project/src/main/puzzle/level/level-settings.gd
@@ -209,12 +209,19 @@ func _get_max_speed_id() -> String:
 
 
 static func level_path(level_name: String) -> String:
-	return "res://assets/main/puzzle/levels/%s.json" % (level_name.replace("_", "-"))
+	var level_path := StringUtils.underscores_to_hyphens(level_name)
+	level_path = "res://assets/main/puzzle/levels/%s.json" % level_path
+	return level_path
 
 
 static func level_name(path: String) -> String:
-	return path.get_file().trim_suffix(".json").replace("_", "-")
+	var level_name := path.get_file()
+	level_name = level_name.trim_suffix(".json")
+	level_name = StringUtils.underscores_to_hyphens(level_name)
+	return level_name
 
 
 static func level_filename(level_name: String) -> String:
-	return "%s.json" % level_name.replace("_", "-")
+	var level_filename := StringUtils.underscores_to_hyphens(level_name)
+	level_filename = "%s.json" % level_filename
+	return level_filename

--- a/project/src/main/puzzle/piece/active-piece.gd
+++ b/project/src/main/puzzle/piece/active-piece.gd
@@ -68,14 +68,21 @@ func reset_target() -> void:
 Returns the orientation the piece will be in if it rotates clockwise.
 """
 func get_cw_orientation() -> int:
-	return wrapi(orientation + 1, 0, type.pos_arr.size())
+	return type.get_cw_orientation(orientation)
+
+
+"""
+Returns the orientation the piece will be in if it rotates counter-clockwise.
+"""
+func get_ccw_orientation() -> int:
+	return type.get_ccw_orientation(orientation)
 
 
 """
 Returns the orientation the piece will be in if it rotates 180 degrees.
 """
 func get_flip_orientation() -> int:
-	return wrapi(orientation + 2, 0, type.pos_arr.size())
+	return type.get_flip_orientation(orientation)
 
 
 """
@@ -83,13 +90,6 @@ Returns the position the piece will be in if it rotates 180 degrees.
 """
 func get_flip_position() -> Vector2:
 	return pos + type.flips[orientation]
-
-
-"""
-Returns the orientation the piece will be in if it rotates counter-clockwise.
-"""
-func get_ccw_orientation() -> int:
-	return wrapi(orientation - 1, 0, type.pos_arr.size())
 
 
 """

--- a/project/src/main/puzzle/piece/next-piece-display.gd
+++ b/project/src/main/puzzle/piece/next-piece-display.gd
@@ -24,7 +24,7 @@ func _process(_delta: float) -> void:
 		if next_piece != PieceTypes.piece_null:
 			var bounding_box := Rect2( \
 					next_piece.type.get_cell_position(next_piece.orientation, 0), Vector2(1.0, 1.0))
-			# update the tile map with the new piece type
+			# update the tilemap with the new piece type
 			for i in range(next_piece.type.pos_arr[0].size()):
 				var block_pos := next_piece.type.get_cell_position(next_piece.orientation, i)
 				var block_color := next_piece.type.get_cell_color(next_piece.orientation, i)

--- a/project/src/main/puzzle/piece/next-piece.gd
+++ b/project/src/main/puzzle/piece/next-piece.gd
@@ -16,21 +16,21 @@ var orientation := 0
 Returns the orientation the piece will be in if it rotates clockwise.
 """
 func get_cw_orientation() -> int:
-	return wrapi(orientation + 1, 0, type.pos_arr.size())
+	return type.get_cw_orientation(orientation)
 
 
 """
 Returns the orientation the piece will be in if it rotates counter-clockwise.
 """
 func get_ccw_orientation() -> int:
-	return wrapi(orientation - 1, 0, type.pos_arr.size())
+	return type.get_ccw_orientation(orientation)
 
 
 """
 Returns the orientation the piece will be in if it rotates 180 degrees.
 """
 func get_flip_orientation() -> int:
-	return wrapi(orientation + 2, 0, type.pos_arr.size())
+	return type.get_flip_orientation(orientation)
 
 
 func _to_string() -> String:

--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -40,7 +40,7 @@ export (NodePath) var playfield_path: NodePath
 # settings and state for the currently active piece.
 var piece: ActivePiece
 
-# information about the piece previously rendered to the tile map
+# information about the piece previously rendered to the tilemap
 var drawn_piece_type: PieceType
 var drawn_piece_pos: Vector2
 var drawn_piece_orientation: int
@@ -185,7 +185,7 @@ func _clear_piece() -> void:
 
 
 """
-Refresh the tile map which displays the piece, based on the current piece's position and orientation.
+Refresh the tilemap which displays the piece, based on the current piece's position and orientation.
 """
 func _update_tile_map() -> void:
 	tile_map.clear()

--- a/project/src/main/puzzle/piece/piece-type.gd
+++ b/project/src/main/puzzle/piece/piece-type.gd
@@ -19,7 +19,7 @@ var cw_kicks: Array
 # array of piece kicks to try when rotating counterclockwise
 var ccw_kicks: Array
 
-# position the piece should kick to when flipping in place
+# a piece kick to attempt for each orientation when rotating 180
 var flips: Array
 
 # maximum number of 'floor kicks', kicks which move the piece upward
@@ -74,3 +74,24 @@ func get_color_int() -> int:
 
 func _to_string() -> String:
 	return string
+
+
+"""
+Returns the orientation the piece will be in if it rotates clockwise.
+"""
+func get_cw_orientation(orientation: int) -> int:
+	return (orientation + 1) % pos_arr.size()
+
+
+"""
+Returns the orientation the piece will be in if it rotates counter-clockwise.
+"""
+func get_ccw_orientation(orientation: int) -> int:
+	return wrapi(orientation - 1, 0, pos_arr.size())
+
+
+"""
+Returns the orientation the piece will be in if it rotates 180 degrees.
+"""
+func get_flip_orientation(orientation: int) -> int:
+	return (orientation + 2) % pos_arr.size()

--- a/project/src/main/puzzle/piece/puzzle-corner-map.gd
+++ b/project/src/main/puzzle/piece/puzzle-corner-map.gd
@@ -1,9 +1,9 @@
 extends TileMap
 """
-Tile map which covers the corners of another tilemap.
+Tilemap which covers the corners of another tilemap.
 
-Without this tile map, a simple 16-tile autotiling would result in tiny holes at the corners of a filled in area. This
-tile map fills in the holes.
+Without this tilemap, a simple 16-tile autotiling would result in tiny holes at the corners of a filled in area. This
+tilemap fills in the holes.
 
 This tilemap assumes tiles are arranged so that the X coordinates of the tiles correspond to the directions they're
 connected. This type of tilemap is used for puzzle pieces.

--- a/project/src/main/puzzle/puzzle-tile-map-reader.gd
+++ b/project/src/main/puzzle/puzzle-tile-map-reader.gd
@@ -1,0 +1,25 @@
+class_name PuzzleTileMapReader
+
+"""
+Parses a json fragment listing tiles in a puzzle tilemap.
+
+Instead of directly populating a puzzle tilemap, we invoke a callback function for greater flexibility.
+
+Parameters:
+	'json_tiles': A json fragment listing tiles in a puzzle tilemap.
+	
+	'set_block': A reference to a function which accepts three parameters:
+		'pos' (Vector2): Position of the cell
+		'tile' (int): Tile index of the cell
+		'autotile_coord' (Vector2): Coordinate of the autotile variation in the tileset
+"""
+static func read(json_tiles: Array, set_block: FuncRef) -> void:
+	for json_tile in json_tiles:
+		var json_pos_arr: PoolStringArray = json_tile.get("pos", "").split(" ")
+		var json_tile_arr: PoolStringArray = json_tile.get("tile", "").split(" ")
+		if json_pos_arr.size() < 2 or json_tile_arr.size() < 3:
+			continue
+		var pos := Vector2(int(json_pos_arr[0]), int(json_pos_arr[1]))
+		var tile := int(json_tile_arr[0])
+		var autotile_coord := Vector2(int(json_tile_arr[1]), int(json_tile_arr[2]))
+		set_block.call_func(pos, tile, autotile_coord)

--- a/project/src/main/puzzle/puzzle-tile-map.gd
+++ b/project/src/main/puzzle/puzzle-tile-map.gd
@@ -30,13 +30,13 @@ const TILE_VEG := 2 # vegetable created from line clears
 const ROW_COUNT = 20
 const COL_COUNT = 9
 
-# a number in the range [0, 1] which can be set to make the tile map flash or blink.
+# a number in the range [0, 1] which can be set to make the tilemap flash or blink.
 var whiteness := 0.0 setget set_whiteness
 
 # offset used for drawing the 'ghost piece'
 var ghost_shadow_offset: Vector2
 
-# fields used to roll the tile map back to a previous state
+# fields used to roll the tilemap back to a previous state
 var _saved_used_cells := []
 var _saved_tiles := []
 var _saved_autotile_coords := []
@@ -70,7 +70,7 @@ func save_state() -> void:
 
 
 """
-Rolls back the piece previously written to the tile map.
+Rolls back the piece previously written to the tilemap.
 
 Also undoes any boxes that were built and lines that were cleared.
 """
@@ -83,6 +83,16 @@ func restore_state() -> void:
 		set_block(cell, tile, autotile_coord)
 
 
+"""
+Assigns a block to a tilemap cell.
+
+Parameters:
+	'pos': Position of the cell
+	
+	'tile': Tile index of the cell
+	
+	'autotile_coord': Coordinate of the autotile variation in the tileset
+"""
 func set_block(pos: Vector2, tile: int, autotile_coord: Vector2 = Vector2.ZERO) -> void:
 	set_cell(pos.x, pos.y, tile, false, false, false, autotile_coord)
 	if is_inside_tree():
@@ -109,7 +119,7 @@ func build_box(rect: Rect2, color_int: int) -> void:
 
 
 """
-Deletes the specified row in the tile map, dropping all higher rows down to fill the gap.
+Deletes the specified row in the tilemap, dropping all higher rows down to fill the gap.
 """
 func delete_row(y: int) -> void:
 	# First, erase and store all the old cells which are dropping
@@ -133,7 +143,7 @@ func delete_row(y: int) -> void:
 
 
 """
-Deletes the specified row in the tile map, dropping all higher rows down to fill the gap.
+Deletes the specified row in the tilemap, dropping all higher rows down to fill the gap.
 """
 func delete_rows(rows: Array) -> void:
 	# sort to avoid edge cases with row indexes changing during deletion
@@ -195,7 +205,7 @@ func erase_playfield_row(y: int) -> void:
 
 
 """
-Sets the whiteness property to make the tile map flash or blink.
+Sets the whiteness property to make the tilemap flash or blink.
 """
 func set_whiteness(new_whiteness: float) -> void:
 	if whiteness == new_whiteness:
@@ -211,7 +221,7 @@ Returns a position randomly near a cell.
 This is useful when we want visual effects to appear somewhere within the cell at (3, 6) with random variation.
 
 Parameters:
-	'cell_pos': Grid-based coordinates of a cell in the tile map.
+	'cell_pos': Grid-based coordinates of a cell in the tilemap.
 	
 	'cell_offset': (Optional) Grid-based coordinates of the random offset to apply. If unspecified, the coordinate
 		will be randomly offset by a value in the range [(0, 0), (1, 1)]

--- a/project/src/main/string-utils.gd
+++ b/project/src/main/string-utils.gd
@@ -199,3 +199,21 @@ Returns either the passed in String, or if the String is empty or null, the valu
 """
 static func default_if_empty(s: String, default: String) -> String:
 	return s if s else default
+
+
+"""
+Replaces hyphens with underscores in a string.
+
+JSON keys and values use underscores to separate words, for consistency with Python conventions.
+"""
+static func hyphens_to_underscores(s: String) -> String:
+	return s.replace("-", "_")
+
+
+"""
+Replaces underscores with hyphens in a string.
+
+Filenames use kebab-case.
+"""
+static func underscores_to_hyphens(s: String) -> String:
+	return s.replace("_", "-")

--- a/project/src/main/ui/chat/chat-library.gd
+++ b/project/src/main/ui/chat/chat-library.gd
@@ -206,7 +206,7 @@ func filler_ids_for_creature(creature_id: String) -> Array:
 	for i in range(0, 1000):
 		var filler_id := "filler_%03d" % i
 		var chat_path := "res://assets/main/creatures/primary/%s/%s%s" % \
-				[creature_id, filler_id.replace("_", "-"), CHAT_EXTENSION]
+				[creature_id, StringUtils.underscores_to_hyphens(filler_id), CHAT_EXTENSION]
 		if FileUtils.file_exists(chat_path):
 			filler_ids.append(filler_id)
 		else:
@@ -267,7 +267,8 @@ func add_mega_lull_characters(s: String) -> String:
 
 
 func _creature_chat_path(creature_id: String, chat_id: String) -> String:
-	return "res://assets/main/creatures/primary/%s/%s%s" % [creature_id, chat_id.replace("_", "-"), CHAT_EXTENSION]
+	return "res://assets/main/creatures/primary/%s/%s%s" % \
+			[creature_id, StringUtils.underscores_to_hyphens(chat_id), CHAT_EXTENSION]
 
 
 """
@@ -286,7 +287,7 @@ func _chat_tree_from_chatscript_file(path: String) -> ChatTree:
 	history_key = history_key.trim_suffix(".chat")
 	history_key = history_key.trim_prefix("res://assets/main/")
 	history_key = history_key.replace("creatures/primary", "chat")
-	history_key = history_key.replace("-", "_")
+	history_key = StringUtils.hyphens_to_underscores(history_key)
 	chat_tree.history_key = history_key
 	
 	return chat_tree
@@ -314,9 +315,9 @@ func _creature_chat_state(creature_id: String, forced_level_id: String = "") -> 
 
 func _preroll_path(level_id: String) -> String:
 	return "res://assets/main/puzzle/levels/cutscenes/%s-%s%s" % \
-			[level_id.replace("_", "-"), PREROLL_SUFFIX, CHAT_EXTENSION]
+			[StringUtils.underscores_to_hyphens(level_id), PREROLL_SUFFIX, CHAT_EXTENSION]
 
 
 func _postroll_path(level_id: String) -> String:
 	return "res://assets/main/puzzle/levels/cutscenes/%s-%s%s" % \
-			[level_id.replace("_", "-"), POSTROLL_SUFFIX, CHAT_EXTENSION]
+			[StringUtils.underscores_to_hyphens(level_id), POSTROLL_SUFFIX, CHAT_EXTENSION]

--- a/project/src/main/ui/scene-transition.gd
+++ b/project/src/main/ui/scene-transition.gd
@@ -17,7 +17,7 @@ var fading: bool
 var fade_color: Color = ProjectSettings.get_setting("rendering/environment/default_clear_color")
 
 # The method and parameters to call on the Breadcrumb node after fading out.
-var breadcrumb_method: String
+var breadcrumb_method: FuncRef
 var breadcrumb_arg_array: Array
 
 """
@@ -36,7 +36,7 @@ func push_trail(path: String, skip_transition: bool = false) -> void:
 		
 		Breadcrumb.push_trail(path)
 	else:
-		_fade_out("push_trail", [path])
+		_fade_out(funcref(Breadcrumb, "push_trail"), [path])
 
 
 """
@@ -51,7 +51,7 @@ func pop_trail(skip_transition: bool = false) -> void:
 			or (Breadcrumb.trail and "::" in Breadcrumb.trail.front()):
 		Breadcrumb.pop_trail()
 	else:
-		_fade_out("pop_trail")
+		_fade_out(funcref(Breadcrumb, "pop_trail"))
 
 
 """
@@ -69,7 +69,7 @@ func replace_trail(path: String, skip_transition: bool = false) -> void:
 			or "::" in path:
 		Breadcrumb.replace_trail(path)
 	else:
-		_fade_out("replace_trail", [path])
+		_fade_out(funcref(Breadcrumb, "replace_trail"), [path])
 
 
 """
@@ -77,7 +77,7 @@ Called when the 'fade out' visual transition ends, triggering a scene transition
 """
 func end_fade_out() -> void:
 	if breadcrumb_method:
-		Breadcrumb.callv(breadcrumb_method, breadcrumb_arg_array)
+		breadcrumb_method.call_funcv(breadcrumb_arg_array)
 
 
 """
@@ -97,7 +97,7 @@ func end_fade_in() -> void:
 """
 Launches the 'fade out' visual transition.
 """
-func _fade_out(new_breadcrumb_method: String, new_breadcrumb_arg_array: Array = []) -> void:
+func _fade_out(new_breadcrumb_method: FuncRef, new_breadcrumb_arg_array: Array = []) -> void:
 	breadcrumb_method = new_breadcrumb_method
 	breadcrumb_arg_array = new_breadcrumb_arg_array
 	fading = true

--- a/project/src/main/world/environment/obstacle-map-shadows.gd
+++ b/project/src/main/world/environment/obstacle-map-shadows.gd
@@ -1,6 +1,6 @@
 extends TileMap
 """
-Draws shadows under tiles from an obstacle tile map.
+Draws shadows under tiles from an obstacle tilemap.
 """
 
 export (NodePath) var obstacle_map_path: NodePath

--- a/project/src/main/world/goop-ground-map.gd
+++ b/project/src/main/world/goop-ground-map.gd
@@ -7,7 +7,7 @@ The view_to_local shader parameter changes whenever the tilemap moves visually i
 it whenever the camera moves.
 """
 
-# Applies autotiling rules to all cells in the tile map
+# Applies autotiling rules to all cells in the tilemap
 export var _reapply_autotiles: bool setget set_reapply_autotiles
 
 var _goop_material: ShaderMaterial = tile_set.tile_get_material(0)

--- a/project/src/main/world/overworld-corner-map.gd
+++ b/project/src/main/world/overworld-corner-map.gd
@@ -1,9 +1,9 @@
 extends TileMap
 """
-Tile map which covers the corners of the overworld tilemap.
+Tilemap which covers the corners of the overworld tilemap.
 
-Without this tile map, a simple 16-tile autotiling would result in tiny holes at the corners of a filled in area. This
-tile map fills in the holes.
+Without this tilemap, a simple 16-tile autotiling would result in tiny holes at the corners of a filled in area. This
+tilemap fills in the holes.
 """
 
 onready var _parent_map: TileMap = get_parent()


### PR DESCRIPTION
Extracted 'rotate piece' logic into PieceType.

Extracted 'underscores_to_hyphens' utilities. These are one-liners, but
we may eventually move away from hyphenated filenames in which case it will be
nice having this logic centralized.

Extracted PuzzleTileMapReader.

Changed 'tile map' to 'tilemap' to conform to Godot's documentation.

SceneTransition stores a FuncRef instead of a method name.