### PR TITLE
Fixed alternate tiles level editor bug. New editor block chunks.

### DIFF
--- a/project/src/main/editor/puzzle/PlayfieldEditor.tscn
+++ b/project/src/main/editor/puzzle/PlayfieldEditor.tscn
@@ -91,7 +91,7 @@ expand_icon = true
 margin_left = 81.0
 margin_top = 68.0
 margin_right = 381.0
-margin_bottom = 336.0
+margin_bottom = 404.0
 size_flags_horizontal = 4
 columns = 4
 __meta__ = {
@@ -169,49 +169,72 @@ margin_bottom = 200.0
 script = ExtResource( 8 )
 editor_piece = 7
 
-[node name="Box3x1" parent="Palette/VBoxContainer/LevelChunks" instance=ExtResource( 5 )]
+[node name="Box1x1" parent="Palette/VBoxContainer/LevelChunks" instance=ExtResource( 5 )]
 margin_left = 152.0
 margin_top = 136.0
 margin_right = 224.0
 margin_bottom = 200.0
 script = ExtResource( 11 )
-box_size = Vector2( 3, 1 )
+box_size = Vector2( 1, 1 )
 
-[node name="Box3x2" parent="Palette/VBoxContainer/LevelChunks" instance=ExtResource( 5 )]
+[node name="Box1x2" parent="Palette/VBoxContainer/LevelChunks" instance=ExtResource( 5 )]
 margin_left = 228.0
 margin_top = 136.0
 margin_right = 300.0
 margin_bottom = 200.0
 script = ExtResource( 11 )
-box_size = Vector2( 3, 2 )
+box_size = Vector2( 1, 2 )
 
-[node name="Box3x3" parent="Palette/VBoxContainer/LevelChunks" instance=ExtResource( 5 )]
+[node name="Box2x1" parent="Palette/VBoxContainer/LevelChunks" instance=ExtResource( 5 )]
 margin_top = 204.0
 margin_right = 72.0
 margin_bottom = 268.0
 script = ExtResource( 11 )
+box_size = Vector2( 2, 1 )
 
-[node name="Box3x4" parent="Palette/VBoxContainer/LevelChunks" instance=ExtResource( 5 )]
+[node name="Box3x1" parent="Palette/VBoxContainer/LevelChunks" instance=ExtResource( 5 )]
 margin_left = 76.0
 margin_top = 204.0
 margin_right = 148.0
 margin_bottom = 268.0
 script = ExtResource( 11 )
-box_size = Vector2( 3, 4 )
+box_size = Vector2( 3, 1 )
 
-[node name="Box3x5" parent="Palette/VBoxContainer/LevelChunks" instance=ExtResource( 5 )]
+[node name="Box3x2" parent="Palette/VBoxContainer/LevelChunks" instance=ExtResource( 5 )]
 margin_left = 152.0
 margin_top = 204.0
 margin_right = 224.0
 margin_bottom = 268.0
 script = ExtResource( 11 )
-box_size = Vector2( 3, 5 )
+box_size = Vector2( 3, 2 )
 
-[node name="Pickup" type="Control" parent="Palette/VBoxContainer/LevelChunks"]
+[node name="Box3x3" parent="Palette/VBoxContainer/LevelChunks" instance=ExtResource( 5 )]
 margin_left = 228.0
 margin_top = 204.0
 margin_right = 300.0
 margin_bottom = 268.0
+script = ExtResource( 11 )
+
+[node name="Box3x4" parent="Palette/VBoxContainer/LevelChunks" instance=ExtResource( 5 )]
+margin_top = 272.0
+margin_right = 72.0
+margin_bottom = 336.0
+script = ExtResource( 11 )
+box_size = Vector2( 3, 4 )
+
+[node name="Box3x5" parent="Palette/VBoxContainer/LevelChunks" instance=ExtResource( 5 )]
+margin_left = 76.0
+margin_top = 272.0
+margin_right = 148.0
+margin_bottom = 336.0
+script = ExtResource( 11 )
+box_size = Vector2( 3, 5 )
+
+[node name="Pickup" type="Control" parent="Palette/VBoxContainer/LevelChunks"]
+margin_left = 152.0
+margin_top = 272.0
+margin_right = 224.0
+margin_bottom = 336.0
 script = ExtResource( 1 )
 
 [node name="Pickup" parent="Palette/VBoxContainer/LevelChunks/Pickup" instance=ExtResource( 6 )]

--- a/project/src/main/editor/puzzle/editor-json.gd
+++ b/project/src/main/editor/puzzle/editor-json.gd
@@ -67,6 +67,12 @@ func refresh_properties_editor() -> void:
 		_properties_editor.set_master_pickup_score(rank_rules.master_pickup_score)
 
 
+func reset_editors() -> void:
+	_playfield_editor.set_tiles_key("start")
+	refresh_playfield_editor()
+	refresh_properties_editor()
+
+
 """
 Refreshes our json text based on the tiles keys.
 

--- a/project/src/main/editor/puzzle/level-editor.gd
+++ b/project/src/main/editor/puzzle/level-editor.gd
@@ -20,8 +20,7 @@ onready var _level_json := $HBoxContainer/SideButtons/Json
 func _ready() -> void:
 	var level_text := FileUtils.get_file_as_text(LevelSettings.path_from_level_key(DEFAULT_LEVEL_ID))
 	_level_json.text = level_text
-	_level_json.refresh_playfield_editor()
-	_level_json.refresh_properties_editor()
+	_level_json.reset_editors()
 	level_id_label.text = DEFAULT_LEVEL_ID
 	Breadcrumb.connect("trail_popped", self, "_on_Breadcrumb_trail_popped")
 
@@ -34,8 +33,7 @@ func save_level(path: String) -> void:
 func load_level(path: String) -> void:
 	var level_text := FileUtils.get_file_as_text(path)
 	_level_json.text = level_text
-	_level_json.refresh_playfield_editor()
-	_level_json.refresh_properties_editor()
+	_level_json.reset_editors()
 	level_id_label.text = LevelSettings.level_key_from_path(path)
 
 

--- a/project/src/main/editor/puzzle/playfield-editor-control.gd
+++ b/project/src/main/editor/puzzle/playfield-editor-control.gd
@@ -17,7 +17,7 @@ signal pickups_changed
 # tiles keys which can be selected. 'start' is always the first item in this array
 var tiles_keys := ["start"] setget set_tiles_keys
 # the currently selected tiles key
-var tiles_key := "start"
+var tiles_key := "start" setget set_tiles_key
 
 onready var _playfield_nav := $PlayfieldNav
 
@@ -32,6 +32,14 @@ func set_tiles_keys(new_tiles_keys: Array) -> void:
 		return
 	
 	tiles_keys = new_normalized_tile_keys
+	emit_signal("tiles_keys_changed", tiles_keys, tiles_key)
+
+
+func set_tiles_key(new_tiles_key: String) -> void:
+	if tiles_key == new_tiles_key:
+		return
+	
+	tiles_key = new_tiles_key
 	emit_signal("tiles_keys_changed", tiles_keys, tiles_key)
 
 
@@ -115,8 +123,7 @@ func _on_PlayfieldNav_next_tiles_key_pressed() -> void:
 		push_error("Can't navigate to next tiles key (%s > %s)" % [new_tiles_key_index, tiles_keys.size() - 1])
 		return
 	
-	tiles_key = tiles_keys[new_tiles_key_index]
-	emit_signal("tiles_keys_changed", tiles_keys, tiles_key)
+	set_tiles_key(tiles_keys[new_tiles_key_index])
 
 
 """
@@ -130,5 +137,4 @@ func _on_PlayfieldNav_prev_tiles_key_pressed() -> void:
 		push_error("Can't navigate to previous tiles key (%s < 0)" % [new_tiles_key_index])
 		return
 	
-	tiles_key = tiles_keys[new_tiles_key_index]
-	emit_signal("tiles_keys_changed", tiles_keys, tiles_key)
+	set_tiles_key(tiles_keys[new_tiles_key_index])

--- a/project/src/main/editor/puzzle/properties-editor-control.gd
+++ b/project/src/main/editor/puzzle/properties-editor-control.gd
@@ -18,5 +18,5 @@ func set_master_pickup_score(new_master_pickup_score: int) -> void:
 	_line_edit.text = str(new_master_pickup_score)
 
 
-func _on_PickupsLineEdit_text_entered(new_text: String) -> void:
+func _on_PickupsLineEdit_text_entered(_new_text: String) -> void:
 	emit_signal("properties_changed")


### PR DESCRIPTION
The level editor could crash if you picked an alternate tiles key like
'0' and loaded another level. It now automatically loads the tiles key
'start' when loading a level.

Added small block chunks to level editor (1x2, 3x1, etc). These are
useful for decorating levels.