### PR TITLE
Refactor: '!' -> 'not'. LevelSelect nodepath. ChatLibrary 'state' dict.

### DIFF
--- a/project/assets/main/creatures/primary/boatricia/creature.json
+++ b/project/assets/main/creatures/primary/boatricia/creature.json
@@ -33,12 +33,12 @@
     },
     {
       "chat": "my_maid_died",
-      "if_condition": "notable",
+      "available_if": "notable",
       "repeat": 999999
     },
     {
       "chat": "life_is_so_short",
-      "if_condition": "notable",
+      "available_if": "notable",
       "repeat": 999999
     }
   ]

--- a/project/src/demo/ui/chat/chat-frame-demo.gd
+++ b/project/src/demo/ui/chat/chat-frame-demo.gd
@@ -130,7 +130,7 @@ func _input(event: InputEvent) -> void:
 				_scale_index -= 1
 				_play_chat_event()
 		KEY_Z:
-			_squished = !_squished
+			_squished = not _squished
 			_play_chat_event()
 
 

--- a/project/src/demo/world/cutscene-demo.gd
+++ b/project/src/demo/world/cutscene-demo.gd
@@ -18,7 +18,7 @@ func _on_StartButton_pressed() -> void:
 	
 	if cutscene_index >= 0 and cutscene_index < 100:
 		# launch 'before level' cutscene
-		CurrentLevel.push_cutscene_trail(true)
+		CurrentLevel.push_preroll_trail(true)
 	elif cutscene_index >= 100 and cutscene_index < 200:
 		# launch 'after level' cutscene
 		CurrentLevel.cutscene_state = CurrentLevel.CutsceneState.AFTER

--- a/project/src/main/keybind/keybind-manager.gd
+++ b/project/src/main/keybind/keybind-manager.gd
@@ -103,7 +103,7 @@ Parameters:
 	'input_events': the InputEvents to bind
 """
 func _bind_keys(action_name: String, input_events: Array) -> void:
-	if !InputMap.has_action(action_name):
+	if not InputMap.has_action(action_name):
 		InputMap.add_action(action_name)
 	InputMap.action_erase_events(action_name)
 	for input_event in input_events:

--- a/project/src/main/puzzle/chalkboard.gd
+++ b/project/src/main/puzzle/chalkboard.gd
@@ -5,8 +5,8 @@ Chalkboard which displays the player's score and progress during a puzzle.
 
 func _ready() -> void:
 	CurrentLevel.connect("settings_changed", self, "_on_Level_settings_changed")
-	visible = !CurrentLevel.settings.other.tutorial
+	visible = not CurrentLevel.settings.other.tutorial
 
 
 func _on_Level_settings_changed() -> void:
-	visible = !CurrentLevel.settings.other.tutorial
+	visible = not CurrentLevel.settings.other.tutorial

--- a/project/src/main/puzzle/frame-drops-label.gd
+++ b/project/src/main/puzzle/frame-drops-label.gd
@@ -83,7 +83,7 @@ func _reset() -> void:
 
 func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDetector) -> void:
 	if cheat == "bigfps":
-		visible = !visible
+		visible = not visible
 		_reset()
 		if visible:
 			_refresh_text()

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -110,12 +110,13 @@ Parameters:
 Returns:
 	'true' if the cutscene was launched, or 'false' if the cutscene was not found or did not specify a location id
 """
-func push_cutscene_trail(force: bool = false) -> bool:
-	if not creature_id:
-		return false
-	
+func push_preroll_trail(force: bool = false) -> bool:
 	var result := false
-	var chat_tree: ChatTree = ChatLibrary.chat_tree_for_creature_id(creature_id, level_id)
+	
+	var chat_tree: ChatTree
+	if level_id and ChatLibrary.has_preroll(level_id):
+		chat_tree = ChatLibrary.chat_tree_for_preroll(level_id)
+
 	if chat_tree and (chat_tree.location_id or force):
 		SceneTransition.push_trail(chat_tree.cutscene_scene_path())
 		result = true

--- a/project/src/main/puzzle/piece/next-piece-displays.gd
+++ b/project/src/main/puzzle/piece/next-piece-displays.gd
@@ -41,4 +41,4 @@ func _on_PuzzleState_game_prepared() -> void:
 
 func _on_Pauser_paused_changed(value: bool) -> void:
 	for display in _next_piece_displays:
-		display.visible = !value
+		display.visible = not value

--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -246,7 +246,7 @@ func _on_PuzzleState_after_level_changed() -> void:
 
 
 func _on_Pauser_paused_changed(value: bool) -> void:
-	visible = !value
+	visible = not value
 
 
 func _on_Dropper_hard_dropped() -> void: emit_signal("hard_dropped")

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -171,5 +171,5 @@ func _on_FrostingGlobs_hit_playfield(glob: Node) -> void:
 
 
 func _on_Pauser_paused_changed(value: bool) -> void:
-	$TileMapClip.visible = !value
-	$ShadowTexture.visible = !value
+	$TileMapClip.visible = not value
+	$ShadowTexture.visible = not value

--- a/project/src/main/puzzle/puzzle-trace.gd
+++ b/project/src/main/puzzle/puzzle-trace.gd
@@ -52,5 +52,5 @@ func input_char(frame_input: FrameInput, character: String) -> String:
 
 func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDetector) -> void:
 	if cheat == "delays":
-		visible = !visible
+		visible = not visible
 		detector.play_cheat_sound(visible)

--- a/project/src/main/puzzle/star-seeds.gd
+++ b/project/src/main/puzzle/star-seeds.gd
@@ -280,4 +280,4 @@ func _on_Playfield_before_line_cleared(y: int, _total_lines: int, _remaining_lin
 
 
 func _on_Pauser_paused_changed(value: bool) -> void:
-	visible = !value
+	visible = not value

--- a/project/src/main/ui/fps-label.gd
+++ b/project/src/main/ui/fps-label.gd
@@ -9,5 +9,5 @@ func _process(_delta: float) -> void:
 
 func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDetector) -> void:
 	if cheat == "bigfps":
-		visible = !visible
+		visible = not visible
 		detector.play_cheat_sound(visible)

--- a/project/src/main/ui/level-select/LevelSelectPanel.tscn
+++ b/project/src/main/ui/level-select/LevelSelectPanel.tscn
@@ -45,6 +45,7 @@ script = ExtResource( 6 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+level_buttons_path = NodePath("VBoxContainer/Top/ScrollContainer/MarginContainer/LevelButtons")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 anchor_right = 1.0

--- a/project/src/main/ui/level-select/level-buttons.gd
+++ b/project/src/main/ui/level-select/level-buttons.gd
@@ -37,7 +37,7 @@ export (PackedScene) var LevelSelectButtonScene: PackedScene
 export (PackedScene) var WorldSelectButtonScene: PackedScene
 
 # Allows for hiding/showing certain levels
-export (LevelsToInclude) var levels_to_include := ALL_LEVELS
+export (LevelsToInclude) var levels_to_include := ALL_LEVELS setget set_levels_to_include
 
 # VBoxContainer instances containing columns of level buttons
 var _max_row_count
@@ -49,6 +49,15 @@ var _column_width := COLUMN_WIDTH_SMALL
 var _duration_calculator := DurationCalculator.new()
 
 func _ready() -> void:
+	_clear_contents()
+	_add_buttons()
+
+
+func set_levels_to_include(new_levels_to_include: int) -> void:
+	if levels_to_include == new_levels_to_include:
+		return
+	
+	levels_to_include = new_levels_to_include
 	_clear_contents()
 	_add_buttons()
 
@@ -214,7 +223,7 @@ func _on_LevelSelectButton_level_started(settings: LevelSettings) -> void:
 		play_cutscene = ChatLibrary.should_play_cutscene(chat_tree)
 	
 	if play_cutscene:
-		if not CurrentLevel.push_cutscene_trail(true):
+		if not CurrentLevel.push_preroll_trail(true):
 			CurrentLevel.push_level_trail()
 	else:
 		CurrentLevel.push_level_trail()

--- a/project/src/main/ui/level-select/level-select.gd
+++ b/project/src/main/ui/level-select/level-select.gd
@@ -3,9 +3,15 @@ extends Control
 The level select screen which shows buttons and level info.
 """
 
-# Allows for hiding/showing certain levels.
-# Virtual property; value is only exposed through getters/setters
+export (NodePath) var level_buttons_path: NodePath
+
+# Allows for hiding/showing certain levels
 export (LevelButtons.LevelsToInclude) var levels_to_include: int setget set_levels_to_include
+
+onready var _level_buttons: LevelButtons = get_node(level_buttons_path)
+
+func _ready() -> void:
+	_level_buttons.levels_to_include = levels_to_include
 
 """
 Parameters:
@@ -13,11 +19,19 @@ Parameters:
 			showing certain levels.
 """
 func set_levels_to_include(new_levels_to_include: int) -> void:
-	$VBoxContainer/Top/ScrollContainer/MarginContainer/LevelButtons.levels_to_include = new_levels_to_include
+	levels_to_include = new_levels_to_include
+	_refresh_levels_to_include()
 
 
 func get_levels_to_include() -> int:
-	return $VBoxContainer/Top/ScrollContainer/MarginContainer/LevelButtons.levels_to_include
+	return levels_to_include
+
+
+func _refresh_levels_to_include() -> void:
+	if not is_inside_tree():
+		return
+	
+	_level_buttons.levels_to_include = levels_to_include
 
 
 func _on_SettingsMenu_quit_pressed() -> void:

--- a/project/src/main/ui/menu/settings-menu.gd
+++ b/project/src/main/ui/menu/settings-menu.gd
@@ -106,4 +106,4 @@ func _on_Settings_pressed() -> void:
 func _on_CustomKeybindButton_awaiting_changed(awaiting: bool) -> void:
 	# when the user is rebinding their keys, we disable the shortcut helper. otherwise trying to rebind something like
 	# 'escape' will close the settings menu
-	$Window/UiArea/Bottom/Ok/ShortcutHelper.set_process_input(!awaiting)
+	$Window/UiArea/Bottom/Ok/ShortcutHelper.set_process_input(not awaiting)

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -307,20 +307,23 @@ func _on_TalkButton_pressed() -> void:
 	get_tree().set_input_as_handled()
 	
 	var level_id: String = ChattableManager.focused_chattable_level_id()
-	var chat_tree := _focused_chattable_chat_tree()
 	
+	var chat_tree: ChatTree
 	if level_id:
 		CurrentLevel.set_launched_level(level_id)
+		if ChatLibrary.has_preroll(level_id):
+			chat_tree = ChatLibrary.chat_tree_for_preroll(level_id)
 		if ChatLibrary.should_play_cutscene(chat_tree):
 			# launch a cutscene if a location change is necessary
-			if not CurrentLevel.push_cutscene_trail():
+			if not CurrentLevel.push_preroll_trail():
 				# if no cutscene was launched, start a chat
 				start_chat(chat_tree, ChattableManager.focused_chattable)
 		else:
 			# if there is no cutscene/chat, or if the cutscene should be skipped, skip to the level
 			CurrentLevel.push_level_trail()
 	else:
-		# if no cutscene was launched, start a chat
+		# load the conversation and start a chat
+		chat_tree = _focused_chattable_chat_tree()
 		start_chat(chat_tree, ChattableManager.focused_chattable)
 
 

--- a/project/src/test/ui/chat/test-chat-library.gd
+++ b/project/src/test/ui/chat/test-chat-library.gd
@@ -30,15 +30,12 @@ var _chat_selectors := [
 	},
 ]
 
-var _state := {}
+var _creature_id := "gurus750"
 
 var _filler_ids := ["filler_000", "filler_001"]
 
 func before_each() -> void:
 	PlayerData.chat_history.reset()
-	
-	_state["creature_id"] = "gurus750"
-	_state["level_num"] = 1
 	
 	PlayerData.chat_history.add_history_item("chat/gurus750/level_001")
 	PlayerData.chat_history.add_history_item("chat/gurus750/level_002")
@@ -46,34 +43,38 @@ func before_each() -> void:
 	PlayerData.chat_history.add_history_item("chat/gurus750/notable_001")
 	PlayerData.chat_history.add_history_item("chat/gurus750/notable_002")
 	
-	PlayerData.chat_history.increment_filler_count("gurus750")
+	PlayerData.chat_history.increment_filler_count(_creature_id)
+
+
+func _select_from_chat_selectors() -> String:
+	return ChatLibrary.select_from_chat_selectors(_chat_selectors, _creature_id, _filler_ids)
 
 
 func test_greeting() -> void:
 	PlayerData.chat_history.delete_history_item("chat/gurus750/greeting_001")
 	
-	assert_eq(ChatLibrary.select_from_chat_selectors(_chat_selectors, _state, _filler_ids), "greeting_001")
+	assert_eq(_select_from_chat_selectors(), "greeting_001")
 
 
 func test_chat_1() -> void:
 	PlayerData.chat_history.delete_history_item("chat/gurus750/notable_001")
 	
-	assert_eq(ChatLibrary.select_from_chat_selectors(_chat_selectors, _state, _filler_ids), "notable_001")
+	assert_eq(_select_from_chat_selectors(), "notable_001")
 
 
 func test_chat_2() -> void:
 	PlayerData.chat_history.delete_history_item("chat/gurus750/notable_002")
 	
-	assert_eq(ChatLibrary.select_from_chat_selectors(_chat_selectors, _state, _filler_ids), "notable_002")
+	assert_eq(_select_from_chat_selectors(), "notable_002")
 
 
 func test_chat_no_notable_chats_remaining() -> void:
-	assert_eq(ChatLibrary.select_from_chat_selectors(_chat_selectors, _state, _filler_ids), "filler_000")
+	assert_eq(_select_from_chat_selectors(), "filler_000")
 
 
 func test_chat_avoid_repeat_filler() -> void:
 	PlayerData.chat_history.add_history_item("chat/gurus750/filler_000")
-	assert_eq(ChatLibrary.select_from_chat_selectors(_chat_selectors, _state, _filler_ids), "filler_001")
+	assert_eq(_select_from_chat_selectors(), "filler_001")
 
 
 func test_chat_non_notable() -> void:
@@ -83,17 +84,17 @@ func test_chat_non_notable() -> void:
 	PlayerData.chat_history.delete_history_item("chat/gurus750/notable_001")
 	PlayerData.chat_history.delete_history_item("chat/gurus750/notable_002")
 	
-	assert_eq(ChatLibrary.select_from_chat_selectors(_chat_selectors, _state, _filler_ids), "filler_000")
+	assert_eq(_select_from_chat_selectors(), "filler_000")
 
 
 func test_chat_prioritized() -> void:
 	# priority_001 is skipped because its 'available_if' condition is not met
 	PlayerData.chat_history.add_history_item("chat/gurus750/trigger_002")
-	assert_eq(ChatLibrary.select_from_chat_selectors(_chat_selectors, _state, _filler_ids), "priority_002")
+	assert_eq(_select_from_chat_selectors(), "priority_002")
 	
 	# priority_001 and priority_002 are both available, so the earlier chat is prioritized
 	PlayerData.chat_history.add_history_item("chat/gurus750/trigger_001")
-	assert_eq(ChatLibrary.select_from_chat_selectors(_chat_selectors, _state, _filler_ids), "priority_001")
+	assert_eq(_select_from_chat_selectors(), "priority_001")
 
 
 func test_add_lull_characters_no_effect() -> void:


### PR DESCRIPTION
Replaced '!' operator with 'not'. GDScript guidelines recommend plain english
versions of operators.

level-select.gd now references its LevelButtons instance with a NodePath. This
requires more code but prevents things from breaking when reorganizing
the node tree.

Removed vestigial 'creature_chat_state' from ChatLibrary. The 'notable'
and 'level_id' functionality were moved into other places, so we were just
passing around a dictionary with a creature_id.

Minor tweaks to ChatLibrary to ensure focused_chattable_chat_tree() is
not invoked when starting a level. This prevents creatures from making
incongruent chit chat before their level is launched.

Changed CurrentLevel.push_cutscene_trail() to push_preroll_trail() to
make its purpose more clear.

Fixed boatricia's chat tree to use 'available_if'. The absence of this
flag was skipping her filler dialog.