### PR TITLE
Smoother cutscene cameras. Better camera adjustments for fat creatures.

### DIFF
--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-everyone-000.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-everyone-000.chat
@@ -4,14 +4,13 @@
 indoors
 
 [characters]
-player, p1, !kitchen-9
-sensei, s1, !kitchen-11
-richie, r, !kitchen-1
+player, p1, kitchen-9
+sensei, s1, kitchen-11
+richie, r, kitchen-1
 skins, s, kitchen-3
 bones, b, kitchen-5
 
 s1: -_- So explain again why my beloved restaurant is very, very empty?
- (player enters, sensei enters, richie enters)
 r: Aw come on now! It's not empty, we got the two line cooks here...
 b: ^_^ Bork!
 r: ^_^/ And as far as customers, we got Chonkers McRhonkers over there! What more could you need?

--- a/project/src/demo/world/CutsceneDemo.tscn
+++ b/project/src/demo/world/CutsceneDemo.tscn
@@ -143,6 +143,7 @@ window_title = "Error"
 dialog_autowrap = true
 
 [node name="SceneTransitionCover" parent="." instance=ExtResource( 6 )]
+
 [connection signal="toggled" from="VBoxContainer/LongNames" to="VBoxContainer/LongNames" method="_on_toggled"]
 [connection signal="pressed" from="VBoxContainer/Fatness/CheckBox" to="VBoxContainer/Fatness" method="_on_CheckBox_pressed"]
 [connection signal="value_changed" from="VBoxContainer/Fatness/HSlider" to="VBoxContainer/Fatness" method="_on_HSlider_value_changed"]

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -15,6 +15,10 @@ signal dna_loaded
 # emitted on the frame when creature bites into some food
 signal food_eaten
 
+# emitted after a creature finishes fading in/out and their visible/modulate values are finalized
+signal fade_in_finished
+signal fade_out_finished
+
 const IDLE = CreatureVisuals.IDLE
 
 const SOUTHEAST = CreatureOrientation.SOUTHEAST
@@ -584,6 +588,9 @@ func _on_CreatureVisuals_movement_mode_changed(_old_mode: int, new_mode: int) ->
 func _on_FadeTween_tween_all_completed() -> void:
 	if modulate.a == 0.0:
 		visible = false
+		emit_signal("fade_out_finished")
+	else:
+		emit_signal("fade_in_finished")
 
 
 """


### PR DESCRIPTION
Creatures entering or exiting a cutscene now launch a tween which smoothly moves
the camera instead of lerping. The previous lerp effect caused the camera to
leap into motion which was unpleasant.

Cutscene camera zooms and pans slower than before. The rapid zooming and
panning was also unpleasant.

Better camera adjustments for fat creatures. Camera is adjusted vertically to
keep fat creature's faces in frame. Camera is zoomed out when fat creatures are
in a cutscene, this logic was accidentally removed in f0f31d1

hello-everyone-000 cutscene no longer fades in three creatures on the
first line of dialog. This was unnoticable, but resulted in the camera
(correctly) zooming in on just the two visible creatures, and pulling out to all
five creatures, which looked strange.