### PR TITLE
Overworld bugs: impassable tiles, settings visible, spawner scale

### DIFF
--- a/project/src/main/ui/SettingsMenu.tscn
+++ b/project/src/main/ui/SettingsMenu.tscn
@@ -75,6 +75,7 @@ visible = false
 emit_actions = false
 
 [node name="Window" type="Panel" parent="."]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -900,6 +901,7 @@ __meta__ = {
 }
 
 [node name="Dialogs" type="Control" parent="."]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2

--- a/project/src/main/ui/menu/settings-menu.gd
+++ b/project/src/main/ui/menu/settings-menu.gd
@@ -67,6 +67,7 @@ Shows the menu and pauses the scene tree.
 func show() -> void:
 	_bg.show()
 	_touch_buttons.visible = true
+	_dialogs.visible = true
 	_window.show()
 	get_tree().paused = true
 	_old_focus_owner = $Window/UiArea/Bottom/Ok.get_focus_owner()
@@ -80,6 +81,7 @@ Hides the menu and unpauses the scene tree.
 func hide() -> void:
 	_bg.hide()
 	_touch_buttons.visible = false
+	_dialogs.visible = false
 	_window.hide()
 	get_tree().paused = false
 	if _old_focus_owner:

--- a/project/src/main/world/environment/MarshCrystalSpawner.tscn
+++ b/project/src/main/world/environment/MarshCrystalSpawner.tscn
@@ -5,7 +5,7 @@
 [ext_resource path="res://assets/main/world/environment/marsh-crystal.png" type="Texture" id=3]
 
 [node name="ButtercupCrystal" type="Sprite"]
-scale = Vector2( 0.4, 0.4 )
+scale = Vector2( 0.539, 0.539 )
 texture = ExtResource( 3 )
 centered = false
 offset = Vector2( -70, -102 )

--- a/project/src/main/world/obstacle-map.gd
+++ b/project/src/main/world/obstacle-map.gd
@@ -28,9 +28,9 @@ a patch of ground.
 """
 func _refresh_invisible_obstacles() -> void:
 	# remove all invisible obstacles
-	for cell_obj in get_used_cells_by_id(1):
+	for cell_obj in get_used_cells_by_id(impassable_tile_index):
 		var cell: Vector2 = cell_obj
-		set_cell(cell.x, cell.y, impassable_tile_index)
+		set_cell(cell.x, cell.y, -1)
 	
 	# calculate empty unwalkable cells which are adjacent to walkable cells
 	var unwalkable_cells := {}


### PR DESCRIPTION
Fixed bug where obstacle-map.gd was not clearing invisible obstacles
appropriately.

Made SettingsMenu invisible again, including its new dialogs. If it's
visible it makes it hard to edit scenes which use a settings menu.

Fixed scale of marsh crystal spawners (in editor). The spawners were
slightly smaller than actual crystals resulting in a mismatch when
starting the game, and also making the overworld look strange in the
editor as different crystals were different sizes.