### PR TITLE
Fixed bug where head would stop bobbing sometimes

### DIFF
--- a/project/src/main/world/creature/MovementPlayer.tscn
+++ b/project/src/main/world/creature/MovementPlayer.tscn
@@ -50,6 +50,18 @@ tracks/3/keys = {
 "update": 1,
 "values": [ 2 ]
 }
+tracks/4/type = "value"
+tracks/4/path = NodePath("Neck0/HeadBobber:head_bob_mode")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ 1 ]
+}
 
 [sub_resource type="Animation" id=2]
 step = 0.166667
@@ -96,6 +108,18 @@ tracks/3/loop_wrap = true
 tracks/3/imported = false
 tracks/3/enabled = true
 tracks/3/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ 1 ]
+}
+tracks/4/type = "value"
+tracks/4/path = NodePath("Neck0/HeadBobber:head_bob_mode")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
 "update": 1,

--- a/project/src/main/world/creature/creature-animations.gd
+++ b/project/src/main/world/creature/creature-animations.gd
@@ -26,7 +26,7 @@ var _emote_eye_z1: PackedSprite
 var _eye_z0: PackedSprite
 var _eye_z1: PackedSprite
 var _far_arm: PackedSprite
-var _head_bobber: Sprite
+var _head_bobber: HeadBobber
 var _near_arm: PackedSprite
 var _tail_z0: PackedSprite
 var _tail_z1: PackedSprite


### PR DESCRIPTION
If your character was heavy enough to do the bipedal running animation,
their head would stop bobbing after you sat still. I've added some
head_bob_mode keys to the idle animations so that the head bob will be
restored.