### PR TITLE
Extracted Levels from CurrentLevel to avoid cyclic references

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -384,6 +384,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/puzzle/level/level-triggers.gd"
 }, {
+"base": "Reference",
+"class": "Levels",
+"language": "GDScript",
+"path": "res://src/main/puzzle/level/levels.gd"
+}, {
 "base": "Node",
 "class": "LineClearer",
 "language": "GDScript",
@@ -860,6 +865,7 @@ _global_script_class_icons={
 "LevelTrigger": "",
 "LevelTriggerEffect": "",
 "LevelTriggers": "",
+"Levels": "",
 "LineClearer": "",
 "LockAlleleButton": "",
 "LoseConditionRules": "",

--- a/project/src/demo/world/cutscene-demo.gd
+++ b/project/src/demo/world/cutscene-demo.gd
@@ -42,7 +42,7 @@ func _on_StartButton_pressed() -> void:
 	var cutscene_prefix := StringUtils.substring_before_last(_open_input.value, "_")
 	var cutscene_index := int(StringUtils.substring_after_last(_open_input.value, "_"))
 	CurrentLevel.set_launched_level(cutscene_prefix)
-	CurrentLevel.cutscene_force = CurrentLevel.CutsceneForce.PLAY
+	CurrentLevel.cutscene_force = Levels.CutsceneForce.PLAY
 	
 	if cutscene_index >= 0 and cutscene_index < 100:
 		# launch 'before level' cutscene

--- a/project/src/main/misc-settings.gd
+++ b/project/src/main/misc-settings.gd
@@ -4,7 +4,7 @@ Manages miscellaneous settings such as language.
 """
 
 # Whether cutscenes should play by default.
-var cutscene_force: int = CurrentLevel.CutsceneForce.NONE
+var cutscene_force: int = Levels.CutsceneForce.NONE
 
 """
 Resets the miscellaneous settings to their default values.
@@ -21,7 +21,7 @@ func to_json_dict() -> Dictionary:
 
 
 func from_json_dict(json: Dictionary) -> void:
-	cutscene_force = json.get("cutscene_force", CurrentLevel.CutsceneForce.NONE)
+	cutscene_force = json.get("cutscene_force", Levels.CutsceneForce.NONE)
 	
 	if json.has("locale"):
 		TranslationServer.set_locale(json.get("locale"))

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -15,12 +15,6 @@ enum CutsceneState {
 	AFTER, # the level has been finished successfully. The player didn't lose or give up
 }
 
-enum CutsceneForce {
-	NONE, # do not force the cutscene to play or skip
-	PLAY, # force the cutscene to play, even if it is a repeat
-	SKIP, # force the cutscene to skip, even if it has never been seen
-}
-
 # If 'true' then the level is one which the player might keep retrying, even after clearing it.
 # This is especially true for practice levels such as the 3 minute sprint level.
 var keep_retrying := false
@@ -45,7 +39,7 @@ var chef_id: String
 var cutscene_state: int = CutsceneState.NONE setget set_cutscene_state
 
 # Tracks whether or not the player wants to play/skip this level's cutscene.
-var cutscene_force: int = CutsceneForce.NONE
+var cutscene_force: int = Levels.CutsceneForce.NONE
 
 """
 Unsets all of the 'launched level' data.
@@ -71,15 +65,14 @@ func set_launched_level(new_level_id: String) -> void:
 	if level_id:
 		level_lock = LevelLibrary.level_lock(level_id)
 	
+	set_cutscene_state(CutsceneState.BEFORE if level_lock else CutsceneState.NONE)
+	cutscene_force = Levels.CutsceneForce.NONE
+	
 	if level_lock:
-		set_cutscene_state(CutsceneState.BEFORE)
-		cutscene_force = CutsceneForce.NONE
 		creature_id = level_lock.creature_id
 		customer_ids = level_lock.customer_ids
 		chef_id = level_lock.chef_id
 	else:
-		set_cutscene_state(CutsceneState.NONE)
-		cutscene_force = CutsceneForce.NONE
 		creature_id = ""
 		customer_ids = []
 		chef_id = ""
@@ -94,7 +87,6 @@ func start_level(new_settings: LevelSettings) -> void:
 func switch_level(new_settings: LevelSettings) -> void:
 	settings = new_settings
 	emit_signal("settings_changed")
-
 
 
 """
@@ -114,10 +106,10 @@ func should_play_cutscene(chat_tree: ChatTree, ignore_player_preferences = false
 	if not chat_tree:
 		# return 'false' to account for levels without cutscenes
 		result = false
-	elif not ignore_player_preferences and cutscene_force == CutsceneForce.SKIP:
+	elif not ignore_player_preferences and cutscene_force == Levels.CutsceneForce.SKIP:
 		# player wants to skip this cutscene
 		result = false
-	elif not ignore_player_preferences and cutscene_force == CutsceneForce.PLAY:
+	elif not ignore_player_preferences and cutscene_force == Levels.CutsceneForce.PLAY:
 		# player wants to play this cutscene
 		result = true
 	elif PlayerData.chat_history.is_chat_finished(chat_tree.history_key):

--- a/project/src/main/puzzle/level/levels.gd
+++ b/project/src/main/puzzle/level/levels.gd
@@ -1,0 +1,21 @@
+class_name Levels
+"""
+This script consists exclusively of constants and enums related to levels.
+
+This prevents cyclic dependency errors which arise if these constants and enums are pushed down to individual scripts.
+"""
+
+enum CutsceneForce {
+	NONE, # do not force the cutscene to play or skip
+	PLAY, # force the cutscene to play, even if it is a repeat
+	SKIP, # force the cutscene to skip, even if it has never been seen
+}
+
+# Tracks whether the player has lost, finished, or met a success condition. These enums should be ordered from worst to
+# best so that we can calculate the player's best result by comparing enums numerically.
+enum Result {
+	NONE, # The player didn't place any pieces.
+	LOST, # The player gave up or failed.
+	FINISHED, # The player survived until the end.
+	WON, # The player was successful.
+}

--- a/project/src/main/puzzle/puzzle-messages.gd
+++ b/project/src/main/puzzle/puzzle-messages.gd
@@ -89,13 +89,13 @@ func _on_PuzzleState_after_level_changed() -> void:
 func _on_PuzzleState_game_ended() -> void:
 	var message: String
 	match PuzzleState.end_result():
-		PuzzleState.Result.NONE:
+		Levels.Result.NONE:
 			hide_message()
-		PuzzleState.Result.LOST:
+		Levels.Result.LOST:
 			message = tr("Game over")
-		PuzzleState.Result.FINISHED:
+		Levels.Result.FINISHED:
 			message = tr("Finish!")
-		PuzzleState.Result.WON:
+		Levels.Result.WON:
 			message = tr("You win!")
 	show_message(message)
 
@@ -126,7 +126,7 @@ func _on_PuzzleState_after_game_ended() -> void:
 	
 	# the start button changes its label after the player finishes the level
 	match PuzzleState.end_result():
-		PuzzleState.Result.NONE:
+		Levels.Result.NONE:
 			# if they abort the level without playing it, the button doesn't change
 			pass
 		_:

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -54,13 +54,6 @@ signal combo_ended
 # emitted when the current piece can't be placed in the _playfield
 signal topped_out
 
-enum Result {
-	NONE, # The player didn't place any pieces.
-	WON, # The player was successful.
-	FINISHED, # The player survived until the end.
-	LOST, # The player gave up or failed.
-}
-
 const DELAY_NONE := 0.00
 const DELAY_SHORT := 2.35
 const DELAY_LONG := 4.70
@@ -159,11 +152,11 @@ func end_game() -> void:
 	emit_signal("game_ended")
 	var yield_duration: float
 	match end_result():
-		Result.FINISHED, Result.LOST:
+		Levels.Result.FINISHED, Levels.Result.LOST:
 			yield_duration = 2.2
-		Result.WON:
+		Levels.Result.WON:
 			yield_duration = 4.2
-		Result.NONE:
+		Levels.Result.NONE:
 			yield_duration = 0.0
 	yield(get_tree().create_timer(yield_duration), "timeout")
 	emit_signal("after_game_ended")
@@ -301,13 +294,13 @@ func set_combo(new_combo: int) -> void:
 
 func end_result() -> int:
 	if level_performance.pieces == 0:
-		return Result.NONE
+		return Levels.Result.NONE
 	elif level_performance.lost:
-		return Result.LOST
+		return Levels.Result.LOST
 	elif MilestoneManager.milestone_met(CurrentLevel.settings.success_condition):
-		return Result.WON
+		return Levels.Result.WON
 	else:
-		return Result.FINISHED
+		return Levels.Result.FINISHED
 
 
 func before_piece_written() -> void:

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -233,7 +233,7 @@ func _on_PuzzleState_game_ended() -> void:
 		_:
 			if not PuzzleState.level_performance.lost and rank_result.score_rank < 24: $ApplauseSound.play()
 	
-	if PuzzleState.end_result() in [PuzzleState.Result.FINISHED, PuzzleState.Result.WON]:
+	if PuzzleState.end_result() in [Levels.Result.FINISHED, Levels.Result.WON]:
 		CurrentLevel.cutscene_state = CurrentLevel.CutsceneState.AFTER
 
 

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -207,14 +207,14 @@ When the game ends, the chef smiles/cries/rages based on how they did.
 func _on_PuzzleState_game_ended() -> void:
 	var mood: int = ChatEvent.Mood.NONE
 	match PuzzleState.end_result():
-		PuzzleState.Result.NONE:
+		Levels.Result.NONE:
 			pass
-		PuzzleState.Result.LOST:
+		Levels.Result.LOST:
 			mood = Utils.rand_value([ChatEvent.Mood.RAGE1, ChatEvent.Mood.RAGE2,
 					ChatEvent.Mood.CRY1, ChatEvent.Mood.THINK1])
-		PuzzleState.Result.FINISHED:
+		Levels.Result.FINISHED:
 			mood = ChatEvent.Mood.SMILE0
-		PuzzleState.Result.WON:
+		Levels.Result.WON:
 			mood = ChatEvent.Mood.LAUGH1
 	if mood != ChatEvent.Mood.NONE:
 		get_chef().play_mood(mood)

--- a/project/src/main/puzzle/start-end-sfx.gd
+++ b/project/src/main/puzzle/start-end-sfx.gd
@@ -56,11 +56,11 @@ func _on_PuzzleState_after_level_changed() -> void:
 func _on_PuzzleState_game_ended() -> void:
 	var sound: AudioStreamPlayer
 	match PuzzleState.end_result():
-		PuzzleState.Result.LOST:
+		Levels.Result.LOST:
 			sound = $GameOverSound
-		PuzzleState.Result.FINISHED:
+		Levels.Result.FINISHED:
 			sound = $MatchEndSound
-		PuzzleState.Result.WON:
+		Levels.Result.WON:
 			sound = $ExcellentSound
 	if sound:
 		sound.play()

--- a/project/src/main/ui/cutscene-button.gd
+++ b/project/src/main/ui/cutscene-button.gd
@@ -34,9 +34,9 @@ func _ready() -> void:
 	connect("pressed", self, "_on_pressed")
 	_level_buttons.connect("unlocked_level_selected", self, "_on_LevelButtons_unlocked_level_selected")
 	match PlayerData.misc_settings.cutscene_force:
-		CurrentLevel.CutsceneForce.NONE: _cutscene_force = IMPLICIT_PLAY
-		CurrentLevel.CutsceneForce.PLAY: _cutscene_force = FORCE_PLAY
-		CurrentLevel.CutsceneForce.SKIP: _cutscene_force = FORCE_SKIP
+		Levels.CutsceneForce.NONE: _cutscene_force = IMPLICIT_PLAY
+		Levels.CutsceneForce.PLAY: _cutscene_force = FORCE_PLAY
+		Levels.CutsceneForce.SKIP: _cutscene_force = FORCE_SKIP
 	_refresh_cutscene_force()
 
 
@@ -71,11 +71,11 @@ func _refresh_cutscene_force() -> void:
 	# update the global cutscene_force setting
 	match _cutscene_force:
 		IMPLICIT_PLAY, IMPLICIT_SKIP:
-			PlayerData.misc_settings.cutscene_force = CurrentLevel.CutsceneForce.NONE
+			PlayerData.misc_settings.cutscene_force = Levels.CutsceneForce.NONE
 		FORCE_PLAY:
-			PlayerData.misc_settings.cutscene_force = CurrentLevel.CutsceneForce.PLAY
+			PlayerData.misc_settings.cutscene_force = Levels.CutsceneForce.PLAY
 		FORCE_SKIP:
-			PlayerData.misc_settings.cutscene_force = CurrentLevel.CutsceneForce.SKIP
+			PlayerData.misc_settings.cutscene_force = Levels.CutsceneForce.SKIP
 
 
 """


### PR DESCRIPTION
Other classes depend on the CutsceneState enum. These classes introduce cyclic
dependencies with an upcomic CutsceneManager enhancement. Introducing a
static Levels class to house level-related enums resolves these cyclic
dependency issues.