### PR TITLE
Removed PieceQueue autoload singleton.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -579,6 +579,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/puzzle/piece/piece-physics.gd"
 }, {
+"base": "Node",
+"class": "PieceQueue",
+"language": "GDScript",
+"path": "res://src/main/puzzle/piece/piece-queue.gd"
+}, {
 "base": "Reference",
 "class": "PieceSpeed",
 "language": "GDScript",
@@ -954,6 +959,7 @@ _global_script_class_icons={
 "PieceManager": "",
 "PieceMover": "",
 "PiecePhysics": "",
+"PieceQueue": "",
 "PieceSpeed": "",
 "PieceSquisher": "",
 "PieceStates": "",
@@ -1039,7 +1045,6 @@ MilestoneManager="*res://src/main/puzzle/milestone-manager.gd"
 MusicPlayer="*res://src/main/music/MusicPlayer.tscn"
 MusicTransition="*res://src/main/music/music-transition.gd"
 Pauser="*res://src/main/pauser.gd"
-PieceQueue="*res://src/main/puzzle/piece/piece-queue.gd"
 PlayerData="*res://src/main/player-data.gd"
 PlayerSave="*res://src/main/player-save.gd"
 PuzzleState="*res://src/main/puzzle/puzzle-state.gd"

--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=91 format=2]
+[gd_scene load_steps=92 format=2]
 
 [ext_resource path="res://src/main/ui/menu/theme/h3.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/tutorial/TutorialHud.tscn" type="PackedScene" id=2]
@@ -69,6 +69,7 @@
 [ext_resource path="res://src/main/puzzle/start-end-sfx.gd" type="Script" id=67]
 [ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=68]
 [ext_resource path="res://src/main/puzzle/frame-drops-label.gd" type="Script" id=69]
+[ext_resource path="res://src/main/puzzle/piece/piece-queue.gd" type="Script" id=71]
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 1, 1, 1, 0.333333 )
@@ -374,12 +375,14 @@ SeedScene = ExtResource( 33 )
 
 [node name="PieceManager" parent="." instance=ExtResource( 9 )]
 playfield_path = NodePath("../Playfield")
+piece_queue_path = NodePath("../PieceQueue")
 
 [node name="NextPieceDisplays" parent="." instance=ExtResource( 64 )]
 margin_left = 688.0
 margin_top = 28.0
 margin_right = 752.0
 margin_bottom = 572.0
+piece_queue_path = NodePath("../PieceQueue")
 
 [node name="WallGlobViewports" parent="." instance=ExtResource( 17 )]
 margin_left = 356.5
@@ -498,6 +501,9 @@ margin_top = 314.0
 margin_right = 1011.0
 margin_bottom = 434.0
 script = ExtResource( 59 )
+
+[node name="PieceQueue" type="Node" parent="."]
+script = ExtResource( 71 )
 
 [node name="Hud" type="CanvasLayer" parent="."]
 

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -16,6 +16,9 @@ var keep_retrying := false
 # The settings for the level currently being launched or played
 var settings := LevelSettings.new() setget switch_level
 
+# The puzzle scene
+var puzzle: Puzzle
+
 # The level which was originally launched. Some tutorial levels transition
 # into other levels, so this keeps track of the original.
 var level_id: String
@@ -34,6 +37,10 @@ var best_result: int = Levels.Result.NONE setget set_best_result
 
 # Tracks whether or not the player wants to play/skip this level's cutscene.
 var cutscene_force: int = Levels.CutsceneForce.NONE
+
+func _ready() -> void:
+	Breadcrumb.connect("before_scene_changed", self, "_on_Breadcrumb_before_scene_changed")
+
 
 """
 Unsets all of the 'launched level' data.
@@ -139,3 +146,13 @@ func push_level_trail() -> void:
 func set_best_result(new_best_result: int) -> void:
 	best_result = new_best_result
 	emit_signal("best_result_changed")
+
+
+"""
+Purges all node instances from the singleton.
+
+Because CurrentLevel is a singleton, node instances should be purged before changing scenes. Otherwise they'll
+continue consuming resources and could cause side effects.
+"""
+func _on_Breadcrumb_before_scene_changed() -> void:
+	puzzle = null

--- a/project/src/main/puzzle/level/level-trigger-effects.gd
+++ b/project/src/main/puzzle/level/level-trigger-effects.gd
@@ -52,10 +52,11 @@ class RotateNextPiecesEffect extends LevelTriggerEffect:
 	Rotates one or more pieces in the piece queue.
 	"""
 	func run(_params: Array = []) -> void:
+		var pieces: Array = CurrentLevel.puzzle.get_piece_queue().pieces
 		for i in range(next_piece_from_index, next_piece_to_index + 1):
-			if i >= PieceQueue.pieces.size():
+			if i >= pieces.size():
 				break
-			var next_piece: NextPiece = PieceQueue.pieces[i]
+			var next_piece: NextPiece = pieces[i]
 			match rotate_dir:
 				Rotation.CW: next_piece.orientation = next_piece.get_cw_orientation()
 				Rotation.CCW: next_piece.orientation = next_piece.get_ccw_orientation()

--- a/project/src/main/puzzle/piece/next-piece-display.gd
+++ b/project/src/main/puzzle/piece/next-piece-display.gd
@@ -5,6 +5,8 @@ Contains logic for a single 'next piece display'. A single display might only di
 pieces from now. Several displays are shown at once.
 """
 
+var _piece_queue: PieceQueue
+
 # how far into the future this display should look; 0 = show the next piece, 10 = show the 11th piece
 var _piece_index := 0
 
@@ -13,12 +15,13 @@ var _displayed_orientation: int
 
 onready var _tile_map: PuzzleTileMap = $TileMap
 
-func initialize(piece_index: int) -> void:
+func initialize(piece_queue: PieceQueue, piece_index: int) -> void:
+	_piece_queue = piece_queue
 	_piece_index = piece_index
 
 
 func _process(_delta: float) -> void:
-	var next_piece: NextPiece = PieceQueue.get_next_piece(_piece_index)
+	var next_piece: NextPiece = _piece_queue.get_next_piece(_piece_index)
 	if next_piece.type != _displayed_type or next_piece.orientation != _displayed_orientation:
 		_tile_map.clear()
 		if next_piece.type != PieceTypes.piece_null:

--- a/project/src/main/puzzle/piece/next-piece-displays.gd
+++ b/project/src/main/puzzle/piece/next-piece-displays.gd
@@ -6,10 +6,13 @@ Displays upcoming pieces to the player and manages the next piece displays.
 
 const DISPLAY_COUNT := 9
 
+export (NodePath) var piece_queue_path: NodePath
 export (PackedScene) var NextPieceDisplayScene
 
-# The "next piece displays" which are shown to the user
+# array of NextPieceDisplays which are shown to the user
 var _next_piece_displays := []
+
+onready var _piece_queue: PieceQueue = get_node(piece_queue_path)
 
 func _ready() -> void:
 	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
@@ -23,7 +26,7 @@ Adds a new next piece display.
 """
 func _add_display(piece_index: int, x: float, y: float, scale: float) -> void:
 	var new_display: NextPieceDisplay = NextPieceDisplayScene.instance()
-	new_display.initialize(piece_index)
+	new_display.initialize(_piece_queue, piece_index)
 	new_display.scale = Vector2(scale, scale)
 	new_display.position = Vector2(x, y)
 	new_display.hide()

--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -36,6 +36,7 @@ signal lock_started
 signal tiles_changed(tile_map)
 
 export (NodePath) var playfield_path: NodePath
+export (NodePath) var piece_queue_path: NodePath
 
 # settings and state for the currently active piece.
 var piece: ActivePiece
@@ -51,6 +52,7 @@ onready var input: PieceInput = $Input
 
 onready var _physics: PiecePhysics = $Physics
 onready var _playfield: Playfield = get_node(playfield_path)
+onready var _piece_queue: PieceQueue = get_node(piece_queue_path)
 onready var _states: PieceStates = $States
 
 func _ready() -> void:
@@ -116,7 +118,7 @@ Spawns a new piece at the top of the _playfield.
 Returns 'true' if the piece was spawned successfully, or 'false' if the player topped out.
 """
 func spawn_piece() -> bool:
-	var next_piece := PieceQueue.pop_next_piece()
+	var next_piece := _piece_queue.pop_next_piece()
 	piece = ActivePiece.new(next_piece.type, funcref(_playfield.tile_map, "is_cell_blocked"))
 	piece.orientation = next_piece.orientation
 	var success := _physics.spawn_piece(piece)

--- a/project/src/main/puzzle/piece/piece-queue.gd
+++ b/project/src/main/puzzle/piece/piece-queue.gd
@@ -1,3 +1,4 @@
+class_name PieceQueue
 extends Node
 """
 Queue of upcoming randomized pieces.

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -15,6 +15,7 @@ func _ready() -> void:
 	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")
 	PuzzleState.connect("after_game_ended", self, "_on_PuzzleState_after_game_ended")
 	$Playfield/TileMapClip/TileMap/Viewport/ShadowMap.piece_tile_map = $PieceManager/TileMap
+	CurrentLevel.puzzle = self
 	
 	# set a baseline fatness state
 	PlayerData.creature_library.save_fatness_state()
@@ -48,6 +49,10 @@ func get_playfield() -> Playfield:
 
 func get_piece_manager() -> PieceManager:
 	return $PieceManager as PieceManager
+
+
+func get_piece_queue() -> PieceQueue:
+	return $PieceQueue as PieceQueue
 
 
 func hide_buttons() -> void:
@@ -126,7 +131,7 @@ func _start_puzzle() -> void:
 			
 			if PlayerData.creature_library.has_fatness(starting_creature_id):
 				# restore their fatness so they start skinny again when replaying a puzzle
-				var fatness := PlayerData.creature_library.get_fatness(starting_creature_id)
+				var fatness: float = PlayerData.creature_library.get_fatness(starting_creature_id)
 				_restaurant_view.get_customer(starting_creature_index).set_fatness(fatness)
 		
 		# summon the other creatures
@@ -159,7 +164,7 @@ func _quit_puzzle() -> void:
 	
 	if _should_play_epilogue():
 		# enqueue the epilogue cutscene (after any postroll cutscene)
-		var world_lock := LevelLibrary.world_lock_for_level(CurrentLevel.level_id)
+		var world_lock: WorldLock = LevelLibrary.world_lock_for_level(CurrentLevel.level_id)
 		var chat_tree := ChatLibrary.chat_tree_for_key(world_lock.epilogue_chat_key)
 		_enqueue_cutscene(chat_tree)
 	
@@ -197,7 +202,7 @@ world's epilogue scene yet.
 """
 func _should_play_epilogue() -> bool:
 	var result := false
-	var world_lock := LevelLibrary.world_lock_for_level(CurrentLevel.level_id)
+	var world_lock: WorldLock = LevelLibrary.world_lock_for_level(CurrentLevel.level_id)
 	if not world_lock:
 		result = false
 	elif not LevelLibrary.is_world_finished(world_lock.world_id):

--- a/project/src/main/puzzle/rank-calculator.gd
+++ b/project/src/main/puzzle/rank-calculator.gd
@@ -141,7 +141,7 @@ func master_lpm() -> float:
 		var piece_speed: PieceSpeed = PieceSpeeds.speed(milestone.get_meta("speed"))
 		
 		var min_frames_per_line := min_frames_per_line(piece_speed)
-		var master_seconds_per_line := min_frames_per_line / 60 \
+		var master_seconds_per_line: float = min_frames_per_line / 60 \
 				+ 2 * CurrentLevel.settings.rank.extra_seconds_per_piece
 		
 		var finish_condition: Milestone = CurrentLevel.settings.finish_condition


### PR DESCRIPTION
PieceQueue was an autoload singleton to support LevelTriggerEffects,
which needed to rotate the pieces in the queue. However this sets a
difficult precedent for future effects which need to change the
active piece or add rows to the playfield. We don't want autoload
singletons for the active piece, playfield, and a hundred other
puzzle-specific things.

I've changed the design so that CurrentLevel keeps a reference to the
Puzzle scene, which contains a PieceQueue. When a puzzle is active,
LevelTriggerEffects can go through CurrentLevel to obtain references to
its piece queue, active piece, playfield, or a hundred other
puzzle-specific things.