### PR TITLE
Creature collision shapes no longer increase as they get fatter.

### DIFF
--- a/project/src/main/world/creature-spawner.gd
+++ b/project/src/main/world/creature-spawner.gd
@@ -22,6 +22,8 @@ export (Array) var target_groups: Array
 # a boolean expression which, if evaluated to 'true', will result in the creature being spawned
 export (String) var spawn_if: String
 
+# Maximum fatness for a spawned creature.
+# If a fatter creature spawns here, they will spontaneously and permanently slim down.
 export (float) var max_fatness := 10.0
 
 var CreaturePackedScene: PackedScene = load("res://src/main/world/creature/Creature.tscn")

--- a/project/src/main/world/creature/creature-collision-shape.gd
+++ b/project/src/main/world/creature/creature-collision-shape.gd
@@ -3,34 +3,12 @@ extends CollisionShape2D
 Collision shape for creatures on the overworld.
 """
 
-# emitted when the collision shape's extents change
-signal extents_changed(value)
-
-var creature_visuals: CreatureVisuals setget set_creature_visuals
-
-func _ready() -> void:
-	_connect_creature_visuals_listeners()
-	_refresh_extents()
-
-
-func set_creature_visuals(new_creature_visuals: CreatureVisuals) -> void:
-	if creature_visuals:
-		creature_visuals.disconnect("visual_fatness_changed", self, "_on_CreatureVisuals_visual_fatness_changed")
-	creature_visuals = new_creature_visuals
-	_connect_creature_visuals_listeners()
-
-
-func _connect_creature_visuals_listeners() -> void:
-	if not creature_visuals:
-		return
-	
-	creature_visuals.connect("visual_fatness_changed", self, "_on_CreatureVisuals_visual_fatness_changed")
-
+var creature_visuals: CreatureVisuals
 
 """
 Increases the collision shape size for fatter creatures.
 """
-func _refresh_extents() -> void:
+func refresh_extents() -> void:
 	if not creature_visuals:
 		return
 	
@@ -42,8 +20,3 @@ func _refresh_extents() -> void:
 	# small creatures still occupy a minimal amount of space
 	rectangle_shape.extents.x = max(rectangle_shape.extents.x, 28)
 	rectangle_shape.extents.y = max(rectangle_shape.extents.y, 14)
-	emit_signal("extents_changed", rectangle_shape.extents)
-
-
-func _on_CreatureVisuals_visual_fatness_changed() -> void:
-	_refresh_extents()

--- a/project/src/main/world/creature/player.gd
+++ b/project/src/main/world/creature/player.gd
@@ -17,6 +17,7 @@ func _ready() -> void:
 	if PlayerData.creature_library.forced_fatness:
 		set_fatness(PlayerData.creature_library.forced_fatness)
 		set_visual_fatness(PlayerData.creature_library.forced_fatness)
+	refresh_collision_extents()
 	creature_id = CreatureLibrary.PLAYER_ID
 	ChattableManager.player = self
 


### PR DESCRIPTION
It makes sense they should increase, but this causes bugs when they can't sit on
certain seats anymore. It means there are edge cases where certain areas
work fine for skinny NPCs, but they appear glitchy or block player
access when NPCs gain weight.