### PR TITLE
Added missing level creature_ids. if_condition -> available_if.

### DIFF
--- a/project/assets/main/puzzle/worlds.json
+++ b/project/assets/main/puzzle/worlds.json
@@ -35,31 +35,31 @@
         {
           "id": "marsh/hello_everyone",
           "creature_id": "richie",
+          "groups": "marsh/hello",
           "chef_id": "skins",
           "customer_ids": [
             "rhonk"
-          ],
-          "groups": "marsh/hello"
+          ]
         },
         {
           "id": "marsh/hello_bones",
+          "creature_id": "bones",
           "groups": "marsh/hello",
           "locked_until": "level_finished marsh/hello_everyone",
-          "creature_id": "bones",
           "chef_id": "bones"
         },
         {
           "id": "marsh/hello_shirts",
+          "creature_id": "shirts",
           "groups": "marsh/hello",
           "locked_until": "level_finished marsh/hello_everyone",
-          "creature_id": "shirts",
           "chef_id": "shirts"
         },
         {
           "id": "marsh/hello_skins",
+          "creature_id": "skins",
           "groups": "marsh/hello",
           "locked_until": "level_finished marsh/hello_everyone",
-          "creature_id": "skins",
           "chef_id": "skins"
         },
         {
@@ -69,19 +69,24 @@
         },
         {
           "id": "marsh/pulling_for_bones",
+          "creature_id": "bones",
           "groups": "marsh/pulling_for",
-          "locked_until": "level_finished marsh/pulling_for_everyone"
+          "locked_until": "level_finished marsh/pulling_for_everyone",
+          "chef_id": "bones"
         },
         {
           "id": "marsh/pulling_for_shirts",
+          "creature_id": "shirts",
           "groups": "marsh/pulling_for",
-          "locked_until": "level_finished marsh/pulling_for_everyone"
+          "locked_until": "level_finished marsh/pulling_for_everyone",
+          "chef_id": "shirts"
         },
         {
           "id": "marsh/pulling_for_skins",
-          "chef_id": "skins",
+          "creature_id": "skins",
           "groups": "marsh/pulling_for",
-          "locked_until": "level_finished marsh/pulling_for_everyone"
+          "locked_until": "level_finished marsh/pulling_for_everyone",
+          "chef_id": "skins"
         },
         {
           "id": "marsh/lets_all_get_merry",
@@ -89,19 +94,23 @@
         },
         {
           "id": "marsh/goodbye_bones",
+          "creature_id": "bones",
           "groups": "marsh/goodbye",
-          "locked_until": "level_finished marsh/lets_all_get_merry"
+          "chef_id": "bones"
         },
         {
           "id": "marsh/goodbye_shirts",
+          "creature_id": "shirts",
           "groups": "marsh/goodbye",
-          "locked_until": "level_finished marsh/lets_all_get_merry"
+          "locked_until": "level_finished marsh/lets_all_get_merry",
+          "chef_id": "shirts"
         },
         {
           "id": "marsh/goodbye_skins",
-          "chef_id": "skins",
+          "creature_id": "skins",
           "groups": "marsh/goodbye",
-          "locked_until": "level_finished marsh/lets_all_get_merry"
+          "locked_until": "level_finished marsh/lets_all_get_merry",
+          "chef_id": "skins"
         },
         {
           "id": "marsh/goodbye_everyone",

--- a/project/src/main/ui/chat/chat-library.gd
+++ b/project/src/main/ui/chat/chat-library.gd
@@ -164,11 +164,10 @@ func select_from_chat_selectors(chat_selectors: Array, state: Dictionary, filler
 				# skip; we've had this conversation too recently
 				continue
 			
-			var if_condition_met := true
-			if chat_selector.has("if_condition"):
-				var if_condition: String = chat_selector["if_condition"]
-				if_condition_met = ChatBoolEvaluator.evaluate(if_condition, creature_id)
-			if not if_condition_met:
+			var available_if_met := true
+			if chat_selector.has("available_if"):
+				available_if_met = ChatBoolEvaluator.evaluate(chat_selector["available_if"], creature_id)
+			if not available_if_met:
 				# skip; if condition wasn't met
 				continue
 

--- a/project/src/main/ui/level-select/level-library.gd
+++ b/project/src/main/ui/level-select/level-library.gd
@@ -85,9 +85,13 @@ func first_unfinished_level_id_for_creature(creature_id: String) -> String:
 		var world_lock: WorldLock = world_lock_obj
 		for level_id in world_lock.level_ids:
 			var level_lock: LevelLock = _level_locks[level_id]
-			if level_lock.creature_id == creature_id and not level_lock.is_locked() \
-					and not PlayerData.level_history.is_level_finished(level_lock.level_id):
-				return level_lock.level_id
+			if level_lock.creature_id != creature_id:
+				continue
+			if level_lock.is_locked():
+				continue
+			if PlayerData.level_history.is_level_finished(level_lock.level_id):
+				continue
+			return level_lock.level_id
 	
 	return ""
 

--- a/project/src/test/ui/chat/test-chat-library.gd
+++ b/project/src/test/ui/chat/test-chat-library.gd
@@ -10,12 +10,12 @@ var _chat_selectors := [
 	},
 	{
 		"chat": "notable_001",
-		"if_condition": "notable",
+		"available_if": "notable",
 		"repeat": 999999
 	},
 	{
 		"chat": "notable_002",
-		"if_condition": "notable",
+		"available_if": "notable",
 		"repeat": 999999
 	}
 ]


### PR DESCRIPTION
Replaced 'if_condition' with 'available_if'. The term if_condition is woefully
ambiguous when there are multiple conditional statements.

Added missing creature_id entries in worlds.json. This should allow
more levels to be available when walking around on the overworld.