### PR TITLE
Improved rotation rank parameters. LevelRankDemo.

### DIFF
--- a/project/assets/main/puzzle/levels/marsh/hello-everyone.json
+++ b/project/assets/main/puzzle/levels/marsh/hello-everyone.json
@@ -17,7 +17,7 @@
     "top_out 9"
   ],
   "rank": [
-    "extra_seconds_per_piece", "0.4"
+    "extra_seconds_per_piece 0.4"
   ],
   "triggers": [
     {

--- a/project/assets/main/puzzle/levels/marsh/hello-skins.json
+++ b/project/assets/main/puzzle/levels/marsh/hello-skins.json
@@ -11,7 +11,7 @@
     "top_out 9"
   ],
   "rank": [
-    "extra_seconds_per_piece", "0.4"
+    "extra_seconds_per_piece 0.4"
   ],
   "triggers": [
     {

--- a/project/assets/main/puzzle/levels/marsh/pulling-for-skins.json
+++ b/project/assets/main/puzzle/levels/marsh/pulling-for-skins.json
@@ -8,7 +8,7 @@
     "value": "150"
   },
   "rank": [
-    "extra_seconds_per_piece", "0.6",
+    "extra_seconds_per_piece 0.6",
     "box_factor 0.8"
   ],
   "piece_types": [

--- a/project/src/demo/puzzle/level/LevelRankDemo.tscn
+++ b/project/src/demo/puzzle/level/LevelRankDemo.tscn
@@ -1,0 +1,140 @@
+[gd_scene load_steps=7 format=2]
+
+[ext_resource path="res://src/main/ui/menu/theme/h5.theme" type="Theme" id=1]
+[ext_resource path="res://src/demo/puzzle/level/level-rank-demo.gd" type="Script" id=2]
+[ext_resource path="res://src/main/ui/DialogBackdrop.tscn" type="PackedScene" id=3]
+[ext_resource path="res://src/demo/puzzle/level/level-rank-demo-open.gd" type="Script" id=4]
+[ext_resource path="res://src/demo/puzzle/level/level-rank-demo-grade.gd" type="Script" id=5]
+[ext_resource path="res://src/demo/DemoSave.tscn" type="PackedScene" id=6]
+
+[node name="LevelRankDemo" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 2 )
+__meta__ = {
+"_edit_lock_": true,
+"_edit_use_anchors_": false
+}
+
+[node name="Input" type="VBoxContainer" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -200.0
+margin_top = -96.0
+margin_right = 200.0
+margin_bottom = 96.0
+rect_min_size = Vector2( 400, 0 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="PlayerGrade" type="HBoxContainer" parent="Input"]
+margin_right = 400.0
+margin_bottom = 24.0
+script = ExtResource( 5 )
+
+[node name="Label" type="Label" parent="Input/PlayerGrade"]
+margin_top = 3.0
+margin_right = 88.0
+margin_bottom = 21.0
+theme = ExtResource( 1 )
+text = "Player Grade"
+align = 2
+
+[node name="OptionButton" type="OptionButton" parent="Input/PlayerGrade"]
+margin_left = 92.0
+margin_right = 192.0
+margin_bottom = 24.0
+rect_min_size = Vector2( 100, 0 )
+theme = ExtResource( 1 )
+text = "SSS"
+
+[node name="Open" type="HBoxContainer" parent="Input"]
+margin_top = 28.0
+margin_right = 400.0
+margin_bottom = 56.0
+script = ExtResource( 4 )
+
+[node name="Button" type="Button" parent="Input/Open"]
+margin_right = 47.0
+margin_bottom = 28.0
+theme = ExtResource( 1 )
+text = "Open"
+
+[node name="LineEdit" type="LineEdit" parent="Input/Open"]
+margin_left = 51.0
+margin_right = 400.0
+margin_bottom = 28.0
+size_flags_horizontal = 3
+theme = ExtResource( 1 )
+text = "experiment/000"
+
+[node name="CalculateButton" type="Button" parent="Input"]
+margin_top = 60.0
+margin_right = 400.0
+margin_bottom = 84.0
+theme = ExtResource( 1 )
+text = "Calculate"
+
+[node name="Output" type="TextEdit" parent="Input"]
+margin_top = 88.0
+margin_right = 400.0
+margin_bottom = 188.0
+rect_min_size = Vector2( 0, 100 )
+theme = ExtResource( 1 )
+text = "Oh!
+What an output"
+readonly = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Dialogs" type="Control" parent="."]
+pause_mode = 2
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+__meta__ = {
+"_edit_lock_": true,
+"_edit_use_anchors_": false
+}
+
+[node name="Backdrop" parent="Dialogs" instance=ExtResource( 3 )]
+
+[node name="OpenFile" type="FileDialog" parent="Dialogs"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -320.0
+margin_top = -200.0
+margin_right = 320.0
+margin_bottom = 200.0
+popup_exclusive = true
+window_title = "Open a File"
+mode = 0
+filters = PoolStringArray( "*.json" )
+current_dir = "res://assets/main/puzzle/levels"
+current_path = "res://assets/main/puzzle/levels/"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Error" type="AcceptDialog" parent="Dialogs"]
+margin_right = 250.0
+margin_bottom = 58.0
+popup_exclusive = true
+window_title = "Error"
+dialog_autowrap = true
+
+[node name="DemoSave" parent="." instance=ExtResource( 6 )]
+
+[connection signal="about_to_show" from="Dialogs/Error" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
+[connection signal="popup_hide" from="Dialogs/Error" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
+[connection signal="about_to_show" from="Dialogs/OpenFile" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
+[connection signal="file_selected" from="Dialogs/OpenFile" to="." method="_on_OpenFileDialog_file_selected"]
+[connection signal="popup_hide" from="Dialogs/OpenFile" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
+[connection signal="pressed" from="Input/CalculateButton" to="." method="_on_CalculateButton_pressed"]
+[connection signal="pressed" from="Input/Open/Button" to="." method="_on_OpenButton_pressed"]

--- a/project/src/demo/puzzle/level/level-rank-demo-grade.gd
+++ b/project/src/demo/puzzle/level/level-rank-demo-grade.gd
@@ -1,0 +1,26 @@
+extends HBoxContainer
+"""
+UI input for specifying the target grade
+"""
+
+# The level to open
+# Virtual property; value is only exposed through getters/setters
+var value: String setget set_value, get_value
+
+# key: (String) letter grade such as 'SSS' or 'AA+'
+# value: (int) OptionButton index
+var _index_by_grade := {}
+
+func _ready() -> void:
+	for i in range(RankCalculator.GRADE_RANKS.size()):
+		var grade: String = RankCalculator.GRADE_RANKS[i][0]
+		$OptionButton.add_item(grade, i)
+		_index_by_grade[grade] = i
+
+
+func set_value(new_value: String) -> void:
+	$OptionButton.select(_index_by_grade[new_value])
+
+
+func get_value() -> String:
+	return $OptionButton.get_item_text($OptionButton.selected)

--- a/project/src/demo/puzzle/level/level-rank-demo-open.gd
+++ b/project/src/demo/puzzle/level/level-rank-demo-open.gd
@@ -1,0 +1,15 @@
+extends HBoxContainer
+"""
+UI input for specifying the level to open
+"""
+
+# The level to open
+# Virtual property; value is only exposed through getters/setters
+var value: String setget set_value, get_value
+
+func set_value(new_value: String) -> void:
+	$LineEdit.text = new_value
+
+
+func get_value() -> String:
+	return $LineEdit.text

--- a/project/src/demo/puzzle/level/level-rank-demo.gd
+++ b/project/src/demo/puzzle/level/level-rank-demo.gd
@@ -1,0 +1,163 @@
+extends Control
+"""
+A demo which calculates the necessary level metadata for the player to attain their expected grade.
+
+This demo takes the player's best performance and calculates the necessary level adjustments so that their best
+performance will result in the specified grade. For example, a player might usually play at an 'SSS' rank, but they
+make very few boxes on one specific level, because the level is difficult. So this demo might calculate and print
+something like 'box_factor=0.5' indicating that the level should be more lenient for players who don't make many boxes.
+"""
+
+# property keys to use when saving/loading data
+const SAVE_KEY_GRADE := "level-rank-demo.grade"
+const SAVE_KEY_OPEN := "level-rank-demo.open"
+
+var _rank_calculator := RankCalculator.new()
+
+onready var _error_dialog := $Dialogs/Error
+onready var _open_dialog := $Dialogs/OpenFile
+onready var _open_input := $Input/Open
+onready var _grade_input := $Input/PlayerGrade
+onready var _text_edit := $Input/Output
+onready var _demo_save := $DemoSave
+
+func _ready() -> void:
+	_load_demo_data()
+
+
+"""
+Calculates and outputs the necessary level metadata for the player to attain their expected grade.
+"""
+func _calculate() -> void:
+	_text_edit.text = ""
+	
+	# load the level settings
+	var level_settings := LevelSettings.new()
+	level_settings.load_from_resource(_open_input.value)
+	CurrentLevel.start_level(level_settings)
+	
+	# peform the calculations
+	_calculate_extra_seconds_per_piece()
+	_calculate_box_factor()
+	_calculate_combo_factor()
+	
+	# trim extra newlines from the output
+	_text_edit.text = _text_edit.text.strip_edges()
+
+
+"""
+Calculates and outputs the extra_seconds_per_piece for levels which inhibit fast players.
+"""
+func _calculate_extra_seconds_per_piece() -> void:
+	var target_rank := _target_rank()
+	var best_result := _best_result()
+	
+	var extra_seconds_per_piece_min := 0.0
+	var extra_seconds_per_piece_max := 2.0
+	for _i in range(20):
+		CurrentLevel.settings.rank.extra_seconds_per_piece = \
+				0.5 * (extra_seconds_per_piece_min + extra_seconds_per_piece_max)
+		var lpm_for_grade := _rank_calculator.master_lpm() * pow(RankCalculator.RDF_SPEED, target_rank)
+		if lpm_for_grade >= best_result.speed:
+			extra_seconds_per_piece_min = CurrentLevel.settings.rank.extra_seconds_per_piece
+		else:
+			extra_seconds_per_piece_max = CurrentLevel.settings.rank.extra_seconds_per_piece
+	
+	_text_edit.text += "extra_seconds_per_piece=%.2f\n" % [CurrentLevel.settings.rank.extra_seconds_per_piece]
+
+
+"""
+Calculates and outputs the box_factor for levels which inhibit snack and cake boxes.
+"""
+func _calculate_box_factor() -> void:
+	var target_rank := _target_rank()
+	var best_result := _best_result()
+	
+	var box_factor_min := 0.0
+	var box_factor_max := 4.0
+	for _i in range(20):
+		CurrentLevel.settings.rank.box_factor = \
+				0.5 * (box_factor_min + box_factor_max)
+		var box_score_for_grade := CurrentLevel.settings.rank.box_factor \
+				* RankCalculator.MASTER_BOX_SCORE * pow(RankCalculator.RDF_BOX_SCORE_PER_LINE, target_rank)
+		if box_score_for_grade >= best_result.box_score_per_line:
+			box_factor_max = CurrentLevel.settings.rank.box_factor
+		else:
+			box_factor_min = CurrentLevel.settings.rank.box_factor
+	
+	_text_edit.text += "box_factor=%.2f\n" % [CurrentLevel.settings.rank.box_factor]
+
+
+"""
+Calculates and outputs the combo_factor for levels which inhibit combos.
+"""
+func _calculate_combo_factor() -> void:
+	var target_rank := _target_rank()
+	var best_result := _best_result()
+	
+	var combo_factor_min := 0.0
+	var combo_factor_max := 4.0
+	for _i in range(20):
+		CurrentLevel.settings.rank.combo_factor = \
+				0.5 * (combo_factor_min + combo_factor_max)
+		var combo_score_for_grade := CurrentLevel.settings.rank.combo_factor \
+				* RankCalculator.MASTER_COMBO_SCORE * pow(RankCalculator.RDF_COMBO_SCORE_PER_LINE, target_rank)
+		if combo_score_for_grade >= best_result.combo_score_per_line:
+			combo_factor_max = CurrentLevel.settings.rank.combo_factor
+		else:
+			combo_factor_min = CurrentLevel.settings.rank.combo_factor
+	
+	_text_edit.text += "combo_factor=%.2f\n" % [CurrentLevel.settings.rank.combo_factor]
+
+
+"""
+Returns the player's best result for the level selected in the demo.
+
+The player's data is loaded from the current save slot.
+"""
+func _best_result() -> RankResult:
+	return PlayerData.level_history.best_result(CurrentLevel.level_id)
+
+
+"""
+Returns the rank corresponding to the grade chosen in the demo.
+"""
+func _target_rank() -> float:
+	return RankCalculator.rank(_grade_input.value)
+
+
+"""
+Reads the developer's in-memory data from a save file.
+"""
+func _load_demo_data() -> void:
+	if _demo_save.demo_data.has(SAVE_KEY_GRADE):
+		_grade_input.value = _demo_save.demo_data[SAVE_KEY_GRADE]
+	if _demo_save.demo_data.has(SAVE_KEY_OPEN):
+		_open_input.value = _demo_save.demo_data[SAVE_KEY_OPEN]
+
+
+"""
+Writes the developer's in-memory data to a save file.
+"""
+func _save_demo_data() -> void:
+	_demo_save.demo_data[SAVE_KEY_GRADE] = _grade_input.value
+	_demo_save.demo_data[SAVE_KEY_OPEN] = _open_input.value
+	_demo_save.save_demo_data()
+
+
+func _on_CalculateButton_pressed() -> void:
+	_save_demo_data()
+	_calculate()
+
+
+func _on_OpenFileDialog_file_selected(path: String) -> void:
+	if path.begins_with("res://assets/main/") and path.ends_with(".json"):
+		_open_input.value = LevelSettings.level_key_from_path(path)
+	else:
+		_error_dialog.dialog_text = "%s doesn't seem like the path to a level file." % [path]
+		_error_dialog.popup_centered()
+
+
+func _on_OpenButton_pressed() -> void:
+	_open_dialog.current_path = LevelSettings.path_from_level_key(_open_input.value)
+	_open_dialog.popup_centered()

--- a/project/src/demo/world/cutscene-demo.gd
+++ b/project/src/demo/world/cutscene-demo.gd
@@ -59,15 +59,15 @@ func _on_StartButton_pressed() -> void:
 		push_warning("Invalid cutscene path: %s" % [_open_input.value])
 
 
-func _on_OpenFileDialog_file_selected(_path: String) -> void:
-	var full_path: String = _open_dialog.current_path
-	if full_path.begins_with("res://assets/main/") \
-			and full_path.ends_with(ChatLibrary.CHAT_EXTENSION):
-		_open_input.value = ChatHistory.history_key_from_path(full_path)
+func _on_OpenFileDialog_file_selected(path: String) -> void:
+	if path.begins_with("res://assets/main/") \
+			and path.ends_with(ChatLibrary.CHAT_EXTENSION):
+		_open_input.value = ChatHistory.history_key_from_path(path)
 	else:
-		_error_dialog.dialog_text = "%s doesn't seem like the path to a cutscene file." % [full_path]
+		_error_dialog.dialog_text = "%s doesn't seem like the path to a cutscene file." % [path]
 		_error_dialog.popup_centered()
 
 
 func _on_OpenButton_pressed() -> void:
+	_open_dialog.current_path = ChatHistory.path_from_history_key(_open_input.value)
 	_open_dialog.popup_centered()

--- a/project/src/main/editor/puzzle/dialogs.gd
+++ b/project/src/main/editor/puzzle/dialogs.gd
@@ -42,5 +42,5 @@ func _on_Save_pressed() -> void:
 	
 	Utils.assign_default_dialog_path($Save, "res://assets/main/puzzle/levels/")
 	var file_root := StringUtils.sanitize_file_root(_level_editor.level_name.text)
-	$Save.current_file = LevelSettings.level_filename(file_root)
+	$Save.current_file = "%s.json" % StringUtils.underscores_to_hyphens(file_root)
 	$Save.popup_centered()

--- a/project/src/main/editor/puzzle/level-editor.gd
+++ b/project/src/main/editor/puzzle/level-editor.gd
@@ -18,7 +18,7 @@ onready var level_name := $HBoxContainer/SideButtons/LevelName
 onready var _level_json := $HBoxContainer/SideButtons/Json
 
 func _ready() -> void:
-	var level_text := FileUtils.get_file_as_text(LevelSettings.level_path(DEFAULT_LEVEL))
+	var level_text := FileUtils.get_file_as_text(LevelSettings.path_from_level_key(DEFAULT_LEVEL))
 	_level_json.text = level_text
 	_level_json.refresh_tile_map()
 	level_name.text = DEFAULT_LEVEL
@@ -33,7 +33,11 @@ func load_level(path: String) -> void:
 	var level_text := FileUtils.get_file_as_text(path)
 	_level_json.text = level_text
 	_level_json.refresh_tile_map()
-	level_name.text = LevelSettings.level_name(path)
+	
+	var new_level_name := path.get_file()
+	new_level_name = new_level_name.trim_suffix(".json")
+	new_level_name = StringUtils.hyphens_to_underscores(new_level_name)
+	level_name.text = new_level_name
 
 
 func _start_test() -> void:

--- a/project/src/main/puzzle/level/level-settings.gd
+++ b/project/src/main/puzzle/level/level-settings.gd
@@ -156,7 +156,7 @@ func from_json_dict(new_id: String, json: Dictionary) -> void:
 
 
 func load_from_resource(new_id: String) -> void:
-	load_from_text(new_id, FileUtils.get_file_as_text(level_path(new_id)))
+	load_from_text(new_id, FileUtils.get_file_as_text(path_from_level_key(new_id)))
 
 
 func load_from_text(new_id: String, text: String) -> void:
@@ -208,20 +208,13 @@ func _get_max_speed_id() -> String:
 	return max_speed_id
 
 
-static func level_path(level_name: String) -> String:
-	var level_path := StringUtils.underscores_to_hyphens(level_name)
-	level_path = "res://assets/main/puzzle/levels/%s.json" % level_path
-	return level_path
+static func path_from_level_key(level_key: String) -> String:
+	var level_path := StringUtils.underscores_to_hyphens(level_key)
+	return "res://assets/main/puzzle/levels/%s.json" % level_path
 
 
-static func level_name(path: String) -> String:
-	var level_name := path.get_file()
-	level_name = level_name.trim_suffix(".json")
-	level_name = StringUtils.underscores_to_hyphens(level_name)
-	return level_name
-
-
-static func level_filename(level_name: String) -> String:
-	var level_filename := StringUtils.underscores_to_hyphens(level_name)
-	level_filename = "%s.json" % level_filename
-	return level_filename
+static func level_key_from_path(level_path: String) -> String:
+	var level_key := StringUtils.hyphens_to_underscores(level_path)
+	level_key = level_key.trim_prefix("res://assets/main/puzzle/levels/")
+	level_key = level_key.trim_suffix(".json")
+	return level_key

--- a/project/src/test/puzzle/level/test-level-settings.gd
+++ b/project/src/test/puzzle/level/test-level-settings.gd
@@ -18,3 +18,17 @@ func test_load_1922_data() -> void:
 	assert_eq(settings.speed_ups[0].get_meta("speed"), "2")
 	assert_eq(settings.speed_ups[1].get_meta("speed"), "3")
 	assert_eq(settings.speed_ups[2].get_meta("speed"), "4")
+
+
+func test_path_from_level_key() -> void:
+	assert_eq(LevelSettings.path_from_level_key("boatricia1"),
+			"res://assets/main/puzzle/levels/boatricia1.json")
+	assert_eq(LevelSettings.path_from_level_key("marsh/goodbye_bones"),
+			"res://assets/main/puzzle/levels/marsh/goodbye-bones.json")
+
+
+func test_level_key_from_path() -> void:
+	assert_eq(LevelSettings.level_key_from_path("res://assets/main/puzzle/levels/boatricia1.json"),
+			"boatricia1")
+	assert_eq(LevelSettings.level_key_from_path("res://assets/main/puzzle/levels/marsh/goodbye_bones.json"),
+			"marsh/goodbye_bones")

--- a/project/src/test/puzzle/test-rank-calculator.gd
+++ b/project/src/test/puzzle/test-rank-calculator.gd
@@ -19,17 +19,17 @@ func before_each() -> void:
 
 func test_master_lpm_slow_marathon() -> void:
 	CurrentLevel.settings.set_start_speed("0")
-	assert_almost_eq(_rank_calculator._master_lpm(), 30.77, 0.1)
+	assert_almost_eq(_rank_calculator.master_lpm(), 30.77, 0.1)
 
 
 func test_master_lpm_medium_marathon() -> void:
 	CurrentLevel.settings.set_start_speed("A0")
-	assert_almost_eq(_rank_calculator._master_lpm(), 35.64, 0.1)
+	assert_almost_eq(_rank_calculator.master_lpm(), 35.64, 0.1)
 
 
 func test_master_lpm_fast_marathon() -> void:
 	CurrentLevel.settings.set_start_speed("F0")
-	assert_almost_eq(_rank_calculator._master_lpm(), 68.90, 0.1)
+	assert_almost_eq(_rank_calculator.master_lpm(), 68.90, 0.1)
 
 
 func test_master_lpm_mixed_marathon() -> void:
@@ -37,7 +37,7 @@ func test_master_lpm_mixed_marathon() -> void:
 	CurrentLevel.settings.add_speed_up(Milestone.LINES, 30, "A0")
 	CurrentLevel.settings.add_speed_up(Milestone.LINES, 60, "F0")
 	CurrentLevel.settings.set_finish_condition(Milestone.LINES, 100)
-	assert_almost_eq(_rank_calculator._master_lpm(), 46.23, 0.1)
+	assert_almost_eq(_rank_calculator.master_lpm(), 46.23, 0.1)
 
 
 func test_master_lpm_mixed_sprint() -> void:
@@ -45,7 +45,7 @@ func test_master_lpm_mixed_sprint() -> void:
 	CurrentLevel.settings.add_speed_up(Milestone.TIME_OVER, 30, "A0")
 	CurrentLevel.settings.add_speed_up(Milestone.TIME_OVER, 60, "F0")
 	CurrentLevel.settings.set_finish_condition(Milestone.TIME_OVER, 90)
-	assert_almost_eq(_rank_calculator._master_lpm(), 50.98, 0.1)
+	assert_almost_eq(_rank_calculator.master_lpm(), 50.98, 0.1)
 
 
 func test_calculate_rank_marathon_300_master() -> void:


### PR DESCRIPTION
Created a new LevelRankDemo which can calculate appropriate values for
'extra_seconds_per_piece', 'box_factor' and 'combo_factor' based on the
player's best performance.

Fixed malformed 'extra_seconds_per_piece' parameters in level data.
Recalculated 'extra_seconds_per_piece' metadata.

Refactored LevelSettings utility methods. The old utility methods were
only used by the LevelEditor and were sort of specialized and strange.
The new utility methods should be more reusable.