### PR TITLE
Chatscript uses snake case - not kebab case, not multiple words.

### DIFF
--- a/project/assets/main/chat/meet-the-competition.chat
+++ b/project/assets/main/chat/meet-the-competition.chat
@@ -4,10 +4,10 @@
 outdoors
 
 [characters]
-player, p1, buttercup-10
-sensei, s1, buttercup-8
-richie, r, buttercup-6
-diota, d, !buttercup-2
+player, p1, buttercup_10
+sensei, s1, buttercup_8
+richie, r, buttercup_6
+diota, d, !buttercup_2
 
 s1: Hmm, another restaurant this close!? I wonder if this is a part of the problem.
  (player faces left)

--- a/project/assets/main/creatures/primary/diota/hard-times.chat
+++ b/project/assets/main/creatures/primary/diota/hard-times.chat
@@ -4,16 +4,16 @@
 outdoors
 
 [characters]
-player, p1, buttercup-10
-sensei, s1, buttercup-8
-diota, d, buttercup-2
+player, p1, buttercup_10
+sensei, s1, buttercup_8
+diota, d, buttercup_2
 
 d: -_- Oh hello. Did you need something?
-[butts-up] Butt's up with you
-[you-fixed-your-sign] You fixed your sign?
-[are-you-out-of-business] Are you out of business yet
+[butts_up] Butt's up with you
+[you_fixed_your_sign] You fixed your sign?
+[are_you_out_of_business] Are you out of business yet
 
-[butts-up]
+[butts_up]
 p1: ^O^ Hello! Butt's up with you?
 d: /._. Butt's... Butt's up? What?
 p1: <__< Oh! You fixed your ‘butt up cafe' sign. Now my joke doesn't work. Anyway, how's business?
@@ -21,13 +21,13 @@ d: Right, we fixed that like a WEEK ago! ...But yeah, things have been weird!
 d: A bunch of our customers just... like... stopped showing up all of a sudden?
 [end]
 
-[you-fixed-your-sign]
+[you_fixed_your_sign]
 p1: /._. Oh, you fixed your sign!
 d: <_< Right, we fixed that like a WEEK ago! ...But yeah, things have been weird!
 d: A bunch of our customers just... like... stopped showing up all of a sudden?
 [end]
 
-[are-you-out-of-business]
+[are_you_out_of_business]
 p1: >_< So are you out of business yet?
 d: <_< Ugh well. We fixed our sign last week, so at least the 'butt cafe' jokes have stopped.
 d: But a bunch of our customers just... like... stopped showing up all of a sudden?

--- a/project/assets/main/creatures/primary/diota/having-trouble.chat
+++ b/project/assets/main/creatures/primary/diota/having-trouble.chat
@@ -4,9 +4,9 @@
 outdoors
 
 [characters]
-player, p1, buttercup-10
-sensei, s1, buttercup-8
-diota, d, buttercup-2
+player, p1, buttercup_10
+sensei, s1, buttercup_8
+diota, d, buttercup_2
 
 p1: /._. Any news?
 d: u_u So yeah, I mean... We're trying a few promotions to get people back, but I don't know.
@@ -14,11 +14,11 @@ d: I HATE marketing, and I always sort of hoped word of mouth would be enough fo
 d: @_@ And I mean for a while things were going great! ... ...I don't really get what changed....
 p1: Well, maybe people don't like the new name. ...Have you thought about changing it again?
 d: /._. ....Wait, what?
-[butt-up-cafe] ^o^ Switch it back to Butt Up Cafe!
-[butt-cafe] ^O^ Shorten it to Butt Cafe!
+[butt_up_cafe] ^o^ Switch it back to Butt Up Cafe!
+[butt_cafe] ^O^ Shorten it to Butt Cafe!
 [nevermind] Oh, nevermind
 
-[butt-up-cafe]
+[butt_up_cafe]
 p1: ^o^ You know, maybe people miss the old Butt Up cafe!
  (s1 mood ^O^)
 d: ...
@@ -26,7 +26,7 @@ d: <__< S-sorry. What? I can't tell if that's a joke or if you're actually makin
 d: I'm not really in the right headspace to parse that right now.
 p1: Ha ha. You'll figure it out.
 
-[butt-cafe]
+[butt_cafe]
 p1: ^o^ Maybe just call it The Butt Cafe this time! You know, shorter! Punchier!
  (s1 mood ^O^)
 d: ...

--- a/project/assets/main/creatures/primary/jayton/soliciting-buttercup-customers-2.chat
+++ b/project/assets/main/creatures/primary/jayton/soliciting-buttercup-customers-2.chat
@@ -4,9 +4,9 @@
 outdoors
 
 [characters]
-player, p1, buttercup-fence-3
-sensei, s1, buttercup-fence-12
-jayton, j, buttercup-seat
+player, p1, buttercup_fence_3
+sensei, s1, buttercup_fence_12
+jayton, j, buttercup_seat
 
 p1: ._.; ...In hindsight we probably should not have done that.
 s1: -_- ...

--- a/project/assets/main/creatures/primary/jayton/soliciting-buttercup-customers.chat
+++ b/project/assets/main/creatures/primary/jayton/soliciting-buttercup-customers.chat
@@ -4,30 +4,30 @@
 outdoors
 
 [characters]
-player, p1, buttercup-6
-sensei, s1, buttercup-10
-diota, d, !buttercup-2
-jayton, j, buttercup-seat
+player, p1, buttercup_6
+sensei, s1, buttercup_10
+diota, d, !buttercup_2
+jayton, j, buttercup_seat
 
 p1: ^_^/ Hello! We run the Turbo Fat restaurant down the street, and if you're ever-
  (player faces right)
 j: -Eh? Hello! So... you work at a different restaurant?
  (jayton faces left)
 p1: Yeah! It's a restaurant with hmm...
-[better-food] Way better food
-[better-service] Better service
-[not-healthy] None of this healthy crap
+[better_food] Way better food
+[better_service] Better service
+[not_healthy] None of this healthy crap
 [oops] ...I shouldn't do this
 
-[better-food]
+[better_food]
 p1: ^_^ It's a restaurant with way better food than this place! Even if you're vegetarian, we-
 [end]
 
-[better-service]
+[better_service]
 p1: ^o^ It's a restaurant with way better service than this place! And don't worry if you're vegetarian, we-
 [end]
 
-[not-healthy]
+[not_healthy]
 p1: ^O^ It's a restaurant with none of this healthy crap! All our food is-
 [end]
 
@@ -42,4 +42,4 @@ d: >__< You just thought you could randomly come to my restaurant and pitch to m
  (player mood ._.;)
 p1: <__< ...Well!
 d: >___< Go away! Just... get out of here, seriously!
- (next scene creature/jayton/soliciting-buttercup-customers-2)
+ (next_scene creature/jayton/soliciting-buttercup-customers-2)

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/goodbye-bones-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/goodbye-bones-100.chat
@@ -4,8 +4,8 @@
 outdoors
 
 [characters]
-player, p1, restaurant-11
-bones, b, restaurant-1
+player, p1, restaurant_11
+bones, b, restaurant_1
 
 p1: <_< Sorry, I should probably tell you - Fat Sensei and I are planning to leave MerryMellow marsh.
 b: .__.; You're leaving!? ...Well, when?
@@ -19,7 +19,7 @@ p1: Sorry, Bones. You're a special dog. And you'll always have a special place..
 [thoughts] In my thoughts
 [butt] In my butt
 [registry] On a registry
-[heart-and-thoughts] In my heart and thoughts
+[heart_and_thoughts] In my heart and thoughts
 
 [heart]
 p1: ^_^ You'll always have a special place in my heart.
@@ -31,7 +31,7 @@ p1: ^_^ You'll always have a special place in my thoughts.
 b: ^Y^ Well... Thanks. I'm glad I'll always be close to your thoughts.
 (You are no longer in a relationship with Bones.)
 
-[heart-and-thoughts]
+[heart_and_thoughts]
 p1: ^_^/ You'll always have a special place in my heart, and in my thoughts.
 b: u_u But... I want you to stay! I don't want hearts and thoughts. Hearts and thoughts, they fade. Fade away.
 b: ...

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/goodbye-shirts-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/goodbye-shirts-100.chat
@@ -4,36 +4,36 @@
 outdoors
 
 [characters]
-player, p1, restaurant-4
-sensei, s1, restaurant-1
-shirts, s, restaurant-8
+player, p1, restaurant_4
+sensei, s1, restaurant_1
+shirts, s, restaurant_8
 
 p1: <_< So I don't know if you've heard, but -- Fat Sensei and I are leaving MerryMellow Marsh.
 s: /._. Oh. Yeah, it was only supposed to be a week, right? ...Well, sorry to see you go. This place will suck a little more without you.
-[maybe-manager] Want to be manager?
-[maybe-leave] You could leave
-[not-so-bad] It's not so bad
-[pretty-bad] It's pretty bad
+[maybe_manager] Want to be manager?
+[maybe_leave] You could leave
+[not_so_bad] It's not so bad
+[pretty_bad] It's pretty bad
 
-[maybe-manager]
+[maybe_manager]
 p1: /._. Do you want us to make you a manager? You could hire new staff or fix the culture here.
 s: ^O^ Wow! Managing. ...I mean even if I hate it here, I don't know if I give enough of a crap to actually try and improve things. Ha ha.
 s: Yeah, I don't know. I'll probably just let it suck for awhile, see how that goes.
 [monologue]
 
-[maybe-leave]
+[maybe_leave]
 p1: ._.; You could find a new job if things are that bad here. I'm sure you'll land on your feet.
 s: ^O^ Yeah, I don't know. Even if I hate it, I'm more the type to stick it out rather than lifting a finger to help myself. Ha ha.
 s: I'll probably just let it suck for awhile, see how that goes.
 [monologue]
 
-[pretty-bad]
+[pretty_bad]
 p1: u_u Yeah, sorry, it seems pretty bad. Do you think you'll keep working here?
 s: ^O^ Yeah, I don't know. Even if I hate it, I'm more the type to stick it out rather than lifting a finger to help myself. Ha ha.
 s: I'll probably just let it suck for awhile, see how that goes.
 [monologue]
 
-[not-so-bad]
+[not_so_bad]
 p1: ^__^/ It doesn't seem so bad! I'm sure you'll get by.
 s: ^O^ Yeah, I don't know. Even if I hate it, I'm more the type to stick it out rather than lifting a finger to help myself. Ha ha.
 s: I'll probably just let it suck for awhile, see how that goes.

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/goodbye-skins-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/goodbye-skins-100.chat
@@ -4,52 +4,52 @@
 outdoors
 
 [characters]
-player, p1, restaurant-11
-skins, s, restaurant-1
+player, p1, restaurant_11
+skins, s, restaurant_1
 
 p1: <_< Sorry, this is hard to say but we were only supposed to be here for one week. And that was like... several weeks ago.
 p1: Fat Sensei and I need to leave.
 s: .__.; Wahhhh! What about us?
-[plan-you-stay] I could stay
-[plan-i-go] You could come
-[plan-no-following] Long distance relationship?
-[plan-superman] We should break up
+[plan_you_stay] I could stay
+[plan_i_go] You could come
+[plan_no_following] Long distance relationship?
+[plan_superman] We should break up
 
-[plan-you-stay]
+[plan_you_stay]
 p1: ^__^ I guess I could stay here!
 s: @_@ Wh-what!?! ...But you said you were leaving!
 p1: /._. Oh, you're right! I forgot.
 s: ._.; Well, well ummm... We could do the long distance thing, right?
 s: Like maybe a relationship where we never talk, and we never see each other, and we can date other people...
 s: /._. ...But we're still in a relationship and we still think about each other. What about that?
-[thats-your-plan]
+[thats_your_plan]
 
-[plan-i-go]
+[plan_i_go]
 p1: ^_^ You could come with me!
 s: ._.; ...Come with you? That's a big step. Couldn't we start with a long-distance relationship?
 p1: <__< Ohh... I don't think that will work out.
 s: What about a long-distance relationship where we never talk, and we never see each other, and we can date other people...
 s: /._. ...But we're still in a relationship and we still think about each other. What about that?
-[thats-your-plan]
+[thats_your_plan]
 
-[plan-no-following]
+[plan_no_following]
 p1: /._. I guess we could... try the long distance thing.
 s: Long distance? Hmm... So maybe, a relationship where we never talk, and we never see each other, and we can date other people...
 s: /._. ...But we're still in a relationship and we still think about each other. Something like that?
-[thats-your-plan]
+[thats_your_plan]
 
-[plan-superman]
+[plan_superman]
 p1: u_u I guess we need to... break up.
 s: ._.; Well what about a long-distance relationship?
 p1: <__< Ohh... I don't think that will work out.
 s: What about a long-distance relationship where we never talk, and we never see each other, and we can date other people...
 s: /._. ...But we're still in a relationship and we still think about each other. What about that?
-[thats-your-plan]
+[thats_your_plan]
 
-[thats-your-plan]
+[thats_your_plan]
 p1: ._.; I... what?
 s: ... ...
-[must-break-up] Or we break up
+[must_break_up] Or we break up
 [disapprove] That sounds awful
 [approve] That sounds fine
 
@@ -58,7 +58,7 @@ p1: ^y^ That... sounds fine.
 s: ^__^ Mowr!
 (You are no longer in a relationship with Skins.)
 
-[must-break-up]
+[must_break_up]
 p1: ._.; Or we can just break up.
 s: ^__^ Don't worry! I'll just long distance you. ...You don't have to long distance me back. Mowr!
 (You are no longer in a relationship with Skins.)

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-bones-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-bones-100.chat
@@ -4,9 +4,9 @@
 outdoors
 
 [characters]
-player, p1, restaurant-1
-sensei, s1, restaurant-4
-bones, b, restaurant-8
+player, p1, restaurant_1
+sensei, s1, restaurant_4
+bones, b, restaurant_8
 
 p1: Well that was... good!
 b: <_< Just good?
@@ -15,21 +15,21 @@ p1: ^_^ You're... You're doing good. ...You're a good boy.
 b: u_u Groarf.
 p1: ^o^ C'mon, let's like... let's get drinks or something, blow off some steam! You did... good today.
 b: /._. Ohhh. Actually, I really gotta work out tonight. I already missed two nights this week. I can't miss a third night.
-[you-need-exercise] Yeah, you're looking a little chunky
-[yay-exercise] That's some good discipline!
-[boo-exercise] Well, can we hang out tomorrow?
+[you_need_exercise] Yeah, you're looking a little chunky
+[yay_exercise] That's some good discipline!
+[boo_exercise] Well, can we hang out tomorrow?
 
-[you-need-exercise]
+[you_need_exercise]
 p1: /._. Heh yeah, I thought you were looking a little chunky around the middle.
 b: .__.; W-what!?!
 p1: ^o^ Ha ha, go exercise.
 b: ._.; Y-yeah, bye!
 
-[yay-exercise]
+[yay_exercise]
 p1: ^_^ Oh good for you, that's some good discipline! ...See you around.
 b: ^_^ Bye!
 
-[boo-exercise]
+[boo_exercise]
 p1: ._.; How about tomorrow then? ...Can we hang out tomorrow?
 b: Uhhh, I gotta go. See you around!
  (bones exits)

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-everyone-000.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-everyone-000.chat
@@ -4,11 +4,11 @@
 indoors
 
 [characters]
-player, p1, kitchen-9
-sensei, s1, kitchen-11
-richie, r, kitchen-1
-skins, s, kitchen-3
-bones, b, kitchen-5
+player, p1, kitchen_9
+sensei, s1, kitchen_11
+richie, r, kitchen_1
+skins, s, kitchen_3
+bones, b, kitchen_5
 
 s1: -_- So explain again why my beloved restaurant is very, very empty?
 r: Aw come on now! It's not empty, we got the two line cooks here...
@@ -21,32 +21,32 @@ r: Maybe kind of like a, hmm... Like a anchor made of something slightly buoyant
 b: /._. An anchor made of... Boats?
 r: Nope. Not that buoyant!
 [walnuts] Walnuts?
-[rotting-flesh] Rotting flesh?
-[smaller-boats] Slightly smaller boats?
-[avenue-of-discussion] This isn't a helpful avenue of discussion.
+[rotting_flesh] Rotting flesh?
+[smaller_boats] Slightly smaller boats?
+[avenue_of_discussion] This isn't a helpful avenue of discussion.
 
 [walnuts]
 p1: /._. Walnuts?
 r: ^Y^ There you go, well put! Like a anchor made of walnuts.
-[following-our-recipes]
+[following_our_recipes]
 
-[rotting-flesh]
+[rotting_flesh]
 p1: /._. Rotting flesh?
 r: ._.; There you go, well put! Like a anchor made of... wait what!?
 r: /._. ...I mean, maybe? ...Hold up, are you on some kind of watchlist I should know about?
-[following-our-recipes]
+[following_our_recipes]
 
-[smaller-boats]
+[smaller_boats]
 p1: /._. Slightly smaller boats?
 r: ^Y^ There you go, well put! Like a anchor made of slightly smaller boats.
-[following-our-recipes]
+[following_our_recipes]
 
-[avenue-of-discussion]
+[avenue_of_discussion]
 p1: This isn't a helpful avenue of discussion.
 r: /._. Oh sure, I'm with you. ...We'll come back to that one later.
-[following-our-recipes]
+[following_our_recipes]
 
-[following-our-recipes]
+[following_our_recipes]
 s1: /._. Well, anyway... I know you said you were following our recipes to a tee. But just in case...
 r: You want us to show you, right?
 s1: I mean... well...

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-everyone-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-everyone-100.chat
@@ -4,41 +4,41 @@
 indoors
 
 [characters]
-player, p1, kitchen-3
-sensei, s1, kitchen-5
-richie, r, kitchen-11
-skins, s, kitchen-9
-bones, b, kitchen-7
+player, p1, kitchen_3
+sensei, s1, kitchen_5
+richie, r, kitchen_11
+skins, s, kitchen_9
+bones, b, kitchen_7
 
 s: So how was that?
-[very-good] I think you killed it!
+[very_good] I think you killed it!
 [good] That was pretty good!
 [bad] ...
-[very-bad] That was terrible! Are you kidding me?
+[very_bad] That was terrible! Are you kidding me?
 
-[very-good]
+[very_good]
 p1: ^__^ Wow, I think you killed it! You have some real talent.
 s: ^__^ Whoa, thanks!
-[sensei-answers-praise]
+[sensei_answers_praise]
 
 [good]
 p1: ^_^ Hey, that was pretty good! And y'know, with a little more training you'll get even better.
 s: ^_^ Oh okay cool!
-[sensei-answers-praise]
+[sensei_answers_praise]
 
 [bad]
 p1: /._. ...
 s: ._.; ...?
 p1: ._.; ... ...
 s: .__.; ... ... ...
-[sensei-answers-insult]
+[sensei_answers_insult]
 
-[very-bad]
+[very_bad]
 p1: >__< That was terrible! Are you kidding me? ...Did you have any cooking experience before this?
 s: ._.; Uhh I mean like, Richie's been helping me figure out the kitchen stuff. ...Did I mess something up?
-[sensei-answers-insult]
+[sensei_answers_insult]
 
-[sensei-answers-praise]
+[sensei_answers_praise]
 s1: /._. Hmm. Yes! Pretty good. Your technique is ahhh... a little off though!
 s: My... my technique?
 s1: You should focus on the piece of food you're cooking. You don't need to flip all those other pieces beforehand.
@@ -46,9 +46,9 @@ s: @_@ But I have to keep them flipped the same way! Otherwise it makes my head 
 s1: Well, flipping them slows you down.
 s1: That food should be coming out like pap-/pap-/pap-/pap-/pap!/ Right now you're more like pappap,// pappa/ pap.
 s1: You don't want to give your customers any break. Eating should become an unconscious reflex to them, like blinking!
-[oh-okay]
+[oh_okay]
 
-[sensei-answers-insult]
+[sensei_answers_insult]
 s1: /._. What I think #player# is trying to say is your technique is ahhh... a little strange.
 s: My... my technique?
 s1: You should focus on the piece of food you're cooking. You don't need to flip all those other pieces beforehand.
@@ -56,9 +56,9 @@ s: @_@ But I have to keep them flipped the same way! Otherwise it makes my head 
 s1: Well, flipping them slows you down.
 s1: That food should be coming out like pap-/pap-/pap-/pap-/pap!/ Right now you're more like pappap,// pappa/ pap.
 s1: You don't want to give your customers any break. Eating should become an unconscious reflex to them, like blinking!
-[oh-okay]
+[oh_okay]
 
-[oh-okay]
+[oh_okay]
 s: u_u Oh, hmm... okay. Mowr...
 r: ^__^ Hey hey! Don't worry, we'll work on that. Good work everybody!
 r: ^_^ #sensei#, #player# -- see what you can do to drum up more business!

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-shirts-000.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-shirts-000.chat
@@ -4,9 +4,9 @@
 indoors
 
 [characters]
-player, p1, entrance-10
-sensei, s1, entrance-7
-shirts, s, entrance-2
+player, p1, entrance_10
+sensei, s1, entrance_7
+shirts, s, entrance_2
 
 s: Oh hey what's up. I heard you guys came the other day when I wasn't here. So did I miss like anything... important?
 s1: Ahh, nothing important. We're still trying to figure out why this location isn't attracting more customers.

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/hello-skins-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/hello-skins-100.chat
@@ -4,9 +4,9 @@
 indoors
 
 [characters]
-player, p1, kitchen-5
-sensei, s1, kitchen-3
-skins, s, kitchen-7
+player, p1, kitchen_5
+sensei, s1, kitchen_3
+skins, s, kitchen_7
 
 s1: /._. Hmm... so, do you remember that thing I said not to do?
 s: ._.; ...

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/lets-all-get-merry-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/lets-all-get-merry-100.chat
@@ -4,11 +4,11 @@
 indoors
 
 [characters]
-player, p1, kitchen-7
-sensei, s1, kitchen-5
-richie, r, kitchen-11
-skins, s, kitchen-9
-bones, b, kitchen-3
+player, p1, kitchen_7
+sensei, s1, kitchen_5
+richie, r, kitchen_11
+skins, s, kitchen_9
+bones, b, kitchen_3
 
 s1: <_< Well... I'm sorry we still couldn't figure out what's wrong with the food here.
 r: ^_^/ Hey, it ain't your fault! Maybe things are just different here for some reason.

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/pulling-for-bones-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/pulling-for-bones-100.chat
@@ -4,8 +4,8 @@
 outdoors
 
 [characters]
-player, p1, restaurant-1
-bones, b, restaurant-11
+player, p1, restaurant_1
+bones, b, restaurant_11
 
 b: ^O^ Hey, remember a few days ago when you said there's more than one way to bone a dog! Ha ha!
 p1: ^_^ Ha ha! Yeah. Wait, what's so funny about that?
@@ -13,49 +13,49 @@ p1: ^_^ Ha ha! Yeah. Wait, what's so funny about that?
 p1: <__< Why does everyone keep asking me that!?
  (say_if chat_finished level/marsh/pulling_for_skins_100)
 b: OwO... I was thinking maybe if you come over to my place, you can tell me more jokes and then we can get married.
-[yes-id-love-to] Yes, I'd love to
-[no-1] No that's okay
-[yes-i-guess] Umm... I guess
+[yes_id_love_to] Yes, I'd love to
+[no_1] No that's okay
+[yes_i_guess] Umm... I guess
 
-[yes-id-love-to]
+[yes_id_love_to]
 p1: OwO Yes, yes! Oh, I'd love to marry you, Bones!
 [yes]
 
-[yes-i-guess]
+[yes_i_guess]
 p1: <_< Umm... I guess that's alright.
 [yes]
 
-[no-1]
+[no_1]
 p1: /._. N-no, that's okay. I'm not really in the mood for jokes right now.
 b: Okay! Well, let's just get married then.
-[no-2] Umm... I can't
-[yes-why-not] I don't see why not
-[yes-no-problem] No problem at all
+[no_2] Umm... I can't
+[yes_why_not] I don't see why not
+[yes_no_problem] No problem at all
 
-[yes-why-not]
+[yes_why_not]
 p1: /._. Well, I don't see why not.
 [yes]
 
-[yes-no-problem]
+[yes_no_problem]
 p1: No problem, sounds good.
 [yes]
 
-[no-2]
+[no_2]
 p1: <_< Umm, I think I have other plans.
 b: Let's just marry before your plans! Just a quick marry.
-[yes-no-reason] No reason not to
-[yes-okay] Umm... Okay
-[no-3] ._. I don't want to
+[yes_no_reason] No reason not to
+[yes_okay] Umm... Okay
+[no_3] ._. I don't want to
 
-[yes-no-reason]
+[yes_no_reason]
 p1: /._. Well, I don't see any reason not to.
 [yes]
 
-[yes-okay]
+[yes_okay]
 p1: <_< Umm... Okay, whatever.
 [yes]
 
-[no-3]
+[no_3]
 p1: ._. ...I don't want to marry you. Let's be friends.
 b: Marry~
 p1: ._.; ...Friends.
@@ -68,20 +68,20 @@ b: ^O^ Oh boy! Oh boy oh boy oh boy. That is... You're just...
 b: ^_^ My mother always warned me not to settle for the first person I fell in love with. And here you are!
 b: ^__^ And now I get to call them, and tell them that I have a boyfriend or girlfriend.
 b: /._. ...Actually, I probably should have asked you about that. But, I didn't want to be rude.
-[yes-2] ._. I'm a boy
-[yes-2] ._. I'm a girl
-[yes-totally-2] OwO I love you
-[yes-2] >_< I didn't mean to click that
+[yes_2] ._. I'm a boy
+[yes_2] ._. I'm a girl
+[yes_totally_2] OwO I love you
+[yes_2] >_< I didn't mean to click that
 
-[yes-totally-2]
+[yes_totally_2]
 p1: OwO... I-
-[yes-continuation-2]
+[yes_continuation_2]
 
-[yes-2]
+[yes_2]
 p1: I-
-[yes-continuation-2]
+[yes_continuation_2]
 
-[yes-continuation-2]
+[yes_continuation_2]
 b: ^_^ No, no, don't tell me yet! I can just find out on our honeymoon.
 b: OwO... I love surprises~
 (You are now in a relationship with Bones.)

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/pulling-for-everyone-000.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/pulling-for-everyone-000.chat
@@ -4,11 +4,11 @@
 indoors
 
 [characters]
-player, p1, kitchen-9
-sensei, s1, kitchen-5
-richie, r, kitchen-1
-skins, s, kitchen-3
-bones, b, kitchen-7
+player, p1, kitchen_9
+sensei, s1, kitchen_5
+richie, r, kitchen_1
+skins, s, kitchen_3
+bones, b, kitchen_7
 
 p1: Well! I guess this is our last day here.
 r: Yeah! Thanks for all your help. We're putting out better food now, and business is starting to pick up a little.

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/pulling-for-everyone-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/pulling-for-everyone-100.chat
@@ -4,11 +4,11 @@
 indoors
 
 [characters]
-player, p1, kitchen-9
-sensei, s1, kitchen-5
-richie, r, kitchen-1
-skins, s, kitchen-3
-bones, b, kitchen-7
+player, p1, kitchen_9
+sensei, s1, kitchen_5
+richie, r, kitchen_1
+skins, s, kitchen_3
+bones, b, kitchen_7
 
 p1: /._. So one thing I noticed, Skins, is when you switch from one dish to the next-
 b: <_< ...My name is Bones...

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/pulling-for-shirts-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/pulling-for-shirts-100.chat
@@ -4,57 +4,57 @@
 outdoors
 
 [characters]
-player, p1, restaurant-1
-shirts, s, restaurant-11
+player, p1, restaurant_1
+shirts, s, restaurant_11
 
 s: /._. So are they driving you crazy yet?
-[bones-drives-me-crazy] Bones is clingy
+[bones_drives_me_crazy] Bones is clingy
  (link_if chat_finished level/marsh/pulling_for_bones_100)
-[skins-drives-me-crazy] Skins is a bit much
+[skins_drives_me_crazy] Skins is a bit much
  (link_if chat_finished level/marsh/pulling_for_skins_100)
-[who-drives-me-crazy] Who do you mean?
+[who_drives_me_crazy] Who do you mean?
 
-[skins-drives-me-crazy]
+[skins_drives_me_crazy]
 p1: ._.; Skins is... a bit much. They can't seem to take a hint.
 s: ^y^ Yeah, that sounds about right. I think I was here for what... two weeks at most when it started.
-[shirts-explains]
+[shirts_explains]
 
-[bones-drives-me-crazy]
+[bones_drives_me_crazy]
 p1: ._.; Bones became pretty clingy all of a sudden. They can't seem to take a hint.
 s: ^y^ Yeah, that sounds about right. I think I was here for what... two weeks at most when it started.
-[shirts-explains]
+[shirts_explains]
 
-[who-drives-me-crazy]
+[who_drives_me_crazy]
 p1: /._. Is who driving me crazy? I've met a bunch of new people here.
 s: Oh. Really? No one comes to mind, huh? Well that's nice.
 s: ^y^ It sounds like they're taking it easy on you so far. For me, it started like two weeks in.
-[shirts-explains]
+[shirts_explains]
 
-[shirts-explains]
+[shirts_explains]
 s: I dunno if it's flirting, it's just -- the more you treat them like a human being, the less they treat you like one.
 s: >_< Every conversation feels like a contest. They squeeze in these awkward compliments whenever they talk to you.
 s: And they stop farting around you.... And they're always watching you to see what you laugh at, so they can laugh too.
 s: -__- It's just... (sigh) Whatever. It could be worse.
-[ill-fart] I'll fart around you
-[thats-horrible] That's horrible
-[awkward-compliment] You're so smart
-[ive-been-there] I've been there
+[ill_fart] I'll fart around you
+[thats_horrible] That's horrible
+[awkward_compliment] You're so smart
+[ive_been_there] I've been there
 [hmm] Hmm
 
-[ill-fart]
+[ill_fart]
 p1: ^_^ I'll fart around you!
 s: ^o^ Ha ha. Thanks. I think.
 
-[thats-horrible]
+[thats_horrible]
 p1: u_u Ugh, that sounds horrible.
 s: Ahh it's not so bad, just gotta keep those shields up. I'm sure you know the drill.
 [violence]
 
-[awkward-compliment]
+[awkward_compliment]
 p1: ^__^ Wow, what an insightful monologue. You're so smart! And so beautiful.
 s: ^o^ Ha ha. Thanks. I think.
 
-[ive-been-there]
+[ive_been_there]
 p1: >_< Yeah... I've been there before.
 s: Ahh it's not so bad, just gotta keep those shields up. I'm sure you know the drill.
 [violence]

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/pulling-for-skins-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/pulling-for-skins-100.chat
@@ -4,8 +4,8 @@
 outdoors
 
 [characters]
-player, p1, restaurant-1
-skins, s, restaurant-11
+player, p1, restaurant_1
+skins, s, restaurant_11
 
 s: ^O^ Remember when you said, like, there's more than one way to bone a dog? Ha ha! That was really funny~
 p1: ^_^ Ha ha! Yeah. Wait, what's so funny about that?
@@ -14,36 +14,36 @@ p1: <__< Why does everyone keep asking me that!?
  (say_if chat_finished level/marsh/pulling_for_bones_100)
 s: /._. Umm! I don't know. I don't remember now! ...So what are you doing later? Did you want to see a movie together?
 [yes] OwO It's a date!
-[no-movie-0] No, I've seen it
-[no-movie-1] No, I'm busy
+[no_movie_0] No, I've seen it
+[no_movie_1] No, I'm busy
 
-[no-movie-0]
+[no_movie_0]
 p1: <_< No, that's okay. I think I've already seen that movie...
 s: ^_^ You did? Well um... maybe we could watch some dinner instead?
 [yes] It's a date!
-[no-dinner-0a] No, I've seen it
-[no-dinner-0b] No, I'm not hungry
+[no_dinner_0a] No, I've seen it
+[no_dinner_0b] No, I'm not hungry
 
-[no-movie-1]
+[no_movie_1]
 p1: ^n^ Oh, That's okay. I think I already have plans tonight...
 s: ^_^ You did? Well um... maybe we could get dinner later this week?
 [yes] It's a date!
-[no-dinner-1a] I'll be busy
-[no-dinner-1b] I won't be hungry
+[no_dinner_1a] I'll be busy
+[no_dinner_1b] I won't be hungry
 
-[no-dinner-0a]
+[no_dinner_0a]
 p1: <__< Actually, I think I've already seen that dinner, too...
 [ending]
 
-[no-dinner-0b]
+[no_dinner_0b]
 p1: ^N^ Oh I'm not hungry, I just ate lunch...
 [ending]
 
-[no-dinner-1a]
+[no_dinner_1a]
 p1: <__< Actually, I think I already have plans later this week, too...
 [ending]
 
-[no-dinner-1b]
+[no_dinner_1b]
 p1: ^N^ I don't think I'll want dinner later this week! I'll have already eaten such a big lunch...
 [ending]
 

--- a/project/assets/test/ui/chat/chat-condition.chat
+++ b/project/assets/test/ui/chat/chat-condition.chat
@@ -9,16 +9,16 @@ player: Nice to meet you, too!
 player: I remember you too!
  (say_if chat_finished creature/boatricia/hi)
 player: I'd also like to say...
-[first-time]
+[first_time]
  (link_if not chat_finished creature/boatricia/hi)
-[not-first-time]
+[not_first_time]
  (link_if chat_finished creature/boatricia/hi)
 [other]
 
-[first-time]
+[first_time]
 player: It's a shame we've never spoken before!
 
-[not-first-time]
+[not_first_time]
 player: I'm glad to speak with you again!
 
 [other]

--- a/project/assets/test/ui/chat/chat-newlines.chat
+++ b/project/assets/test/ui/chat/chat-newlines.chat
@@ -3,10 +3,10 @@
 boatricia: Have we met?
 (Hmm...\nYou're not sure.)
 boatricia: Anyway!\nUmm, it's nice to meet you.
-[oh-hi] Oh!\nHi!
+[oh_hi] Oh!\nHi!
 [hello] Hello!
 
-[oh-hi]
+[oh_hi]
 player: Oh!\nHi, it's a pleasure to meet you!
 
 [hello]

--- a/project/assets/test/ui/chat/cutscene-full.chat
+++ b/project/assets/test/ui/chat/cutscene-full.chat
@@ -4,55 +4,55 @@
 indoors
 
 [characters]
-player, p1, kitchen-3
-sensei, s1, kitchen-5
-richie, r, kitchen-11
-skins, s, kitchen-9
-bones, b, kitchen-7
+player, p1, kitchen_3
+sensei, s1, kitchen_5
+richie, r, kitchen_11
+skins, s, kitchen_9
+bones, b, kitchen_7
 
 s: So how was that?
-[very-good] I think you killed it!
+[very_good] I think you killed it!
 [good] That was pretty good!
 [bad] ...
-[very-bad] Well... I wouldn't eat it.
+[very_bad] Well... I wouldn't eat it.
 
-[very-good]
+[very_good]
 p1: ^__^ Wow, I think you killed it! You have some real talent.
 s: ^__^ Whoa, thanks!
-[sensei-answers-praise]
+[sensei_answers_praise]
 
 [good]
 p1: ^_^ Hey, that was pretty good! And y'know, with a little more training you'll get even better.
 s: ^_^ Oh okay cool!
-[sensei-answers-praise]
+[sensei_answers_praise]
 
 [bad]
 p1: /._. ...
 s: ._.; ...?
 p1: ._.; ... ...
 s: .__.; ... ... ...
-[sensei-answers-insult]
+[sensei_answers_insult]
 
-[very-bad]
+[very_bad]
 p1: /._. Well... I wouldn't eat it. Did you have any cooking experience before this?
 s: ._.; Uhh I mean like, Richie's been helping me figure out the kitchen stuff. ...Did I mess something up?
-[sensei-answers-insult]
+[sensei_answers_insult]
 
-[sensei-answers-praise]
+[sensei_answers_praise]
 s1: /._. Hmm. Yes! Pretty good. Your rhythm's ahhh... a little off though!
 s: My... my rhythm?
 s1: Yes!/ That food should be coming out like pap-/pap-/pap-/pap-/pap!/ Right now you're more like pappap,// pappa/ pap.
 s1: You don't want to give them any break. Eating should become an unconscious reflex to them, like blinking!
-[oh-okay]
+[oh_okay]
 
-[sensei-answers-insult]
+[sensei_answers_insult]
 s1: /._. What I think #player# is trying to say is your rhythm is ahhh... a little off.
 s: My... my rhythm?
 s1: Yes!/ That food should be coming out like pap-/pap-/pap-/pap-/pap!/ Right now you're more like pappap,// pappa/ pap.
 s1: You don't want to give them any break. Eating should become an unconscious reflex to them, like blinking!
-[oh-okay]
+[oh_okay]
 
-[oh-okay]
+[oh_okay]
 s: u_u Oh, hmm... okay. Mowr...
 r: ^__^ Hey hey! Don't worry, we'll work on that. Good work everybody!
 r: ^_^ #sensei#, #player# -- see what you can do to drum up more business!

--- a/project/src/main/ui/chat/chatscript-parser.gd
+++ b/project/src/main/ui/chat/chatscript-parser.gd
@@ -112,8 +112,8 @@ class CharactersState extends AbstractState:
 	
 	"""
 	Syntax:
-		skins, s, kitchen-9        - a character named 'skins' with an alias 's' spawns at kitchen-9
-		skins, s, !kitchen-9        - a character named 'skins' with an alias 's' spawns invisible at kitchen-9
+		skins, s, kitchen_9        - a character named 'skins' with an alias 's' spawns at kitchen_9
+		skins, s, !kitchen_9        - a character named 'skins' with an alias 's' spawns invisible at kitchen_9
 		skins, s                   - a character named 'skins' with an alias 's'
 		skins                      - a character named 'skins'
 	"""
@@ -290,34 +290,30 @@ class ChatState extends AbstractState:
 	
 	
 	"""
-	Translates human-readable phrases like 'spira enters' into metadata like 'creature-enter spira'
+	Translates human-readable phrases like 'spira enters' into metadata like 'creature_enter spira'
 	"""
 	func _translate_meta_item(item: String) -> String:
 		var result := item
-		if item.begins_with("next scene "):
-			# next scene creature/john/hello -> next-scene creature/john/hello
-			var path := item.trim_prefix("next scene ")
-			result = "next-scene %s" % [path]
-		elif item.ends_with(" enters"):
-			# spira enters -> creature-enter spira
+		if item.ends_with(" enters"):
+			# spira enters -> creature_enter spira
 			var name := item.trim_suffix(" enters")
-			result = "creature-enter %s" % [_unalias(name)]
+			result = "creature_enter %s" % [_unalias(name)]
 		elif item.ends_with(" exits"):
-			# spira exits -> creature-exit spira
+			# spira exits -> creature_exit spira
 			var name := item.trim_suffix(" exits")
-			result = "creature-exit %s" % [_unalias(name)]
+			result = "creature_exit %s" % [_unalias(name)]
 		elif " mood " in item:
-			# spira mood ^_^ -> creature-mood spira 7
+			# spira mood ^_^ -> creature_mood spira 7
 			var name := StringUtils.substring_before(item, " mood ")
 			name = _unalias(name)
 			var mood := StringUtils.substring_after(item, " mood ")
-			result = "creature-mood %s %s" % [name, MOOD_PREFIXES[mood]]
+			result = "creature_mood %s %s" % [name, MOOD_PREFIXES[mood]]
 		elif " faces " in item:
-			# spira faces left -> creature-orientation spira 1
+			# spira faces left -> creature_orientation spira 1
 			var name := StringUtils.substring_before(item, " faces ")
 			name = _unalias(name)
 			var orientation := StringUtils.substring_after(item, " faces ")
-			result = "creature-orientation %s %s" % [name, ORIENTATION_STRINGS[orientation]]
+			result = "creature_orientation %s %s" % [name, ORIENTATION_STRINGS[orientation]]
 		return result
 	
 	

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -213,29 +213,29 @@ creature referenced by the metadata and performs the appropriate action.
 func _apply_chat_event_meta(meta_item: String) -> void:
 	var meta_item_split := meta_item.split(" ")
 	match(meta_item_split[0]):
-		"next-scene":
+		"next_scene":
 			# schedule another cutscene to happen after this cutscene
 			var next_scene_key := meta_item_split[1]
 			var next_scene_path := ChatHistory.path_from_history_key(next_scene_key)
 			var next_scene_chat_tree: ChatTree = ChatLibrary.chat_tree_from_file(next_scene_path)
 			# insert the chat tree to ensure it happens before any enqueued levels
 			CutsceneManager.insert_chat_tree(0, next_scene_chat_tree)
-		"creature-enter":
+		"creature_enter":
 			var creature_id := meta_item_split[1]
 			var creature: Creature = ChattableManager.get_creature_by_id(creature_id)
 			creature.fade_in()
 			emit_signal("visible_chatters_changed")
-		"creature-exit":
+		"creature_exit":
 			var creature_id := meta_item_split[1]
 			var creature: Creature = ChattableManager.get_creature_by_id(creature_id)
 			creature.fade_out()
 			creature.connect("fade_out_finished", self, "_on_Creature_fade_out_finished", [creature])
-		"creature-mood":
+		"creature_mood":
 			var creature_id: String = meta_item_split[1]
 			var creature: Creature = ChattableManager.get_creature_by_id(creature_id)
 			var mood: int = int(meta_item_split[2])
 			creature.play_mood(mood)
-		"creature-orientation":
+		"creature_orientation":
 			var creature_id: String = meta_item_split[1]
 			var creature: Creature = ChattableManager.get_creature_by_id(creature_id)
 			var orientation: int = int(meta_item_split[2])

--- a/project/src/main/world/Overworld.tscn
+++ b/project/src/main/world/Overworld.tscn
@@ -566,15 +566,15 @@ position = Vector2( 700, 1201 )
 position = Vector2( -1021.27, -156.99 )
 destination_scene_path = "res://src/main/world/Overworld.tscn"
 exit_direction = 7
-player_spawn_id = "se-player"
-sensei_spawn_id = "se-sensei"
+player_spawn_id = "se_player"
+sensei_spawn_id = "se_sensei"
 
 [node name="SeExit" parent="World/Obstacles" instance=ExtResource( 24 )]
 position = Vector2( 3406.39, 2245.14 )
 destination_scene_path = "res://src/main/world/Overworld.tscn"
 exit_direction = 3
-player_spawn_id = "nw-player"
-sensei_spawn_id = "nw-sensei"
+player_spawn_id = "nw_player"
+sensei_spawn_id = "nw_sensei"
 
 [node name="MarshCrystal1" parent="World/Obstacles" instance=ExtResource( 23 )]
 position = Vector2( 399, 700 )
@@ -775,114 +775,114 @@ spawn_if = "level_finished marsh/goodbye_skins"
 [node name="SpawnRestaurant1" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 956.39, 1219.86 )
 orientation = 1
-id = "restaurant-1"
+id = "restaurant_1"
 
 [node name="SpawnRestaurant4" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 1005.78, 1308.53 )
 orientation = 1
-id = "restaurant-4"
+id = "restaurant_4"
 
 [node name="SpawnRestaurant8" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 779.04, 1322 )
-id = "restaurant-8"
+id = "restaurant_8"
 
 [node name="SpawnRestaurant11" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 814.96, 1220.98 )
-id = "restaurant-11"
+id = "restaurant_11"
 
 [node name="SpawnRestaurantPlayer" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 687, 1212 )
 orientation = 1
-id = "restaurant-player"
+id = "restaurant_player"
 
 [node name="SpawnRestaurantSensei" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 860, 1240 )
-id = "restaurant-sensei"
+id = "restaurant_sensei"
 
 [node name="SpawnButtercup10" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 2249.48, 843.851 )
-id = "buttercup-10"
+id = "buttercup_10"
 
 [node name="SpawnButtercup8" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 2105.85, 898.027 )
-id = "buttercup-8"
+id = "buttercup_8"
 
 [node name="SpawnButtercup6" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 2318.78, 918.186 )
 orientation = 1
-id = "buttercup-6"
+id = "buttercup_6"
 
 [node name="SpawnButtercup2" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 2501.47, 822.432 )
 orientation = 1
-id = "buttercup-2"
+id = "buttercup_2"
 
 [node name="SpawnButtercupSeat" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 2493, 929 )
 stool_path = NodePath("../ButtercupStool1")
-id = "buttercup-seat"
+id = "buttercup_seat"
 elevation = 80.0
 
 [node name="SpawnButtercupFence" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 2217.94, 1070.42 )
 orientation = 1
-id = "buttercup-fence-3"
+id = "buttercup_fence_3"
 
 [node name="SpawnButtercupFence2" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 2091.36, 1018.8 )
-id = "buttercup-fence-12"
+id = "buttercup_fence_12"
 
 [node name="SpawnSePlayer" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 3251.73, 2165.58 )
 orientation = 2
-id = "se-player"
+id = "se_player"
 
 [node name="SpawnSeSensei" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 3403.09, 2222.76 )
 orientation = 2
-id = "se-sensei"
+id = "se_sensei"
 
 [node name="EExit" parent="World/Obstacles" instance=ExtResource( 24 )]
 position = Vector2( 8332.17, 874.941 )
 destination_scene_path = "res://src/main/world/Overworld.tscn"
 exit_direction = 1
-player_spawn_id = "w-player"
-sensei_spawn_id = "w-sensei"
+player_spawn_id = "w_player"
+sensei_spawn_id = "w_sensei"
 
 [node name="SpawnEPlayer" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 8198.28, 936.019 )
 orientation = 1
-id = "e-player"
+id = "e_player"
 
 [node name="SpawnESensei" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 8360.02, 845.01 )
 orientation = 1
-id = "e-sensei"
+id = "e_sensei"
 
 [node name="WExit" parent="World/Obstacles" instance=ExtResource( 24 )]
 position = Vector2( -3635.54, 1987.22 )
 destination_scene_path = "res://src/main/world/Overworld.tscn"
 exit_direction = 5
-player_spawn_id = "e-player"
-sensei_spawn_id = "e-sensei"
+player_spawn_id = "e_player"
+sensei_spawn_id = "e_sensei"
 
 [node name="SpawnWPlayer" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( -3511.97, 1915.56 )
 orientation = 3
-id = "w-player"
+id = "w_player"
 
 [node name="SpawnWSensei" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( -3468.71, 1900.27 )
 orientation = 3
-id = "w-sensei"
+id = "w_sensei"
 
 [node name="SpawnNwPlayer" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( -848.458, -81.4955 )
-id = "nw-player"
+id = "nw_player"
 
 [node name="SpawnNwPlayer2" parent="World/Obstacles" instance=ExtResource( 17 )]
 position = Vector2( -954.411, -160.54 )
-id = "nw-sensei"
+id = "nw_sensei"
 
 [node name="ChatLetters" parent="World" instance=ExtResource( 3 )]
 

--- a/project/src/main/world/OverworldIndoors.tscn
+++ b/project/src/main/world/OverworldIndoors.tscn
@@ -173,8 +173,8 @@ impassable_tile_index = 1
 position = Vector2( 130.547, 315.908 )
 destination_scene_path = "res://src/main/world/Overworld.tscn"
 exit_direction = 4
-player_spawn_id = "restaurant-player"
-sensei_spawn_id = "restaurant-sensei"
+player_spawn_id = "restaurant_player"
+sensei_spawn_id = "restaurant_sensei"
 
 [node name="Player" parent="World/Obstacles" instance=ExtResource( 19 )]
 position = Vector2( 154.174, 285.058 )
@@ -805,47 +805,47 @@ position = Vector2( 1383.76, 123.852 )
 [node name="SpawnEntrance2" parent="World/Spawns" instance=ExtResource( 6 )]
 position = Vector2( 342.245, 52.3916 )
 orientation = 1
-id = "entrance-2"
+id = "entrance_2"
 
 [node name="SpawnEntrance5" parent="World/Spawns" instance=ExtResource( 6 )]
 position = Vector2( 394.38, 152.458 )
 orientation = 1
-id = "entrance-5"
+id = "entrance_5"
 
 [node name="SpawnEntrance7" parent="World/Spawns" instance=ExtResource( 6 )]
 position = Vector2( 126.975, 170.117 )
-id = "entrance-7"
+id = "entrance_7"
 
 [node name="SpawnEntrance10" parent="World/Spawns" instance=ExtResource( 6 )]
 position = Vector2( 179.111, 52.3916 )
-id = "entrance-10"
+id = "entrance_10"
 
 [node name="SpawnKitchen1" parent="World/Spawns" instance=ExtResource( 6 )]
 position = Vector2( 1863.6, 75.8002 )
 orientation = 1
-id = "kitchen-1"
+id = "kitchen_1"
 
 [node name="SpawnKitchen3" parent="World/Spawns" instance=ExtResource( 6 )]
 position = Vector2( 1910.61, 182.605 )
 orientation = 1
-id = "kitchen-3"
+id = "kitchen_3"
 
 [node name="SpawnKitchen5" parent="World/Spawns" instance=ExtResource( 6 )]
 position = Vector2( 1955.82, 282.207 )
 orientation = 1
-id = "kitchen-5"
+id = "kitchen_5"
 
 [node name="SpawnKitchen7" parent="World/Spawns" instance=ExtResource( 6 )]
 position = Vector2( 1596.46, 279.091 )
-id = "kitchen-7"
+id = "kitchen_7"
 
 [node name="SpawnKitchen9" parent="World/Spawns" instance=ExtResource( 6 )]
 position = Vector2( 1667.9, 173.54 )
-id = "kitchen-9"
+id = "kitchen_9"
 
 [node name="SpawnKitchen11" parent="World/Spawns" instance=ExtResource( 6 )]
 position = Vector2( 1740.68, 77.2144 )
-id = "kitchen-11"
+id = "kitchen_11"
 
 [node name="ChatLetters" parent="World" instance=ExtResource( 12 )]
 

--- a/project/src/main/world/cutscene-manager.gd
+++ b/project/src/main/world/cutscene-manager.gd
@@ -12,17 +12,17 @@ overworld scene. This script maintains a queue of the pending cutscenes and leve
 # was absent, we spawn them near the player. This dictionary contains a list of those spawn locations keyed by the
 # player's location in the cutscene, in the format '<location_id>/<spawn_id>'
 const SENSEI_SPAWN_IDS_BY_PLAYER_LOCATION := {
-	"outdoors/restaurant-1": "restaurant-11",
-	"outdoors/restaurant-4": "restaurant-11",
-	"outdoors/restaurant-8": "restaurant-1",
-	"outdoors/restaurant-11": "restaurant-1",
+	"outdoors/restaurant_1": "restaurant_11",
+	"outdoors/restaurant_4": "restaurant_11",
+	"outdoors/restaurant_8": "restaurant_1",
+	"outdoors/restaurant_11": "restaurant_1",
 	
-	"indoors/kitchen-1": "kitchen-7",
-	"indoors/kitchen-3": "kitchen-7",
-	"indoors/kitchen-5": "kitchen-7",
-	"indoors/kitchen-7": "kitchen-5",
-	"indoors/kitchen-9": "kitchen-5",
-	"indoors/kitchen-11": "kitchen-5",
+	"indoors/kitchen_1": "kitchen_7",
+	"indoors/kitchen_3": "kitchen_7",
+	"indoors/kitchen_5": "kitchen_7",
+	"indoors/kitchen_7": "kitchen_5",
+	"indoors/kitchen_9": "kitchen_5",
+	"indoors/kitchen_11": "kitchen_5",
 }
 
 # Queue of ChatTree and String instances. ChatTrees represent cutscenes, and strings represent level IDs.

--- a/project/src/test/ui/chat/test-chatscript-parser.gd
+++ b/project/src/test/ui/chat/test-chatscript-parser.gd
@@ -33,11 +33,11 @@ func test_overall_meta() -> void:
 func test_cutscene_spawn_locations() -> void:
 	var chat_tree := _chat_tree_from_file(CUTSCENE_FULL)
 	
-	assert_has(chat_tree.spawn_locations, "#player#", "kitchen-3")
-	assert_has(chat_tree.spawn_locations, "#sensei#", "kitchen-5")
-	assert_has(chat_tree.spawn_locations, "richie", "kitchen-11")
-	assert_has(chat_tree.spawn_locations, "skins", "kitchen-9")
-	assert_has(chat_tree.spawn_locations, "bones", "kitchen-7")
+	assert_has(chat_tree.spawn_locations, "#player#", "kitchen_3")
+	assert_has(chat_tree.spawn_locations, "#sensei#", "kitchen_5")
+	assert_has(chat_tree.spawn_locations, "richie", "kitchen_11")
+	assert_has(chat_tree.spawn_locations, "skins", "kitchen_9")
+	assert_has(chat_tree.spawn_locations, "bones", "kitchen_7")
 
 
 func test_cutscene_chat() -> void:
@@ -47,7 +47,7 @@ func test_cutscene_chat() -> void:
 	assert_eq(event.who, "skins")
 	assert_eq(event.text, "So how was that?")
 	assert_eq(event.mood, ChatEvent.Mood.NONE)
-	assert_eq(event.links, ["very-good", "good", "bad", "very-bad"])
+	assert_eq(event.links, ["very_good", "good", "bad", "very_bad"])
 	assert_eq(event.link_texts, ["I think you killed it!", "That was pretty good!", "...",
 			"Well... I wouldn't eat it."])
 
@@ -74,12 +74,12 @@ func test_chatevent_meta() -> void:
 	var chat_tree := _chat_tree_from_file(CUTSCENE_META)
 	
 	# multiple metadata events on one line
-	assert_eq(chat_tree.get_event().meta, ["creature-enter john", "creature-enter jane"])
+	assert_eq(chat_tree.get_event().meta, ["creature_enter john", "creature_enter jane"])
 	
 	# multiple metadata events on different lines
 	chat_tree.advance()
 	chat_tree.advance()
-	assert_eq(chat_tree.get_event().meta, ["creature-exit john", "creature-exit jane"])
+	assert_eq(chat_tree.get_event().meta, ["creature_exit john", "creature_exit jane"])
 
 
 func test_chatevent_meta_orientation() -> void:
@@ -90,7 +90,7 @@ func test_chatevent_meta_orientation() -> void:
 	var event := chat_tree.get_event()
 	
 	assert_eq(event.text, "Oh? Is someone there?")
-	assert_eq(event.meta, ["creature-orientation john 1"])
+	assert_eq(event.meta, ["creature_orientation john 1"])
 
 
 func test_cutscene_thought() -> void:
@@ -139,7 +139,7 @@ func test_chat_condition() -> void:
 	chat_tree.advance()
 	assert_eq(chat_tree.get_event().text, "Nice to meet you, too!")
 	chat_tree.advance()
-	assert_eq(chat_tree.get_event().links, ["first-time", "not-first-time", "other"])
+	assert_eq(chat_tree.get_event().links, ["first_time", "not_first_time", "other"])
 	assert_eq(chat_tree.get_event().enabled_link_indexes(), [0, 2])
 	
 	PlayerData.chat_history.add_history_item("creature/boatricia/hi")
@@ -149,7 +149,7 @@ func test_chat_condition() -> void:
 	chat_tree.advance()
 	assert_eq(chat_tree.get_event().text, "I remember you too!")
 	chat_tree.advance()
-	assert_eq(chat_tree.get_event().links, ["first-time", "not-first-time", "other"])
+	assert_eq(chat_tree.get_event().links, ["first_time", "not_first_time", "other"])
 	assert_eq(chat_tree.get_event().enabled_link_indexes(), [1, 2])
 
 


### PR DESCRIPTION
Chatscript was mixing snake case, kebab case and multiple words in
different contexts. Things like 'next scene', 'link_if' and
'part-2' were all inconsistent with each other. It now uses snake case
consistently.

Snake case is preferable because our JSON uses snake case. Chatscript
derives from (and gets translated to) JSON.

Changed spawn IDs to use underscores too. This is consistent with our
creature IDs (and our JSON conventions.)