### PR TITLE
Improved left/right nametag algorithm

### DIFF
--- a/project/src/demo/ui/chat/chat-frame-demo.gd
+++ b/project/src/demo/ui/chat/chat-frame-demo.gd
@@ -146,7 +146,7 @@ func _play_chat_event() -> void:
 	chat_event.who = "lorum"
 	chat_event.text = TEXTS[_text_index]
 	chat_event.chat_theme_def = _get_chat_theme_def()
-	$ChatFrame.play_chat_event(chat_event, _nametag_right, _squished)
+	$ChatFrame.play_chat_event(chat_event, _squished)
 
 
 """

--- a/project/src/main/ui/chat/chat-event.gd
+++ b/project/src/main/ui/chat/chat-event.gd
@@ -34,8 +34,17 @@ enum Mood {
 	YES1, # nodding a few times
 }
 
+enum NametagSide {
+	NO_PREFERENCE,
+	LEFT,
+	RIGHT,
+}
+
 # The name of the person speaking, or blank if nobody is speaking
 var who := ""
+
+# whether the chatter's nametag should be drawn on the right/left side of the frame
+var nametag_side: int = NametagSide.NO_PREFERENCE
 
 # The chat line
 var text: String

--- a/project/src/main/ui/chat/chat-frame.gd
+++ b/project/src/main/ui/chat/chat-frame.gd
@@ -53,7 +53,7 @@ Animates the chat UI to gradually reveal the specified text, mimicking speech.
 Also updates the chat UI's appearance based on the amount of text being displayed and the specified color and
 background texture.
 """
-func play_chat_event(chat_event: ChatEvent, nametag_right: bool, squished: bool) -> void:
+func play_chat_event(chat_event: ChatEvent, squished: bool) -> void:
 	if not $ChatLineLabel.visible:
 		# Ensure the chat window is showing before we start changing its text and playing sounds
 		pop_in()
@@ -83,6 +83,7 @@ func play_chat_event(chat_event: ChatEvent, nametag_right: bool, squished: bool)
 	# update the UI's appearance
 	$ChatLineLabel.update_appearance(chat_theme)
 	$ChatLinePanel.update_appearance(chat_theme, chat_line_size)
+	var nametag_right: bool = chat_event.nametag_side == ChatEvent.NametagSide.RIGHT
 	$ChatLinePanel/NametagPanel.show_label(chat_theme, nametag_right)
 
 

--- a/project/src/main/ui/chat/chat-ui.gd
+++ b/project/src/main/ui/chat/chat-ui.gd
@@ -100,24 +100,12 @@ func _on_ChatAdvancer_chat_event_shown(chat_event: ChatEvent) -> void:
 		# if we're asked to rewind or play more chat lines without picking a choice, hide the choices
 		_chat_choices.hide_choices()
 	
-	# reposition the nametags for whether the characters are on the left or right side
-	var creature := ChattableManager.get_creature_by_id(chat_event["who"])
-	var nametag_right := false
 	var squished := false
-	if creature:
-		var orientation: int = creature.orientation
-		if orientation in [Creature.NORTHEAST, Creature.SOUTHEAST]:
-			# If we're facing right, we're on the left side. Put the nametag on the left.
-			nametag_right = false
-		elif orientation in [Creature.NORTHWEST, Creature.SOUTHWEST]:
-			# If we're facing left, we're on the right side. Put the nametag on the right.
-			nametag_right = true
-	
 	if _chat_advancer.should_prompt():
 		# we're going to prompt the player for a response; squish the chat frame to the side
 		squished = true
 	
-	_chat_frame.play_chat_event(chat_event, nametag_right, squished)
+	_chat_frame.play_chat_event(chat_event, squished)
 	
 	if _chat_advancer.rewinding_text:
 		# immediately make all text visible when rewinding, so the player can rewind faster

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -67,6 +67,8 @@ func start_chat(new_chat_tree: ChatTree, target: Node2D) -> void:
 	if target:
 		chatters.append(target)
 	
+	_assign_nametag_sides(new_chat_tree)
+	
 	_update_visible()
 	ChattableManager.set_focus_enabled(false)
 	# emit 'chat_started' event first to prepare chatters before emoting
@@ -179,6 +181,33 @@ func _find_creatures_in_chat_tree(chat_tree: ChatTree) -> Array:
 			creatures.append(chatter)
 	
 	return creatures
+
+
+"""
+Assign nametag sides for each chat line.
+
+We calculate the midpoint of the chatters. Creatures to the right of the midpoint have their nametags on the right.
+Creatures to the left have their nametags on the left.
+
+This information is stored back into the chat tree so that it can be utilized by the chat ui.
+"""
+func _assign_nametag_sides(new_chat_tree: ChatTree) -> void:
+	var chatter_bounding_box := get_chatter_bounding_box([], [])
+	var center_of_chatters: Vector2 = chatter_bounding_box.position + chatter_bounding_box.size * 0.5
+	
+	for chat_events_obj in new_chat_tree.events.values():
+		var chat_events: Array = chat_events_obj
+		for chat_event_obj in chat_events:
+			var chat_event: ChatEvent = chat_event_obj
+			if not chat_event.who:
+				continue
+			var chatter: Creature = ChattableManager.get_creature_by_id(chat_event.who)
+			if not chatter:
+				continue
+			if chatter.position.x > center_of_chatters.x:
+				chat_event.nametag_side = ChatEvent.NametagSide.RIGHT
+			else:
+				chat_event.nametag_side = ChatEvent.NametagSide.LEFT
 
 
 """

--- a/project/src/main/world/chattable-manager.gd
+++ b/project/src/main/world/chattable-manager.gd
@@ -11,10 +11,10 @@ signal focus_changed
 const MAX_INTERACT_DISTANCE := 240.0
 
 # The player's sprite
-var player: Player setget set_player
+var player: Creature setget set_player
 
 # The sensei's sprite
-var sensei: Sensei setget set_sensei
+var sensei: Creature setget set_sensei
 
 # The overworld object which the player will currently interact with if they hit the button
 var focused_chattable: Node2D setget set_focused_chattable
@@ -113,12 +113,12 @@ func load_chat_tree() -> ChatTree:
 	return chat_tree
 
 
-func set_player(new_player: Player) -> void:
+func set_player(new_player: Creature) -> void:
 	player = new_player
 	unregister_creature(player)
 
 
-func set_sensei(new_sensei: Sensei) -> void:
+func set_sensei(new_sensei: Creature) -> void:
 	sensei = new_sensei
 	unregister_creature(sensei)
 


### PR DESCRIPTION
Instead of basing it on which way the creature is facing, it now
calculates the midpoint of the conversation and attaches metadata to
each ChatEvent specifying whether the nametag should appear on the left
or right.

This is more consistent. Creatures might talk to each other when they're
both walking in the same direction. Or a creature might turn left and
right during a cutscene.