### PR TITLE
Refactorings: SeedPickupScene, CreatureScene

### DIFF
--- a/project/src/main/editor/puzzle/PlayfieldEditor.tscn
+++ b/project/src/main/editor/puzzle/PlayfieldEditor.tscn
@@ -342,7 +342,7 @@ script = ExtResource( 15 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
-SeedPickupScene = ExtResource( 6 )
+PickupScene = ExtResource( 6 )
 _puzzle_tile_map_path = NodePath("../TileMap")
 
 [node name="PickupsDropPreview" type="Control" parent="CenterPanel/Playfield/Bg"]
@@ -354,7 +354,7 @@ script = ExtResource( 15 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
-SeedPickupScene = ExtResource( 6 )
+PickupScene = ExtResource( 6 )
 _puzzle_tile_map_path = NodePath("../TileMap")
 
 [connection signal="tiles_keys_changed" from="." to="PlayfieldNav" method="_on_Playfield_tiles_keys_changed"]

--- a/project/src/main/editor/puzzle/editor-pickups.gd
+++ b/project/src/main/editor/puzzle/editor-pickups.gd
@@ -7,7 +7,7 @@ This stripped down class excludes gameplay code for sound effects and scoring. I
 level editor.
 """
 
-export (PackedScene) var SeedPickupScene: PackedScene
+export (PackedScene) var PickupScene: PackedScene
 export (NodePath) var _puzzle_tile_map_path: NodePath
 
 # key: Vector2 playfield cell positions
@@ -23,7 +23,7 @@ func set_pickup(cell: Vector2, box_type: int) -> void:
 	remove_pickup(cell)
 	
 	if box_type != -1:
-		var pickup: Pickup = SeedPickupScene.instance()
+		var pickup: Pickup = PickupScene.instance()
 		pickup.food_type = _food_type_for_cell(box_type, cell)
 	
 		pickup.position = _puzzle_tile_map.map_to_world(cell)

--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -374,7 +374,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 _puzzle_tile_map_path = NodePath("../Playfield/TileMapClip/TileMap")
-SeedPickupScene = ExtResource( 73 )
+PickupScene = ExtResource( 73 )
 
 [node name="Visuals" type="Control" parent="Pickups"]
 anchor_right = 1.0

--- a/project/src/main/puzzle/pickups.gd
+++ b/project/src/main/puzzle/pickups.gd
@@ -12,7 +12,7 @@ signal food_spawned(cell, remaining_food, food_type)
 const OVERLAP_VOLUME_DB := -6.0
 
 export (NodePath) var _puzzle_tile_map_path: NodePath
-export (PackedScene) var SeedPickupScene: PackedScene
+export (PackedScene) var PickupScene: PackedScene
 
 # key: Vector2 playfield cell positions
 # value: Pickup node contained within that cell
@@ -50,7 +50,7 @@ func set_pickup(cell: Vector2, box_type: int) -> void:
 	remove_pickup(cell)
 	
 	if box_type != -1:
-		var pickup: Pickup = SeedPickupScene.instance()
+		var pickup: Pickup = PickupScene.instance()
 		pickup.food_type = _food_type_for_box_type(box_type, cell)
 
 		pickup.position = _puzzle_tile_map.map_to_world(cell + Vector2(0, -3))

--- a/project/src/main/world/CreatureSpawner.tscn
+++ b/project/src/main/world/CreatureSpawner.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://src/main/world/creature-spawner.gd" type="Script" id=1]
 [ext_resource path="res://assets/main/creatures/creature-editor-preview.png" type="Texture" id=2]
+[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=3]
 
 [node name="CreatureSpawner" type="Sprite" groups=[
 "creature_spawners",
@@ -14,3 +15,4 @@ target_properties = {
 "elevation": 0.0,
 "orientation": 0
 }
+CreatureScene = ExtResource( 3 )

--- a/project/src/main/world/creature-spawner.gd
+++ b/project/src/main/world/creature-spawner.gd
@@ -26,7 +26,7 @@ export (String) var spawn_if: String
 # If a fatter creature spawns here, they will spontaneously and permanently slim down.
 export (float) var max_fatness := 10.0
 
-var CreatureScene: PackedScene = load("res://src/main/world/creature/Creature.tscn")
+export (PackedScene) var CreatureScene: PackedScene
 
 # a Stool or ObstacleSpawner instance for the stool the spawned creature sits on, if any
 var _stool: Node2D


### PR DESCRIPTION
'SeedPickupScene' field is now just called PickupScene to match the
Pickup.tscn filename.

CreatureSpawner's CreatureScene is now exported, instead of being
hard-coded into the script. Godot seems to play better with exported
scene files as the editor can keep them hooked up during renames.
Additionally, it's consistent with the rest of the project.