### PR TITLE
CutsceneDemo improvements; 'flags', save state

### DIFF
--- a/project/src/demo/DemoSave.tscn
+++ b/project/src/demo/DemoSave.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/demo/demo-save.gd" type="Script" id=1]
+
+[node name="DemoSave" type="Node"]
+script = ExtResource( 1 )

--- a/project/src/demo/demo-save.gd
+++ b/project/src/demo/demo-save.gd
@@ -1,0 +1,42 @@
+extends Node
+"""
+Reads and writes data about demos from a file.
+
+This allows demos to remember a developer's selections, so that they don't need to keep retyping or reselecting the
+same choices.
+
+This data is stored independently of the player data to prevent demos from overwriting the developer's game data
+with invalid data. Demos often put the game into a weird state temporarily, and we don't want to persist this weird
+temporary data.
+"""
+
+# the path to the save file
+const FILENAME := "user://demo-data.json"
+
+# the json data read from the save file
+var demo_data := {}
+
+func _ready() -> void:
+	demo_data.clear()
+	load_demo_data()
+
+
+"""
+Writes the developer's in-memory data to a save file.
+"""
+func save_demo_data() -> void:
+	FileUtils.write_file(FILENAME, Utils.print_json(demo_data))
+
+
+"""
+Populates the player's in-memory data based on their save files.
+"""
+func load_demo_data() -> void:
+	var file := File.new()
+	var open_result := file.open(FILENAME, File.READ)
+	if open_result == OK:
+		var save_json_text := FileUtils.get_file_as_text(FILENAME)
+		demo_data = parse_json(save_json_text)
+	else:
+		# validation failed; couldn't open file
+		push_warning("Couldn't open file '%s' for reading: %s" % [FILENAME, open_result])

--- a/project/src/demo/world/CutsceneDemo.tscn
+++ b/project/src/demo/world/CutsceneDemo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=1]
 [ext_resource path="res://src/demo/world/cutscene-demo.gd" type="Script" id=2]
@@ -6,48 +6,73 @@
 [ext_resource path="res://src/demo/world/cutscene-demo-fatness.gd" type="Script" id=4]
 [ext_resource path="res://src/demo/world/cutscene-demo-long-names.gd" type="Script" id=5]
 [ext_resource path="res://src/main/ui/SceneTransitionCover.tscn" type="PackedScene" id=6]
+[ext_resource path="res://src/main/ui/menu/theme/h5.theme" type="Theme" id=7]
+[ext_resource path="res://src/demo/world/cutscene-demo-flags.gd" type="Script" id=8]
+[ext_resource path="res://src/demo/DemoSave.tscn" type="PackedScene" id=9]
+[ext_resource path="res://src/demo/world/cutscene-demo-open.gd" type="Script" id=10]
 
 [node name="CutsceneDemo" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource( 2 )
 __meta__ = {
+"_edit_lock_": true,
 "_edit_use_anchors_": false
 }
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="Input" type="VBoxContainer" parent="."]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 margin_left = -200.0
-margin_top = -30.0
+margin_top = -114.0
 margin_right = 200.0
-margin_bottom = 30.0
+margin_bottom = 114.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="LongNames" type="CheckBox" parent="VBoxContainer"]
+[node name="Flags" type="VBoxContainer" parent="Input"]
 margin_right = 400.0
-margin_bottom = 28.0
+margin_bottom = 124.0
+script = ExtResource( 8 )
+
+[node name="Label" type="Label" parent="Input/Flags"]
+margin_right = 400.0
+margin_bottom = 20.0
+theme = ExtResource( 1 )
+text = "Flags"
+
+[node name="TextEdit" type="TextEdit" parent="Input/Flags"]
+margin_top = 24.0
+margin_right = 400.0
+margin_bottom = 124.0
+rect_min_size = Vector2( 0, 100 )
+theme = ExtResource( 7 )
+text = "chat_finished puzzle/levels/cutscenes/marsh/pulling_for_skins_100"
+
+[node name="LongNames" type="CheckBox" parent="Input"]
+margin_top = 128.0
+margin_right = 400.0
+margin_bottom = 156.0
 theme = ExtResource( 1 )
 text = "Long Names"
 script = ExtResource( 5 )
 
-[node name="Fatness" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 32.0
+[node name="Fatness" type="HBoxContainer" parent="Input"]
+margin_top = 160.0
 margin_right = 400.0
-margin_bottom = 60.0
+margin_bottom = 188.0
 script = ExtResource( 4 )
 
-[node name="CheckBox" type="CheckBox" parent="VBoxContainer/Fatness"]
+[node name="CheckBox" type="CheckBox" parent="Input/Fatness"]
 margin_right = 90.0
 margin_bottom = 28.0
 theme = ExtResource( 1 )
 text = "Fatness"
 
-[node name="HSlider" type="HSlider" parent="VBoxContainer/Fatness"]
+[node name="HSlider" type="HSlider" parent="Input/Fatness"]
 margin_left = 94.0
 margin_right = 361.0
 margin_bottom = 28.0
@@ -59,7 +84,7 @@ value = 10.0
 tick_count = 10
 ticks_on_borders = true
 
-[node name="Value" type="Label" parent="VBoxContainer/Fatness"]
+[node name="Value" type="Label" parent="Input/Fatness"]
 margin_left = 365.0
 margin_top = 4.0
 margin_right = 400.0
@@ -70,12 +95,13 @@ theme = ExtResource( 1 )
 text = "10.0"
 align = 1
 
-[node name="Open" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 64.0
+[node name="Open" type="HBoxContainer" parent="Input"]
+margin_top = 192.0
 margin_right = 400.0
-margin_bottom = 94.0
+margin_bottom = 222.0
+script = ExtResource( 10 )
 
-[node name="Button" type="Button" parent="VBoxContainer/Open"]
+[node name="Button" type="Button" parent="Input/Open"]
 margin_right = 52.0
 margin_bottom = 30.0
 theme = ExtResource( 1 )
@@ -84,21 +110,21 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="LineEdit" type="LineEdit" parent="VBoxContainer/Open"]
+[node name="LineEdit" type="LineEdit" parent="Input/Open"]
 margin_left = 56.0
 margin_right = 400.0
 margin_bottom = 30.0
 size_flags_horizontal = 3
 theme = ExtResource( 1 )
-text = "marsh/hello_everyone_000"
+text = "marsh/pulling_for_bones_100"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="StartButton" type="Button" parent="VBoxContainer"]
-margin_top = 98.0
+[node name="StartButton" type="Button" parent="Input"]
+margin_top = 226.0
 margin_right = 400.0
-margin_bottom = 124.0
+margin_bottom = 252.0
 theme = ExtResource( 1 )
 text = "Start"
 __meta__ = {
@@ -111,6 +137,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
 __meta__ = {
+"_edit_lock_": true,
 "_edit_use_anchors_": false
 }
 
@@ -144,13 +171,15 @@ dialog_autowrap = true
 
 [node name="SceneTransitionCover" parent="." instance=ExtResource( 6 )]
 
-[connection signal="toggled" from="VBoxContainer/LongNames" to="VBoxContainer/LongNames" method="_on_toggled"]
-[connection signal="pressed" from="VBoxContainer/Fatness/CheckBox" to="VBoxContainer/Fatness" method="_on_CheckBox_pressed"]
-[connection signal="value_changed" from="VBoxContainer/Fatness/HSlider" to="VBoxContainer/Fatness" method="_on_HSlider_value_changed"]
-[connection signal="pressed" from="VBoxContainer/Open/Button" to="." method="_on_OpenButton_pressed"]
-[connection signal="pressed" from="VBoxContainer/StartButton" to="." method="_on_StartButton_pressed"]
+[node name="DemoSave" parent="." instance=ExtResource( 9 )]
+
+[connection signal="about_to_show" from="Dialogs/Error" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
+[connection signal="popup_hide" from="Dialogs/Error" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
 [connection signal="about_to_show" from="Dialogs/OpenFile" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
 [connection signal="file_selected" from="Dialogs/OpenFile" to="." method="_on_OpenFileDialog_file_selected"]
 [connection signal="popup_hide" from="Dialogs/OpenFile" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
-[connection signal="about_to_show" from="Dialogs/Error" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
-[connection signal="popup_hide" from="Dialogs/Error" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
+[connection signal="pressed" from="Input/Fatness/CheckBox" to="Input/Fatness" method="_on_CheckBox_pressed"]
+[connection signal="value_changed" from="Input/Fatness/HSlider" to="Input/Fatness" method="_on_HSlider_value_changed"]
+[connection signal="toggled" from="Input/LongNames" to="Input/LongNames" method="_on_toggled"]
+[connection signal="pressed" from="Input/Open/Button" to="." method="_on_OpenButton_pressed"]
+[connection signal="pressed" from="Input/StartButton" to="." method="_on_StartButton_pressed"]

--- a/project/src/demo/world/cutscene-demo-flags.gd
+++ b/project/src/demo/world/cutscene-demo-flags.gd
@@ -1,0 +1,47 @@
+extends VBoxContainer
+"""
+UI input for specifying flags to assign or unassign during cutscenes.
+"""
+
+# Describes flags to assign or unassign during cutscenes
+# Virtual property; value is only exposed through getters/setters
+var value: String setget set_value, get_value
+
+"""
+Applies the text contents to the player's data.
+
+This involves assigning and unassigning conversations they've had and levels they've played based on the input. The
+input field supports the following flags:
+	
+	'chat_finished foo'
+	'not chat_finished foo'
+	'level_finished foo'
+	'not level_finished foo'
+"""
+func apply_flags() -> void:
+	for line_obj in $TextEdit.text.split("\n"):
+		var line: String = line_obj
+		if not line:
+			pass
+		elif line.begins_with("chat_finished "):
+			var history_key := StringUtils.substring_after(line, "chat_finished ")
+			PlayerData.chat_history.add_history_item(history_key)
+		elif line.begins_with("not chat_finished "):
+			var history_key := StringUtils.substring_after(line, "chat_finished ")
+			PlayerData.chat_history.delete_history_item(history_key)
+		elif line.begins_with("level_finished "):
+			var level_key := StringUtils.substring_after(line, "level_finished ")
+			PlayerData.level_history.finished_levels[level_key] = OS.get_datetime()
+		elif line.begins_with("not level_finished "):
+			var level_key := StringUtils.substring_after(line, "level_finished ")
+			PlayerData.level_history.finished_levels.erase(level_key)
+		else:
+			push_warning("Unrecognized flag: %s" % [line])
+
+
+func set_value(new_value: String) -> void:
+	$TextEdit.text = new_value
+
+
+func get_value() -> String:
+	return $TextEdit.text

--- a/project/src/demo/world/cutscene-demo-open.gd
+++ b/project/src/demo/world/cutscene-demo-open.gd
@@ -1,0 +1,15 @@
+extends HBoxContainer
+"""
+UI input for specifying the cutscene to open
+"""
+
+# The cutscene to open
+# Virtual property; value is only exposed through getters/setters
+var value: String setget set_value, get_value
+
+func set_value(new_value: String) -> void:
+	$LineEdit.text = new_value
+
+
+func get_value() -> String:
+	return $LineEdit.text


### PR DESCRIPTION
Added 'flags' field to CutsceneDemo. This allows developers to specify
things like 'chat_finished foo' 'not level_finished bar' to test
cutscenes under specific circumstances.

CutsceneDemo stores its state using a new 'DemoSave' script. This script
is generic and can save state for other demos as well.