### PR TITLE
Rules refactoring: json_array, 'an dictionary', reordering

### DIFF
--- a/project/src/main/editor/puzzle/editor-json.gd
+++ b/project/src/main/editor/puzzle/editor-json.gd
@@ -63,7 +63,7 @@ func refresh_properties_editor() -> void:
 	
 	if _json_tree.has("rank"):
 		var rank_rules := RankRules.new()
-		rank_rules.from_json_string_array(_json_tree["rank"])
+		rank_rules.from_json_array(_json_tree["rank"])
 		_properties_editor.set_master_pickup_score(rank_rules.master_pickup_score)
 
 
@@ -200,7 +200,7 @@ func _update_properties_master_pickup_score_with_calculated_value() -> void:
 	
 	if _json_tree.has("score"):
 		_score_rules = ScoreRules.new()
-		_score_rules.from_json_string_array(_json_tree["score"])
+		_score_rules.from_json_array(_json_tree["score"])
 	
 	# parse json data
 	var json_tiles_set: Array = _json_tree.get("tiles", {}).get("start", [])

--- a/project/src/main/puzzle/input-replay.gd
+++ b/project/src/main/puzzle/input-replay.gd
@@ -65,6 +65,6 @@ func is_action_held(action: String) -> bool:
 	return _pressed_actions.get(action, false)
 
 
-func from_json_string_array(json: Array) -> void:
+func from_json_array(json: Array) -> void:
 	for json_obj in json:
 		_action_timings[json_obj] = true

--- a/project/src/main/puzzle/level/blocks-during-rules.gd
+++ b/project/src/main/puzzle/level/blocks-during-rules.gd
@@ -43,7 +43,7 @@ var pickup_type: int = PickupType.DEFAULT
 # whether inserted rows should start from a random row in the source tiles instead of starting from the top
 var random_tiles_start: bool = false
 
-func from_json_string_array(json: Array) -> void:
+func from_json_array(json: Array) -> void:
 	var rules := RuleParser.new(json)
 	if rules.has("clear_on_top_out"): clear_on_top_out = true
 	if rules.has("line_clear_type"):

--- a/project/src/main/puzzle/level/combo-break-rules.gd
+++ b/project/src/main/puzzle/level/combo-break-rules.gd
@@ -12,7 +12,7 @@ var pieces := 2
 # 'true' if clearing a vegetable row (a row with no snack/cake blocks) breaks their combo
 var veg_row := false
 
-func from_json_string_array(json: Array) -> void:
+func from_json_array(json: Array) -> void:
 	var rules := RuleParser.new(json)
 	if rules.has("pieces"): pieces = rules.int_value()
 	if rules.has("veg_row"): veg_row = true

--- a/project/src/main/puzzle/level/level-settings.gd
+++ b/project/src/main/puzzle/level/level-settings.gd
@@ -6,8 +6,21 @@ This includes information about how the player loses/wins, what kind of pieces t
 time limit, and any other special rules.
 """
 
-# Sets of blocks which are shown initially, or appear during the game
-var tiles := LevelTiles.new()
+# The level id used for saving/loading data.
+var id := ""
+
+# The level title shown in menus.
+var title := ""
+
+# The level description shown when selecting a level.
+var description := ""
+
+# (optional) The level difficulty shown when selecting a level.
+var difficulty := "" setget ,get_difficulty
+
+# Array of Milestone objects representing the requirements to speed up. This mostly applies to 'Marathon Mode' where
+# clearing lines makes you speed up.
+var speed_ups := []
 
 # Blocks/boxes which appear or disappear while the game is going on.
 var blocks_during := BlocksDuringRules.new()
@@ -22,30 +35,9 @@ var finish_condition := Milestone.new()
 # Sequence of puzzle inputs to be replayed for things such as tutorials.
 var input_replay := InputReplay.new()
 
-var timers := LevelTimers.new()
-
-# Triggers which cause strange things to happen during a level.
-var triggers := LevelTriggers.new()
-
-# Array of Milestone objects representing the requirements to speed up. This mostly applies to 'Marathon Mode' where
-# clearing lines makes you speed up.
-var speed_ups := []
-
 # How the player loses. The player usually loses if they top out a certain number of times, but some levels might
 # have different rules.
 var lose_condition := LoseConditionRules.new()
-
-# The level id used for saving/loading data.
-var id := ""
-
-# The level title shown in menus.
-var title := ""
-
-# The level description shown when selecting a level.
-var description := ""
-
-# (optional) The level difficulty shown when selecting a level.
-var difficulty := "" setget ,get_difficulty
 
 # Rules which are unique enough that it doesn't make sense to put them in their own groups.
 var other := OtherRules.new()
@@ -63,6 +55,15 @@ var score := ScoreRules.new()
 # accomplishments such as surviving 10 minutes or getting 1,000 points.
 var success_condition := Milestone.new()
 
+# Sets of blocks which are shown initially, or appear during the game.
+var tiles := LevelTiles.new()
+
+# Timers which cause strange things to happen during a level.
+var timers := LevelTimers.new()
+
+# Triggers which cause strange things to happen during a level.
+var triggers := LevelTriggers.new()
+
 var _upgrader := LevelSettingsUpgrader.new()
 
 func _init() -> void:
@@ -72,6 +73,13 @@ func _init() -> void:
 
 """
 Adds criteria for speeding up, such as a time, score, or line limit.
+
+Parameters:
+	'type': an enum from Milestone.MilestoneType describing the milestone criteria (lines, score, time)
+	
+	'value': an value describing the milestone criteria (number of lines, points, seconds)
+	
+	'speed_id': a string from PieceSpeeds defining the new speed
 """
 func add_speed_up(type: int, value: int, speed_id: String) -> void:
 	var speed_up := Milestone.new()
@@ -119,32 +127,32 @@ func from_json_dict(new_id: String, json: Dictionary) -> void:
 	description = json.get("description", "")
 	difficulty = json.get("difficulty", "")
 	set_start_speed(json.get("start_speed", "0"))
-
-	if json.has("blocks_during"):
-		blocks_during.from_json_string_array(json["blocks_during"])
-	if json.has("combo_break"):
-		combo_break.from_json_string_array(json["combo_break"])
-	if json.has("finish_condition"):
-		finish_condition.from_json_dict(json["finish_condition"])
 	if json.has("speed_ups"):
 		for json_speed_up in json["speed_ups"]:
 			var speed_up := Milestone.new()
 			speed_up.from_json_dict(json_speed_up)
 			speed_ups.append(speed_up)
+	
+	if json.has("blocks_during"):
+		blocks_during.from_json_array(json["blocks_during"])
+	if json.has("combo_break"):
+		combo_break.from_json_array(json["combo_break"])
+	if json.has("finish_condition"):
+		finish_condition.from_json_dict(json["finish_condition"])
+	if json.has("input_replay"):
+		input_replay.from_json_array(json["input_replay"])
 	if json.has("lose_condition"):
-		lose_condition.from_json_string_array(json["lose_condition"])
+		lose_condition.from_json_array(json["lose_condition"])
 	if json.has("other"):
-		other.from_json_string_array(json["other"])
+		other.from_json_array(json["other"])
 	if json.has("piece_types"):
-		piece_types.from_json_string_array(json["piece_types"])
+		piece_types.from_json_array(json["piece_types"])
 	if json.has("rank"):
-		rank.from_json_string_array(json["rank"])
+		rank.from_json_array(json["rank"])
 	if json.has("score"):
-		score.from_json_string_array(json["score"])
+		score.from_json_array(json["score"])
 	if json.has("success_condition"):
 		success_condition.from_json_dict(json["success_condition"])
-	if json.has("input_replay"):
-		input_replay.from_json_string_array(json["input_replay"])
 	if json.has("tiles"):
 		tiles.from_json_dict(json["tiles"])
 	if json.has("timers"):

--- a/project/src/main/puzzle/level/level-trigger-effect.gd
+++ b/project/src/main/puzzle/level/level-trigger-effect.gd
@@ -16,7 +16,7 @@ func run() -> void:
 Populates this level trigger with the specified string parameters.
 
 Parameters:
-	'new_config': An dictionary of string parameters parsed from json. For example, a level trigger effect which
+	'new_config': A dictionary of string parameters parsed from json. For example, a level trigger effect which
 		rotates the piece could pass in parameters specifying the direction to rotate.
 """
 func set_config(_new_config: Dictionary = {}) -> void:

--- a/project/src/main/puzzle/level/level-trigger-effects.gd
+++ b/project/src/main/puzzle/level/level-trigger-effects.gd
@@ -14,7 +14,7 @@ class RotateNextPiecesEffect extends LevelTriggerEffect:
 	}
 	
 	# an enum in Rotation corresponding to the direction to rotate
-	var rotate_dir: int
+	var rotate_dir: int = Rotation.NONE
 	
 	# The first piece index in the queue to rotate, inclusive
 	var next_piece_from_index: int = 0

--- a/project/src/main/puzzle/level/level-trigger.gd
+++ b/project/src/main/puzzle/level/level-trigger.gd
@@ -78,15 +78,17 @@ func run() -> void:
 
 
 func from_json_dict(json: Dictionary) -> void:
+	# parse the phases from json
 	for phase_expression in json.get("phases", []):
 		var phase_expression_split: Array = phase_expression.split(" ")
 		var phase_key: String = phase_expression_split[0]
-		var phase_config: Dictionary = dict_config(phase_expression_split.slice(1, phase_expression_split.size()))
+		var phase_config: Dictionary = dict_config_from_array(phase_expression_split.slice(1, phase_expression_split.size()))
 		_add_phase(phase_key, phase_config)
 	
+	# parse the effect from json
 	var effect_split: Array = json.get("effect").split(" ")
 	var effect_key: String = effect_split[0]
-	var effect_config: Dictionary = dict_config(effect_split.slice(1, effect_split.size()))
+	var effect_config: Dictionary = dict_config_from_array(effect_split.slice(1, effect_split.size()))
 	effect = LevelTriggerEffects.create(effect_key, effect_config)
 
 
@@ -96,10 +98,10 @@ Enables this trigger for the specified phase.
 Parameters:
 	'phase_key': A string key corresponding to the phase, such as 'after_line_cleared'.
 	
-	'phase_config': An array of strings defining any special conditions for the phase.
+	'phase_config': A dictionary of strings defining any special conditions for the phase.
 """
 func _add_phase(phase_key: String, phase_config: Dictionary) -> void:
-	if not PHASE_INTS_BY_STRING.has(phase_key):
+	if not LevelTriggerPhase.has(phase_key.to_upper()):
 		push_warning("Unrecognized phase: %s" % [phase_key])
 	var phase_condition: PhaseCondition = PhaseConditions.create(phase_key, phase_config)
 	var phase: int = PHASE_INTS_BY_STRING[phase_key]
@@ -119,9 +121,9 @@ Parameters:
 	'param_array': An array of configuration strings.
 
 Returns:
-	A dictionary of configuration strings organized into key/value pairs.
+	A dictionary of configuration strings organized as key/value pairs.
 """
-static func dict_config(param_array: Array) -> Dictionary:
+static func dict_config_from_array(param_array: Array) -> Dictionary:
 	var result := {}
 	var param_index := 0
 	for param in param_array:

--- a/project/src/main/puzzle/level/lose-condition-rules.gd
+++ b/project/src/main/puzzle/level/lose-condition-rules.gd
@@ -10,7 +10,7 @@ var finish_on_lose := false
 # by default, the player loses if they top out three times
 var top_out := 3
 
-func from_json_string_array(json: Array) -> void:
+func from_json_array(json: Array) -> void:
 	var rules := RuleParser.new(json)
 	if rules.has("finish_on_lose"): finish_on_lose = true
 	if rules.has("top_out"): top_out = rules.int_value()

--- a/project/src/main/puzzle/level/milestone.gd
+++ b/project/src/main/puzzle/level/milestone.gd
@@ -35,11 +35,20 @@ const JSON_MILESTONE_TYPES := {
 	"time_under": MilestoneType.TIME_UNDER,
 }
 
-# These two parameters describe a MilestoneType and value to reach, such as scoring 50 points, clearing 10 lines
-# or surviving for 30 seconds.
-var type: int
-var value: int
+# an enum from Milestone.MilestoneType describing the milestone criteria (lines, score, time)
+var type: int = MilestoneType.NONE
 
+# an value describing the milestone criteria (number of lines, points, seconds)
+var value := 0
+
+"""
+Initializes the milestone with a MilestoneType and value to reach, such as scoring 50 points or clearing 10 lines.
+
+Parameters:
+	'new_type': an enum from Milestone.MilestoneType describing the milestone criteria (lines, score, time)
+	
+	'new_value': an value describing the milestone criteria (number of lines, points, seconds)
+"""
 func set_milestone(new_type: int, new_value: int) -> void:
 	type = new_type
 	value = new_value

--- a/project/src/main/puzzle/level/other-rules.gd
+++ b/project/src/main/puzzle/level/other-rules.gd
@@ -39,7 +39,7 @@ var tile_set: int = PuzzleTileMap.TileSetType.DEFAULT
 # 'true' for tutorial levels which are led by Turbo
 var tutorial := false
 
-func from_json_string_array(json: Array) -> void:
+func from_json_array(json: Array) -> void:
 	var rules := RuleParser.new(json)
 	if rules.has("after_tutorial"): after_tutorial = true
 	if rules.has("enhance_combo_fx"): enhance_combo_fx = true

--- a/project/src/main/puzzle/level/phase-condition.gd
+++ b/project/src/main/puzzle/level/phase-condition.gd
@@ -21,6 +21,19 @@ func _init(_phase_config: Dictionary) -> void:
 
 
 """
+Extracts a set of phase configuration strings from this phase condition.
+
+This performs the inverse of the configuration part of the _init() function, extracting values from the phase
+condition's properties and using them to populate a dictionary.
+
+Returns:
+	A set of phase configuration strings defining criteria for this phase condition.
+"""
+func get_phase_config() -> Dictionary:
+	return {}
+
+
+"""
 Can be overridden to return 'true' if a trigger should run during this phase.
 
 The default implementation always returns true, but subclasses can override this behavior.

--- a/project/src/main/puzzle/level/piece-type-rules.gd
+++ b/project/src/main/puzzle/level/piece-type-rules.gd
@@ -4,7 +4,7 @@ Pieces the player is given.
 """
 
 # if 'true', the start pieces always appear in the same order instead of being shuffled.
-var ordered_start: bool = false
+var ordered_start := false
 
 # pieces to prepend to the piece queue before a game begins. these pieces are shuffled
 var start_types := []
@@ -12,7 +12,7 @@ var start_types := []
 # piece types to choose from. if empty, reverts to the default 8 types (jlopqtuv)
 var types := []
 
-func from_json_string_array(json: Array) -> void:
+func from_json_array(json: Array) -> void:
 	var types_by_json_string := {
 		"piece_j": PieceTypes.piece_j,
 		"piece_l": PieceTypes.piece_l,

--- a/project/src/main/puzzle/level/rank-rules.gd
+++ b/project/src/main/puzzle/level/rank-rules.gd
@@ -40,7 +40,7 @@ var show_pieces_rank: int = ShowRank.DEFAULT
 var show_speed_rank: int = ShowRank.DEFAULT
 
 # 'true' if the results screen should be skipped. Used for tutorials.
-var skip_results: bool
+var skip_results := false
 
 # Bonus rank given if the player achieves the level's success condition. Useful when designing levels where
 # achieving a target score of 1,000 is an A grade, but failing with a score of 999 is also an A grade. This property
@@ -51,9 +51,9 @@ var success_bonus := 0.0
 var top_out_penalty := 4
 
 # If 'true' the player is not given a rank for this level.
-var unranked: bool = false
+var unranked := false
 
-func from_json_string_array(json: Array) -> void:
+func from_json_array(json: Array) -> void:
 	var rules := RuleParser.new(json)
 	if rules.has("box_factor"): box_factor = rules.float_value()
 	if rules.has("combo_factor"): combo_factor = rules.float_value()

--- a/project/src/main/puzzle/level/score-rules.gd
+++ b/project/src/main/puzzle/level/score-rules.gd
@@ -21,7 +21,7 @@ var snack_pickup_points := 10
 # box points awarded for clearing a row with no boxes, a vegetable row.
 var veg_points := 0
 
-func from_json_string_array(json: Array) -> void:
+func from_json_array(json: Array) -> void:
 	var rules := RuleParser.new(json)
 	if rules.has("cake_all"): cake_points = rules.int_value()
 	if rules.has("snack_all"): snack_points = rules.int_value()


### PR DESCRIPTION
Changed 'from_json_string_array' methods to 'from_json_array'.
'from_json_string_array' is more informative, but we don't provide similar
granularity for other json methods. We don't have a 'from_json_dict_array'
method for LevelTriggers, or a 'from_json_string_to_string_dict' methods in a
number of places. The main reason for not calling it something super simple like
'from_json' is to clarify that this is a json object, and not a string of json
text.

Fixed 'an dictionary' typo.

Reordered LevelSettings fields. Grouped up and alphabetized 'rules
fields' together. Simpler fields like the id/title/description are up
top.

Changed some rules properties to use explicit defaults. This seems
especially helpful for enum fields like 'Milestone.type'.