### PR TITLE
LevelEditor dialog state fixes. PuzzleDemo accepts path.

### DIFF
--- a/project/src/demo/puzzle/PuzzleDemo.tscn
+++ b/project/src/demo/puzzle/PuzzleDemo.tscn
@@ -5,5 +5,6 @@
 
 [node name="PuzzleDemo" type="Node"]
 script = ExtResource( 2 )
+level_path = "res://assets/main/puzzle/levels/practice/marathon-normal.json"
 
 [node name="Puzzle" parent="." instance=ExtResource( 1 )]

--- a/project/src/demo/puzzle/puzzle-demo.gd
+++ b/project/src/demo/puzzle/puzzle-demo.gd
@@ -19,19 +19,16 @@ var _box_type := 0
 var _food_item_index := 0
 var _cake_box_type: int = Foods.BoxType.CAKE_JJO
 
+# a local path to a json level resource to demo
+export (String, FILE, "*.json") var level_path: String
+
 func _ready() -> void:
-	CurrentLevel.settings.set_start_speed("T")
-	CurrentLevel.settings.add_speed_up(Milestone.LINES, 100, "1")
-	CurrentLevel.settings.add_speed_up(Milestone.LINES, 110, "2")
-	CurrentLevel.settings.add_speed_up(Milestone.LINES, 120, "3")
-	CurrentLevel.settings.add_speed_up(Milestone.LINES, 130, "4")
-	CurrentLevel.settings.add_speed_up(Milestone.LINES, 140, "5")
-	CurrentLevel.settings.add_speed_up(Milestone.LINES, 150, "6")
-	CurrentLevel.settings.add_speed_up(Milestone.LINES, 160, "7")
-	CurrentLevel.settings.add_speed_up(Milestone.LINES, 170, "8")
-	CurrentLevel.settings.add_speed_up(Milestone.LINES, 180, "9")
-	CurrentLevel.settings.set_finish_condition(Milestone.NONE, 300)
-	PuzzleState.prepare_and_start_game()
+	var settings: LevelSettings = LevelSettings.new()
+	if level_path:
+		var json_text := FileUtils.get_file_as_text(level_path)
+		var json_dict: Dictionary = parse_json(json_text)
+		settings.from_json_dict("test_5952", json_dict)
+	CurrentLevel.start_level(settings)
 
 
 func _input(event: InputEvent) -> void:

--- a/project/src/main/editor/puzzle/dialogs.gd
+++ b/project/src/main/editor/puzzle/dialogs.gd
@@ -17,7 +17,15 @@ func _show_save_load_not_supported_error() -> void:
 func _preserve_file_dialog_path(dialog: FileDialog) -> void:
 	for other_dialog in [_open_file_dialog, _open_resource_dialog, _save_dialog]:
 		other_dialog.current_file = dialog.current_file
-		other_dialog.current_path = dialog.current_path
+		
+		if other_dialog.access == FileDialog.ACCESS_RESOURCES and dialog.access == FileDialog.ACCESS_FILESYSTEM:
+			# localize the path when switching from file to resource dialogs
+			other_dialog.current_path = ProjectSettings.localize_path(dialog.current_path)
+		elif other_dialog.access == FileDialog.ACCESS_FILESYSTEM and dialog.access == FileDialog.ACCESS_RESOURCES:
+			# globalize the path when switching from resource to file dialogs
+			other_dialog.current_path = ProjectSettings.globalize_path(dialog.current_path)
+		else:
+			other_dialog.current_path = dialog.current_path
 
 
 func _on_OpenResource_file_selected(path: String) -> void:


### PR DESCRIPTION
Level editor preserves dialog state when switching between
file/resource dialogs. Assigning a file dialog's path to something like
'res://' results in the dialog just getting reset to the file root 'C:\'
so it's important to globalize/localize paths.

PuzzleDemo now accepts a level resource path for quickly trying
arbitrary levels.