### PR TITLE
Pickups are erased on topout.

### DIFF
--- a/project/src/main/puzzle/Playfield.tscn
+++ b/project/src/main/puzzle/Playfield.tscn
@@ -377,6 +377,7 @@ bus = "Sound Bus"
 [connection signal="box_built" from="." to="TileMapClip/PlayfieldFx" method="_on_Playfield_box_built"]
 [connection signal="line_cleared" from="." to="ComboTracker" method="_on_Playfield_line_cleared"]
 [connection signal="line_erased" from="." to="LineClearSfx" method="_on_Playfield_line_erased"]
+[connection signal="line_erased" from="." to="TileMapClip/Pickups" method="_on_Playfield_line_erased"]
 [connection signal="line_inserted" from="." to="LineClearer" method="_on_Playfield_line_inserted"]
 [connection signal="line_inserted" from="." to="TileMapClip/Pickups" method="_on_Playfield_line_inserted"]
 [connection signal="lines_deleted" from="." to="TileMapClip/Pickups" method="_on_Playfield_lines_deleted"]

--- a/project/src/main/puzzle/pickups.gd
+++ b/project/src/main/puzzle/pickups.gd
@@ -280,13 +280,25 @@ func _on_PuzzleState_after_piece_written() -> void:
 				pickup.visible = true
 
 
+func _on_Playfield_line_erased(y: int, _total_lines: int, _remaining_lines: int, _box_ints: Array) -> void:
+	if _pickup_type() in [PICKUP_FLOAT_REGEN]:
+		# pickups are not erased
+		pass
+	else:
+		# erase pickups; this is especially important when the player tops out
+		_erase_row(y)
+
+
 func _on_Playfield_lines_deleted(lines: Array) -> void:
 	if _pickup_type() in [PICKUP_FLOAT, PICKUP_FLOAT_REGEN]:
 		# pickups do not move
 		pass
 	else:
-		# drop all pickups above the deleted lines to fill the gap
 		for y in lines:
+			# some levels might have rows which are deleted, but not erased. erase any pickups
+			_erase_row(y)
+			
+			# drop all pickups above the deleted lines to fill the gap
 			_shift_rows(y - 1, Vector2.DOWN)
 
 


### PR DESCRIPTION
In 12791c9a, pickups were modified to not erase when lines are erased.
This makes sense in most circumstances such as line clears, but during
topouts pickups need to be erased. Otherwise new pickups can spawn on
top of them.