### PR TITLE
Save improvements: seconds played, 199c compatibility, float to int

### DIFF
--- a/project/assets/test/turbofat-2783.json
+++ b/project/assets/test/turbofat-2783.json
@@ -1,0 +1,36 @@
+[
+  {
+    "type": "version",
+    "value": "2783"
+  },
+  {
+    "type": "player_info",
+    "value": {
+      "money": 5906795
+    }
+  },
+  {
+    "type": "volume_settings",
+    "value": {
+      "master": 0.5,
+      "music": 0,
+      "sound": 0.7,
+      "voice": 0.7
+    }
+  },
+  {
+    "type": "finished_levels",
+    "value": {
+      "marsh/hello_everyone": {
+        "year": 2021,
+        "month": 7,
+        "day": 13,
+        "weekday": 2,
+        "dst": false,
+        "hour": 9,
+        "minute": 58,
+        "second": 49
+      }
+    }
+  }
+]

--- a/project/project.godot
+++ b/project/project.godot
@@ -500,9 +500,9 @@ _global_script_classes=[ {
 "path": "res://src/main/world/obstacle-spawner.gd"
 }, {
 "base": "Reference",
-"class": "OldSave",
+"class": "OldPlayerSave",
 "language": "GDScript",
-"path": "res://src/main/old-save.gd"
+"path": "res://src/main/old-player-save.gd"
 }, {
 "base": "Reference",
 "class": "OtherRules",
@@ -913,7 +913,7 @@ _global_script_class_icons={
 "ObstacleMap": "",
 "ObstacleMapIndoors": "",
 "ObstacleSpawner": "",
-"OldSave": "",
+"OldPlayerSave": "",
 "OtherRules": "",
 "OvalShadow": "",
 "OverworldObstacle": "",

--- a/project/src/main/player-data.gd
+++ b/project/src/main/player-data.gd
@@ -10,6 +10,9 @@ signal money_changed(value)
 # emitted when the player beats a level, or when the level history is reset or reloaded
 signal level_history_changed
 
+# how often in seconds to increment the 'seconds_played' value
+const SECONDS_PLAYED_INCREMENT := 0.619
+
 var level_history := LevelHistory.new()
 var chat_history := ChatHistory.new()
 
@@ -25,6 +28,20 @@ var misc_settings := MiscSettings.new()
 
 var money := 0 setget set_money
 
+# the player's playtime in seconds
+var seconds_played := 0.0
+
+# periodically increments the 'seconds_played' value
+var seconds_played_timer: Timer
+
+func _ready() -> void:
+	seconds_played_timer = Timer.new()
+	seconds_played_timer.wait_time = SECONDS_PLAYED_INCREMENT
+	seconds_played_timer.connect("timeout", self, "_on_SecondsPlayedTimer_timeout")
+	add_child(seconds_played_timer)
+	seconds_played_timer.start()
+
+
 """
 Resets the player's in-memory data to a default state.
 """
@@ -38,6 +55,7 @@ func reset() -> void:
 	touch_settings.reset()
 	keybind_settings.reset()
 	money = 0
+	seconds_played = 0.0
 	
 	emit_signal("level_history_changed")
 
@@ -45,3 +63,7 @@ func reset() -> void:
 func set_money(new_money: int) -> void:
 	money = new_money
 	emit_signal("money_changed", money)
+
+
+func _on_SecondsPlayedTimer_timeout() -> void:
+	seconds_played += SECONDS_PLAYED_INCREMENT

--- a/project/src/main/rolling-backups.gd
+++ b/project/src/main/rolling-backups.gd
@@ -39,7 +39,7 @@ const SECONDS_PER_HOUR = 60 * SECONDS_PER_MINUTE
 const SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR
 
 # Filename for the current save. Backup filenames are derived based on this filename
-var current_filename: String
+var data_filename: String
 
 # Enum value for the backup was successfully loaded, 'Backup.CURRENT' if the current file worked.
 var loaded_backup := -1
@@ -92,7 +92,7 @@ func load_newest_save(target: Object, method: String) -> void:
 		
 		if load_successful:
 			# copy the good file back to 'foo.save'
-			dir.copy(rolling_filename(loaded_backup), current_filename)
+			dir.copy(rolling_filename(loaded_backup), data_filename)
 
 
 """
@@ -118,9 +118,9 @@ Parameters:
 	'backup': A constant from the Backup enum for to the filename to return.
 """
 func rolling_filename(backup: int) -> String:
-	var suffix := StringUtils.substring_after_last(current_filename, ".")
+	var suffix := StringUtils.substring_after_last(data_filename, ".")
 	var middle := "."
-	var prefix := StringUtils.substring_before_last(current_filename, ".")
+	var prefix := StringUtils.substring_before_last(data_filename, ".")
 	match backup:
 		Backup.THIS_HOUR: middle += "this-hour."
 		Backup.PREV_HOUR: middle += "prev-hour."
@@ -142,7 +142,7 @@ file.
 Afterwards, if the 'this-xxx' backup file does not exist or was just rotated, it's replaced with the current save file.
 """
 func _rotate_backup(this_save: int, prev_save: int, rotate_millis: int) -> void:
-	if not FileUtils.file_exists(current_filename):
+	if not FileUtils.file_exists(data_filename):
 		return
 	
 	var dir := Directory.new()
@@ -160,4 +160,4 @@ func _rotate_backup(this_save: int, prev_save: int, rotate_millis: int) -> void:
 	
 	if not dir.file_exists(this_filename):
 		# populate the 'this-xxx' backup from the current save
-		dir.copy(current_filename, this_filename)
+		dir.copy(data_filename, this_filename)

--- a/project/src/main/ui/chat/chat-history.gd
+++ b/project/src/main/ui/chat/chat-history.gd
@@ -102,8 +102,25 @@ func to_json_dict() -> Dictionary:
 
 func from_json_dict(json: Dictionary) -> void:
 	chat_history = json.get("history_items", {})
+	_convert_float_values_to_ints(chat_history)
+	
 	chat_counts = json.get("counts", {})
+	_convert_float_values_to_ints(chat_counts)
+	
 	filler_counts = json.get("filler_counts", {})
+	_convert_float_values_to_ints(filler_counts)
+
+
+"""
+Converts the float values in a Dictionary to int values.
+
+Godot's JSON parser converts all ints into floats, so we need to change them back. See Godot #9499
+https://github.com/godotengine/godot/issues/9499
+"""
+func _convert_float_values_to_ints(dict: Dictionary) -> void:
+	for key in dict:
+		if dict[key] is float:
+			dict[key] = int(dict[key])
 
 
 """

--- a/project/src/test/test-old-player-save.gd
+++ b/project/src/test/test-old-player-save.gd
@@ -6,7 +6,10 @@ Tests backwards compatibility with older save formats.
 const TEMP_FILENAME := "test-ground-lucky.save"
 
 func before_each() -> void:
-	PlayerSave.current_player_data_filename = "user://%s" % TEMP_FILENAME
+	PlayerSave.data_filename = "user://%s" % TEMP_FILENAME
+	
+	# don't increment playtime during this test or it ruins our assertions
+	PlayerData.seconds_played_timer.stop()
 	PlayerData.reset()
 
 
@@ -47,6 +50,16 @@ func test_1682_chat_history_preserved() -> void:
 	assert_eq(PlayerData.chat_history.get_filler_count("creature/boatricia"), 13)
 
 
+func test_199c() -> void:
+	load_player_data("turbofat-199c.json")
+	
+	assert_eq(PlayerData.level_history.successful_levels.has("practice/marathon_normal"), true)
+	assert_eq(PlayerData.level_history.successful_levels.has("rank/7k"), true)
+	
+	assert_eq(PlayerData.level_history.finished_levels.has("boatricia"), true)
+	assert_eq(PlayerData.level_history.finished_levels.has("example"), true)
+
+
 func test_19c5() -> void:
 	load_player_data("turbofat-19c5.json")
 	
@@ -68,9 +81,6 @@ func test_1b3c() -> void:
 	var history_marathon: RankResult = PlayerData.level_history.results("practice/marathon_hard")[0]
 	assert_eq(history_marathon.lost, false)
 	assert_eq(history_marathon.score, 5115)
-	
-	# 'miscellaneous settings' were renamed to 'misc settings'
-	assert_eq(TranslationServer.get_locale(), "es")
 
 
 func test_245b() -> void:
@@ -117,3 +127,10 @@ func test_2743() -> void:
 	assert_almost_eq(PlayerData.creature_library.get_fatness("#filler_000#"), 1.03, 0.01)
 	assert_almost_eq(PlayerData.creature_library.get_fatness("#filler_100#"), 1.68, 0.01)
 	assert_almost_eq(PlayerData.creature_library.get_fatness("i_n_cognito"), 1.30, 0.01)
+
+
+func test_2783() -> void:
+	load_player_data("turbofat-2783.json")
+	
+	# We did not measure playtime in 2783, but we can approximate it based on the player's money.
+	assert_almost_eq(PlayerData.seconds_played, 1181359, 0.1)

--- a/project/src/test/test-player-save.gd
+++ b/project/src/test/test-player-save.gd
@@ -10,7 +10,7 @@ const TEMP_FILENAME := "test936.save"
 var _rank_result: RankResult
 
 func before_each() -> void:
-	PlayerSave.current_player_data_filename = "user://%s" % TEMP_FILENAME
+	PlayerSave.data_filename = "user://%s" % TEMP_FILENAME
 	PlayerData.reset()
 	
 	_rank_result = RankResult.new()
@@ -23,13 +23,12 @@ func before_each() -> void:
 
 func after_each() -> void:
 	var dir := Directory.new()
-	dir.remove(PlayerSave.rolling_backups.rolling_filename(RollingBackups.CURRENT))
-	dir.remove(PlayerSave.rolling_backups.rolling_filename(RollingBackups.THIS_HOUR))
-	dir.remove(PlayerSave.rolling_backups.rolling_filename(RollingBackups.PREV_HOUR))
-	dir.remove(PlayerSave.rolling_backups.rolling_filename(RollingBackups.THIS_DAY))
-	dir.remove(PlayerSave.rolling_backups.rolling_filename(RollingBackups.PREV_DAY))
-	dir.remove(PlayerSave.rolling_backups.rolling_filename(RollingBackups.THIS_WEEK))
-	dir.remove(PlayerSave.rolling_backups.rolling_filename(RollingBackups.PREV_WEEK))
+	for backup in [
+			RollingBackups.CURRENT,
+			RollingBackups.THIS_HOUR, RollingBackups.PREV_HOUR,
+			RollingBackups.THIS_DAY, RollingBackups.PREV_DAY,
+			RollingBackups.THIS_WEEK, RollingBackups.PREV_WEEK]:
+		dir.remove(PlayerSave.rolling_backups.rolling_filename(backup))
 
 
 func test_save_and_load() -> void:
@@ -45,7 +44,7 @@ func test_one_bad_file() -> void:
 	PlayerData.level_history.add("level_895", _rank_result)
 	PlayerSave.save_player_data()
 	PlayerData.reset()
-	FileUtils.write_file(PlayerSave.current_player_data_filename, "invalid-772")
+	FileUtils.write_file(PlayerSave.data_filename, "invalid-772")
 	PlayerSave.load_player_data()
 	assert_true(PlayerData.level_history.has("level_895"))
 	assert_eq(PlayerData.level_history.results("level_895")[0].score, 7890)

--- a/project/src/test/test-rolling-backups.gd
+++ b/project/src/test/test-rolling-backups.gd
@@ -8,7 +8,7 @@ const TEMP_FILENAME := "test837.save"
 var _backups := RollingBackups.new()
 
 func before_each() -> void:
-	_backups.current_filename = "user://%s" % TEMP_FILENAME
+	_backups.data_filename = "user://%s" % TEMP_FILENAME
 
 
 func after_each() -> void:
@@ -42,7 +42,7 @@ func test_corrupt_filename() -> void:
 
 
 func test_rotate_backups_none_exist() -> void:
-	FileUtils.write_file(_backups.current_filename, "")
+	FileUtils.write_file(_backups.data_filename, "")
 	_backups.rotate_backups()
 	var file := File.new()
 	
@@ -64,7 +64,7 @@ func test_rotate_backups_none_exist() -> void:
 Don't overwrite the 'this_xxx' backups if they already exist
 """
 func test_rotate_backups_dont_overwrite_thisxxx() -> void:
-	FileUtils.write_file(_backups.current_filename, "new-920")
+	FileUtils.write_file(_backups.data_filename, "new-920")
 	FileUtils.write_file(_backups.rolling_filename(RollingBackups.THIS_HOUR), "old-920")
 	_backups.rotate_backups()
 	


### PR DESCRIPTION
PlayerData now tracks seconds played.

Restored 199c backwards compatibility tests. These were inadvertently
removed in cd7cb49a

Fixed 'float to int' errors stemming from chat history. ChatHistory was
saving/loading ints from JSON, but Godot's JSON parser converts all
numeric in JSON to floats. ChatHistory now explicitly converts these to
ints.

Renamed test-backwards-compatible.gd to test-old-player-save.gd

Updated data version to 27bb