### PR TITLE
Refactoring: music fading, overworld_world_path

### DIFF
--- a/project/src/demo/music/music-player-demo.gd
+++ b/project/src/demo/music/music-player-demo.gd
@@ -20,10 +20,10 @@ func _ready() -> void:
 
 func _input(event: InputEvent) -> void:
 	match Utils.key_scancode(event):
-		KEY_C: MusicPlayer.play_chill_bgm()
+		KEY_C: MusicPlayer.play_chill_bgm(false)
 		KEY_EQUAL: MusicPlayer.fade_in()
-		KEY_U: MusicPlayer.play_upbeat_bgm()
-		KEY_T: MusicPlayer.play_tutorial_bgm()
+		KEY_U: MusicPlayer.play_upbeat_bgm(false)
+		KEY_T: MusicPlayer.play_tutorial_bgm(false)
 		KEY_MINUS: MusicPlayer.stop()
 		KEY_BRACERIGHT: next_checkpoint()
 

--- a/project/src/main/music/music-transition.gd
+++ b/project/src/main/music/music-transition.gd
@@ -13,10 +13,6 @@ func _ready() -> void:
 	SceneTransition.connect("fade_in_started", self, "_on_SceneTransition_fade_in_started")
 
 
-func is_fading_in_bgm() -> bool:
-	return true if _faded_bgm else false
-
-
 """
 When the scene fades back in, we un-fade any music we previously faded out.
 """

--- a/project/src/main/puzzle/puzzle-music-manager.gd
+++ b/project/src/main/puzzle/puzzle-music-manager.gd
@@ -10,9 +10,9 @@ func _ready() -> void:
 
 func start_puzzle_music() -> void:
 	if CurrentLevel.settings.other.tutorial:
-		MusicPlayer.play_tutorial_bgm()
+		MusicPlayer.play_tutorial_bgm(false)
 	else:
-		MusicPlayer.play_upbeat_bgm()
+		MusicPlayer.play_upbeat_bgm(false)
 
 
 func _on_PuzzleState_game_prepared() -> void:
@@ -21,4 +21,3 @@ func _on_PuzzleState_game_prepared() -> void:
 
 func _on_PuzzleState_game_ended() -> void:
 	MusicPlayer.play_chill_bgm()
-	MusicPlayer.fade_in()

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -10,6 +10,7 @@ onready var _settings_menu: SettingsMenu = $SettingsMenu
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
+	MusicPlayer.play_chill_bgm()
 	
 	PuzzleState.connect("game_started", self, "_on_PuzzleState_game_started")
 	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")
@@ -308,8 +309,4 @@ func _on_SettingsMenu_quit_pressed() -> void:
 	if _settings_menu.quit_type == SettingsMenu.GIVE_UP:
 		PuzzleState.make_player_lose()
 	else:
-		if not MusicPlayer.is_playing_chill_bgm():
-			MusicPlayer.stop()
-			MusicPlayer.play_chill_bgm()
-			MusicPlayer.fade_in()
 		_quit_puzzle()

--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -33,7 +33,7 @@ This is used at the end of each tutorial when customers come in.
 """
 func start_customer_countdown() -> void:
 	yield(PuzzleState, "after_level_changed")
-	MusicPlayer.play_upbeat_bgm()
+	MusicPlayer.play_upbeat_bgm(false)
 	puzzle.start_level_countdown()
 
 

--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -8,11 +8,7 @@ Includes buttons for starting a new game, launching the level editor, and exitin
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
-	
-	# Fade in music when redirected from a scene with no music, such as the level editor
-	if not MusicPlayer.is_playing_chill_bgm() and not MusicTransition.is_fading_in_bgm():
-		MusicPlayer.play_chill_bgm()
-		MusicPlayer.fade_in()
+	MusicPlayer.play_chill_bgm()
 	
 	$DropPanel/Play/Practice.grab_focus()
 

--- a/project/src/main/ui/menu/practice-menu.gd
+++ b/project/src/main/ui/menu/practice-menu.gd
@@ -68,6 +68,7 @@ var _rank_lowlights := []
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
+	MusicPlayer.play_chill_bgm()
 	
 	# default mode/difficulty if the player hasn't played a level recently
 	var current_mode := "Ultra"

--- a/project/src/main/ui/menu/splash-screen.gd
+++ b/project/src/main/ui/menu/splash-screen.gd
@@ -5,9 +5,8 @@ A splash screen which precedes the main menu.
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
+	MusicPlayer.play_chill_bgm(false)
 	
-	if not MusicPlayer.is_playing_chill_bgm() and not MusicTransition.is_fading_in_bgm():
-		MusicPlayer.play_chill_bgm()
 	$DropPanel/PlayHolder/Play.grab_focus()
 	if PlayerSave.corrupt_filenames:
 		$BadSaveDataControl.popup()

--- a/project/src/main/ui/menu/tutorial-menu.gd
+++ b/project/src/main/ui/menu/tutorial-menu.gd
@@ -5,6 +5,7 @@ Scene which lets the player launch tutorials.
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
+	MusicPlayer.play_chill_bgm()
 
 
 func _exit_tree() -> void:

--- a/project/src/main/world/CreatureSpawner.tscn
+++ b/project/src/main/world/CreatureSpawner.tscn
@@ -6,7 +6,6 @@
 [node name="CreatureSpawner" type="Sprite" groups=[
 "creature_spawners",
 ]]
-position = Vector2( 0, -28 )
 scale = Vector2( 0.6, 0.6 )
 texture = ExtResource( 2 )
 script = ExtResource( 1 )

--- a/project/src/main/world/Overworld.tscn
+++ b/project/src/main/world/Overworld.tscn
@@ -259,7 +259,6 @@ orientation = 1
 
 [node name="Diota" parent="World/Obstacles" instance=ExtResource( 49 )]
 position = Vector2( 454.437, 1395.6 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 "creature_id": "diota",
 "elevation": 0.0,
@@ -277,7 +276,6 @@ dna = {
 [node name="Jayton" parent="World/Obstacles" instance=ExtResource( 49 )]
 position = Vector2( 339.509, 1583.36 )
 offset = Vector2( 0, -100 )
-overworld_world_path = NodePath("../..")
 stool_path = NodePath("../ButtercupStool1")
 target_properties = {
 "creature_id": "jayton",
@@ -325,7 +323,6 @@ shadow_scale = 4.0
 
 [node name="ButtercupStool1" parent="World/Obstacles" instance=ExtResource( 52 )]
 position = Vector2( 339.509, 1582.36 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 "occupied_texture": ExtResource( 47 ),
 "unoccupied_texture": ExtResource( 44 )
@@ -334,7 +331,6 @@ spawn_if = "not level_finished marsh/goodbye_everyone"
 
 [node name="ButtercupStool2" parent="World/Obstacles" instance=ExtResource( 54 )]
 position = Vector2( 561.509, 1582.36 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 "occupied_texture": ExtResource( 46 ),
 "unoccupied_texture": ExtResource( 45 )
@@ -343,7 +339,6 @@ spawn_if = "not level_finished marsh/goodbye_everyone"
 
 [node name="ButtercupTable1" parent="World/Obstacles" instance=ExtResource( 43 )]
 position = Vector2( 449.589, 1635.08 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 }
 spawn_if = "not level_finished marsh/goodbye_everyone"
@@ -356,7 +351,6 @@ position = Vector2( 601.101, 1318.58 )
 scale = Vector2( 0.4, 0.4 )
 texture = ExtResource( 56 )
 offset = Vector2( 0, -80 )
-overworld_world_path = NodePath("../..")
 TargetScene = ExtResource( 13 )
 target_properties = {
 }
@@ -399,7 +393,6 @@ position = Vector2( 974.527, 916.947 )
 
 [node name="ButtercupCrystalSign" parent="World/Obstacles" instance=ExtResource( 53 )]
 position = Vector2( 583.168, 1297.78 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 "chat_key": ""
 }
@@ -407,105 +400,90 @@ spawn_if = "not level_finished marsh/pulling_for_everyone"
 
 [node name="ButtercupCrystal1" parent="World/Obstacles" instance=ExtResource( 53 )]
 position = Vector2( 148.917, 1575.15 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 }
 spawn_if = "not level_finished marsh/pulling_for_everyone"
 
 [node name="ButtercupCrystal2" parent="World/Obstacles" instance=ExtResource( 53 )]
 position = Vector2( 577.392, 1088.6 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 }
 spawn_if = "not level_finished marsh/pulling_for_everyone"
 
 [node name="ButtercupCrystal3" parent="World/Obstacles" instance=ExtResource( 53 )]
 position = Vector2( 799.533, 1542.64 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 }
 spawn_if = "not level_finished marsh/pulling_for_everyone"
 
 [node name="ButtercupCrystal4" parent="World/Obstacles" instance=ExtResource( 53 )]
 position = Vector2( -37.5356, 1316.09 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 }
 spawn_if = "not level_finished marsh/pulling_for_everyone"
 
 [node name="ButtercupCrystal5" parent="World/Obstacles" instance=ExtResource( 53 )]
 position = Vector2( 578.976, 1639.99 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 }
 spawn_if = "not level_finished marsh/pulling_for_everyone"
 
 [node name="ButtercupCrystal6" parent="World/Obstacles" instance=ExtResource( 53 )]
 position = Vector2( 749.714, 1234.5 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 }
 spawn_if = "not level_finished marsh/pulling_for_everyone"
 
 [node name="ButtercupCrystal7" parent="World/Obstacles" instance=ExtResource( 53 )]
 position = Vector2( 178.464, 1418.09 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 }
 spawn_if = "not level_finished marsh/pulling_for_everyone"
 
 [node name="TurboFatCrystal1" parent="World/Obstacles" instance=ExtResource( 53 )]
 position = Vector2( 1975.49, 874.757 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 }
 spawn_if = "level_finished marsh/pulling_for_shirts"
 
 [node name="TurboFatCrystal2" parent="World/Obstacles" instance=ExtResource( 53 )]
 position = Vector2( 1827.16, 996.117 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 }
 spawn_if = "level_finished marsh/pulling_for_bones"
 
 [node name="TurboFatCrystal3" parent="World/Obstacles" instance=ExtResource( 53 )]
 position = Vector2( 1756.54, 1036.03 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 }
 spawn_if = "level_finished marsh/goodbye_shirts"
 
 [node name="TurboFatCrystal4" parent="World/Obstacles" instance=ExtResource( 53 )]
 position = Vector2( 1780.98, 1216.18 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 }
 spawn_if = "level_finished marsh/pulling_for_everyone"
 
 [node name="TurboFatCrystal5" parent="World/Obstacles" instance=ExtResource( 53 )]
 position = Vector2( 941.954, 847.977 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 }
 spawn_if = "level_finished marsh/goodbye_bones"
 
 [node name="TurboFatCrystal6" parent="World/Obstacles" instance=ExtResource( 53 )]
 position = Vector2( 1206.64, 682.821 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 }
 spawn_if = "level_finished marsh/pulling_for_skins"
 
 [node name="TurboFatCrystal7" parent="World/Obstacles" instance=ExtResource( 53 )]
 position = Vector2( 1499.38, 1292.35 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 }
 spawn_if = "level_finished marsh/lets_get_merry"
 
 [node name="TurboFatCrystal8" parent="World/Obstacles" instance=ExtResource( 53 )]
 position = Vector2( 1238.62, 921.227 )
-overworld_world_path = NodePath("../..")
 target_properties = {
 }
 spawn_if = "level_finished marsh/goodbye_skins"

--- a/project/src/main/world/OverworldIndoors.tscn
+++ b/project/src/main/world/OverworldIndoors.tscn
@@ -701,7 +701,6 @@ elevation = 150.0
 [node name="Richie" parent="World/Obstacles" instance=ExtResource( 33 )]
 position = Vector2( 490.501, 119.061 )
 flip_h = true
-overworld_world_path = NodePath("../..")
 target_properties = {
 "creature_id": "richie",
 "elevation": 0.0,
@@ -713,7 +712,6 @@ spawn_if = "not level_finished marsh/hello_everyone"
 [node name="Terpion" parent="World/Obstacles" instance=ExtResource( 33 )]
 position = Vector2( 349, 323 )
 offset = Vector2( 0, -140 )
-overworld_world_path = NodePath("../..")
 stool_path = NodePath("../Stool4")
 target_properties = {
 "creature_id": "terpion",
@@ -727,7 +725,6 @@ max_fatness = 4.0
 position = Vector2( 525, 323 )
 offset = Vector2( 0, -140 )
 flip_h = true
-overworld_world_path = NodePath("../..")
 stool_path = NodePath("../Stool3")
 target_properties = {
 "creature_id": "pandon",
@@ -740,7 +737,6 @@ max_fatness = 4.0
 [node name="Nictor" parent="World/Obstacles" instance=ExtResource( 33 )]
 position = Vector2( 1313.39, 220 )
 offset = Vector2( 0, -140 )
-overworld_world_path = NodePath("../..")
 stool_path = NodePath("../Stool10")
 target_properties = {
 "creature_id": "nictor",
@@ -754,7 +750,6 @@ max_fatness = 3.0
 position = Vector2( 768, 36 )
 offset = Vector2( 0, -140 )
 flip_h = true
-overworld_world_path = NodePath("../..")
 stool_path = NodePath("../Stool1")
 target_properties = {
 "creature_id": "beats",

--- a/project/src/main/world/creature-spawner.gd
+++ b/project/src/main/world/creature-spawner.gd
@@ -8,7 +8,7 @@ The creature's creature_id, properties and groups (the 'chattables' group in par
 target_properties and target_groups fields.
 """
 
-export (NodePath) var overworld_world_path: NodePath
+export (NodePath) var overworld_world_path: NodePath = NodePath("../..")
 
 # (optional) path to a stool the spawned creature sits on
 export (NodePath) var stool_path: NodePath

--- a/project/src/main/world/obstacle-spawner.gd
+++ b/project/src/main/world/obstacle-spawner.gd
@@ -9,7 +9,7 @@ The obstacle's properties and groups (the 'chattables' group in particular) can 
 target_groups fields.
 """
 
-export (NodePath) var overworld_world_path: NodePath
+export (NodePath) var overworld_world_path: NodePath = NodePath("../..")
 
 # the PackedScene of the spawned obstacle
 export (PackedScene) var TargetScene: PackedScene

--- a/project/src/main/world/overworld-walk-world.gd
+++ b/project/src/main/world/overworld-walk-world.gd
@@ -6,8 +6,7 @@ Prepares the the overworld walking scene.
 onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
 
 func _ready() -> void:
-	if not MusicPlayer.is_playing_tutorial_bgm() and not MusicTransition.is_fading_in_bgm():
-		MusicPlayer.play_tutorial_bgm()
+	MusicPlayer.play_tutorial_bgm()
 	
 	$Camera.position = ChattableManager.player.position
 	ChattableManager.refresh_creatures()

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -20,8 +20,7 @@ func _ready() -> void:
 		# For regular players the Breadcrumb trail will already be initialized by the menus.
 		Breadcrumb.initialize_trail()
 	
-	if not MusicPlayer.is_playing_chill_bgm() and not MusicTransition.is_fading_in_bgm():
-		MusicPlayer.play_chill_bgm()
+	MusicPlayer.play_chill_bgm()
 	
 	if CutsceneManager.is_front_chat_tree():
 		_launch_cutscene()


### PR DESCRIPTION
Many different scripts had logic saying 'if a chill song isn't playing, fade in
a new chill song'. This logic is now centralized within MusicPlayer with a
'fade_in' parameter.

Added default overworld_world_path for spawners. This prevents us from needing
to assign it everywhere, cutting down on cruft in overworld scenes