### PR TITLE
Added fix for lagging viewport glitch. Iguana nose fix.

### DIFF
--- a/project/src/main/world/creature/dna-utils.gd
+++ b/project/src/main/world/creature/dna-utils.gd
@@ -278,7 +278,7 @@ func _ready() -> void:
 		_set_allele_combo_adjustment("mouth", mouth, "collar", "2", -2)
 		_set_allele_combo_adjustment("mouth", mouth, "collar", "3", -2)
 	
-	for nose in ["1", "2", "3"]:
+	for nose in ["1", "2", "3", "4"]:
 		# creatures with beak can NEVER have nose
 		_set_allele_combo_adjustment("mouth", "4", "nose", nose, -999)
 	

--- a/project/src/main/world/goop-ground-map.gd
+++ b/project/src/main/world/goop-ground-map.gd
@@ -21,7 +21,8 @@ func _ready() -> void:
 
 
 func _process(_delta: float) -> void:
-	_refresh_view_to_local()
+	# wait until the viewport updates to update the shader parameters
+	call_deferred('_refresh_view_to_local')
 
 
 """

--- a/project/src/main/world/screwport-texrect.gd
+++ b/project/src/main/world/screwport-texrect.gd
@@ -32,7 +32,8 @@ func _process(_delta: float) -> void:
 	if not _viewport:
 		return
 	
-	_reposition_viewport()
+	# wait until the viewport updates to reposition the texture
+	call_deferred("_reposition_viewport")
 
 
 """


### PR DESCRIPTION
The goop viewport adjustment was consistently a frame behind any camera
movement, making the goop and textures drift around if you paid close
attention.

Birds can no longer have 'iguana nose'. This was accidentally omitted
from the list of bad body part combos.