### PR TITLE
Fixed save corruption bug with pickups. Vee kick tests.

### DIFF
--- a/project/src/main/puzzle/rank-calculator.gd
+++ b/project/src/main/puzzle/rank-calculator.gd
@@ -362,6 +362,9 @@ func _apply_top_out_penalty(rank_result: RankResult) -> void:
 """
 Clamps the player's ranks within [0, 999] to avoid edge cases.
 
+Most importantly, this patches up cases where we've previously divided by zero or calculated the natural log of zero.
+Serializing an infinite/undefined float into JSON corrupts the player's save file.
+
 The player cannot achieve a master rank if the lenient flag is set.
 """
 func _clamp_result(rank_result: RankResult, lenient: bool) -> void:
@@ -374,6 +377,7 @@ func _clamp_result(rank_result: RankResult, lenient: bool) -> void:
 	rank_result.combo_score_per_line_rank = clamp(rank_result.combo_score_per_line_rank, min_rank, max_rank)
 	rank_result.score_rank = clamp(rank_result.score_rank, min_rank, max_rank)
 	rank_result.seconds_rank = clamp(rank_result.seconds_rank, min_rank, max_rank)
+	rank_result.pickup_score_rank = clamp(rank_result.pickup_score_rank, min_rank, max_rank)
 
 
 """

--- a/project/src/test/puzzle/piece/test-piece-kicks-jl.gd
+++ b/project/src/test/puzzle/piece/test-piece-kicks-jl.gd
@@ -231,6 +231,27 @@ func test_j_vee_kick0() -> void:
 	assert_kick()
 
 
+"""
+It would be nice if this kick worked, but it conflicts with the wall kicks and snack kicks.
+"""
+func test_j_vee_kick0_failed() -> void:
+	from_grid = [
+		"   ::",
+		"   : ",
+		"  j: ",
+		"  jjj",
+		"   ::",
+	]
+	to_grid = [
+		"   ::",
+		"   : ",
+		"  j: ",
+		"  j  ",
+		" jj::",
+	]
+	assert_kick()
+
+
 func test_j_vee_kick1() -> void:
 	from_grid = [
 		"     ",
@@ -291,6 +312,27 @@ func test_l_vee_kick_cw0() -> void:
 		"l:   ",
 		"l:   ",
 		"ll   ",
+	]
+	assert_kick()
+
+
+"""
+It would be nice if this kick worked, but it conflicts with the wall kicks and snack kicks.
+"""
+func test_l_vee_kick_cw0_failed() -> void:
+	from_grid = [
+		"::   ",
+		" :   ",
+		" :l  ",
+		"lll  ",
+		"::   ",
+	]
+	to_grid = [
+		"::   ",
+		" :   ",
+		" :l  ",
+		"  l  ",
+		"::ll ",
 	]
 	assert_kick()
 
@@ -491,7 +533,7 @@ func test_l_gold_kick3() -> void:
 
 
 """
-A 'gold kick' is when a J/L piece hooks its short end into a small gap from far away.
+A 'golder kick' is when a J/L piece hooks its short end into a small gap from far away.
 """
 func test_j_golder_kick() -> void:
 	from_grid = [

--- a/project/src/test/puzzle/test-rank-calculator.gd
+++ b/project/src/test/puzzle/test-rank-calculator.gd
@@ -417,3 +417,18 @@ func test_master_pickup_score_per_line() -> void:
 	CurrentLevel.settings.rank.master_pickup_score_per_line = 20
 	var rank2 := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank2.pickup_score_rank), "S-")
+
+
+func test_avoid_infinite_ranks() -> void:
+	PuzzleState.level_performance.lines = 0
+	PuzzleState.level_performance.pickup_score = 0
+	
+	CurrentLevel.settings.rank.master_pickup_score_per_line = 0
+	CurrentLevel.settings.rank.master_pickup_score = 10
+	var rank1 := _rank_calculator.calculate_rank()
+	assert_eq(rank1.pickup_score_rank, 999.0)
+	
+	CurrentLevel.settings.rank.master_pickup_score = 0
+	CurrentLevel.settings.rank.master_pickup_score_per_line = 10
+	var rank2 := _rank_calculator.calculate_rank()
+	assert_eq(rank2.pickup_score_rank, 999.0)


### PR DESCRIPTION
Fixed bug where rank calculator calculated a value of '1#INF' which got
converted to JSON, but couldn't be converted back from JSON. This
occurred when calculating the log of zero. The rank calculator now
clamps the resulting rank to a value of 999.

Added tests for vee kicks which I want to implement -- but which
conflict with wall kicks and snack kicks.