### PR TITLE
Pickup scores are ranked, shown. Rank screen shows/hides categories.

### DIFF
--- a/project/assets/main/puzzle/levels/experiment/003.json
+++ b/project/assets/main/puzzle/levels/experiment/003.json
@@ -12,7 +12,8 @@
   ],
   "rank": [
     "box_factor 0.0",
-    "combo_factor 0.6"
+    "combo_factor 0.6",
+    "hide_boxes_rank"
   ],
   "timers": [
     {

--- a/project/assets/main/puzzle/levels/experiment/004.json
+++ b/project/assets/main/puzzle/levels/experiment/004.json
@@ -7,6 +7,12 @@
     "type": "time_over",
     "value": "150"
   },
+  "rank": [
+    "box_factor 0.3",
+    "combo_factor 0.4",
+    "master_pickup_score_per_line 2.0",
+    "show_pickups_rank"
+  ],
   "triggers": [
     {
       "phases": [

--- a/project/assets/main/puzzle/levels/experiment/005.json
+++ b/project/assets/main/puzzle/levels/experiment/005.json
@@ -10,6 +10,10 @@
   "blocks_during": [
     "pickup_type float_regen"
   ],
+  "rank": [
+    "master_pickup_score_per_line 3.4",
+    "show_pickups_rank"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/experiment/006.json
+++ b/project/assets/main/puzzle/levels/experiment/006.json
@@ -1,0 +1,145 @@
+{
+  "version": "19c5",
+  "start_speed": "5",
+  "title": "Just Cream",
+  "description": "Too much of a good thing is still a good thing!",
+  "finish_condition": {
+    "type": "lines",
+    "value": "35"
+  },
+  "piece_types": [
+    "piece_o",
+    "piece_v"
+  ],
+  "rank": [
+    "master_pickup_score 70"
+  ],
+  "tiles": {
+    "start": [
+      {
+        "pos": "4 16",
+        "pickup": "3"
+      },
+      {
+        "pos": "5 16",
+        "tile": "2 8 2"
+      },
+      {
+        "pos": "6 16",
+        "tile": "2 16 0"
+      },
+      {
+        "pos": "7 16",
+        "pickup": "3"
+      },
+      {
+        "pos": "0 17",
+        "tile": "1 8 3"
+      },
+      {
+        "pos": "1 17",
+        "tile": "1 12 3"
+      },
+      {
+        "pos": "2 17",
+        "tile": "1 4 3"
+      },
+      {
+        "pos": "3 17",
+        "pickup": "3"
+      },
+      {
+        "pos": "4 17",
+        "pickup": "3"
+      },
+      {
+        "pos": "5 17",
+        "pickup": "3"
+      },
+      {
+        "pos": "6 17",
+        "tile": "2 10 1"
+      },
+      {
+        "pos": "7 17",
+        "pickup": "3"
+      },
+      {
+        "pos": "8 17",
+        "pickup": "3"
+      },
+      {
+        "pos": "0 18",
+        "tile": "1 10 3"
+      },
+      {
+        "pos": "1 18",
+        "tile": "1 14 3"
+      },
+      {
+        "pos": "2 18",
+        "tile": "1 6 3"
+      },
+      {
+        "pos": "3 18",
+        "tile": "2 4 3"
+      },
+      {
+        "pos": "4 18",
+        "pickup": "3"
+      },
+      {
+        "pos": "5 18",
+        "pickup": "3"
+      },
+      {
+        "pos": "6 18",
+        "tile": "2 14 2"
+      },
+      {
+        "pos": "7 18",
+        "pickup": "3"
+      },
+      {
+        "pos": "8 18",
+        "pickup": "3"
+      },
+      {
+        "pos": "0 19",
+        "tile": "1 9 3"
+      },
+      {
+        "pos": "1 19",
+        "tile": "1 13 3"
+      },
+      {
+        "pos": "2 19",
+        "tile": "1 5 3"
+      },
+      {
+        "pos": "3 19",
+        "tile": "2 13 1"
+      },
+      {
+        "pos": "4 19",
+        "tile": "2 16 1"
+      },
+      {
+        "pos": "5 19",
+        "pickup": "3"
+      },
+      {
+        "pos": "6 19",
+        "tile": "2 0 0"
+      },
+      {
+        "pos": "7 19",
+        "pickup": "3"
+      },
+      {
+        "pos": "8 19",
+        "pickup": "3"
+      }
+    ]
+  }
+}

--- a/project/assets/main/puzzle/levels/marsh/hello-everyone.json
+++ b/project/assets/main/puzzle/levels/marsh/hello-everyone.json
@@ -17,7 +17,8 @@
     "top_out 9"
   ],
   "rank": [
-    "extra_seconds_per_piece 0.4"
+    "extra_seconds_per_piece 0.4",
+    "hide_combos_rank"
   ],
   "triggers": [
     {

--- a/project/assets/main/puzzle/worlds.json
+++ b/project/assets/main/puzzle/worlds.json
@@ -338,6 +338,9 @@
         },
         {
           "id": "experiment/005"
+        },
+        {
+          "id": "experiment/006"
         }
       ]
     }

--- a/project/src/demo/puzzle/PuzzleDemo.tscn
+++ b/project/src/demo/puzzle/PuzzleDemo.tscn
@@ -5,6 +5,6 @@
 
 [node name="PuzzleDemo" type="Node"]
 script = ExtResource( 2 )
-level_path = "res://assets/main/puzzle/levels/experiment/005.json"
+level_path = "res://assets/main/puzzle/levels/experiment/006.json"
 
 [node name="Puzzle" parent="." instance=ExtResource( 1 )]

--- a/project/src/demo/puzzle/level/level-rank-demo.gd
+++ b/project/src/demo/puzzle/level/level-rank-demo.gd
@@ -40,6 +40,7 @@ func _calculate() -> void:
 	_calculate_extra_seconds_per_piece()
 	_calculate_box_factor()
 	_calculate_combo_factor()
+	_calculate_master_pickup_score_per_line()
 	
 	# trim extra newlines from the output
 	_text_edit.text = _text_edit.text.strip_edges()
@@ -108,6 +109,29 @@ func _calculate_combo_factor() -> void:
 			combo_factor_min = CurrentLevel.settings.rank.combo_factor
 	
 	_text_edit.text += "combo_factor=%.2f\n" % [CurrentLevel.settings.rank.combo_factor]
+
+
+"""
+Calculates and outputs the master_pickup_score_per_line for levels with pickups.
+"""
+func _calculate_master_pickup_score_per_line() -> void:
+	var target_rank := _target_rank()
+	var best_result := _best_result()
+	
+	var master_pickup_score_per_line_min := 0.0
+	var master_pickup_score_per_line_max := 100.0
+	for _i in range(20):
+		CurrentLevel.settings.rank.master_pickup_score_per_line = \
+				0.5 * (master_pickup_score_per_line_min + master_pickup_score_per_line_max)
+		var master_pickup_score_per_line_for_grade := CurrentLevel.settings.rank.master_pickup_score_per_line \
+				* CurrentLevel.settings.rank.master_pickup_score_per_line \
+				* pow(RankCalculator.RDF_PICKUP_SCORE_PER_LINE, target_rank)
+		if master_pickup_score_per_line_for_grade >= best_result.pickup_score_per_line:
+			master_pickup_score_per_line_max = CurrentLevel.settings.rank.master_pickup_score_per_line
+		else:
+			master_pickup_score_per_line_min = CurrentLevel.settings.rank.master_pickup_score_per_line
+	
+	_text_edit.text += "master_pickup_score_per_line=%.2f\n" % [CurrentLevel.settings.rank.master_pickup_score_per_line]
 
 
 """

--- a/project/src/main/puzzle/duration-calculator.gd
+++ b/project/src/main/puzzle/duration-calculator.gd
@@ -40,7 +40,10 @@ func duration(settings: LevelSettings) -> float:
 	
 	match settings.finish_condition.type:
 		Milestone.SCORE:
-			var lines := settings.finish_condition.value / _score_per_line(settings)
+			# assume the player collects all the one-time pickups
+			var lines := (settings.finish_condition.value - settings.rank.master_pickup_score) \
+					/ _score_per_line(settings)
+			lines = clamp(lines, 1, 10000)
 			result = _duration_for_lines(settings, lines)
 		Milestone.LINES:
 			result = _duration_for_lines(settings, settings.finish_condition.value)
@@ -92,7 +95,7 @@ func _score_per_line(settings: LevelSettings) -> float:
 	var box_score_per_line := RankCalculator.master_box_score(settings)
 	box_score_per_line *= pow(RankCalculator.RDF_BOX_SCORE_PER_LINE, _rank(settings))
 	
-	var pickup_score_per_line := RankCalculator.master_pickup_score(settings)
+	var pickup_score_per_line := RankCalculator.master_pickup_score_per_line(settings)
 	pickup_score_per_line *= pow(RankCalculator.RDF_PICKUP_SCORE_PER_LINE, _rank(settings))
 	
 	return box_score_per_line + combo_score_per_line + pickup_score_per_line + 1

--- a/project/src/main/puzzle/level/rank-rules.gd
+++ b/project/src/main/puzzle/level/rank-rules.gd
@@ -3,25 +3,41 @@ class_name RankRules
 Tweaks to rank calculation.
 """
 
-# multiplier for the expected box_points_per_line. '3.0' means the player
+enum ShowRank {
+	DEFAULT, # rank should be automatically shown/hidden based on the finish condition
+	SHOW, # rank should be shown
+	HIDE, # rank should be hidden
+}
+
+# multiplier for the expected box_score_per_line. '3.0' means the player
 # needs 3x the usual box points per line to get a good rank
 var box_factor := 1.0
 
-# multiplier for the expected combo_points_per_line. '3.0' means the player
+# multiplier for the expected combo_score_per_line. '3.0' means the player
 # needs 3x the usual combo points per line to get a good rank
 var combo_factor := 1.0
-
-# expected bonus points per line awarded for pickups
-var master_pickup_points_per_line := 0.0
-
-# extra time it takes an expert to move the piece where it belongs
-var extra_seconds_per_piece := 0.0
 
 # expected combo per customer
 var customer_combo := 0
 
+# extra time it takes an expert to move the piece where it belongs
+var extra_seconds_per_piece := 0.0
+
 # expected leftover lines
 var leftover_lines := 0
+
+# expected bonus points for pickups
+var master_pickup_score := 0.0
+
+# expected bonus points per line awarded for pickups
+var master_pickup_score_per_line := 0.0
+
+var show_boxes_rank: int = ShowRank.DEFAULT
+var show_combos_rank: int = ShowRank.DEFAULT
+var show_lines_rank: int = ShowRank.DEFAULT
+var show_pickups_rank: int = ShowRank.DEFAULT
+var show_pieces_rank: int = ShowRank.DEFAULT
+var show_speed_rank: int = ShowRank.DEFAULT
 
 # 'true' if the results screen should be skipped. Used for tutorials.
 var skip_results: bool
@@ -42,9 +58,44 @@ func from_json_string_array(json: Array) -> void:
 	if rules.has("box_factor"): box_factor = rules.float_value()
 	if rules.has("combo_factor"): combo_factor = rules.float_value()
 	if rules.has("customer_combo"): customer_combo = rules.int_value()
+	if rules.has("extra_seconds_per_piece"): extra_seconds_per_piece = rules.float_value()
 	if rules.has("leftover_lines"): leftover_lines = rules.int_value()
+	if rules.has("master_pickup_score"): master_pickup_score = rules.float_value()
+	if rules.has("master_pickup_score_per_line"): master_pickup_score_per_line = rules.float_value()
+	
+	_assign_show_rank(rules, "boxes")
+	_assign_show_rank(rules, "combos")
+	_assign_show_rank(rules, "lines")
+	_assign_show_rank(rules, "pickups")
+	_assign_show_rank(rules, "pieces")
+	_assign_show_rank(rules, "speed")
+	
 	if rules.has("skip_results"): skip_results = true
 	if rules.has("success_bonus"): success_bonus = rules.float_value()
 	if rules.has("top_out_penalty"): top_out_penalty = rules.int_value()
 	if rules.has("unranked"): unranked = true
-	if rules.has("extra_seconds_per_piece"): extra_seconds_per_piece = rules.float_value()
+
+
+"""
+Populates one of our 'show_rank' fields based on the specified rule.
+
+A value of 'hide_foo_rank' sets the show_foo_rank field to ShowRank.HIDE. A value of 'show_foo_rank' sets the
+show_foo_rank field to ShowRank.SHOW.
+
+Parameters:
+	'rules': The rule parser containing 'hide_foo_rank' and 'show_foo_rank' rules.
+	
+	'rank_string': A string such as 'boxes' or 'pieces' indicating which rule should be parsed and assigned.
+"""
+func _assign_show_rank(rules: RuleParser, rank_string: String) -> void:
+	var hide_string := "hide_%s_rank" % [rank_string]
+	var show_string := "show_%s_rank" % [rank_string]
+	if rules.has(hide_string) != rules.has(show_string):
+		# one of hide_rank and show_rank is present; assign it
+		set("show_%s_rank" % [rank_string], ShowRank.SHOW if rules.has(show_string) else ShowRank.HIDE)
+	elif rules.has(hide_string) and rules.has(show_string):
+		# both hide_rank and show_rank are present; report an error
+		push_warning("'%s' conflicts with '%s'" % [hide_string, show_string])
+	else:
+		# neither hide_rank nor show_rank are present; ignore it
+		pass

--- a/project/src/main/puzzle/piece/piece-queue.gd
+++ b/project/src/main/puzzle/piece/piece-queue.gd
@@ -245,10 +245,12 @@ func _insert_annoying_piece(max_pieces_to_right: int) -> void:
 		Utils.remove_all(extra_piece_types, pieces[new_piece_index - 1].type)
 		if new_piece_index < pieces.size():
 			Utils.remove_all(extra_piece_types, pieces[new_piece_index].type)
-	if extra_piece_types[0] == PieceTypes.piece_o:
-		# the o piece is awful, so it comes 10% less often
-		extra_piece_types.shuffle()
-	pieces.insert(new_piece_index, _new_next_piece(extra_piece_types[0]))
+	
+	if extra_piece_types:
+		if extra_piece_types[0] == PieceTypes.piece_o:
+			# the o piece is awful, so it comes 10% less often
+			extra_piece_types.shuffle()
+		pieces.insert(new_piece_index, _new_next_piece(extra_piece_types[0]))
 
 
 func _on_Level_settings_changed() -> void:

--- a/project/src/main/puzzle/rank-result.gd
+++ b/project/src/main/puzzle/rank-result.gd
@@ -42,7 +42,7 @@ var combo_score_per_line_rank := WORST_RANK
 # bonus points awarded for pickups
 var pickup_score := 0
 var pickup_score_per_line := 0.0
-var pickup_score_per_line_rank := WORST_RANK
+var pickup_score_rank := WORST_RANK
 
 # number of seconds until the player won or lost
 var seconds := 0.0
@@ -70,8 +70,8 @@ func to_json_dict() -> Dictionary:
 		"combo_score_per_line": combo_score_per_line,
 		"combo_score_per_line_rank": combo_score_per_line_rank,
 		"pickup_score": pickup_score,
-		"pickup_score_per_line": pickup_score,
-		"pickup_score_per_piece_rank": pickup_score,
+		"pickup_score_per_line": pickup_score_per_line,
+		"pickup_score_rank": pickup_score_rank,
 		"compare": compare,
 		"leftover_score": leftover_score,
 		"lines": lines,
@@ -100,7 +100,7 @@ func from_json_dict(json: Dictionary) -> void:
 	combo_score_per_line_rank = float(json.get("combo_score_per_line_rank", "999"))
 	pickup_score = int(json.get("pickup_score", "0"))
 	pickup_score_per_line = float(json.get("pickup_score_per_line", "0"))
-	pickup_score_per_line_rank = float(json.get("pickup_score_per_line_rank", "999"))
+	pickup_score_rank = float(json.get("pickup_score_rank", "999"))
 	compare = json.get("compare", "+score")
 	leftover_score = json.get("leftover_score", 0)
 	lines = int(json.get("lines", "0"))

--- a/project/src/main/puzzle/results-hud.gd
+++ b/project/src/main/puzzle/results-hud.gd
@@ -80,37 +80,57 @@ func _append_grade_information(rank_result: RankResult, _customer_scores: Array,
 	if rank_result.topped_out() and CurrentLevel.settings.rank.top_out_penalty > 0:
 		topped_out = "?"
 	
-	text += "/////\n"
-	if finish_condition_type == Milestone.SCORE:
-		text += tr("Speed: %d") % round(rank_result.speed * 200 / 60)
+	text += "\n"
+	
+	if _speed_shown(finish_condition_type):
+		text += "/////" + tr("Speed: %d") % round(rank_result.speed * 200 / 60)
 		text += topped_out
 		if not CurrentLevel.settings.rank.unranked:
 			text += " (%s)" % RankCalculator.grade(rank_result.speed_rank)
 		text += "\n"
-	elif finish_condition_type == Milestone.PIECES:
-		text += tr("Pieces: %d") % rank_result.pieces
+	
+	if _pieces_shown(finish_condition_type):
+		text += "/////" + tr("Pieces: %d") % rank_result.pieces
 		text += topped_out
 		if not CurrentLevel.settings.rank.unranked:
 			text += " (%s)" % RankCalculator.grade(rank_result.pieces_rank)
 		text += "\n"
-	else:
-		text += tr("Lines: %d") % rank_result.lines
+	
+	if _lines_shown(finish_condition_type):
+		text += "/////" + tr("Lines: %d") % rank_result.lines
 		text += topped_out
 		if not CurrentLevel.settings.rank.unranked:
 			text += " (%s)" % RankCalculator.grade(rank_result.lines_rank)
 		text += "\n"
-		
-	text += "/////" + tr("Boxes: %d") % round(rank_result.box_score_per_line * 10)
-	text += topped_out
-	if not CurrentLevel.settings.rank.unranked:
-		text += " (%s)" % RankCalculator.grade(rank_result.box_score_per_line_rank)
-	text += "\n"
 	
-	text += "/////" + tr("Combos: %d") % round(rank_result.combo_score_per_line * 10)
-	text += topped_out
-	if not CurrentLevel.settings.rank.unranked:
-		text += " (%s)" % RankCalculator.grade(rank_result.combo_score_per_line_rank)
-	text += "\n"
+	if _boxes_shown():
+		text += "/////" + tr("Boxes: %d") % round(rank_result.box_score_per_line * 10)
+		text += topped_out
+		if not CurrentLevel.settings.rank.unranked:
+			text += " (%s)" % RankCalculator.grade(rank_result.box_score_per_line_rank)
+		text += "\n"
+	
+	if _combos_shown():
+		text += "/////" + tr("Combos: %d") % round(rank_result.combo_score_per_line * 10)
+		text += topped_out
+		if not CurrentLevel.settings.rank.unranked:
+			text += " (%s)" % RankCalculator.grade(rank_result.combo_score_per_line_rank)
+		text += "\n"
+	
+	if _pickups_shown():
+		var shown_pickup_score: float
+		if CurrentLevel.settings.rank.master_pickup_score_per_line:
+			# show the 'per line' pickup score
+			shown_pickup_score = round(rank_result.pickup_score_per_line * 10)
+		else:
+			# show the 'total' pickup score
+			shown_pickup_score = float(rank_result.pickup_score)
+		
+		text += "/////" + tr("Pickups: %d") % shown_pickup_score
+		text += topped_out
+		if not CurrentLevel.settings.rank.unranked:
+			text += " (%s)" % RankCalculator.grade(rank_result.pickup_score_rank)
+		text += "\n"
 	
 	if not CurrentLevel.settings.rank.unranked:
 		text += "/////\n" + tr("Overall: ")
@@ -121,6 +141,45 @@ func _append_grade_information(rank_result: RankResult, _customer_scores: Array,
 		else:
 			text += "(%s)\n" % RankCalculator.grade(rank_result.score_rank)
 	return text
+
+
+func _speed_shown(finish_condition_type: int) -> bool:
+	var result: bool
+	match CurrentLevel.settings.rank.show_speed_rank:
+		RankRules.ShowRank.SHOW: result = true
+		RankRules.ShowRank.HIDE: result = false
+		_: result = true if finish_condition_type == Milestone.SCORE else false
+	return result
+
+
+func _pieces_shown(finish_condition_type: int) -> bool:
+	var result: bool
+	match CurrentLevel.settings.rank.show_pieces_rank:
+		RankRules.ShowRank.SHOW: result = true
+		RankRules.ShowRank.HIDE: result = false
+		_: result = true if finish_condition_type == Milestone.PIECES else false
+	return result
+
+
+func _lines_shown(finish_condition_type: int) -> bool:
+	var result: bool
+	match CurrentLevel.settings.rank.show_lines_rank:
+		RankRules.ShowRank.SHOW: result = true
+		RankRules.ShowRank.HIDE: result = false
+		_: result = false if finish_condition_type in [Milestone.PIECES, Milestone.SCORE] else true
+	return result
+
+
+func _boxes_shown() -> bool:
+	return CurrentLevel.settings.rank.show_boxes_rank in [RankRules.ShowRank.SHOW, RankRules.ShowRank.DEFAULT]
+
+
+func _combos_shown() -> bool:
+	return CurrentLevel.settings.rank.show_combos_rank in [RankRules.ShowRank.SHOW, RankRules.ShowRank.DEFAULT]
+
+
+func _pickups_shown() -> bool:
+	return CurrentLevel.settings.rank.show_pickups_rank in [RankRules.ShowRank.SHOW]
 
 
 """

--- a/project/src/test/puzzle/test-duration-calculator.gd
+++ b/project/src/test/puzzle/test-duration-calculator.gd
@@ -89,3 +89,19 @@ func test_customers_high_difficulty() -> void:
 	_settings.finish_condition.set_milestone(Milestone.CUSTOMERS, 5)
 	
 	assert_almost_eq(_duration_calculator.duration(_settings), 185.0, 10.0)
+
+
+func test_master_pickup_score() -> void:
+	_settings.finish_condition.set_milestone(Milestone.SCORE, 1000)
+	assert_almost_eq(_duration_calculator.duration(_settings), 889.0, 10.0)
+	
+	_settings.rank.master_pickup_score = 800
+	assert_almost_eq(_duration_calculator.duration(_settings), 177.0, 10.0)
+
+
+func test_master_pickup_score_per_line() -> void:
+	_settings.finish_condition.set_milestone(Milestone.SCORE, 1000)
+	assert_almost_eq(_duration_calculator.duration(_settings), 889.0, 10.0)
+	
+	_settings.rank.master_pickup_score_per_line = 20
+	assert_almost_eq(_duration_calculator.duration(_settings), 574.0, 10.0)

--- a/project/src/test/puzzle/test-rank-calculator.gd
+++ b/project/src/test/puzzle/test-rank-calculator.gd
@@ -394,3 +394,26 @@ func test_combo_factor_zero() -> void:
 	CurrentLevel.settings.rank.combo_factor = 0.0
 	var rank2 :=  _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank2.combo_score_per_line_rank), "M")
+
+
+func test_master_pickup_score() -> void:
+	PuzzleState.level_performance.pickup_score = 100
+	CurrentLevel.settings.rank.master_pickup_score = 100
+	var rank1 :=  _rank_calculator.calculate_rank()
+	assert_eq(RankCalculator.grade(rank1.pickup_score_rank), "M")
+
+	CurrentLevel.settings.rank.master_pickup_score = 200
+	var rank2 :=  _rank_calculator.calculate_rank()
+	assert_eq(RankCalculator.grade(rank2.pickup_score_rank), "AA")
+
+
+func test_master_pickup_score_per_line() -> void:
+	PuzzleState.level_performance.lines = 100
+	PuzzleState.level_performance.pickup_score = 1000
+	CurrentLevel.settings.rank.master_pickup_score_per_line = 10
+	var rank1 :=  _rank_calculator.calculate_rank()
+	assert_eq(RankCalculator.grade(rank1.pickup_score_rank), "M")
+
+	CurrentLevel.settings.rank.master_pickup_score_per_line = 20
+	var rank2 :=  _rank_calculator.calculate_rank()
+	assert_eq(RankCalculator.grade(rank2.pickup_score_rank), "S-")


### PR DESCRIPTION
The rank and duration algorithms now apply pickup scores. Pickup scores
can be manually applied via two new JSON tags, 'master_pickup_score' and
'master_pickup_score_per_line'

The player's pickup rank can be shown at the end of a level with the new
'show_pickups_rank' rule. There are similar rules for things like
'hide_boxes_rank' and 'hide_combos_rank'

New level: 'Just Cream'