### PR TITLE
Boatricia filler, facing fixes. Obstacle coordinates.

### DIFF
--- a/project/src/main/ui/chat/chat-library.gd
+++ b/project/src/main/ui/chat/chat-library.gd
@@ -170,7 +170,7 @@ func select_from_chat_selectors(chat_selectors: Array, creature_id: String, fill
 				result = filler_id
 				result_chat_age = chat_age
 			
-			if result and result_chat_age == -1:
+			if result and result_chat_age == ChatHistory.CHAT_AGE_NEVER:
 				break
 	
 	return result

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -95,10 +95,6 @@ func is_show_version() -> bool:
 Turn the the active chat participants towards each other, and make them face the camera.
 """
 func make_chatters_face_eachother() -> void:
-	if cutscene:
-		# don't automatically orient characters during cutscenes
-		return
-	
 	var chatter_bounding_box: Rect2
 	chatter_bounding_box = get_chatter_bounding_box([], [ChattableManager.player, ChattableManager.sensei])
 	if not chatter_bounding_box:
@@ -238,7 +234,11 @@ func _on_ChatUi_pop_out_completed() -> void:
 
 
 func _on_ChatUi_chat_event_played(chat_event: ChatEvent) -> void:
-	make_chatters_face_eachother()
+	if cutscene:
+		# don't automatically orient characters during cutscenes
+		pass
+	else:
+		make_chatters_face_eachother()
 	
 	for meta_item_obj in chat_event.meta:
 		var meta_item: String = meta_item_obj

--- a/project/src/main/world/Overworld.tscn
+++ b/project/src/main/world/Overworld.tscn
@@ -498,6 +498,7 @@ position = Vector2( 2946.34, 823.922 )
 shadow_scale = 1.2
 
 [node name="ButtercupSign" parent="World/Obstacles" instance=ExtResource( 48 )]
+position = Vector2( 2171, 809 )
 
 [node name="MarshHouse1" parent="World/Obstacles" instance=ExtResource( 33 )]
 position = Vector2( 4634.93, 1161.59 )
@@ -556,6 +557,7 @@ player_spawn_id = "nw-player"
 sensei_spawn_id = "nw-sensei"
 
 [node name="MarshCrystal" parent="World/Obstacles" instance=ExtResource( 23 )]
+position = Vector2( 399, 700 )
 
 [node name="MarshCrystal2" parent="World/Obstacles" instance=ExtResource( 23 )]
 position = Vector2( -1469.98, 1670.85 )

--- a/project/src/main/world/environment/ButtercupSign.tscn
+++ b/project/src/main/world/environment/ButtercupSign.tscn
@@ -15,7 +15,6 @@ shader_param/edge_fix_factor = 1.0
 extents = Vector2( 105, 10 )
 
 [node name="ButtercupSign" type="KinematicBody2D"]
-position = Vector2( 2171.2, 808.832 )
 script = ExtResource( 1 )
 shadow_scale = 1.1
 

--- a/project/src/main/world/environment/MarshCrystal.tscn
+++ b/project/src/main/world/environment/MarshCrystal.tscn
@@ -15,7 +15,6 @@ shader_param/edge_fix_factor = 1.0
 extents = Vector2( 24, 12 )
 
 [node name="MarshCrystal" type="KinematicBody2D"]
-position = Vector2( 399, 700 )
 script = ExtResource( 1 )
 shadow_scale = 0.4
 chat_path = "res://assets/main/chat/marsh-crystal.chat"

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -70,6 +70,9 @@ func _launch_cutscene() -> void:
 	
 	yield(get_tree(), "idle_frame")
 	_overworld_ui.start_chat(chat_tree, cutscene_creature)
+	
+	if not chat_tree.spawn_locations and cutscene_creature:
+		_overworld_ui.make_chatters_face_eachother()
 
 
 """


### PR DESCRIPTION
Fixed bug where certain filler chats would never play because the logic
was checking for '-1' instead of 'CHAT_AGE_NEVER'

Fixed bug where creatures didn't face each other during locationless
cutscenes, such as Boatricia's 'real meal' cutscene

Overworld obstacle scenes (ButtercupSign, MarshCrystal) are positioned at 0,0
instead of an arbitrary overworld coordinate