### PR TITLE
'hard times' cutscene. Bush gets cut. Inplace logic.

### DIFF
--- a/project/assets/main/chat/meet-the-competition.chat
+++ b/project/assets/main/chat/meet-the-competition.chat
@@ -37,7 +37,6 @@ d: Like, that makes sense, right? I'm not being selfish?
 [okay] That makes sense
 [fine] We won't help you either
 
-
 [umm]
 p1: <_< ...
 d: Sorry. Bye!

--- a/project/assets/main/creatures/primary/diota/creature.json
+++ b/project/assets/main/creatures/primary/diota/creature.json
@@ -36,5 +36,12 @@
   },
   "fatness": 1.1,
   "weight_gain_scale": 1,
-  "metabolism_scale": 1
+  "metabolism_scale": 1,
+  "chat_selectors": [
+    {
+      "chat": "hard_times",
+      "available_if": "level_finished marsh/pulling_for_everyone",
+      "repeat": 999999
+    }
+  ]
 }

--- a/project/assets/main/creatures/primary/diota/hard-times.chat
+++ b/project/assets/main/creatures/primary/diota/hard-times.chat
@@ -1,0 +1,45 @@
+{"version": "2476", "inplace": true}
+
+[location]
+outdoors
+
+[characters]
+player, p1, buttercup-10
+sensei, s1, buttercup-8
+diota, d, buttercup-2
+
+d: -_- Oh hello. Did you need something?
+[butts-up] Butt's up with you
+[you-fixed-your-sign] You fixed your sign?
+[are-you-out-of-business] Are you out of business yet
+
+[butts-up]
+p1: ^O^ Hello! Butt's up with you?
+d: /._. Butt's... Butt's up? What?
+p1: <__< Oh! You fixed your ‘butt up cafe' sign. Now my joke doesn't work. Anyway, how's business?
+d: Right, we fixed that like a WEEK ago! ...But yeah, things have been weird!
+d: A bunch of our customers just... like... stopped showing up all of a sudden?
+[end]
+
+[you-fixed-your-sign]
+p1: /._. Oh, you fixed your sign!
+d: <_< Right, we fixed that like a WEEK ago! ...But yeah, things have been weird!
+d: A bunch of our customers just... like... stopped showing up all of a sudden?
+[end]
+
+[are-you-out-of-business]
+p1: >_< So are you out of business yet?
+d: <_< Ugh well. We fixed our sign last week, so at least the 'butt cafe' jokes have stopped.
+d: But a bunch of our customers just... like... stopped showing up all of a sudden?
+[end]
+
+[end]
+d: ._.; No idea why! And it's not like we have any of their contact info. So... yeah.
+s1: /._. Ah. That's just the worst. I wonder where they could have gone?
+d: /._. ...Yeah. Well. ...How about you, any new customers?
+s1: ^N^ No, no, don't worry. We're not stealing your customers.
+d: ^O^ Ha ha ha, Stealing our customers! ...No, ha ha!
+d: ^n^ No, um. I wasn't worried about that. I was just being polite.
+s1: <__< Oh! ...Well thank you.
+d: ^o^ Sorry. That probably shouldn't be as funny as it is. Ha ha ha.
+s1: <_< ...Your sign looks nice.

--- a/project/src/demo/world/cutscene-demo.gd
+++ b/project/src/demo/world/cutscene-demo.gd
@@ -42,8 +42,7 @@ func _on_StartButton_pressed() -> void:
 	_flags_input.apply_flags()
 	
 	var cutscene_prefix := StringUtils.substring_before_last(_open_input.value, "_")
-	var path := "res://assets/main/%s.chat" \
-			% [StringUtils.underscores_to_hyphens(_open_input.value)]
+	var path := ChatHistory.path_from_history_key(_open_input.value)
 	var chat_tree := ChatLibrary.chat_tree_from_file(path)
 	CurrentLevel.set_launched_level(cutscene_prefix)
 	

--- a/project/src/main/ui/chat/chat-tree.gd
+++ b/project/src/main/ui/chat/chat-tree.gd
@@ -38,7 +38,7 @@ const LOCATION_SCENE_PATHS_BY_ID := {
 # unique key to identify this conversation in the chat history
 var history_key: String
 
-# metadata including whether the chat event is 'filler' or 'notable'
+# metadata including whether the chat event is 'filler', 'notable' or 'inplace'
 var meta: Dictionary
 
 # tree of chat event objects

--- a/project/src/main/world/Overworld.tscn
+++ b/project/src/main/world/Overworld.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=57 format=2]
+[gd_scene load_steps=58 format=2]
 
 [ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/environment/MarshHouse2.tscn" type="PackedScene" id=2]
@@ -48,6 +48,7 @@
 [ext_resource path="res://assets/main/world/environment/buttercup-stool-green-occupied.png" type="Texture" id=46]
 [ext_resource path="res://assets/main/world/environment/buttercup-stool-white-occupied.png" type="Texture" id=47]
 [ext_resource path="res://src/main/world/environment/ButtercupSign.tscn" type="PackedScene" id=48]
+[ext_resource path="res://src/main/world/environment/MarshCrystalForSign.tscn" type="PackedScene" id=49]
 [ext_resource path="res://src/main/world/chat-icons.gd" type="Script" id=50]
 [ext_resource path="res://src/main/world/overworld-world.gd" type="Script" id=51]
 [ext_resource path="res://src/main/world/shadow-caster-shadows.gd" type="Script" id=72]
@@ -582,9 +583,8 @@ position = Vector2( -4407.77, 920.238 )
 [node name="MarshCrystal7" parent="World/Obstacles" instance=ExtResource( 23 )]
 position = Vector2( 4231.21, 1567.3 )
 
-[node name="MarshCrystal8" parent="World/Obstacles" instance=ExtResource( 23 )]
-position = Vector2( 2158.46, 813.65 )
-chat_path = ""
+[node name="MarshCrystalForSign" parent="World/Obstacles" instance=ExtResource( 49 )]
+position = Vector2( 2158, 813 )
 
 [node name="MarshCrystal9" parent="World/Obstacles" instance=ExtResource( 23 )]
 position = Vector2( 4053.02, 1334.73 )

--- a/project/src/main/world/environment/ButtercupSign.tscn
+++ b/project/src/main/world/environment/ButtercupSign.tscn
@@ -19,6 +19,7 @@ extents = Vector2( 105, 10 )
 ]]
 script = ExtResource( 1 )
 shadow_scale = 1.1
+chat_path = "res://assets/main/chat/meet-the-competition.chat"
 
 [node name="Sprite" type="Sprite" parent="."]
 material = SubResource( 1 )

--- a/project/src/main/world/environment/MarshCrystalForSign.tscn
+++ b/project/src/main/world/environment/MarshCrystalForSign.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=6 format=2]
+
+[ext_resource path="res://src/main/outline.shader" type="Shader" id=1]
+[ext_resource path="res://assets/main/world/environment/marsh-crystal.png" type="Texture" id=2]
+[ext_resource path="res://src/main/world/environment/marsh-crystal-for-sign.gd" type="Script" id=3]
+
+[sub_resource type="ShaderMaterial" id=1]
+resource_local_to_scene = true
+shader = ExtResource( 1 )
+shader_param/width = 1.5
+shader_param/black = Color( 0.423529, 0.262745, 0.192157, 1 )
+shader_param/edge_fix_factor = 1.0
+
+[sub_resource type="RectangleShape2D" id=2]
+extents = Vector2( 24, 12 )
+
+[node name="MarshCrystalForSign" type="KinematicBody2D"]
+script = ExtResource( 3 )
+shadow_scale = 0.4
+
+[node name="Sprite" type="Sprite" parent="."]
+material = SubResource( 1 )
+scale = Vector2( 0.539476, 0.539476 )
+texture = ExtResource( 2 )
+centered = false
+offset = Vector2( -70, -102 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource( 2 )
+
+[node name="ChatIconHook" type="RemoteTransform2D" parent="."]

--- a/project/src/main/world/environment/buttercup-sign.gd
+++ b/project/src/main/world/environment/buttercup-sign.gd
@@ -4,7 +4,10 @@ The 'Buttercup Cafe' sign which appears on the overworld.
 """
 
 func _ready() -> void:
-	if PlayerData.chat_history.is_chat_finished("chat/meet_the_competition"):
+	if PlayerData.level_history.is_level_finished("marsh/pulling_for_everyone"):
+		# if the trees have been chopped down, the sign is readable
+		set_chat_path(ChatHistory.path_from_history_key("chat/buttercup_sign"))
+	elif PlayerData.chat_history.is_chat_finished("chat/meet_the_competition"):
 		# if the player's already seen the 'meet the competition' cutscene, we only provide a short description
 		set_chat_path(ChatHistory.path_from_history_key("chat/butt_up_sign"))
 	else:

--- a/project/src/main/world/environment/marsh-crystal-for-sign.gd
+++ b/project/src/main/world/environment/marsh-crystal-for-sign.gd
@@ -1,0 +1,9 @@
+extends OverworldObstacle
+"""
+The marsh crystal which obstructs the Buttercup Cafe sign.
+"""
+
+func _ready() -> void:
+	if PlayerData.level_history.is_level_finished("marsh/pulling_for_everyone"):
+		# the tree has been chopped down
+		queue_free()


### PR DESCRIPTION
Added Diota's 'hard times' cutscene dialog, including logic for having
the bush get cut and the sign changing its description.

Added logic where cutscenes can be 'inplace', which means they do not
require a scene change.