### PR TITLE
Avoid crumb performance hiccup. Squishes trigger DAS.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -204,6 +204,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/world/creature/creature-visuals.gd"
 }, {
+"base": "Node2D",
+"class": "CrumbCluster",
+"language": "GDScript",
+"path": "res://src/main/puzzle/crumb-cluster.gd"
+}, {
 "base": "Reference",
 "class": "DnaAlternatives",
 "language": "GDScript",
@@ -794,6 +799,7 @@ _global_script_class_icons={
 "CreatureShadow": "",
 "CreatureShadows": "",
 "CreatureVisuals": "",
+"CrumbCluster": "",
 "DnaAlternatives": "",
 "DurationCalculator": "",
 "EditorPlayfield": "",

--- a/project/src/main/puzzle/crumb-cluster.gd
+++ b/project/src/main/puzzle/crumb-cluster.gd
@@ -1,3 +1,4 @@
+class_name CrumbCluster
 extends Node2D
 """
 A cluster of crumbs which appears when the customer eats.

--- a/project/src/main/puzzle/food-crumbs.gd
+++ b/project/src/main/puzzle/food-crumbs.gd
@@ -10,11 +10,26 @@ export (PackedScene) var CrumbClusterScene: PackedScene
 
 onready var _restaurant_view: RestaurantView = get_node(restaurant_view_path)
 
+# Crumb clusters are pooled for performance reasons. Spawning the first crumb cluster sometimes causes a performance
+# hiccup, and it's better for this to happen on load rather than during gameplay.
+var _crumb_cluster_pool := []
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	for customer_obj in _restaurant_view.get_customers():
 		var customer: Creature = customer_obj
 		customer.connect("food_eaten", self, "_on_Creature_food_eaten", [customer])
+
+
+func _process(_delta: float) -> void:
+	if _crumb_cluster_pool.size() < 10:
+		_crumb_cluster_pool.append(CrumbClusterScene.instance())
+
+
+func _exit_tree() -> void:
+	# empty the crumb cluster pool
+	for crumb_cluster in _crumb_cluster_pool:
+		crumb_cluster.free()
 
 
 """
@@ -25,7 +40,14 @@ func _on_Creature_food_eaten(food_type: int, customer: Creature) -> void:
 	# calculate the position within the global viewport
 	target_pos = get_global_transform_with_canvas().xform_inv(target_pos)
 	
-	var crumb_cluster := CrumbClusterScene.instance()
+	var crumb_cluster: CrumbCluster
+	if _crumb_cluster_pool:
+		# obtain a pooled crumb cluster
+		crumb_cluster = _crumb_cluster_pool.pop_back()
+	else:
+		# no more pooled crumb clusters; initialize a new crumb cluster
+		crumb_cluster = CrumbClusterScene.instance()
+	
 	crumb_cluster.food_type = food_type
 	crumb_cluster.position = target_pos
 	add_child(crumb_cluster)

--- a/project/src/main/puzzle/piece/active-piece.gd
+++ b/project/src/main/puzzle/piece/active-piece.gd
@@ -15,6 +15,10 @@ var target_orientation := 0
 # Amount of accumulated gravity for this piece. When this number reaches 256, the piece will move down one row
 var gravity := 0
 
+# Number of frames until gravity affects this piece again. After the player does a 'squish move' the piece is
+# unaffected by gravity for a few frames.
+var remaining_post_squish_frames := 0
+
 # Number of frames this piece has been locked into the playfield, or '0' if the piece is not locked
 var lock := 0
 

--- a/project/src/main/puzzle/piece/piece-dropper.gd
+++ b/project/src/main/puzzle/piece/piece-dropper.gd
@@ -18,8 +18,6 @@ var did_hard_drop: bool
 # The hard drop destination for the current piece. Used for drawing the ghost piece.
 var hard_drop_target_pos: Vector2
 
-var _gravity_pause_frames := 0
-
 onready var input: PieceInput = get_node(input_path)
 onready var piece_mover: PieceMover = get_node(piece_mover_path)
 
@@ -56,8 +54,8 @@ func apply_hard_drop_input(piece: ActivePiece) -> void:
 Increments the piece's gravity. A piece will fall once its accumulated gravity exceeds a certain threshold.
 """
 func apply_gravity(piece: ActivePiece) -> void:
-	if _gravity_pause_frames > 0:
-		_gravity_pause_frames -= 1
+	if piece.remaining_post_squish_frames > 0:
+		piece.remaining_post_squish_frames -= 1
 	else:
 		if input.is_soft_drop_pressed():
 			# soft drop
@@ -84,7 +82,7 @@ Squish moving pauses gravity for a moment.
 This allows players to squish and slide a piece before it drops, even at 20G.
 """
 func _on_Squisher_squish_moved(_piece: ActivePiece, _old_pos: Vector2) -> void:
-	_gravity_pause_frames = PieceSpeeds.SQUISH_FRAMES
+	_piece.remaining_post_squish_frames = PieceSpeeds.POST_SQUISH_FRAMES
 
 
 func _on_PieceManager_piece_changed(piece: ActivePiece) -> void:

--- a/project/src/main/puzzle/piece/piece-mover.gd
+++ b/project/src/main/puzzle/piece/piece-mover.gd
@@ -115,6 +115,13 @@ func apply_move_input(piece: ActivePiece) -> void:
 		input.set_left_das_active()
 	if input.is_right_pressed() and not piece.can_move_to(piece.pos + Vector2.RIGHT, piece.orientation):
 		input.set_right_das_active()
+	
+	# To prevent pieces from slipping past nooks after a squish move, we automatically trigger DAS if a movement key
+	# is pressed after a squish move.
+	if input.is_left_pressed() and piece.remaining_post_squish_frames > 0:
+		input.set_left_das_active()
+	if input.is_right_pressed() and piece.remaining_post_squish_frames > 0:
+		input.set_right_das_active()
 
 
 """

--- a/project/src/main/puzzle/piece/piece-speeds.gd
+++ b/project/src/main/puzzle/piece/piece-speeds.gd
@@ -18,8 +18,8 @@ const MAX_LOCK_RESETS := 15
 # The gravity constant used when the player soft-drops a piece.
 const DROP_G := 128
 
-# When the player does a 'squish move' the piece is unaffected by gravity for this many frames.
-const SQUISH_FRAMES := 4
+# After the player does a 'squish move' the piece is unaffected by gravity for this many frames.
+const POST_SQUISH_FRAMES := 4
 
 # How fast the pieces are moving right now
 var current_speed: PieceSpeed

--- a/project/src/main/puzzle/piece/squish-fx.gd
+++ b/project/src/main/puzzle/piece/squish-fx.gd
@@ -91,7 +91,7 @@ Initialize the squish animation for long squish moves
 func _on_PieceManager_squish_moved(piece: ActivePiece, old_pos: Vector2) -> void:
 	if piece.pos.y - old_pos.y >= 3:
 		var unblocked_blocks: Array = piece.type.pos_arr[piece.orientation].duplicate()
-		_squish_map.start_squish(PieceSpeeds.SQUISH_FRAMES, piece.type.color_arr[piece.orientation][0].y)
+		_squish_map.start_squish(PieceSpeeds.POST_SQUISH_FRAMES, piece.type.color_arr[piece.orientation][0].y)
 		for dy in range(piece.pos.y - old_pos.y):
 			var i := 0
 			while i < unblocked_blocks.size():

--- a/project/src/main/puzzle/squish-map.gd
+++ b/project/src/main/puzzle/squish-map.gd
@@ -65,8 +65,8 @@ func stretch_to(piece_pos_arr: Array, offset: Vector2) -> void:
 """
 Starts a new squish move, which will make the piece appear vertically stretched for a few frames.
 """
-func start_squish(squish_frames: int, new_color_y: int) -> void:
-	squish_seconds_total = squish_frames / 60.0
+func start_squish(post_squish_frames: int, new_color_y: int) -> void:
+	squish_seconds_total = post_squish_frames / 60.0
 	squish_seconds_remaining = squish_seconds_total
 	set_process(true)
 	_max_distance = 0


### PR DESCRIPTION
Initializing the first crumb cluster sometimes causes a performance hiccup. I've
introduced a pool so that this hiccup occurs on load, rather than during
gameplay.

Squish moves trigger DAS. This fixes misdrops related to rocket drops,
which occurred when trying to squish a piece into a nook while playing
quickly or during 20G.