### PR TITLE
Multiple save slots. Split SystemData from PlayerData.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -505,6 +505,11 @@ _global_script_classes=[ {
 "path": "res://src/main/old-player-save.gd"
 }, {
 "base": "Reference",
+"class": "OldSystemSave",
+"language": "GDScript",
+"path": "res://src/main/old-system-save.gd"
+}, {
+"base": "Reference",
 "class": "OtherRules",
 "language": "GDScript",
 "path": "res://src/main/puzzle/level/other-rules.gd"
@@ -678,6 +683,11 @@ _global_script_classes=[ {
 "class": "SaveItem",
 "language": "GDScript",
 "path": "res://src/main/save-item.gd"
+}, {
+"base": "HBoxContainer",
+"class": "SaveSlotControl",
+"language": "GDScript",
+"path": "res://src/main/ui/settings-save-slot.gd"
 }, {
 "base": "Reference",
 "class": "ScoreRules",
@@ -914,6 +924,7 @@ _global_script_class_icons={
 "ObstacleMapIndoors": "",
 "ObstacleSpawner": "",
 "OldPlayerSave": "",
+"OldSystemSave": "",
 "OtherRules": "",
 "OvalShadow": "",
 "OverworldObstacle": "",
@@ -949,6 +960,7 @@ _global_script_class_icons={
 "RollingBackups": "",
 "RuleParser": "",
 "SaveItem": "",
+"SaveSlotControl": "",
 "ScoreRules": "",
 "Sensei": "",
 "SettingsMenu": "",
@@ -1015,6 +1027,8 @@ PlayerSave="*res://src/main/player-save.gd"
 PuzzleState="*res://src/main/puzzle/puzzle-state.gd"
 ResourceCache="*res://src/main/ResourceCache.tscn"
 SceneTransition="*res://src/main/ui/scene-transition.gd"
+SystemData="*res://src/main/system-data.gd"
+SystemSave="*res://src/main/system-save.gd"
 
 [debug]
 

--- a/project/src/demo/music/music-player-demo.gd
+++ b/project/src/demo/music/music-player-demo.gd
@@ -15,7 +15,7 @@ Keys:
 """
 
 func _ready() -> void:
-	PlayerData.volume_settings.set_bus_volume_linear(VolumeSettings.MUSIC, 0.5)
+	SystemData.volume_settings.set_bus_volume_linear(VolumeSettings.MUSIC, 0.5)
 
 
 func _input(event: InputEvent) -> void:

--- a/project/src/main/keybind/keybind-manager.gd
+++ b/project/src/main/keybind/keybind-manager.gd
@@ -4,7 +4,7 @@ Binds the player's input settings to the input map.
 """
 
 func _ready() -> void:
-	PlayerData.keybind_settings.connect("settings_changed", self, "_on_KeybindSettings_settings_changed")
+	SystemData.keybind_settings.connect("settings_changed", self, "_on_KeybindSettings_settings_changed")
 
 
 """
@@ -114,12 +114,12 @@ func _bind_keys(action_name: String, input_events: Array) -> void:
 Updates the InputMap when the player's keybind settings change
 """
 func _on_KeybindSettings_settings_changed() -> void:
-	match PlayerData.keybind_settings.preset:
+	match SystemData.keybind_settings.preset:
 		KeybindSettings.GUIDELINE:
 			_bind_keys_from_file("res://assets/main/keybind/guideline.json")
 		KeybindSettings.WASD:
 			_bind_keys_from_file("res://assets/main/keybind/wasd.json")
 		KeybindSettings.CUSTOM:
-			_bind_keys_from_json_dict(PlayerData.keybind_settings.custom_keybinds)
+			_bind_keys_from_json_dict(SystemData.keybind_settings.custom_keybinds)
 		_:
-			push_warning("Unrecognized keybind settings preset: %s" % PlayerData.keybind_settings.preset)
+			push_warning("Unrecognized keybind settings preset: %s" % SystemData.keybind_settings.preset)

--- a/project/src/main/misc-settings.gd
+++ b/project/src/main/misc-settings.gd
@@ -3,6 +3,27 @@ class_name MiscSettings
 Manages miscellaneous settings such as language.
 """
 
+signal save_slot_changed
+
+# Different save slots where the player can save/load their progress
+enum SaveSlot {
+	SLOT_A,
+	SLOT_B,
+	SLOT_C,
+	SLOT_D,
+}
+
+# Human-readable prefixes for the save slots. These are shown to the user in menus
+const SAVE_SLOT_PREFIXES := {
+	SaveSlot.SLOT_A: "A",
+	SaveSlot.SLOT_B: "B",
+	SaveSlot.SLOT_C: "C",
+	SaveSlot.SLOT_D: "D",
+}
+
+# The current save slot for saving/loading progress
+var save_slot: int = SaveSlot.SLOT_A setget set_save_slot
+
 # Whether cutscenes should play by default.
 var cutscene_force: int = Levels.CutsceneForce.NONE
 
@@ -13,15 +34,24 @@ func reset() -> void:
 	from_json_dict({})
 
 
+func set_save_slot(new_save_slot: int) -> void:
+	if save_slot == new_save_slot:
+		return
+	save_slot = new_save_slot
+	emit_signal("save_slot_changed")
+
+
 func to_json_dict() -> Dictionary:
 	return {
 		"locale": TranslationServer.get_locale(),
 		"cutscene_force": cutscene_force,
+		"save_slot": save_slot,
 	}
 
 
 func from_json_dict(json: Dictionary) -> void:
 	cutscene_force = json.get("cutscene_force", Levels.CutsceneForce.NONE)
+	save_slot = json.get("save_slot", SaveSlot.SLOT_A)
 	
 	if json.has("locale"):
 		TranslationServer.set_locale(json.get("locale"))

--- a/project/src/main/old-player-save.gd
+++ b/project/src/main/old-player-save.gd
@@ -59,10 +59,8 @@ func transform_old_save_items(json_save_items: Array) -> Array:
 	match version_string:
 		"2783":
 			json_save_items = _convert_2783(json_save_items)
-		"2743":
+		"2743", "252a":
 			json_save_items = _convert_2743(json_save_items)
-		"252a":
-			json_save_items = _convert_252a(json_save_items)
 		"24cc":
 			json_save_items = _convert_24cc(json_save_items)
 		"245b":
@@ -100,6 +98,9 @@ func _convert_2783(json_save_items: Array) -> Array:
 				# them about accidentally deleting their main save file.
 				# warning-ignore:integer_division
 				save_item["value"]["seconds_played"] = money / 5
+			"gameplay_settings", "graphics_settings", "keybind_settings", \
+			"misc_settings", "miscellaneous_settings", "touch_settings", "volume_settings":
+				save_item = null
 		if save_item:
 			new_save_items.append(save_item.to_json_dict())
 	return new_save_items
@@ -152,20 +153,6 @@ func _replace_fatness_keys_for_2743(dict: Dictionary) -> void:
 			# if two keys conflict, take the higher value of the two
 			dict[new_key] = max(dict[key], dict.get(new_key, 0))
 			dict.erase(key)
-
-
-func _convert_252a(json_save_items: Array) -> Array:
-	var new_save_items := []
-	for json_save_item_obj in json_save_items:
-		var save_item: SaveItem = SaveItem.new()
-		save_item.from_json_dict(json_save_item_obj)
-		match save_item.type:
-			"version":
-				save_item["value"] = "2743"
-			"miscellaneous_settings":
-				save_item.type = "misc_settings"
-		new_save_items.append(save_item.to_json_dict())
-	return new_save_items
 
 
 func _convert_24cc(json_save_items: Array) -> Array:

--- a/project/src/main/old-system-save.gd
+++ b/project/src/main/old-system-save.gd
@@ -1,0 +1,78 @@
+class_name OldSystemSave
+"""
+Provides backwards compatibility with older system save formats.
+
+This class will grow with each change to our save system. Once it gets too large (600 lines or so) we should drop
+backwards compatibility for older versions.
+"""
+
+"""
+Returns 'true' if the specified json save items are from an older version of the game.
+"""
+func is_old_save_items(json_save_items: Array) -> bool:
+	var is_old: bool = false
+	var version_string := get_version_string(json_save_items)
+	match version_string:
+		PlayerSave.PLAYER_DATA_VERSION:
+			is_old = false
+		"1b3c", "19c5", "199c", "1922", "1682", "163e", "15d2", "245b", "24cc", "252a", "2743", "2783":
+			is_old = true
+		_:
+			push_warning("Unrecognized save data version: '%s'" % version_string)
+	return is_old
+
+
+"""
+Extracts a version string from the specified json save items.
+"""
+func get_version_string(json_save_items: Array) -> String:
+	var version: SaveItem
+	for json_save_item_obj in json_save_items:
+		var save_item: SaveItem = SaveItem.new()
+		save_item.from_json_dict(json_save_item_obj)
+		if save_item.type == "version":
+			version = save_item
+			break
+	return version.value if version else ""
+
+
+"""
+Transforms the specified json save items to the latest format.
+"""
+func transform_old_save_items(json_save_items: Array) -> Array:
+	var version_string := get_version_string(json_save_items)
+	match version_string:
+		"2783":
+			json_save_items = _convert_2783(json_save_items)
+		"2743", "252a", "24cc", "245b", "1b3c", "19c5", "199c", "1922", "1682", "163e", "15d2":
+			json_save_items = _convert_252a(json_save_items)
+	return json_save_items
+
+
+func _convert_2783(json_save_items: Array) -> Array:
+	var new_save_items := []
+	for json_save_item_obj in json_save_items:
+		var save_item: SaveItem = SaveItem.new()
+		save_item.from_json_dict(json_save_item_obj)
+		match save_item.type:
+			"version":
+				save_item["value"] = "27bb"
+			"chat_history", "creature_library", "finished_levels", "level_history", "player_info", "successful_levels":
+				save_item = null
+		if save_item:
+			new_save_items.append(save_item.to_json_dict())
+	return new_save_items
+
+
+func _convert_252a(json_save_items: Array) -> Array:
+	var new_save_items := []
+	for json_save_item_obj in json_save_items:
+		var save_item: SaveItem = SaveItem.new()
+		save_item.from_json_dict(json_save_item_obj)
+		match save_item.type:
+			"version":
+				save_item["value"] = "2783"
+			"miscellaneous_settings":
+				save_item.type = "misc_settings"
+		new_save_items.append(save_item.to_json_dict())
+	return new_save_items

--- a/project/src/main/player-data.gd
+++ b/project/src/main/player-data.gd
@@ -1,8 +1,10 @@
 extends Node
 """
-Stores data about the player's progress in memory.
+Stores data about the player's progress.
 
 This data includes how well they've done on each level and how much money they've earned.
+
+Configuration data like the graphics and keybindings is stored in the SystemData class, not here.
 """
 
 signal money_changed(value)
@@ -18,13 +20,6 @@ var chat_history := ChatHistory.new()
 
 var creature_library := CreatureLibrary.new()
 var creature_queue := CreatureQueue.new()
-
-var gameplay_settings := GameplaySettings.new()
-var graphics_settings := GraphicsSettings.new()
-var volume_settings := VolumeSettings.new()
-var touch_settings := TouchSettings.new()
-var keybind_settings := KeybindSettings.new()
-var misc_settings := MiscSettings.new()
 
 var money := 0 setget set_money
 
@@ -49,11 +44,6 @@ func reset() -> void:
 	level_history.reset()
 	chat_history.reset()
 	creature_library.reset()
-	
-	gameplay_settings.reset()
-	volume_settings.reset()
-	touch_settings.reset()
-	keybind_settings.reset()
 	money = 0
 	seconds_played = 0.0
 	

--- a/project/src/main/puzzle/piece/ghost-mover.gd
+++ b/project/src/main/puzzle/piece/ghost-mover.gd
@@ -14,12 +14,12 @@ var _ghost_shadow_offset := Vector2.ZERO
 onready var _tile_map: PuzzleTileMap = get_node(tile_map_path)
 
 func _ready() -> void:
-	PlayerData.gameplay_settings.connect("ghost_piece_changed", self, "_on_GameplaySettings_ghost_piece_changed")
+	SystemData.gameplay_settings.connect("ghost_piece_changed", self, "_on_GameplaySettings_ghost_piece_changed")
 	_refresh_ghost_piece()
 
 
 func _refresh_ghost_piece() -> void:
-	if PlayerData.gameplay_settings.ghost_piece:
+	if SystemData.gameplay_settings.ghost_piece:
 		_tile_map.set_ghost_shadow_offset(_ghost_shadow_offset)
 	else:
 		_tile_map.set_ghost_shadow_offset(Vector2.ZERO)

--- a/project/src/main/puzzle/puzzle-touch-buttons.gd
+++ b/project/src/main/puzzle/puzzle-touch-buttons.gd
@@ -58,7 +58,7 @@ onready var _menu_button := $MenuButtonHolder/MenuButton
 
 func _ready() -> void:
 	if OS.has_touchscreen_ui_hint():
-		PlayerData.touch_settings.connect("settings_changed", self, "_on_TouchSettings_settings_changed")
+		SystemData.touch_settings.connect("settings_changed", self, "_on_TouchSettings_settings_changed")
 		_refresh_emit_actions()
 		_refresh_settings()
 		show()
@@ -101,14 +101,14 @@ Updates the buttons based on the player's settings.
 This updates their location and size.
 """
 func _refresh_button_positions() -> void:
-	$ButtonsSw.rect_scale = Vector2(1.0, 1.0) * PlayerData.touch_settings.size
+	$ButtonsSw.rect_scale = Vector2(1.0, 1.0) * SystemData.touch_settings.size
 	$ButtonsSw.rect_position.y = rect_size.y - 10 - $ButtonsSw.rect_size.y * $ButtonsSw.rect_scale.y
 	
-	$ButtonsSe.rect_scale = Vector2(1.0, 1.0) * PlayerData.touch_settings.size
+	$ButtonsSe.rect_scale = Vector2(1.0, 1.0) * SystemData.touch_settings.size
 	$ButtonsSe.rect_position.x = rect_size.x - 10 - $ButtonsSw.rect_size.x * $ButtonsSw.rect_scale.x
 	$ButtonsSe.rect_position.y = rect_size.y - 10 - $ButtonsSw.rect_size.y * $ButtonsSw.rect_scale.y
 	
-	_menu_button.scale = Vector2(0.375, 0.375) * PlayerData.touch_settings.size
+	_menu_button.scale = Vector2(0.375, 0.375) * SystemData.touch_settings.size
 	$MenuButtonHolder.rect_position.x = rect_size.x - 20 - _menu_button.pressed.get_size().x * _menu_button.scale.x
 
 
@@ -122,7 +122,7 @@ func _refresh_settings() -> void:
 	_refresh_button_positions()
 	
 	# update actions
-	var scheme_dict: Dictionary = SCHEMES.get(PlayerData.touch_settings.scheme, TouchSettings.EASY_CONSOLE)
+	var scheme_dict: Dictionary = SCHEMES.get(SystemData.touch_settings.scheme, TouchSettings.EASY_CONSOLE)
 	$ButtonsSw.up_action = scheme_dict["sw_actions"][0]
 	$ButtonsSw.down_action = scheme_dict["sw_actions"][1]
 	$ButtonsSw.left_action = scheme_dict["sw_actions"][2]
@@ -133,14 +133,14 @@ func _refresh_settings() -> void:
 	$ButtonsSe.right_action = scheme_dict["se_actions"][3]
 	
 	# update diagonal sensitivity
-	$ButtonsSw.up_left_weight = scheme_dict["sw_weights"][0] * PlayerData.touch_settings.fat_finger
-	$ButtonsSw.up_right_weight = scheme_dict["sw_weights"][1] * PlayerData.touch_settings.fat_finger
-	$ButtonsSw.down_left_weight = scheme_dict["sw_weights"][2] * PlayerData.touch_settings.fat_finger
-	$ButtonsSw.down_right_weight = scheme_dict["sw_weights"][3] * PlayerData.touch_settings.fat_finger
-	$ButtonsSe.up_left_weight = scheme_dict["se_weights"][0] * PlayerData.touch_settings.fat_finger
-	$ButtonsSe.up_right_weight = scheme_dict["se_weights"][1] * PlayerData.touch_settings.fat_finger
-	$ButtonsSe.down_left_weight = scheme_dict["se_weights"][2] * PlayerData.touch_settings.fat_finger
-	$ButtonsSe.down_right_weight = scheme_dict["se_weights"][3] * PlayerData.touch_settings.fat_finger
+	$ButtonsSw.up_left_weight = scheme_dict["sw_weights"][0] * SystemData.touch_settings.fat_finger
+	$ButtonsSw.up_right_weight = scheme_dict["sw_weights"][1] * SystemData.touch_settings.fat_finger
+	$ButtonsSw.down_left_weight = scheme_dict["sw_weights"][2] * SystemData.touch_settings.fat_finger
+	$ButtonsSw.down_right_weight = scheme_dict["sw_weights"][3] * SystemData.touch_settings.fat_finger
+	$ButtonsSe.up_left_weight = scheme_dict["se_weights"][0] * SystemData.touch_settings.fat_finger
+	$ButtonsSe.up_right_weight = scheme_dict["se_weights"][1] * SystemData.touch_settings.fat_finger
+	$ButtonsSe.down_left_weight = scheme_dict["se_weights"][2] * SystemData.touch_settings.fat_finger
+	$ButtonsSe.down_right_weight = scheme_dict["se_weights"][3] * SystemData.touch_settings.fat_finger
 
 
 func _on_TouchSettings_settings_changed() -> void:

--- a/project/src/main/puzzle/tutorial-keybinds-label.gd
+++ b/project/src/main/puzzle/tutorial-keybinds-label.gd
@@ -4,7 +4,7 @@ A label for tutorials which shows the keybinds.
 """
 
 func _ready() -> void:
-	PlayerData.keybind_settings.connect("settings_changed", self, "_on_KeybindSettings_settings_changed")
+	SystemData.keybind_settings.connect("settings_changed", self, "_on_KeybindSettings_settings_changed")
 	_refresh_message()
 
 

--- a/project/src/main/rolling-backups.gd
+++ b/project/src/main/rolling-backups.gd
@@ -24,6 +24,7 @@ enum Backup {
 	PREV_DAY, # a backup which is 1-2 days old
 	THIS_WEEK, # a temporary file which will eventually become the weekly backup
 	PREV_WEEK, # a backup which is 1-2 weeks old
+	LEGACY, # old save data from before July 2021
 }
 
 const CURRENT := Backup.CURRENT
@@ -33,6 +34,7 @@ const THIS_DAY := Backup.THIS_DAY
 const PREV_DAY := Backup.PREV_DAY
 const THIS_WEEK := Backup.THIS_WEEK
 const PREV_WEEK := Backup.PREV_WEEK
+const LEGACY := Backup.LEGACY
 
 const SECONDS_PER_MINUTE = 60
 const SECONDS_PER_HOUR = 60 * SECONDS_PER_MINUTE
@@ -40,6 +42,9 @@ const SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR
 
 # Filename for the current save. Backup filenames are derived based on this filename
 var data_filename: String
+
+# Filename for save data older than July 2021
+var legacy_filename: String
 
 # Enum value for the backup was successfully loaded, 'Backup.CURRENT' if the current file worked.
 var loaded_backup := -1
@@ -63,7 +68,7 @@ func load_newest_save(target: Object, method: String) -> void:
 	var bad_filenames := [] # save filenames which couldn't be loaded
 	
 	var load_successful := false
-	for backup in [CURRENT, THIS_HOUR, PREV_HOUR, THIS_DAY, PREV_DAY, THIS_WEEK, PREV_WEEK]:
+	for backup in [CURRENT, THIS_HOUR, PREV_HOUR, THIS_DAY, PREV_DAY, THIS_WEEK, PREV_WEEK, LEGACY]:
 		var rolling_filename := rolling_filename(backup)
 		if not FileUtils.file_exists(rolling_filename):
 			# file not found; try next file
@@ -118,6 +123,9 @@ Parameters:
 	'backup': A constant from the Backup enum for to the filename to return.
 """
 func rolling_filename(backup: int) -> String:
+	if backup == Backup.LEGACY:
+		return legacy_filename
+	
 	var suffix := StringUtils.substring_after_last(data_filename, ".")
 	var middle := "."
 	var prefix := StringUtils.substring_before_last(data_filename, ".")

--- a/project/src/main/string-utils.gd
+++ b/project/src/main/string-utils.gd
@@ -60,6 +60,25 @@ static func comma_sep(n: int) -> String:
 
 
 """
+Formats a float with commas like '1,234,567.89'.
+
+Parameters:
+	'n': The number to format
+	
+	'precision': The number of decimal places to show. Rounding is used.
+"""
+static func comma_sep_float(n: float, precision: int) -> String:
+	var result := str(stepify(abs(n) - int(abs(n)), pow(0.1, precision))).substr(1)
+	var i: int = abs(n)
+	
+	while i > 999:
+		result = ",%03d%s" % [i % 1000, result]
+		i /= 1000
+	
+	return "%s%s%s" % ["-" if n < 0 else "", i, result]
+
+
+"""
 Gets the substring before the first occurrence of a separator.
 """
 static func substring_before(s: String, sep: String) -> String:

--- a/project/src/main/system-data.gd
+++ b/project/src/main/system-data.gd
@@ -1,0 +1,26 @@
+extends Node
+"""
+Stores data about the system and its configuration.
+
+This data includes configuration data like language, keybindings, and graphics settings.
+
+Data about the player's progress and high scores is stored in the PlayerData class, not here.
+"""
+
+var gameplay_settings := GameplaySettings.new()
+var graphics_settings := GraphicsSettings.new()
+var volume_settings := VolumeSettings.new()
+var touch_settings := TouchSettings.new()
+var keybind_settings := KeybindSettings.new()
+var misc_settings := MiscSettings.new()
+
+"""
+Resets the system's in-memory data to a default state.
+"""
+func reset() -> void:
+	gameplay_settings.reset()
+	graphics_settings.reset()
+	volume_settings.reset()
+	touch_settings.reset()
+	keybind_settings.reset()
+	misc_settings.reset()

--- a/project/src/main/system-save.gd
+++ b/project/src/main/system-save.gd
@@ -1,0 +1,235 @@
+extends Node
+"""
+Reads and writes data about the system from a file.
+
+This data includes configuration data like language, keybindings, and which save slot is active.
+"""
+
+signal save_slot_deleted
+
+const SYSTEM_DATA_VERSION := "27bb"
+
+# Save files older than July 2021 which should be deleted during an upgrade
+const OLD_SAVES_TO_DELETE := [
+	"user://turbofat0.this-hour.save.bak",
+	"user://turbofat0.this-day.save.bak",
+	"user://turbofat0.this-week.save.bak",
+	"user://turbofat0.prev-hour.save.bak",
+	"user://turbofat0.prev-day.save.bak",
+	"user://turbofat0.prev-week.save.bak",
+]
+
+# Player data filenames organized by save slot
+const FILENAMES_BY_SAVE_SLOT: Dictionary = {
+	MiscSettings.SaveSlot.SLOT_A: "user://saveslot0.save",
+	MiscSettings.SaveSlot.SLOT_B: "user://saveslot1.save",
+	MiscSettings.SaveSlot.SLOT_C: "user://saveslot2.save",
+	MiscSettings.SaveSlot.SLOT_D: "user://saveslot3.save",
+}
+
+# Filename for saving/loading system data. Can be changed for tests
+var data_filename := "user://config.json"
+
+# Filename for loading data older than July 2021. Can be changed for tests
+var legacy_filename := "user://turbofat0.save"
+
+# Provides backwards compatibility with older save formats
+var old_save := OldSystemSave.new()
+
+func _ready() -> void:
+	load_system_data()
+	SystemData.misc_settings.connect("save_slot_changed", self, "_on_MiscSettings_save_slot_changed")
+	_refresh_save_slot()
+	PlayerSave.load_player_data()
+
+
+"""
+Writes the system's in-memory data to a save file.
+"""
+func save_system_data() -> void:
+	var save_json := []
+	save_json.append(_save_item("version", SYSTEM_DATA_VERSION).to_json_dict())
+	save_json.append(_save_item("gameplay_settings", SystemData.gameplay_settings.to_json_dict()).to_json_dict())
+	save_json.append(_save_item("graphics_settings", SystemData.graphics_settings.to_json_dict()).to_json_dict())
+	save_json.append(_save_item("volume_settings", SystemData.volume_settings.to_json_dict()).to_json_dict())
+	save_json.append(_save_item("touch_settings", SystemData.touch_settings.to_json_dict()).to_json_dict())
+	save_json.append(_save_item("keybind_settings", SystemData.keybind_settings.to_json_dict()).to_json_dict())
+	save_json.append(_save_item("misc_settings", SystemData.misc_settings.to_json_dict()).to_json_dict())
+	FileUtils.write_file(data_filename, Utils.print_json(save_json))
+	
+	if FileUtils.file_exists(legacy_filename):
+		# Data older than July 2021 used a different filename.
+		# We load it once and then move it aside when saving.
+		var dir := Directory.new()
+		dir.open("user://")
+		var rename_from := legacy_filename.trim_prefix("user://")
+		var rename_to := rename_from + ".bak"
+		dir.rename(rename_from, rename_to)
+		
+		# Legacy data includes player data and configuration data.
+		# Save the player data as well to ensure both halves are written to disk.
+		PlayerSave.save_player_data()
+		
+		# Preserve turbofat0.save.bak, but delete the hourly/daily/weekly backups
+		for filename in OLD_SAVES_TO_DELETE:
+			Directory.new().remove(filename)
+
+
+"""
+Populates the system's in-memory data based on a save file.
+
+Returns 'true' if the data is loaded successfully.
+"""
+func load_system_data() -> bool:
+	SystemData.reset()
+	
+	var filename := data_filename
+	if not FileUtils.file_exists(data_filename) and FileUtils.file_exists(legacy_filename):
+		# If the player only has older July 2021 save data, we load that instead
+		filename = legacy_filename
+	
+	var file := File.new()
+	var open_result := file.open(filename, File.READ)
+	if open_result != OK:
+		# validation failed; couldn't open file
+		push_warning("Couldn't open file '%s' for reading: %s" % [filename, open_result])
+		return false
+	
+	var save_json_text := FileUtils.get_file_as_text(filename)
+	
+	var validate_json_result := validate_json(save_json_text)
+	if validate_json_result != "":
+		# validation failed; invalid json
+		push_warning("Invalid json in file '%s': %s" % [filename, validate_json_result])
+		return false
+	
+	var json_save_items: Array = parse_json(save_json_text)
+	
+	while old_save.is_old_save_items(json_save_items):
+		# convert the old save file to a new format
+		var old_version := old_save.get_version_string(json_save_items)
+		json_save_items = old_save.transform_old_save_items(json_save_items)
+		if old_save.get_version_string(json_save_items) == old_version:
+			# failed to convert, but the data might still load
+			push_warning("Couldn't convert old save data version '%s'" % old_version)
+			break
+	
+	for json_save_item_obj in json_save_items:
+		var save_item: SaveItem = SaveItem.new()
+		save_item.from_json_dict(json_save_item_obj)
+		_load_line(save_item.type, save_item.key, save_item.value)
+	
+	# emit a signal indicating the level history was loaded
+	PlayerData.emit_signal("level_history_changed")
+	
+	return true
+
+
+"""
+Returns the playtime in seconds for the specified save slot.
+"""
+func get_save_slot_playtime(save_slot: int) -> float:
+	var filename: String = FILENAMES_BY_SAVE_SLOT[save_slot]
+	return PlayerSave.get_save_slot_playtime(filename)
+
+
+"""
+Returns the player's short name for the specified save slot.
+"""
+func get_save_slot_player_short_name(save_slot: int) -> String:
+	var filename: String = FILENAMES_BY_SAVE_SLOT[save_slot]
+	return PlayerSave.get_save_slot_player_short_name(filename)
+
+
+"""
+Returns a human-readable name for the specified save slot.
+"""
+func get_save_slot_name(save_slot: int) -> String:
+	var prefix: String = MiscSettings.SAVE_SLOT_PREFIXES[save_slot]
+	var filename: String = FILENAMES_BY_SAVE_SLOT[save_slot]
+	var save_slot_name: String
+	if FileUtils.file_exists(filename):
+		var player_short_name := get_save_slot_player_short_name(save_slot)
+		save_slot_name = "%s: %s" % [prefix, player_short_name]
+	else:
+		save_slot_name = "%s: (empty)" % [prefix]
+	return save_slot_name
+
+
+"""
+Deletes the specified save slot and all of its backups.
+"""
+func delete_save_slot(save_slot: int) -> void:
+	var filename: String = FILENAMES_BY_SAVE_SLOT[save_slot]
+	
+	var rolling_backups := RollingBackups.new()
+	rolling_backups.data_filename = filename
+	for backup in [RollingBackups.CURRENT,
+			RollingBackups.THIS_HOUR, RollingBackups.PREV_HOUR,
+			RollingBackups.THIS_DAY, RollingBackups.PREV_DAY,
+			RollingBackups.THIS_WEEK, RollingBackups.PREV_WEEK]:
+		var rolling_filename := rolling_backups.rolling_filename(backup)
+		Directory.new().remove(rolling_filename)
+	
+	emit_signal("save_slot_deleted")
+
+
+"""
+Creates a granular save item. The system's configuration data includes many of these.
+
+Note: Intuitively this method would be a static factory method on the SaveItem class, but that causes console errors
+due to Godot #30668 (https://github.com/godotengine/godot/issues/30668)
+"""
+func _save_item(type: String, value, key: String = "") -> SaveItem:
+	var save_item := SaveItem.new()
+	save_item.type = type
+	save_item.key = key
+	save_item.value = value
+	return save_item
+
+
+"""
+Populates the player's in-memory data based on a single line from their save file.
+
+Parameters:
+	'type': A string unique to each type of data (level-data, player-data)
+	'_key': A string identifying a specific data item (sophie, marathon-normal)
+	'json_value': The value object (array, dictionary, string) containing the data
+"""
+func _load_line(type: String, _key: String, json_value) -> void:
+	match type:
+		"version":
+			var value: String = json_value
+			if value != SYSTEM_DATA_VERSION:
+				push_warning("Unrecognized save data version: '%s'" % value)
+		"gameplay_settings":
+			var value: Dictionary = json_value
+			SystemData.gameplay_settings.from_json_dict(value)
+		"graphics_settings":
+			var value: Dictionary = json_value
+			SystemData.graphics_settings.from_json_dict(value)
+		"volume_settings":
+			var value: Dictionary = json_value
+			SystemData.volume_settings.from_json_dict(value)
+		"touch_settings":
+			var value: Dictionary = json_value
+			SystemData.touch_settings.from_json_dict(value)
+		"keybind_settings":
+			var value: Dictionary = json_value
+			SystemData.keybind_settings.from_json_dict(value)
+		"misc_settings":
+			var value: Dictionary = json_value
+			SystemData.misc_settings.from_json_dict(value)
+		_:
+			push_warning("Unrecognized save data type: '%s'" % type)
+
+
+func _refresh_save_slot() -> void:
+	if not FILENAMES_BY_SAVE_SLOT.has(SystemData.misc_settings.save_slot):
+		SystemData.misc_settings.save_slot = MiscSettings.SaveSlot.SLOT_A
+	var filename: String = FILENAMES_BY_SAVE_SLOT[SystemData.misc_settings.save_slot]
+	PlayerSave.data_filename = filename
+
+
+func _on_MiscSettings_save_slot_changed() -> void:
+	_refresh_save_slot()

--- a/project/src/main/ui/SettingsMenu.tscn
+++ b/project/src/main/ui/SettingsMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=2]
+[gd_scene load_steps=28 format=2]
 
 [ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=2]
@@ -21,6 +21,9 @@
 [ext_resource path="res://src/main/ui/settings-creature-graphics.gd" type="Script" id=19]
 [ext_resource path="res://src/main/ui/menu/theme/h5.theme" type="Theme" id=20]
 [ext_resource path="res://src/main/ui/settings-warning.gd" type="Script" id=21]
+[ext_resource path="res://src/main/ui/settings-save-slot.gd" type="Script" id=22]
+[ext_resource path="res://src/main/ui/DialogBackdrop.tscn" type="PackedScene" id=23]
+[ext_resource path="res://src/main/ui/settings-dialogs.gd" type="Script" id=24]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 5.0
@@ -72,7 +75,6 @@ visible = false
 emit_actions = false
 
 [node name="Window" type="Panel" parent="."]
-visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -229,7 +231,7 @@ margin_right = -5.0
 margin_bottom = -5.0
 
 [node name="GhostPiece" type="HBoxContainer" parent="Window/UiArea/TabContainer/Gameplay"]
-margin_right = 510.0
+margin_right = 560.0
 margin_bottom = 28.0
 rect_min_size = Vector2( 400, 26 )
 size_flags_horizontal = 3
@@ -238,7 +240,7 @@ custom_constants/separation = 20
 script = ExtResource( 12 )
 
 [node name="Label" type="Label" parent="Window/UiArea/TabContainer/Gameplay/GhostPiece"]
-margin_right = 178.0
+margin_right = 196.0
 margin_bottom = 28.0
 rect_min_size = Vector2( 120, 28 )
 size_flags_horizontal = 3
@@ -252,8 +254,8 @@ __meta__ = {
 }
 
 [node name="CheckboxButton" type="CheckBox" parent="Window/UiArea/TabContainer/Gameplay/GhostPiece"]
-margin_left = 198.0
-margin_right = 510.0
+margin_left = 216.0
+margin_right = 560.0
 margin_bottom = 28.0
 rect_min_size = Vector2( 160, 26 )
 size_flags_horizontal = 3
@@ -274,7 +276,7 @@ margin_bottom = -5.0
 script = ExtResource( 15 )
 
 [node name="Presets" type="HBoxContainer" parent="Window/UiArea/TabContainer/Controls"]
-margin_right = 510.0
+margin_right = 560.0
 margin_bottom = 26.0
 rect_min_size = Vector2( 400, 26 )
 size_flags_horizontal = 3
@@ -283,8 +285,8 @@ custom_constants/separation = 20
 alignment = 1
 
 [node name="Guideline" type="Button" parent="Window/UiArea/TabContainer/Controls/Presets"]
-margin_left = 85.0
-margin_right = 185.0
+margin_left = 110.0
+margin_right = 210.0
 margin_bottom = 26.0
 rect_min_size = Vector2( 100, 0 )
 theme = ExtResource( 1 )
@@ -294,8 +296,8 @@ group = SubResource( 3 )
 text = "Guideline"
 
 [node name="Wasd" type="Button" parent="Window/UiArea/TabContainer/Controls/Presets"]
-margin_left = 205.0
-margin_right = 305.0
+margin_left = 230.0
+margin_right = 330.0
 margin_bottom = 26.0
 rect_min_size = Vector2( 100, 0 )
 theme = ExtResource( 1 )
@@ -304,8 +306,8 @@ group = SubResource( 3 )
 text = "WASD"
 
 [node name="Custom" type="Button" parent="Window/UiArea/TabContainer/Controls/Presets"]
-margin_left = 325.0
-margin_right = 425.0
+margin_left = 350.0
+margin_right = 450.0
 margin_bottom = 26.0
 rect_min_size = Vector2( 100, 0 )
 theme = ExtResource( 1 )
@@ -413,7 +415,7 @@ keybind_value = "Tab"
 
 [node name="CustomScrollContainer" type="ScrollContainer" parent="Window/UiArea/TabContainer/Controls"]
 margin_top = 30.0
-margin_right = 510.0
+margin_right = 560.0
 margin_bottom = 256.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -579,7 +581,7 @@ margin_right = -5.0
 margin_bottom = -5.0
 
 [node name="Size" type="HBoxContainer" parent="Window/UiArea/TabContainer/Touch"]
-margin_right = 510.0
+margin_right = 560.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 400, 20 )
 size_flags_horizontal = 3
@@ -588,14 +590,14 @@ custom_constants/separation = 20
 script = ExtResource( 8 )
 
 [node name="Spacer1" type="Control" parent="Window/UiArea/TabContainer/Touch/Size"]
-margin_right = 26.0
+margin_right = 29.0
 margin_bottom = 20.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.1
 
 [node name="Label" type="Label" parent="Window/UiArea/TabContainer/Touch/Size"]
-margin_left = 46.0
-margin_right = 178.0
+margin_left = 49.0
+margin_right = 196.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 120, 0 )
 size_flags_horizontal = 3
@@ -607,8 +609,8 @@ __meta__ = {
 }
 
 [node name="Control" type="HBoxContainer" parent="Window/UiArea/TabContainer/Touch/Size"]
-margin_left = 198.0
-margin_right = 463.0
+margin_left = 216.0
+margin_right = 510.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 140, 20 )
 size_flags_horizontal = 3
@@ -620,7 +622,7 @@ __meta__ = {
 
 [node name="HSlider" type="HSlider" parent="Window/UiArea/TabContainer/Touch/Size/Control"]
 margin_top = 2.0
-margin_right = 195.0
+margin_right = 224.0
 margin_bottom = 18.0
 rect_min_size = Vector2( 80, 16 )
 size_flags_horizontal = 3
@@ -633,23 +635,23 @@ __meta__ = {
 }
 
 [node name="Text" type="Label" parent="Window/UiArea/TabContainer/Touch/Size/Control"]
-margin_left = 205.0
-margin_right = 265.0
+margin_left = 234.0
+margin_right = 294.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 60, 0 )
 theme = ExtResource( 1 )
 text = "1.00x"
 
 [node name="Spacer2" type="Control" parent="Window/UiArea/TabContainer/Touch/Size"]
-margin_left = 483.0
-margin_right = 510.0
+margin_left = 530.0
+margin_right = 560.0
 margin_bottom = 20.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.1
 
 [node name="Scheme" type="HBoxContainer" parent="Window/UiArea/TabContainer/Touch"]
 margin_top = 24.0
-margin_right = 510.0
+margin_right = 560.0
 margin_bottom = 50.0
 rect_min_size = Vector2( 400, 26 )
 size_flags_horizontal = 3
@@ -658,7 +660,7 @@ custom_constants/separation = 20
 script = ExtResource( 10 )
 
 [node name="Label" type="Label" parent="Window/UiArea/TabContainer/Touch/Scheme"]
-margin_right = 197.0
+margin_right = 217.0
 margin_bottom = 26.0
 rect_min_size = Vector2( 120, 0 )
 size_flags_horizontal = 3
@@ -672,8 +674,8 @@ __meta__ = {
 }
 
 [node name="OptionButton" type="OptionButton" parent="Window/UiArea/TabContainer/Touch/Scheme"]
-margin_left = 217.0
-margin_right = 377.0
+margin_left = 237.0
+margin_right = 397.0
 margin_bottom = 26.0
 rect_min_size = Vector2( 160, 0 )
 size_flags_horizontal = 2
@@ -685,7 +687,7 @@ __meta__ = {
 
 [node name="FatFinger" type="HBoxContainer" parent="Window/UiArea/TabContainer/Touch"]
 margin_top = 54.0
-margin_right = 510.0
+margin_right = 560.0
 margin_bottom = 80.0
 rect_min_size = Vector2( 400, 26 )
 size_flags_horizontal = 3
@@ -694,7 +696,7 @@ custom_constants/separation = 20
 script = ExtResource( 11 )
 
 [node name="Label" type="Label" parent="Window/UiArea/TabContainer/Touch/FatFinger"]
-margin_right = 197.0
+margin_right = 217.0
 margin_bottom = 26.0
 rect_min_size = Vector2( 120, 0 )
 size_flags_horizontal = 3
@@ -708,8 +710,8 @@ __meta__ = {
 }
 
 [node name="OptionButton" type="OptionButton" parent="Window/UiArea/TabContainer/Touch/FatFinger"]
-margin_left = 217.0
-margin_right = 377.0
+margin_left = 237.0
+margin_right = 397.0
 margin_bottom = 26.0
 rect_min_size = Vector2( 160, 0 )
 size_flags_horizontal = 2
@@ -729,7 +731,7 @@ margin_right = -5.0
 margin_bottom = -5.0
 
 [node name="Language" type="HBoxContainer" parent="Window/UiArea/TabContainer/Misc"]
-margin_right = 510.0
+margin_right = 560.0
 margin_bottom = 26.0
 rect_min_size = Vector2( 400, 26 )
 size_flags_horizontal = 3
@@ -738,7 +740,7 @@ custom_constants/separation = 20
 script = ExtResource( 17 )
 
 [node name="Label" type="Label" parent="Window/UiArea/TabContainer/Misc/Language"]
-margin_right = 197.0
+margin_right = 217.0
 margin_bottom = 26.0
 rect_min_size = Vector2( 120, 0 )
 size_flags_horizontal = 3
@@ -752,8 +754,8 @@ __meta__ = {
 }
 
 [node name="OptionButton" type="OptionButton" parent="Window/UiArea/TabContainer/Misc/Language"]
-margin_left = 217.0
-margin_right = 377.0
+margin_left = 237.0
+margin_right = 397.0
 margin_bottom = 26.0
 rect_min_size = Vector2( 160, 0 )
 size_flags_horizontal = 2
@@ -762,6 +764,72 @@ size_flags_stretch_ratio = 1.1
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
+[node name="Spacer1" type="Control" parent="Window/UiArea/TabContainer/Misc"]
+margin_top = 30.0
+margin_right = 560.0
+margin_bottom = 50.0
+rect_min_size = Vector2( 0, 20 )
+
+[node name="SaveSlot" type="HBoxContainer" parent="Window/UiArea/TabContainer/Misc"]
+margin_top = 54.0
+margin_right = 560.0
+margin_bottom = 80.0
+rect_min_size = Vector2( 400, 26 )
+size_flags_horizontal = 3
+theme = ExtResource( 1 )
+custom_constants/separation = 20
+script = ExtResource( 22 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Label" type="Label" parent="Window/UiArea/TabContainer/Misc/SaveSlot"]
+margin_right = 217.0
+margin_bottom = 26.0
+rect_min_size = Vector2( 120, 0 )
+size_flags_horizontal = 3
+size_flags_vertical = 5
+size_flags_stretch_ratio = 0.74
+text = "Save Slot"
+align = 2
+valign = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Window/UiArea/TabContainer/Misc/SaveSlot"]
+margin_left = 237.0
+margin_right = 441.0
+margin_bottom = 26.0
+rect_min_size = Vector2( 160, 0 )
+focus_mode = 2
+size_flags_horizontal = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 1.1
+custom_constants/separation = 20
+__meta__ = {
+"_editor_description_": ""
+}
+
+[node name="OptionButton" type="OptionButton" parent="Window/UiArea/TabContainer/Misc/SaveSlot/HBoxContainer"]
+margin_right = 160.0
+margin_bottom = 26.0
+rect_min_size = Vector2( 160, 0 )
+size_flags_horizontal = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 1.1
+text = "Slot A"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Delete" type="Button" parent="Window/UiArea/TabContainer/Misc/SaveSlot/HBoxContainer"]
+margin_left = 180.0
+margin_right = 204.0
+margin_bottom = 26.0
+size_flags_vertical = 4
+text = "X"
 
 [node name="Bottom" type="Control" parent="Window/UiArea"]
 margin_top = 300.0
@@ -831,11 +899,92 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[connection signal="item_selected" from="Window/UiArea/TabContainer/Sound + Graphics/Creature Graphics/OptionButton" to="Window/UiArea/TabContainer/Sound + Graphics/Creature Graphics" method="_on_OptionButton_item_selected"]
-[connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/GhostPiece/CheckboxButton" to="Window/UiArea/TabContainer/Gameplay/GhostPiece" method="_on_OptionButton_toggled"]
-[connection signal="value_changed" from="Window/UiArea/TabContainer/Touch/Size/Control/HSlider" to="Window/UiArea/TabContainer/Touch/Size" method="_on_HSlider_value_changed"]
-[connection signal="item_selected" from="Window/UiArea/TabContainer/Touch/Scheme/OptionButton" to="Window/UiArea/TabContainer/Touch/Scheme" method="_on_OptionButton_item_selected"]
-[connection signal="item_selected" from="Window/UiArea/TabContainer/Touch/FatFinger/OptionButton" to="Window/UiArea/TabContainer/Touch/FatFinger" method="_on_OptionButton_item_selected"]
-[connection signal="item_selected" from="Window/UiArea/TabContainer/Misc/Language/OptionButton" to="Window/UiArea/TabContainer/Misc/Language" method="_on_OptionButton_item_selected"]
+[node name="Dialogs" type="Control" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+script = ExtResource( 24 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+_save_slot_control_path = NodePath("../Window/UiArea/TabContainer/Misc/SaveSlot")
+
+[node name="Backdrop" parent="Dialogs" instance=ExtResource( 23 )]
+
+[node name="ChangeSaveConfirmation" type="ConfirmationDialog" parent="Dialogs"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -100.0
+margin_top = -35.0
+margin_right = 100.0
+margin_bottom = 35.0
+theme = ExtResource( 20 )
+popup_exclusive = true
+window_title = "Confirm"
+dialog_text = "Change save slot?"
+dialog_autowrap = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="DeleteConfirmation1" type="ConfirmationDialog" parent="Dialogs"]
+visible = true
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -100.0
+margin_top = -35.0
+margin_right = 100.0
+margin_bottom = 35.0
+theme = ExtResource( 20 )
+popup_exclusive = true
+window_title = "Confirm"
+dialog_text = "Delete save slot?
+Slot A (34.2 hours)"
+dialog_autowrap = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="DeleteConfirmation2" type="ConfirmationDialog" parent="Dialogs"]
+visible = true
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -100.0
+margin_top = -35.0
+margin_right = 100.0
+margin_bottom = 35.0
+theme = ExtResource( 20 )
+popup_exclusive = true
+window_title = "Confirm"
+dialog_text = "Are you sure?
+Slot A (34.2 hours)"
+dialog_autowrap = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[connection signal="change_save_cancelled" from="Dialogs" to="." method="_on_Dialogs_change_save_cancelled"]
+[connection signal="change_save_confirmed" from="Dialogs" to="." method="_on_Dialogs_change_save_confirmed"]
+[connection signal="delete_confirmed" from="Dialogs" to="." method="_on_Dialogs_delete_confirmed"]
+[connection signal="about_to_show" from="Dialogs/ChangeSaveConfirmation" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
+[connection signal="popup_hide" from="Dialogs/ChangeSaveConfirmation" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
+[connection signal="about_to_show" from="Dialogs/DeleteConfirmation1" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
+[connection signal="popup_hide" from="Dialogs/DeleteConfirmation1" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
+[connection signal="about_to_show" from="Dialogs/DeleteConfirmation2" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
+[connection signal="popup_hide" from="Dialogs/DeleteConfirmation2" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
 [connection signal="pressed" from="Window/UiArea/Bottom/Ok" to="." method="_on_Ok_pressed"]
 [connection signal="pressed" from="Window/UiArea/Bottom/Quit" to="." method="_on_Quit_pressed"]
+[connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/GhostPiece/CheckboxButton" to="Window/UiArea/TabContainer/Gameplay/GhostPiece" method="_on_OptionButton_toggled"]
+[connection signal="item_selected" from="Window/UiArea/TabContainer/Misc/Language/OptionButton" to="Window/UiArea/TabContainer/Misc/Language" method="_on_OptionButton_item_selected"]
+[connection signal="delete_pressed" from="Window/UiArea/TabContainer/Misc/SaveSlot" to="Dialogs" method="_on_SaveSlot_delete_pressed"]
+[connection signal="pressed" from="Window/UiArea/TabContainer/Misc/SaveSlot/HBoxContainer/Delete" to="Window/UiArea/TabContainer/Misc/SaveSlot" method="_on_Delete_pressed"]
+[connection signal="item_selected" from="Window/UiArea/TabContainer/Sound + Graphics/Creature Graphics/OptionButton" to="Window/UiArea/TabContainer/Sound + Graphics/Creature Graphics" method="_on_OptionButton_item_selected"]
+[connection signal="item_selected" from="Window/UiArea/TabContainer/Touch/FatFinger/OptionButton" to="Window/UiArea/TabContainer/Touch/FatFinger" method="_on_OptionButton_item_selected"]
+[connection signal="item_selected" from="Window/UiArea/TabContainer/Touch/Scheme/OptionButton" to="Window/UiArea/TabContainer/Touch/Scheme" method="_on_OptionButton_item_selected"]
+[connection signal="value_changed" from="Window/UiArea/TabContainer/Touch/Size/Control/HSlider" to="Window/UiArea/TabContainer/Touch/Size" method="_on_HSlider_value_changed"]

--- a/project/src/main/ui/cutscene-button.gd
+++ b/project/src/main/ui/cutscene-button.gd
@@ -33,7 +33,7 @@ onready var _level_buttons: LevelButtons = get_node(level_buttons_path)
 func _ready() -> void:
 	connect("pressed", self, "_on_pressed")
 	_level_buttons.connect("unlocked_level_selected", self, "_on_LevelButtons_unlocked_level_selected")
-	match PlayerData.misc_settings.cutscene_force:
+	match SystemData.misc_settings.cutscene_force:
 		Levels.CutsceneForce.NONE: _cutscene_force = IMPLICIT_PLAY
 		Levels.CutsceneForce.PLAY: _cutscene_force = FORCE_PLAY
 		Levels.CutsceneForce.SKIP: _cutscene_force = FORCE_SKIP
@@ -71,11 +71,11 @@ func _refresh_cutscene_force() -> void:
 	# update the global cutscene_force setting
 	match _cutscene_force:
 		IMPLICIT_PLAY, IMPLICIT_SKIP:
-			PlayerData.misc_settings.cutscene_force = Levels.CutsceneForce.NONE
+			SystemData.misc_settings.cutscene_force = Levels.CutsceneForce.NONE
 		FORCE_PLAY:
-			PlayerData.misc_settings.cutscene_force = Levels.CutsceneForce.PLAY
+			SystemData.misc_settings.cutscene_force = Levels.CutsceneForce.PLAY
 		FORCE_SKIP:
-			PlayerData.misc_settings.cutscene_force = Levels.CutsceneForce.SKIP
+			SystemData.misc_settings.cutscene_force = Levels.CutsceneForce.SKIP
 
 
 """

--- a/project/src/main/ui/image-button.gd
+++ b/project/src/main/ui/image-button.gd
@@ -12,7 +12,7 @@ export (Texture) var pressed_icon: Texture setget set_pressed_icon
 
 func _ready() -> void:
 	icon = normal_icon
-	PlayerData.touch_settings.connect("settings_changed", self, "_on_TouchSettings_settings_changed")
+	SystemData.touch_settings.connect("settings_changed", self, "_on_TouchSettings_settings_changed")
 	_refresh_touch_settings()
 
 
@@ -31,7 +31,7 @@ func set_pressed_icon(new_pressed_icon: Texture) -> void:
 
 
 func _refresh_touch_settings() -> void:
-	rect_min_size = Vector2(96, 96) * PlayerData.touch_settings.size
+	rect_min_size = Vector2(96, 96) * SystemData.touch_settings.size
 	rect_size = Vector2(0, 0)
 
 

--- a/project/src/main/ui/keybind/custom-keybind-button.gd
+++ b/project/src/main/ui/keybind/custom-keybind-button.gd
@@ -14,7 +14,7 @@ var awaiting := false
 
 func _ready() -> void:
 	connect("pressed", self, "_on_pressed")
-	PlayerData.keybind_settings.connect("settings_changed", self, "_on_KeybindSettings_settings_changed")
+	SystemData.keybind_settings.connect("settings_changed", self, "_on_KeybindSettings_settings_changed")
 	_refresh_text()
 
 
@@ -23,7 +23,7 @@ func _input(event: InputEvent) -> void:
 		var input_json: Dictionary = KeybindManager.input_event_to_json(event)
 		if input_json:
 			accept_event()
-			PlayerData.keybind_settings.set_custom_keybind(action_name, action_index, input_json)
+			SystemData.keybind_settings.set_custom_keybind(action_name, action_index, input_json)
 			end_awaiting()
 
 
@@ -59,7 +59,7 @@ Updates the button's text based on the player's current keybinds.
 """
 func _refresh_text() -> void:
 	var new_text := ""
-	var json: Dictionary = PlayerData.keybind_settings.get_custom_keybind(action_name, action_index)
+	var json: Dictionary = SystemData.keybind_settings.get_custom_keybind(action_name, action_index)
 	if json:
 		new_text = tr(KeybindManager.pretty_string(json))
 	text = new_text

--- a/project/src/main/ui/keybind/custom-keybind-row.gd
+++ b/project/src/main/ui/keybind/custom-keybind-row.gd
@@ -33,7 +33,7 @@ func _refresh_description_label() -> void:
 
 func _on_Delete_pressed() -> void:
 	for action_index in range(0, 3):
-		PlayerData.keybind_settings.set_custom_keybind(action_name, action_index, {})
+		SystemData.keybind_settings.set_custom_keybind(action_name, action_index, {})
 	
 	var custom_keybind_buttons := get_tree().get_nodes_in_group("custom_keybind_buttons")
 	for keybind_button in custom_keybind_buttons:

--- a/project/src/main/ui/keybind/settings-keybinds-control.gd
+++ b/project/src/main/ui/keybind/settings-keybinds-control.gd
@@ -9,7 +9,7 @@ func _ready() -> void:
 	$Presets/Custom.connect("pressed", self, "_on_Custom_pressed")
 	$CustomScrollContainer/VBoxContainer/ResetToDefault.connect("pressed", self, "_on_ResetToDefault_pressed")
 	
-	match PlayerData.keybind_settings.preset:
+	match SystemData.keybind_settings.preset:
 		KeybindSettings.GUIDELINE: $Presets/Guideline.pressed = true
 		KeybindSettings.WASD: $Presets/Wasd.pressed = true
 		KeybindSettings.CUSTOM: $Presets/Custom.pressed = true
@@ -30,7 +30,7 @@ func _refresh_keybind_labels() -> void:
 	
 	# Workaround for Godot #42224 (https://github.com/godotengine/godot/issues/42224)
 	# The following match statement does not work unless this field is explicitly cast to an int
-	var preset: int = PlayerData.keybind_settings.preset
+	var preset: int = SystemData.keybind_settings.preset
 	
 	match preset:
 		KeybindSettings.GUIDELINE:
@@ -50,19 +50,19 @@ func _refresh_keybind_labels() -> void:
 
 
 func _on_Guideline_pressed() -> void:
-	PlayerData.keybind_settings.preset = KeybindSettings.GUIDELINE
+	SystemData.keybind_settings.preset = KeybindSettings.GUIDELINE
 	_refresh_keybind_labels()
 
 
 func _on_Wasd_pressed() -> void:
-	PlayerData.keybind_settings.preset = KeybindSettings.WASD
+	SystemData.keybind_settings.preset = KeybindSettings.WASD
 	_refresh_keybind_labels()
 
 
 func _on_Custom_pressed() -> void:
-	PlayerData.keybind_settings.preset = KeybindSettings.CUSTOM
+	SystemData.keybind_settings.preset = KeybindSettings.CUSTOM
 	_refresh_keybind_labels()
 
 
 func _on_ResetToDefault_pressed() -> void:
-	PlayerData.keybind_settings.restore_default_custom_keybinds()
+	SystemData.keybind_settings.restore_default_custom_keybinds()

--- a/project/src/main/ui/level-select/level-buttons.gd
+++ b/project/src/main/ui/level-select/level-buttons.gd
@@ -204,7 +204,7 @@ When the player clicks a level button twice, we launch the selected level
 """
 func _on_LevelSelectButton_level_started(settings: LevelSettings) -> void:
 	CurrentLevel.set_launched_level(settings.id)
-	CurrentLevel.cutscene_force = PlayerData.misc_settings.cutscene_force
+	CurrentLevel.cutscene_force = SystemData.misc_settings.cutscene_force
 	
 	var chat_tree := ChatLibrary.chat_tree_for_preroll(CurrentLevel.level_id)
 	if CurrentLevel.should_play_cutscene(chat_tree):

--- a/project/src/main/ui/menu/settings-menu.gd
+++ b/project/src/main/ui/menu/settings-menu.gd
@@ -24,16 +24,31 @@ export (QuitType) var quit_type: int setget set_quit_type
 # the UI control which was focused before this settings menu popped up
 var _old_focus_owner: Control
 
+# method name and parameters for a method to call after system data is saved
+var _post_save_method: String
+var _post_save_args_array: Array
+
+onready var _controls_control := $Window/UiArea/TabContainer/Controls
+onready var _ok_shortcut_helper := $Window/UiArea/Bottom/Ok/ShortcutHelper
+onready var _save_slot_control := $Window/UiArea/TabContainer/Misc/SaveSlot
+onready var _touch_control := $Window/UiArea/TabContainer/Touch
+onready var _quit_button := $Window/UiArea/Bottom/Quit
+
+onready var _bg := $Bg
+onready var _dialogs := $Dialogs
+onready var _touch_buttons := $TouchButtons
+onready var _window := $Window
+
 func _ready() -> void:
 	# starts invisible
 	hide()
 	
 	if OS.has_touchscreen_ui_hint():
 		# hide keybinds settings for mobile devices
-		$Window/UiArea/TabContainer/Controls.queue_free()
+		_controls_control.queue_free()
 	else:
 		# hide touch settings if touch is not enabled
-		$Window/UiArea/TabContainer/Touch.queue_free()
+		_touch_control.queue_free()
 	
 	var custom_keybind_buttons := get_tree().get_nodes_in_group("custom_keybind_buttons")
 	for keybind_button in custom_keybind_buttons:
@@ -50,9 +65,9 @@ func set_quit_type(new_quit_type: int) -> void:
 Shows the menu and pauses the scene tree.
 """
 func show() -> void:
-	$Bg.show()
-	$TouchButtons.visible = true
-	$Window.show()
+	_bg.show()
+	_touch_buttons.visible = true
+	_window.show()
 	get_tree().paused = true
 	_old_focus_owner = $Window/UiArea/Bottom/Ok.get_focus_owner()
 	$Window/UiArea/Bottom/Ok.grab_focus()
@@ -63,14 +78,39 @@ func show() -> void:
 Hides the menu and unpauses the scene tree.
 """
 func hide() -> void:
-	$Bg.hide()
-	$TouchButtons.visible = false
-	$Window.hide()
+	_bg.hide()
+	_touch_buttons.visible = false
+	_window.hide()
 	get_tree().paused = false
 	if _old_focus_owner:
 		_old_focus_owner.grab_focus()
 		_old_focus_owner = null
 	emit_signal("hide")
+
+
+"""
+Prompts the user for confirmation, if necessary, and saves their system settings.
+
+Confirmation is only required when changing the current save slot. If the player confirms changing their save slot, we
+drop them back on the title screen.
+
+In all other cases, either if the player is not confirmed or if they decide to not change their save slot, the
+specified 'post_save_method' is invoked to dismiss the settings menu.
+
+Parameters:
+	'new_post_save_method': The method to use to dismiss the settings menu after data is saved.
+	
+	'new_post_save_args_array': The method parameters to use to dismiss the settings menu after data is saved.
+"""
+func _confirm_and_save(new_post_save_method: String, new_post_save_args_array: Array) -> void:
+	_post_save_method = new_post_save_method
+	_post_save_args_array = new_post_save_args_array
+	
+	if _save_slot_control.get_selected_save_slot() != SystemData.misc_settings.save_slot:
+		_dialogs.confirm_new_save_slot()
+	else:
+		SystemSave.save_system_data()
+		callv(_post_save_method, _post_save_args_array)
 
 
 func _refresh_quit_type() -> void:
@@ -83,20 +123,20 @@ func _refresh_quit_type() -> void:
 		SAVE_AND_QUIT: quit_text = tr("Save + Quit")
 		GIVE_UP: quit_text = tr("Give Up")
 	
-	$Window/UiArea/Bottom/Quit.text = quit_text
+	_quit_button.text = quit_text
 
 
 func _on_Ok_pressed() -> void:
 	# when the player confirms, we save the player's new settings
-	PlayerSave.save_player_data()
-	hide()
+	_confirm_and_save("hide", [])
 
 
 func _on_Quit_pressed() -> void:
 	hide()
 	if quit_type == SAVE_AND_QUIT:
-		PlayerSave.save_player_data()
-	emit_signal("quit_pressed")
+		_confirm_and_save("emit_signal", ["quit_pressed"])
+	else:
+		emit_signal("quit_pressed")
 
 
 func _on_Settings_pressed() -> void:
@@ -104,6 +144,25 @@ func _on_Settings_pressed() -> void:
 
 
 func _on_CustomKeybindButton_awaiting_changed(awaiting: bool) -> void:
-	# when the user is rebinding their keys, we disable the shortcut helper. otherwise trying to rebind something like
+	# When the user is rebinding their keys, we disable the shortcut helper. Otherwise trying to rebind something like
 	# 'escape' will close the settings menu
-	$Window/UiArea/Bottom/Ok/ShortcutHelper.set_process_input(not awaiting)
+	_ok_shortcut_helper.set_process_input(not awaiting)
+
+
+func _on_Dialogs_change_save_cancelled() -> void:
+	SystemSave.save_system_data()
+	callv(_post_save_method, _post_save_args_array)
+
+
+func _on_Dialogs_change_save_confirmed() -> void:
+	SystemData.misc_settings.save_slot = _save_slot_control.get_selected_save_slot()
+	SystemSave.save_system_data()
+	
+	# load the save slot's data and return to the splash screen
+	PlayerSave.load_player_data()
+	Breadcrumb.trail = []
+	SceneTransition.push_trail(Global.SCENE_SPLASH)
+
+
+func _on_Dialogs_delete_confirmed() -> void:
+	SystemSave.delete_save_slot(_save_slot_control.get_selected_save_slot())

--- a/project/src/main/ui/menu/settings-touch-size.gd
+++ b/project/src/main/ui/menu/settings-touch-size.gd
@@ -9,10 +9,10 @@ const VALUES := [
 ]
 
 func _ready() -> void:
-	$Control/HSlider.value = Utils.find_closest(VALUES, PlayerData.touch_settings.size)
+	$Control/HSlider.value = Utils.find_closest(VALUES, SystemData.touch_settings.size)
 
 
 func _on_HSlider_value_changed(index: float) -> void:
 	var value: float = VALUES[int(index)]
 	$Control/Text.text = "%04.2fx" % value
-	PlayerData.touch_settings.size = value
+	SystemData.touch_settings.size = value

--- a/project/src/main/ui/music-popup.gd
+++ b/project/src/main/ui/music-popup.gd
@@ -29,8 +29,8 @@ func _refresh_panel(value: CheckpointSong) -> void:
 		return
 	
 	# if no music is audible, don't show a music popup
-	if PlayerData.volume_settings.is_bus_mute(VolumeSettings.MUSIC) \
-			or PlayerData.volume_settings.is_bus_mute(VolumeSettings.MASTER):
+	if SystemData.volume_settings.is_bus_mute(VolumeSettings.MUSIC) \
+			or SystemData.volume_settings.is_bus_mute(VolumeSettings.MASTER):
 		_shown_bgm = null
 	else:
 		_shown_bgm = value

--- a/project/src/main/ui/settings-creature-graphics.gd
+++ b/project/src/main/ui/settings-creature-graphics.gd
@@ -8,13 +8,13 @@ onready var _option_button: OptionButton = $OptionButton
 func _ready() -> void:
 	_option_button.add_item(tr("Low"))
 	_option_button.add_item(tr("High"))
-	_option_button.selected = PlayerData.graphics_settings.creature_detail
-	PlayerData.graphics_settings.connect(
+	_option_button.selected = SystemData.graphics_settings.creature_detail
+	SystemData.graphics_settings.connect(
 			"creature_detail_changed", self, "_on_GraphicsSettings_creature_detail_changed")
 
 
 func _on_OptionButton_item_selected(_index: int) -> void:
-	PlayerData.graphics_settings.creature_detail = _index
+	SystemData.graphics_settings.creature_detail = _index
 
 
 """

--- a/project/src/main/ui/settings-dialogs.gd
+++ b/project/src/main/ui/settings-dialogs.gd
@@ -1,0 +1,110 @@
+extends Control
+"""
+Shows popup dialogs for the settings menu.
+"""
+
+# emitted when the player is prompted to change their save slot and answers 'yes'
+signal change_save_confirmed
+
+# emitted when the player is prompted to change their save slot and answers 'no' or closes the window
+signal change_save_cancelled
+
+# emitted when the player is prompted to delete a save slot and answers 'yes'
+signal delete_confirmed
+
+# emitted when the player is prompted to delete a save slot and answers 'no' or closes the window
+signal delete_cancelled
+
+export var _save_slot_control_path: NodePath
+
+# 'Are you sure you want to change save slots?' confirmation dialog
+onready var _change_save_confirmation := $ChangeSaveConfirmation
+
+# 'Delete save data?' confirmation dialog
+onready var _delete_confirmation_1 := $DeleteConfirmation1
+
+# 'Are you sure?' confirmation dialog
+onready var _delete_confirmation_2 := $DeleteConfirmation2
+
+# UI component for a changing the current save slot or deleting save slots
+onready var _save_slot_control: SaveSlotControl = get_node(_save_slot_control_path)
+
+func _ready() -> void:
+	_change_save_confirmation.get_ok().text = tr("Yes")
+	_change_save_confirmation.get_cancel().text = tr("No")
+	_change_save_confirmation.connect("confirmed", self, "_on_ChangeSaveConfirmation_confirmed")
+	_change_save_confirmation.get_cancel().connect("pressed", self, "_on_ChangeSaveConfirmation_cancelled")
+	_change_save_confirmation.get_close_button().connect("pressed", self, "_on_ChangeSaveConfirmation_cancelled")
+	
+	_delete_confirmation_1.get_ok().text = tr("Yes")
+	_delete_confirmation_1.get_cancel().text = tr("No")
+	_delete_confirmation_1.get_label().add_color_override("font_color", Color.red)
+	_delete_confirmation_1.connect("confirmed", self, "_on_DeleteConfirmation1_confirmed")
+	_delete_confirmation_1.get_cancel().connect("pressed", self, "_on_DeleteConfirmation_cancelled")
+	_delete_confirmation_1.get_close_button().connect("pressed", self, "_on_DeleteConfirmation_cancelled")
+	
+	_delete_confirmation_2.get_ok().text = tr("Yes")
+	_delete_confirmation_2.get_cancel().text = tr("No")
+	_delete_confirmation_2.get_label().add_color_override("font_color", Color.red)
+	_delete_confirmation_2.connect("confirmed", self, "_on_DeleteConfirmation2_confirmed")
+	_delete_confirmation_2.get_cancel().connect("pressed", self, "_on_DeleteConfirmation_cancelled")
+	_delete_confirmation_2.get_close_button().connect("pressed", self, "_on_DeleteConfirmation_cancelled")
+
+
+"""
+Displays a dialog prompting the user if they want to change their save slot
+"""
+func confirm_new_save_slot() -> void:
+	_change_save_confirmation.popup_centered()
+
+
+"""
+Expands a simple delete confirmation message into a more detailed message.
+
+Parameters:
+	'message': A simple message like 'Are you sure?'
+
+Returns:
+	A more detailed message like 'Are you sure? B: Gordo (13.5 hours)'
+"""
+func _delete_confirmation_dialog_text(message: String) -> String:
+	var selected_save_slot := _save_slot_control.get_selected_save_slot()
+	var playtime_in_seconds: float = SystemSave.get_save_slot_playtime(selected_save_slot)
+	var playtime_in_hours := clamp(playtime_in_seconds / 3600, 0, 9999.9)
+	var playtime_message := tr("%.1f hours") % [playtime_in_hours]
+	var save_slot_name: String = SystemSave.get_save_slot_name(selected_save_slot)
+	return "%s\n%s (%s)" % [message, save_slot_name, playtime_message]
+
+
+"""
+Displays a dialog prompting the user if they want to delete a save
+"""
+func _on_SaveSlot_delete_pressed() -> void:
+	_delete_confirmation_1.dialog_text = _delete_confirmation_dialog_text(tr("Delete save data?"))
+	_delete_confirmation_1.popup_centered()
+	_delete_confirmation_1.get_cancel().grab_focus()
+
+
+"""
+Displays a dialog prompting the user if they're sure want to delete a save
+"""
+func _on_DeleteConfirmation1_confirmed() -> void:
+	_delete_confirmation_2.dialog_text = _delete_confirmation_dialog_text(tr("Are you sure?"))
+	_delete_confirmation_2.popup_centered()
+	_delete_confirmation_2.get_cancel().grab_focus()
+
+
+func _on_DeleteConfirmation2_confirmed() -> void:
+	emit_signal("delete_confirmed")
+
+
+func _on_DeleteConfirmation_cancelled() -> void:
+	emit_signal("delete_cancelled")
+
+
+func _on_ChangeSaveConfirmation_confirmed() -> void:
+	emit_signal("change_save_confirmed")
+
+
+func _on_ChangeSaveConfirmation_cancelled() -> void:
+	emit_signal("change_save_cancelled")

--- a/project/src/main/ui/settings-ghost-piece.gd
+++ b/project/src/main/ui/settings-ghost-piece.gd
@@ -6,8 +6,8 @@ UI control for toggling the ghost piece.
 onready var _checkbox_button := $CheckboxButton
 
 func _ready() -> void:
-	_checkbox_button.pressed = PlayerData.gameplay_settings.ghost_piece
+	_checkbox_button.pressed = SystemData.gameplay_settings.ghost_piece
 
 
 func _on_OptionButton_toggled(_button_pressed: bool) -> void:
-	PlayerData.gameplay_settings.ghost_piece = _checkbox_button.pressed
+	SystemData.gameplay_settings.ghost_piece = _checkbox_button.pressed

--- a/project/src/main/ui/settings-save-slot.gd
+++ b/project/src/main/ui/settings-save-slot.gd
@@ -1,0 +1,39 @@
+class_name SaveSlotControl
+extends HBoxContainer
+"""
+UI component for a changing the current save slot or deleting save slots
+"""
+
+signal delete_pressed
+
+onready var _option_button := $HBoxContainer/OptionButton
+onready var _delete_button := $HBoxContainer/Delete
+
+func _ready() -> void:
+	SystemSave.connect("save_slot_deleted", self, "_on_SystemSave_save_slot_deleted")
+	
+	_refresh_save_slots()
+
+
+func get_selected_save_slot() -> int:
+	return _option_button.get_selected_id()
+
+
+func revert_save_slot() -> void:
+	_option_button.select(SystemData.misc_settings.save_slot)
+
+
+func _refresh_save_slots() -> void:
+	_option_button.clear()
+	for save_slot_index in MiscSettings.SaveSlot.values():
+		var save_slot_name: String = SystemSave.get_save_slot_name(save_slot_index)
+		_option_button.add_item(tr(save_slot_name), save_slot_index)
+	_option_button.select(SystemData.misc_settings.save_slot)
+
+
+func _on_Delete_pressed() -> void:
+	emit_signal("delete_pressed")
+
+
+func _on_SystemSave_save_slot_deleted() -> void:
+	_refresh_save_slots()

--- a/project/src/main/ui/settings-touch-fat-finger.gd
+++ b/project/src/main/ui/settings-touch-fat-finger.gd
@@ -13,8 +13,8 @@ func _ready() -> void:
 	$OptionButton.add_item(tr("Plump"))
 	$OptionButton.add_item(tr("Pudge"))
 	$OptionButton.add_item(tr("Chonk"))
-	$OptionButton.selected = Utils.find_closest(VALUES, PlayerData.touch_settings.scheme)
+	$OptionButton.selected = Utils.find_closest(VALUES, SystemData.touch_settings.scheme)
 
 
 func _on_OptionButton_item_selected(id: int) -> void:
-	PlayerData.touch_settings.fat_finger = VALUES[id]
+	SystemData.touch_settings.fat_finger = VALUES[id]

--- a/project/src/main/ui/settings-touch-scheme.gd
+++ b/project/src/main/ui/settings-touch-scheme.gd
@@ -12,8 +12,8 @@ func _ready() -> void:
 	$OptionButton.add_item(tr("Ambi Desktop"))
 	$OptionButton.add_item(tr("Loco Console"))
 	$OptionButton.add_item(tr("Loco Desktop"))
-	$OptionButton.selected = PlayerData.touch_settings.scheme
+	$OptionButton.selected = SystemData.touch_settings.scheme
 
 
 func _on_OptionButton_item_selected(id: int) -> void:
-	PlayerData.touch_settings.scheme = id
+	SystemData.touch_settings.scheme = id

--- a/project/src/main/ui/settings-warning.gd
+++ b/project/src/main/ui/settings-warning.gd
@@ -5,7 +5,7 @@ Shows a warning if the player changes settings which can't be changed immediatel
 
 func _ready() -> void:
 	visible = false
-	PlayerData.graphics_settings.connect(
+	SystemData.graphics_settings.connect(
 			"creature_detail_changed", self, "_on_GraphicsSettings_creature_detail_changed")
 
 

--- a/project/src/main/ui/volume-setting-control.gd
+++ b/project/src/main/ui/volume-setting-control.gd
@@ -21,7 +21,7 @@ onready var _sample_sound: AudioStreamPlayer = $SampleSound
 onready var _sample_voice: AudioStreamPlayer = $SampleVoice
 
 func _ready() -> void:
-	_slider.value = PlayerData.volume_settings.get_bus_volume_linear(volume_type)
+	_slider.value = SystemData.volume_settings.get_bus_volume_linear(volume_type)
 	_refresh_setting_label()
 	_refresh_percent_label()
 	
@@ -62,7 +62,7 @@ func _refresh_setting_label() -> void:
 
 func _on_HSlider_value_changed(value: float) -> void:
 	_refresh_percent_label()
-	PlayerData.volume_settings.set_bus_volume_linear(volume_type, value)
+	SystemData.volume_settings.set_bus_volume_linear(volume_type, value)
 	_sample_timer.start()
 
 

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -111,7 +111,7 @@ onready var _fade_tween: Tween = $FadeTween
 func _ready() -> void:
 	var creature_outline_scene_path := "res://src/main/world/creature/ViewportCreatureOutline.tscn"
 	if not Engine.is_editor_hint() \
-			and PlayerData.graphics_settings.creature_detail == GraphicsSettings.CreatureDetail.LOW:
+			and SystemData.graphics_settings.creature_detail == GraphicsSettings.CreatureDetail.LOW:
 		creature_outline_scene_path = "res://src/main/world/creature/FastCreatureOutline.tscn"
 	var creature_outline_scene: PackedScene = load(creature_outline_scene_path)
 	_creature_outline = creature_outline_scene.instance()

--- a/project/src/main/world/overworld-buttons.gd
+++ b/project/src/main/world/overworld-buttons.gd
@@ -19,8 +19,8 @@ func _ready() -> void:
 Resizes a button container based on the player's touch settings.
 """
 func _resize_container(container: Control) -> void:
-	if container.rect_min_size.y != 96 * PlayerData.touch_settings.size:
-		container.rect_min_size.y = 96 * PlayerData.touch_settings.size
+	if container.rect_min_size.y != 96 * SystemData.touch_settings.size:
+		container.rect_min_size.y = 96 * SystemData.touch_settings.size
 	container.rect_size.y = 0
 	if container == $Southeast:
 		container.rect_position.y = 600 - 60 - container.rect_size.y

--- a/project/src/main/world/overworld-touch-buttons.gd
+++ b/project/src/main/world/overworld-touch-buttons.gd
@@ -9,7 +9,7 @@ func _ready() -> void:
 	if OS.has_touchscreen_ui_hint():
 		_overworld_ui.connect("chat_started", self, "_on_OverworldUi_chat_started")
 		_overworld_ui.connect("chat_ended", self, "_on_OverworldUi_chat_ended")
-		PlayerData.touch_settings.connect("settings_changed", self, "_on_TouchSettings_settings_changed")
+		SystemData.touch_settings.connect("settings_changed", self, "_on_TouchSettings_settings_changed")
 		_refresh_button_positions()
 		show()
 	else:
@@ -40,7 +40,7 @@ Updates the buttons based on the player's settings.
 This updates their location and size.
 """
 func _refresh_button_positions() -> void:
-	$ButtonsSw.rect_scale = Vector2(1.0, 1.0) * PlayerData.touch_settings.size
+	$ButtonsSw.rect_scale = Vector2(1.0, 1.0) * SystemData.touch_settings.size
 	$ButtonsSw.rect_position.y = rect_size.y - 10 - $ButtonsSw.rect_size.y * $ButtonsSw.rect_scale.y
 
 

--- a/project/src/main/world/phone-menu.gd
+++ b/project/src/main/world/phone-menu.gd
@@ -7,7 +7,7 @@ signal show
 signal hide
 
 func _ready() -> void:
-	PlayerData.touch_settings.connect("settings_changed", self, "_on_TouchSettings_settings_changed")
+	SystemData.touch_settings.connect("settings_changed", self, "_on_TouchSettings_settings_changed")
 	for button in [$Buttons/Northeast/BackButton, $Buttons/Northeast/Spacer]:
 		button.connect("resized", self, "_on_Button_resized", [button])
 	yield(get_tree(), "idle_frame")
@@ -38,8 +38,8 @@ func hide() -> void:
 Resizes a button container based on the player's touch settings.
 """
 func _resize_container(container: Control) -> void:
-	if container.rect_min_size.y != 96 * PlayerData.touch_settings.size:
-		container.rect_min_size.y = 96 * PlayerData.touch_settings.size
+	if container.rect_min_size.y != 96 * SystemData.touch_settings.size:
+		container.rect_min_size.y = 96 * SystemData.touch_settings.size
 	container.rect_size.y = 0
 
 

--- a/project/src/test/test-old-player-save.gd
+++ b/project/src/test/test-old-player-save.gd
@@ -4,9 +4,11 @@ Tests backwards compatibility with older save formats.
 """
 
 const TEMP_FILENAME := "test-ground-lucky.save"
+const TEMP_LEGACY_FILENAME := "test-snatch-lucky.save"
 
 func before_each() -> void:
 	PlayerSave.data_filename = "user://%s" % TEMP_FILENAME
+	PlayerSave.legacy_filename = "user://%s" % TEMP_LEGACY_FILENAME
 	
 	# don't increment playtime during this test or it ruins our assertions
 	PlayerData.seconds_played_timer.stop()
@@ -17,16 +19,17 @@ func after_each() -> void:
 	var save_dir := Directory.new()
 	save_dir.open("user://")
 	save_dir.remove(TEMP_FILENAME)
+	save_dir.remove(TEMP_LEGACY_FILENAME)
 
 
-func load_player_data(filename: String) -> void:
+func load_legacy_player_data(filename: String) -> void:
 	var dir := Directory.new()
-	dir.copy("res://assets/test/%s" % filename, "user://%s" % TEMP_FILENAME)
+	dir.copy("res://assets/test/%s" % filename, "user://%s" % TEMP_LEGACY_FILENAME)
 	PlayerSave.load_player_data()
 
 
 func test_15d2_rank_success() -> void:
-	load_player_data("turbofat-15d2.json")
+	load_legacy_player_data("turbofat-15d2.json")
 	
 	var history_rank_7k: RankResult = PlayerData.level_history.results("rank/7k")[0]
 	
@@ -35,7 +38,7 @@ func test_15d2_rank_success() -> void:
 
 
 func test_163e_lost_erases_success() -> void:
-	load_player_data("turbofat-163e.json")
+	load_legacy_player_data("turbofat-163e.json")
 	
 	# rank-6d was a success, and the player didn't lose
 	assert_eq(PlayerData.level_history.results("rank/6d")[0].success, true)
@@ -44,14 +47,14 @@ func test_163e_lost_erases_success() -> void:
 
 
 func test_1682_chat_history_preserved() -> void:
-	load_player_data("turbofat-1682.json")
+	load_legacy_player_data("turbofat-1682.json")
 	
 	assert_eq(PlayerData.chat_history.get_chat_age("creature/boatricia/my_maid_died"), 5)
 	assert_eq(PlayerData.chat_history.get_filler_count("creature/boatricia"), 13)
 
 
 func test_199c() -> void:
-	load_player_data("turbofat-199c.json")
+	load_legacy_player_data("turbofat-199c.json")
 	
 	assert_eq(PlayerData.level_history.successful_levels.has("practice/marathon_normal"), true)
 	assert_eq(PlayerData.level_history.successful_levels.has("rank/7k"), true)
@@ -61,7 +64,7 @@ func test_199c() -> void:
 
 
 func test_19c5() -> void:
-	load_player_data("turbofat-19c5.json")
+	load_legacy_player_data("turbofat-19c5.json")
 	
 	assert_eq(PlayerData.level_history.successful_levels.has("rank/7k"), true)
 	
@@ -74,7 +77,7 @@ func test_19c5() -> void:
 
 
 func test_1b3c() -> void:
-	load_player_data("turbofat-1b3c.json")
+	load_legacy_player_data("turbofat-1b3c.json")
 	
 	# 'survival mode' was renamed to 'marathon mode'
 	assert_true(PlayerData.level_history.level_names().has("practice/marathon_hard"))
@@ -84,7 +87,7 @@ func test_1b3c() -> void:
 
 
 func test_245b() -> void:
-	load_player_data("turbofat-245b.json")
+	load_legacy_player_data("turbofat-245b.json")
 	
 	# some levels were made much harder/different, and their scores should be invalidated
 	assert_true(PlayerData.level_history.level_names().has("marsh/pulling_for_everyone"))
@@ -95,7 +98,7 @@ func test_245b() -> void:
 
 
 func test_24cc() -> void:
-	load_player_data("turbofat-24cc.json")
+	load_legacy_player_data("turbofat-24cc.json")
 	
 	assert_eq(PlayerData.chat_history.chat_history.get("chat/level_select"), 10)
 	assert_eq(PlayerData.chat_history.chat_history.get("creature/bort/filler"), 6)
@@ -106,7 +109,7 @@ func test_24cc() -> void:
 
 
 func test_2743() -> void:
-	load_player_data("turbofat-2743.json")
+	load_legacy_player_data("turbofat-2743.json")
 	
 	# chat history should use underscores, and new prefixes
 	assert_eq(PlayerData.chat_history.chat_history.get("creature/boatricia/hi"), 57)
@@ -130,7 +133,11 @@ func test_2743() -> void:
 
 
 func test_2783() -> void:
-	load_player_data("turbofat-2783.json")
+	load_legacy_player_data("turbofat-2783.json")
 	
 	# We did not measure playtime in 2783, but we can approximate it based on the player's money.
 	assert_almost_eq(PlayerData.seconds_played, 1181359, 0.1)
+	
+	# Save data was in one file in 2783, but was then split into system and player data.
+	# Level history is a part of the player data, and should be preserved.
+	assert_true(PlayerData.level_history.finished_levels.has("marsh/hello_everyone"))

--- a/project/src/test/test-old-system-save.gd
+++ b/project/src/test/test-old-system-save.gd
@@ -1,0 +1,32 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests backwards compatibility with older save formats.
+"""
+
+const TEMP_FILENAME := "test-ripe-bucket.json"
+const TEMP_LEGACY_FILENAME := "test-oven-bucket.save"
+
+func before_each() -> void:
+	SystemSave.data_filename = "user://%s" % TEMP_FILENAME
+	SystemSave.legacy_filename = "user://%s" % TEMP_LEGACY_FILENAME
+	SystemData.reset()
+
+
+func after_each() -> void:
+	var save_dir := Directory.new()
+	save_dir.open("user://")
+	save_dir.remove(TEMP_FILENAME)
+	save_dir.remove(TEMP_LEGACY_FILENAME)
+
+
+func load_legacy_player_data(filename: String) -> void:
+	var dir := Directory.new()
+	dir.copy("res://assets/test/%s" % filename, "user://%s" % TEMP_LEGACY_FILENAME)
+	SystemSave.load_system_data()
+
+
+func test_1b3c() -> void:
+	load_legacy_player_data("turbofat-1b3c.json")
+	
+	# 'miscellaneous settings' were renamed to 'misc settings'
+	assert_eq(TranslationServer.get_locale(), "es")

--- a/project/src/test/test-player-save.gd
+++ b/project/src/test/test-player-save.gd
@@ -27,7 +27,8 @@ func after_each() -> void:
 			RollingBackups.CURRENT,
 			RollingBackups.THIS_HOUR, RollingBackups.PREV_HOUR,
 			RollingBackups.THIS_DAY, RollingBackups.PREV_DAY,
-			RollingBackups.THIS_WEEK, RollingBackups.PREV_WEEK]:
+			RollingBackups.THIS_WEEK, RollingBackups.PREV_WEEK,
+			RollingBackups.LEGACY]:
 		dir.remove(PlayerSave.rolling_backups.rolling_filename(backup))
 
 

--- a/project/src/test/test-string-utils.gd
+++ b/project/src/test/test-string-utils.gd
@@ -80,6 +80,45 @@ func test_comma_sep_big() -> void:
 	assert_eq(StringUtils.comma_sep(999999999999999999), "999,999,999,999,999,999")
 
 
+func test_comma_sep_float_negative() -> void:
+	assert_eq(StringUtils.comma_sep_float(-1.348, 1), "-1.3")
+	assert_eq(StringUtils.comma_sep_float(-1.384, 1), "-1.4")
+	assert_eq(StringUtils.comma_sep_float(-999.348, 1), "-999.3")
+	assert_eq(StringUtils.comma_sep_float(-1000.348, 1), "-1,000.3")
+	assert_eq(StringUtils.comma_sep_float(-1002034.348, 1), "-1,002,034.3")
+
+
+func test_comma_sep_float_small() -> void:
+	assert_eq(StringUtils.comma_sep_float(0.348, 1), "0.3")
+	assert_eq(StringUtils.comma_sep_float(1.348, 1), "1.3")
+	assert_eq(StringUtils.comma_sep_float(1.384, 1), "1.4")
+	assert_eq(StringUtils.comma_sep_float(13.348, 1), "13.3")
+	assert_eq(StringUtils.comma_sep_float(133.348, 1), "133.3")
+	assert_eq(StringUtils.comma_sep_float(999.348, 1), "999.3")
+
+
+func test_comma_sep_float_big() -> void:
+	assert_eq(StringUtils.comma_sep_float(1000.348, 1), "1,000.3")
+	assert_eq(StringUtils.comma_sep_float(1001.348, 1), "1,001.3")
+	assert_eq(StringUtils.comma_sep_float(999999.348, 1), "999,999.3")
+	assert_eq(StringUtils.comma_sep_float(1000000.348, 1), "1,000,000.3")
+	assert_eq(StringUtils.comma_sep_float(1001001.348, 1), "1,001,001.3")
+	assert_eq(StringUtils.comma_sep_float(999999999.348, 1), "999,999,999.3")
+	
+	# comma_sep_float rounds very big numbers. this isn't deliberate, it's just how floats work
+	assert_eq(StringUtils.comma_sep_float(999999999999999999.348, 1), "1,000,000,000,000,000,000")
+
+
+func test_comma_sep_float_round() -> void:
+	# rounds to the nearest value
+	assert_eq(StringUtils.comma_sep_float(976784.348, 0), "976,784")
+	assert_eq(StringUtils.comma_sep_float(976784.348, 1), "976,784.3")
+	assert_eq(StringUtils.comma_sep_float(976784.348, 2), "976,784.35")
+	
+	# decimals don't use commas or anything silly
+	assert_eq(StringUtils.comma_sep_float(1.348276625375806, 5), "1.34828")
+
+
 func test_sanitize_file_root_valid_characters() -> void:
 	assert_eq(StringUtils.sanitize_file_root("spoil633"), "spoil633")
 	assert_eq(StringUtils.sanitize_file_root("spoil-633"), "spoil-633")

--- a/project/src/test/test-system-save.gd
+++ b/project/src/test/test-system-save.gd
@@ -1,0 +1,45 @@
+extends "res://addons/gut/test.gd"
+"""
+Unit test demonstrating the save functionality. It's easy to introduce bugs related to saving or loading the
+configuration into JSON, since something trivial like renaming a variable or changing its type might change how it's
+saved or loaded. That's why unit tests are particularly important for this code.
+"""
+
+const TEMP_PLAYER_FILENAME := "test253.save"
+const TEMP_SYSTEM_FILENAME := "test254.json"
+const TEMP_LEGACY_FILENAME := "test255.save"
+
+var _rank_result: RankResult
+
+func before_each() -> void:
+	PlayerSave.data_filename = "user://%s" % TEMP_PLAYER_FILENAME
+	SystemSave.data_filename = "user://%s" % TEMP_SYSTEM_FILENAME
+	SystemSave.legacy_filename = "user://%s" % TEMP_LEGACY_FILENAME
+	SystemData.reset()
+
+
+func after_each() -> void:
+	var dir := Directory.new()
+	dir.remove(TEMP_SYSTEM_FILENAME)
+	dir.remove(TEMP_LEGACY_FILENAME)
+	for backup in [
+			RollingBackups.CURRENT,
+			RollingBackups.THIS_HOUR, RollingBackups.PREV_HOUR,
+			RollingBackups.THIS_DAY, RollingBackups.PREV_DAY,
+			RollingBackups.THIS_WEEK, RollingBackups.PREV_WEEK,
+			RollingBackups.LEGACY]:
+		dir.remove(PlayerSave.rolling_backups.rolling_filename(backup))
+
+
+func test_save_and_load() -> void:
+	SystemData.volume_settings.set_bus_volume_linear(VolumeSettings.MASTER, 0.841)
+	SystemData.volume_settings.set_bus_volume_linear(VolumeSettings.MUSIC, 0.695)
+	SystemData.volume_settings.set_bus_volume_linear(VolumeSettings.SOUND, 0.279)
+	SystemData.volume_settings.set_bus_volume_linear(VolumeSettings.VOICE, 0.405)
+	SystemSave.save_system_data()
+	SystemData.reset()
+	SystemSave.load_system_data()
+	assert_almost_eq(SystemData.volume_settings.get_bus_volume_linear(VolumeSettings.MASTER), 0.841, 0.001)
+	assert_almost_eq(SystemData.volume_settings.get_bus_volume_linear(VolumeSettings.MUSIC), 0.695, 0.001)
+	assert_almost_eq(SystemData.volume_settings.get_bus_volume_linear(VolumeSettings.SOUND), 0.279, 0.001)
+	assert_almost_eq(SystemData.volume_settings.get_bus_volume_linear(VolumeSettings.VOICE), 0.405, 0.001)


### PR DESCRIPTION
Save slots are accessible through the Settings/Misc menu. Selecting a
new save slot prompts the user and redirects them to the splash page.
Save slots can also be deleted, the player is prompted twice.

Split SystemData/SystemSave from PlayerData/PlayerSave.

With multiple save slots, we need a centralized place to store which
save slot is active. It makes sense to store configuration information
like language and keybinds to this location. Players don't want to rebind their
keys and reconfigure their language every time they start a new game.