### PR TITLE
Top out layering bug. Pickups revert on restart.

### DIFF
--- a/project/src/main/puzzle/pickups.gd
+++ b/project/src/main/puzzle/pickups.gd
@@ -118,6 +118,8 @@ func _prepare_pickups_for_level() -> void:
 		remove_pickup(cell)
 	for cell in pickups_to_add:
 		set_pickup(cell, src_pickups[cell])
+	for cell in _pickups_by_cell:
+		_pickups_by_cell[cell].food_shown = false
 
 
 """
@@ -207,6 +209,10 @@ func _play_collect_sfx() -> void:
 	_pickup_sfx_index += 1
 	if _remaining_pickup_sfx > 0:
 		_pickup_sfx_timer.start()
+
+
+func _pickup_type() -> int:
+	return CurrentLevel.settings.blocks_during.pickup_type
 
 
 func _on_PuzzleState_game_prepared() -> void:
@@ -318,10 +324,6 @@ func _on_Playfield_line_inserted(y: int, tiles_key: String, src_y: int) -> void:
 				continue
 			var box_type: int = block_bunch.pickups[src_pos]
 			set_pickup(Vector2(x, y), box_type)
-
-
-func _pickup_type() -> int:
-	return CurrentLevel.settings.blocks_during.pickup_type
 
 
 func _on_PickupSfxTimer_timeout() -> void:

--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -39,6 +39,12 @@ signal lock_started
 
 signal tiles_changed(tile_map)
 
+# the z index the piece manager's tilemap defaults to
+const TILE_MAP_DEFAULT_Z_INDEX := 3
+
+# the z index the piece manager's tilemap switches to temporarily when topping out
+const TILE_MAP_TOP_OUT_Z_INDEX := 4
+
 export (NodePath) var playfield_path: NodePath
 export (NodePath) var piece_queue_path: NodePath
 
@@ -223,7 +229,13 @@ func _on_Level_settings_changed() -> void:
 	_prepare_tileset()
 
 
-func _on_States_entered_state(state: State) -> void:
+func _on_States_entered_state(prev_state: State, state: State) -> void:
+	# when topping out, the piece temporarily moves in front of other playfield elements
+	if state in [_states.top_out, _states.game_ended]:
+		tile_map.z_index = TILE_MAP_TOP_OUT_Z_INDEX
+	elif prev_state in [_states.top_out, _states.game_ended]:
+		tile_map.z_index = TILE_MAP_DEFAULT_Z_INDEX
+	
 	if state == _states.prelock:
 		emit_signal("lock_started")
 

--- a/project/src/main/state-machine.gd
+++ b/project/src/main/state-machine.gd
@@ -8,7 +8,7 @@ invoking their methods, and emitting signals.
 """
 
 # emitted once when a state is entered
-signal entered_state(state)
+signal entered_state(prev_state, state)
 
 # the currently active state
 var _state: State
@@ -38,11 +38,12 @@ Transitions to a new state.
 Resets the state's internal variables and notifies any listeners.
 """
 func set_state(new_state: State) -> void:
+	var prev_state := _state
 	var prev_state_name := "" if _state == null else _state.name
 	_state = new_state
 	_state.frames = 0
 	_state.enter(_host, prev_state_name)
-	emit_signal("entered_state", _state)
+	emit_signal("entered_state", prev_state, _state)
 
 
 func get_state() -> State:


### PR DESCRIPTION
When topping out, the player's piece was no longer visible. This was caused by
the pickup layering changes in 54710bc3

Pickups revert from their 'food form' to their 'seed form' when
restarting a level.