### PR TITLE
Merrymellow Marsh sequence changes.

### DIFF
--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-bones-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-bones-100.chat
@@ -1,4 +1,4 @@
-{"version": "2476"}
+{"version": "2476", "skip_if": "level_finished marsh/pulling_for_everyone"}
 
 [location]
 outdoors

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-shirts-000.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-shirts-000.chat
@@ -1,4 +1,4 @@
-{"version": "2476"}
+{"version": "2476", "skip_if": "level_finished marsh/pulling_for_everyone"}
 
 [location]
 indoors

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-skins-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-skins-100.chat
@@ -1,4 +1,4 @@
-{"version": "2476"}
+{"version": "2476", "skip_if": "level_finished marsh/pulling_for_everyone"}
 
 [location]
 indoors

--- a/project/assets/main/puzzle/worlds.json
+++ b/project/assets/main/puzzle/worlds.json
@@ -46,6 +46,7 @@
           "creature_id": "bones",
           "groups": "marsh/hello",
           "locked_until": "level_finished marsh/hello_everyone",
+          "prioritized_if": "not level_finished marsh/pulling_for_everyone",
           "chef_id": "bones"
         },
         {
@@ -53,6 +54,7 @@
           "creature_id": "shirts",
           "groups": "marsh/hello",
           "locked_until": "level_finished marsh/hello_everyone",
+          "prioritized_if": "not level_finished marsh/pulling_for_everyone",
           "chef_id": "shirts"
         },
         {
@@ -60,18 +62,22 @@
           "creature_id": "skins",
           "groups": "marsh/hello",
           "locked_until": "level_finished marsh/hello_everyone",
+          "prioritized_if": "not level_finished marsh/pulling_for_everyone",
           "chef_id": "skins"
         },
         {
           "id": "marsh/pulling_for_everyone",
+          "creature_id": "richie",
           "groups": "marsh/pulling_for",
-          "locked_until": "group_finished marsh/hello"
+          "locked_until": "group_finished marsh/hello 1",
+          "chef_id": "bones"
         },
         {
           "id": "marsh/pulling_for_bones",
           "creature_id": "bones",
           "groups": "marsh/pulling_for",
           "locked_until": "level_finished marsh/pulling_for_everyone",
+          "prioritized_if": "not level_finished marsh/lets_all_get_merry",
           "chef_id": "bones"
         },
         {
@@ -79,6 +85,7 @@
           "creature_id": "shirts",
           "groups": "marsh/pulling_for",
           "locked_until": "level_finished marsh/pulling_for_everyone",
+          "prioritized_if": "not level_finished marsh/lets_all_get_merry",
           "chef_id": "shirts"
         },
         {
@@ -86,17 +93,21 @@
           "creature_id": "skins",
           "groups": "marsh/pulling_for",
           "locked_until": "level_finished marsh/pulling_for_everyone",
+          "prioritized_if": "not level_finished marsh/lets_all_get_merry",
           "chef_id": "skins"
         },
         {
           "id": "marsh/lets_all_get_merry",
-          "locked_until": "group_finished marsh/pulling_for"
+          "creature_id": "richie",
+          "groups": "marsh/goodbye",
+          "locked_until": "group_finished marsh/pulling_for 1"
         },
         {
           "id": "marsh/goodbye_bones",
           "creature_id": "bones",
           "groups": "marsh/goodbye",
           "locked_until": "level_finished marsh/lets_all_get_merry",
+          "prioritized_if": "not level_finished marsh/goodbye_everyone",
           "chef_id": "bones"
         },
         {
@@ -104,6 +115,7 @@
           "creature_id": "shirts",
           "groups": "marsh/goodbye",
           "locked_until": "level_finished marsh/lets_all_get_merry",
+          "prioritized_if": "not level_finished marsh/goodbye_everyone",
           "chef_id": "shirts"
         },
         {
@@ -111,11 +123,13 @@
           "creature_id": "skins",
           "groups": "marsh/goodbye",
           "locked_until": "level_finished marsh/lets_all_get_merry",
+          "prioritized_if": "not level_finished marsh/goodbye_everyone",
           "chef_id": "skins"
         },
         {
           "id": "marsh/goodbye_everyone",
-          "locked_until": "group_finished marsh/goodbye"
+          "creature_id": "richie",
+          "locked_until": "group_finished marsh/goodbye 1"
         }
       ]
     },

--- a/project/src/test/ui/level-select/test-level-library.gd
+++ b/project/src/test/ui/level-select/test-level-library.gd
@@ -53,22 +53,21 @@ func test_level_lock_group_finished() -> void:
 	add_level_history_item("marsh/hello_everyone")
 	LevelLibrary.refresh_cleared_levels()
 	assert_level_lock_status(level_id, LEVEL_SOFT_LOCK)
-	assert_eq(LevelLibrary.level_lock(level_id).keys_needed, 3)
+	assert_eq(LevelLibrary.level_lock(level_id).keys_needed, 2)
 	
 	# these three levels are required to unlock it
 	assert_level_lock_status("marsh/hello_bones", LEVEL_KEY)
 	assert_level_lock_status("marsh/hello_shirts", LEVEL_KEY)
 	assert_level_lock_status("marsh/hello_skins", LEVEL_KEY)
 	
-	# if only two levels are cleared, the level remains locked
+	# if only one level is cleared, the level remains locked
 	add_level_history_item("marsh/hello_bones")
-	add_level_history_item("marsh/hello_shirts")
 	LevelLibrary.refresh_cleared_levels()
 	assert_level_lock_status(level_id, LEVEL_SOFT_LOCK)
 	assert_eq(LevelLibrary.level_lock(level_id).keys_needed, 1)
 	
 	# once the last required level is cleared, the level unlocks
-	add_level_history_item("marsh/hello_skins")
+	add_level_history_item("marsh/hello_shirts")
 	LevelLibrary.refresh_cleared_levels()
 	assert_level_lock_status(level_id, LEVEL_KEY)
 
@@ -151,12 +150,8 @@ func test_next_creature_level() -> void:
 	LevelLibrary.refresh_cleared_levels()
 	assert_eq(LevelLibrary.next_creature_level("bones"), "marsh/hello_bones")
 	
-	# if multiple levels are available, the earliest level is returned
+	# if multiple levels are available, the earliest prioritized level is returned
 	add_level_history_item("marsh/pulling_for_everyone")
-	LevelLibrary.refresh_cleared_levels()
-	assert_eq(LevelLibrary.next_creature_level("bones"), "marsh/hello_bones")
-	
-	# once the creature's level is cleared, it skips to the next in line
 	add_level_history_item("marsh/hello_bones")
 	LevelLibrary.refresh_cleared_levels()
 	assert_eq(LevelLibrary.next_creature_level("bones"), "marsh/pulling_for_bones")


### PR DESCRIPTION
Added prioritized_if/skip_if flags to Merrymellow Marsh levels. The
cutscenes are prioritized when they're next in sequence, and skipped if
the player's past that point in the story.

Level sequence changes; only need to complete about 70% of the
Merrymellow Marsh levels

Set creature id to richie for marsh cutscenes. Without a creature_id,
these cutscenes cannot be accessed outside of the phone menu.