### PR TITLE
Pickups before level start. Redundant LevelTiles fields.

### DIFF
--- a/project/assets/main/puzzle/levels/experiment/004.json
+++ b/project/assets/main/puzzle/levels/experiment/004.json
@@ -1,6 +1,8 @@
 {
   "version": "297a",
   "start_speed": "0",
+  "title": "A Little Extra",
+  "description": "Some fun little bonuses at the bottom. But you have to work for it!",
   "finish_condition": {
     "type": "score",
     "value": "400"

--- a/project/assets/main/puzzle/worlds.json
+++ b/project/assets/main/puzzle/worlds.json
@@ -332,6 +332,9 @@
         },
         {
           "id": "experiment/003"
+        },
+        {
+          "id": "experiment/004"
         }
       ]
     }

--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -764,7 +764,6 @@ script = ExtResource( 19 )
 [connection signal="before_line_cleared" from="Playfield" to="ComboCounters" method="_on_Playfield_before_line_cleared"]
 [connection signal="before_line_cleared" from="Playfield" to="FrostingGlobs" method="_on_Playfield_before_line_cleared"]
 [connection signal="before_line_cleared" from="Playfield" to="StarSeeds" method="_on_Playfield_before_line_cleared"]
-[connection signal="blocks_prepared" from="Playfield" to="Pickups" method="_on_Playfield_blocks_prepared"]
 [connection signal="blocks_prepared" from="Playfield" to="StarSeeds" method="_on_Playfield_blocks_prepared"]
 [connection signal="box_built" from="Playfield" to="FrostingGlobs" method="_on_Playfield_box_built"]
 [connection signal="box_built" from="Playfield" to="StarSeeds" method="_on_Playfield_box_built"]

--- a/project/src/main/puzzle/level/level-tiles.gd
+++ b/project/src/main/puzzle/level/level-tiles.gd
@@ -7,9 +7,6 @@ class BlockBunch:
 	"""
 	A set of blocks which is shown initially, or appears during the game
 	"""
-	
-	# Vector2 array with the positions of all cells containing a tile
-	var block_cells := []
 
 	# key: (Vector2) positions of cells containing a tile
 	# value: (int) tile indexes of each cell
@@ -18,9 +15,6 @@ class BlockBunch:
 	# key: (Vector2) positions of cells containing a tile
 	# value: (Vector2) coordinate of the autotile variation in the tileset
 	var block_autotile_coords := {}
-	
-	# Vector2 array with the positions of all cells containing a pickup
-	var pickup_cells := []
 	
 	# key: (Vector2) positions of cells containing a pickup
 	# value: (int) an enum from Foods.BoxType defining the pickup's color
@@ -37,7 +31,6 @@ class BlockBunch:
 		'autotile_coord': Coordinate of the autotile variation in the tileset
 	"""
 	func set_block(pos: Vector2, tile: int, autotile_coord: Vector2) -> void:
-		block_cells.append(pos)
 		block_tiles[pos] = tile
 		block_autotile_coords[pos] = autotile_coord
 	
@@ -51,7 +44,6 @@ class BlockBunch:
 		'box_type': An enum from Foods.BoxType defining the pickup's color
 	"""
 	func set_pickup(pos: Vector2, box_type: int) -> void:
-		pickup_cells.append(pos)
 		pickups[pos] = box_type
 
 # key: a tiles key for tiles referenced by level rules, or the string 'start' for the initial set of tiles

--- a/project/src/main/puzzle/line-inserter.gd
+++ b/project/src/main/puzzle/line-inserter.gd
@@ -74,7 +74,7 @@ func _reset() -> void:
 	# initialize row_count_by_tiles_key
 	for tiles_key in CurrentLevel.settings.tiles.bunches:
 		var max_y := 0
-		for cell in CurrentLevel.settings.tiles.bunches[tiles_key].block_cells:
+		for cell in CurrentLevel.settings.tiles.bunches[tiles_key].block_tiles:
 			max_y = max(max_y, cell.y)
 		row_count_by_tiles_key[tiles_key] = max_y + 1
 

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -130,7 +130,7 @@ func _prepare_level_blocks() -> void:
 	
 	tile_map.clear()
 	var blocks_start: LevelTiles.BlockBunch = CurrentLevel.settings.tiles.blocks_start()
-	for cell in blocks_start.block_cells:
+	for cell in blocks_start.block_tiles:
 		tile_map.set_block(cell, blocks_start.block_tiles[cell], blocks_start.block_autotile_coords[cell])
 	emit_signal("blocks_prepared")
 

--- a/project/src/test/puzzle/level/test-level-settings.gd
+++ b/project/src/test/puzzle/level/test-level-settings.gd
@@ -28,8 +28,8 @@ func test_load_19c5_data() -> void:
 	load_level("level-19c5")
 	
 	var blocks_start := settings.tiles.blocks_start()
-	assert_eq(Vector2(1, 10) in blocks_start.block_cells, true, "start.block_cells[(1, 10)]")
-	assert_eq(blocks_start.block_tiles.get(Vector2(1, 10)), 1, "start.tiles[(1, 10)]")
+	assert_eq(Vector2(1, 10) in blocks_start.block_tiles, true, "start.block_tiles[(1, 10)]")
+	assert_eq(blocks_start.block_tiles.get(Vector2(1, 10)), 1, "start.block_tiles[(1, 10)]")
 	assert_eq(blocks_start.block_autotile_coords.get(Vector2(1, 10)), Vector2(14, 1), "start.autotile_coords[(1, 10)]")
 
 
@@ -37,16 +37,16 @@ func test_load_tiles() -> void:
 	load_level("level-tiles")
 	
 	var blocks_start := settings.tiles.blocks_start()
-	assert_eq(Vector2(1, 16) in blocks_start.block_cells, true, "start.block_cells[(1, 16)]")
-	assert_eq(blocks_start.block_tiles.get(Vector2(1, 16)), 2, "start.tiles[(1, 16)]")
+	assert_eq(Vector2(1, 16) in blocks_start.block_tiles, true, "start.block_tiles[(1, 16)]")
+	assert_eq(blocks_start.block_tiles.get(Vector2(1, 16)), 2, "start.block_tiles[(1, 16)]")
 	assert_eq(blocks_start.block_autotile_coords.get(Vector2(1, 16)), Vector2(9, 1), "start.autotile_coords[(1, 16)]")
 	
 	var blocks_0 := settings.tiles.get_tiles("0")
-	assert_eq(Vector2(3, 2) in blocks_0.block_cells, true)
-	assert_eq(blocks_0.block_tiles.get(Vector2(3, 2)), 2)
-	assert_eq(blocks_0.block_autotile_coords.get(Vector2(3, 2)), Vector2(6, 3))
-	assert_eq(Vector2(4, 2) in blocks_0.pickup_cells, true)
-	assert_eq(blocks_0.pickups.get(Vector2(4, 2)), 4)
+	assert_eq(Vector2(3, 2) in blocks_0.block_tiles, true, "0.block_tiles[(3, 2)]")
+	assert_eq(blocks_0.block_tiles.get(Vector2(3, 2)), 2, "0.block_tiles[(3, 2)]")
+	assert_eq(blocks_0.block_autotile_coords.get(Vector2(3, 2)), Vector2(6, 3), "0.block_autotile_coords[(3, 2)]")
+	assert_eq(Vector2(4, 2) in blocks_0.pickups, true, "0.pickups[(4, 2)]")
+	assert_eq(blocks_0.pickups.get(Vector2(4, 2)), 4, "0.pickups[(4, 2)]")
 
 
 func test_path_from_level_key() -> void:


### PR DESCRIPTION
Pickups now appear before the player hits 'start'. StarSeeds are not
shown before the player hits 'start' because their locations are random,
but pickups are deterministic.

Removed redundant block_cells and pickup_cells LevelTiles fields. These
might make sense to restore if the order of the cells matters, but for
now i don't see a reason to keep them.

Added experiment 004 to worlds.json.

Improved failure messages for some LevelSettings tests.