### PR TITLE
Doubled default pickup points. Rebalanced levels.

### DIFF
--- a/project/assets/main/puzzle/levels/experiment/004.json
+++ b/project/assets/main/puzzle/levels/experiment/004.json
@@ -8,9 +8,9 @@
     "value": "150"
   },
   "rank": [
-    "box_factor 0.3",
-    "combo_factor 0.4",
-    "master_pickup_score_per_line 2.0",
+    "box_factor 0.16",
+    "combo_factor 0.62",
+    "master_pickup_score_per_line 15.29",
     "show_pickups_rank"
   ],
   "triggers": [

--- a/project/assets/main/puzzle/levels/experiment/005.json
+++ b/project/assets/main/puzzle/levels/experiment/005.json
@@ -11,8 +11,11 @@
     "pickup_type float_regen"
   ],
   "rank": [
-    "master_pickup_score_per_line 3.4",
-    "show_pickups_rank"
+    "box_factor 0.90",
+    "combo_factor 0.90",
+    "master_pickup_score_per_line 18.16",
+    "show_pickups_rank",
+    "master_pickup_score 55"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/experiment/006.json
+++ b/project/assets/main/puzzle/levels/experiment/006.json
@@ -12,7 +12,9 @@
     "piece_v"
   ],
   "rank": [
-    "master_pickup_score 70"
+    "box_factor 0.61",
+    "combo_factor 0.56",
+    "master_pickup_score 140"
   ],
   "tiles": {
     "start": [

--- a/project/src/demo/puzzle/level/level-rank-demo.gd
+++ b/project/src/demo/puzzle/level/level-rank-demo.gd
@@ -118,18 +118,9 @@ func _calculate_master_pickup_score_per_line() -> void:
 	var target_rank := _target_rank()
 	var best_result := _best_result()
 	
-	var master_pickup_score_per_line_min := 0.0
-	var master_pickup_score_per_line_max := 100.0
-	for _i in range(20):
-		CurrentLevel.settings.rank.master_pickup_score_per_line = \
-				0.5 * (master_pickup_score_per_line_min + master_pickup_score_per_line_max)
-		var master_pickup_score_per_line_for_grade := CurrentLevel.settings.rank.master_pickup_score_per_line \
-				* CurrentLevel.settings.rank.master_pickup_score_per_line \
-				* pow(RankCalculator.RDF_PICKUP_SCORE_PER_LINE, target_rank)
-		if master_pickup_score_per_line_for_grade >= best_result.pickup_score_per_line:
-			master_pickup_score_per_line_max = CurrentLevel.settings.rank.master_pickup_score_per_line
-		else:
-			master_pickup_score_per_line_min = CurrentLevel.settings.rank.master_pickup_score_per_line
+	CurrentLevel.settings.rank.master_pickup_score_per_line = \
+			best_result.pickup_score_per_line \
+			/ pow(RankCalculator.RDF_PICKUP_SCORE_PER_LINE, target_rank)
 	
 	_text_edit.text += "master_pickup_score_per_line=%.2f\n" % [CurrentLevel.settings.rank.master_pickup_score_per_line]
 

--- a/project/src/main/puzzle/level/score-rules.gd
+++ b/project/src/main/puzzle/level/score-rules.gd
@@ -10,10 +10,10 @@ var cake_points := 10
 var snack_points := 5
 
 # box points for collecting a cake pickup.
-var cake_pickup_points := 10
+var cake_pickup_points := 20
 
 # box points for collecting a snack pickup.
-var snack_pickup_points := 5
+var snack_pickup_points := 10
 
 # box points awarded for clearing a row with no boxes, a vegetable row.
 var veg_points := 0


### PR DESCRIPTION
On a default level, an experienced player can earn ¥1000 per minute. But
on other levels, even with tons of powerups, it is difficult to score
more than ¥500 per minute. I want powerups to offset the disadvantage of
harder levels, but it is hard to do that unless they are worth more
points.

Fixed a calculation issue in LevelRankDemo. Rebalanced level rank data
for new powerup levels.