### PR TITLE
Different pickup modes: float, float_regen

### DIFF
--- a/project/assets/main/puzzle/levels/experiment/005.json
+++ b/project/assets/main/puzzle/levels/experiment/005.json
@@ -1,95 +1,100 @@
 {
   "version": "19c5",
-  "start_speed": "T",
+  "start_speed": "6",
+  "title": "Secret Brownies",
+  "description": "Secret brownies? Where? ...I must have them!",
   "finish_condition": {
     "type": "score",
-    "value": "200"
+    "value": "1000"
   },
+  "blocks_during": [
+    "pickup_type float_regen"
+  ],
   "tiles": {
     "start": [
       {
-        "pos": "7 13",
-        "tile": "2 7 2"
-      },
-      {
         "pos": "8 13",
-        "tile": "2 11 2"
+        "tile": "0 2 0"
       },
       {
         "pos": "6 14",
-        "tile": "2 2 0"
+        "tile": "0 8 0"
       },
       {
         "pos": "7 14",
-        "tile": "2 4 3"
+        "tile": "0 12 0"
       },
       {
         "pos": "8 14",
-        "tile": "2 9 0"
+        "tile": "0 5 0"
       },
       {
         "pos": "6 15",
-        "tile": "2 13 1"
+        "tile": "1 10 2"
       },
       {
         "pos": "7 15",
-        "tile": "2 1 3"
+        "tile": "1 14 2"
       },
       {
         "pos": "8 15",
-        "tile": "2 7 0"
+        "tile": "1 6 2",
+        "pickup": "2"
       },
       {
         "pos": "6 16",
-        "tile": "2 6 3"
+        "tile": "1 11 2"
       },
       {
         "pos": "7 16",
-        "tile": "2 8 2"
+        "tile": "1 15 2",
+        "pickup": "2"
       },
       {
         "pos": "8 16",
-        "tile": "2 4 2"
+        "tile": "1 7 2"
       },
       {
         "pos": "6 17",
-        "tile": "2 11 0"
+        "tile": "1 9 2",
+        "pickup": "2"
       },
       {
         "pos": "7 17",
-        "tile": "2 14 2"
+        "tile": "1 13 2"
       },
       {
         "pos": "8 17",
-        "tile": "2 13 1",
+        "tile": "1 5 2",
         "pickup": "2"
       },
       {
         "pos": "6 18",
-        "tile": "2 12 1"
+        "tile": "1 10 0"
       },
       {
         "pos": "7 18",
-        "tile": "2 5 0",
-        "pickup": "2"
+        "tile": "1 14 0",
+        "pickup": "8"
       },
       {
         "pos": "8 18",
-        "tile": "2 17 1"
+        "tile": "1 6 0"
       },
       {
         "pos": "6 19",
-        "tile": "2 2 0",
-        "pickup": "2"
+        "tile": "1 9 0",
+        "pickup": "8"
       },
       {
         "pos": "7 19",
-        "tile": "2 13 2"
+        "tile": "1 13 0",
+        "pickup": "0"
       },
       {
         "pos": "8 19",
-        "tile": "2 0 2",
-        "pickup": "2"
+        "tile": "1 5 0",
+        "pickup": "8"
       }
     ]
   }

--- a/project/assets/main/puzzle/worlds.json
+++ b/project/assets/main/puzzle/worlds.json
@@ -335,6 +335,9 @@
         },
         {
           "id": "experiment/004"
+        },
+        {
+          "id": "experiment/005"
         }
       ]
     }

--- a/project/src/main/puzzle/Playfield.tscn
+++ b/project/src/main/puzzle/Playfield.tscn
@@ -377,7 +377,6 @@ bus = "Sound Bus"
 [connection signal="box_built" from="." to="TileMapClip/PlayfieldFx" method="_on_Playfield_box_built"]
 [connection signal="line_cleared" from="." to="ComboTracker" method="_on_Playfield_line_cleared"]
 [connection signal="line_erased" from="." to="LineClearSfx" method="_on_Playfield_line_erased"]
-[connection signal="line_erased" from="." to="TileMapClip/Pickups" method="_on_Playfield_line_erased"]
 [connection signal="line_inserted" from="." to="LineClearer" method="_on_Playfield_line_inserted"]
 [connection signal="line_inserted" from="." to="TileMapClip/Pickups" method="_on_Playfield_line_inserted"]
 [connection signal="lines_deleted" from="." to="TileMapClip/Pickups" method="_on_Playfield_lines_deleted"]

--- a/project/src/main/puzzle/level/blocks-during-rules.gd
+++ b/project/src/main/puzzle/level/blocks-during-rules.gd
@@ -9,6 +9,12 @@ enum LineClearType {
 	FLOAT_FALL, # blocks are left floating; the entire playfield drops following line clears
 }
 
+enum PickupType {
+	DEFAULT, # pickups raise/lower with the playfield blocks
+	FLOAT, # pickups float in place behind the playfield blocks
+	FLOAT_REGEN, # pickups float in place and regenerate if collected
+}
+
 # key: (string) line clear type which appears in level definitions
 # value: (int) an enum from LineClearType
 const LINE_CLEAR_TYPES_BY_NAME := {
@@ -17,11 +23,22 @@ const LINE_CLEAR_TYPES_BY_NAME := {
 	"float_fall": LineClearType.FLOAT_FALL,
 }
 
+# key: (string) pickup type which appears in level definitions
+# value: (int) an enum from PickupType
+const PICKUP_TYPES_BY_NAME := {
+	"default": PickupType.DEFAULT,
+	"float": PickupType.FLOAT,
+	"float_regen": PickupType.FLOAT_REGEN,
+}
+
 # if true, the entire playfield is cleared when the player tops out
 var clear_on_top_out := false
 
-# whether lines drop following a line clear
+# whether blocks drop following a line clear
 var line_clear_type: int = LineClearType.DEFAULT
+
+# whether pickups move with the playfield blocks
+var pickup_type: int = PickupType.DEFAULT
 
 func from_json_string_array(json: Array) -> void:
 	var rules := RuleParser.new(json)
@@ -31,3 +48,8 @@ func from_json_string_array(json: Array) -> void:
 			push_warning("Unrecognized line_clear_type: %s" % [rules.string_value()])
 		else:
 			line_clear_type = LINE_CLEAR_TYPES_BY_NAME[rules.string_value()]
+	if rules.has("pickup_type"):
+		if not PICKUP_TYPES_BY_NAME.has(rules.string_value()):
+			push_warning("Unrecognized pickup_type: %s" % [rules.string_value()])
+		else:
+			pickup_type = PICKUP_TYPES_BY_NAME[rules.string_value()]


### PR DESCRIPTION
Levels now support floating pickups which regenerate.

Pickups are no longer erased on line clear. I couldn't think of a use
case for this, and it's weird for regenerating powerups to erase.