### PR TITLE
Added row insertion logic.

### DIFF
--- a/project/src/demo/puzzle/puzzle-demo.gd
+++ b/project/src/demo/puzzle/puzzle-demo.gd
@@ -4,6 +4,7 @@ Shows off the visual effects for the puzzle.
 
 Keys:
 	[Q,W,E]: Build a box at different locations in the playfield
+	[T,Y]: Insert a line at different locations in the playfield
 	[A,S,D,F,G]: Change the box color to brown, pink, bread, white, cake
 	[H]: Change the cake box variation used to make cake boxes
 	[U,I,O]: Clear a line at different locations in the playfield
@@ -38,6 +39,9 @@ func _input(event: InputEvent) -> void:
 		KEY_W: _build_box(9)
 		KEY_E: _build_box(15)
 		
+		KEY_T: _insert_line(PuzzleTileMap.ROW_COUNT - 1)
+		KEY_Y: _insert_line(PuzzleTileMap.ROW_COUNT - 2)
+		
 		KEY_A: _color_int = PuzzleTileMap.BoxColorInt.BROWN
 		KEY_S: _color_int = PuzzleTileMap.BoxColorInt.PINK
 		KEY_D: _color_int = PuzzleTileMap.BoxColorInt.BREAD
@@ -64,6 +68,10 @@ func _input(event: InputEvent) -> void:
 
 func _build_box(y: int) -> void:
 	$Puzzle/Playfield/BoxBuilder.build_box(Rect2(6, y, 3, 3), _color_int)
+
+
+func _insert_line(y: int) -> void:
+	CurrentLevel.puzzle.get_playfield().line_inserter.insert_line(y)
 
 
 func _clear_line(cleared_line: int) -> void:

--- a/project/src/main/puzzle/Playfield.tscn
+++ b/project/src/main/puzzle/Playfield.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=42 format=2]
+[gd_scene load_steps=43 format=2]
 
 [ext_resource path="res://src/main/puzzle/playfield.gd" type="Script" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleTileMap.tscn" type="PackedScene" id=2]
@@ -24,6 +24,7 @@
 [ext_resource path="res://src/main/ui/blogger-sans-medium-18.tres" type="DynamicFont" id=22]
 [ext_resource path="res://src/main/puzzle/LeafPoof.tscn" type="PackedScene" id=23]
 [ext_resource path="res://src/main/puzzle/tutorial-keybinds-label.gd" type="Script" id=24]
+[ext_resource path="res://src/main/puzzle/line-inserter.gd" type="Script" id=25]
 [ext_resource path="res://assets/main/puzzle/playfield-bg.png" type="Texture" id=37]
 [ext_resource path="res://src/main/puzzle/combo-tracker.gd" type="Script" id=61]
 [ext_resource path="res://assets/main/fuzzy-circle-128.png" type="Texture" id=62]
@@ -293,6 +294,14 @@ bus = "Sound Bus"
 stream = ExtResource( 14 )
 bus = "Sound Bus"
 
+[node name="LineInserter" type="Node" parent="."]
+script = ExtResource( 25 )
+tile_map_path = NodePath("../TileMapClip/TileMap")
+
+[node name="LineInsertSound" type="AudioStreamPlayer" parent="LineInserter"]
+stream = ExtResource( 6 )
+bus = "Sound Bus"
+
 [node name="BuildBoxSfx" type="Node" parent="."]
 script = ExtResource( 8 )
 
@@ -313,6 +322,7 @@ bus = "Sound Bus"
 [connection signal="box_built" from="." to="TileMapClip/PlayfieldFx" method="_on_Playfield_box_built"]
 [connection signal="line_cleared" from="." to="ComboTracker" method="_on_Playfield_line_cleared"]
 [connection signal="line_erased" from="." to="LineClearSfx" method="_on_Playfield_line_erased"]
+[connection signal="lines_inserted" from="." to="LineClearer" method="_on_Playfield_lines_inserted"]
 [connection signal="after_boxes_built" from="BoxBuilder" to="." method="_on_BoxBuilder_after_boxes_built"]
 [connection signal="box_built" from="BoxBuilder" to="." method="_on_BoxBuilder_box_built"]
 [connection signal="box_built" from="BoxBuilder" to="LineClearer" method="_on_BoxBuilder_box_built"]
@@ -321,3 +331,4 @@ bus = "Sound Bus"
 [connection signal="line_clears_scheduled" from="LineClearer" to="." method="_on_LineClearer_line_clears_scheduled"]
 [connection signal="line_erased" from="LineClearer" to="." method="_on_LineClearer_line_erased"]
 [connection signal="lines_deleted" from="LineClearer" to="." method="_on_LineClearer_lines_deleted"]
+[connection signal="lines_inserted" from="LineInserter" to="." method="_on_LineInserter_lines_inserted"]

--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -714,6 +714,8 @@ script = ExtResource( 19 )
 [connection signal="line_clears_scheduled" from="Playfield" to="StarSeeds" method="_on_Playfield_line_clears_scheduled"]
 [connection signal="line_erased" from="Playfield" to="StarSeeds" method="_on_Playfield_line_erased"]
 [connection signal="lines_deleted" from="Playfield" to="StarSeeds" method="_on_Playfield_lines_deleted"]
+[connection signal="lines_inserted" from="Playfield" to="PieceManager" method="_on_Playfield_lines_inserted"]
+[connection signal="lines_inserted" from="Playfield" to="StarSeeds" method="_on_Playfield_lines_inserted"]
 [connection signal="customer_changed" from="RestaurantView" to="FoodItems" method="_on_RestaurantView_customer_changed"]
 [connection signal="hide" from="SettingsMenu" to="Hud/TouchButtons" method="_on_Menu_hide"]
 [connection signal="quit_pressed" from="SettingsMenu" to="." method="_on_SettingsMenu_quit_pressed"]

--- a/project/src/main/puzzle/line-clearer.gd
+++ b/project/src/main/puzzle/line-clearer.gd
@@ -1,7 +1,7 @@
 class_name LineClearer
 extends Node
 """
-Clears lines in a tilemap as new pieces are placed.
+Clears lines in a puzzle tilemap as new pieces are placed.
 
 Lines are cleared when the player completes rows, tops out or completes a level.
 """
@@ -328,3 +328,21 @@ func _on_BoxBuilder_box_built(rect: Rect2, _color_int: int) -> void:
 	if _rows_to_preserve_at_end:
 		for y in range(rect.position.y, rect.end.y):
 			_rows_to_preserve_at_end.erase(y)
+
+
+"""
+When lines are inserted, we adjust the lines being cleared/erased/deleted.
+
+Without these adjustments, strange behavior happens when lines are inserted and deleted simultaneously.
+"""
+func _on_Playfield_lines_inserted(lines: Array) -> void:
+	for inserted_line in lines:
+		for i in range(0, lines_being_cleared.size()):
+			if lines_being_cleared[i] <= inserted_line:
+				lines_being_cleared[i] -= 1
+		for i in range(0, lines_being_erased.size()):
+			if lines_being_erased[i] <= inserted_line:
+				lines_being_erased[i] -= 1
+		for i in range(0, lines_being_deleted.size()):
+			if lines_being_deleted[i] <= inserted_line:
+				lines_being_deleted[i] -= 1

--- a/project/src/main/puzzle/line-inserter.gd
+++ b/project/src/main/puzzle/line-inserter.gd
@@ -1,0 +1,35 @@
+extends Node
+"""
+Inserts lines in a puzzle tilemap.
+
+Most levels don't insert lines, but this script handles it for the levels that do.
+"""
+
+# emitted after one or more lines are inserted
+signal lines_inserted(lines)
+
+export (NodePath) var tile_map_path: NodePath
+
+onready var _tile_map: PuzzleTileMap = get_node(tile_map_path)
+onready var _line_insert_sound := $LineInsertSound
+
+"""
+Inserts a line into the puzzle tilemap.
+
+Parameters:
+	'new_line_y': (Optional) The y coordinate of the line to insert. If omitted, the line will be inserted at the
+		bottom of the puzzle tilemap.
+"""
+func insert_line(new_line_y: int = PuzzleTileMap.ROW_COUNT - 1) -> void:
+	# shift playfield up
+	_tile_map.insert_row(new_line_y)
+	
+	# fill bottom row
+	_line_insert_sound.play()
+	for x in range(0, PuzzleTileMap.COL_COUNT):
+		var pos := Vector2(x, new_line_y)
+		var veg_autotile_coord := Vector2(randi() % 18, randi() % 4)
+		_tile_map.set_block(pos, PuzzleTileMap.TILE_VEG, veg_autotile_coord)
+	_tile_map.set_block(Vector2(randi() % PuzzleTileMap.COL_COUNT, new_line_y), -1)
+	
+	emit_signal("lines_inserted", [new_line_y])

--- a/project/src/main/puzzle/piece/PieceManager.tscn
+++ b/project/src/main/puzzle/piece/PieceManager.tscn
@@ -203,6 +203,8 @@ bus = "Sound Bus"
 [connection signal="moved_right" from="." to="Sfx" method="_on_PieceManager_moved_right"]
 [connection signal="piece_changed" from="." to="Physics/Dropper" method="_on_PieceManager_piece_changed"]
 [connection signal="piece_changed" from="." to="Physics/Squisher" method="_on_PieceManager_piece_changed"]
+[connection signal="piece_disturbed" from="." to="Physics/Dropper" method="_on_PieceManager_piece_disturbed"]
+[connection signal="piece_disturbed" from="." to="Physics/Squisher" method="_on_PieceManager_piece_disturbed"]
 [connection signal="rotated_180" from="." to="Sfx" method="_on_PieceManager_rotated_180"]
 [connection signal="rotated_ccw" from="." to="Sfx" method="_on_PieceManager_rotated_ccw"]
 [connection signal="rotated_cw" from="." to="Sfx" method="_on_PieceManager_rotated_cw"]

--- a/project/src/main/puzzle/piece/piece-dropper.gd
+++ b/project/src/main/puzzle/piece/piece-dropper.gd
@@ -88,3 +88,8 @@ func _on_Squisher_squish_moved(_piece: ActivePiece, _old_pos: Vector2) -> void:
 func _on_PieceManager_piece_changed(piece: ActivePiece) -> void:
 	# recalculate hard drop target to draw ghost piece
 	calculate_hard_drop_target(piece)
+
+
+func _on_PieceManager_piece_disturbed(piece: ActivePiece) -> void:
+	# recalculate hard drop target to draw ghost piece
+	calculate_hard_drop_target(piece)

--- a/project/src/main/puzzle/piece/piece-squisher.gd
+++ b/project/src/main/puzzle/piece/piece-squisher.gd
@@ -136,3 +136,7 @@ func _squish_target(piece: ActivePiece, reset_target: bool = true) -> Vector2:
 
 func _on_PieceManager_piece_changed(_piece: ActivePiece) -> void:
 	squish_state = UNKNOWN
+
+
+func _on_PieceManager_piece_disturbed(_piece: ActivePiece) -> void:
+	squish_state = UNKNOWN

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -23,12 +23,15 @@ signal line_erased(y, total_lines, remaining_lines, box_ints)
 # emitted when erased lines are deleted, causing the rows above them to drop down
 signal lines_deleted(lines)
 
+signal lines_inserted(lines)
+
 signal blocks_prepared
 
 # remaining frames to delay for something besides making boxes/clearing lines
 var _remaining_misc_delay_frames := 0
 
 onready var tile_map := $TileMapClip/TileMap
+onready var line_inserter := $LineInserter
 
 onready var _bg_glob_viewports: FrostingViewports = $BgGlobViewports
 onready var _box_builder: BoxBuilder = $BoxBuilder
@@ -173,3 +176,7 @@ func _on_FrostingGlobs_hit_playfield(glob: Node) -> void:
 func _on_Pauser_paused_changed(value: bool) -> void:
 	$TileMapClip.visible = not value
 	$ShadowTexture.visible = not value
+
+
+func _on_LineInserter_lines_inserted(lines: Array) -> void:
+	emit_signal("lines_inserted", lines)

--- a/project/src/main/puzzle/puzzle-tile-map.gd
+++ b/project/src/main/puzzle/puzzle-tile-map.gd
@@ -119,27 +119,17 @@ func build_box(rect: Rect2, color_int: int) -> void:
 
 
 """
-Deletes the specified row in the tilemap, dropping all higher rows down to fill the gap.
+Deletes the row at the specified location, lowering all higher rows to fill the gap.
 """
 func delete_row(y: int) -> void:
-	# First, erase and store all the old cells which are dropping
-	var piece_colors_to_set := {}
-	var autotile_coords_to_set := {}
-	for cell in get_used_cells():
-		if cell.y > y:
-			# cells below the deleted row are left alone
-			continue
-		if cell.y < y:
-			# cells above the deleted row are shifted
-			var piece_color: int = get_cellv(cell)
-			var autotile_coord: Vector2 = get_cell_autotile_coord(cell.x, cell.y)
-			piece_colors_to_set[cell + Vector2.DOWN] = piece_color
-			autotile_coords_to_set[cell + Vector2.DOWN] = autotile_coord
-		set_block(cell, -1)
-	
-	# Next, write the old cells in their new locations
-	for cell in piece_colors_to_set:
-		set_block(cell, piece_colors_to_set[cell], autotile_coords_to_set[cell])
+	_shift_rows(y - 1, Vector2.DOWN)
+
+
+"""
+Inserts a blank row at the specified location, raising all higher rows to make room.
+"""
+func insert_row(y: int) -> void:
+	_shift_rows(y, Vector2.UP)
 
 
 """
@@ -284,6 +274,34 @@ func _disconnect_block(pos: Vector2, dir_mask: int = 15) -> void:
 	var autotile_coord := get_cell_autotile_coord(pos.x, pos.y)
 	autotile_coord.x = PuzzleConnect.unset_dirs(autotile_coord.x, dir_mask)
 	set_block(pos, get_cellv(pos), autotile_coord)
+
+
+"""
+Shifts a group of rows up or down.
+
+Parameters:
+	'bottom_row': The lowest row to shift. All rows at or above this row will be shifted.
+	
+	'direction': The direction to shift the rows, such as Vector2.UP or Vector2.DOWN.
+"""
+func _shift_rows(bottom_row: int, direction: Vector2) -> void:
+	# First, erase and store all the old cells which are shifting
+	var piece_colors_to_set := {}
+	var autotile_coords_to_set := {}
+	for cell in get_used_cells():
+		if cell.y > bottom_row:
+			# cells below the specified bottom row are left alone
+			continue
+		# cells at or above the specified bottom row are shifted
+		var piece_color: int = get_cellv(cell)
+		var autotile_coord: Vector2 = get_cell_autotile_coord(cell.x, cell.y)
+		piece_colors_to_set[cell + direction] = piece_color
+		autotile_coords_to_set[cell + direction] = autotile_coord
+		set_block(cell, -1)
+	
+	# Next, write the old cells in their new locations
+	for cell in piece_colors_to_set:
+		set_block(cell, piece_colors_to_set[cell], autotile_coords_to_set[cell])
 
 
 """


### PR DESCRIPTION
Inserting a new row can have many side effects, including shifting the
piece, shifting the ghost piece, changing which rows are being
deleted/shifted during a line clear, or altering the squish behavior.
These are all updated using a new 'piece_disturbed' signal.

This row insertion logic is currently only accessible through
PuzzleDemo.