### PR TITLE
Level editor calculates pickup score. Level editor drag/drop shortcut.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -670,6 +670,11 @@ _global_script_classes=[ {
 "path": "res://src/main/puzzle/piece/presquish-sfx.gd"
 }, {
 "base": "Control",
+"class": "PropertiesEditorControl",
+"language": "GDScript",
+"path": "res://src/main/editor/puzzle/properties-editor-control.gd"
+}, {
+"base": "Control",
 "class": "Puzzle",
 "language": "GDScript",
 "path": "res://src/main/puzzle/puzzle.gd"
@@ -1027,6 +1032,7 @@ _global_script_class_icons={
 "PlayfieldEditorControl": "",
 "PlayfieldNav": "",
 "PresquishSfx": "",
+"PropertiesEditorControl": "",
 "Puzzle": "",
 "PuzzleAreas": "",
 "PuzzleConnect": "",

--- a/project/src/main/editor/puzzle/LevelEditor.tscn
+++ b/project/src/main/editor/puzzle/LevelEditor.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://src/main/editor/puzzle/PlayfieldEditor.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/editor/puzzle/editor-json.gd" type="Script" id=2]
+[ext_resource path="res://src/main/editor/puzzle/properties-editor-control.gd" type="Script" id=4]
 [ext_resource path="res://src/main/editor/puzzle/level-editor.gd" type="Script" id=8]
 [ext_resource path="res://src/main/ui/settings/SettingsMenu.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/ui/UiMenuShortcut.tres" type="ShortCut" id=10]
@@ -53,6 +54,47 @@ margin_left = 4.0
 margin_top = 32.0
 margin_right = -4.0
 margin_bottom = -4.0
+script = ExtResource( 4 )
+
+[node name="Pickups" type="VBoxContainer" parent="HBoxContainer/TabContainer/Properties"]
+margin_right = 120.0
+margin_bottom = 60.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="HBoxContainer1" type="HBoxContainer" parent="HBoxContainer/TabContainer/Properties/Pickups"]
+margin_right = 120.0
+margin_bottom = 30.0
+size_flags_vertical = 3
+
+[node name="Label" type="Label" parent="HBoxContainer/TabContainer/Properties/Pickups/HBoxContainer1"]
+margin_top = 5.0
+margin_right = 58.0
+margin_bottom = 25.0
+size_flags_horizontal = 3
+theme = ExtResource( 11 )
+text = "Pickups"
+align = 2
+
+[node name="LineEdit" type="LineEdit" parent="HBoxContainer/TabContainer/Properties/Pickups/HBoxContainer1"]
+margin_left = 62.0
+margin_right = 120.0
+margin_bottom = 30.0
+size_flags_horizontal = 3
+theme = ExtResource( 11 )
+text = "0"
+
+[node name="Button" type="Button" parent="HBoxContainer/TabContainer/Properties/Pickups"]
+margin_top = 34.0
+margin_right = 120.0
+margin_bottom = 60.0
+size_flags_horizontal = 3
+theme = ExtResource( 11 )
+text = "Calculate"
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="SideButtons" type="VBoxContainer" parent="HBoxContainer"]
 margin_left = 834.0
@@ -128,6 +170,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 playfield_editor_path = NodePath("../../TabContainer/Playfield")
+properties_editor_path = NodePath("../../TabContainer/Properties")
 
 [node name="Settings" type="Button" parent="HBoxContainer/SideButtons"]
 margin_top = 534.0
@@ -247,6 +290,9 @@ dialog_autowrap = true
 [connection signal="pickups_changed" from="HBoxContainer/TabContainer/Playfield" to="HBoxContainer/SideButtons/Json" method="_on_PlayfieldEditor_pickups_changed"]
 [connection signal="tile_map_changed" from="HBoxContainer/TabContainer/Playfield" to="HBoxContainer/SideButtons/Json" method="_on_PlayfieldEditor_tile_map_changed"]
 [connection signal="tiles_keys_changed" from="HBoxContainer/TabContainer/Playfield" to="HBoxContainer/SideButtons/Json" method="_on_PlayfieldEditor_tiles_keys_changed"]
+[connection signal="properties_changed" from="HBoxContainer/TabContainer/Properties" to="HBoxContainer/SideButtons/Json" method="_on_PropertiesEditor_properties_changed"]
+[connection signal="pressed" from="HBoxContainer/TabContainer/Properties/Pickups/Button" to="HBoxContainer/SideButtons/Json" method="_on_PropertiesPickupsButton_pressed"]
+[connection signal="text_entered" from="HBoxContainer/TabContainer/Properties/Pickups/HBoxContainer1/LineEdit" to="HBoxContainer/TabContainer/Properties" method="_on_PickupsLineEdit_text_entered"]
 [connection signal="quit_pressed" from="SettingsMenu" to="." method="_on_Quit_pressed"]
 [connection signal="about_to_show" from="Ui/Dialogs/Error" to="Ui/Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
 [connection signal="popup_hide" from="Ui/Dialogs/Error" to="Ui/Dialogs/Backdrop" method="_on_Dialog_popup_hide"]

--- a/project/src/main/editor/puzzle/level-editor.gd
+++ b/project/src/main/editor/puzzle/level-editor.gd
@@ -21,6 +21,7 @@ func _ready() -> void:
 	var level_text := FileUtils.get_file_as_text(LevelSettings.path_from_level_key(DEFAULT_LEVEL_ID))
 	_level_json.text = level_text
 	_level_json.refresh_playfield_editor()
+	_level_json.refresh_properties_editor()
 	level_id_label.text = DEFAULT_LEVEL_ID
 	Breadcrumb.connect("trail_popped", self, "_on_Breadcrumb_trail_popped")
 
@@ -34,6 +35,7 @@ func load_level(path: String) -> void:
 	var level_text := FileUtils.get_file_as_text(path)
 	_level_json.text = level_text
 	_level_json.refresh_playfield_editor()
+	_level_json.refresh_properties_editor()
 	level_id_label.text = LevelSettings.level_key_from_path(path)
 
 

--- a/project/src/main/editor/puzzle/properties-editor-control.gd
+++ b/project/src/main/editor/puzzle/properties-editor-control.gd
@@ -1,0 +1,22 @@
+class_name PropertiesEditorControl
+extends Control
+"""
+UI control for editing level properties.
+"""
+
+# emitted when the user edits level property values using the UI.
+signal properties_changed
+
+onready var _button: Button = $Pickups/Button
+onready var _line_edit: LineEdit = $Pickups/HBoxContainer1/LineEdit
+
+func get_master_pickup_score() -> int:
+	return int(_line_edit.text)
+
+
+func set_master_pickup_score(new_master_pickup_score: int) -> void:
+	_line_edit.text = str(new_master_pickup_score)
+
+
+func _on_PickupsLineEdit_text_entered(new_text: String) -> void:
+	emit_signal("properties_changed")


### PR DESCRIPTION
Level editor's 'properties' tab now has a panel for the pickup score.
The player can enter a score, or click the 'calculate' button to sum up
all of the visible pickups.

Dragging from the level editor playfield will now repeat the previously
dropped item for convenience. This makes it easier to create puzzles
with tons of veggies or powerups.