### PR TITLE
Fixed button where tutorial selection didn't show checkmarks.

### DIFF
--- a/project/src/main/ui/level-select/LevelSelectPanel.tscn
+++ b/project/src/main/ui/level-select/LevelSelectPanel.tscn
@@ -197,9 +197,10 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[connection signal="locked_level_selected" from="VBoxContainer/Top/ScrollContainer/MarginContainer/LevelButtons" to="VBoxContainer/Bottom/HBoxContainer/Info" method="_on_LevelButtons_locked_level_selected"]
+[connection signal="button_added" from="VBoxContainer/Top/ScrollContainer/MarginContainer/LevelButtons" to="VBoxContainer/Top/ScrollContainer/MarginContainer/GradeLabels" method="_on_LevelButtons_button_added"]
 [connection signal="locked_level_selected" from="VBoxContainer/Top/ScrollContainer/MarginContainer/LevelButtons" to="VBoxContainer/Bottom/HBoxContainer/Description" method="_on_LevelButtons_locked_level_selected"]
-[connection signal="overall_selected" from="VBoxContainer/Top/ScrollContainer/MarginContainer/LevelButtons" to="VBoxContainer/Bottom/HBoxContainer/Info" method="_on_LevelButtons_overall_selected"]
+[connection signal="locked_level_selected" from="VBoxContainer/Top/ScrollContainer/MarginContainer/LevelButtons" to="VBoxContainer/Bottom/HBoxContainer/Info" method="_on_LevelButtons_locked_level_selected"]
 [connection signal="overall_selected" from="VBoxContainer/Top/ScrollContainer/MarginContainer/LevelButtons" to="VBoxContainer/Bottom/HBoxContainer/Description" method="_on_LevelButtons_overall_selected"]
-[connection signal="unlocked_level_selected" from="VBoxContainer/Top/ScrollContainer/MarginContainer/LevelButtons" to="VBoxContainer/Bottom/HBoxContainer/Info" method="_on_LevelButtons_unlocked_level_selected"]
+[connection signal="overall_selected" from="VBoxContainer/Top/ScrollContainer/MarginContainer/LevelButtons" to="VBoxContainer/Bottom/HBoxContainer/Info" method="_on_LevelButtons_overall_selected"]
 [connection signal="unlocked_level_selected" from="VBoxContainer/Top/ScrollContainer/MarginContainer/LevelButtons" to="VBoxContainer/Bottom/HBoxContainer/Description" method="_on_LevelButtons_unlocked_level_selected"]
+[connection signal="unlocked_level_selected" from="VBoxContainer/Top/ScrollContainer/MarginContainer/LevelButtons" to="VBoxContainer/Bottom/HBoxContainer/Info" method="_on_LevelButtons_unlocked_level_selected"]

--- a/project/src/main/ui/level-select/grade-labels.gd
+++ b/project/src/main/ui/level-select/grade-labels.gd
@@ -11,11 +11,6 @@ export (PackedScene) var GradeLabelScene: PackedScene
 # value: HookableGradeLabel for the specified button
 var _labels_by_button: Dictionary
 
-func _ready() -> void:
-	for button_obj in get_tree().get_nodes_in_group("level_select_buttons"):
-		_add_label(button_obj)
-
-
 """
 Add a grade label for the specified button.
 """
@@ -28,7 +23,13 @@ func _add_label(button: LevelSelectButton) -> void:
 	add_child(new_label)
 	_labels_by_button[button] = new_label
 	new_label.button = button
+	
+	button.connect("tree_exited", self, "_on_LevelSelectButton_tree_exited", [button])
 
 
 func _on_LevelButtons_button_added(button: LevelSelectButton) -> void:
 	_add_label(button)
+
+
+func _on_LevelSelectButton_tree_exited(button: LevelSelectButton) -> void:
+	_labels_by_button.erase(button)

--- a/project/src/main/ui/level-select/level-buttons.gd
+++ b/project/src/main/ui/level-select/level-buttons.gd
@@ -18,6 +18,9 @@ signal locked_level_selected(level_lock, settings)
 # Emitted when the player highlights the 'overall' button.
 signal overall_selected(world_id, ranks)
 
+# Emitted when a new level select button or world select button is added.
+signal button_added(button)
+
 const ALL_LEVELS := LevelsToInclude.ALL_LEVELS
 const TUTORIALS_ONLY := LevelsToInclude.TUTORIALS_ONLY
 
@@ -108,12 +111,12 @@ func _add_buttons() -> void:
 			if level_lock.status == LevelLock.STATUS_HARD_LOCK:
 				# 'hard lock' levels are hidden from the player
 				continue
-			_add_node_to_column(_level_select_button(world_id, level_id))
+			_add_button_to_column(_level_select_button(world_id, level_id))
 			
 			# warning-ignore:integer_division
 			if i == (shown_level_ids.size() - 1) / 2:
 				last_world_button = _world_button(world_id)
-				_add_node_to_column(last_world_button)
+				_add_button_to_column(last_world_button)
 	
 	if last_world_button:
 		last_world_button.grab_focus()
@@ -122,7 +125,7 @@ func _add_buttons() -> void:
 """
 Adds a node to the rightmost column, or creates a new column if the column is full
 """
-func _add_node_to_column(node: Node) -> void:
+func _add_button_to_column(button: LevelSelectButton) -> void:
 	if not _columns or _columns[_columns.size() - 1].get_child_count() >= _max_row_count:
 		# create a new column
 		var column := VBoxContainer.new()
@@ -132,8 +135,9 @@ func _add_node_to_column(node: Node) -> void:
 		_columns.append(column)
 		add_child(column)
 	
-	# add the node to the rightmost column
-	_columns[_columns.size() - 1].add_child(node)
+	# add the button to the rightmost column
+	_columns[_columns.size() - 1].add_child(button)
+	emit_signal("button_added", button)
 
 
 """


### PR DESCRIPTION
These checkmarks were erased in 39c8ba1 which changed the LevelSelect
script to load its LevelButtons once at startup. However the tutorial
selector removes and recreates all its buttons, but the LevelButtons
script did not recreate a new set of grade labels to go with them.

This new logic automatically creates/removes grade labels every time a
LevelButton is created/destroyed.