### PR TITLE
Sort signal connections. Reset creature colors, emote positions

### DIFF
--- a/delint.sh
+++ b/delint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ################################################################################
 # Analyzes code and assets for stylistic errors, correcting them or printing
 # them to the console
@@ -83,4 +83,25 @@ then
   find project/assets -name "*.chat" -exec sed -i "s/[…]/.../g" {} +
   find project/assets -name "*.chat" -exec sed -i "s/[’]/\'/g" {} +
   find project/assets -name "*.chat" -exec sed -i "s/[“”]/\"/g" {} +
+fi
+
+# sort signal connections
+if [ "$CLEAN" ]
+then
+  while read -r IN_FILE
+  do
+    echo "Sorting signal connections in $IN_FILE..."
+    OUT_FILE="$IN_FILE"~
+
+    FIRST_LINE=$(awk '/^\[connection signal/{print NR; exit}' "$IN_FILE")
+    LINE_COUNT=$(grep -c "^\[connection signal" "$IN_FILE")
+
+    (head -n $(("$FIRST_LINE" - 1)); head -n "$LINE_COUNT" | sort; cat ) < "$IN_FILE" 1<> "$OUT_FILE"~
+    mv -f "$OUT_FILE"~ "$IN_FILE"
+  done < <(git diff master --name-only | grep "\.tscn$")
+
+  # The preceding command sorts only modified files. Sorting all files takes longer but can be done by replacing the
+  # preceding loop condition:
+  #
+  # done < <(find project/src -type f -name '*.tscn' -print)
 fi

--- a/project/src/main/world/creature/creature-animations.gd
+++ b/project/src/main/world/creature/creature-animations.gd
@@ -63,6 +63,18 @@ func set_emote_eye_frame(new_emote_eye_frame: int) -> void:
 	_refresh_emote_eye_frame()
 
 
+"""
+Resets the eye/arm frames to default values.
+
+This is used during development to ensure the .tscn file doesn't include unnecessary changes when we play animations
+in the Godot editor. It is not used during the game.
+"""
+func reset() -> void:
+	set_emote_eye_frame(0)
+	set_eye_frame(0)
+	set_emote_arm_frame(0)
+
+
 func play_idle_animation(idle_anim: String) -> void:
 	_idle_timer.play_idle_animation(idle_anim)
 
@@ -189,6 +201,9 @@ func _refresh_creature_visuals_path() -> void:
 
 
 func _on_CreatureVisuals_orientation_changed(_old_orientation: int, new_orientation: int) -> void:
+	if not _movement_player:
+		return
+	
 	if _movement_player.current_animation == "idle-nw" and CreatureOrientation.oriented_south(new_orientation):
 		_movement_player.play("idle-se")
 	elif _movement_player.current_animation == "idle-se" and CreatureOrientation.oriented_north(new_orientation):

--- a/project/src/main/world/creature/dna-loader.gd
+++ b/project/src/main/world/creature/dna-loader.gd
@@ -54,6 +54,7 @@ func unload_dna() -> void:
 		"Sprint",
 		"TailZ0",
 		"TailZ1",
+		"Neck0/HeadBobber",
 		"Neck0/HeadBobber/AccessoryZ0",
 		"Neck0/HeadBobber/AccessoryZ1",
 		"Neck0/HeadBobber/AccessoryZ2",
@@ -78,14 +79,16 @@ func unload_dna() -> void:
 		"Neck0/HeadBobber/Nose",
 	]:
 		if _creature_visuals.has_node(node_path):
-			var packed_sprite: PackedSprite = _creature_visuals.get_node(node_path)
-			packed_sprite.texture = null
-			packed_sprite.frame_data = ""
-			if packed_sprite.material:
-				packed_sprite.material.set_shader_param("red", Color.black)
-				packed_sprite.material.set_shader_param("green", Color.black)
-				packed_sprite.material.set_shader_param("blue", Color.black)
-				packed_sprite.material.set_shader_param("black", Color.black)
+			var node: Node2D = _creature_visuals.get_node(node_path)
+			if node is PackedSprite:
+				var packed_sprite: PackedSprite = node as PackedSprite
+				packed_sprite.texture = null
+				packed_sprite.frame_data = ""
+			if node.get("material"):
+				node.material.set_shader_param("red", Color.black)
+				node.material.set_shader_param("green", Color.black)
+				node.material.set_shader_param("blue", Color.black)
+				node.material.set_shader_param("black", Color.black)
 	
 	_creature_visuals.get_node("Neck0/HeadBobber").position = Vector2(0, -100)
 	_creature_visuals.rescale(1.00)
@@ -99,6 +102,7 @@ func unload_dna() -> void:
 	_remove_dna_node("Body/NeckBlend")
 	_remove_dna_node("Body/Shadows")
 	_creature_visuals.get_node("Body").refresh_children()
+	_creature_visuals.get_node("Animations").reset()
 
 
 """

--- a/project/src/main/world/creature/emote-player.gd
+++ b/project/src/main/world/creature/emote-player.gd
@@ -394,12 +394,26 @@ green.
 """
 func _post_unemote() -> void:
 	for emote_sprite in _emote_sprites:
-		emote_sprite.scale = Vector2(2.0, 2.0)
-		emote_sprite.rotation_degrees = 0.0
+		emote_sprite.frame = 0
 		emote_sprite.modulate = Color.transparent
+		emote_sprite.rotation_degrees = 0.0
+		emote_sprite.scale = Vector2(2.0, 2.0)
+		emote_sprite.position = Vector2(0, 0)
+		if emote_sprite.material:
+			if emote_sprite.material.get("blend_mode"):
+				emote_sprite.material.blend_mode = SpatialMaterial.BLEND_MODE_MIX
+			if emote_sprite.material.has_method("set_shader_param") and Engine.is_editor_hint():
+				# In the editor, we reset shader parameters to known values to avoid unnecessary churn in our scene
+				# files. At runtime, this behavior would be destructive since some of these values are only
+				# initialized when the creature is first loaded.
+				emote_sprite.material.set_shader_param("red", Color.black)
+				emote_sprite.material.set_shader_param("green", Color.black)
+				emote_sprite.material.set_shader_param("blue", Color.black)
+				emote_sprite.material.set_shader_param("black", Color.black)
+	_creature_visuals.get_node("Neck0/HeadBobber/EmoteBrain").material.set_shader_param("red", Color.white)
 	_creature_visuals.get_node("EmoteBody").scale = Vector2(0.836, 0.836)
+	_creature_visuals.get_node("Neck0/HeadBobber/EmoteHead").position = Vector2( 0, 256 )
 	_creature_visuals.get_node("Neck0").scale = Vector2(1.0, 1.0)
-	_creature_visuals.get_node("Neck0/HeadBobber/EmoteGlow").material.blend_mode = SpatialMaterial.BLEND_MODE_MIX
 
 
 """


### PR DESCRIPTION
delint.sh now sorts signal connections. By default Godot shuffles signal
connections randomly, and sometimes randomly drops signal connections as
well. This makes it easy to accidentally remove signals, and for those
deletions to be obfuscated in a huge sea of changes. Alphabetizing the
list should give us a chance to catch those kinds of bugs during code
review.

The 'reset_creature' option in CreatureVisuals.tscn now resets their
colors, shader parameters, and emote positions. This cuts down on
unnecessary noise during commits involving the CreatureVisuals class.

Delint.sh now uses bash script instead of shell script. In POSIX sh,
proecss substitution is undefined.