### PR TITLE
PuzzleState, customer_score. Moved history key logic.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -939,7 +939,7 @@ Pauser="*res://src/main/pauser.gd"
 PieceQueue="*res://src/main/puzzle/piece/piece-queue.gd"
 PlayerData="*res://src/main/player-data.gd"
 PlayerSave="*res://src/main/player-save.gd"
-PuzzleScore="*res://src/main/puzzle/puzzle-score.gd"
+PuzzleState="*res://src/main/puzzle/puzzle-state.gd"
 ResourceCache="*res://src/main/ResourceCache.tscn"
 SceneTransition="*res://src/main/ui/scene-transition.gd"
 

--- a/project/src/demo/puzzle/level/rank-mode-demo.gd
+++ b/project/src/demo/puzzle/level/rank-mode-demo.gd
@@ -150,14 +150,14 @@ func _target_score(target_rank: float) -> float:
 	var max_score := 50000
 	var rank_result: RankResult
 	for _i in range(20):
-		PuzzleScore.level_performance.score = (min_score + max_score) / 2.0
+		PuzzleState.level_performance.score = (min_score + max_score) / 2.0
 		rank_result = _rank_calculator.calculate_rank()
 		if rank_result.score_rank > target_rank:
 			# graded poorly; we need to score more points
-			min_score = PuzzleScore.level_performance.score
+			min_score = PuzzleState.level_performance.score
 		else:
 			# graded well; we need to score fewer points
-			max_score = PuzzleScore.level_performance.score
+			max_score = PuzzleState.level_performance.score
 	return (min_score + max_score) / 2.0
 
 
@@ -171,12 +171,12 @@ func _target_lines(target_rank: int) -> float:
 	var max_target_lines := 5000
 	var rank_result: RankResult
 	for _i in range(20):
-		PuzzleScore.level_performance.lines = ceil((min_target_lines + max_target_lines) / 2.0)
+		PuzzleState.level_performance.lines = ceil((min_target_lines + max_target_lines) / 2.0)
 		rank_result = _rank_calculator.calculate_rank()
 		if rank_result.lines_rank > target_rank:
 			# graded poorly; we need to clear more lines than that
-			min_target_lines = PuzzleScore.level_performance.lines
+			min_target_lines = PuzzleState.level_performance.lines
 		else:
 			# graded well; we need to clear fewer lines than that
-			max_target_lines = PuzzleScore.level_performance.lines
+			max_target_lines = PuzzleState.level_performance.lines
 	return (max_target_lines + min_target_lines) / 2.0

--- a/project/src/demo/puzzle/puzzle-demo.gd
+++ b/project/src/demo/puzzle/puzzle-demo.gd
@@ -29,7 +29,7 @@ func _ready() -> void:
 	CurrentLevel.settings.add_speed_up(Milestone.LINES, 170, "8")
 	CurrentLevel.settings.add_speed_up(Milestone.LINES, 180, "9")
 	CurrentLevel.settings.set_finish_condition(Milestone.NONE, 300)
-	PuzzleScore.prepare_and_start_game()
+	PuzzleState.prepare_and_start_game()
 
 
 func _input(event: InputEvent) -> void:
@@ -59,7 +59,7 @@ func _input(event: InputEvent) -> void:
 			$Puzzle/FoodItems.add_food_item(Vector2(1, 4), _food_item_index)
 		
 		KEY_L:
-			PuzzleScore.set_speed_index((PuzzleScore.speed_index + 1) % CurrentLevel.settings.speed_ups.size())
+			PuzzleState.set_speed_index((PuzzleState.speed_index + 1) % CurrentLevel.settings.speed_ups.size())
 
 
 func _build_box(y: int) -> void:

--- a/project/src/demo/puzzle/results-hud-demo.gd
+++ b/project/src/demo/puzzle/results-hud-demo.gd
@@ -8,7 +8,7 @@ Keys:
 """
 
 var _rank_result: RankResult = RankResult.new()
-var _creature_scores := [
+var _customer_scores := [
 		40, 82, 226, 49, 10, 50, 36, 490, 651, 43, 942, 305, 231, 172, 223, 44, 34, 184, 37, 653, 283, 376, 1, 8, 687,
 		19, 89, 853, 986, 713, 294, 468, 207, 63, 59, 570, 98, 341, 461, 39, 56, 51, 6, 3, 16, 94, 72, 739, 459, 552,
 		968, 648, 688, 594, 9, 23, 669, 784, 496, 2, 258, 79, 679, 377, 41, 53, 522, 636, 77, 706, 981, 86, 438, 151,
@@ -27,5 +27,5 @@ func _ready() -> void:
 
 func _input(event: InputEvent) -> void:
 	match Utils.key_scancode(event):
-		KEY_S: $ResultsHud.show_results_message(_rank_result, _creature_scores, _finish_condition_type)
+		KEY_S: $ResultsHud.show_results_message(_rank_result, _customer_scores, _finish_condition_type)
 		KEY_H: $ResultsHud.hide_results_message()

--- a/project/src/demo/world/cutscene-demo.gd
+++ b/project/src/demo/world/cutscene-demo.gd
@@ -19,7 +19,7 @@ func _on_StartButton_pressed() -> void:
 		CurrentLevel.push_cutscene_trail(true)
 	elif cutscene_index >= 100 and cutscene_index < 200:
 		# launch 'after level' cutscene
-		CurrentLevel.level_state = CurrentLevel.LevelState.AFTER
+		CurrentLevel.cutscene_state = CurrentLevel.CutsceneState.AFTER
 		var chat_tree := ChatLibrary.chat_tree_for_postroll(CurrentLevel.level_id)
 		SceneTransition.push_trail(chat_tree.cutscene_scene_path())
 	else:

--- a/project/src/main/puzzle/combo-counters.gd
+++ b/project/src/main/puzzle/combo-counters.gd
@@ -19,7 +19,7 @@ onready var _piece_manager: PieceManager = get_node(piece_manager_path)
 onready var _playfield: Playfield = get_node(playfield_path)
 
 func _ready() -> void:
-	PuzzleScore.connect("before_piece_written", self, "_on_PuzzleScore_before_piece_written")
+	PuzzleState.connect("before_piece_written", self, "_on_PuzzleState_before_piece_written")
 
 
 """
@@ -27,7 +27,7 @@ When the player places a piece, we store the piece's position in _piece_x_by_y
 
 This allows combo counters to appear horizontally aligned with the most recent piece.
 """
-func _on_PuzzleScore_before_piece_written() -> void:
+func _on_PuzzleState_before_piece_written() -> void:
 	var piece_min_x_by_y := {}
 	var piece_max_x_by_y := {}
 	for pos_arr_item in _piece_manager.piece.get_pos_arr():
@@ -47,7 +47,7 @@ func _on_PuzzleScore_before_piece_written() -> void:
 When a line is cleared we add a new combo counter.
 """
 func _on_Playfield_before_line_cleared(y: int, _total_lines: int, _remaining_lines: int, _box_ints: Array) -> void:
-	if PuzzleScore.combo < 3:
+	if PuzzleState.combo < 3:
 		# no combo counters below 3x
 		return
 	
@@ -75,5 +75,5 @@ func _on_Playfield_before_line_cleared(y: int, _total_lines: int, _remaining_lin
 	combo_counter.position = _playfield.tile_map.map_to_world(target_cell + Vector2(0, -3))
 	combo_counter.position += _playfield.tile_map.cell_size * Vector2(0.5, 0.5)
 	combo_counter.position *= _playfield.tile_map.scale
-	combo_counter.combo = PuzzleScore.combo
+	combo_counter.combo = PuzzleState.combo
 	add_child(combo_counter)

--- a/project/src/main/puzzle/combo-score-value-label.gd
+++ b/project/src/main/puzzle/combo-score-value-label.gd
@@ -6,10 +6,10 @@ This only includes bonuses and should be a round number like +55 or +130 for vis
 """
 
 func _ready() -> void:
-	PuzzleScore.connect("score_changed", self, "_on_PuzzleScore_score_changed")
+	PuzzleState.connect("score_changed", self, "_on_PuzzleState_score_changed")
 	text = "-"
 
 
-func _on_PuzzleScore_score_changed() -> void:
-	var bonus_score := PuzzleScore.get_bonus_score()
+func _on_PuzzleState_score_changed() -> void:
+	var bonus_score := PuzzleState.get_bonus_score()
 	text = "-" if bonus_score == 0 else "+¥%s" % StringUtils.comma_sep(bonus_score)

--- a/project/src/main/puzzle/combo-tracker.gd
+++ b/project/src/main/puzzle/combo-tracker.gd
@@ -22,9 +22,9 @@ var piece_continued_combo := false
 var piece_broke_combo := false
 
 func _ready() -> void:
-	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
-	PuzzleScore.connect("after_piece_written", self, "_on_PuzzleScore_after_piece_written")
-	PuzzleScore.connect("game_ended", self, "_on_PuzzleScore_game_ended")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
+	PuzzleState.connect("after_piece_written", self, "_on_PuzzleState_after_piece_written")
+	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")
 	CurrentLevel.connect("settings_changed", self, "_on_Level_settings_changed")
 
 
@@ -34,15 +34,15 @@ func set_combo_break(new_combo_break: int) -> void:
 
 
 func break_combo() -> void:
-	if PuzzleScore.combo >= 20:
+	if PuzzleState.combo >= 20:
 		$Fanfare3.play()
-	elif PuzzleScore.combo >= 10:
+	elif PuzzleState.combo >= 10:
 		$Fanfare2.play()
-	elif PuzzleScore.combo >= 5:
+	elif PuzzleState.combo >= 5:
 		$Fanfare1.play()
 	
-	if PuzzleScore.combo > 0:
-		PuzzleScore.end_combo()
+	if PuzzleState.combo > 0:
+		PuzzleState.end_combo()
 	emit_signal("combo_break_changed", combo_break)
 
 
@@ -51,7 +51,7 @@ func _reset() -> void:
 	emit_signal("combo_break_changed", combo_break)
 
 
-func _on_PuzzleScore_game_prepared() -> void:
+func _on_PuzzleState_game_prepared() -> void:
 	_reset()
 
 
@@ -76,7 +76,7 @@ func _on_Playfield_line_cleared(_y: int, _total_lines: int, _remaining_lines: in
 		emit_signal("combo_break_changed", combo_break)
 
 
-func _on_PuzzleScore_after_piece_written() -> void:
+func _on_PuzzleState_after_piece_written() -> void:
 	if piece_broke_combo:
 		combo_break = CurrentLevel.settings.combo_break.pieces
 		break_combo()
@@ -96,15 +96,15 @@ func _on_PuzzleScore_after_piece_written() -> void:
 	piece_continued_combo = false
 
 
-func _on_PuzzleScore_game_ended() -> void:
-	PuzzleScore.end_combo()
+func _on_PuzzleState_game_ended() -> void:
+	PuzzleState.end_combo()
 
 
 """
 Increments the combo and score for the specified line clear.
 """
 func _on_Playfield_before_line_cleared(_y: int, _total_lines: int, _remaining_lines: int, box_ints: Array) -> void:
-	var combo_score: int = COMBO_SCORE_ARR[clamp(PuzzleScore.combo, 0, COMBO_SCORE_ARR.size() - 1)]
+	var combo_score: int = COMBO_SCORE_ARR[clamp(PuzzleState.combo, 0, COMBO_SCORE_ARR.size() - 1)]
 	var box_score := 0
 	for box_int in box_ints:
 		if PuzzleTileMap.is_snack_box(box_int):
@@ -113,4 +113,4 @@ func _on_Playfield_before_line_cleared(_y: int, _total_lines: int, _remaining_li
 			box_score += CurrentLevel.settings.score.cake_points
 		else:
 			box_score += CurrentLevel.settings.score.veg_points
-	PuzzleScore.add_line_score(combo_score, box_score)
+	PuzzleState.add_line_score(combo_score, box_score)

--- a/project/src/main/puzzle/food-items.gd
+++ b/project/src/main/puzzle/food-items.gd
@@ -50,7 +50,7 @@ onready var _food_flight_timer := $FoodFlightTimer
 onready var _customer_change_timer := $CustomerChangeTimer
 
 func _ready() -> void:
-	PuzzleScore.connect("speed_index_changed", self, "_on_PuzzleScore_speed_index_changed")
+	PuzzleState.connect("speed_index_changed", self, "_on_PuzzleState_speed_index_changed")
 
 
 func _physics_process(_delta: float) -> void:
@@ -162,7 +162,7 @@ func _on_StarSeeds_food_spawned(cell: Vector2, remaining_food: int, food_type: i
 	var customer := _puzzle.get_customer()
 	var old_fatness: float = _pending_food_fatness.back() if _pending_food_fatness else customer.get_fatness()
 	var base_score := customer.fatness_to_score(customer.base_fatness)
-	var target_fatness := customer.score_to_fatness(base_score + PuzzleScore.get_bonus_score())
+	var target_fatness := customer.score_to_fatness(base_score + PuzzleState.get_bonus_score())
 	
 	var fatness_pct: float = 1.0 / (remaining_food + 1)
 	_pending_food_fatness.append(lerp(old_fatness, target_fatness, fatness_pct))
@@ -194,5 +194,5 @@ func _on_RestaurantView_customer_changed() -> void:
 	_pending_food_fatness.clear()
 
 
-func _on_PuzzleScore_speed_index_changed(_value: int) -> void:
+func _on_PuzzleState_speed_index_changed(_value: int) -> void:
 	_update_food_speed()

--- a/project/src/main/puzzle/input-replay.gd
+++ b/project/src/main/puzzle/input-replay.gd
@@ -34,7 +34,7 @@ Returns 'true' if the replay data specifies that the action was pressed on the c
 This only true for the exact frame when the press is first triggered.
 """
 func is_action_pressed(action: String) -> bool:
-	var action_frame_key := "%s +%s" % [PuzzleScore.input_frame, action]
+	var action_frame_key := "%s +%s" % [PuzzleState.input_frame, action]
 	var pressed := _action_timings.has(action_frame_key)
 	if pressed:
 		_pressed_actions[action] = true
@@ -47,7 +47,7 @@ Returns 'true' if the replay data specifies that the action was released on the 
 This only true for the exact frame when the release is first triggered.
 """
 func is_action_released(action: String) -> bool:
-	var action_frame_key := "%s -%s" % [PuzzleScore.input_frame, action]
+	var action_frame_key := "%s -%s" % [PuzzleState.input_frame, action]
 	var released := _action_timings.has(action_frame_key)
 	if released:
 		_pressed_actions[action] = false

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -6,10 +6,10 @@ Stores information about the current level.
 # emitted after the level has customized the puzzle's settings.
 signal settings_changed
 
-# emitted when the 'level_state' field changes, such as when starting or clearing a level.
-signal level_state_changed
+# emitted when the 'cutscene_state' field changes, such as when starting or clearing a level.
+signal cutscene_state_changed
 
-enum LevelState {
+enum CutsceneState {
 	NONE, # the level hasn't been launched
 	BEFORE, # the level has been launched, but the hasn't yet been finished successfully
 	AFTER # the level has been finished successfully. The player didn't lose or give up
@@ -36,7 +36,7 @@ var customer_ids: Array
 var chef_id: String
 
 # Tracks whether or not the player has started or cleared the level.
-var level_state: int = LevelState.NONE setget set_level_state
+var cutscene_state: int = CutsceneState.NONE setget set_cutscene_state
 
 """
 Unsets all of the 'launched level' data.
@@ -63,12 +63,12 @@ func set_launched_level(new_level_id: String) -> void:
 		level_lock = LevelLibrary.level_lock(level_id)
 	
 	if level_lock:
-		set_level_state(LevelState.BEFORE)
+		set_cutscene_state(CutsceneState.BEFORE)
 		creature_id = level_lock.creature_id
 		customer_ids = level_lock.customer_ids
 		chef_id = level_lock.chef_id
 	else:
-		set_level_state(LevelState.NONE)
+		set_cutscene_state(CutsceneState.NONE)
 		creature_id = ""
 		customer_ids = []
 		chef_id = ""
@@ -76,7 +76,7 @@ func set_launched_level(new_level_id: String) -> void:
 
 func start_level(new_settings: LevelSettings) -> void:
 	level_id = new_settings.id
-	PuzzleScore.reset()
+	PuzzleState.reset()
 	switch_level(new_settings)
 
 
@@ -132,6 +132,6 @@ func push_level_trail() -> void:
 	SceneTransition.push_trail(Global.SCENE_PUZZLE)
 
 
-func set_level_state(new_level_state: int) -> void:
-	level_state = new_level_state
-	emit_signal("level_state_changed")
+func set_cutscene_state(new_cutscene_state: int) -> void:
+	cutscene_state = new_cutscene_state
+	emit_signal("cutscene_state_changed")

--- a/project/src/main/puzzle/line-clear-sfx.gd
+++ b/project/src/main/puzzle/line-clear-sfx.gd
@@ -69,13 +69,13 @@ a repeating list where the repetition is concealed using a shepard tone.
 """
 func _play_combo_sound(_y: int, _total_lines: int, _remaining_lines: int, _box_ints: Array) -> void:
 	var sound: AudioStream
-	if PuzzleScore.combo <= 0:
+	if PuzzleState.combo <= 0:
 		# lines were cleared from top out or another unusual case. don't play combo sounds
 		pass
-	elif PuzzleScore.combo < _combo_sounds.size():
-		sound = _combo_sounds[PuzzleScore.combo - 1]
+	elif PuzzleState.combo < _combo_sounds.size():
+		sound = _combo_sounds[PuzzleState.combo - 1]
 	else:
-		sound = _combo_endless_sounds[(PuzzleScore.combo - 1 - _combo_sounds.size()) % _combo_endless_sounds.size()]
+		sound = _combo_endless_sounds[(PuzzleState.combo - 1 - _combo_sounds.size()) % _combo_endless_sounds.size()]
 	if sound:
 		$ComboSound.stream = sound
 		$ComboSound.play()

--- a/project/src/main/puzzle/line-clearer.gd
+++ b/project/src/main/puzzle/line-clearer.gd
@@ -52,7 +52,7 @@ onready var _line_fall_sound: AudioStreamPlayer = $LineFallSound
 
 func _ready() -> void:
 	set_physics_process(false)
-	PuzzleScore.connect("finish_triggered", self, "_on_PuzzleScore_finish_triggered")
+	PuzzleState.connect("finish_triggered", self, "_on_PuzzleState_finish_triggered")
 
 
 func _physics_process(_delta: float) -> void:
@@ -287,11 +287,11 @@ func _schedule_finish_line_clears() -> void:
 	remaining_line_erase_frames = max(1, remaining_line_erase_frames)
 
 
-func _on_PuzzleScore_finish_triggered() -> void:
+func _on_PuzzleState_finish_triggered() -> void:
 	if CurrentLevel.settings.other.clear_on_finish:
 		_schedule_finish_line_clears()
 	else:
-		PuzzleScore.end_game()
+		PuzzleState.end_game()
 
 
 """

--- a/project/src/main/puzzle/milestone-hud.gd
+++ b/project/src/main/puzzle/milestone-hud.gd
@@ -24,8 +24,8 @@ onready var _value: FontFitLabel = $Value
 onready var _progress_bar_particles: Control = $ProgressBarParticles
 
 func _ready() -> void:
-	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
-	PuzzleScore.connect("speed_index_changed", self, "_on_PuzzleScore_speed_index_changed")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
+	PuzzleState.connect("speed_index_changed", self, "_on_PuzzleState_speed_index_changed")
 	CurrentLevel.connect("settings_changed", self, "_on_Level_settings_changed")
 	match CurrentLevel.settings.finish_condition.type:
 		Milestone.CUSTOMERS:
@@ -140,7 +140,7 @@ func _emit_particles() -> void:
 		particles_2d.emitting = true
 
 
-func _on_PuzzleScore_game_prepared() -> void:
+func _on_PuzzleState_game_prepared() -> void:
 	init_milebar()
 
 
@@ -149,7 +149,7 @@ Emits particles when the player levels up.
 
 This provides visual feedback for people playing without sound.
 """
-func _on_PuzzleScore_speed_index_changed(value: int) -> void:
+func _on_PuzzleState_speed_index_changed(value: int) -> void:
 	if value == 0:
 		# initializing the level; don't emit any particles
 		return

--- a/project/src/main/puzzle/milestone-manager.gd
+++ b/project/src/main/puzzle/milestone-manager.gd
@@ -9,10 +9,10 @@ Reaching a milestone can increase the speed, end the level, or trigger a success
 """
 
 func _ready() -> void:
-	PuzzleScore.connect("before_piece_written", self, "_on_PuzzleScore_before_piece_written")
-	PuzzleScore.connect("after_piece_written", self, "_on_PuzzleScore_after_piece_written")
-	PuzzleScore.connect("score_changed", self, "_on_PuzzleScore_score_changed")
-	PuzzleScore.connect("combo_ended", self, "_on_PuzzleScore_combo_ended")
+	PuzzleState.connect("before_piece_written", self, "_on_PuzzleState_before_piece_written")
+	PuzzleState.connect("after_piece_written", self, "_on_PuzzleState_after_piece_written")
+	PuzzleState.connect("score_changed", self, "_on_PuzzleState_score_changed")
+	PuzzleState.connect("combo_ended", self, "_on_PuzzleState_combo_ended")
 
 
 func _physics_process(_delta: float) -> void:
@@ -44,19 +44,19 @@ func milestone_progress(milestone: Milestone) -> float:
 	var progress: float
 	match milestone.type:
 		Milestone.CUSTOMERS:
-			progress = PuzzleScore.creature_scores.size()
-			if not PuzzleScore.no_more_customers:
+			progress = PuzzleState.customer_scores.size()
+			if not PuzzleState.no_more_customers:
 				progress -= 0.5
-				if PuzzleScore.get_creature_score() == 0:
+				if PuzzleState.get_customer_score() == 0:
 					progress -= 0.5
 		Milestone.LINES:
-			progress = PuzzleScore.level_performance.lines
+			progress = PuzzleState.level_performance.lines
 		Milestone.PIECES:
-			progress = PuzzleScore.level_performance.pieces
+			progress = PuzzleState.level_performance.pieces
 		Milestone.SCORE:
-			progress = PuzzleScore.get_score() + PuzzleScore.get_bonus_score()
+			progress = PuzzleState.get_score() + PuzzleState.get_bonus_score()
 		Milestone.TIME_OVER, Milestone.TIME_UNDER:
-			progress = PuzzleScore.level_performance.seconds
+			progress = PuzzleState.level_performance.seconds
 	return progress
 
 
@@ -66,7 +66,7 @@ Returns the previously completed milestone.
 This controls the speed at which the pieces move.
 """
 func prev_milestone() -> Milestone:
-	return CurrentLevel.settings.speed_ups[PuzzleScore.speed_index]
+	return CurrentLevel.settings.speed_ups[PuzzleState.speed_index]
 
 
 """
@@ -77,8 +77,8 @@ finish condition.
 """
 func next_milestone() -> Milestone:
 	var milestone: Milestone
-	if PuzzleScore.speed_index + 1 < CurrentLevel.settings.speed_ups.size():
-		milestone = CurrentLevel.settings.speed_ups[PuzzleScore.speed_index + 1]
+	if PuzzleState.speed_index + 1 < CurrentLevel.settings.speed_ups.size():
+		milestone = CurrentLevel.settings.speed_ups[PuzzleState.speed_index + 1]
 	else:
 		milestone = CurrentLevel.settings.finish_condition
 	return milestone
@@ -88,38 +88,38 @@ func next_milestone() -> Milestone:
 If the player reached a milestone, we increase the speed.
 """
 func _check_for_speed_up() -> void:
-	var new_speed_index: int = PuzzleScore.speed_index
+	var new_speed_index: int = PuzzleState.speed_index
 	
 	while new_speed_index + 1 < CurrentLevel.settings.speed_ups.size() \
 			and milestone_met(CurrentLevel.settings.speed_ups[new_speed_index + 1]):
 		new_speed_index += 1
 	
-	if PuzzleScore.speed_index != new_speed_index:
-		PuzzleScore.speed_index = new_speed_index
+	if PuzzleState.speed_index != new_speed_index:
+		PuzzleState.speed_index = new_speed_index
 
 
 """
 If the player reached the finish milestone, we end the level.
 """
 func _check_for_finish() -> void:
-	if PuzzleScore.game_active and milestone_met(CurrentLevel.settings.finish_condition):
-		PuzzleScore.trigger_finish()
+	if PuzzleState.game_active and milestone_met(CurrentLevel.settings.finish_condition):
+		PuzzleState.trigger_finish()
 
 
-func _on_PuzzleScore_before_piece_written() -> void:
+func _on_PuzzleState_before_piece_written() -> void:
 	_check_for_speed_up()
 
 
-func _on_PuzzleScore_after_piece_written() -> void:
+func _on_PuzzleState_after_piece_written() -> void:
 	_check_for_speed_up()
 	_check_for_finish()
 
 
-func _on_PuzzleScore_score_changed() -> void:
+func _on_PuzzleState_score_changed() -> void:
 	_check_for_speed_up()
 
 
-func _on_PuzzleScore_combo_ended() -> void:
+func _on_PuzzleState_combo_ended() -> void:
 	# most milestones end when the piece is written; but customer milestones end when the combo ends
 	if CurrentLevel.settings.finish_condition.type == Milestone.CUSTOMERS:
 		_check_for_finish()

--- a/project/src/main/puzzle/pan/puzzle-frying-pans-ui.gd
+++ b/project/src/main/puzzle/pan/puzzle-frying-pans-ui.gd
@@ -4,9 +4,9 @@ Updates the FryingPansUi based on the level's settings and how the player is doi
 """
 
 func _ready() -> void:
-	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
-	PuzzleScore.connect("topped_out", self, "_on_PuzzleScore_topped_out")
-	PuzzleScore.connect("game_ended", self, "_on_PuzzleScore_game_ended")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
+	PuzzleState.connect("topped_out", self, "_on_PuzzleState_topped_out")
+	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")
 	_refresh_lives()
 
 
@@ -15,19 +15,19 @@ Updates the state of the FryingPansUi and refreshes the tilemap.
 """
 func _refresh_lives() -> void:
 	pans_max = CurrentLevel.settings.lose_condition.top_out
-	if PuzzleScore.level_performance.lost:
+	if PuzzleState.level_performance.lost:
 		pans_remaining = 0
 	else:
-		pans_remaining = CurrentLevel.settings.lose_condition.top_out - PuzzleScore.level_performance.top_out_count
+		pans_remaining = CurrentLevel.settings.lose_condition.top_out - PuzzleState.level_performance.top_out_count
 	gold = CurrentLevel.settings.blocks_during.clear_on_top_out
 	refresh_tilemap()
 
 
-func _on_PuzzleScore_game_prepared() -> void:
+func _on_PuzzleState_game_prepared() -> void:
 	_refresh_lives()
 
 
-func _on_PuzzleScore_game_ended() -> void:
+func _on_PuzzleState_game_ended() -> void:
 	_refresh_lives()
 
 
@@ -36,5 +36,5 @@ Updates the state of the FryingPansUi when the player loses a life.
 
 We deliberately avoid calling refresh_lives because we want to trigger the animation where a frying pan fades out.
 """
-func _on_PuzzleScore_topped_out() -> void:
+func _on_PuzzleState_topped_out() -> void:
 	set_pans_remaining(pans_remaining - 1)

--- a/project/src/main/puzzle/piece-sfx.gd
+++ b/project/src/main/puzzle/piece-sfx.gd
@@ -4,10 +4,10 @@ Plays sound effects when the player piece is moved.
 """
 
 func _ready() -> void:
-	PuzzleScore.connect("speed_index_changed", self, "_on_PuzzleScore_speed_index_changed")
+	PuzzleState.connect("speed_index_changed", self, "_on_PuzzleState_speed_index_changed")
 
 
-func _on_PuzzleScore_speed_index_changed(value: int) -> void:
+func _on_PuzzleState_speed_index_changed(value: int) -> void:
 	if value > 0:
 		$LevelUpSound.play()
 

--- a/project/src/main/puzzle/piece/frame-input.gd
+++ b/project/src/main/puzzle/piece/frame-input.gd
@@ -31,11 +31,11 @@ func _unhandled_input(event: InputEvent) -> void:
 		return
 	
 	if event.is_action_pressed(action):
-		if _print_inputs: print("\"%s +%s\"," % [PuzzleScore.input_frame, action])
+		if _print_inputs: print("\"%s +%s\"," % [PuzzleState.input_frame, action])
 		_just_pressed = true
 		_pressed = true
 	elif event.is_action_released(action):
-		if _print_inputs: print("\"%s -%s\"," % [PuzzleScore.input_frame, action])
+		if _print_inputs: print("\"%s -%s\"," % [PuzzleState.input_frame, action])
 		_pressed = false
 	
 	if cancel_action:
@@ -106,11 +106,11 @@ Applies prerecorded puzzle inputs for things such as tutorials.
 """
 func _process_input_replay() -> void:
 	if CurrentLevel.settings.input_replay.is_action_pressed(action):
-		if _print_inputs: print("\"%s +%s\"," % [PuzzleScore.input_frame, action])
+		if _print_inputs: print("\"%s +%s\"," % [PuzzleState.input_frame, action])
 		_just_pressed = true
 		_pressed = true
 	elif CurrentLevel.settings.input_replay.is_action_released(action):
-		if _print_inputs: print("\"%s -%s\"," % [PuzzleScore.input_frame, action])
+		if _print_inputs: print("\"%s -%s\"," % [PuzzleState.input_frame, action])
 		_pressed = false
 	
 	if cancel_action:

--- a/project/src/main/puzzle/piece/next-piece-displays.gd
+++ b/project/src/main/puzzle/piece/next-piece-displays.gd
@@ -12,7 +12,7 @@ export (PackedScene) var NextPieceDisplayScene
 var _next_piece_displays := []
 
 func _ready() -> void:
-	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
 	Pauser.connect("paused_changed", self, "_on_Pauser_paused_changed")
 	for i in range(DISPLAY_COUNT):
 		_add_display(i, 5, 5 + i * (486.0 / (DISPLAY_COUNT - 1)), 0.5)
@@ -34,7 +34,7 @@ func _add_display(piece_index: int, x: float, y: float, scale: float) -> void:
 """
 Gets ready for a new game, randomizing the pieces and filling the piece queues.
 """
-func _on_PuzzleScore_game_prepared() -> void:
+func _on_PuzzleState_game_prepared() -> void:
 	for next_piece_display in _next_piece_displays:
 		next_piece_display.show()
 

--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -54,12 +54,12 @@ onready var _playfield: Playfield = get_node(playfield_path)
 onready var _states: PieceStates = $States
 
 func _ready() -> void:
-	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
-	PuzzleScore.connect("game_started", self, "_on_PuzzleScore_game_started")
-	PuzzleScore.connect("before_level_changed", self, "_on_PuzzleScore_before_level_changed")
-	PuzzleScore.connect("after_level_changed", self, "_on_PuzzleScore_after_level_changed")
-	PuzzleScore.connect("finish_triggered", self, "_on_PuzzleScore_finish_triggered")
-	PuzzleScore.connect("game_ended", self, "_on_PuzzleScore_game_ended")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
+	PuzzleState.connect("game_started", self, "_on_PuzzleState_game_started")
+	PuzzleState.connect("before_level_changed", self, "_on_PuzzleState_before_level_changed")
+	PuzzleState.connect("after_level_changed", self, "_on_PuzzleState_after_level_changed")
+	PuzzleState.connect("finish_triggered", self, "_on_PuzzleState_finish_triggered")
+	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")
 	Pauser.connect("paused_changed", self, "_on_Pauser_paused_changed")
 	
 	piece = ActivePiece.new(PieceTypes.piece_null, funcref(tile_map, "is_cell_blocked"))
@@ -212,11 +212,11 @@ func _on_States_entered_state(state: State) -> void:
 		emit_signal("lock_started")
 
 
-func _on_PuzzleScore_game_prepared() -> void:
+func _on_PuzzleState_game_prepared() -> void:
 	_clear_piece()
 
 
-func _on_PuzzleScore_game_started() -> void:
+func _on_PuzzleState_game_started() -> void:
 	_start_first_piece()
 
 
@@ -224,7 +224,7 @@ func _on_PuzzleScore_game_started() -> void:
 The player finished the level, possibly while they were still moving a piece around. We clear their piece so that it's
 not left floating.
 """
-func _on_PuzzleScore_finish_triggered() -> void:
+func _on_PuzzleState_finish_triggered() -> void:
 	_clear_piece()
 	_states.set_state(_states.game_ended)
 
@@ -232,15 +232,15 @@ func _on_PuzzleScore_finish_triggered() -> void:
 """
 The game ended the game, possibly by a top out. We leave the piece in place so that they can see why they topped out.
 """
-func _on_PuzzleScore_game_ended() -> void:
+func _on_PuzzleState_game_ended() -> void:
 	_states.set_state(_states.game_ended)
 
 
-func _on_PuzzleScore_before_level_changed(_new_level_id: String) -> void:
+func _on_PuzzleState_before_level_changed(_new_level_id: String) -> void:
 	set_physics_process(false)
 
 
-func _on_PuzzleScore_after_level_changed() -> void:
+func _on_PuzzleState_after_level_changed() -> void:
 	set_physics_process(true)
 	_start_first_piece()
 

--- a/project/src/main/puzzle/piece/piece-physics.gd
+++ b/project/src/main/puzzle/piece/piece-physics.gd
@@ -36,7 +36,7 @@ func spawn_piece(piece: ActivePiece) -> bool:
 	
 	var success := true
 	if not piece.can_move_to_target():
-		PuzzleScore.top_out()
+		PuzzleState.top_out()
 		success = false
 	return success
 

--- a/project/src/main/puzzle/piece/piece-queue.gd
+++ b/project/src/main/puzzle/piece/piece-queue.gd
@@ -20,7 +20,7 @@ var _remaining_piece_count := UNLIMITED_PIECES
 
 func _ready() -> void:
 	CurrentLevel.connect("settings_changed", self, "_on_Level_settings_changed")
-	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
 	_fill()
 
 
@@ -254,7 +254,7 @@ func _on_Level_settings_changed() -> void:
 	clear()
 
 
-func _on_PuzzleScore_game_prepared() -> void:
+func _on_PuzzleState_game_prepared() -> void:
 	clear()
 
 

--- a/project/src/main/puzzle/piece/piece-speeds.gd
+++ b/project/src/main/puzzle/piece/piece-speeds.gd
@@ -77,8 +77,8 @@ func _ready() -> void:
 	_add_speed(PieceSpeed.new("FFF", 20*G,  2, 2, 7,  8, 12, 3, 3))
 	
 	current_speed = PieceSpeeds.speed("0")
-	PuzzleScore.connect("speed_index_changed", self, "_on_PuzzleScore_speed_index_changed")
-	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
+	PuzzleState.connect("speed_index_changed", self, "_on_PuzzleState_speed_index_changed")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
 
 
 func speed(string: String) -> PieceSpeed:
@@ -94,9 +94,9 @@ func _update_current_speed() -> void:
 	PieceSpeeds.current_speed = PieceSpeeds.speed(MilestoneManager.prev_milestone().get_meta("speed"))
 
 
-func _on_PuzzleScore_speed_index_changed(_value: int) -> void:
+func _on_PuzzleState_speed_index_changed(_value: int) -> void:
 	_update_current_speed()
 
 
-func _on_PuzzleScore_game_prepared() -> void:
+func _on_PuzzleState_game_prepared() -> void:
 	_update_current_speed()

--- a/project/src/main/puzzle/playfield-fx.gd
+++ b/project/src/main/puzzle/playfield-fx.gd
@@ -92,9 +92,9 @@ onready var _bg_strobe: ColorRect = $BgStrobe
 onready var _glow_tween: Tween = $GlowTween
 
 func _ready() -> void:
-	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
 	_combo_tracker.connect("combo_break_changed", self, "_on_ComboTracker_combo_break_changed")
-	PuzzleScore.connect("combo_changed", self, "_on_PuzzleScore_combo_changed")
+	PuzzleState.connect("combo_changed", self, "_on_PuzzleState_combo_changed")
 	_init_tile_set()
 	_init_color_tile_indexes()
 	reset()
@@ -256,7 +256,7 @@ func _on_ComboTracker_combo_break_changed(_value: int) -> void:
 	_refresh_tile_maps()
 
 
-func _on_PuzzleScore_combo_changed(value: int) -> void:
+func _on_PuzzleState_combo_changed(value: int) -> void:
 	_calculate_brightness(value)
 	_start_glow_tween()
 	_refresh_tile_maps()
@@ -270,5 +270,5 @@ func _on_Playfield_box_built(_rect: Rect2, _color_int: int) -> void:
 	_start_glow_tween()
 
 
-func _on_PuzzleScore_game_prepared() -> void:
+func _on_PuzzleState_game_prepared() -> void:
 	reset()

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -36,15 +36,15 @@ onready var _combo_tracker: ComboTracker = $ComboTracker
 onready var _line_clearer: LineClearer = $LineClearer
 
 func _ready() -> void:
-	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
 	CurrentLevel.connect("settings_changed", self, "_on_Level_settings_changed")
 	Pauser.connect("paused_changed", self, "_on_Pauser_paused_changed")
 	_prepare_level_blocks()
 
 
 func _physics_process(delta: float) -> void:
-	if PuzzleScore.game_active:
-		PuzzleScore.level_performance.seconds += delta
+	if PuzzleState.game_active:
+		PuzzleState.level_performance.seconds += delta
 	
 	if _box_builder.remaining_box_build_frames > 0:
 		if not _box_builder.is_physics_processing():
@@ -101,12 +101,12 @@ func write_piece(pos: Vector2, orientation: int, type: PieceType, death_piece :=
 		_box_builder.process_boxes()
 		_line_clearer.schedule_full_row_line_clears()
 	
-	PuzzleScore.before_piece_written()
+	PuzzleState.before_piece_written()
 	
 	if _box_builder.remaining_box_build_frames == 0 and _line_clearer.remaining_line_erase_frames == 0:
 		# If any boxes are being built or lines are being cleared, we emit the
 		# signal later. Otherwise we emit it now.
-		PuzzleScore.after_piece_written()
+		PuzzleState.after_piece_written()
 
 
 func break_combo() -> void:
@@ -126,7 +126,7 @@ func _prepare_level_blocks() -> void:
 	emit_signal("blocks_prepared")
 
 
-func _on_PuzzleScore_game_prepared() -> void:
+func _on_PuzzleState_game_prepared() -> void:
 	_prepare_level_blocks()
 
 
@@ -142,7 +142,7 @@ func _on_BoxBuilder_after_boxes_built() -> void:
 	if _line_clearer.remaining_line_erase_frames > 0:
 		_line_clearer.set_physics_process(true)
 	else:
-		PuzzleScore.after_piece_written()
+		PuzzleState.after_piece_written()
 
 
 func _on_LineClearer_line_clears_scheduled(ys: Array) -> void:
@@ -163,7 +163,7 @@ func _on_LineClearer_line_cleared(y: int, total_lines: int, remaining_lines: int
 
 func _on_LineClearer_lines_deleted(lines: Array) -> void:
 	emit_signal("lines_deleted", lines)
-	PuzzleScore.after_piece_written()
+	PuzzleState.after_piece_written()
 
 
 func _on_FrostingGlobs_hit_playfield(glob: Node) -> void:

--- a/project/src/main/puzzle/puzzle-music-manager.gd
+++ b/project/src/main/puzzle/puzzle-music-manager.gd
@@ -4,8 +4,8 @@ Starts and stops music during the puzzle mode.
 """
 
 func _ready() -> void:
-	PuzzleScore.connect("game_ended", self, "_on_PuzzleScore_game_ended")
-	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
+	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
 
 
 func start_puzzle_music() -> void:
@@ -15,10 +15,10 @@ func start_puzzle_music() -> void:
 		MusicPlayer.play_upbeat_bgm()
 
 
-func _on_PuzzleScore_game_prepared() -> void:
+func _on_PuzzleState_game_prepared() -> void:
 	start_puzzle_music()
 
 
-func _on_PuzzleScore_game_ended() -> void:
+func _on_PuzzleState_game_ended() -> void:
 	MusicPlayer.play_chill_bgm()
 	MusicPlayer.fade_in()

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -75,7 +75,7 @@ var input_frame := -1
 var level_performance := PuzzlePerformance.new()
 
 # The scores for each creature in the current level (bonuses and line clears)
-var creature_scores := [0]
+var customer_scores := [0]
 
 # The number of lines the player has cleared without dropping their combo
 var combo := 0 setget set_combo
@@ -218,7 +218,7 @@ func add_line_score(combo_score: int, box_score: int) -> void:
 		level_performance.leftover_score += combo_score + box_score + 1
 	
 	combo += 1
-	_add_creature_score(1 + combo_score + box_score)
+	_add_customer_score(1 + combo_score + box_score)
 	_add_bonus_score(combo_score + box_score)
 	_add_score(1)
 	
@@ -234,19 +234,19 @@ func end_combo() -> void:
 	var old_combo := combo
 	if CurrentLevel.settings.other.tutorial:
 		# during tutorials, reset the combo and line clears
-		creature_scores[creature_scores.size() - 1] = 0
+		customer_scores[customer_scores.size() - 1] = 0
 		combo = 0
 	elif no_more_customers or game_ended:
 		pass
-	elif get_creature_score() == 0:
+	elif get_customer_score() == 0:
 		# don't add $0 creatures. creatures don't pay if they owe $0
 		pass
 	elif CurrentLevel.settings.finish_condition.type == Milestone.CUSTOMERS \
-			and PuzzleScore.creature_scores.size() >= CurrentLevel.settings.finish_condition.value:
+			and PuzzleState.customer_scores.size() >= CurrentLevel.settings.finish_condition.value:
 		# some levels have a limited number of customers
 		no_more_customers = true
 	else:
-		creature_scores.append(0)
+		customer_scores.append(0)
 		combo = 0
 	
 	_add_score(bonus_score)
@@ -262,7 +262,7 @@ func end_combo() -> void:
 Reset all score data, such as when starting a level over.
 """
 func reset() -> void:
-	creature_scores = [0]
+	customer_scores = [0]
 	combo = 0
 	bonus_score = 0
 	level_performance = PuzzlePerformance.new()
@@ -286,8 +286,8 @@ func get_bonus_score() -> int:
 	return bonus_score
 
 
-func get_creature_score() -> int:
-	return creature_scores[creature_scores.size() - 1]
+func get_customer_score() -> int:
+	return customer_scores[customer_scores.size() - 1]
 
 
 func set_combo(new_combo: int) -> void:
@@ -359,5 +359,5 @@ func _add_line() -> void:
 	level_performance.lines += 1
 
 
-func _add_creature_score(delta: int) -> void:
-	creature_scores[creature_scores.size() - 1] += delta
+func _add_customer_score(delta: int) -> void:
+	customer_scores[customer_scores.size() - 1] += delta

--- a/project/src/main/puzzle/puzzle-timer.gd
+++ b/project/src/main/puzzle/puzzle-timer.gd
@@ -20,4 +20,4 @@ func _process(_delta: float) -> void:
 Updates the label to show the number of seconds the player has spent on the current puzzle.
 """
 func _refresh_text() -> void:
-	text = StringUtils.format_duration(int(ceil(PuzzleScore.level_performance.seconds)))
+	text = StringUtils.format_duration(int(ceil(PuzzleState.level_performance.seconds)))

--- a/project/src/main/puzzle/rank-calculator.gd
+++ b/project/src/main/puzzle/rank-calculator.gd
@@ -168,16 +168,16 @@ func _unranked_result() -> RankResult:
 		rank_result.compare = "-seconds"
 
 	# calculate raw player performance statistics
-	rank_result.box_score = PuzzleScore.level_performance.box_score
-	rank_result.combo_score = PuzzleScore.level_performance.combo_score
-	rank_result.leftover_score = PuzzleScore.level_performance.leftover_score
-	rank_result.lines = PuzzleScore.level_performance.lines
-	rank_result.pieces = PuzzleScore.level_performance.pieces
-	rank_result.lost = PuzzleScore.level_performance.lost
-	rank_result.success = PuzzleScore.level_performance.success
-	rank_result.score = PuzzleScore.level_performance.score
-	rank_result.seconds = PuzzleScore.level_performance.seconds
-	rank_result.top_out_count = PuzzleScore.level_performance.top_out_count
+	rank_result.box_score = PuzzleState.level_performance.box_score
+	rank_result.combo_score = PuzzleState.level_performance.combo_score
+	rank_result.leftover_score = PuzzleState.level_performance.leftover_score
+	rank_result.lines = PuzzleState.level_performance.lines
+	rank_result.pieces = PuzzleState.level_performance.pieces
+	rank_result.lost = PuzzleState.level_performance.lost
+	rank_result.success = PuzzleState.level_performance.success
+	rank_result.score = PuzzleState.level_performance.score
+	rank_result.seconds = PuzzleState.level_performance.seconds
+	rank_result.top_out_count = PuzzleState.level_performance.top_out_count
 	
 	rank_result.box_score_per_line = float(rank_result.box_score) / max(rank_result.lines, 1)
 	rank_result.combo_score_per_line = 20 * float(rank_result.combo_score) \

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -33,10 +33,10 @@ func _ready() -> void:
 	# these values in the editor. Otherwise it keeps changing the values back.
 	_customer_view_viewport.size = _customer_view.rect_size * 4
 	
-	PuzzleScore.connect("game_ended", self, "_on_PuzzleScore_game_ended")
-	PuzzleScore.connect("combo_changed", self, "_on_PuzzleScore_combo_changed")
-	PuzzleScore.connect("topped_out", self, "_on_PuzzleScore_topped_out")
-	PuzzleScore.connect("added_line_score", self, "_on_PuzzleScore_added_line_score")
+	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")
+	PuzzleState.connect("combo_changed", self, "_on_PuzzleState_combo_changed")
+	PuzzleState.connect("topped_out", self, "_on_PuzzleState_topped_out")
+	PuzzleState.connect("added_line_score", self, "_on_PuzzleState_added_line_score")
 	
 	get_chef().connect("creature_name_changed", self, "_on_Chef_creature_name_changed")
 	for customer in get_customers():
@@ -165,31 +165,31 @@ func _on_Chef_creature_name_changed() -> void:
 """
 Cycle out the customer when the combo resets to 0.
 """
-func _on_PuzzleScore_combo_changed(value: int) -> void:
+func _on_PuzzleState_combo_changed(value: int) -> void:
 	if value > 0:
 		# if the combo is not resetting, we ignore the change
 		return
 	
-	if PuzzleScore.no_more_customers:
+	if PuzzleState.no_more_customers:
 		pass
-	elif PuzzleScore.game_active:
+	elif PuzzleState.game_active:
 		get_customer().play_goodbye_voice()
 		scroll_to_new_creature()
 	
 	# losing your combo doesn't erase the 'recent bonus' value, but decreases it a lot
 	_recent_bonuses = _recent_bonuses.slice(3, _recent_bonuses.size() - 1)
-	if PuzzleScore.game_active:
+	if PuzzleState.game_active:
 		get_chef().play_mood(ChatEvent.Mood.DEFAULT)
 
 
-func _on_PuzzleScore_topped_out() -> void:
+func _on_PuzzleState_topped_out() -> void:
 	get_chef().play_mood(ChatEvent.Mood.CRY0)
 
 
 """
 When clearing lines, the chef smiles if they're scoring a lot of bonuses.
 """
-func _on_PuzzleScore_added_line_score(combo_score: int, box_score: int) -> void:
+func _on_PuzzleState_added_line_score(combo_score: int, box_score: int) -> void:
 	_recent_bonuses.append(combo_score + box_score)
 	if _recent_bonuses.size() >= 6:
 		_recent_bonuses = _recent_bonuses.slice(_recent_bonuses.size() - 6, _recent_bonuses.size() - 1)
@@ -204,17 +204,17 @@ func _on_PuzzleScore_added_line_score(combo_score: int, box_score: int) -> void:
 """
 When the game ends, the chef smiles/cries/rages based on how they did.
 """
-func _on_PuzzleScore_game_ended() -> void:
+func _on_PuzzleState_game_ended() -> void:
 	var mood: int = ChatEvent.Mood.NONE
-	match PuzzleScore.end_result():
-		PuzzleScore.Result.NONE:
+	match PuzzleState.end_result():
+		PuzzleState.Result.NONE:
 			pass
-		PuzzleScore.Result.LOST:
+		PuzzleState.Result.LOST:
 			mood = Utils.rand_value([ChatEvent.Mood.RAGE1, ChatEvent.Mood.RAGE2,
 					ChatEvent.Mood.CRY1, ChatEvent.Mood.THINK1])
-		PuzzleScore.Result.FINISHED:
+		PuzzleState.Result.FINISHED:
 			mood = ChatEvent.Mood.SMILE0
-		PuzzleScore.Result.WON:
+		PuzzleState.Result.WON:
 			mood = ChatEvent.Mood.LAUGH1
 	if mood != ChatEvent.Mood.NONE:
 		get_chef().play_mood(mood)

--- a/project/src/main/puzzle/results-hud.gd
+++ b/project/src/main/puzzle/results-hud.gd
@@ -23,8 +23,8 @@ var _hints := [
 ]
 
 func _ready() -> void:
-	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
-	PuzzleScore.connect("after_game_ended", self, "_on_PuzzleScore_after_game_ended")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
+	PuzzleState.connect("after_game_ended", self, "_on_PuzzleState_after_game_ended")
 
 
 func hide_results_message() -> void:
@@ -38,11 +38,11 @@ Prepares a game over message to show to the player.
 The message is littered with lull characters, '/', which are hidden from the player but result in a brief pause when
 displayed.
 """
-func show_results_message(rank_result: RankResult, creature_scores: Array, finish_condition_type: int) -> void:
+func show_results_message(rank_result: RankResult, customer_scores: Array, finish_condition_type: int) -> void:
 	# Generate post-game message with stats, grades, and a gameplay hint
 	var text := "//////////"
-	text = _append_creature_scores(rank_result, creature_scores, finish_condition_type, text)
-	text = _append_grade_information(rank_result, creature_scores, finish_condition_type, text)
+	text = _append_customer_scores(rank_result, customer_scores, finish_condition_type, text)
+	text = _append_grade_information(rank_result, customer_scores, finish_condition_type, text)
 	text += "//////////\n"
 	text += tr("Hint: %s") % Utils.rand_value(_hints)
 	text += "\n"
@@ -53,16 +53,16 @@ func show_results_message(rank_result: RankResult, creature_scores: Array, finis
 	$MoneyLabel.set_shown_money(PlayerData.money - rank_result.score)
 
 
-func _append_creature_scores(rank_result: RankResult, creature_scores: Array, \
+func _append_customer_scores(rank_result: RankResult, customer_scores: Array, \
 		_finish_condition_type: int, text: String) -> String:
 	# Append creature scores
-	for i in range(creature_scores.size()):
-		var creature_score: int = creature_scores[i]
-		if creature_score == 0:
-			# last entry in creature_score is always 0; ignore it
+	for i in range(customer_scores.size()):
+		var customer_score: int = customer_scores[i]
+		if customer_score == 0:
+			# last entry in customer_score is always 0; ignore it
 			continue
 		var left := tr("Customer #%s") % StringUtils.comma_sep(i + 1)
-		var right := "¥%s/\n" % StringUtils.comma_sep(creature_score)
+		var right := "¥%s/\n" % StringUtils.comma_sep(customer_score)
 		var middle := " "
 		var period_count := 50 - _period_count(left + right)
 		for _p in range(period_count):
@@ -73,7 +73,7 @@ func _append_creature_scores(rank_result: RankResult, creature_scores: Array, \
 	return text
 
 
-func _append_grade_information(rank_result: RankResult, _creature_scores: Array, \
+func _append_grade_information(rank_result: RankResult, _customer_scores: Array, \
 		finish_condition_type: int, text: String) -> String:
 	# We add a '?' to make the player aware if their rank is adjusted because they topped out or lost.
 	var topped_out := ""
@@ -138,19 +138,19 @@ func _period_count(s: String) -> int:
 	return result
 
 
-func _on_PuzzleScore_game_prepared() -> void:
+func _on_PuzzleState_game_prepared() -> void:
 	hide_results_message()
 
 
-func _on_PuzzleScore_after_game_ended() -> void:
+func _on_PuzzleState_after_game_ended() -> void:
 	var rank_result: RankResult = PlayerData.level_history.prev_result(CurrentLevel.settings.id)
 	if not rank_result or CurrentLevel.settings.rank.skip_results:
 		return
 	
-	var creature_scores: Array = PuzzleScore.creature_scores
+	var customer_scores: Array = PuzzleState.customer_scores
 	var finish_condition_type := CurrentLevel.settings.finish_condition.type
 	
-	show_results_message(rank_result, creature_scores, finish_condition_type)
+	show_results_message(rank_result, customer_scores, finish_condition_type)
 
 
 func _on_ResultsLabel_text_shown(new_text: String) -> void:

--- a/project/src/main/puzzle/score-value-label.gd
+++ b/project/src/main/puzzle/score-value-label.gd
@@ -4,9 +4,9 @@ Displays the player's score.
 """
 
 func _ready() -> void:
-	PuzzleScore.connect("score_changed", self, "_on_PuzzleScore_score_changed")
+	PuzzleState.connect("score_changed", self, "_on_PuzzleState_score_changed")
 	text = "¥0"
 
 
-func _on_PuzzleScore_score_changed() -> void:
-	text = "¥%s" % StringUtils.comma_sep(PuzzleScore.get_score())
+func _on_PuzzleState_score_changed() -> void:
+	text = "¥%s" % StringUtils.comma_sep(PuzzleState.get_score())

--- a/project/src/main/puzzle/start-end-sfx.gd
+++ b/project/src/main/puzzle/start-end-sfx.gd
@@ -6,11 +6,11 @@ Plays sound effects at the start and end of a puzzle.
 onready var _go_voices := [$GoVoice0, $GoVoice1, $GoVoice2]
 
 func _ready() -> void:
-	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
-	PuzzleScore.connect("game_started", self, "_on_PuzzleScore_game_started")
-	PuzzleScore.connect("before_level_changed", self, "_on_PuzzleScore_before_level_changed")
-	PuzzleScore.connect("after_level_changed", self, "_on_PuzzleScore_after_level_changed")
-	PuzzleScore.connect("game_ended", self, "_on_PuzzleScore_game_ended")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
+	PuzzleState.connect("game_started", self, "_on_PuzzleState_game_started")
+	PuzzleState.connect("before_level_changed", self, "_on_PuzzleState_before_level_changed")
+	PuzzleState.connect("after_level_changed", self, "_on_PuzzleState_after_level_changed")
+	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")
 
 
 func play_ready_sound() -> void:
@@ -22,7 +22,7 @@ func play_go_sound() -> void:
 	Utils.rand_value(_go_voices).play()
 
 
-func _on_PuzzleScore_game_prepared() -> void:
+func _on_PuzzleState_game_prepared() -> void:
 	if CurrentLevel.settings.other.skip_intro:
 		# when skipping the intro, we don't play startup sounds
 		return
@@ -30,7 +30,7 @@ func _on_PuzzleScore_game_prepared() -> void:
 	play_ready_sound()
 
 
-func _on_PuzzleScore_game_started() -> void:
+func _on_PuzzleState_game_started() -> void:
 	if CurrentLevel.settings.other.skip_intro:
 		# when skipping the intro, we don't play startup sounds
 		return
@@ -38,7 +38,7 @@ func _on_PuzzleScore_game_started() -> void:
 	play_go_sound()
 
 
-func _on_PuzzleScore_before_level_changed(new_level_id: String) -> void:
+func _on_PuzzleState_before_level_changed(new_level_id: String) -> void:
 	if CurrentLevel.settings.other.non_interactive or not CurrentLevel.settings.input_replay.empty():
 		# no sound effect or fanfare for non-interactive levels
 		return
@@ -49,18 +49,18 @@ func _on_PuzzleScore_before_level_changed(new_level_id: String) -> void:
 		$SectionCompleteSound.play()
 
 
-func _on_PuzzleScore_after_level_changed() -> void:
+func _on_PuzzleState_after_level_changed() -> void:
 	$LevelChangeSound.play()
 
 
-func _on_PuzzleScore_game_ended() -> void:
+func _on_PuzzleState_game_ended() -> void:
 	var sound: AudioStreamPlayer
-	match PuzzleScore.end_result():
-		PuzzleScore.Result.LOST:
+	match PuzzleState.end_result():
+		PuzzleState.Result.LOST:
 			sound = $GameOverSound
-		PuzzleScore.Result.FINISHED:
+		PuzzleState.Result.FINISHED:
 			sound = $MatchEndSound
-		PuzzleScore.Result.WON:
+		PuzzleState.Result.WON:
 			sound = $ExcellentSound
 	if sound:
 		sound.play()

--- a/project/src/main/puzzle/topout-tracker.gd
+++ b/project/src/main/puzzle/topout-tracker.gd
@@ -6,13 +6,13 @@ onready var _playfield: Playfield = _puzzle.get_playfield()
 onready var _piece_manager: PieceManager = _puzzle.get_piece_manager()
 
 func _ready() -> void:
-	PuzzleScore.connect("topped_out", self, "_on_PuzzleScore_topped_out")
+	PuzzleState.connect("topped_out", self, "_on_PuzzleState_topped_out")
 
 
-func _on_PuzzleScore_topped_out() -> void:
+func _on_PuzzleState_topped_out() -> void:
 	Utils.rand_value(_game_over_voices).play()
 	
-	if not PuzzleScore.level_performance.lost:
+	if not PuzzleState.level_performance.lost:
 		var top_out_delay := PieceSpeeds.current_speed.appearance_delay + PieceSpeeds.current_speed.lock_delay
 		_playfield.break_combo()
 		if CurrentLevel.settings.blocks_during.clear_on_top_out:

--- a/project/src/main/puzzle/tutorial/skill-tally-item.gd
+++ b/project/src/main/puzzle/tutorial/skill-tally-item.gd
@@ -27,7 +27,7 @@ var _bright_tween_active: bool
 
 func _ready() -> void:
 	reset()
-	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
 
 
 func set_puzzle(new_puzzle: Puzzle) -> void:
@@ -141,7 +141,7 @@ func update_label() -> void:
 		$Label.text = "%s\n(%d/%d)" % [label_text, value, max_value]
 
 
-func _on_PuzzleScore_game_prepared() -> void:
+func _on_PuzzleState_game_prepared() -> void:
 	reset()
 
 

--- a/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
@@ -20,11 +20,11 @@ var _did_build_cake := false
 var _did_squish_move := false
 
 func _ready() -> void:
-	PuzzleScore.connect("after_game_prepared", self, "_on_PuzzleScore_after_game_prepared")
-	PuzzleScore.connect("game_started", self, "_on_PuzzleScore_game_started")
+	PuzzleState.connect("after_game_prepared", self, "_on_PuzzleState_after_game_prepared")
+	PuzzleState.connect("game_started", self, "_on_PuzzleState_game_started")
 	
 	playfield.connect("box_built", self, "_on_Playfield_box_built")
-	PuzzleScore.connect("after_piece_written", self, "_on_PuzzleScore_after_piece_written")
+	PuzzleState.connect("after_piece_written", self, "_on_PuzzleState_after_piece_written")
 	playfield.connect("line_cleared", self, "_on_Playfield_line_cleared")
 	piece_manager.connect("squish_moved", self, "_on_PieceManager_squish_moved")
 	piece_manager.connect("piece_spawned", self, "_on_PieceManager_piece_spawned")
@@ -52,7 +52,7 @@ func prepare_tutorial_level() -> void:
 			hud.set_message(tr("One last lesson! Try holding soft drop to squish and complete these boxes."))
 		"tutorial/basics_4":
 			# reset timer, scores
-			PuzzleScore.reset()
+			PuzzleState.reset()
 			puzzle.scroll_to_new_creature()
 			
 			hud.set_message(tr("You're a remarkably quick learner." \
@@ -69,25 +69,25 @@ before they're instructed to, they can skip parts of the tutorial.
 func _advance_level() -> void:
 	if CurrentLevel.settings.id == "tutorial/basics_0" and _did_build_cake and _did_squish_move:
 		# the player did something crazy; skip the tutorial entirely
-		PuzzleScore.change_level("tutorial/oh_my", false)
+		PuzzleState.change_level("tutorial/oh_my", false)
 		hud.set_big_message(ChatLibrary.add_mega_lull_characters(tr("OH, MY!!!")))
 		hud.enqueue_pop_out()
 		
 		# force match to end
-		PuzzleScore.level_performance.lines = 100
-		PuzzleScore.end_game()
+		PuzzleState.level_performance.lines = 100
+		PuzzleState.end_game()
 	elif _boxes_built == 0 or _box_clears == 0:
 		hud.set_message(tr("Good job!"))
-		PuzzleScore.change_level("tutorial/basics_1")
+		PuzzleState.change_level("tutorial/basics_1")
 	elif _squish_moves == 0:
 		hud.set_message(tr("Nicely done!"))
-		PuzzleScore.change_level("tutorial/basics_2")
+		PuzzleState.change_level("tutorial/basics_2")
 	elif _snack_stacks == 0:
 		hud.set_message(tr("Impressive!"))
-		PuzzleScore.change_level("tutorial/basics_3")
+		PuzzleState.change_level("tutorial/basics_3")
 	else:
 		hud.set_message(tr("Oh! I thought that would be more difficult..."))
-		PuzzleScore.change_level("tutorial/basics_4")
+		PuzzleState.change_level("tutorial/basics_4")
 		start_customer_countdown()
 
 
@@ -201,7 +201,7 @@ func _on_Playfield_line_cleared(_y: int, _total_lines: int, _remaining_lines: in
 """
 After a piece is written to the playfield, we check if the player should advance further in the tutorial.
 """
-func _on_PuzzleScore_after_piece_written() -> void:
+func _on_PuzzleState_after_piece_written() -> void:
 	# print tutorial messages if the player did something noteworthy
 	_handle_line_clear_message()
 	_handle_squish_move_message()
@@ -226,7 +226,7 @@ func _on_PuzzleScore_after_piece_written() -> void:
 				_advance_level()
 
 
-func _on_PuzzleScore_after_game_prepared() -> void:
+func _on_PuzzleState_after_game_prepared() -> void:
 	hud.show_skill_tally_items()
 	
 	hud.skill_tally_item("SnackBox").visible = false
@@ -243,7 +243,7 @@ func _on_PuzzleScore_after_game_prepared() -> void:
 	prepare_tutorial_level()
 
 
-func _on_PuzzleScore_game_started() -> void:
+func _on_PuzzleState_game_started() -> void:
 	if CurrentLevel.settings.other.skip_intro:
 		hud.set_message(tr("Welcome to Turbo Fat!"
 					+ " You seem to already be familiar with this sort of game, so let's dive right in."

--- a/project/src/main/puzzle/tutorial/tutorial-hud.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-hud.gd
@@ -13,8 +13,8 @@ onready var puzzle: Puzzle = get_node(puzzle_path)
 
 func _ready() -> void:
 	visible = false
-	PuzzleScore.connect("game_prepared", self, "_on_PuzzleScore_game_prepared")
-	PuzzleScore.connect("after_level_changed", self, "_on_PuzzleScore_after_level_changed")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
+	PuzzleState.connect("after_level_changed", self, "_on_PuzzleState_after_level_changed")
 	CurrentLevel.connect("settings_changed", self, "_on_Level_settings_changed")
 	replace_tutorial_module()
 
@@ -146,12 +146,12 @@ func _flash() -> void:
 	$Tween.start()
 
 
-func _on_PuzzleScore_after_level_changed() -> void:
+func _on_PuzzleState_after_level_changed() -> void:
 	$SkillTallyItems.visible = CurrentLevel.settings.other.tutorial
 	_flash()
 
 
-func _on_PuzzleScore_game_prepared() -> void:
+func _on_PuzzleState_game_prepared() -> void:
 	refresh()
 
 

--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -17,7 +17,7 @@ func _ready() -> void:
 	playfield = puzzle.get_playfield()
 	piece_manager = puzzle.get_piece_manager()
 	
-	PuzzleScore.connect("after_level_changed", self, "_on_PuzzleScore_after_level_changed")
+	PuzzleState.connect("after_level_changed", self, "_on_PuzzleState_after_level_changed")
 	
 	for skill_tally_item in $SkillTallyItems.get_children():
 		if skill_tally_item is SkillTallyItem:
@@ -32,7 +32,7 @@ Starts a countdown and switches from tutorial music to regular music.
 This is used at the end of each tutorial when customers come in.
 """
 func start_customer_countdown() -> void:
-	yield(PuzzleScore, "after_level_changed")
+	yield(PuzzleState, "after_level_changed")
 	MusicPlayer.play_upbeat_bgm()
 	puzzle.start_level_countdown()
 
@@ -46,7 +46,7 @@ prepare other aspects of the level as well.
 func prepare_tutorial_level() -> void:
 	# Reset the player's combo between puzzle sections. Each tutorial section should have a fresh start; We don't want
 	# them to receive a discouraging 'you broke your combo' fanfare at the start of a section.
-	PuzzleScore.set_combo(0)
+	PuzzleState.set_combo(0)
 	
 	# Hide all completed skill tally items.
 	for skill_tally_item_obj in hud.skill_tally_items():
@@ -55,5 +55,5 @@ func prepare_tutorial_level() -> void:
 			skill_tally_item.visible = false
 
 
-func _on_PuzzleScore_after_level_changed() -> void:
+func _on_PuzzleState_after_level_changed() -> void:
 	prepare_tutorial_level()

--- a/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
@@ -28,8 +28,8 @@ var _squish_diagram_1 := preload("res://assets/main/puzzle/tutorial/squish-diagr
 var _failed_section := false
 
 func _ready() -> void:
-	PuzzleScore.connect("after_game_prepared", self, "_on_PuzzleScore_after_game_prepared")
-	PuzzleScore.connect("after_piece_written", self, "_on_PuzzleScore_after_piece_written")
+	PuzzleState.connect("after_game_prepared", self, "_on_PuzzleState_after_game_prepared")
+	PuzzleState.connect("after_piece_written", self, "_on_PuzzleState_after_piece_written")
 	
 	playfield.connect("box_built", self, "_on_Playfield_box_built")
 	piece_manager.connect("squish_moved", self, "_on_PieceManager_squish_moved")
@@ -64,8 +64,8 @@ func prepare_tutorial_level() -> void:
 		"tutorial/squish_5":
 			hud.skill_tally_item("LineClear").visible = true
 			hud.skill_tally_item("LineClear").reset()
-			PuzzleScore.level_performance.lines = 0
-			PuzzleScore.level_performance.pieces = 0
+			PuzzleState.level_performance.lines = 0
+			PuzzleState.level_performance.pieces = 0
 			if _failed_section:
 				hud.set_message(tr("Here, let me help you with that."))
 			else:
@@ -74,15 +74,15 @@ func prepare_tutorial_level() -> void:
 		"tutorial/squish_6":
 			hud.skill_tally_item("LineClear").visible = true
 			hud.skill_tally_item("LineClear").reset()
-			PuzzleScore.level_performance.lines = 0
-			PuzzleScore.level_performance.pieces = 0
+			PuzzleState.level_performance.lines = 0
+			PuzzleState.level_performance.pieces = 0
 			if _failed_section:
 				hud.set_message(tr("Should I make it worse this time?\n\nNo, that would be mean."))
 			else:
 				hud.set_message(tr("Hmmm... What are you up to this time?"))
 		"tutorial/squish_7":
 			# reset timer, scores
-			PuzzleScore.reset()
+			PuzzleState.reset()
 			puzzle.scroll_to_new_creature()
 
 			# the sixth tutorial section ends with a long message, so we enqueue these messages
@@ -98,28 +98,28 @@ Advance to the next level in the tutorial.
 """
 func _advance_level() -> void:
 	_failed_section = false
-	var delay_between_levels := PuzzleScore.DELAY_SHORT
+	var delay_between_levels := PuzzleState.DELAY_SHORT
 	match CurrentLevel.settings.id:
 		"tutorial/squish_1":
 			# no delay for the non-interactive segment where we show the player a diagram
-			delay_between_levels = PuzzleScore.DELAY_NONE
+			delay_between_levels = PuzzleState.DELAY_NONE
 		"tutorial/squish_2":
 			hud.set_message(tr("Yes, that's right."))
 		"tutorial/squish_3":
 			hud.set_message(tr("That's right! Hmm, how about something tricky..."))
 		"tutorial/squish_4":
 			hud.set_message(tr("Wow, okay! ...I need to think of some harder puzzles."))
-			delay_between_levels = PuzzleScore.DELAY_LONG
+			delay_between_levels = PuzzleState.DELAY_LONG
 		"tutorial/squish_5":
-			if PuzzleScore.level_performance.lines >= 3:
+			if PuzzleState.level_performance.lines >= 3:
 				hud.set_message(tr("Good job!"))
 			else:
 				_failed_section = true
 				hud.set_message(tr("Oops! ...Let's try that again."))
 		"tutorial/squish_6":
-			if PuzzleScore.level_performance.lines >= 3:
+			if PuzzleState.level_performance.lines >= 3:
 				hud.set_message(tr("Wow! ...I had a few more of these planned, but it looks like you get the idea."))
-				delay_between_levels = PuzzleScore.DELAY_LONG
+				delay_between_levels = PuzzleState.DELAY_LONG
 				start_customer_countdown()
 			else:
 				_failed_section = true
@@ -135,7 +135,7 @@ func _advance_level() -> void:
 		new_level_id = CurrentLevel.settings.id
 	else:
 		new_level_id = level_ids[level_ids.find(CurrentLevel.settings.id) + 1]
-	PuzzleScore.change_level(new_level_id, delay_between_levels)
+	PuzzleState.change_level(new_level_id, delay_between_levels)
 
 
 func _handle_squish_move_message() -> void:
@@ -193,7 +193,7 @@ After a piece is written to the playfield, we check if the player should advance
 
 We also sometimes display messages from the sensei.
 """
-func _on_PuzzleScore_after_piece_written() -> void:
+func _on_PuzzleState_after_piece_written() -> void:
 	# print tutorial messages if the player did something noteworthy
 	_handle_squish_move_message()
 	
@@ -209,7 +209,7 @@ func _on_PuzzleScore_after_piece_written() -> void:
 			else:
 				playfield.tile_map.restore_state()
 		"tutorial/squish_5":
-			if PuzzleScore.level_performance.pieces == 1:
+			if PuzzleState.level_performance.pieces == 1:
 				CurrentLevel.settings.input_replay.clear()
 				if not hud.get_tutorial_messages().is_all_messages_visible():
 					yield(hud.get_tutorial_messages(), "all_messages_shown")
@@ -222,11 +222,11 @@ func _on_PuzzleScore_after_piece_written() -> void:
 								+ " ...Can you clean this up using squish moves?"
 								+ "\n\nTry to clear three lines."))
 			
-			if PuzzleScore.level_performance.pieces >= CurrentLevel.settings.finish_condition.value \
-					or PuzzleScore.level_performance.lines >= 3:
+			if PuzzleState.level_performance.pieces >= CurrentLevel.settings.finish_condition.value \
+					or PuzzleState.level_performance.lines >= 3:
 				_advance_level()
 		"tutorial/squish_6":
-			if PuzzleScore.level_performance.pieces == 1:
+			if PuzzleState.level_performance.pieces == 1:
 				CurrentLevel.settings.input_replay.clear()
 				if not hud.get_tutorial_messages().is_all_messages_visible():
 					yield(hud.get_tutorial_messages(), "all_messages_shown")
@@ -238,12 +238,12 @@ func _on_PuzzleScore_after_piece_written() -> void:
 					hud.set_messages([tr("Oh no! Now you've done it.\n\nLook at how clumsy you are!"),
 						tr("That's okay.\n\nI'm sure you'll think of a clever way to clean this up, too.")])
 			
-			if PuzzleScore.level_performance.pieces >= CurrentLevel.settings.finish_condition.value \
-					or PuzzleScore.level_performance.lines >= 3:
+			if PuzzleState.level_performance.pieces >= CurrentLevel.settings.finish_condition.value \
+					or PuzzleState.level_performance.lines >= 3:
 				_advance_level()
 
 
-func _on_PuzzleScore_after_game_prepared() -> void:
+func _on_PuzzleState_after_game_prepared() -> void:
 	hud.show_skill_tally_items()
 	hud.skill_tally_item("SquishMove").visible = false
 	hud.skill_tally_item("SnackBox").visible = false

--- a/project/src/main/ui/chat/chat-library.gd
+++ b/project/src/main/ui/chat/chat-library.gd
@@ -283,13 +283,6 @@ func _chat_tree_from_chatscript_file(path: String) -> ChatTree:
 		var parser := ChatscriptParser.new()
 		chat_tree = parser.chat_tree_from_file(path)
 	
-	var history_key := path
-	history_key = history_key.trim_suffix(".chat")
-	history_key = history_key.trim_prefix("res://assets/main/")
-	history_key = history_key.replace("creatures/primary", "chat")
-	history_key = StringUtils.hyphens_to_underscores(history_key)
-	chat_tree.history_key = history_key
-	
 	return chat_tree
 
 

--- a/project/src/main/ui/chat/chatscript-parser.gd
+++ b/project/src/main/ui/chat/chatscript-parser.gd
@@ -402,4 +402,22 @@ func chat_tree_from_file(path: String) -> ChatTree:
 	
 	f.close()
 	
+	_chat_tree.history_key = history_key_from_path(path)
+	
 	return _chat_tree
+
+
+"""
+Converts a path like 'res://assets/main/creatures/primary/bones/filler-001.chat' into a history key like
+'chat/bones/filler_001'.
+
+Using these clean short history keys has many benefits. Most notably they aren't invalidated if we move files or
+change extensions.
+"""
+func history_key_from_path(path: String) -> String:
+	var history_key := path
+	history_key = history_key.trim_suffix(".chat")
+	history_key = history_key.trim_prefix("res://assets/main/")
+	history_key = history_key.replace("creatures/primary", "chat")
+	history_key = StringUtils.hyphens_to_underscores(history_key)
+	return history_key

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -223,7 +223,7 @@ func _on_ChatUi_pop_out_completed() -> void:
 		if Breadcrumb.trail.size() >= 2 and Breadcrumb.trail[1] == Global.SCENE_CUTSCENE_DEMO:
 			# don't launch the level; go back to CutsceneDemo after playing the cutscene
 			SceneTransition.pop_trail()
-		elif CurrentLevel.level_state == CurrentLevel.LevelState.BEFORE:
+		elif CurrentLevel.cutscene_state == CurrentLevel.CutsceneState.BEFORE:
 			# pre-level chat or pre-level cutscene finished playing
 			
 			if cutscene:
@@ -231,7 +231,7 @@ func _on_ChatUi_pop_out_completed() -> void:
 				Breadcrumb.trail.remove(0)
 			
 			CurrentLevel.push_level_trail()
-		elif CurrentLevel.level_state == CurrentLevel.LevelState.AFTER:
+		elif CurrentLevel.cutscene_state == CurrentLevel.CutsceneState.AFTER:
 			# ending cutscene finished playing
 			CurrentLevel.clear_launched_level()
 			SceneTransition.pop_trail()

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -599,7 +599,7 @@ func score_to_fatness(in_score: float) -> float:
 	return result
 
 
-func score_to_comfort(combo: float, creature_score: float) -> float:
+func score_to_comfort(combo: float, customer_score: float) -> float:
 	var comfort := 0.0
 	if weight_gain_scale == 0.0:
 		# tutorial sensei doesn't become comfortable
@@ -608,9 +608,9 @@ func score_to_comfort(combo: float, creature_score: float) -> float:
 		# ate five things; comfortable
 		comfort += clamp(inverse_lerp(5, 15, combo), 0.0, 1.0)
 		# starting to overeat; less comfortable
-		comfort -= clamp(inverse_lerp(400, 600, creature_score * weight_gain_scale), 0.0, 1.0)
+		comfort -= clamp(inverse_lerp(400, 600, customer_score * weight_gain_scale), 0.0, 1.0)
 		# overate; uncomfortable
-		comfort -= clamp(inverse_lerp(600, 1200, creature_score * weight_gain_scale), 0.0, 1.0)
+		comfort -= clamp(inverse_lerp(600, 1200, customer_score * weight_gain_scale), 0.0, 1.0)
 	return comfort
 
 

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -18,7 +18,7 @@ func _ready() -> void:
 	if Global.sensei_spawn_id:
 		move_creature_to_spawn(ChattableManager.sensei, Global.sensei_spawn_id)
 	
-	if CurrentLevel.level_state != CurrentLevel.LevelState.NONE:
+	if CurrentLevel.cutscene_state != CurrentLevel.CutsceneState.NONE:
 		_launch_cutscene()
 	
 	$Camera.position = ChattableManager.player.position
@@ -41,13 +41,13 @@ func _launch_cutscene() -> void:
 	
 	# get the location, spawn location data
 	var chat_tree: ChatTree
-	match CurrentLevel.level_state:
-		CurrentLevel.LevelState.BEFORE:
+	match CurrentLevel.cutscene_state:
+		CurrentLevel.CutsceneState.BEFORE:
 			chat_tree = ChatLibrary.chat_tree_for_preroll(CurrentLevel.level_id)
-		CurrentLevel.LevelState.AFTER:
+		CurrentLevel.CutsceneState.AFTER:
 			chat_tree = ChatLibrary.chat_tree_for_postroll(CurrentLevel.level_id)
 		_:
-			push_warning("Unexpected CurrentLevel.level_state: %s" % [CurrentLevel.level_state])
+			push_warning("Unexpected CurrentLevel.cutscene_state: %s" % [CurrentLevel.cutscene_state])
 	
 	if not chat_tree.spawn_locations:
 		# apply a default position to the cutscene creature

--- a/project/src/test/puzzle/test-rank-calculator.gd
+++ b/project/src/test/puzzle/test-rank-calculator.gd
@@ -14,7 +14,7 @@ var _rank_calculator := RankCalculator.new()
 func before_each() -> void:
 	CurrentLevel.settings = LevelSettings.new()
 	CurrentLevel.settings.set_start_speed("0")
-	PuzzleScore.level_performance = PuzzlePerformance.new()
+	PuzzleState.level_performance = PuzzlePerformance.new()
 
 
 func test_master_lpm_slow_marathon() -> void:
@@ -50,11 +50,11 @@ func test_master_lpm_mixed_sprint() -> void:
 
 func test_calculate_rank_marathon_300_master() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.LINES, 300)
-	PuzzleScore.level_performance.seconds = 580
-	PuzzleScore.level_performance.lines = 300
-	PuzzleScore.level_performance.box_score = 4400
-	PuzzleScore.level_performance.combo_score = 5300
-	PuzzleScore.level_performance.score = 10400
+	PuzzleState.level_performance.seconds = 580
+	PuzzleState.level_performance.lines = 300
+	PuzzleState.level_performance.box_score = 4400
+	PuzzleState.level_performance.combo_score = 5300
+	PuzzleState.level_performance.score = 10400
 	var rank :=  _rank_calculator.calculate_rank()
 	assert_eq(rank.speed_rank, 0.0)
 	assert_eq(rank.lines_rank, 0.0)
@@ -65,11 +65,11 @@ func test_calculate_rank_marathon_300_master() -> void:
 
 func test_calculate_rank_marathon_300_mixed() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.LINES, 300)
-	PuzzleScore.level_performance.seconds = 240
-	PuzzleScore.level_performance.lines = 60
-	PuzzleScore.level_performance.box_score = 600
-	PuzzleScore.level_performance.combo_score = 500
-	PuzzleScore.level_performance.score = 1160
+	PuzzleState.level_performance.seconds = 240
+	PuzzleState.level_performance.lines = 60
+	PuzzleState.level_performance.box_score = 600
+	PuzzleState.level_performance.combo_score = 500
+	PuzzleState.level_performance.score = 1160
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank.speed_rank), "S")
 	assert_eq(RankCalculator.grade(rank.lines_rank), "A+")
@@ -80,11 +80,11 @@ func test_calculate_rank_marathon_300_mixed() -> void:
 
 func test_calculate_rank_marathon_lenient() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.LINES, 300, 200)
-	PuzzleScore.level_performance.seconds = 240
-	PuzzleScore.level_performance.lines = 60
-	PuzzleScore.level_performance.box_score = 600
-	PuzzleScore.level_performance.combo_score = 500
-	PuzzleScore.level_performance.score = 1160
+	PuzzleState.level_performance.seconds = 240
+	PuzzleState.level_performance.lines = 60
+	PuzzleState.level_performance.box_score = 600
+	PuzzleState.level_performance.combo_score = 500
+	PuzzleState.level_performance.score = 1160
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank.speed_rank), "S")
 	assert_eq(RankCalculator.grade(rank.lines_rank), "AA+")
@@ -95,11 +95,11 @@ func test_calculate_rank_marathon_lenient() -> void:
 
 func test_calculate_rank_marathon_300_fail() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.LINES, 300)
-	PuzzleScore.level_performance.seconds = 0
-	PuzzleScore.level_performance.lines = 0
-	PuzzleScore.level_performance.box_score = 0
-	PuzzleScore.level_performance.combo_score = 0
-	PuzzleScore.level_performance.score = 0
+	PuzzleState.level_performance.seconds = 0
+	PuzzleState.level_performance.lines = 0
+	PuzzleState.level_performance.box_score = 0
+	PuzzleState.level_performance.combo_score = 0
+	PuzzleState.level_performance.score = 0
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(rank.speed_rank, 999.0)
 	assert_eq(rank.lines_rank, 999.0)
@@ -110,7 +110,7 @@ func test_calculate_rank_marathon_300_fail() -> void:
 
 func test_calculate_pieces_rank() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.PIECES, 80)
-	PuzzleScore.level_performance.pieces = 40
+	PuzzleState.level_performance.pieces = 40
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank.pieces_rank), "S")
 
@@ -118,11 +118,11 @@ func test_calculate_pieces_rank() -> void:
 func test_calculate_rank_sprint_120() -> void:
 	CurrentLevel.settings.set_start_speed("A0")
 	CurrentLevel.settings.set_finish_condition(Milestone.TIME_OVER, 120)
-	PuzzleScore.level_performance.seconds = 120
-	PuzzleScore.level_performance.lines = 47
-	PuzzleScore.level_performance.box_score = 395
-	PuzzleScore.level_performance.combo_score = 570
-	PuzzleScore.level_performance.score = 1012
+	PuzzleState.level_performance.seconds = 120
+	PuzzleState.level_performance.lines = 47
+	PuzzleState.level_performance.box_score = 395
+	PuzzleState.level_performance.combo_score = 570
+	PuzzleState.level_performance.score = 1012
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank.speed_rank), "S+")
 	assert_eq(RankCalculator.grade(rank.lines_rank), "S+")
@@ -134,12 +134,12 @@ func test_calculate_rank_sprint_120() -> void:
 func test_calculate_rank_top_out_once() -> void:
 	CurrentLevel.settings.set_start_speed("A0")
 	CurrentLevel.settings.set_finish_condition(Milestone.TIME_OVER, 120)
-	PuzzleScore.level_performance.seconds = 120
-	PuzzleScore.level_performance.lines = 47
-	PuzzleScore.level_performance.box_score = 395
-	PuzzleScore.level_performance.combo_score = 570
-	PuzzleScore.level_performance.score = 1012
-	PuzzleScore.level_performance.top_out_count = 1
+	PuzzleState.level_performance.seconds = 120
+	PuzzleState.level_performance.lines = 47
+	PuzzleState.level_performance.box_score = 395
+	PuzzleState.level_performance.combo_score = 570
+	PuzzleState.level_performance.score = 1012
+	PuzzleState.level_performance.top_out_count = 1
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank.speed_rank), "S+")
 	assert_eq(RankCalculator.grade(rank.lines_rank), "S+")
@@ -151,12 +151,12 @@ func test_calculate_rank_top_out_once() -> void:
 func test_calculate_rank_top_out_twice() -> void:
 	CurrentLevel.settings.set_start_speed("A0")
 	CurrentLevel.settings.set_finish_condition(Milestone.TIME_OVER, 120)
-	PuzzleScore.level_performance.seconds = 120
-	PuzzleScore.level_performance.lines = 47
-	PuzzleScore.level_performance.box_score = 395
-	PuzzleScore.level_performance.combo_score = 570
-	PuzzleScore.level_performance.score = 1012
-	PuzzleScore.level_performance.top_out_count = 2
+	PuzzleState.level_performance.seconds = 120
+	PuzzleState.level_performance.lines = 47
+	PuzzleState.level_performance.box_score = 395
+	PuzzleState.level_performance.combo_score = 570
+	PuzzleState.level_performance.score = 1012
+	PuzzleState.level_performance.top_out_count = 2
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank.speed_rank), "S")
 	assert_eq(RankCalculator.grade(rank.lines_rank), "S")
@@ -167,11 +167,11 @@ func test_calculate_rank_top_out_twice() -> void:
 
 func test_calculate_rank_ultra_200() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 200)
-	PuzzleScore.level_performance.seconds = 20.233
-	PuzzleScore.level_performance.lines = 8
-	PuzzleScore.level_performance.box_score = 135
-	PuzzleScore.level_performance.combo_score = 60
-	PuzzleScore.level_performance.score = 8
+	PuzzleState.level_performance.seconds = 20.233
+	PuzzleState.level_performance.lines = 8
+	PuzzleState.level_performance.box_score = 135
+	PuzzleState.level_performance.combo_score = 60
+	PuzzleState.level_performance.score = 8
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank.speed_rank), "SS+")
 	assert_eq(RankCalculator.grade(rank.box_score_per_line_rank), "M")
@@ -182,12 +182,12 @@ func test_calculate_rank_ultra_200() -> void:
 
 func test_calculate_rank_ultra_200_lost() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 200)
-	PuzzleScore.level_performance.seconds = 60
-	PuzzleScore.level_performance.lines = 10
-	PuzzleScore.level_performance.box_score = 80
-	PuzzleScore.level_performance.combo_score = 60
-	PuzzleScore.level_performance.score = 150
-	PuzzleScore.level_performance.lost = true
+	PuzzleState.level_performance.seconds = 60
+	PuzzleState.level_performance.lines = 10
+	PuzzleState.level_performance.box_score = 80
+	PuzzleState.level_performance.combo_score = 60
+	PuzzleState.level_performance.score = 150
+	PuzzleState.level_performance.lost = true
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank.speed_rank), "AA+")
 	assert_eq(rank.seconds_rank, 999.0)
@@ -200,11 +200,11 @@ This is an edge case where, if the player gets too many points for ultra, they c
 """
 func test_calculate_rank_ultra_200_overshot() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 200)
-	PuzzleScore.level_performance.seconds = 19
-	PuzzleScore.level_performance.lines = 10
-	PuzzleScore.level_performance.box_score = 150
-	PuzzleScore.level_performance.combo_score = 100
-	PuzzleScore.level_performance.score = 260
+	PuzzleState.level_performance.seconds = 19
+	PuzzleState.level_performance.lines = 10
+	PuzzleState.level_performance.box_score = 150
+	PuzzleState.level_performance.combo_score = 100
+	PuzzleState.level_performance.score = 260
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank.speed_rank), "M")
 	assert_eq(RankCalculator.grade(rank.box_score_per_line_rank), "M")
@@ -217,9 +217,9 @@ A level requiring only one line clear used to trigger divide by zero errors.
 """
 func test_calculate_rank_ultra_1() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 1)
-	PuzzleScore.level_performance.seconds = 7.233
-	PuzzleScore.level_performance.lines = 1
-	PuzzleScore.level_performance.score = 1
+	PuzzleState.level_performance.seconds = 7.233
+	PuzzleState.level_performance.lines = 1
+	PuzzleState.level_performance.score = 1
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank.seconds_rank), "SSS")
 
@@ -227,10 +227,10 @@ func test_calculate_rank_ultra_1() -> void:
 func test_calculate_rank_five_creatures_good() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.CUSTOMERS, 5)
 	CurrentLevel.settings.set_start_speed("4")
-	PuzzleScore.level_performance.lines = 100
-	PuzzleScore.level_performance.box_score = 1025
-	PuzzleScore.level_performance.combo_score = 915
-	PuzzleScore.level_performance.score = 2040
+	PuzzleState.level_performance.lines = 100
+	PuzzleState.level_performance.box_score = 1025
+	PuzzleState.level_performance.combo_score = 915
+	PuzzleState.level_performance.score = 2040
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank.lines_rank), "SSS")
 	assert_eq(RankCalculator.grade(rank.box_score_per_line_rank), "S+")
@@ -241,10 +241,10 @@ func test_calculate_rank_five_creatures_good() -> void:
 func test_calculate_rank_five_creatures_bad() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.CUSTOMERS, 5)
 	CurrentLevel.settings.set_start_speed("4")
-	PuzzleScore.level_performance.lines = 18
-	PuzzleScore.level_performance.box_score = 90
-	PuzzleScore.level_performance.combo_score = 60
-	PuzzleScore.level_performance.score = 168
+	PuzzleState.level_performance.lines = 18
+	PuzzleState.level_performance.box_score = 90
+	PuzzleState.level_performance.combo_score = 60
+	PuzzleState.level_performance.score = 168
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank.lines_rank), "A-")
 	assert_eq(RankCalculator.grade(rank.box_score_per_line_rank), "AA")
@@ -258,12 +258,12 @@ These two times are pretty far apart; they shouldn't yield the same rank
 func test_two_rank_s() -> void:
 	CurrentLevel.settings.set_start_speed("A0")
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 1000)
-	PuzzleScore.level_performance.seconds = 88.55
+	PuzzleState.level_performance.seconds = 88.55
 	var rank1 := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank1.seconds_rank), "SS+")
 
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 1000)
-	PuzzleScore.level_performance.seconds = 128.616
+	PuzzleState.level_performance.seconds = 128.616
 	var rank2 := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank2.seconds_rank), "S+")
 
@@ -273,8 +273,8 @@ This edge case used to result in a combo_score_per_line of 22.5
 """
 func test_combo_score_per_line_ultra_overshot() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 200)
-	PuzzleScore.level_performance.combo_score = 45
-	PuzzleScore.level_performance.lines = 7
+	PuzzleState.level_performance.combo_score = 45
+	PuzzleState.level_performance.lines = 7
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(rank.combo_score_per_line, 20.0)
 
@@ -284,9 +284,9 @@ This edge case used to result in a combo_score_per_line of 0.305
 """
 func test_combo_score_per_line_death() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.LINES, 200, 150)
-	PuzzleScore.level_performance.combo_score = 195
-	PuzzleScore.level_performance.lines = 37
-	PuzzleScore.level_performance.top_out_count = 1
+	PuzzleState.level_performance.combo_score = 195
+	PuzzleState.level_performance.lines = 37
+	PuzzleState.level_performance.top_out_count = 1
 	var rank := _rank_calculator.calculate_rank()
 	assert_almost_eq(rank.combo_score_per_line, 6.09, 0.1)
 
@@ -296,8 +296,8 @@ A player reaching a success condition should be given a rank boost.
 """
 func test_success_bonus_score() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.LINES, 300, 200)
-	PuzzleScore.level_performance.seconds = 240
-	PuzzleScore.level_performance.score = 1160
+	PuzzleState.level_performance.seconds = 240
+	PuzzleState.level_performance.score = 1160
 	CurrentLevel.settings.rank.success_bonus = 8
 	
 	# the player doesn't achieve the success condition; they get a worse grade
@@ -313,8 +313,8 @@ func test_success_bonus_score() -> void:
 
 func test_success_bonus_seconds() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 1000)
-	PuzzleScore.level_performance.seconds = 240
-	PuzzleScore.level_performance.score = 1160
+	PuzzleState.level_performance.seconds = 240
+	PuzzleState.level_performance.score = 1160
 	CurrentLevel.settings.rank.success_bonus = 8
 	
 	# the player doesn't achieve the success condition; they get a worse grade
@@ -332,7 +332,7 @@ func test_customer_combo() -> void:
 	CurrentLevel.settings.rank.customer_combo = 8
 	CurrentLevel.settings.rank.leftover_lines = 3
 	CurrentLevel.settings.set_finish_condition(Milestone.CUSTOMERS, 1)
-	PuzzleScore.level_performance.score = 296
+	PuzzleState.level_performance.score = 296
 	
 	# the player doesn't achieve the success condition; they get a worse grade
 	var rank := _rank_calculator.calculate_rank()
@@ -350,7 +350,7 @@ func test_unranked() -> void:
 
 func test_unranked_loss() -> void:
 	CurrentLevel.settings.rank.unranked = true
-	PuzzleScore.level_performance.lost = true
+	PuzzleState.level_performance.lost = true
 	
 	# the player lost the level; they get the worst rank
 	var rank := _rank_calculator.calculate_rank()
@@ -360,9 +360,9 @@ func test_unranked_loss() -> void:
 
 func test_extra_seconds_per_piece() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.TIME_OVER, 180)
-	PuzzleScore.level_performance.seconds = 180
-	PuzzleScore.level_performance.lines = 60
-	PuzzleScore.level_performance.score = 1160
+	PuzzleState.level_performance.seconds = 180
+	PuzzleState.level_performance.lines = 60
+	PuzzleState.level_performance.score = 1160
 	var rank1 := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank1.speed_rank), "S+")
 	assert_eq(RankCalculator.grade(rank1.score_rank), "S+")

--- a/project/src/test/ui/chat/test-chatscript-parser.gd
+++ b/project/src/test/ui/chat/test-chatscript-parser.gd
@@ -13,6 +13,11 @@ func _chat_tree_from_file(path: String) -> ChatTree:
 	return parser.chat_tree_from_file(path)
 
 
+func _history_key_from_path(path: String) -> String:
+	var parser := ChatscriptParser.new()
+	return parser.history_key_from_path(path)
+
+
 func test_cutscene_location() -> void:
 	var chat_tree := _chat_tree_from_file(CUTSCENE_FULL)
 	
@@ -97,3 +102,12 @@ func test_chat_thought() -> void:
 	assert_eq(event.who, "")
 	assert_eq(event.text, "(A crystalline marshmallow has sprouted from the soil. The five-second rule precludes" \
 			+ " me from eating it.)")
+
+
+func test_history_key_from_path() -> void:
+	assert_eq(_history_key_from_path("res://assets/main/creatures/primary/bones/filler-001.chat"),
+			"chat/bones/filler_001")
+	assert_eq(_history_key_from_path("res://assets/main/puzzle/levels/cutscenes/marsh/hello-everyone-000.chat"),
+			"puzzle/levels/cutscenes/marsh/hello_everyone_000")
+	assert_eq(_history_key_from_path("res://assets/main/chat/marsh-crystal.chat"),
+			"chat/marsh_crystal")


### PR DESCRIPTION
PuzzleScore is now PuzzleState. This script tracks a lot more than just score
information including the current combo, how many customers have been served,
and what speed level the player is at.

LevelState is now CutsceneState to avoid ambiguity with PuzzleState.

creature_score is now customer_score. This score only has value during a
puzzle when the creature acts as a customer.

Moved history key logic into ChatscriptParser, and added some unit tests