### PR TITLE
Fixed crash in 'only drop X pieces' levels

### DIFF
--- a/project/assets/main/creatures/secondary/tunathy.json
+++ b/project/assets/main/creatures/secondary/tunathy.json
@@ -1,0 +1,40 @@
+{
+  "version": "19dd",
+  "id": "tunathy",
+  "name": "Tunathy",
+  "short_name": "Tunathy",
+  "dna": {
+    "belly": "1",
+    "bellybutton": "0",
+    "body": "1",
+    "cheek": "2",
+    "collar": "0",
+    "ear": "1",
+    "eye": "8",
+    "hair": "0",
+    "head": "5",
+    "horn": "0",
+    "mouth": "6",
+    "nose": "2",
+    "tail": "0",
+    "accessory": "0",
+    "line_rgb": "6c4331",
+    "body_rgb": "b23823",
+    "belly_rgb": "ffd461",
+    "cloth_rgb": "a7b958",
+    "glass_rgb": "72d2eb",
+    "plastic_rgb": "292828",
+    "hair_rgb": "af845c",
+    "eye_rgb": "a7b958 ecf1bf",
+    "horn_rgb": "f1e398"
+  },
+  "chat_theme_def": {
+    "accent_scale": 1.33,
+    "accent_swapped": true,
+    "accent_texture": 13,
+    "color": "b23823"
+  },
+  "fatness": 1.2,
+  "weight_gain_scale": 1,
+  "metabolism_scale": 1
+}

--- a/project/src/main/editor/puzzle/LevelEditor.tscn
+++ b/project/src/main/editor/puzzle/LevelEditor.tscn
@@ -476,6 +476,7 @@ dialog_autowrap = true
 [node name="SettingsMenu" parent="." instance=ExtResource( 9 )]
 
 [node name="SceneTransitionCover" parent="." instance=ExtResource( 18 )]
+
 [connection signal="tile_map_changed" from="HBoxContainer/TabContainer/Playfield/CenterPanel/Playfield" to="HBoxContainer/SideButtons/Json" method="_on_Playfield_tile_map_changed"]
 [connection signal="pressed" from="HBoxContainer/SideButtons/OpenFile" to="Dialogs" method="_on_OpenFile_pressed"]
 [connection signal="pressed" from="HBoxContainer/SideButtons/OpenResource" to="Dialogs" method="_on_OpenResource_pressed"]

--- a/project/src/main/puzzle/piece/next-piece-display.gd
+++ b/project/src/main/puzzle/piece/next-piece-display.gd
@@ -21,7 +21,7 @@ func _process(_delta: float) -> void:
 	var next_piece: NextPiece = PieceQueue.get_next_piece(_piece_index)
 	if next_piece.type != _displayed_type or next_piece.orientation != _displayed_orientation:
 		_tile_map.clear()
-		if next_piece != PieceTypes.piece_null:
+		if next_piece.type != PieceTypes.piece_null:
 			var bounding_box := Rect2( \
 					next_piece.type.get_cell_position(next_piece.orientation, 0), Vector2(1.0, 1.0))
 			# update the tilemap with the new piece type


### PR DESCRIPTION
This crash occurred when the next piece display needed to display a
'null piece'. The null piece check was not properly changed after the 'next
pieces can rotate' gimmick was implemented.

New creature: Tunathy