### PR TITLE
Chat/cutscene refactorings, method renames.

### DIFF
--- a/project/src/demo/localization-demo.gd
+++ b/project/src/demo/localization-demo.gd
@@ -72,13 +72,13 @@ func _extract_localizables_from_creatures() -> void:
 		
 		# extract the creature's filler chat as localizables
 		for filler_id in ChatLibrary.filler_ids_for_creature(creature_id):
-			var chat_tree := ChatLibrary.chat_tree_for_chat_id(creature_def, filler_id)
+			var chat_tree := ChatLibrary.chat_tree_for_creature_chat_id(creature_def, filler_id)
 			_extract_localizables_from_chat_tree(chat_tree)
 		
 		# extract the creature's level/story chat as localizables
 		for chat_selector_obj in creature_def.chat_selectors:
 			var chat_selector: Dictionary = chat_selector_obj
-			var chat_tree := ChatLibrary.chat_tree_for_chat_id(creature_def, chat_selector.get("chat"))
+			var chat_tree := ChatLibrary.chat_tree_for_creature_chat_id(creature_def, chat_selector.get("chat"))
 			_extract_localizables_from_chat_tree(chat_tree)
 
 

--- a/project/src/demo/ui/chat/chat-frame-demo.gd
+++ b/project/src/demo/ui/chat/chat-frame-demo.gd
@@ -87,7 +87,7 @@ func _input(event: InputEvent) -> void:
 				_text_index = Utils.key_num(event)
 			_play_chat_event()
 		KEY_A:
-			if $ChatFrame.chat_window_showing():
+			if $ChatFrame.is_chat_window_showing():
 				$ChatFrame.pop_out()
 			else:
 				_play_chat_event()

--- a/project/src/demo/world/cutscene-demo.gd
+++ b/project/src/demo/world/cutscene-demo.gd
@@ -42,8 +42,7 @@ func _on_StartButton_pressed() -> void:
 	_flags_input.apply_flags()
 	
 	var cutscene_prefix := StringUtils.substring_before_last(_open_input.value, "_")
-	var path := ChatHistory.path_from_history_key(_open_input.value)
-	var chat_tree := ChatLibrary.chat_tree_from_file(path)
+	var chat_tree := ChatLibrary.chat_tree_for_key(_open_input.value)
 	CurrentLevel.set_launched_level(cutscene_prefix)
 	
 	if chat_tree:
@@ -52,7 +51,7 @@ func _on_StartButton_pressed() -> void:
 		CutsceneManager.reset()
 		
 		CutsceneManager.enqueue_chat_tree(chat_tree)
-		SceneTransition.push_trail(chat_tree.cutscene_scene_path())
+		SceneTransition.push_trail(chat_tree.chat_scene_path())
 	else:
 		push_warning("Invalid cutscene path: %s" % [_open_input.value])
 

--- a/project/src/main/creature-library.gd
+++ b/project/src/main/creature-library.gd
@@ -22,7 +22,7 @@ var forced_fatness := 0.0
 
 # Virtual properties; values are only exposed through getters/setters
 var player_def: CreatureDef setget set_player_def, get_player_def
-var sensei_def: CreatureDef setget set_sensei_def,get_sensei_def
+var sensei_def: CreatureDef setget set_sensei_def, get_sensei_def
 
 # fatnesses by creature id
 var _fatnesses: Dictionary

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -165,7 +165,7 @@ func _quit_puzzle() -> void:
 	if play_cutscene:
 		# insert cutscene into breadcrumb trail so it will show up after we pop the trail
 		CutsceneManager.enqueue_chat_tree(chat_tree)
-		Breadcrumb.trail.insert(1, chat_tree.cutscene_scene_path())
+		Breadcrumb.trail.insert(1, chat_tree.chat_scene_path())
 	
 	CurrentLevel.clear_launched_level()
 	PlayerData.creature_queue.clear()

--- a/project/src/main/ui/chat/ChatUi.tscn
+++ b/project/src/main/ui/chat/ChatUi.tscn
@@ -45,7 +45,7 @@ __meta__ = {
 chat_frame_path = NodePath("../ChatFrame")
 
 [connection signal="chat_event_played" from="." to="ChatAdvancer" method="_on_ChatUi_chat_event_played"]
-[connection signal="pop_out_completed" from="." to="TouchTranslator" method="_on_ChatUi_pop_out_completed"]
+[connection signal="chat_finished" from="." to="TouchTranslator" method="_on_ChatUi_chat_finished"]
 [connection signal="popped_in" from="." to="TouchTranslator" method="_on_ChatUi_popped_in"]
 [connection signal="showed_choices" from="." to="TouchTranslator" method="_on_ChatUi_showed_choices"]
 [connection signal="chat_event_shown" from="ChatAdvancer" to="." method="_on_ChatAdvancer_chat_event_shown"]

--- a/project/src/main/ui/chat/chat-frame.gd
+++ b/project/src/main/ui/chat/chat-frame.gd
@@ -86,7 +86,7 @@ func play_chat_event(chat_event: ChatEvent, nametag_right: bool, squished: bool)
 	$ChatLinePanel/NametagPanel.show_label(chat_theme, nametag_right)
 
 
-func chat_window_showing() -> bool:
+func is_chat_window_showing() -> bool:
 	return $ChatLineLabel.visible
 
 

--- a/project/src/main/ui/chat/chat-library.gd
+++ b/project/src/main/ui/chat/chat-library.gd
@@ -29,7 +29,7 @@ func chat_tree_for_creature(creature: Creature) -> ChatTree:
 	var filler_ids := filler_ids_for_creature(creature.creature_id)
 	var chosen_chat := select_from_chat_selectors(creature.chat_selectors, creature.creature_id, filler_ids)
 
-	var chat_tree := chat_tree_for_chat_id(creature.creature_def, chosen_chat)
+	var chat_tree := chat_tree_for_creature_chat_id(creature.creature_def, chosen_chat)
 	if not chat_tree and has_preroll(chosen_chat):
 		chat_tree = chat_tree_for_preroll(chosen_chat)
 
@@ -41,11 +41,19 @@ Returns the chat tree for the specified creature and chat id.
 
 Returns null if the chat tree cannot be found.
 """
-func chat_tree_for_chat_id(creature_def: CreatureDef, chat_id: String) -> ChatTree:
+func chat_tree_for_creature_chat_id(creature_def: CreatureDef, chat_id: String) -> ChatTree:
 	var chat_tree: ChatTree
 	if FileUtils.file_exists(_creature_chat_path(creature_def.creature_id, chat_id)):
 		chat_tree = chat_tree_from_file(_creature_chat_path(creature_def.creature_id, chat_id))
 	return chat_tree
+
+
+"""
+Returns the chat tree for the specified chat key, such as 'chat/marsh_prologue'.
+"""
+func chat_tree_for_key(chat_key: String) -> ChatTree:
+	var path := ChatHistory.path_from_history_key(chat_key)
+	return chat_tree_from_file(path)
 
 
 """

--- a/project/src/main/ui/chat/chat-line-panel.gd
+++ b/project/src/main/ui/chat/chat-line-panel.gd
@@ -1,6 +1,8 @@
 class_name ChatLinePanel
 extends Panel
 """
+Displays an empty frame around spoken dialog.
+
 Note: ChatLinePanel does not contain its own chat line labels to avoid the labels being distorted as the panel
 	stretches and shrinks. It would make the text annoying to read.
 """

--- a/project/src/main/ui/chat/chat-tree.gd
+++ b/project/src/main/ui/chat/chat-tree.gd
@@ -141,7 +141,10 @@ func can_advance() -> bool:
 	return can_increment
 
 
-func cutscene_scene_path() -> String:
+"""
+Returns the scene path where this chat takes place.
+"""
+func chat_scene_path() -> String:
 	return LOCATION_SCENE_PATHS_BY_ID.get(location_id, Global.SCENE_OVERWORLD)
 
 

--- a/project/src/main/ui/chat/touch-translator.gd
+++ b/project/src/main/ui/chat/touch-translator.gd
@@ -25,7 +25,7 @@ func _ready() -> void:
 
 
 func _input(event: InputEvent) -> void:
-	if not _chat_frame.chat_window_showing() or not is_processing():
+	if not _chat_frame.is_chat_window_showing() or not is_processing():
 		return
 	
 	if event is InputEventScreenTouch:
@@ -92,5 +92,5 @@ func _on_ChatChoices_chat_choice_chosen(_choice_index: int) -> void:
 	_enable_translation()
 
 
-func _on_ChatUi_pop_out_completed() -> void:
+func _on_ChatUi_chat_finished() -> void:
 	_disable_translation()

--- a/project/src/main/world/OverworldUi.tscn
+++ b/project/src/main/world/OverworldUi.tscn
@@ -349,7 +349,7 @@ mouse_filter = 2
 [connection signal="pressed" from="Control/CellPhoneMenu/Buttons/Northeast/BackButton" to="Control/CellPhoneMenu" method="_on_BackButton_pressed"]
 [connection signal="chat_choice_chosen" from="Control/ChatUi" to="." method="_on_ChatUi_chat_choice_chosen"]
 [connection signal="chat_event_played" from="Control/ChatUi" to="." method="_on_ChatUi_chat_event_played"]
-[connection signal="pop_out_completed" from="Control/ChatUi" to="." method="_on_ChatUi_pop_out_completed"]
+[connection signal="chat_finished" from="Control/ChatUi" to="." method="_on_ChatUi_chat_finished"]
 [connection signal="showed_choices" from="Control/ChatUi" to="." method="_on_ChatUi_showed_choices"]
 [connection signal="cheat_detected" from="Control/CheatCodeDetector" to="Control/Labels/SoutheastLabels/FpsLabel" method="_on_CheatCodeDetector_cheat_detected"]
 [connection signal="hide" from="Control/SettingsMenu" to="." method="_on_SettingsMenu_hide"]

--- a/project/src/main/world/creature/creature-visuals.gd
+++ b/project/src/main/world/creature/creature-visuals.gd
@@ -52,6 +52,7 @@ const SPRINT := MovementMode.SPRINT
 const RUN := MovementMode.RUN
 const WALK := MovementMode.WALK
 const WIGGLE := MovementMode.WIGGLE
+const SOUTHEAST_DIR := Vector2(0.70710678118, 0.70710678118)
 
 # toggle to assign default animation frames based on the creature's orientation
 export (bool) var _reset_frames setget reset_frames
@@ -64,8 +65,6 @@ export (bool) var _random_creature setget random_creature
 
 # the state of whether the creature is walking, running or idle
 export (MovementMode) var movement_mode := MovementMode.IDLE setget set_movement_mode
-
-export (Vector2) var southeast_dir := Vector2(0.70710678118, 0.70710678118)
 
 # the direction the creature is facing
 export (CreatureOrientation.Orientation) var orientation := CreatureOrientation.SOUTHEAST setget set_orientation
@@ -425,7 +424,7 @@ func _compute_orientation(direction: Vector2) -> int:
 	# when our direction puts us between two orientations.
 	var new_orientation: int = orientation
 	# unrounded orientation is a float in the range [-2.0, 2.0]
-	var unrounded_orientation := -2 * direction.angle_to(southeast_dir) / PI
+	var unrounded_orientation := -2 * direction.angle_to(SOUTHEAST_DIR) / PI
 	if abs(unrounded_orientation - orientation) >= 0.6 and abs(unrounded_orientation + 4 - orientation) >= 0.6:
 		# convert the float orientation [-2.0, 2.0] to an int orientation [0, 3]
 		new_orientation = wrapi(int(round(unrounded_orientation)), 0, 4)

--- a/project/src/main/world/creature/player.gd
+++ b/project/src/main/world/creature/player.gd
@@ -14,11 +14,11 @@ func _ready() -> void:
 	SceneTransition.connect("fade_out_started", self, "_on_SceneTransition_fade_out_started")
 	
 	set_creature_def(PlayerData.creature_library.player_def)
+	creature_id = CreatureLibrary.PLAYER_ID
 	if PlayerData.creature_library.forced_fatness:
 		set_fatness(PlayerData.creature_library.forced_fatness)
 		set_visual_fatness(PlayerData.creature_library.forced_fatness)
 	refresh_collision_extents()
-	creature_id = CreatureLibrary.PLAYER_ID
 	ChattableManager.player = self
 
 

--- a/project/src/main/world/cutscene-manager.gd
+++ b/project/src/main/world/cutscene-manager.gd
@@ -90,7 +90,7 @@ func replace_cutscene_trail() -> void:
 		return
 	
 	var chat_tree: ChatTree = _queue.front()
-	SceneTransition.replace_trail(chat_tree.cutscene_scene_path())
+	SceneTransition.replace_trail(chat_tree.chat_scene_path())
 
 
 """
@@ -102,7 +102,7 @@ func push_cutscene_trail() -> void:
 		return
 	
 	var chat_tree: ChatTree = _queue.front()
-	SceneTransition.push_trail(chat_tree.cutscene_scene_path())
+	SceneTransition.push_trail(chat_tree.chat_scene_path())
 
 
 """


### PR DESCRIPTION
Replaced ChatUi's 'pop_out_completed' signal with 'chat_finished'
signal. Its windows popping in and out is sort of a UI detail, callers care
about the chat ending.

Extracted ChatLibrary.chat_tree_for_key method from CutsceneDemo. Renamed
ChatLibrary's chat_tree_for_chat_id method to be creature specific. A 'chat_id'
sounds like it could maybe be comparable to a history_key, but they're not the
same. The new method names make this slightly more evident.

Renamed ChatFrame.chat_window_showing to is_chat_window_showing to adhere to
typical conventions, and for consistency with ChatFrame.is_all_text_visible

Split up OverworldUi.start_chat method and added comments around some unusual
code.

Changed CreatureVisuals.southeast_dir from an export variable to a
constant. I don't think anyone will ever want to customize this, it
shouldn't be an export variable.

Changed ChatTree.cutscene_scene_path to ChatTree.chat_scene_path. It
feels like a simpler name.