### PR TITLE
Cutscene queuing. Creatures don't reorient for thoughts.

### DIFF
--- a/delint.sh
+++ b/delint.sh
@@ -34,7 +34,7 @@ REGEX+="\|^"$'\t'"{2}.\{112,\}$"
 REGEX+="\|^"$'\t'"{3}.\{108,\}$"
 REGEX+="\|^"$'\t'"{4}.\{104,\}$"
 REGEX+="\|^"$'\t'"{5}.\{100,\}$\)"
-RESULT="${RESULT}$(grep -R -n "$REGEX" --include="dna-utils.gd" project/src)"
+RESULT="${RESULT}$(grep -R -n "$REGEX" --include="*.gd" project/src)"
 if [ -n "$RESULT" ]
 then
   echo ""

--- a/project/src/demo/world/cutscene-demo.gd
+++ b/project/src/demo/world/cutscene-demo.gd
@@ -47,6 +47,10 @@ func _on_StartButton_pressed() -> void:
 	CurrentLevel.set_launched_level(cutscene_prefix)
 	
 	if chat_tree:
+		# Empty the cutscene queue. It's unlikely to be non-empty, but strange
+		# bugs can result if we play a mismatched scene/cutscene combo
+		CutsceneManager.reset()
+		
 		CutsceneManager.enqueue_chat_tree(chat_tree)
 		SceneTransition.push_trail(chat_tree.cutscene_scene_path())
 	else:

--- a/project/src/main/ui/chat/chat-event.gd
+++ b/project/src/main/ui/chat/chat-event.gd
@@ -92,5 +92,12 @@ func enabled_link_indexes() -> Array:
 	return enabled_link_indexes
 
 
+"""
+Returns 'true' if this chat event represents something the player is thinking.
+"""
+func is_thought() -> bool:
+	return text.begins_with("(") and text.ends_with(")") and not who
+
+
 func _to_string() -> String:
 	return ("%s:%s" % [who, text]) if who else text

--- a/project/src/main/ui/chat/chatscript-parser.gd
+++ b/project/src/main/ui/chat/chatscript-parser.gd
@@ -294,7 +294,11 @@ class ChatState extends AbstractState:
 	"""
 	func _translate_meta_item(item: String) -> String:
 		var result := item
-		if item.ends_with(" enters"):
+		if item.begins_with("next scene "):
+			# next scene creature/john/hello -> next-scene creature/john/hello
+			var path := item.trim_prefix("next scene ")
+			result = "next-scene %s" % [path]
+		elif item.ends_with(" enters"):
 			# spira enters -> creature-enter spira
 			var name := item.trim_suffix(" enters")
 			result = "creature-enter %s" % [_unalias(name)]

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -151,6 +151,17 @@ func _physics_process(delta: float) -> void:
 	_maybe_play_bonk_sound(old_non_iso_velocity)
 
 
+"""
+Increases the collision shape size for fatter creatures.
+
+This is not done on all creatures, because having fatter creatures collide with chairs/tables differently as they gain
+weight introduces problems. It's easier to leave their collision shapes consistent and just have a few visual bugs here
+and there.
+"""
+func refresh_collision_extents() -> void:
+	_collision_shape.refresh_extents()
+
+
 func set_collision_disabled(new_collision_disabled: bool) -> void:
 	_collision_shape.disabled = new_collision_disabled
 

--- a/project/src/main/world/cutscene-manager.gd
+++ b/project/src/main/world/cutscene-manager.gd
@@ -28,11 +28,22 @@ const SENSEI_SPAWN_IDS_BY_PLAYER_LOCATION := {
 # Queue of ChatTree and String instances. ChatTrees represent cutscenes, and strings represent level IDs.
 var _queue := []
 
+func reset() -> void:
+	_queue.clear()
+
+
 """
 Adds a cutscene to the back of the queue.
 """
 func enqueue_chat_tree(chat_tree: ChatTree) -> void:
 	_queue.push_back(chat_tree)
+
+
+"""
+Inserts a cutscene in the given position in the queue.
+"""
+func insert_chat_tree(position: int, chat_tree: ChatTree) -> void:
+	_queue.insert(position, chat_tree)
 
 
 """

--- a/project/src/test/ui/chat/test-chat-history.gd
+++ b/project/src/test/ui/chat/test-chat-history.gd
@@ -6,7 +6,8 @@ Unit test for the chat history.
 func test_history_key_from_path() -> void:
 	assert_eq(ChatHistory.history_key_from_path("res://assets/main/creatures/primary/bones/filler-001.chat"),
 			"creature/bones/filler_001")
-	assert_eq(ChatHistory.history_key_from_path("res://assets/main/puzzle/levels/cutscenes/marsh/hello-everyone-000.chat"),
+	assert_eq(ChatHistory.history_key_from_path(
+				"res://assets/main/puzzle/levels/cutscenes/marsh/hello-everyone-000.chat"),
 			"level/marsh/hello_everyone_000")
 	assert_eq(ChatHistory.history_key_from_path("res://assets/main/chat/marsh-crystal.chat"),
 			"chat/marsh_crystal")


### PR DESCRIPTION
Cutscene queueing logic. Chatscript now supports 'next scene foo' to
queue up a cutscene.

Creatures don't face eachother during thoughts. This avoids an odd
circumstance where you think 'i shouldn't disturb this customer' but they turn
to face you anyways.