### PR TITLE
Overworld labels stay in corners.

### DIFF
--- a/delint.sh
+++ b/delint.sh
@@ -154,9 +154,9 @@ fi
 # https://github.com/godotengine/godot/issues/35084
 if [ "$CLEAN" ]
 then
+  echo ""
   while read -r IN_FILE
   do
-    echo ""
     echo "Sorting signal connections in $IN_FILE..."
     OUT_FILE="$IN_FILE"~
 

--- a/project/src/main/world/OverworldUi.tscn
+++ b/project/src/main/world/OverworldUi.tscn
@@ -90,15 +90,8 @@ __meta__ = {
 }
 
 [node name="Labels" type="Control" parent="Control"]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -512.0
-margin_top = -300.0
-margin_right = 512.0
-margin_bottom = 300.0
-rect_min_size = Vector2( 1024, 600 )
+anchor_right = 1.0
+anchor_bottom = 1.0
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/project/src/test/ui/chat/test-chatscript-parser.gd
+++ b/project/src/test/ui/chat/test-chatscript-parser.gd
@@ -87,7 +87,7 @@ func test_cutscene_metadata() -> void:
 	assert_eq(chat_tree.get_event().meta, ["creature-exit john", "creature-exit jane"])
 
 
-func test_cutscene_self_chat() -> void:
+func test_cutscene_thought() -> void:
 	var chat_tree := _chat_tree_from_file(CUTSCENE_META)
 	chat_tree.advance()
 	var event := chat_tree.get_event()


### PR DESCRIPTION
The overworld labels now stay in corners when the game is resized.
Before they would stay towards the center of the screen.