### PR TITLE
Turtle/cutscene bugs. ChatHistory utilities. Breadcrumb fixes.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -509,6 +509,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/world/environment/oval-shadow.gd"
 }, {
+"base": "KinematicBody2D",
+"class": "OverworldObstacle",
+"language": "GDScript",
+"path": "res://src/main/world/environment/overworld-obstacle.gd"
+}, {
 "base": "CanvasLayer",
 "class": "OverworldUi",
 "language": "GDScript",
@@ -890,6 +895,7 @@ _global_script_class_icons={
 "OldSave": "",
 "OtherRules": "",
 "OvalShadow": "",
+"OverworldObstacle": "",
 "OverworldUi": "",
 "PackedSprite": "",
 "PaletteButton": "",

--- a/project/src/demo/world/cutscene-demo.gd
+++ b/project/src/demo/world/cutscene-demo.gd
@@ -17,8 +17,10 @@ onready var _error_dialog := $Dialogs/Error
 onready var _open_dialog := $Dialogs/OpenFile
 
 func _ready() -> void:
+	# Initialize the Breadcrumb trail so that cutscenes will return to this demo after they finish.
+	Breadcrumb.initialize_trail()
+	
 	_load_demo_data()
-	Breadcrumb.trail = ["res://src/demo/world/CutsceneDemo.tscn"]
 	_start_button.grab_focus()
 
 

--- a/project/src/main/breadcrumb.gd
+++ b/project/src/main/breadcrumb.gd
@@ -20,6 +20,16 @@ signal before_scene_changed
 var trail := []
 
 """
+Initializes the trail to be empty except for the current scene.
+
+This is useful for demos and development where having an empty breadcrumb trail causes bugs. During regular play the
+breadcrumb trail should be initialized conventionally in the splash screen or menus.
+"""
+func initialize_trail() -> void:
+	trail = [get_tree().current_scene.filename]
+
+
+"""
 Navigates back one level in the breadcrumb trail.
 
 Pops the front path off of the breadcrumb trail. Emits a signal and changes the current scene.

--- a/project/src/main/ui/chat/chat-history.gd
+++ b/project/src/main/ui/chat/chat-history.gd
@@ -104,3 +104,19 @@ func from_json_dict(json: Dictionary) -> void:
 	chat_history = json.get("history_items", {})
 	chat_counts = json.get("counts", {})
 	filler_counts = json.get("filler_counts", {})
+
+
+"""
+Converts a path like 'res://assets/main/creatures/primary/bones/filler-001.chat' into a history key like
+'chat/bones/filler_001'.
+
+Using these clean short history keys has many benefits. Most notably they aren't invalidated if we move files or
+change extensions.
+"""
+static func history_key_from_path(path: String) -> String:
+	var history_key := path
+	history_key = history_key.trim_suffix(".chat")
+	history_key = history_key.trim_prefix("res://assets/main/")
+	history_key = history_key.replace("creatures/primary", "chat")
+	history_key = StringUtils.hyphens_to_underscores(history_key)
+	return history_key

--- a/project/src/main/ui/chat/chatscript-parser.gd
+++ b/project/src/main/ui/chat/chatscript-parser.gd
@@ -113,6 +113,7 @@ class CharactersState extends AbstractState:
 	"""
 	Syntax:
 		skins, s, kitchen-9        - a character named 'skins' with an alias 's' spawns at kitchen-9
+		skins, s, !kitchen-9        - a character named 'skins' with an alias 's' spawns invisible at kitchen-9
 		skins, s                   - a character named 'skins' with an alias 's'
 		skins                      - a character named 'skins'
 	"""
@@ -304,6 +305,7 @@ class ChatState extends AbstractState:
 		elif " mood " in item:
 			# spira mood ^_^ -> creature-mood spira 7
 			var name := StringUtils.substring_before(item, " mood ")
+			name = _unalias(name)
 			var mood := StringUtils.substring_after(item, " mood ")
 			result = "creature-mood %s %s" % [name, MOOD_PREFIXES[mood]]
 		return result
@@ -326,6 +328,8 @@ class ChatState extends AbstractState:
 const CHATSCRIPT_VERSION := "2476"
 
 # Emoticons which can appear at the start of a chat line to define its mood
+# key: String emoji representing a chatscript mood
+# value: int corresponding to an entry in ChatEvent.Mood
 const MOOD_PREFIXES := {
 	"._.": ChatEvent.Mood.DEFAULT,
 	"<_<": ChatEvent.Mood.AWKWARD0,
@@ -434,9 +438,4 @@ Using these clean short history keys has many benefits. Most notably they aren't
 change extensions.
 """
 func history_key_from_path(path: String) -> String:
-	var history_key := path
-	history_key = history_key.trim_suffix(".chat")
-	history_key = history_key.trim_prefix("res://assets/main/")
-	history_key = history_key.replace("creatures/primary", "chat")
-	history_key = StringUtils.hyphens_to_underscores(history_key)
-	return history_key
+	return ChatHistory.history_key_from_path(path)

--- a/project/src/main/world/creature/Mouth7Player.tscn
+++ b/project/src/main/world/creature/Mouth7Player.tscn
@@ -74,7 +74,7 @@ tracks/0/keys = {
 "times": PoolRealArray( 0, 1, 1.66667, 3.33333, 4 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 5, 6, 7, 6, 5 ]
+"values": [ 1, 3, 4, 3, 1 ]
 }
 tracks/1/type = "value"
 tracks/1/path = NodePath("Neck0/HeadBobber/Chin:frame")

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -636,5 +636,9 @@ func _on_CreatureVisuals_talking_changed() -> void:
 When a new scene is loaded, creatures fade in. This conceals visual glitches as their body parts load.
 """
 func _on_SceneTransition_fade_in_started() -> void:
-	visible = false
-	fade_in()
+	if visible:
+		visible = false
+		fade_in()
+	else:
+		# Don't fade in invisible creatures. Some creatures start invisible during cutscenes.
+		pass

--- a/project/src/main/world/environment/overworld-obstacle.gd
+++ b/project/src/main/world/environment/overworld-obstacle.gd
@@ -1,3 +1,4 @@
+class_name OverworldObstacle
 extends KinematicBody2D
 """
 Something which blocks the player on the overworld, such as a tree or bush.

--- a/project/src/main/world/environment/stool.gd
+++ b/project/src/main/world/environment/stool.gd
@@ -1,5 +1,5 @@
 tool
-extends "res://src/main/world/environment/overworld-obstacle.gd"
+extends OverworldObstacle
 """
 A stool which appears on the overworld.
 

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -12,6 +12,11 @@ onready var _chat_icons: ChatIcons = get_node(chat_icons_path)
 onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
 
 func _ready() -> void:
+	if not Breadcrumb.trail:
+		# For developers accessing the Overworld scene directly, we initialize a default Breadcrumb trail.
+		# For regular players the Breadcrumb trail will already be initialized by the menus.
+		Breadcrumb.initialize_trail()
+	
 	if CutsceneManager.is_front_chat_tree():
 		_launch_cutscene()
 	else:

--- a/project/src/test/ui/chat/test-chat-history.gd
+++ b/project/src/test/ui/chat/test-chat-history.gd
@@ -1,0 +1,12 @@
+extends "res://addons/gut/test.gd"
+"""
+Unit test for the chat history.
+"""
+
+func test_history_key_from_path() -> void:
+	assert_eq(ChatHistory.history_key_from_path("res://assets/main/creatures/primary/bones/filler-001.chat"),
+			"chat/bones/filler_001")
+	assert_eq(ChatHistory.history_key_from_path("res://assets/main/puzzle/levels/cutscenes/marsh/hello-everyone-000.chat"),
+			"puzzle/levels/cutscenes/marsh/hello_everyone_000")
+	assert_eq(ChatHistory.history_key_from_path("res://assets/main/chat/marsh-crystal.chat"),
+			"chat/marsh_crystal")

--- a/project/src/test/ui/chat/test-chatscript-parser.gd
+++ b/project/src/test/ui/chat/test-chatscript-parser.gd
@@ -18,18 +18,13 @@ func _chat_tree_from_file(path: String) -> ChatTree:
 	return chat_tree
 
 
-func _history_key_from_path(path: String) -> String:
-	var parser := ChatscriptParser.new()
-	return parser.history_key_from_path(path)
-
-
 func test_cutscene_location() -> void:
 	var chat_tree := _chat_tree_from_file(CUTSCENE_FULL)
 	
 	assert_eq(chat_tree.location_id, "indoors")
 
 
-func test_cutscene_meta() -> void:
+func test_overall_meta() -> void:
 	var chat_tree := _chat_tree_from_file(CUTSCENE_META)
 	
 	assert_eq(chat_tree.meta.get("filler"), false)
@@ -75,7 +70,7 @@ func test_cutscene_mood_smile0() -> void:
 	assert_eq(event.text, "Hey, that was pretty good! And y'know, with a little more training you'll get even better.")
 
 
-func test_cutscene_metadata() -> void:
+func test_chatevent_meta() -> void:
 	var chat_tree := _chat_tree_from_file(CUTSCENE_META)
 	
 	# multiple metadata events on one line
@@ -112,15 +107,6 @@ func test_chat_thought() -> void:
 	assert_eq(event.who, "")
 	assert_eq(event.text, "(A crystalline marshmallow has sprouted from the soil. The five-second rule precludes" \
 			+ " me from eating it.)")
-
-
-func test_history_key_from_path() -> void:
-	assert_eq(_history_key_from_path("res://assets/main/creatures/primary/bones/filler-001.chat"),
-			"chat/bones/filler_001")
-	assert_eq(_history_key_from_path("res://assets/main/puzzle/levels/cutscenes/marsh/hello-everyone-000.chat"),
-			"puzzle/levels/cutscenes/marsh/hello_everyone_000")
-	assert_eq(_history_key_from_path("res://assets/main/chat/marsh-crystal.chat"),
-			"chat/marsh_crystal")
 
 
 func test_chat_choice_mood() -> void:


### PR DESCRIPTION
Fixed bug where angry turtles would continue opening/closing their mouths after
speaking because of some bad animation keys.

Fixed bug where creatures who were supposed to not be present at the
start of a cutscene were still shown. This was inadvertently broken when
adding a 'fade in' effect to creatures as the world was loaded.

Fixed bug where 'player' and 'sensei' could not make use of the mood
metadata during cutscenes. Their names were not translated into the
placeholder '#player#' and '#sensei#' values.

Moved 'history_key_from_path' method from ChatscriptParser into ChatHistory.

Overworld is now given a default breadcrumb trail if the scene is loaded
directly. Without this, the cutscene pushing/popping logic would
sometimes cause the game to quit or error during development, because
the breadcrumb trail was unexpectedly empty.