### PR TITLE
Creature/level editor path refactoring. Removed unused code.

### DIFF
--- a/project/src/main/editor/creature/dialogs.gd
+++ b/project/src/main/editor/creature/dialogs.gd
@@ -6,10 +6,20 @@ Shows popup dialogs for the creature editor.
 export (NodePath) var creature_editor_path: NodePath
 
 onready var _creature_editor: CreatureEditor = get_node(creature_editor_path)
+onready var _error_dialog := $Error
+onready var _import_dialog := $Import
+onready var _export_dialog := $Export
+onready var _save_confirmation := $SaveConfirmation
 
 func _show_import_export_not_supported_error() -> void:
-	$Error.dialog_text = "Import/export isn't supported over the web. Sorry!"
-	$Error.popup_centered()
+	_error_dialog.dialog_text = "Import/export isn't supported over the web. Sorry!"
+	_error_dialog.popup_centered()
+
+
+func _preserve_file_dialog_paths(dialog: FileDialog) -> void:
+	for other_dialog in [_import_dialog, _export_dialog]:
+		other_dialog.current_file = dialog.current_file
+		other_dialog.current_path = dialog.current_path
 
 
 func _on_ImportButton_pressed() -> void:
@@ -17,8 +27,8 @@ func _on_ImportButton_pressed() -> void:
 		_show_import_export_not_supported_error()
 		return
 	
-	Utils.assign_default_dialog_path($Import, "res://assets/main/creatures/secondary/")
-	$Import.popup_centered()
+	Utils.assign_default_dialog_path(_import_dialog, "res://assets/main/creatures/secondary/")
+	_import_dialog.popup_centered()
 
 
 """
@@ -30,8 +40,9 @@ func _on_ImportDialog_file_selected(path: String) -> void:
 		_creature_editor.set_center_creature_def(loaded_def)
 		_creature_editor.mutate_all_creatures()
 	else:
-		$Error.dialog_text = "Error importing creature."
-		$Error.popup_centered()
+		_error_dialog.dialog_text = "Error importing creature."
+		_error_dialog.popup_centered()
+	_preserve_file_dialog_paths(_import_dialog)
 
 
 func _on_ExportButton_pressed() -> void:
@@ -39,11 +50,11 @@ func _on_ExportButton_pressed() -> void:
 		_show_import_export_not_supported_error()
 		return
 	
-	Utils.assign_default_dialog_path($Export, "res://assets/main/creatures/secondary/")
+	Utils.assign_default_dialog_path(_export_dialog, "res://assets/main/creatures/secondary/")
 	var exported_creature: Creature = _creature_editor.center_creature
 	var sanitized_creature_name := StringUtils.sanitize_file_root(exported_creature.creature_short_name)
-	$Export.current_file = "%s.json" % sanitized_creature_name
-	$Export.popup_centered()
+	_export_dialog.current_file = "%s.json" % sanitized_creature_name
+	_export_dialog.popup_centered()
 
 
 """
@@ -53,10 +64,11 @@ func _on_ExportDialog_file_selected(path: String) -> void:
 	var exported_creature: Creature = _creature_editor.center_creature
 	var exported_json := exported_creature.creature_def.to_json_dict()
 	FileUtils.write_file(path, Utils.print_json(exported_json))
+	_preserve_file_dialog_paths(_export_dialog)
 
 
 func _on_SaveButton_pressed() -> void:
-	$SaveConfirmation.popup_centered()
+	_save_confirmation.popup_centered()
 
 
 """

--- a/project/src/main/editor/puzzle/LevelEditor.tscn
+++ b/project/src/main/editor/puzzle/LevelEditor.tscn
@@ -305,12 +305,13 @@ margin_right = 1014.0
 margin_bottom = 590.0
 rect_min_size = Vector2( 180, 0 )
 
-[node name="LevelName" type="LineEdit" parent="HBoxContainer/SideButtons"]
+[node name="LevelId" type="LineEdit" parent="HBoxContainer/SideButtons"]
 margin_right = 180.0
 margin_bottom = 30.0
 rect_min_size = Vector2( 0, 20 )
 theme = ExtResource( 11 )
 text = "default"
+editable = false
 
 [node name="HSeparator1" type="HSeparator" parent="HBoxContainer/SideButtons"]
 margin_top = 34.0
@@ -459,6 +460,7 @@ margin_right = 792.0
 margin_bottom = 480.0
 popup_exclusive = true
 access = 2
+filters = PoolStringArray( "*.json" )
 current_dir = "/"
 current_file = "509e7c82-9399-425a-9f15-9370c2b3de8b"
 current_path = "/509e7c82-9399-425a-9f15-9370c2b3de8b"

--- a/project/src/main/editor/puzzle/dialogs.gd
+++ b/project/src/main/editor/puzzle/dialogs.gd
@@ -5,21 +5,34 @@ Shows popup dialogs for the level editor.
 
 onready var _level_editor: LevelEditor = get_parent()
 
+onready var _open_file_dialog := $OpenFile
+onready var _open_resource_dialog := $OpenResource
+onready var _save_dialog := $Save
+
 func _show_save_load_not_supported_error() -> void:
 	$Error.dialog_text = "Saving/loading files isn't supported over the web. Sorry!"
 	$Error.popup_centered()
 
 
+func _preserve_file_dialog_path(dialog: FileDialog) -> void:
+	for other_dialog in [_open_file_dialog, _open_resource_dialog, _save_dialog]:
+		other_dialog.current_file = dialog.current_file
+		other_dialog.current_path = dialog.current_path
+
+
 func _on_OpenResource_file_selected(path: String) -> void:
 	_level_editor.load_level(path)
+	_preserve_file_dialog_path(_open_resource_dialog)
 
 
 func _on_OpenFile_file_selected(path: String) -> void:
 	_level_editor.load_level(path)
+	_preserve_file_dialog_path(_open_file_dialog)
 
 
 func _on_Save_file_selected(path: String) -> void:
 	_level_editor.save_level(path)
+	_preserve_file_dialog_path(_save_dialog)
 
 
 func _on_OpenFile_pressed() -> void:
@@ -27,12 +40,14 @@ func _on_OpenFile_pressed() -> void:
 		_show_save_load_not_supported_error()
 		return
 	
-	Utils.assign_default_dialog_path($OpenFile, "res://assets/main/puzzle/levels/")
-	$OpenFile.popup_centered()
+	Utils.assign_default_dialog_path(_open_file_dialog, "res://assets/main/puzzle/levels/practice/")
+	_open_file_dialog.popup_centered()
 
 
 func _on_OpenResource_pressed() -> void:
-	$OpenResource.popup_centered()
+	_open_resource_dialog.popup_centered()
+	Utils.assign_default_dialog_path(_open_resource_dialog, "res://assets/main/puzzle/levels/practice/")
+	_open_resource_dialog.popup_centered()
 
 
 func _on_Save_pressed() -> void:
@@ -40,7 +55,10 @@ func _on_Save_pressed() -> void:
 		_show_save_load_not_supported_error()
 		return
 	
-	Utils.assign_default_dialog_path($Save, "res://assets/main/puzzle/levels/")
-	var file_root := StringUtils.sanitize_file_root(_level_editor.level_name.text)
-	$Save.current_file = "%s.json" % StringUtils.underscores_to_hyphens(file_root)
-	$Save.popup_centered()
+	Utils.assign_default_dialog_path(_save_dialog, "res://assets/main/puzzle/levels/practice/")
+	_save_dialog.popup_centered()
+	if not _save_dialog.current_file:
+		# We assign a sensible filename based on the current level, like "level_512". Unfortunately, this filename is
+		# replaced if a .json file is selected, which almost always happens immediately
+		var raw_level_id := StringUtils.substring_after_last(_level_editor.level_id_label.text, "/")
+		_save_dialog.current_file = "%s.json" % [raw_level_id]

--- a/project/src/main/editor/puzzle/level-editor.gd
+++ b/project/src/main/editor/puzzle/level-editor.gd
@@ -7,42 +7,39 @@ Full instructions are available at https://github.com/Poobslag/turbofat/wiki/lev
 """
 
 # default to an empty level; players may be confused if it's not empty
-const DEFAULT_LEVEL := "practice/ultra_normal"
+const DEFAULT_LEVEL_ID := "practice/ultra_normal"
 
 export (PackedScene) var PuzzleScene: PackedScene
 
 # level scene currently being tested
 var _test_scene: Node
 
-onready var level_name := $HBoxContainer/SideButtons/LevelName
+onready var level_id_label := $HBoxContainer/SideButtons/LevelId
 onready var _level_json := $HBoxContainer/SideButtons/Json
 
 func _ready() -> void:
-	var level_text := FileUtils.get_file_as_text(LevelSettings.path_from_level_key(DEFAULT_LEVEL))
+	var level_text := FileUtils.get_file_as_text(LevelSettings.path_from_level_key(DEFAULT_LEVEL_ID))
 	_level_json.text = level_text
 	_level_json.refresh_tile_map()
-	level_name.text = DEFAULT_LEVEL
+	level_id_label.text = DEFAULT_LEVEL_ID
 	Breadcrumb.connect("trail_popped", self, "_on_Breadcrumb_trail_popped")
 
 
 func save_level(path: String) -> void:
 	FileUtils.write_file(path, _level_json.text)
+	level_id_label.text = LevelSettings.level_key_from_path(path)
 
 
 func load_level(path: String) -> void:
 	var level_text := FileUtils.get_file_as_text(path)
 	_level_json.text = level_text
 	_level_json.refresh_tile_map()
-	
-	var new_level_name := path.get_file()
-	new_level_name = new_level_name.trim_suffix(".json")
-	new_level_name = StringUtils.hyphens_to_underscores(new_level_name)
-	level_name.text = new_level_name
+	level_id_label.text = LevelSettings.level_key_from_path(path)
 
 
 func _start_test() -> void:
 	var settings := LevelSettings.new()
-	settings.load_from_text(level_name.text, _level_json.text)
+	settings.load_from_text(level_id_label.text, _level_json.text)
 	CurrentLevel.start_level(settings)
 	_test_scene = PuzzleScene.instance()
 	
@@ -76,8 +73,4 @@ func _on_Breadcrumb_trail_popped(prev_path: String) -> void:
 
 
 func _on_Quit_pressed() -> void:
-	var skip_transition := false
-	if Breadcrumb.trail.back() == "res://src/main/editor/puzzle/LevelEditor.tscn::test":
-		# player exited the level under test; no scene transition
-		skip_transition = true
-	SceneTransition.pop_trail(skip_transition)
+	SceneTransition.pop_trail()

--- a/project/src/main/puzzle/level/level-settings.gd
+++ b/project/src/main/puzzle/level/level-settings.gd
@@ -219,6 +219,11 @@ static func path_from_level_key(level_key: String) -> String:
 
 static func level_key_from_path(level_path: String) -> String:
 	var level_key := StringUtils.hyphens_to_underscores(level_path)
-	level_key = level_key.trim_prefix("res://assets/main/puzzle/levels/")
 	level_key = level_key.trim_suffix(".json")
+	if level_key.begins_with("res://"):
+		# preserve part of the path, resulting in 'foo/bar/level_183'
+		level_key = level_key.trim_prefix("res://assets/main/puzzle/levels/")
+	else:
+		# strip the entire path, resulting in 'level_183'
+		level_key = StringUtils.substring_after_last(level_key, "/")
 	return level_key

--- a/project/src/test/puzzle/level/test-level-settings.gd
+++ b/project/src/test/puzzle/level/test-level-settings.gd
@@ -27,8 +27,17 @@ func test_path_from_level_key() -> void:
 			"res://assets/main/puzzle/levels/marsh/goodbye-bones.json")
 
 
-func test_level_key_from_path() -> void:
+func test_level_key_from_path_resources() -> void:
 	assert_eq(LevelSettings.level_key_from_path("res://assets/main/puzzle/levels/boatricia1.json"),
 			"boatricia1")
 	assert_eq(LevelSettings.level_key_from_path("res://assets/main/puzzle/levels/marsh/goodbye_bones.json"),
 			"marsh/goodbye_bones")
+
+
+func test_level_key_from_path_files() -> void:
+	assert_eq(LevelSettings.level_key_from_path("d:/level_894.json"),
+			"level_894")
+	assert_eq(LevelSettings.level_key_from_path("/usr/local/bin/level_894.json"),
+			"level_894")
+	assert_eq(LevelSettings.level_key_from_path("~/.local/share/godot/level_894.json"),
+			"level_894")


### PR DESCRIPTION
When importing/exporting files, the creature editor and level editor now
remember the path which was imported and recommend to export to the same
path. This way if you want to import from File A and export to File A,
you don't need to navigate to it twice.

The level editor's 'level_key' field is no longer editable. It is for
display purposes only, and shows the path the level was loaded from.

Removed unused level editor quit code. The level editor had some edge-case code
when quitting a level. This code never seemed to execute, and was causing an
error 'Can't take value from empty array.'