### PR TITLE
Cutscene camera, orientation fixes.

### DIFF
--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -155,7 +155,9 @@ func _quit_puzzle() -> void:
 	if CurrentLevel.cutscene_state == CurrentLevel.CutsceneState.AFTER \
 			and ChatLibrary.has_postroll(CurrentLevel.level_id):
 		var chat_tree := ChatLibrary.chat_tree_for_postroll(CurrentLevel.level_id)
-		if not ChatLibrary.is_chat_skipped(chat_tree):
+		if ChatLibrary.is_chat_skipped(chat_tree):
+			CurrentLevel.cutscene_state = CurrentLevel.CutsceneState.NONE
+		else:
 			# insert cutscene into breadcrumb trail so it will show up after we pop the trail
 			Breadcrumb.trail.insert(1, chat_tree.cutscene_scene_path())
 	else:

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -50,7 +50,11 @@ func _exit_tree() -> void:
 func start_chat(new_chat_tree: ChatTree, target: Node2D) -> void:
 	_current_chat_tree = new_chat_tree
 	
-	var new_chatters := [ChattableManager.player, target]
+	var new_chatters := []
+	if ChattableManager.player:
+		new_chatters.append(ChattableManager.player)
+	if target:
+		new_chatters.append(target)
 	var chatter_ids := {}
 	for chat_events_obj in new_chat_tree.events.values():
 		var chat_events: Array = chat_events_obj
@@ -88,8 +92,16 @@ func is_show_version() -> bool:
 Turn the the active chat participants towards each other, and make them face the camera.
 """
 func make_chatters_face_eachother() -> void:
-	var chatter_bounding_box := get_chatter_bounding_box(
-			[], [ChattableManager.player, ChattableManager.sensei])
+	if cutscene:
+		# don't automatically orient characters during cutscenes
+		return
+	
+	var chatter_bounding_box: Rect2
+	chatter_bounding_box = get_chatter_bounding_box([], [ChattableManager.player, ChattableManager.sensei])
+	if not chatter_bounding_box:
+		# for conversations between the player and the sensei, the sensei faces their midpoint
+		chatter_bounding_box = get_chatter_bounding_box([], [])
+		
 	var center_of_non_player_chatters := chatter_bounding_box.position + chatter_bounding_box.size * 0.5
 	
 	for chatter in chatters:

--- a/project/src/main/world/creature/sensei.gd
+++ b/project/src/main/world/creature/sensei.gd
@@ -10,6 +10,9 @@ The sensei follows the player around.
 const TOO_CLOSE_THRESHOLD := 140.0
 const TOO_FAR_THRESHOLD := 280.0
 
+# If 'true' the sensei cannot move. Used during cutscenes.
+var movement_disabled := false
+
 func _ready() -> void:
 	set_creature_id(CreatureLibrary.SENSEI_ID)
 	$MoveTimer.connect("timeout", self, "_on_MoveTimer_timeout")
@@ -17,6 +20,9 @@ func _ready() -> void:
 
 
 func _on_MoveTimer_timeout() -> void:
+	if movement_disabled:
+		return
+	
 	var player_relative_pos: Vector2 = Global.from_iso(ChattableManager.player.position - position)
 	# the sensei runs at isometric 45 degree angles to mimic the player's inputs
 	var player_angle := stepify(player_relative_pos.normalized().angle(), PI / 4)

--- a/project/src/main/world/overworld-camera.gd
+++ b/project/src/main/world/overworld-camera.gd
@@ -59,6 +59,8 @@ func _process(_delta: float) -> void:
 		if new_close_up_bounding_box != close_up_bounding_box:
 			close_up_bounding_box = new_close_up_bounding_box
 			close_up_position = close_up_bounding_box.position + close_up_bounding_box.size * 0.5
+			# Move cutscene camera lower so that dialog bubbles don't hide the creatures
+			close_up_position.y += close_up_bounding_box.size.y * 0.1
 			
 			zoom_close_up.x = max(close_up_bounding_box.size.x / _project_resolution.x, \
 					close_up_bounding_box.size.y / _project_resolution.y)

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -27,6 +27,8 @@ func _ready() -> void:
 
 func _launch_cutscene() -> void:
 	_overworld_ui.cutscene = true
+	ChattableManager.player.input_disabled = true
+	ChattableManager.sensei.movement_disabled = true
 	
 	# remove all of the creatures from the overworld except for the player and sensei
 	for node in get_tree().get_nodes_in_group("creatures"):
@@ -35,9 +37,10 @@ func _launch_cutscene() -> void:
 			node.get_parent().remove_child(node)
 			node.queue_free()
 	
-	# add the cutscene creature
-	var cutscene_creature: Creature = _add_creature(CurrentLevel.creature_id)
-	ChattableManager.player.input_disabled = true
+	var cutscene_creature: Creature
+	if CurrentLevel.creature_id:
+		# add the cutscene creature
+		cutscene_creature = _add_creature(CurrentLevel.creature_id)
 	
 	# get the location, spawn location data
 	var chat_tree: ChatTree
@@ -49,7 +52,7 @@ func _launch_cutscene() -> void:
 		_:
 			push_warning("Unexpected CurrentLevel.cutscene_state: %s" % [CurrentLevel.cutscene_state])
 	
-	if not chat_tree.spawn_locations:
+	if not chat_tree.spawn_locations and cutscene_creature:
 		# apply a default position to the cutscene creature
 		cutscene_creature.position = ChattableManager.player.position
 		cutscene_creature.position += Vector2(cutscene_creature.chat_extents.x, 0)


### PR DESCRIPTION
Moved cutscene camera lower. The dialog bubbles were hiding the creatures.

Fix cutscene camera bug for levels with no creature. The 'no creature'
creature would be spawned at a default location and the camera would
struggle to keep them in frame.

Creatures no longer turn left and right during cutscenes. This was
resulting in unnatural behavior where, in a group of 5 creatures, they would all
face the player even when someone else was talking.

The sensei and player orient correctly during conversations between the player
and the sensei. The 'calculate the midpoint of the chatters' logic was not
behaving correctly when they were the only ones talking.

Sensei no longer follows player during cutscenes

Fixed bug where cutscenes would dump player back to the title screen
after a puzzle, if the cutscene was marked as 'skipped'.