### PR TITLE
Camera tween follows player. No chat icons in cutscenes.

### DIFF
--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -213,16 +213,6 @@ func _on_ChatUi_pop_out_completed() -> void:
 		_next_chat_tree = null
 		$Control/ChatUi.play_chat_tree(_current_chat_tree)
 	else:
-		# unset mood
-		for chatter in chatters:
-			if chatter and chatter.has_method("play_mood"):
-				chatter.call("play_mood", ChatEvent.Mood.DEFAULT)
-		
-		chatters = []
-		ChattableManager.set_focus_enabled(true)
-		_update_visible()
-		emit_signal("chat_ended")
-		
 		if Breadcrumb.trail.size() >= 2 and Breadcrumb.trail[1] == Global.SCENE_CUTSCENE_DEMO:
 			# don't launch the level; go back to CutsceneDemo after playing the cutscene
 			SceneTransition.pop_trail()
@@ -238,6 +228,13 @@ func _on_ChatUi_pop_out_completed() -> void:
 			# ending cutscene finished playing
 			CurrentLevel.clear_launched_level()
 			SceneTransition.pop_trail()
+		else:
+			# if we're in a regular overworld conversation and not a cutscene,
+			# restore the ui so the player can interact again
+			chatters = []
+			emit_signal("chat_ended")
+			ChattableManager.set_focus_enabled(true)
+			_update_visible()
 
 
 func _on_ChatUi_chat_event_played(chat_event: ChatEvent) -> void:
@@ -270,7 +267,7 @@ func _on_ChatUi_chat_event_played(chat_event: ChatEvent) -> void:
 		emit_signal("chatter_talked", chatter)
 
 
-func _on_Creature_fade_out_finished(creature: Creature) -> void:
+func _on_Creature_fade_out_finished(_creature: Creature) -> void:
 	emit_signal("visible_chatters_changed")
 
 

--- a/project/src/main/world/overworld-camera.gd
+++ b/project/src/main/world/overworld-camera.gd
@@ -134,10 +134,19 @@ func _tween_camera_to_chatters() -> void:
 	_tween.remove_all()
 	var new_zoom := _calculate_zoom()
 	var new_position := _calculate_position()
+	
 	_tween.interpolate_property(self, "zoom", zoom, new_zoom,
 			ZOOM_DURATION, Tween.TRANS_SINE, Tween.EASE_IN_OUT)
-	_tween.interpolate_property(self, "position", position, new_position,
-			ZOOM_DURATION, Tween.TRANS_SINE, Tween.EASE_IN_OUT)
+	
+	if not close_up:
+		# camera will follow the player; the tween should track the player's position
+		_tween.follow_property(self, "position", position,
+				ChattableManager.player, "position",
+				ZOOM_DURATION, Tween.TRANS_SINE, Tween.EASE_IN_OUT)
+	else:
+		_tween.interpolate_property(self, "position", position,
+				new_position,
+				ZOOM_DURATION, Tween.TRANS_SINE, Tween.EASE_IN_OUT)
 	_tween.start()
 
 


### PR DESCRIPTION
The camera tween now follows the player when they exit a conversation.
Before, the camera would tween to the player's previous position, and
then snap to them if they moved. This resulted in an awkward behavior
where they could run almost off the screen, and then the camera would
jolt over to them.

Chat icons no longer reappear at the end of a cutscene. This was
especially strange when characters had left a chat, as it resulted in a
floating chat icon with no target.