### PR TITLE
Chatscript handles '\n' characters.

### DIFF
--- a/project/assets/test/ui/chat/chat-newlines.chat
+++ b/project/assets/test/ui/chat/chat-newlines.chat
@@ -1,0 +1,13 @@
+{"version": "2476"}
+
+boatricia: Have we met?
+(Hmm...\nYou're not sure.)
+boatricia: Anyway!\nUmm, it's nice to meet you.
+[oh-hi] Oh!\nHi!
+[hello] Hello!
+
+[oh-hi]
+player: Oh!\nHi, it's a pleasure to meet you!
+
+[hello]
+player: Hello!

--- a/project/src/main/ui/chat/chatscript-parser.gd
+++ b/project/src/main/ui/chat/chatscript-parser.gd
@@ -205,6 +205,7 @@ class ChatState extends AbstractState:
 		_event.who = who
 		
 		_event.text = StringUtils.substring_after(line, ": ")
+		_event.text = _event.text.c_unescape() # turn '\n' characters into newlines
 		var creature_def: CreatureDef = PlayerData.creature_library.get_creature_def(_event.who)
 		if creature_def:
 			_event.chat_theme_def = creature_def.chat_theme_def
@@ -228,11 +229,13 @@ class ChatState extends AbstractState:
 		
 		var branch_name := StringUtils.substring_between(line, "[", "]").strip_edges()
 		var branch_text := StringUtils.substring_after(line, "]").strip_edges()
+		branch_text = branch_text.c_unescape() # turn '\n' characters into newlines
 		var branch_mood := -1
 		var mood_prefix := StringUtils.substring_before(branch_text, " ")
 		if mood_prefix in MOOD_PREFIXES:
 			branch_mood = MOOD_PREFIXES[mood_prefix]
 			branch_text = branch_text.trim_prefix(mood_prefix).strip_edges()
+			# turn '\n' characters into newlines
 		_event.add_link(branch_name, branch_text, branch_mood)
 	
 	
@@ -259,6 +262,7 @@ class ChatState extends AbstractState:
 		
 		_event = ChatEvent.new()
 		_event.text = line
+		_event.text = _event.text.c_unescape() # turn '\n' characters into newlines
 		var creature_def: CreatureDef = PlayerData.creature_library.get_creature_def(CreatureLibrary.PLAYER_ID)
 		if creature_def:
 			_event.chat_theme_def = creature_def.chat_theme_def

--- a/project/src/test/ui/chat/test-chatscript-parser.gd
+++ b/project/src/test/ui/chat/test-chatscript-parser.gd
@@ -8,6 +8,7 @@ const CUTSCENE_META := "res://assets/test/ui/chat/cutscene-meta.chat"
 const CHAT_CONDITION := "res://assets/test/ui/chat/chat-condition.chat"
 const CHAT_FULL := "res://assets/test/ui/chat/chat-full.chat"
 const CHAT_LINK_MOOD := "res://assets/test/ui/chat/chat-link-mood.chat"
+const CHAT_NEWLINES := "res://assets/test/ui/chat/chat-newlines.chat"
 const CHAT_THOUGHT := "res://assets/test/ui/chat/chat-thought.chat"
 
 func _chat_tree_from_file(path: String) -> ChatTree:
@@ -153,3 +154,12 @@ func test_chat_condition() -> void:
 	chat_tree.advance()
 	assert_eq(chat_tree.get_event().links, ["first-time", "not-first-time", "other"])
 	assert_eq(chat_tree.get_event().enabled_link_indexes(), [1, 2])
+
+
+func test_newlines() -> void:
+	var chat_tree := _chat_tree_from_file(CHAT_NEWLINES)
+	chat_tree.advance()
+	assert_eq(chat_tree.get_event().text, "(Hmm...\nYou're not sure.)")
+	chat_tree.advance()
+	assert_eq(chat_tree.get_event().text, "Anyway!\nUmm, it's nice to meet you.")
+	assert_eq(chat_tree.get_event().link_texts[0], "Oh!\nHi!")


### PR DESCRIPTION
Godot's JSON parser automatically translates '\n' into newlines in
strings, but my Chatscript parser did not do this.