### PR TITLE
Added 'skip_if' to cutscenes, chat library.

### DIFF
--- a/project/assets/main/creatures/primary/boatricia/creature.json
+++ b/project/assets/main/creatures/primary/boatricia/creature.json
@@ -33,16 +33,12 @@
     },
     {
       "chat": "my_maid_died",
-      "if_conditions": [
-        "notable_chat"
-      ],
+      "if_condition": "notable",
       "repeat": 999999
     },
     {
       "chat": "life_is_so_short",
-      "if_conditions": [
-        "notable_chat"
-      ],
+      "if_condition": "notable",
       "repeat": 999999
     }
   ]

--- a/project/project.godot
+++ b/project/project.godot
@@ -44,6 +44,16 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/ui/chat/chat-advancer.gd"
 }, {
+"base": "Reference",
+"class": "ChatBoolEvaluator",
+"language": "GDScript",
+"path": "res://src/main/ui/chat/chat-bool-evaluator.gd"
+}, {
+"base": "Reference",
+"class": "ChatBoolParser",
+"language": "GDScript",
+"path": "res://src/main/ui/chat/chat-bool-parser.gd"
+}, {
 "base": "Button",
 "class": "ChatChoiceButton",
 "language": "GDScript",
@@ -777,6 +787,8 @@ _global_script_class_icons={
 "Body": "",
 "BoxBuilder": "",
 "ChatAdvancer": "",
+"ChatBoolEvaluator": "",
+"ChatBoolParser": "",
 "ChatChoiceButton": "",
 "ChatChoices": "",
 "ChatEvent": "",

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -121,7 +121,7 @@ func push_level_trail() -> void:
 	
 	# When the player first launches the game and does the tutorial, we skip the typical puzzle intro.
 	if level_id == LevelLibrary.BEGINNER_TUTORIAL \
-			and not PlayerData.level_history.finished_levels.has(LevelLibrary.BEGINNER_TUTORIAL):
+			and not PlayerData.level_history.is_level_finished(LevelLibrary.BEGINNER_TUTORIAL):
 		level_settings.other.skip_intro = true
 	
 	start_level(level_settings)

--- a/project/src/main/puzzle/level/level-history.gd
+++ b/project/src/main/puzzle/level/level-history.gd
@@ -28,6 +28,8 @@ Resets the level history to its default empty state.
 """
 func reset() -> void:
 	rank_results.clear()
+	successful_levels.clear()
+	finished_levels.clear()
 
 
 """
@@ -131,6 +133,10 @@ func prune(level_id: String) -> void:
 		best[result] = ""
 	best.erase(rank_results[level_id][0])
 	rank_results[level_id] = [rank_results[level_id][0]] + best.keys()
+
+
+func is_level_finished(level_id: String) -> bool:
+	return finished_levels.has(level_id)
 
 
 func _compare_by_low_seconds(a: RankResult, b: RankResult) -> bool:

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -155,8 +155,9 @@ func _quit_puzzle() -> void:
 	if CurrentLevel.cutscene_state == CurrentLevel.CutsceneState.AFTER \
 			and ChatLibrary.has_postroll(CurrentLevel.level_id):
 		var chat_tree := ChatLibrary.chat_tree_for_postroll(CurrentLevel.level_id)
-		# insert cutscene into breadcrumb trail so it will show up after we pop the trail
-		Breadcrumb.trail.insert(1, chat_tree.cutscene_scene_path())
+		if not ChatLibrary.is_chat_skipped(chat_tree):
+			# insert cutscene into breadcrumb trail so it will show up after we pop the trail
+			Breadcrumb.trail.insert(1, chat_tree.cutscene_scene_path())
 	else:
 		CurrentLevel.clear_launched_level()
 

--- a/project/src/main/ui/chat/chat-bool-evaluator.gd
+++ b/project/src/main/ui/chat/chat-bool-evaluator.gd
@@ -1,0 +1,22 @@
+class_name ChatBoolEvaluator
+"""
+Evaluates boolean expressions.
+
+This includes expressions like 'not (level_finished level_001 or level_finished level_002)'.
+"""
+
+"""
+Evaluates the specified boolean expression based on the current game state.
+
+Parameters:
+	'string': The boolean expression to evaluate.
+	
+	'subject': The subject the specified boolean expression should be applied to.
+
+Returns:
+	'true' if the specified boolean expression is met by the current game state.
+"""
+static func evaluate(string: String, subject = null) -> bool:
+	var parser: ChatBoolParser = ChatBoolParser.new(string, subject)
+	var expression: ChatBoolParser.BoolExpression = parser.parse()
+	return expression.evaluate()

--- a/project/src/main/ui/chat/chat-bool-parser.gd
+++ b/project/src/main/ui/chat/chat-bool-parser.gd
@@ -1,0 +1,290 @@
+class_name ChatBoolParser
+"""
+Parses a string boolean expression into a tree of ChatExpressions.
+"""
+
+"""
+A lexical token which occurs in a boolean expression.
+
+This token represents a single word, and includes data about the occurrence of the word in the original statement.
+"""
+class BoolToken:
+	var start: int
+	var end: int
+	var string: String
+	
+	func string_value() -> String:
+		return string
+
+
+"""
+An node in a tree of boolean expressions.
+
+This node includes information about how to evaluate the expression and its children.
+"""
+class BoolExpression:
+	var token: BoolToken
+	var args: Array
+	
+	func evaluate() -> bool:
+		return false
+	
+	
+	func string_value() -> String:
+		return "%s [%s]" % [token, args]
+
+
+class OrExpression extends BoolExpression:
+	func _init(new_token: BoolToken, left: BoolExpression, right: BoolExpression) -> void:
+		token = new_token
+		args = [left, right]
+	
+	
+	func evaluate() -> bool:
+		return args[0].evaluate() or args[1].evaluate()
+
+
+class AndExpression extends BoolExpression:
+	func _init(new_token: BoolToken, left: BoolExpression, right: BoolExpression) -> void:
+		token = new_token
+		args = [left, right]
+	
+	
+	func evaluate() -> bool:
+		return args[0].evaluate() and args[1].evaluate()
+
+
+class NotExpression extends BoolExpression:
+	func _init(new_token: BoolToken, child: BoolExpression) -> void:
+		token = new_token
+		args = [child]
+	
+	
+	func evaluate() -> bool:
+		return not args[0].evaluate()
+
+
+class ChatFinishedExpression extends BoolExpression:
+	func _init(new_token: BoolToken, arg: BoolToken) -> void:
+		token = new_token
+		args = [arg]
+	
+	
+	func evaluate() -> bool:
+		return PlayerData.chat_history.is_chat_finished(args[0].string)
+
+
+class LevelFinishedExpression extends BoolExpression:
+	func _init(new_token: BoolToken, arg: BoolToken) -> void:
+		token = new_token
+		args = [arg]
+	
+	
+	func evaluate() -> bool:
+		return PlayerData.level_history.is_level_finished(args[0].string)
+
+
+class NotableExpression extends BoolExpression:
+	var _creature_id: String
+	
+	func _init(new_token: BoolToken, creature_id: String) -> void:
+		token = new_token
+		_creature_id = creature_id
+	
+	
+	func evaluate() -> bool:
+		return PlayerData.chat_history.get_filler_count(_creature_id) > 0
+
+# error encountered when parsing the boolean string
+var _parse_error: String
+
+# list of parsed BoolToken instances
+var _tokens := []
+
+# the index of the next BoolToken to process in the token array
+var _token_index := 0
+
+# the boolean string to parse
+var _string: String
+
+# The target for which the boolean string is being evaluated, if evaluated for a specific creature or level.
+var _subject
+
+"""
+Initializes the parser, parsing the specified string into a list of ChatTokens.
+
+Parameters:
+	'string': The boolean expression to evaluate.
+	
+	'subject': The subject the specified boolean expression should be applied to.
+"""
+func _init(string: String, subject = null) -> void:
+	_string = string
+	_subject = subject
+	var regex := RegEx.new()
+	regex.compile("[^() ]+|[()]")
+	for result in regex.search_all(string):
+		var chat_token := BoolToken.new()
+		chat_token.start = result.get_start()
+		chat_token.end = result.get_end()
+		chat_token.string = result.get_string()
+		_tokens.append(chat_token)
+
+
+"""
+Parses a list of ChatTokens into a tree of ChatExpressions which can be evaluated.
+
+Returns:
+	The root of a ChatExpression tree representing the parsed boolean string.
+"""
+func parse() -> BoolExpression:
+	var expression := _parse_or()
+	if _token_index < _tokens.size():
+		_report_error(_tokens[_token_index].start, "Unexpected token '%s'" % [_tokens[_token_index].string])
+	return expression
+
+
+"""
+Parses an 'or' chat token, as well as any tokens of higher precedence (and, not, functions, parentheses).
+"""
+func _parse_or() -> BoolExpression:
+	if _parse_error:
+		return null
+	
+	var expression := _parse_and()
+	if _peek_next_token_string() == "or":
+		expression = OrExpression.new(_get_next_token(), expression, _parse_and())
+	return expression
+
+
+"""
+Parses an 'and' chat token, as well as any tokens of higher precedence (not, functions, parentheses).
+"""
+func _parse_and() -> BoolExpression:
+	if _parse_error:
+		return null
+	
+	var expression := _parse_not()
+	if _peek_next_token_string() == "and":
+		expression = AndExpression.new(_get_next_token(), expression, _parse_not())
+	return expression
+
+
+"""
+Parses a 'not' chat token, as well as any tokens of higher precedence (functions, parentheses).
+"""
+func _parse_not() -> BoolExpression:
+	if _parse_error:
+		return null
+	
+	var expression: BoolExpression
+	if _peek_next_token_string() == "not":
+		expression = NotExpression.new(_get_next_token(), _parse_function())
+	else:
+		expression = _parse_function()
+	return expression
+
+
+"""
+Parses a 'function' chat token, specifying a function to be evaluated.
+
+Also evaluates any tokens of higher precedence (parentheses).
+"""
+func _parse_function() -> BoolExpression:
+	if _parse_error:
+		return null
+	
+	var expression: BoolExpression
+	match _peek_next_token_string():
+		"chat_finished":
+			expression = ChatFinishedExpression.new(_get_next_token(), _get_next_token())
+		"level_finished":
+			expression = LevelFinishedExpression.new(_get_next_token(), _get_next_token())
+		"notable":
+			if _subject is String:
+				expression = NotableExpression.new(_get_next_token(), _subject)
+			else:
+				_report_error(_get_next_token().start, "Keyword %s cannot be applied to type '%s'" \
+						% [_subject, null if _subject == null else _subject.get_class()])
+		_:
+			expression = _parse_atom()
+	return expression
+
+
+"""
+Parses an 'atom' chat token; a series of tokens within parentheses.
+
+Reports errors if the next chat token is not an open parenthesis.
+"""
+func _parse_atom() -> BoolExpression:
+	if _parse_error:
+		return null
+	
+	var expression: BoolExpression
+	var token := _get_next_token()
+	if token.string == "(":
+		expression = _parse_or()
+		_expect_token(")")
+	else:
+		_report_error(token.start, "Unexpected token '%s'" % [token.string])
+	
+	return expression
+
+
+"""
+Advances to the next token, throwing an error if it does not match the specified token string.
+"""
+func _expect_token(token_string: String) -> void:
+	var next_token := _peek_next_token()
+	if not next_token:
+		_report_error(_string.length(), "Expected '%s'" % [token_string])
+		return
+	elif next_token.string != token_string:
+		_report_error(next_token.start, "Expected '%s' but found '%s'" % [token_string, next_token.string])
+		return
+	
+	_get_next_token()
+
+
+"""
+Returns the next token without advancing the token index.
+"""
+func _peek_next_token() -> BoolToken:
+	var next_token: BoolToken = null
+	if _token_index < _tokens.size():
+		next_token = _tokens[_token_index]
+	return next_token
+
+
+"""
+Returns the next token string without advancing the token index.
+"""
+func _peek_next_token_string() -> String:
+	var next_token := _peek_next_token()
+	return next_token.string if next_token else ""
+
+
+"""
+Returns the next token and advances the token index.
+"""
+func _get_next_token() -> BoolToken:
+	var next_token: BoolToken = null
+	if _token_index < _tokens.size():
+		next_token = _tokens[_token_index]
+		_token_index += 1
+	return next_token
+
+
+"""
+Records and reports a parse error.
+
+This error is recorded to ensure the parser doesn't continue parsing and encountering further errors. It is also
+recorded for unit tests.
+"""
+func _report_error(position: int, error_description: String) -> void:
+	if _parse_error:
+		# don't report a second error. it's redundant and overwrites the first
+		return
+	
+	_parse_error = "Error parsing \"%s\"(%s): %s" % [_string, position, error_description]
+	push_error(_parse_error)

--- a/project/src/main/ui/chat/chat-history.gd
+++ b/project/src/main/ui/chat/chat-history.gd
@@ -88,6 +88,10 @@ func get_chat_age(history_key: String) -> int:
 	return result
 
 
+func is_chat_finished(history_key: String) -> bool:
+	return get_chat_age(history_key) != CHAT_AGE_NEVER
+
+
 func to_json_dict() -> Dictionary:
 	return {
 		"history_items": chat_history,

--- a/project/src/main/ui/level-select/level-buttons.gd
+++ b/project/src/main/ui/level-select/level-buttons.gd
@@ -196,10 +196,12 @@ When the player clicks a level button twice, we launch the selected level
 func _on_LevelSelectButton_level_started(settings: LevelSettings) -> void:
 	CurrentLevel.set_launched_level(settings.id)
 	
-	var pushed_cutscene_trail := CurrentLevel.push_cutscene_trail(true)
-	
-	if not pushed_cutscene_trail:
+	var chat_tree: ChatTree = ChatLibrary.chat_tree_for_creature_id(CurrentLevel.creature_id, settings.id)
+	if ChatLibrary.is_chat_skipped(chat_tree):
 		CurrentLevel.push_level_trail()
+	else:
+		if not CurrentLevel.push_cutscene_trail(true):
+			CurrentLevel.push_level_trail()
 
 
 """

--- a/project/src/main/ui/level-select/level-info-panel.gd
+++ b/project/src/main/ui/level-select/level-info-panel.gd
@@ -15,7 +15,7 @@ var _duration_calculator := DurationCalculator.new()
 
 func _update_tutorial_level_text(settings: LevelSettings) -> void:
 	var text := ""
-	if PlayerData.level_history.finished_levels.has(settings.id):
+	if PlayerData.level_history.is_level_finished(settings.id):
 		var result := PlayerData.level_history.best_result(settings.id)
 		text += "Completed: %04d-%02d-%02d" % [
 				result.timestamp["year"],

--- a/project/src/main/ui/level-select/level-library.gd
+++ b/project/src/main/ui/level-select/level-library.gd
@@ -86,7 +86,7 @@ func first_unfinished_level_id_for_creature(creature_id: String) -> String:
 		for level_id in world_lock.level_ids:
 			var level_lock: LevelLock = _level_locks[level_id]
 			if level_lock.creature_id == creature_id and not level_lock.is_locked() \
-					and not PlayerData.level_history.finished_levels.has(level_lock.level_id):
+					and not PlayerData.level_history.is_level_finished(level_lock.level_id):
 				return level_lock.level_id
 	
 	return ""
@@ -191,7 +191,7 @@ func _update_locked_worlds() -> void:
 		var unlock_world_ids := world_lock.locked_until_values
 		for unlock_world_id in unlock_world_ids:
 			var other_world_lock: WorldLock = _world_locks[unlock_world_id]
-			if not PlayerData.level_history.finished_levels.has(other_world_lock.last_level):
+			if not PlayerData.level_history.is_level_finished(other_world_lock.last_level):
 				world_lock.status = WorldLock.STATUS_LOCK
 
 
@@ -217,7 +217,7 @@ func _update_locked_levels() -> void:
 		var allowed_skips := _allowed_skips(level_lock)
 		var skip_count := 0
 		for unlock_level_id in unlock_level_ids:
-			if not PlayerData.level_history.finished_levels.has(unlock_level_id):
+			if not PlayerData.level_history.is_level_finished(unlock_level_id):
 				skip_count += 1
 		if skip_count > allowed_skips:
 			level_lock.status = LevelLock.STATUS_HARD_LOCK
@@ -273,7 +273,7 @@ func _update_unlockable_levels() -> void:
 		var unlock_level_ids := _unlock_level_ids(level_lock)
 		for unlock_level_id in unlock_level_ids:
 			var other_level_lock: LevelLock = _level_locks[unlock_level_id]
-			if PlayerData.level_history.finished_levels.has(other_level_lock.level_id):
+			if PlayerData.level_history.is_level_finished(other_level_lock.level_id):
 				# key already collected
 				continue
 			if is_locked(unlock_level_id):
@@ -297,7 +297,7 @@ func _update_unlockable_levels() -> void:
 		if not world_lock.last_level:
 			# world doesn't have a last level
 			continue
-		if PlayerData.level_history.finished_levels.has(world_lock.last_level):
+		if PlayerData.level_history.is_level_finished(world_lock.last_level):
 			# crown already collected
 			continue
 		if is_locked(world_lock.last_level):
@@ -313,7 +313,7 @@ func _update_cleared_tutorials() -> void:
 		var level_settings: LevelSettings = _level_settings_by_id[level_lock.level_id]
 		
 		if level_lock.status == LevelLock.STATUS_NONE and level_settings.other.tutorial \
-				and PlayerData.level_history.finished_levels.has(level_lock.level_id):
+				and PlayerData.level_history.is_level_finished(level_lock.level_id):
 			level_lock.status = LevelLock.STATUS_CLEARED
 
 

--- a/project/src/main/ui/menu/splash-screen.gd
+++ b/project/src/main/ui/menu/splash-screen.gd
@@ -28,7 +28,7 @@ func _launch_tutorial() -> void:
 
 
 func _on_Play_pressed() -> void:
-	if not PlayerData.level_history.finished_levels.has(LevelLibrary.BEGINNER_TUTORIAL):
+	if not PlayerData.level_history.is_level_finished(LevelLibrary.BEGINNER_TUTORIAL):
 		_launch_tutorial()
 	else:
 		SceneTransition.push_trail(Global.SCENE_MAIN_MENU, true)

--- a/project/src/main/world/chattable-manager.gd
+++ b/project/src/main/world/chattable-manager.gd
@@ -180,6 +180,27 @@ func substitute_variables(string: String, full_name: bool = false) -> String:
 
 
 """
+Returns the level id (if any) corresponding to the curently focused chattable.
+
+This is relevant when the player talks to a creature with a food speech bubble.
+"""
+func focused_chattable_level_id() -> String:
+	var focused_creature: Creature = ChattableManager.focused_chattable as Creature
+	if not focused_creature:
+		return ""
+	
+	return LevelLibrary.first_unfinished_level_id_for_creature(focused_creature.creature_id)
+
+
+func focused_chattable_creature_id() -> String:
+	var focused_creature: Creature = ChattableManager.focused_chattable as Creature
+	if not focused_creature:
+		return ""
+	
+	return focused_creature.creature_id
+
+
+"""
 Remove the specified creature from the '_creatures_by_id' mapping.
 """
 func _remove_from_creatures_by_id(creature: Creature) -> void:

--- a/project/src/test/test-backwards-compatible.gd
+++ b/project/src/test/test-backwards-compatible.gd
@@ -52,8 +52,8 @@ func test_19c5() -> void:
 	
 	assert_eq(PlayerData.level_history.successful_levels.has("rank/7k"), true)
 	
-	assert_eq(PlayerData.level_history.finished_levels.has("tutorial/basics_0"), true)
-	assert_eq(PlayerData.level_history.finished_levels.has("practice/ultra_normal"), true)
+	assert_eq(PlayerData.level_history.is_level_finished("tutorial/basics_0"), true)
+	assert_eq(PlayerData.level_history.is_level_finished("practice/ultra_normal"), true)
 	
 	assert_eq(PlayerData.level_history.best_result("tutorial/basics_0").score, 158)
 	assert_eq(PlayerData.level_history.best_result("rank/7k").score, 230)

--- a/project/src/test/ui/chat/test-chat-bool-evaluator.gd
+++ b/project/src/test/ui/chat/test-chat-bool-evaluator.gd
@@ -1,0 +1,76 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests that boolean expressions can be parsed and evaluated correctly.
+"""
+
+func before_each() -> void:
+	PlayerData.chat_history.reset()
+	PlayerData.level_history.reset()
+	
+	PlayerData.chat_history.add_history_item("chat/gurus750/chat_200")
+	PlayerData.chat_history.add_history_item("chat/gurus750/chat_201")
+	
+	# the player cleared level_200 and level_201, but failed level_400
+	add_level_history_item("level_200", true)
+	add_level_history_item("level_201", true)
+	add_level_history_item("level_400", false)
+	
+	PlayerData.chat_history.increment_filler_count("creature_200")
+
+
+func add_level_history_item(level_id: String, cleared: bool) -> void:
+	var result := RankResult.new()
+	result.lost = not cleared
+	PlayerData.level_history.add(level_id, result)
+
+
+func assert_evaluate(expected: bool, string: String, subject = null) -> void:
+	var actual := ChatBoolEvaluator.evaluate(string, subject)
+	assert_true(expected == actual,
+			"\"%s\" expected [%s] but was [%s]" % [string, expected, actual])
+
+
+func test_chat_finished() -> void:
+	assert_evaluate(true, "chat_finished chat/gurus750/chat_200")
+	assert_evaluate(false, "chat_finished chat/gurus750/chat_404")
+
+
+func test_level_finished() -> void:
+	assert_evaluate(true, "level_finished level_200")
+	assert_evaluate(false, "level_finished level_400")
+	assert_evaluate(false, "level_finished level_404")
+
+
+func test_and_expression() -> void:
+	assert_evaluate(true, "chat_finished chat/gurus750/chat_200 and level_finished level_200")
+	assert_evaluate(false, "chat_finished chat/gurus750/chat_200 and level_finished level_404")
+	assert_evaluate(false, "chat_finished chat/gurus750/chat_404 and level_finished level_200")
+
+
+func test_or_expression() -> void:
+	assert_evaluate(true, "chat_finished chat/gurus750/chat_200 or level_finished level_404")
+	assert_evaluate(true, "chat_finished chat/gurus750/chat_404 or level_finished level_200")
+	assert_evaluate(false, "chat_finished chat/gurus750/chat_404 or level_finished level_404")
+
+
+func test_not_expression() -> void:
+	assert_evaluate(false, "not chat_finished chat/gurus750/chat_200")
+	assert_evaluate(true, "not chat_finished chat/gurus750/chat_404")
+
+
+func test_complex_expression() -> void:
+	assert_evaluate(false, "not (chat_finished chat/gurus750/chat_200 or level_finished level_200)")
+	assert_evaluate(false, "not (chat_finished chat/gurus750/chat_200 or level_finished level_404)")
+	assert_evaluate(false, "not (chat_finished chat/gurus750/chat_404 or level_finished level_200)")
+	assert_evaluate(true, "not (chat_finished chat/gurus750/chat_404 or level_finished level_404)")
+
+
+func test_notable_expression() -> void:
+	# creature with a filler chat triggers the 'notable' flag; they're ready for a serious chat
+	assert_evaluate(true, "notable", "creature_200")
+	
+	# creature with no filler chats does not trigger the 'notable' flag; they're not ready for a serious chat
+	assert_evaluate(false, "notable", "creature_201")
+	
+	# null creature doesn't trigger the 'notable' flag
+	assert_evaluate(false, "notable", "")

--- a/project/src/test/ui/chat/test-chat-bool-parser.gd
+++ b/project/src/test/ui/chat/test-chat-bool-parser.gd
@@ -1,0 +1,171 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests that boolean expressions can be parsed correctly.
+"""
+
+var parser: ChatBoolParser
+
+func assert_token(token: ChatBoolParser.BoolToken, string: String, start: int = -1, end: int = -1) -> void:
+	assert_not_null(token)
+	assert_eq(token.string, string)
+	if start != -1:
+		assert_eq(token.start, start)
+	if end != -1:
+		assert_eq(token.end, end)
+
+
+func assert_expression(expression: ChatBoolParser.BoolExpression, token: String, args: Array) -> void:
+	assert_token(expression.token, token)
+	assert_eq(expression.args.size(), args.size())
+	for i in range(0, args.size()):
+		assert_eq(expression.args[i].string, args[i])
+
+
+func parse_tokens(string: String) -> Array:
+	parser = ChatBoolParser.new(string)
+	return parser._tokens
+
+
+func parse_expression(string: String) -> ChatBoolParser.BoolExpression:
+	parser = ChatBoolParser.new(string)
+	return parser.parse()
+
+
+func test_parse_tokens_empty() -> void:
+	var tokens := parse_tokens("")
+	
+	assert_eq(tokens.size(), 0)
+
+
+func test_parse_tokens_many() -> void:
+	var tokens := parse_tokens("chat_finished abc")
+	
+	assert_eq(tokens.size(), 2)
+	assert_token(tokens[0], "chat_finished", 0, 13)
+	assert_token(tokens[1], "abc", 14, 17)
+
+
+func test_parse_tokens_parens() -> void:
+	var tokens := parse_tokens("(not (chat_finished abc))")
+	
+	assert_eq(tokens.size(), 7)
+	assert_token(tokens[0], "(", 0, 1)
+	assert_token(tokens[1], "not", 1, 4)
+	assert_token(tokens[2], "(", 5, 6)
+	assert_token(tokens[3], "chat_finished", 6, 19)
+	assert_token(tokens[4], "abc", 20, 23)
+	assert_token(tokens[5], ")", 23, 24)
+	assert_token(tokens[6], ")", 24, 25)
+
+
+func test_parse_expression() -> void:
+	var expression := parse_expression("chat_finished abc")
+	assert_expression(expression, "chat_finished", ["abc"])
+
+
+func test_parse_expression_and() -> void:
+	var expression := parse_expression("chat_finished abc and chat_finished def")
+	
+	# assert: chat_finished abc [AND] chat_finished def
+	assert_token(expression.token, "and")
+	assert_eq(expression.args.size(), 2)
+	
+	# assert: [CHAT_FINISHED ABC] and chat_finished def
+	assert_expression(expression.args[0], "chat_finished", ["abc"])
+	
+	# assert: chat_finished abc and [CHAT_FINISHED DEF]
+	assert_expression(expression.args[1], "chat_finished", ["def"])
+
+
+func test_parse_expression_not() -> void:
+	var expression := parse_expression("not chat_finished abc")
+	
+	assert_token(expression.token, "not")
+	assert_eq(expression.args.size(), 1)
+	assert_expression(expression.args[0], "chat_finished", ["abc"])
+
+
+func test_parse_expression_or() -> void:
+	var expression := parse_expression("chat_finished abc or chat_finished def")
+	
+	# assert: chat_finished abc [OR] chat_finished def
+	assert_token(expression.token, "or")
+	assert_eq(expression.args.size(), 2)
+	
+	# assert: [CHAT_FINISHED ABC] or chat_finished def
+	assert_expression(expression.args[0], "chat_finished", ["abc"])
+	
+	# assert: chat_finished abc or [CHAT_FINISHED DEF]
+	assert_expression(expression.args[1], "chat_finished", ["def"])
+
+
+func test_parse_expression_parentheses_0() -> void:
+	var expression := parse_expression("(chat_finished abc)")
+	
+	assert_expression(expression, "chat_finished", ["abc"])
+
+
+func test_parse_expression_parentheses_1() -> void:
+	var expression := parse_expression("not (chat_finished abc or chat_finished def)")
+	
+	# assert: [NOT] (chat_finished abc or chat_finished def)
+	assert_token(expression.token, "not")
+	assert_eq(expression.args.size(), 1)
+	
+	# assert: not (chat_finished abc [OR] chat_finished def)
+	assert_token(expression.args[0].token, "or")
+	assert_eq(expression.args[0].args.size(), 2)
+	
+	# assert: not ([CHAT_FINISHED ABC] or chat_finished def)
+	assert_expression(expression.args[0].args[0], "chat_finished", ["abc"])
+	
+	# assert: not (chat_finished abc or [CHAT_FINISHED DEF])
+	assert_expression(expression.args[0].args[1], "chat_finished", ["def"])
+
+
+func test_parse_expression_order_of_operations() -> void:
+	var expression := parse_expression("not chat_finished def and chat_finished ghi or chat_finished abc")
+	
+	# assert: 'not chat_finished def and chat_finished ghi [OR] chat_finished abc'
+	assert_token(expression.token, "or")
+	assert_eq(expression.args.size(), 2)
+	
+	# assert: 'not chat_finished def [AND] chat_finished ghi or chat_finished abc'
+	assert_token(expression.args[0].token, "and")
+	assert_eq(expression.args.size(), 2)
+	
+	# assert: '[NOT CHAT_FINISHED DEF] and chat_finished ghi or chat_finished abc'
+	assert_token(expression.args[0].args[0].token, "not")
+	assert_eq(expression.args[0].args[0].args.size(), 1)
+	assert_expression(expression.args[0].args[0].args[0], "chat_finished", ["def"])
+	
+	# assert: 'not chat_finished def and [CHAT_FINISHED GHI] or chat_finished abc'
+	assert_expression(expression.args[0].args[1], "chat_finished", ["ghi"])
+	
+	# assert: 'not chat_finished def and chat_finished ghi or [CHAT_FINISHED ABC]
+	assert_expression(expression.args[1], "chat_finished", ["abc"])
+
+
+func test_syntax_error_misspelling() -> void:
+	parse_expression("chab_finished abc")
+	
+	assert_eq(parser._parse_error, "Error parsing \"chab_finished abc\"(0): Unexpected token 'chab_finished'")
+
+
+func test_syntax_error_missing_paren() -> void:
+	parse_expression("(chat_finished abc or chat_finished def")
+	
+	assert_eq(parser._parse_error, "Error parsing \"(chat_finished abc or chat_finished def\"(39): Expected ')'")
+
+
+func test_syntax_error_duplicate_keyword() -> void:
+	parse_expression("chat_finished abc and and chat_finished def")
+	
+	assert_eq(parser._parse_error,
+			"Error parsing \"chat_finished abc and and chat_finished def\"(22): Unexpected token 'and'")
+
+
+func test_syntax_error_misplaced_keyword() -> void:
+	parse_expression("or chat_finished abc")
+	
+	assert_eq(parser._parse_error, "Error parsing \"or chat_finished abc\"(0): Unexpected token 'or'")

--- a/project/src/test/ui/chat/test-chat-library.gd
+++ b/project/src/test/ui/chat/test-chat-library.gd
@@ -10,16 +10,12 @@ var _chat_selectors := [
 	},
 	{
 		"chat": "notable_001",
-		"if_conditions": [
-			"notable_chat"
-		],
+		"if_condition": "notable",
 		"repeat": 999999
 	},
 	{
 		"chat": "notable_002",
-		"if_conditions": [
-			"notable_chat"
-		],
+		"if_condition": "notable",
 		"repeat": 999999
 	}
 ]
@@ -33,13 +29,14 @@ func before_each() -> void:
 	
 	_state["creature_id"] = "gurus750"
 	_state["level_num"] = 1
-	_state["notable_chat"] = true
 	
 	PlayerData.chat_history.add_history_item("chat/gurus750/level_001")
 	PlayerData.chat_history.add_history_item("chat/gurus750/level_002")
 	PlayerData.chat_history.add_history_item("chat/gurus750/greeting_001")
 	PlayerData.chat_history.add_history_item("chat/gurus750/notable_001")
 	PlayerData.chat_history.add_history_item("chat/gurus750/notable_002")
+	
+	PlayerData.chat_history.increment_filler_count("gurus750")
 
 
 func test_greeting() -> void:
@@ -70,7 +67,9 @@ func test_chat_avoid_repeat_filler() -> void:
 
 
 func test_chat_non_notable() -> void:
-	_state["notable_chat"] = false
+	# creature is not ready for a notable chat
+	PlayerData.chat_history.filler_counts["gurus750"] = 0
+	
 	PlayerData.chat_history.delete_history_item("chat/gurus750/notable_001")
 	PlayerData.chat_history.delete_history_item("chat/gurus750/notable_002")
 	


### PR DESCRIPTION
Chat 'skip_if' conditions are evaluated. This supports boolean operators
like 'and', 'or' and 'not'. It also supports order of operations and
parentheses.

This new conditional logic has been pushed to the chat selectors as
well. Instead of an array of simple if_conditions, it now supports a
single complex if_condition which accepts boolean operators.

LevelHistory.reset() clears successful_levels, finished_levels. Failing
to clear these was resulting in unpredictable unit tests

Added is_level_finished() utility method