### PR TITLE
Added epilogue. Cutscene tweaks.

### DIFF
--- a/project/assets/main/chat/marsh-epilogue.chat
+++ b/project/assets/main/chat/marsh-epilogue.chat
@@ -1,0 +1,63 @@
+{"version": "2476"}
+
+[location]
+outdoors_walk
+
+[destination]
+outdoors
+
+[characters]
+player, p1
+sensei, s1
+narrator, n
+
+n: Instead of spending a week in Merrymellow Marsh like they originally planned, #sensei# and #player# ended up staying for an entire month.\n\n...But for some, even an entire month wasn't enough.
+p1: u_u I still wish we could have stayed and helped longer. I was finally starting to feel like I belonged there.
+s1: Well, a wise poet once wrote, "Two sofas diverged in a furniture store."
+s1: "I chose the sofa less comfortable, and that has made all the difference."
+[i_understand] I see
+[thats_stupid] That's stupid
+[you_made_that_up] You made that up
+
+[i_understand]
+p1: /._. I see... And Merrymellow Marsh is like one of those big squishy beanbag chairs,
+p1: The kind where you almost pass out in them, and then you have trouble standing up afterwards.
+s1: Yes, something like that.
+[besides_that]
+
+[you_made_that_up]
+p1: -_- Really? A wise poet wrote that?
+ (stop_walking)
+p1: ...It sounds more like an excuse you made up after buying a crappy sofa.
+s1: Hmph.
+ (start_walking)
+[besides_that]
+
+[thats_stupid]
+p1: ^o^ Well that's stupid. Here's a better poem,
+p1: ^O^ "Buy some proper furniture and your butt will hurt less, you big wing wong."
+ (stop_walking)
+s1: Hmph.
+ (start_walking)
+[besides_that]
+
+[besides_that]
+p1: /._. Well, besides that. Did we even do anything while we were there?
+p1: We only finished with a handful of extra customers, and we still don't know why they came.
+p1: <_< They could stop showing up next week, and we'd be back to square one.
+ (stop_walking)
+s1: ^Y^ Well. ...For now it's just a handful of customers, but that will change in time.
+s1: There's an old saying, 'even the greatest avalanche starts with a single snowflake.'
+ (start_walking)
+p1: @_@ ...the GREATEST avalanche?
+s1: ^_^ Three or four customers now will become thirty or forty.
+s1: And the snowflake becomes a snowball, and the snowball gets bigger...
+p1: ._.; Just to be clear, you're using 'GREATEST' in the pejorative sense right? We're not... we're not pro-avalanche!
+s1: ^o^ ...until two or three years later, when our glorious restaurant will have the destructive force to level an entire city!
+s1: ^O^ Ahha ha ha ha!
+p1: .__.; Okay, come on, seriously! ...Use a nicer metaphor! You're being all weird about this.
+ (stop_walking)
+s1: /._. Even the greatest... PESTILENCE begins with a single cough!
+p1: >_< What!? No, we have a NICE restaurant! It's not a pestilence!
+s1: ^O^ Even the greatest MASSACRE begins with...
+p1: @_@ STOP! Augh!

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/pulling-for-everyone-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/pulling-for-everyone-100.chat
@@ -4,8 +4,8 @@
 indoors
 
 [characters]
-player, p1, kitchen_9
-sensei, s1, kitchen_5
+player, p1, kitchen_5
+sensei, s1, kitchen_9
 richie, r, kitchen_1
 skins, s, kitchen_3
 bones, b, kitchen_7
@@ -14,9 +14,9 @@ p1: /._. So one thing I noticed, Skins, is when you switch from one dish to the 
 b: <_< ...My name is Bones...
 p1: ._.; Oh! Sorry, I'm really awful with names.
 r: Hey names are tough! You just need a mnemonic to help you keep things straight.
-r: ^_^/ Like take Skins here, he's sorta like a cat, right? So just remember, "there's more than one way to skin a cat!"
+r: ^_^/ Like take Skins here, they're sorta like a cat, right? So just remember, "there's more than one way to skin a cat!"
 s: .__.; Augh! That's rather graphic!
-r: And Bones here, he's sorta like a dog? You can remember that like-
+r: And Bones here, they're sorta like a dog? You can remember that like-
 p1: ^__^ I get it! 'There's more than one way to bone a dog!'
 r: W-what? ...That's not... ...Well, whatever helps you remember.
  (bones mood OwO...)

--- a/project/assets/main/puzzle/worlds.json
+++ b/project/assets/main/puzzle/worlds.json
@@ -31,6 +31,8 @@
       "id": "world0",
       "name": "Merrymellow Marsh",
       "last_level": "marsh/goodbye_everyone",
+      "prologue_chat_key": "chat/marsh_prologue",
+      "epilogue_chat_key": "chat/marsh_epilogue",
       "levels": [
         {
           "id": "marsh/hello_everyone",

--- a/project/src/main/ui/level-select/level-library.gd
+++ b/project/src/main/ui/level-select/level-library.gd
@@ -149,6 +149,11 @@ func set_worlds_path(new_worlds_path: String) -> void:
 	refresh_cleared_levels()
 
 
+func is_world_finished(world_id: String) -> bool:
+	var world_lock: WorldLock = world_lock(world_id)
+	return world_lock and world_lock.last_level and PlayerData.level_history.is_level_finished(world_lock.last_level)
+
+
 """
 Loads the list of levels from JSON.
 """
@@ -226,7 +231,7 @@ func _update_locked_worlds() -> void:
 		var unlock_world_ids := world_lock.unlocked_if_values
 		for unlock_world_id in unlock_world_ids:
 			var other_world_lock: WorldLock = _world_locks[unlock_world_id]
-			if not PlayerData.level_history.is_level_finished(other_world_lock.last_level):
+			if not is_world_finished(other_world_lock.world_id):
 				world_lock.status = WorldLock.STATUS_LOCK
 
 
@@ -332,7 +337,7 @@ func _update_unlockable_levels() -> void:
 		if not world_lock.last_level:
 			# world doesn't have a last level
 			continue
-		if PlayerData.level_history.is_level_finished(world_lock.last_level):
+		if is_world_finished(world_lock.world_id):
 			# crown already collected
 			continue
 		if is_level_locked(world_lock.last_level):

--- a/project/src/main/ui/level-select/world-lock.gd
+++ b/project/src/main/ui/level-select/world-lock.gd
@@ -23,6 +23,8 @@ const STATUS_LOCK := LockStatus.LOCK
 
 var world_id: String
 var world_name: String
+var prologue_chat_key: String
+var epilogue_chat_key: String
 
 # the requirements to unlock this level
 var unlocked_if_type := ALWAYS_UNLOCKED
@@ -46,6 +48,8 @@ func from_json_dict(json: Dictionary) -> void:
 	world_id = json.get("id", "")
 	world_name = json.get("name", "")
 	last_level = json.get("last_level", "")
+	prologue_chat_key = json.get("prologue_chat_key", "")
+	epilogue_chat_key = json.get("epilogue_chat_key", "")
 	
 	var levels: Array = json.get("levels", [])
 	if levels:

--- a/project/src/main/ui/menu/main-menu-play.gd
+++ b/project/src/main/ui/menu/main-menu-play.gd
@@ -3,16 +3,16 @@ extends VBoxContainer
 A panel shown on the main menu which contains game modes to play.
 """
 
-# the cutscene we load when the player launches story mode for the first time
-const PROLOGUE_CHAT_KEY := "chat/marsh_prologue"
+const WORLD0_ID := "world0"
 
 func _on_Story_pressed() -> void:
 	PlayerData.creature_queue.clear()
 	CurrentLevel.clear_launched_level()
 	
-	if not PlayerData.chat_history.is_chat_finished(PROLOGUE_CHAT_KEY):
+	var world_lock := LevelLibrary.world_lock(WORLD0_ID)
+	if world_lock.prologue_chat_key and not PlayerData.chat_history.is_chat_finished(world_lock.prologue_chat_key):
 		# load the prologue scene
-		var chat_tree := ChatLibrary.chat_tree_for_key(PROLOGUE_CHAT_KEY)
+		var chat_tree := ChatLibrary.chat_tree_for_key(world_lock.prologue_chat_key)
 		CutsceneManager.enqueue_chat_tree(chat_tree)
 		SceneTransition.push_trail(chat_tree.chat_scene_path())
 	else:

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -324,6 +324,11 @@ func _on_ChatUi_chat_finished() -> void:
 				if _current_chat_tree.destination_scene_path() == _current_chat_tree.chat_scene_path():
 					# preserve spawn ids from cutscene
 					CutsceneManager.assign_player_spawn_ids(_current_chat_tree)
+				else:
+					# erase spawn IDs to avoid 'could not locate spawn' warnings when playing multiple cutscenes
+					# consecutively
+					Global.player_spawn_id = ""
+					Global.sensei_spawn_id = ""
 			
 			if CutsceneManager.is_front_level_id():
 				# continue to a level (preroll cutscene finished playing)


### PR DESCRIPTION
Epilogue is played when the player beats the last level of Merrymellow
Marsh. Epilogue/prologue cutscene paths are defined in worlds.json.

Swapped seats for the 'pulling for everyone' cutscene so that the player
faces Bones.