### PR TITLE
Adjusted camera smoothing speed to mitigate stutter.

### DIFF
--- a/project/src/main/world/Overworld.tscn
+++ b/project/src/main/world/Overworld.tscn
@@ -606,6 +606,7 @@ ChatIconScene = ExtResource( 12 )
 position = Vector2( 150, 150 )
 current = true
 smoothing_enabled = true
+smoothing_speed = 12.5
 script = ExtResource( 21 )
 
 [node name="Tween" type="Tween" parent="World/Camera"]


### PR DESCRIPTION
I experimented with many parameters and settings to try and measure and
mitigate stutter. This stutter is not caused by the camera, but having a
slow camera smoothing seems to make it more noticable. (It's possible
the difference is all in my head.)