### PR TITLE
Fixed 'piece_start_t' typo in levels

### DIFF
--- a/project/assets/main/puzzle/levels/marsh/pulling-for-bones.json
+++ b/project/assets/main/puzzle/levels/marsh/pulling-for-bones.json
@@ -8,7 +8,7 @@
     "value": "120"
   },
   "piece_types": [
-    "piece_start_t",
+    "start_piece_t",
     "piece_j",
     "piece_l",
     "piece_o",

--- a/project/assets/main/puzzle/levels/placeholder06.json
+++ b/project/assets/main/puzzle/levels/placeholder06.json
@@ -8,7 +8,7 @@
     "value": "120"
   },
   "piece_types": [
-    "piece_start_t",
+    "start_piece_t",
     "piece_j",
     "piece_l",
     "piece_o",

--- a/project/src/main/puzzle/level/piece-type-rules.gd
+++ b/project/src/main/puzzle/level/piece-type-rules.gd
@@ -33,3 +33,5 @@ func from_json_string_array(json: Array) -> void:
 		elif json_string.begins_with("start_") \
 				and types_by_json_string.has(json_string.trim_prefix("start_")):
 			start_types.append(types_by_json_string[json_string.trim_prefix("start_")])
+		else:
+			push_warning("Unrecognized: %s" % [json_string])


### PR DESCRIPTION
Some levels defined a 'piece_start_t' property instead of
'start_piece_t'. I've fixed the levels and changed piece-type-rules to
report these typos.