### PR TITLE
Player's creature_id is always '#player#'.

### DIFF
--- a/project/src/main/creature-library.gd
+++ b/project/src/main/creature-library.gd
@@ -169,6 +169,7 @@ func from_json_dict(json: Dictionary) -> void:
 	if json.has(PLAYER_ID):
 		var new_player_def := CreatureDef.new()
 		new_player_def.from_json_dict(json.get(PLAYER_ID, {}))
+		new_player_def.creature_id = PLAYER_ID
 		set_player_def(new_player_def)
 	if json.has("fatnesses"):
 		_fatnesses = json.get("fatnesses")

--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -56,7 +56,10 @@ func _ready() -> void:
 	$World/Creatures/ECreature.set_meta("nametag_right", true)
 	$World/Creatures/SeCreature.set_meta("nametag_right", true)
 	
-	set_center_creature_def(PlayerData.creature_library.player_def)
+	var new_center_creature_def := PlayerData.creature_library.player_def
+	# the player's id will always be '#player#'. we change it so that exported creatures will have normal IDs
+	new_center_creature_def.creature_id = NameUtils.short_name_to_id(new_center_creature_def.creature_short_name)
+	set_center_creature_def(new_center_creature_def)
 	mutate_all_creatures()
 
 

--- a/project/src/main/editor/creature/dialogs.gd
+++ b/project/src/main/editor/creature/dialogs.gd
@@ -76,4 +76,6 @@ Updates the player character and writes it to their save file.
 """
 func _on_SaveConfirmation_confirmed() -> void:
 	PlayerData.creature_library.player_def = _creature_editor.center_creature.creature_def
+	# most creatures have ambiguous human-readable IDs but the player's ID must remain unique
+	PlayerData.creature_library.player_def.creature_id = CreatureLibrary.PLAYER_ID
 	PlayerSave.save_player_data()

--- a/project/src/main/ui/chat/chatscript-parser.gd
+++ b/project/src/main/ui/chat/chatscript-parser.gd
@@ -288,7 +288,7 @@ class ChatState extends AbstractState:
 		_event = ChatEvent.new()
 		_event.text = line
 		_event.text = _event.text.c_unescape() # turn '\n' characters into newlines
-		var creature_def: CreatureDef = PlayerData.creature_library.get_creature_def(CreatureLibrary.PLAYER_ID)
+		var creature_def: CreatureDef = PlayerData.creature_library.get_player_def()
 		if creature_def:
 			_event.chat_theme_def = creature_def.chat_theme_def
 		chat_tree.append(_branch_key, _event)

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -480,9 +480,6 @@ func _launch_fade_tween(new_alpha: float, duration: float) -> void:
 func _refresh_creature_id() -> void:
 	if not is_inside_tree():
 		return
-	if creature_id == CreatureLibrary.PLAYER_ID:
-		# player's creature_def is loaded in player.gd
-		return
 	
 	var new_creature_def: CreatureDef = PlayerData.creature_library.get_creature_def(creature_id)
 	if new_creature_def:

--- a/project/src/main/world/creature/player.gd
+++ b/project/src/main/world/creature/player.gd
@@ -12,12 +12,7 @@ var ui_has_focus := false setget set_ui_has_focus
 
 func _ready() -> void:
 	SceneTransition.connect("fade_out_started", self, "_on_SceneTransition_fade_out_started")
-	
-	set_creature_def(PlayerData.creature_library.player_def)
-	creature_id = CreatureLibrary.PLAYER_ID
-	if PlayerData.creature_library.forced_fatness:
-		set_fatness(PlayerData.creature_library.forced_fatness)
-		set_visual_fatness(PlayerData.creature_library.forced_fatness)
+	set_creature_id(CreatureLibrary.PLAYER_ID)
 	refresh_collision_extents()
 	ChattableManager.player = self
 


### PR DESCRIPTION
The player's creature_id in the save data corresponded to their name like
'gordo' or 'dusty' which could cause problems. It meant that other creatures in
the world could share their creature id. It meant the player could 'feed
themselves' and get fat.

In the spirit of refactoring week, it also meant that Creature.gd needed
some clumsy code to ask 'wait, are we loading the creature'. The
resulting code is now cleaner, as the special case code is pushed out
into special places.