### PR TITLE
Removed instant das squish kludge, I don't like it.

### DIFF
--- a/project/src/main/puzzle/piece/piece-mover.gd
+++ b/project/src/main/puzzle/piece/piece-mover.gd
@@ -115,13 +115,6 @@ func apply_move_input(piece: ActivePiece) -> void:
 		input.set_left_das_active()
 	if input.is_right_pressed() and not piece.can_move_to(piece.pos + Vector2.RIGHT, piece.orientation):
 		input.set_right_das_active()
-	
-	# To prevent pieces from slipping past nooks after a squish move, we automatically trigger DAS if a movement key
-	# is pressed after a squish move.
-	if input.is_left_pressed() and piece.remaining_post_squish_frames > 0:
-		input.set_left_das_active()
-	if input.is_right_pressed() and piece.remaining_post_squish_frames > 0:
-		input.set_right_das_active()
 
 
 """


### PR DESCRIPTION
This kludge was introduced in 69672802 to prevent pieces from slipping past
nooks during squish moves. I can't remember the exact circumstances where this
was frustrating, but activating DAS results in weird piece handling at times.
Performing a squish move and moving the piece into an open area makes the piece
suddenly zip across the playfield. If this 'slipping past nooks' issue is a
consistent problem we need a more specific fix for it -- perhaps something that
only activates for a frame, only activates at 20G, or something like that.