### PR TITLE
Extracted SaveConverter from OldPlayerSave, OldSystemSave

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -705,6 +705,11 @@ _global_script_classes=[ {
 "path": "res://src/main/puzzle/level/rule-parser.gd"
 }, {
 "base": "Reference",
+"class": "SaveConverter",
+"language": "GDScript",
+"path": "res://src/main/save-converter.gd"
+}, {
+"base": "Reference",
 "class": "SaveItem",
 "language": "GDScript",
 "path": "res://src/main/save-item.gd"
@@ -994,6 +999,7 @@ _global_script_class_icons={
 "RestaurantView": "",
 "RollingBackups": "",
 "RuleParser": "",
+"SaveConverter": "",
 "SaveItem": "",
 "SaveSlotControl": "",
 "ScoreRules": "",

--- a/project/src/main/old-system-save.gd
+++ b/project/src/main/old-system-save.gd
@@ -7,72 +7,34 @@ backwards compatibility for older versions.
 """
 
 """
-Returns 'true' if the specified json save items are from an older version of the game.
+Creates and configures a SaveConverter capable of converting older system save formats.
 """
-func is_old_save_items(json_save_items: Array) -> bool:
-	var is_old: bool = false
-	var version_string := get_version_string(json_save_items)
-	match version_string:
-		PlayerSave.PLAYER_DATA_VERSION:
-			is_old = false
-		"1b3c", "19c5", "199c", "1922", "1682", "163e", "15d2", "245b", "24cc", "252a", "2743", "2783":
-			is_old = true
-		_:
-			push_warning("Unrecognized save data version: '%s'" % version_string)
-	return is_old
+func new_save_converter() -> SaveConverter:
+	var _save_converter := SaveConverter.new()
+	_save_converter.add_method(self, "_convert_2783", "2783", "27bb")
+	_save_converter.add_method(self, "_convert_2743", "2743", "2783")
+	_save_converter.add_method(self, "_convert_2743", "252a", "2783")
+	_save_converter.add_method(self, "_convert_2743", "24cc", "2783")
+	_save_converter.add_method(self, "_convert_2743", "245b", "2783")
+	_save_converter.add_method(self, "_convert_2743", "1b3c", "2783")
+	_save_converter.add_method(self, "_convert_2743", "19c5", "2783")
+	_save_converter.add_method(self, "_convert_2743", "199c", "2783")
+	_save_converter.add_method(self, "_convert_2743", "1922", "2783")
+	_save_converter.add_method(self, "_convert_2743", "1682", "2783")
+	_save_converter.add_method(self, "_convert_2743", "163e", "2783")
+	_save_converter.add_method(self, "_convert_2743", "15d2", "2783")
+	return _save_converter
 
 
-"""
-Extracts a version string from the specified json save items.
-"""
-func get_version_string(json_save_items: Array) -> String:
-	var version: SaveItem
-	for json_save_item_obj in json_save_items:
-		var save_item: SaveItem = SaveItem.new()
-		save_item.from_json_dict(json_save_item_obj)
-		if save_item.type == "version":
-			version = save_item
-			break
-	return version.value if version else ""
+func _convert_2783(save_item: SaveItem) -> SaveItem:
+	match save_item.type:
+		"chat_history", "creature_library", "finished_levels", "level_history", "player_info", "successful_levels":
+			save_item = null
+	return save_item
 
 
-"""
-Transforms the specified json save items to the latest format.
-"""
-func transform_old_save_items(json_save_items: Array) -> Array:
-	var version_string := get_version_string(json_save_items)
-	match version_string:
-		"2783":
-			json_save_items = _convert_2783(json_save_items)
-		"2743", "252a", "24cc", "245b", "1b3c", "19c5", "199c", "1922", "1682", "163e", "15d2":
-			json_save_items = _convert_252a(json_save_items)
-	return json_save_items
-
-
-func _convert_2783(json_save_items: Array) -> Array:
-	var new_save_items := []
-	for json_save_item_obj in json_save_items:
-		var save_item: SaveItem = SaveItem.new()
-		save_item.from_json_dict(json_save_item_obj)
-		match save_item.type:
-			"version":
-				save_item["value"] = "27bb"
-			"chat_history", "creature_library", "finished_levels", "level_history", "player_info", "successful_levels":
-				save_item = null
-		if save_item:
-			new_save_items.append(save_item.to_json_dict())
-	return new_save_items
-
-
-func _convert_252a(json_save_items: Array) -> Array:
-	var new_save_items := []
-	for json_save_item_obj in json_save_items:
-		var save_item: SaveItem = SaveItem.new()
-		save_item.from_json_dict(json_save_item_obj)
-		match save_item.type:
-			"version":
-				save_item["value"] = "2783"
-			"miscellaneous_settings":
-				save_item.type = "misc_settings"
-		new_save_items.append(save_item.to_json_dict())
-	return new_save_items
+func _convert_2743(save_item: SaveItem) -> SaveItem:
+	match save_item.type:
+		"miscellaneous_settings":
+			save_item.type = "misc_settings"
+	return save_item

--- a/project/src/main/player-save.gd
+++ b/project/src/main/player-save.gd
@@ -26,7 +26,7 @@ var data_filename := "user://saveslot0.json" setget set_data_filename
 var legacy_filename := "user://turbofat0.save" setget set_legacy_filename
 
 # Provides backwards compatibility with older save formats
-var old_save := OldPlayerSave.new()
+var old_save_converter := OldPlayerSave.new().new_save_converter()
 
 func _ready() -> void:
 	rolling_backups.data_filename = data_filename
@@ -178,11 +178,11 @@ func _save_items_from_file(filename: String) -> Array:
 		return []
 	
 	var json_save_items: Array = parse_json(save_json_text)
-	while old_save.is_old_save_items(json_save_items):
+	while old_save_converter.is_old_save_items(json_save_items):
 		# convert the old save file to a new format
-		var old_version := old_save.get_version_string(json_save_items)
-		json_save_items = old_save.transform_old_save_items(json_save_items)
-		if old_save.get_version_string(json_save_items) == old_version:
+		var old_version := SaveConverter.get_version_string(json_save_items)
+		json_save_items = old_save_converter.transform_old_save_items(json_save_items)
+		if SaveConverter.get_version_string(json_save_items) == old_version:
 			# failed to convert, but the data might still load
 			push_warning("Couldn't convert old save data version '%s'" % old_version)
 			break

--- a/project/src/main/save-converter.gd
+++ b/project/src/main/save-converter.gd
@@ -1,0 +1,103 @@
+class_name SaveConverter
+"""
+Provides backwards compatibility with older save formats.
+
+SaveConverter can update the 'version' tag, but any other version-specific updates must be defined externally. These
+version-specific updates can be incorporated via SaveConverter's 'add_method' method.
+"""
+
+"""
+An externally defined method which provides version-specific updates.
+"""
+class ConversionMethod:
+	var object: Object # The object containing the method
+	var method: String # The name of the method which performs the conversion
+	var old_version: String # The old save data version which the method converts from
+	var new_version: String # The new save data version which the method converts to
+
+# Externally defined methods which provide version-specific updates.
+# key: old save data version from which the method converts
+# value: a ConversionMethod corresponding to the method to call
+var conversion_methods := {}
+
+"""
+Adds a new externally defined method which provides version-specific updates.
+
+SaveConverter does not have logic for converting specific save data versions. This conversion logic must be defined on
+an external object and incorporated via this 'add_method' method.
+
+The specified conversion method should accept a SaveData object and return a modified SaveData object. The conversion
+method can also returns null, in which case SaveConverter will omit the SaveData object from the list of transformed
+save items.
+
+Parameters:
+	'object': The object containing the method
+	
+	'method': The name of the method which performs the conversion. This method should accept a SaveData object and
+		return a modified SaveData object.
+	
+	'old_version': The old save data version which the method converts from
+	
+	'new_version': The new save data version which the method converts to
+"""
+func add_method(object: Object, method: String, old_version: String, new_version: String) -> void:
+	var conversion_method: ConversionMethod = ConversionMethod.new()
+	conversion_method.object = object
+	conversion_method.method = method
+	conversion_method.old_version = old_version
+	conversion_method.new_version = new_version
+	conversion_methods[old_version] = conversion_method
+
+
+"""
+Returns 'true' if the specified json save items are from an older version of the game.
+"""
+func is_old_save_items(json_save_items: Array) -> bool:
+	var is_old: bool = false
+	var version := get_version_string(json_save_items)
+	if version == PlayerSave.PLAYER_DATA_VERSION:
+		is_old = false
+	elif conversion_methods.has(version):
+		is_old = true
+	else:
+		push_warning("Unrecognized save data version: '%s'" % version)
+	return is_old
+
+
+"""
+Transforms the specified json save items to the latest format.
+"""
+func transform_old_save_items(json_save_items: Array) -> Array:
+	var old_version := get_version_string(json_save_items)
+	if not conversion_methods.has(old_version):
+		push_warning("Couldn't convert old save data version '%s'" % old_version)
+		return json_save_items
+	
+	var conversion_method: ConversionMethod = conversion_methods[old_version]
+	var new_save_items := []
+	for json_save_item_obj in json_save_items:
+		var save_item: SaveItem = SaveItem.new()
+		save_item.from_json_dict(json_save_item_obj)
+		match save_item.type:
+			"version":
+				save_item.value = conversion_method.new_version
+			_:
+				save_item = conversion_method.object.call(conversion_method.method, save_item)
+		
+		if save_item:
+			new_save_items.append(save_item.to_json_dict())
+	return new_save_items
+
+
+"""
+Extracts a version string from the specified json save items.
+"""
+static func get_version_string(json_save_items: Array) -> String:
+	var version: SaveItem
+	for json_save_item_obj in json_save_items:
+		var save_item: SaveItem = SaveItem.new()
+		save_item.from_json_dict(json_save_item_obj)
+		if save_item.type == "version":
+			version = save_item
+			break
+	return version.value if version else ""

--- a/project/src/main/system-save.gd
+++ b/project/src/main/system-save.gd
@@ -34,7 +34,7 @@ var data_filename := "user://config.json"
 var legacy_filename := "user://turbofat0.save"
 
 # Provides backwards compatibility with older save formats
-var old_save := OldSystemSave.new()
+var old_save := OldSystemSave.new().new_save_converter()
 
 func _ready() -> void:
 	load_system_data()
@@ -107,9 +107,9 @@ func load_system_data() -> bool:
 	
 	while old_save.is_old_save_items(json_save_items):
 		# convert the old save file to a new format
-		var old_version := old_save.get_version_string(json_save_items)
+		var old_version := SaveConverter.get_version_string(json_save_items)
 		json_save_items = old_save.transform_old_save_items(json_save_items)
-		if old_save.get_version_string(json_save_items) == old_version:
+		if SaveConverter.get_version_string(json_save_items) == old_version:
 			# failed to convert, but the data might still load
 			push_warning("Couldn't convert old save data version '%s'" % old_version)
 			break

--- a/project/src/test/test-old-player-save.gd
+++ b/project/src/test/test-old-player-save.gd
@@ -31,6 +31,7 @@ func load_legacy_player_data(filename: String) -> void:
 func test_15d2_rank_success() -> void:
 	load_legacy_player_data("turbofat-15d2.json")
 	
+	assert_true(PlayerData.level_history.results("rank/7k").size() >= 1)
 	var history_rank_7k: RankResult = PlayerData.level_history.results("rank/7k")[0]
 	
 	# we didn't used to store 'success', but it should be calculated based on how well they did
@@ -41,8 +42,10 @@ func test_163e_lost_erases_success() -> void:
 	load_legacy_player_data("turbofat-163e.json")
 	
 	# rank-6d was a success, and the player didn't lose
+	assert_true(PlayerData.level_history.results("rank/6d").size() >= 1)
 	assert_eq(PlayerData.level_history.results("rank/6d")[0].success, true)
 	# rank-7d was recorded as a success, but the player lost
+	assert_true(PlayerData.level_history.results("rank/7d").size() >= 1)
 	assert_eq(PlayerData.level_history.results("rank/7d")[0].success, false)
 
 


### PR DESCRIPTION
All save conversion logic was doing the same logic for iterating over
save data items, converting each one, and updating the version number.
Additionally, there was redundancy where multiple places had the concept
of 'these 12 versions can be upgraded', both in the transformation logic
and the 'is old save item' checking logic.

These redundancies have been resolved by extracting a new SaveConverter
class. This class can be configured with methods to convert specific
versions of save items.

Fixed some OldPlayerSave tests, which would error (and pass!) if it
tried to assert something about an empty array