### PR TITLE
LevelSettings can be written as json.

### DIFF
--- a/project/src/main/puzzle/input-replay.gd
+++ b/project/src/main/puzzle/input-replay.gd
@@ -11,13 +11,13 @@ var _pressed_actions: Dictionary
 # set of frames when different actions are pressed/released
 # key: action key containing the frame number and action, '46 +ui_right'
 # value: true
-var _action_timings: Dictionary
+var action_timings: Dictionary
 
 """
 Returns true if there is no replay data.
 """
 func empty() -> bool:
-	return _action_timings.empty()
+	return action_timings.empty()
 
 
 """
@@ -25,7 +25,7 @@ Clears the replay data, removing all action timings.
 """
 func clear() -> void:
 	_pressed_actions.clear()
-	_action_timings.clear()
+	action_timings.clear()
 
 
 """
@@ -35,7 +35,7 @@ This only true for the exact frame when the press is first triggered.
 """
 func is_action_pressed(action: String) -> bool:
 	var action_frame_key := "%s +%s" % [PuzzleState.input_frame, action]
-	var pressed := _action_timings.has(action_frame_key)
+	var pressed := action_timings.has(action_frame_key)
 	if pressed:
 		_pressed_actions[action] = true
 	return pressed
@@ -48,7 +48,7 @@ This only true for the exact frame when the release is first triggered.
 """
 func is_action_released(action: String) -> bool:
 	var action_frame_key := "%s -%s" % [PuzzleState.input_frame, action]
-	var released := _action_timings.has(action_frame_key)
+	var released := action_timings.has(action_frame_key)
 	if released:
 		_pressed_actions[action] = false
 	return released
@@ -67,4 +67,17 @@ func is_action_held(action: String) -> bool:
 
 func from_json_array(json: Array) -> void:
 	for json_obj in json:
-		_action_timings[json_obj] = true
+		action_timings[json_obj] = true
+
+
+func to_json_array() -> Array:
+	return action_timings.keys()
+
+
+"""
+Returns 'true' if the input replay is empty. Empty replays are omitted from our json output.
+
+Note: This method is called 'is_default' for consistency with other similar methods related to LevelSettings.
+"""
+func is_default() -> bool:
+	return action_timings.empty()

--- a/project/src/main/puzzle/level/blocks-during-rules.gd
+++ b/project/src/main/puzzle/level/blocks-during-rules.gd
@@ -43,17 +43,23 @@ var pickup_type: int = PickupType.DEFAULT
 # whether inserted rows should start from a random row in the source tiles instead of starting from the top
 var random_tiles_start: bool = false
 
+var _rule_parser: RuleParser
+
+func _init() -> void:
+	_rule_parser = RuleParser.new(self)
+	_rule_parser.add_bool("clear_on_top_out")
+	_rule_parser.add_enum("line_clear_type", LineClearType)
+	_rule_parser.add_enum("pickup_type", PickupType)
+	_rule_parser.add_bool("random_tiles_start")
+
+
 func from_json_array(json: Array) -> void:
-	var rules := RuleParser.new(json)
-	if rules.has("clear_on_top_out"): clear_on_top_out = true
-	if rules.has("line_clear_type"):
-		if not LINE_CLEAR_TYPES_BY_NAME.has(rules.string_value()):
-			push_warning("Unrecognized line_clear_type: %s" % [rules.string_value()])
-		else:
-			line_clear_type = LINE_CLEAR_TYPES_BY_NAME[rules.string_value()]
-	if rules.has("pickup_type"):
-		if not PICKUP_TYPES_BY_NAME.has(rules.string_value()):
-			push_warning("Unrecognized pickup_type: %s" % [rules.string_value()])
-		else:
-			pickup_type = PICKUP_TYPES_BY_NAME[rules.string_value()]
-	if rules.has("random_tiles_start"): random_tiles_start = true
+	_rule_parser.from_json_array(json)
+
+
+func to_json_array() -> Array:
+	return _rule_parser.to_json_array()
+
+
+func is_default() -> bool:
+	return _rule_parser.is_default()

--- a/project/src/main/puzzle/level/combo-break-rules.gd
+++ b/project/src/main/puzzle/level/combo-break-rules.gd
@@ -12,7 +12,21 @@ var pieces := 2
 # 'true' if clearing a vegetable row (a row with no snack/cake blocks) breaks their combo
 var veg_row := false
 
+var _rule_parser: RuleParser
+
+func _init() -> void:
+	_rule_parser = RuleParser.new(self)
+	_rule_parser.add_int("pieces").default(2)
+	_rule_parser.add_bool("veg_row")
+
+
 func from_json_array(json: Array) -> void:
-	var rules := RuleParser.new(json)
-	if rules.has("pieces"): pieces = rules.int_value()
-	if rules.has("veg_row"): veg_row = true
+	_rule_parser.from_json_array(json)
+
+
+func to_json_array() -> Array:
+	return _rule_parser.to_json_array()
+
+
+func is_default() -> bool:
+	return _rule_parser.is_default()

--- a/project/src/main/puzzle/level/level-settings.gd
+++ b/project/src/main/puzzle/level/level-settings.gd
@@ -161,6 +161,36 @@ func from_json_dict(new_id: String, json: Dictionary) -> void:
 		triggers.from_json_array(json["triggers"])
 
 
+func to_json_dict() -> Dictionary:
+	var result := {}
+	if title: result["title"] = title
+	if description: result["description"] = description
+	if difficulty: result["difficulty"] = difficulty
+	if speed_ups:
+		var json_speed_ups := []
+		for speed_up_obj in speed_ups:
+			var speed_up: Milestone = speed_up_obj
+			if not result.has("start_speed") and speed_up.type == Milestone.LINES and speed_up.value == 0:
+				result["start_speed"] = speed_up.get_meta("speed")
+			else:
+				json_speed_ups.append(speed_up.to_json_dict())
+		if json_speed_ups: result["speed_ups"] = json_speed_ups
+	if not blocks_during.is_default(): result["blocks_during"] = blocks_during.to_json_array()
+	if not combo_break.is_default(): result["combo_break"] = combo_break.to_json_array()
+	if not finish_condition.is_default(): result["finish_condition"] = finish_condition.to_json_dict()
+	if not input_replay.is_default(): result["input_replay"] = input_replay.to_json_array()
+	if not lose_condition.is_default(): result["lose_condition"] = lose_condition.to_json_array()
+	if not other.is_default(): result["other"] = other.to_json_array()
+	if not piece_types.is_default(): result["piece_types"] = piece_types.to_json_array()
+	if not rank.is_default(): result["rank"] = rank.to_json_array()
+	if not score.is_default(): result["score"] = score.to_json_array()
+	if not success_condition.is_default(): result["success_condition"] = success_condition.to_json_dict()
+	if not tiles.is_default(): result["tiles"] = tiles.to_json_dict()
+	if not timers.is_default(): result["timers"] = timers.to_json_array()
+	if not triggers.is_default(): result["triggers"] = triggers.to_json_array()
+	return result
+
+
 func load_from_resource(new_id: String) -> void:
 	load_from_text(new_id, FileUtils.get_file_as_text(path_from_level_key(new_id)))
 

--- a/project/src/main/puzzle/level/level-tiles.gd
+++ b/project/src/main/puzzle/level/level-tiles.gd
@@ -46,6 +46,7 @@ class BlockBunch:
 	func set_pickup(pos: Vector2, box_type: int) -> void:
 		pickups[pos] = box_type
 
+
 # key: a tiles key for tiles referenced by level rules, or the string 'start' for the initial set of tiles
 # value: a BlockBunch instance
 var bunches: Dictionary = {}
@@ -55,6 +56,35 @@ func from_json_dict(json: Dictionary) -> void:
 		var bunch := BlockBunch.new()
 		PuzzleTileMapReader.read(json[tiles_key], funcref(bunch, "set_block"), funcref(bunch, "set_pickup"))
 		bunches[tiles_key] = bunch
+
+
+func to_json_dict() -> Dictionary:
+	var result := {}
+	for tiles_key in bunches.keys():
+		var bunch: BlockBunch = bunches[tiles_key]
+		result[tiles_key] = []
+		var used_cells := {}
+		for block_cell in bunch.block_tiles:
+			used_cells[block_cell] = true
+		for pickup_cell in bunch.pickups:
+			used_cells[pickup_cell] = true
+		for used_cell in used_cells:
+			var json_tile := {
+				"pos": "%s %s" % [used_cell.x, used_cell.y]
+			}
+			if bunch.block_tiles.has(used_cell):
+				var tile_index: int = bunch.block_tiles[used_cell]
+				var autotile_coord: Vector2 = bunch.block_autotile_coords[used_cell]
+				json_tile["tile"] = "%s %s %s" % [tile_index, autotile_coord.x, autotile_coord.y]
+			if bunch.pickups.has(used_cell):
+				var pickup_index: int = bunch.pickups[used_cell]
+				json_tile["pickup"] = "%s" % [pickup_index]
+			result[tiles_key].append(json_tile)
+	return result
+
+
+func is_default() -> bool:
+	return bunches.empty()
 
 
 """

--- a/project/src/main/puzzle/level/level-timers.gd
+++ b/project/src/main/puzzle/level/level-timers.gd
@@ -26,3 +26,11 @@ func get_timer_count() -> int:
 
 func from_json_array(timers_json: Array) -> void:
 	timers = timers_json
+
+
+func to_json_array() -> Array:
+	return timers
+
+
+func is_default() -> bool:
+	return timers.empty()

--- a/project/src/main/puzzle/level/level-trigger-effect.gd
+++ b/project/src/main/puzzle/level/level-trigger-effect.gd
@@ -21,3 +21,17 @@ Parameters:
 """
 func set_config(_new_config: Dictionary = {}) -> void:
 	pass
+
+
+"""
+Extracts a dictionary of string parameters from this level trigger.
+
+This performs the inverse of the 'set_config' function, extracting values from the trigger's properties and using them
+to populate a dictionary.
+
+Returns:
+	A dictionary of string parameters parsed from json. For example, a level trigger effect which rotates the piece
+		could pass in parameters specifying the direction to rotate.
+"""
+func get_config() -> Dictionary:
+	return {}

--- a/project/src/main/puzzle/level/level-trigger-effects.gd
+++ b/project/src/main/puzzle/level/level-trigger-effects.gd
@@ -61,6 +61,23 @@ class RotateNextPiecesEffect extends LevelTriggerEffect:
 				Rotation.CW: next_piece.orientation = next_piece.get_cw_orientation()
 				Rotation.CCW: next_piece.orientation = next_piece.get_ccw_orientation()
 				Rotation.FLIP: next_piece.orientation = next_piece.get_flip_orientation()
+	
+	
+	func get_config() -> Dictionary:
+		var result := {}
+		match rotate_dir:
+			Rotation.NONE: result["0"] = "none"
+			Rotation.CW: result["0"] = "cw"
+			Rotation.CCW: result["0"] = "ccw"
+			Rotation.FLIP: result["0"] = "180"
+		if next_piece_from_index != 0:
+			result["1"] = str(next_piece_from_index)
+		if next_piece_to_index != 999999:
+			# we also populate result["1"] if it wasn't already populated
+			result["1"] = str(next_piece_from_index)
+			result["2"] = str(next_piece_to_index)
+		
+		return result
 
 
 """
@@ -88,6 +105,13 @@ class InsertLineEffect extends LevelTriggerEffect:
 	"""
 	func run() -> void:
 		CurrentLevel.puzzle.get_playfield().line_inserter.insert_line(tiles_key)
+	
+	
+	func get_config() -> Dictionary:
+		var result := {}
+		if tiles_key:
+			result["tiles_key"] = tiles_key
+		return result
 
 
 var effects_by_string := {
@@ -111,3 +135,7 @@ func create(effect_key: String, effect_config: Dictionary = {}) -> LevelTriggerE
 	if effect_config:
 		effect.set_config(effect_config)
 	return effect
+
+
+func effect_key(effect: LevelTriggerEffect) -> String:
+	return effects_by_string.keys()[effects_by_string.values().find(effect.get_script())]

--- a/project/src/main/puzzle/level/level-triggers.gd
+++ b/project/src/main/puzzle/level/level-triggers.gd
@@ -9,7 +9,7 @@ every time the player places a piece.
 
 # key: An enum from LevelTrigger.LevelTriggerPhase
 # value: An array of LevelTriggers which should happen during that phase
-var _triggers := {}
+var triggers := {}
 
 """
 Runs all triggers for the specified phase.
@@ -20,10 +20,10 @@ Parameters:
 	'event_params': (Optional) Phase-specific metadata used to decide whether the trigger should fire
 """
 func run_triggers(phase: int, event_params: Dictionary = {}) -> void:
-	if not _triggers.has(phase):
+	if not triggers.has(phase):
 		return
 	
-	for trigger in _triggers.get(phase, []):
+	for trigger in triggers.get(phase, []):
 		if trigger.should_run(phase, event_params):
 			trigger.run()
 
@@ -35,8 +35,26 @@ func from_json_array(json: Array) -> void:
 		_add_trigger(trigger)
 
 
+func to_json_array() -> Array:
+	var appended_triggers := {}
+	var result := []
+	for phase in triggers:
+		for trigger in triggers[phase]:
+			if appended_triggers.has(trigger):
+				# already appended
+				continue
+
+			appended_triggers[trigger] = true
+			result.append(trigger.to_json_dict())
+	return result
+
+
+func is_default() -> bool:
+	return triggers.empty()
+
+
 func _add_trigger(trigger: LevelTrigger) -> void:
 	for phase in trigger.phases:
-		if not _triggers.has(phase):
-			_triggers[phase] = []
-		_triggers[phase].append(trigger)
+		if not triggers.has(phase):
+			triggers[phase] = []
+		triggers[phase].append(trigger)

--- a/project/src/main/puzzle/level/lose-condition-rules.gd
+++ b/project/src/main/puzzle/level/lose-condition-rules.gd
@@ -10,7 +10,21 @@ var finish_on_lose := false
 # by default, the player loses if they top out three times
 var top_out := 3
 
+var _rule_parser: RuleParser
+
+func _init() -> void:
+	_rule_parser = RuleParser.new(self)
+	_rule_parser.add_bool("finish_on_lose")
+	_rule_parser.add_int("top_out").default(3)
+
+
 func from_json_array(json: Array) -> void:
-	var rules := RuleParser.new(json)
-	if rules.has("finish_on_lose"): finish_on_lose = true
-	if rules.has("top_out"): top_out = rules.int_value()
+	_rule_parser.from_json_array(json)
+
+
+func to_json_array() -> Array:
+	return _rule_parser.to_json_array()
+
+
+func is_default() -> bool:
+	return _rule_parser.is_default()

--- a/project/src/main/puzzle/level/milestone.gd
+++ b/project/src/main/puzzle/level/milestone.gd
@@ -49,3 +49,26 @@ func from_json_dict(json: Dictionary) -> void:
 	for key in json.keys():
 		if not key in ["type", "value"]:
 			set_meta(key, json.get(key))
+
+
+func to_json_dict() -> Dictionary:
+	var result := {
+		"type": Utils.enum_to_snake_case(MilestoneType, type),
+		"value": value,
+	}
+	for meta_key in get_meta_list():
+		result[meta_key] = get_meta(meta_key)
+	return result
+
+
+"""
+Returns 'true' if all of the milestone's properties are currently set to their default values.
+
+Milestones whose properties are set to their default values are omitted from our json output.
+"""
+func is_default() -> bool:
+	var result := true
+	result = result && (type == MilestoneType.NONE)
+	result = result && (value == 0)
+	result = result && (get_meta_list().empty())
+	return result

--- a/project/src/main/puzzle/level/other-rules.gd
+++ b/project/src/main/puzzle/level/other-rules.gd
@@ -39,28 +39,31 @@ var tile_set: int = PuzzleTileMap.TileSetType.DEFAULT
 # 'true' for tutorial levels which are led by Turbo
 var tutorial := false
 
+var _rule_parser: RuleParser
+
+func _init() -> void:
+	_rule_parser = RuleParser.new(self)
+	_rule_parser.add_bool("after_tutorial")
+	_rule_parser.add_bool("clear_on_finish", "no_clear_on_finish").default(true)
+	_rule_parser.add_bool("enhance_combo_fx")
+	_rule_parser.add_bool("non_interactive")
+	_rule_parser.add_enum("suppress_piece_rotation", SuppressPieceRotation) \
+			.implied(SuppressPieceRotation.ROTATION)
+	_rule_parser.add_enum("suppress_piece_initial_rotation", SuppressPieceRotation) \
+			.implied(SuppressPieceRotation.ROTATION)
+	_rule_parser.add_bool("skip_intro")
+	_rule_parser.add_string("start_level")
+	_rule_parser.add_enum("tile_set", PuzzleTileMap.TileSetType)
+	_rule_parser.add_bool("tutorial")
+
+
 func from_json_array(json: Array) -> void:
-	var rules := RuleParser.new(json)
-	if rules.has("after_tutorial"): after_tutorial = true
-	if rules.has("enhance_combo_fx"): enhance_combo_fx = true
-	if rules.has("no_clear_on_finish"): clear_on_finish = false
-	if rules.has("non_interactive"): non_interactive = true
-	if rules.has("suppress_piece_rotation"):
-		match rules.string_value():
-			# rules.string_value() returns '1' if there are no parameters specified
-			"1", "rotation": suppress_piece_rotation = SuppressPieceRotation.ROTATION
-			"rotation_and_signals": suppress_piece_rotation = SuppressPieceRotation.ROTATION_AND_SIGNALS
-			_: push_warning("Unrecognized suppress_piece_rotation: %s" % [rules.string_value()])
-	if rules.has("suppress_piece_initial_rotation"):
-		match rules.string_value():
-			# rules.string_value() returns '1' if there are no parameters specified
-			"1", "rotation": suppress_piece_initial_rotation = SuppressPieceRotation.ROTATION
-			"rotation_and_signals": suppress_piece_initial_rotation = SuppressPieceRotation.ROTATION_AND_SIGNALS
-			_: push_warning("Unrecognized suppress_piece_initial_rotation: %s" % [rules.string_value()])
-	if rules.has("start_level"): start_level = rules.string_value()
-	if rules.has("tile_set"):
-		match rules.string_value():
-			"default": tile_set = PuzzleTileMap.TileSetType.DEFAULT
-			"veggie": tile_set = PuzzleTileMap.TileSetType.VEGGIE
-			_: push_warning("Unrecognized tile_set: %s" % [rules.string_value()])
-	if rules.has("tutorial"): tutorial = true
+	_rule_parser.from_json_array(json)
+
+
+func to_json_array() -> Array:
+	return _rule_parser.to_json_array()
+
+
+func is_default() -> bool:
+	return _rule_parser.is_default()

--- a/project/src/main/puzzle/level/phase-conditions.gd
+++ b/project/src/main/puzzle/level/phase-conditions.gd
@@ -52,6 +52,39 @@ class AfterLinesClearedPhaseCondition extends PhaseCondition:
 	"""
 	func should_run(event_params: Dictionary) -> bool:
 		return which_lines.has(event_params["y"])
+	
+	
+	"""
+	Extracts a set of phase configuration strings from this phase condition.
+	
+	Reverse-engineers a 'y' expression like {"y": "0,4-6"} based on the `which_lines` property.
+	
+	Returns:
+		A set of phase configuration strings defining criteria for this phase condition.
+	"""
+	func get_phase_config() -> Dictionary:
+		var y_expression: String = ""
+		
+		var range_start := -1
+		for y in range(PuzzleTileMap.ROW_COUNT + 1):
+			var include_prev := which_lines.has(PuzzleTileMap.ROW_COUNT - y)
+			var include_curr := which_lines.has(PuzzleTileMap.ROW_COUNT - y - 1)
+			if include_curr and not include_prev:
+				# start a new range
+				range_start = y
+			if not include_curr and include_prev:
+				# end the range and append it to the y_expression
+				var range_end := y - 1
+				if y_expression:
+					y_expression += ","
+				if range_start == range_end:
+					# isolated lines are output as "1,3,5"
+					y_expression += str(range_start)
+				else:
+					# adjacent lines are hyphenated as "1-3,5-9"
+					y_expression += "%s-%s" % [range_start, range_end]
+		
+		return {"y": y_expression}
 
 var phase_conditions_by_string := {
 	"after_line_cleared": AfterLinesClearedPhaseCondition,

--- a/project/src/main/puzzle/level/piece-type-rules.gd
+++ b/project/src/main/puzzle/level/piece-type-rules.gd
@@ -3,35 +3,70 @@ class_name PieceTypeRules
 Pieces the player is given.
 """
 
-# if 'true', the start pieces always appear in the same order instead of being shuffled.
-var ordered_start := false
+"""
+Parses json strings like 'piece_j' into enums like PieceTypes.piece_j.
 
-# pieces to prepend to the piece queue before a game begins. these pieces are shuffled
+Unlike most property parsers which only populate a single property, this parser populates both the 'types' and
+'start_types' fields.
+"""
+class PieceTypesPropertyParser extends RuleParser.PropertyParser:
+	var start_name: String = "start_types"
+	
+	func _init(init_target: Object).(init_target, "types") -> void:
+		default = []
+		keys = []
+		for piece_string in PieceTypes.pieces_by_string:
+			keys.append("piece_%s" % [piece_string])
+			keys.append("start_piece_%s" % [piece_string])
+	
+	
+	func to_json_strings() -> Array:
+		var result := []
+		for type in target.get(name):
+			result.append("piece_%s" % [type.string])
+		for type in target.get(start_name):
+			result.append("start_piece_%s" % [type.string])
+		return result
+	
+	
+	func from_json_string(json: String) -> void:
+		if json.begins_with("piece_") \
+				and PieceTypes.pieces_by_string.has(json.trim_prefix("piece_")):
+			target.get(name).append(PieceTypes.pieces_by_string[json.trim_prefix("piece_")])
+		elif json.begins_with("start_piece_") \
+				and PieceTypes.pieces_by_string.has(json.trim_prefix("start_piece_")):
+			target.get(start_name).append(PieceTypes.pieces_by_string[json.trim_prefix("start_piece_")])
+		else:
+			push_warning("Unrecognized: %s" % [json])
+	
+	
+	func is_default() -> bool:
+		return target.get(name).empty() and target.get(start_name).empty()
+
+# if 'true', the start pieces always appear in the same order instead of being shuffled.
+var ordered_start: bool = false
+
+# list of PieceTypes to prepend to the piece queue before a game begins. these pieces are shuffled
 var start_types := []
 
-# piece types to choose from. if empty, reverts to the default 8 types (jlopqtuv)
+# list of PieceTypes to choose from. if empty, defaults to the basic 8 types (jlopqtuv)
 var types := []
 
+var _rule_parser: RuleParser
+
+func _init() -> void:
+	_rule_parser = RuleParser.new(self)
+	_rule_parser.add_bool("ordered_start")
+	_rule_parser.add(PieceTypesPropertyParser.new(self))
+
+
 func from_json_array(json: Array) -> void:
-	var types_by_json_string := {
-		"piece_j": PieceTypes.piece_j,
-		"piece_l": PieceTypes.piece_l,
-		"piece_o": PieceTypes.piece_o,
-		"piece_p": PieceTypes.piece_p,
-		"piece_q": PieceTypes.piece_q,
-		"piece_t": PieceTypes.piece_t,
-		"piece_u": PieceTypes.piece_u,
-		"piece_v": PieceTypes.piece_v,
-	}
-	
-	for json_obj in json:
-		var json_string: String = json_obj
-		if json_string == "ordered_start":
-			ordered_start = true
-		elif types_by_json_string.has(json_string):
-			types.append(types_by_json_string[json_string])
-		elif json_string.begins_with("start_") \
-				and types_by_json_string.has(json_string.trim_prefix("start_")):
-			start_types.append(types_by_json_string[json_string.trim_prefix("start_")])
-		else:
-			push_warning("Unrecognized: %s" % [json_string])
+	_rule_parser.from_json_array(json)
+
+
+func to_json_array() -> Array:
+	return _rule_parser.to_json_array()
+
+
+func is_default() -> bool:
+	return _rule_parser.is_default()

--- a/project/src/main/puzzle/level/rule-parser.gd
+++ b/project/src/main/puzzle/level/rule-parser.gd
@@ -1,51 +1,429 @@
 class_name RuleParser
 """
-Parses level rules.
+Serializes and deserializes level rules as json.
 
-Level rules involve lists of strings like 'top-out 3' or 'piece-t'.
+Level rules are defined in json with lists of strings like 'tile_set veggie' or 'skip_intro'. This parses those into
+values like 'tile_set=TileSetType.VEGGIE' or 'skip_intro=true'.
 """
 
-# Stores key/value pairs parsed from JSON.
-# For keys which have no value, we store the number of times the key is repeated.
-var _parsed_rules: Dictionary
+"""
+Abstract class which provides a framework for parsing and formatting json strings.
 
-# The queried key which we store to avoid repetitive 'has value foo, get value foo' code
-var _prev_key: String
-
-func _init(strings: Array) -> void:
-	for string_obj in strings:
-		var string: String = string_obj
-		var split := string.split(" ")
-		if split.size() == 1:
-			if not _parsed_rules.has(split[0]):
-				_parsed_rules[split[0]] = 0
-			_parsed_rules[split[0]] += 1
-		elif split.size() >= 2:
-			_parsed_rules[split[0]] = split[1]
-
-
-func has(key: String) -> bool:
-	_prev_key = key
-	return _parsed_rules.has(key)
+Subclasses can override methods to define their own specialized behavior. A single property parser typically
+corresponds to a single property, although some parsers can populate many properties.
+"""
+class PropertyParser:
+	# The rules class which contains one or more properties to parse.
+	var target: Object
+	
+	# The name of the property and json key to parse. This is useful for the most common scenario where a single json
+	# key maps to a single property. Subclasses can ignore this property if they are doing something unusual.
+	var name: String
+	
+	# The json keys which are handled by this property parser. The RuleParser uses this to decide which PropertyParser
+	# to activate.
+	var keys := []
+	
+	# Default value if the json property is omitted.
+	var default
+	
+	# Default value if the json property is specified without a value. For example, a json string like 'skip_intro'
+	# might imply a value of 'skip_intro=true' for example.
+	var implied
+	
+	"""
+	Parameters:
+		'init_target': The rules object with properties to parse.
+			
+		'init_name': The name of the property and json key to parse.
+	"""
+	func _init(init_target: Object, init_name: String) -> void:
+		target = init_target
+		name = init_name
+		keys = [name]
+	
+	
+	"""
+	Returns one or more json strings corresponding to the rule's current values.
+	
+	This will typically return an array with a single value. However some parsers can populate many properties, in
+	which case they would return multiple values.
+	
+	The default implementation returns a string like 'veg_points 15' with a string representation of the rule's
+	current value. This can be overridden for custom behavior, for example an enum serializer might prefer to write
+	'tile_set veggie' instead of the default 'tile_set 1'.
+	
+	Returns:
+		One or more json strings corresponding to the rule's current values.
+	"""
+	func to_json_strings() -> Array:
+		var result: String
+		if target.get(name) == implied:
+			result = name
+		else:
+			result = "%s %s" % [name, target.get(name)]
+		return [result]
+	
+	
+	"""
+	Updates the rule's properties based on the specified json string.
+	
+	The default implementation only works for string fields, and must be overridden to avoid type conversion errors.
+	
+	Parameters:
+		'json': The full json string being parsed, such as 'tile_set veggie'.
+	"""
+	func from_json_string(json: String) -> void:
+		var split := json.split(" ")
+		match split.size():
+			1:
+				target.set(name, implied)
+			2:
+				target.set(name, json.split(" ")[1])
+	
+	
+	"""
+	Returns 'true' if the rule's property is currently set to the default value.
+	
+	Properties currently set to the default value are omitted from our json output.
+	"""
+	func is_default() -> bool:
+		return default == target.get(name)
 
 
 """
-Returns the int value for the key previously passed into the 'has' function.
+Parses a json string like 'skip_intro' into a bool.
 """
-func int_value() -> int:
-	return int(_parsed_rules[_prev_key])
+class BoolPropertyParser extends PropertyParser:
+	# A json string corresponding to a value of 'false', such as 'no_clear_on_finish'
+	var _false_string: String
+	
+	"""
+	Parameters:
+		'init_target': The rules object with properties to parse.
+			
+		'init_name': The name of the property and json key to parse. This json key should correspond to a value of
+			'true'.
+		
+		'init_false_string': (Optional) A json string corresponding to a value of 'false', such as
+			'no_clear_on_finish'
+	"""
+	func _init(init_target: Object, init_name: String, init_false_string: String = "").(init_target, init_name) -> void:
+		default = false
+		implied = true
+		_false_string = init_false_string
+		if _false_string: keys = [name, _false_string]
+	
+	
+	"""
+	Parses a json string into a boolean value.
+	
+	This covers many use cases:
+		'clear': Assigns a value 'clear' to true
+		'clear true': Assigns a value 'clear' to true
+		'clear false': Assigns a value 'clear' to false
+		'no_clear': assigns a value 'clear' to false
+		'no_clear true': assigns a value 'clear' to false
+		'no_clear false': assigns a value 'clear' to true
+	
+	The values "True", "TRUE", "true" or "1" are treated as true. The values "False", "FALSE", "false" or "0" are
+	treated as false.
+	
+	Parameters:
+		'json': The full json string being parsed, such as 'clear' or 'no_clear true'.
+	"""
+	func from_json_string(json: String) -> void:
+		var split := json.split(" ")
+		match split.size():
+			1:
+				match split[0]:
+					name:
+						# parse positive string like 'clear_on_finish'
+						target.set(name, true)
+					_false_string:
+						# parse negative string like 'no_clear_on_finish'
+						target.set(name, false)
+					_:
+						push_warning("Unrecognized: %s" % [split[0]])
+			2:
+				match split[0]:
+					name:
+						# parse compound string like 'clear_on_finish true'
+						target.set(name, true if Utils.to_bool(split[1]) else false)
+					_false_string:
+						# parse negative compound string like 'no_clear_on_finish false' (why...)
+						target.set(name, false if Utils.to_bool(split[1]) else true)
+					_:
+						push_warning("Unrecognized: %s" % [split[0]])
+	
+	
+	"""
+	Returns an array with a json string like 'clear' corresponding to the rule's current value.
+	
+	This returns a short value like 'clear' or 'no_clear' if possible, or a verbose value like 'clear false' if no
+	false string is defined.
+	
+	Returns:
+		An array with a json string like 'clear' corresponding to the rule's current value.
+	"""
+	func to_json_strings() -> Array:
+		var result: String
+		if target.get(name) == true:
+			# return positive string like 'clear_on_finish'
+			result = name
+		elif _false_string:
+			# return negative string like 'no_clear_on_finish'
+			result = _false_string
+		else:
+			# return compound string like 'clear_on_finish false'
+			result = "%s %s" % [name, target.get(name)]
+		return [result]
 
 
 """
-Returns the float value for the key previously passed into the 'has' function.
+Parses a json string like 'box_factor 0.5' into a float.
 """
-func float_value() -> float:
-	return float(_parsed_rules[_prev_key])
+class FloatPropertyParser extends PropertyParser:
+	func _init(init_target: Object, init_name: String).(init_target, init_name) -> void:
+		default = 0.0
+	
+	
+	func from_json_string(json: String) -> void:
+		var split := json.split(" ")
+		match split.size():
+			1:
+				target.set(name, implied)
+			2:
+				target.set(name, float(json.split(" ")[1]))
+	
+	
+	func is_default() -> bool:
+		return is_equal_approx(default, target.get(name))
 
 
 """
-Returns the string value for the key previously passed into the 'has' function.
+Parses a json string like 'veg_points 10' into an int.
 """
-func string_value() -> String:
-	return str(_parsed_rules[_prev_key])
+class IntPropertyParser extends PropertyParser:
+	func _init(init_target: Object, init_name: String).(init_target, init_name) -> void:
+		default = 0
+	
+	
+	func from_json_string(json: String) -> void:
+		var split := json.split(" ")
+		match split.size():
+			1:
+				target.set(name, implied)
+			2:
+				target.set(name, int(json.split(" ")[1]))
 
+
+"""
+Parses a json string like 'start_level level_10' into a string like "level_10".
+"""
+class StringPropertyParser extends PropertyParser:
+	func _init(init_target: Object, init_name: String).(init_target, init_name) -> void:
+		default = ""
+
+
+"""
+Parses a json string like 'tile_set veggie' into an enum like 'TileSetType.VEGGIE'
+
+This parser assumes all json strings are lower case snake case strings like 'time_over', and all enum values are upper
+case snake case strings like 'TIME_OVER'.
+"""
+class EnumPropertyParser extends PropertyParser:
+	# key: (String) upper case snake case enum key
+	# value: (int) enum index
+	var _enum_dict: Dictionary
+	
+	"""
+	Parameters:
+		'init_target': The rules object with properties to parse.
+			
+		'init_name': The name of the property and json key to parse.
+		
+		'init_enum_dict': The property's enum type, such as 'PuzzleTileMap.TileSetType'
+	"""
+	func _init(init_target: Object, init_name: String, init_enum_dict).(init_target, init_name) -> void:
+		_enum_dict = init_enum_dict
+		default = 0
+		implied = 0
+	
+	
+	func from_json_string(json: String) -> void:
+		var split := json.split(" ")
+		match split.size():
+			1:
+				target.set(name, implied)
+			2:
+				var snake_case_enum: String = json.split(" ")[1]
+				if not _enum_dict.has(snake_case_enum.to_upper()):
+					push_warning("Unrecognized %s: %s" % [json.split(" ")[0], json.split(" ")[1]])
+				else:
+					target.set(name, Utils.enum_from_snake_case(_enum_dict, snake_case_enum))
+	
+	
+	func to_json_strings() -> Array:
+		var result: String
+		if target.get(name) == implied:
+			result = name
+		else:
+			result = "%s %s" % [name, Utils.enum_to_snake_case(_enum_dict, target.get(name))]
+		return [result]
+
+
+"""
+Allows for extended configuration of properties.
+"""
+class OngoingPropertyDefinition:
+	var _property_parser: PropertyParser
+	
+	func _init(init_property_parser: PropertyParser) -> void:
+		_property_parser = init_property_parser
+	
+	
+	"""
+	Sets the default value to use when the json property is omitted.
+	
+	Parameters:
+		'new_default': A default value, such as 'true', '0.0', or TileSetType.DEFAULT
+	"""
+	func default(new_default) -> void:
+		_property_parser.default = new_default
+	
+	
+	"""
+	Sets the implied value to use when the json property is specified without a value.
+	
+	Parameters:
+		'new_default': An implied value, such as 'true', '0.0', or TileSetType.DEFAULT
+	"""
+	func implied(new_implied) -> void:
+		_property_parser.implied = new_implied
+
+# The rules class which contains one or more properties to parse.
+var _target: Object
+
+# List of PropertyParser instances for serializing and deserializing json. This array's order dictates the order the
+# properties will be written to the json file.
+var _property_parsers := []
+
+# key: (String) json key such as 'clear_on_finish' or 'piece_j'
+# value: (PropertyParser) PropertyParser instance which is activated for the specified key
+var _property_parsers_by_key := {}
+
+func _init(init_target: Object) -> void:
+	_target = init_target
+
+
+"""
+Adds a boolean property parser.
+
+Parameters:
+	'name': The name of the property and json key to parse. This json key should correspond to a value of 'true'.
+	
+	'false_string': (Optional) A json string corresponding to a value of 'false', such as 'no_clear_on_finish'
+"""
+func add_bool(name: String, false_string: String = "") -> OngoingPropertyDefinition:
+	return add(BoolPropertyParser.new(_target, name, false_string))
+
+
+"""
+Adds an enum property parser.
+
+Parameters:
+	'name': The name of the property and json key to parse.
+	
+	'enum_dict': The property's enum type, such as 'PuzzleTileMap.TileSetType'
+"""
+func add_enum(name: String, enum_dict: Dictionary) -> OngoingPropertyDefinition:
+	return add(EnumPropertyParser.new(_target, name, enum_dict))
+
+
+"""
+Adds a float property parser.
+
+Parameters:
+	'name': The name of the property and json key to parse.
+"""
+func add_float(name: String) -> OngoingPropertyDefinition:
+	return add(FloatPropertyParser.new(_target, name))
+
+
+"""
+Adds an int property parser.
+
+Parameters:
+	'name': The name of the property and json key to parse.
+"""
+func add_int(name: String) -> OngoingPropertyDefinition:
+	return add(IntPropertyParser.new(_target, name))
+
+
+"""
+Adds a string property parser.
+
+Parameters:
+	'name': The name of the property and json key to parse.
+"""
+func add_string(name: String) -> OngoingPropertyDefinition:
+	return add(StringPropertyParser.new(_target, name))
+
+
+"""
+Adds a custom property parser.
+
+Parameters:
+	'property_parser': Defines behavior for parsing and formatting json strings.
+"""
+func add(property_parser: PropertyParser) -> OngoingPropertyDefinition:
+	_property_parsers.append(property_parser)
+	for rule_key in property_parser.keys:
+		_property_parsers_by_key[rule_key] = property_parser
+	var ongoing_rule_definition := OngoingPropertyDefinition.new(property_parser)
+	return ongoing_rule_definition
+
+
+"""
+Updates the rule's properties based on the specified json strings.
+
+Parameters:
+	'json': An array of json strings to parse, such as 'tile_set veggie'.
+"""
+func from_json_array(json: Array) -> void:
+	for json_string in json:
+		var split: Array = json_string.split(" ")
+		if not _property_parsers_by_key.has(split[0]):
+			push_warning("Unrecognized: %s" % [split[0]])
+			continue
+		var property_parser: PropertyParser = _property_parsers_by_key[split[0]]
+		property_parser.from_json_string(json_string)
+
+
+"""
+Returns a minimal list of json strings corresponding to the rule's current values.
+
+Properties which are set to their default value are omitted from the resulting list. If all properties are assigned to
+their default value, the list will be empty.
+"""
+func to_json_array() -> Array:
+	var result := []
+	for property_parser in _property_parsers:
+		if not property_parser.is_default():
+			result.append_array(property_parser.to_json_strings())
+	return result
+
+
+"""
+Returns 'true' if all of the rule's properties are currently set to their default values.
+
+Rules whose properties are set to their default values are omitted from our json output.
+"""
+func is_default() -> bool:
+	var result := true
+	for property_parser in _property_parsers:
+		if not property_parser.is_default():
+			result = false
+			break
+	return result

--- a/project/src/main/puzzle/level/score-rules.gd
+++ b/project/src/main/puzzle/level/score-rules.gd
@@ -3,6 +3,29 @@ class_name ScoreRules
 Rules for scoring points.
 """
 
+"""
+Parses a json string like 'cake_all 15' into an int.
+
+This is distinct from IntPropertyParser because json values like 'cake_all' are not directly stored into a 'cake_all'
+property, there is some translation logic.
+"""
+class PointsPropertyParser extends RuleParser.PropertyParser:
+	var _all_string: String
+	
+	func _init(init_target: Object, init_name: String).(init_target, init_name) -> void:
+		default = 0
+		_all_string = "%sall" % [init_name.trim_suffix("points")]
+		keys = [_all_string]
+	
+	
+	func to_json_strings() -> Array:
+		return ["%s %s" % [_all_string, target.get(name)]]
+	
+	
+	func from_json_string(json: String) -> void:
+		target.set(name, int(json.split(" ")[1]))
+
+
 const DEFAULT_CAKE_POINTS := 10
 const DEFAULT_SNACK_POINTS := 5
 
@@ -21,8 +44,24 @@ var snack_pickup_points := 10
 # box points awarded for clearing a row with no boxes, a vegetable row.
 var veg_points := 0
 
+var _rule_parser: RuleParser
+
+func _init() -> void:
+	_rule_parser = RuleParser.new(self)
+	_rule_parser.add(PointsPropertyParser.new(self, "cake_points")).default(DEFAULT_CAKE_POINTS)
+	_rule_parser.add(PointsPropertyParser.new(self, "snack_points")).default(DEFAULT_SNACK_POINTS)
+	_rule_parser.add(PointsPropertyParser.new(self, "cake_pickup_points")).default(cake_pickup_points)
+	_rule_parser.add(PointsPropertyParser.new(self, "snack_pickup_points")).default(snack_pickup_points)
+	_rule_parser.add_int("veg_points")
+
+
 func from_json_array(json: Array) -> void:
-	var rules := RuleParser.new(json)
-	if rules.has("cake_all"): cake_points = rules.int_value()
-	if rules.has("snack_all"): snack_points = rules.int_value()
-	if rules.has("veg_row"): veg_points = rules.int_value()
+	_rule_parser.from_json_array(json)
+
+
+func to_json_array() -> Array:
+	return _rule_parser.to_json_array()
+
+
+func is_default() -> bool:
+	return _rule_parser.is_default()

--- a/project/src/test/puzzle/level/test-blocks-during-rules.gd
+++ b/project/src/test/puzzle/level/test-blocks-during-rules.gd
@@ -1,0 +1,64 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests rules for blocks/boxes which appear or disappear while the game is going on.
+"""
+
+var rules: BlocksDuringRules
+
+func before_each() -> void:
+	rules = BlocksDuringRules.new()
+
+
+func test_is_default() -> void:
+	assert_eq(rules.is_default(), true)
+	rules.pickup_type = BlocksDuringRules.PickupType.FLOAT_REGEN
+	assert_eq(rules.is_default(), false)
+
+
+func test_to_json_empty() -> void:
+	assert_eq(rules.to_json_array(), [])
+
+
+func test_to_json_full() -> void:
+	rules.clear_on_top_out = true
+	rules.line_clear_type = BlocksDuringRules.LineClearType.FLOAT_FALL
+	rules.pickup_type = BlocksDuringRules.PickupType.FLOAT_REGEN
+	rules.random_tiles_start = true
+	assert_eq(rules.to_json_array(),
+			["clear_on_top_out", "line_clear_type float_fall", "pickup_type float_regen", "random_tiles_start"])
+
+
+func test_from_json_empty() -> void:
+	rules.from_json_array([])
+	assert_eq(rules.clear_on_top_out, false)
+	assert_eq(rules.line_clear_type, BlocksDuringRules.LineClearType.DEFAULT)
+	assert_eq(rules.pickup_type, BlocksDuringRules.PickupType.DEFAULT)
+	assert_eq(rules.random_tiles_start, false)
+
+
+func test_from_json_full() -> void:
+	rules.from_json_array(
+			["clear_on_top_out", "line_clear_type float_fall", "pickup_type float_regen", "random_tiles_start"])
+	assert_eq(rules.clear_on_top_out, true)
+	assert_eq(rules.line_clear_type, BlocksDuringRules.LineClearType.FLOAT_FALL)
+	assert_eq(rules.pickup_type, BlocksDuringRules.PickupType.FLOAT_REGEN)
+	assert_eq(rules.random_tiles_start, true)
+
+
+func test_convert_to_json_and_back() -> void:
+	rules.clear_on_top_out = true
+	rules.line_clear_type = BlocksDuringRules.LineClearType.FLOAT_FALL
+	rules.pickup_type = BlocksDuringRules.PickupType.FLOAT_REGEN
+	rules.random_tiles_start = true
+	_convert_to_json_and_back()
+	
+	assert_eq(rules.clear_on_top_out, true)
+	assert_eq(rules.line_clear_type, BlocksDuringRules.LineClearType.FLOAT_FALL)
+	assert_eq(rules.pickup_type, BlocksDuringRules.PickupType.FLOAT_REGEN)
+	assert_eq(rules.random_tiles_start, true)
+
+
+func _convert_to_json_and_back() -> void:
+	var json := rules.to_json_array()
+	rules = BlocksDuringRules.new()
+	rules.from_json_array(json)

--- a/project/src/test/puzzle/level/test-combo-break-rules.gd
+++ b/project/src/test/puzzle/level/test-combo-break-rules.gd
@@ -1,0 +1,28 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests rules for blocks/boxes which appear or disappear while the game is going on.
+"""
+
+var rules: ComboBreakRules
+
+func before_each() -> void:
+	rules = ComboBreakRules.new()
+
+
+func test_to_json_empty() -> void:
+	assert_eq(rules.to_json_array(), [])
+
+
+func test_convert_to_json_and_back() -> void:
+	rules.pieces = 3
+	rules.veg_row = true
+	_convert_to_json_and_back()
+	
+	assert_eq(rules.pieces, 3)
+	assert_eq(rules.veg_row, true)
+
+
+func _convert_to_json_and_back() -> void:
+	var json := rules.to_json_array()
+	rules = ComboBreakRules.new()
+	rules.from_json_array(json)

--- a/project/src/test/puzzle/level/test-level-settings.gd
+++ b/project/src/test/puzzle/level/test-level-settings.gd
@@ -70,3 +70,82 @@ func test_level_key_from_path_files() -> void:
 			"level_894")
 	assert_eq(LevelSettings.level_key_from_path("~/.local/share/godot/level_894.json"),
 			"level_894")
+
+
+func _convert_to_json_and_back() -> void:
+	var json_dict := settings.to_json_dict()
+	settings = LevelSettings.new()
+	settings.from_json_dict("id_873", json_dict)
+
+
+func test_to_json_basic_properties() -> void:
+	settings.title = "title 215"
+	settings.description = "description 356"
+	settings.difficulty = "FD"
+	_convert_to_json_and_back()
+	
+	assert_eq(settings.title, "title 215")
+	assert_eq(settings.description, "description 356")
+	assert_eq(settings.difficulty, "FD")
+
+
+func test_to_json_speed_ups() -> void:
+	settings.set_start_speed("FC")
+	settings.add_speed_up(Milestone.LINES, 10, "FD")
+	settings.add_speed_up(Milestone.LINES, 20, "FE")
+	settings.speed_ups[2].set_meta("meta_719", "value_719")
+	_convert_to_json_and_back()
+	
+	assert_eq(settings.speed_ups.size(), 3)
+	assert_eq(settings.speed_ups[0].type, Milestone.LINES)
+	assert_eq(settings.speed_ups[0].value, 0)
+	assert_eq(settings.speed_ups[0].get_meta("speed"), "FC")
+	assert_eq(settings.speed_ups[1].type, Milestone.LINES)
+	assert_eq(settings.speed_ups[1].value, 10)
+	assert_eq(settings.speed_ups[1].get_meta("speed"), "FD")
+	assert_eq(settings.speed_ups[2].type, Milestone.LINES)
+	assert_eq(settings.speed_ups[2].value, 20)
+	assert_eq(settings.speed_ups[2].get_meta("speed"), "FE")
+	assert_eq(settings.speed_ups[2].get_meta("meta_719"), "value_719")
+
+
+func test_to_json_milestones_and_tiles() -> void:
+	settings.finish_condition.set_milestone(Milestone.TIME_OVER, 180)
+	settings.success_condition.set_milestone(Milestone.LINES, 100)
+	settings.tiles.bunches["start"] = LevelTiles.BlockBunch.new()
+	settings.tiles.bunches["start"].set_block(Vector2(1, 2), 3, Vector2(4, 5))
+	_convert_to_json_and_back()
+	
+	assert_eq(settings.finish_condition.type, Milestone.TIME_OVER)
+	assert_eq(settings.finish_condition.value, 180)
+	assert_eq(settings.success_condition.type, Milestone.LINES)
+	assert_eq(settings.success_condition.value, 100)
+	assert_eq(settings.tiles.bunches.keys(), ["start"])
+	assert_eq(settings.tiles.bunches["start"].block_tiles[Vector2(1, 2)], 3)
+	assert_eq(settings.tiles.bunches["start"].block_autotile_coords[Vector2(1, 2)], Vector2(4, 5))
+
+
+func test_to_json_rules() -> void:
+	settings.blocks_during.clear_on_top_out = true
+	settings.combo_break.pieces = 3
+	settings.input_replay.action_timings = {"25 +rotate_cw": true, "33 -rotate_cw": true}
+	settings.lose_condition.finish_on_lose = true
+	settings.other.after_tutorial = true
+	settings.piece_types.start_types = [PieceTypes.piece_j, PieceTypes.piece_l]
+	settings.rank.box_factor = 2.0
+	settings.score.cake_points = 30
+	settings.timers.timers = [{"interval": 5}]
+	settings.triggers.from_json_array(
+			[{"phases": ["after_line_cleared y=0-5"], "effect": "insert_line tiles_key=0"}])
+	_convert_to_json_and_back()
+	
+	assert_eq(settings.blocks_during.clear_on_top_out, true)
+	assert_eq(settings.combo_break.pieces, 3)
+	assert_eq(settings.input_replay.action_timings.keys(), ["25 +rotate_cw", "33 -rotate_cw"])
+	assert_eq(settings.lose_condition.finish_on_lose, true)
+	assert_eq(settings.other.after_tutorial, true)
+	assert_eq(settings.piece_types.start_types, [PieceTypes.piece_j, PieceTypes.piece_l])
+	assert_eq(settings.rank.box_factor, 2.0)
+	assert_eq(settings.score.cake_points, 30)
+	assert_eq_deep(settings.timers.timers, [{"interval": 5}])
+	assert_eq(settings.triggers.triggers.keys(), [LevelTrigger.AFTER_LINE_CLEARED])

--- a/project/src/test/puzzle/level/test-level-tiles.gd
+++ b/project/src/test/puzzle/level/test-level-tiles.gd
@@ -1,0 +1,39 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests for sets of blocks which are shown initially, or appear during the game
+"""
+
+var tiles: LevelTiles
+
+func before_each() -> void:
+	tiles = LevelTiles.new()
+
+
+func test_is_default() -> void:
+	assert_eq(tiles.is_default(), true)
+	tiles.bunches["start"] = LevelTiles.BlockBunch.new()
+	tiles.bunches["start"].set_block(Vector2(1, 2), 3, Vector2(4, 5))
+	assert_eq(tiles.is_default(), false)
+
+
+func test_to_json_empty() -> void:
+	assert_eq_shallow(tiles.to_json_dict(), {})
+
+
+func test_convert_to_json_and_back() -> void:
+	tiles.bunches["start"] = LevelTiles.BlockBunch.new()
+	tiles.bunches["start"].set_block(Vector2(1, 2), 3, Vector2(4, 5))
+	tiles.bunches["1"] = LevelTiles.BlockBunch.new()
+	tiles.bunches["1"].set_pickup(Vector2(2, 3), 4)
+	_convert_to_json_and_back()
+	
+	assert_eq(tiles.bunches.keys(), ["start", "1"])
+	assert_eq(tiles.bunches["start"].block_tiles[Vector2(1, 2)], 3)
+	assert_eq(tiles.bunches["start"].block_autotile_coords[Vector2(1, 2)], Vector2(4, 5))
+	assert_eq(tiles.bunches["1"].pickups[Vector2(2, 3)], 4)
+
+
+func _convert_to_json_and_back() -> void:
+	var json := tiles.to_json_dict()
+	tiles = LevelTiles.new()
+	tiles.from_json_dict(json)

--- a/project/src/test/puzzle/level/test-level-timers.gd
+++ b/project/src/test/puzzle/level/test-level-timers.gd
@@ -1,0 +1,32 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests for timers which cause strange things to happen during a level.
+"""
+
+var timers: LevelTimers
+
+func before_each() -> void:
+	timers = LevelTimers.new()
+
+
+func test_is_default() -> void:
+	assert_eq(timers.is_default(), true)
+	timers.timers.append({"interval": 12})
+	assert_eq(timers.is_default(), false)
+
+
+func test_to_json_empty() -> void:
+	assert_eq(timers.to_json_array(), [])
+
+
+func test_convert_to_json_and_back() -> void:
+	timers.timers.append({"interval": 12})
+	_convert_to_json_and_back()
+	
+	assert_eq_deep(timers.timers, [{"interval": 12}])
+
+
+func _convert_to_json_and_back() -> void:
+	var json := timers.to_json_array()
+	timers = LevelTimers.new()
+	timers.from_json_array(json)

--- a/project/src/test/puzzle/level/test-level-trigger-effects.gd
+++ b/project/src/test/puzzle/level/test-level-trigger-effects.gd
@@ -1,0 +1,32 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests library of level trigger effects.
+"""
+
+func test_rotate_next_pieces_to_json_string() -> void:
+	var effect: LevelTriggerEffects.RotateNextPiecesEffect
+	effect = LevelTriggerEffects.RotateNextPiecesEffect.new()
+	assert_eq_shallow(effect.get_config(), {"0": "none"})
+	
+	effect = LevelTriggerEffects.RotateNextPiecesEffect.new()
+	effect.set_config({"0": "cw", "1": "0", "2": "0"})
+	assert_eq_shallow(effect.get_config(), {"0": "cw", "1": "0", "2": "0"})
+
+	effect = LevelTriggerEffects.RotateNextPiecesEffect.new()
+	effect.set_config({"0": "180"})
+	assert_eq_shallow(effect.get_config(), {"0": "180"})
+
+
+func test_insert_line_to_json_string() -> void:
+	var effect: LevelTriggerEffects.InsertLineEffect
+	effect = LevelTriggerEffects.InsertLineEffect.new()
+	assert_eq_shallow(effect.get_config(), {})
+	
+	effect = LevelTriggerEffects.InsertLineEffect.new()
+	effect.set_config({"tiles_key": "0"})
+	assert_eq_shallow(effect.get_config(), {"tiles_key": "0"})
+
+
+func test_effect_key() -> void:
+	assert_eq(LevelTriggerEffects.effect_key(LevelTriggerEffects.InsertLineEffect.new()), "insert_line")
+	assert_eq(LevelTriggerEffects.effect_key(LevelTriggerEffects.RotateNextPiecesEffect.new()), "rotate_next_pieces")

--- a/project/src/test/puzzle/level/test-level-trigger.gd
+++ b/project/src/test/puzzle/level/test-level-trigger.gd
@@ -45,20 +45,42 @@ func test_after_line_cleared_0456() -> void:
 	assert_true(trigger.should_run(LevelTrigger.AFTER_LINE_CLEARED, {"y": 13}), "should_run y=6")
 
 
+func test_after_line_cleared_to_json_dict() -> void:
+	var json_dict := {
+		"phases": ["after_line_cleared y=1,4-6"],
+		"effect": "insert_line"
+	}
+	
+	var trigger := LevelTrigger.new()
+	trigger.from_json_dict(json_dict)
+	assert_eq_shallow(trigger.to_json_dict(), json_dict)
+
+
 func test_dict_config_from_array_unkeyed() -> void:
 	var params := LevelTrigger.dict_config_from_array(["uppity", "fragile"])
-	assert_eq(params.get("0"), "uppity", "params.get(\"0\")")
-	assert_eq(params.get("1"), "fragile", "params.get(\"1\")")
+	assert_eq_shallow(params, {"0": "uppity", "1": "fragile"})
 
 
 func test_dict_config_from_array_keyed() -> void:
 	var params := LevelTrigger.dict_config_from_array(["uppity=736", "fragile=662"])
-	assert_eq(params.get("uppity"), "736", "params.get(\"uppity\")")
-	assert_eq(params.get("fragile"), "662", "params.get(\"fragile\")")
+	assert_eq_shallow(params, {"uppity": "736", "fragile": "662"})
 
 
 func test_dict_config_from_array_mixed() -> void:
 	var params := LevelTrigger.dict_config_from_array(["uppity", "fragile=662", "stiff"])
-	assert_eq(params.get("0"), "uppity", "params.get(\"0\")")
-	assert_eq(params.get("fragile"), "662", "params.get(\"fragile\")")
-	assert_eq(params.get("1"), "stiff", "params.get(\"1\")")
+	assert_eq_shallow(params, {"0": "uppity", "fragile": "662", "1": "stiff"})
+
+
+func test_dict_config_to_array_unkeyed() -> void:
+	var params := LevelTrigger.dict_config_to_array({"0": "uppity", "1": "unkeyed"})
+	assert_eq(params, ["uppity", "unkeyed"])
+
+
+func test_dict_config_to_array_keyed() -> void:
+	var params := LevelTrigger.dict_config_to_array({"uppity": "736", "fragile": "662"})
+	assert_eq(params, ["uppity=736", "fragile=662"])
+
+
+func test_dict_config_to_array_mixed() -> void:
+	var params := LevelTrigger.dict_config_to_array({"0": "uppity", "fragile": "662", "1": "stiff"})
+	assert_eq(params, ["uppity", "fragile=662", "stiff"])

--- a/project/src/test/puzzle/level/test-level-triggers.gd
+++ b/project/src/test/puzzle/level/test-level-triggers.gd
@@ -1,0 +1,57 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests for triggers which cause strange things to happen during a level.
+"""
+
+var triggers: LevelTriggers
+
+func before_each() -> void:
+	triggers = LevelTriggers.new()
+
+
+func test_is_default() -> void:
+	assert_eq(triggers.is_default(), true)
+	triggers.from_json_array(
+			[{"phases": ["after_line_cleared y=0-5"], "effect": "insert_line tiles_key=0"}])
+	assert_eq(triggers.is_default(), false)
+
+
+func test_to_json_empty() -> void:
+	assert_eq(triggers.to_json_array(), [])
+
+
+func test_convert_to_json_and_back_complex() -> void:
+	triggers.from_json_array(
+			[{"phases": ["after_line_cleared y=0-5"], "effect": "insert_line tiles_key=0"}])
+	_convert_to_json_and_back()
+	
+	assert_eq(triggers.triggers.keys(), [LevelTrigger.AFTER_LINE_CLEARED])
+	assert_eq(triggers.triggers[LevelTrigger.AFTER_LINE_CLEARED].size(), 1)
+	var trigger: LevelTrigger = triggers.triggers[LevelTrigger.AFTER_LINE_CLEARED][0]
+	assert_eq(trigger.phases.size(), 1)
+	assert_eq(trigger.phases[LevelTrigger.AFTER_LINE_CLEARED].size(), 1)
+	assert_is(trigger.phases[LevelTrigger.AFTER_LINE_CLEARED][0], PhaseConditions.AfterLinesClearedPhaseCondition)
+	assert_eq(trigger.phases[LevelTrigger.AFTER_LINE_CLEARED][0].which_lines.keys(), [19, 18, 17, 16, 15, 14])
+	assert_is(trigger.effect, LevelTriggerEffects.InsertLineEffect)
+	assert_eq(trigger.effect.tiles_key, "0")
+
+
+func test_convert_to_json_and_back_simple() -> void:
+	triggers.from_json_array(
+			[{"phases": ["rotated_cw", "initial_rotated_cw"], "effect": "rotate_next_pieces cw"}])
+	_convert_to_json_and_back()
+	
+	assert_eq(triggers.triggers.keys(), [LevelTrigger.ROTATED_CW, LevelTrigger.INITIAL_ROTATED_CW])
+	assert_eq(triggers.triggers[LevelTrigger.ROTATED_CW].size(), 1)
+	assert_eq(triggers.triggers[LevelTrigger.INITIAL_ROTATED_CW].size(), 1)
+	var trigger: LevelTrigger = triggers.triggers[LevelTrigger.ROTATED_CW][0]
+	assert_eq(trigger.phases.size(), 2)
+	assert_eq(trigger.phases.keys(), [LevelTrigger.ROTATED_CW, LevelTrigger.INITIAL_ROTATED_CW])
+	assert_is(trigger.effect, LevelTriggerEffects.RotateNextPiecesEffect)
+	assert_eq(trigger.effect.rotate_dir, LevelTriggerEffects.RotateNextPiecesEffect.Rotation.CW)
+
+
+func _convert_to_json_and_back() -> void:
+	var json := triggers.to_json_array()
+	triggers = LevelTriggers.new()
+	triggers.from_json_array(json)

--- a/project/src/test/puzzle/level/test-lose-condition-rules.gd
+++ b/project/src/test/puzzle/level/test-lose-condition-rules.gd
@@ -1,0 +1,31 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests for how the player loses. The player usually loses if they top out a certain number of times, but some levels
+might have different rules.
+"""
+
+var rules: LoseConditionRules
+
+func before_each() -> void:
+	rules = LoseConditionRules.new()
+
+
+func test_is_default() -> void:
+	assert_eq(rules.is_default(), true)
+	rules.finish_on_lose = true
+	assert_eq(rules.is_default(), false)
+
+
+func test_convert_to_json_and_back() -> void:
+	rules.finish_on_lose = true
+	rules.top_out = 5
+	_convert_to_json_and_back()
+	
+	assert_eq(rules.finish_on_lose, true)
+	assert_eq(rules.top_out, 5)
+
+
+func _convert_to_json_and_back() -> void:
+	var json := rules.to_json_array()
+	rules = LoseConditionRules.new()
+	rules.from_json_array(json)

--- a/project/src/test/puzzle/level/test-milestone.gd
+++ b/project/src/test/puzzle/level/test-milestone.gd
@@ -1,0 +1,40 @@
+extends "res://addons/gut/test.gd"
+"""
+Unit test demonstrating goals/milestones for puzzles.
+"""
+
+var milestone: Milestone
+
+func before_each() -> void:
+	milestone = Milestone.new()
+
+
+func test_is_default() -> void:
+	assert_eq(milestone.is_default(), true)
+	
+	milestone = Milestone.new()
+	milestone.set_meta("speed", "FB")
+	assert_eq(milestone.is_default(), false)
+	
+	milestone = Milestone.new()
+	milestone.type = Milestone.LINES
+	assert_eq(milestone.is_default(), false)
+	
+	milestone = Milestone.new()
+	milestone.value = 80
+	assert_eq(milestone.is_default(), false)
+
+
+func test_convert_to_json_and_back() -> void:
+	milestone.type = Milestone.LINES
+	milestone.value = 120
+	_convert_to_json_and_back()
+	
+	assert_eq(milestone.type, Milestone.LINES)
+	assert_eq(milestone.value, 120)
+
+
+func _convert_to_json_and_back() -> void:
+	var json := milestone.to_json_dict()
+	milestone = Milestone.new()
+	milestone.from_json_dict(json)

--- a/project/src/test/puzzle/level/test-other-rules.gd
+++ b/project/src/test/puzzle/level/test-other-rules.gd
@@ -1,0 +1,83 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests for rules which are unique enough that it doesn't make sense to put them in their own groups.
+"""
+
+var rules: OtherRules
+
+func before_each() -> void:
+	rules = OtherRules.new()
+
+
+func test_is_default() -> void:
+	assert_eq(rules.is_default(), true)
+	rules.after_tutorial = true
+	assert_eq(rules.is_default(), false)
+
+
+func test_convert_to_json_and_back() -> void:
+	rules.after_tutorial = true
+	rules.clear_on_finish = false
+	rules.enhance_combo_fx = true
+	rules.non_interactive = true
+	rules.suppress_piece_rotation = OtherRules.SuppressPieceRotation.ROTATION
+	rules.suppress_piece_initial_rotation = OtherRules.SuppressPieceRotation.ROTATION_AND_SIGNALS
+	rules.skip_intro = true
+	rules.start_level = "advanced/level_614"
+	rules.tile_set = PuzzleTileMap.TileSetType.VEGGIE
+	rules.tutorial = true
+	_convert_to_json_and_back()
+	
+	assert_eq(rules.after_tutorial, true)
+	assert_eq(rules.clear_on_finish, false)
+	assert_eq(rules.enhance_combo_fx, true)
+	assert_eq(rules.non_interactive, true)
+	assert_eq(rules.suppress_piece_rotation, OtherRules.SuppressPieceRotation.ROTATION)
+	assert_eq(rules.suppress_piece_initial_rotation, OtherRules.SuppressPieceRotation.ROTATION_AND_SIGNALS)
+	assert_eq(rules.skip_intro, true)
+	assert_eq(rules.start_level, "advanced/level_614")
+	assert_eq(rules.tile_set, PuzzleTileMap.TileSetType.VEGGIE)
+	assert_eq(rules.tutorial, true)
+
+
+func test_from_json_array_suppress_piece_rotation() -> void:
+	rules.from_json_array(["suppress_piece_rotation", "suppress_piece_initial_rotation"])
+	assert_eq(rules.suppress_piece_rotation, OtherRules.SuppressPieceRotation.ROTATION)
+	assert_eq(rules.suppress_piece_initial_rotation, OtherRules.SuppressPieceRotation.ROTATION)
+
+
+func test_to_json_array_suppress_piece_rotation() -> void:
+	rules.suppress_piece_rotation = OtherRules.SuppressPieceRotation.ROTATION
+	rules.suppress_piece_initial_rotation = OtherRules.SuppressPieceRotation.ROTATION
+	assert_eq(rules.to_json_array(), ["suppress_piece_rotation", "suppress_piece_initial_rotation"])
+
+
+func test_from_json_array_clear_on_finish() -> void:
+	rules.from_json_array(["no_clear_on_finish"])
+	assert_eq(rules.clear_on_finish, false)
+	
+	rules = OtherRules.new()
+	rules.from_json_array(["clear_on_finish false"])
+	assert_eq(rules.clear_on_finish, false)
+	
+	rules = OtherRules.new()
+	rules.from_json_array(["clear_on_finish true"])
+	assert_eq(rules.clear_on_finish, true)
+	
+	rules = OtherRules.new()
+	rules.from_json_array(["no_clear_on_finish false"])
+	assert_eq(rules.clear_on_finish, true)
+
+
+func test_to_json_array_clear_on_finish() -> void:
+	rules.clear_on_finish = false
+	assert_eq(rules.to_json_array(), ["no_clear_on_finish"])
+	
+	rules.clear_on_finish = true
+	assert_eq(rules.to_json_array(), [])
+
+
+func _convert_to_json_and_back() -> void:
+	var json := rules.to_json_array()
+	rules = OtherRules.new()
+	rules.from_json_array(json)

--- a/project/src/test/puzzle/level/test-phase-conditions.gd
+++ b/project/src/test/puzzle/level/test-phase-conditions.gd
@@ -1,0 +1,18 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests library of phase conditions for level triggers.
+"""
+
+func test_after_lines_cleared_phase_config() -> void:
+	var condition: PhaseConditions.AfterLinesClearedPhaseCondition
+	condition = PhaseConditions.AfterLinesClearedPhaseCondition.new({"y": "2"})
+	assert_eq_shallow(condition.get_phase_config(), {"y": "2"})
+	
+	condition = PhaseConditions.AfterLinesClearedPhaseCondition.new({"y": "1,3,5"})
+	assert_eq_shallow(condition.get_phase_config(), {"y": "1,3,5"})
+	
+	condition = PhaseConditions.AfterLinesClearedPhaseCondition.new({"y": "0-3"})
+	assert_eq_shallow(condition.get_phase_config(), {"y": "0-3"})
+	
+	condition = PhaseConditions.AfterLinesClearedPhaseCondition.new({"y": "0,4-6"})
+	assert_eq_shallow(condition.get_phase_config(), {"y": "0,4-6"})

--- a/project/src/test/puzzle/level/test-piece-type-rules.gd
+++ b/project/src/test/puzzle/level/test-piece-type-rules.gd
@@ -1,0 +1,33 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests the pieces the player is given.
+"""
+
+var rules: PieceTypeRules
+
+func before_each() -> void:
+	rules = PieceTypeRules.new()
+
+
+func test_is_default() -> void:
+	assert_eq(rules.is_default(), true)
+	
+	rules.ordered_start = true
+	assert_eq(rules.is_default(), false)
+
+
+func test_convert_to_json_and_back() -> void:
+	rules.ordered_start = true
+	rules.start_types = [PieceTypes.piece_j, PieceTypes.piece_l]
+	rules.types = [PieceTypes.piece_o, PieceTypes.piece_p]
+	_convert_to_json_and_back()
+	
+	assert_eq(rules.ordered_start, true)
+	assert_eq(rules.start_types, [PieceTypes.piece_j, PieceTypes.piece_l])
+	assert_eq(rules.types, [PieceTypes.piece_o, PieceTypes.piece_p])
+
+
+func _convert_to_json_and_back() -> void:
+	var json := rules.to_json_array()
+	rules = PieceTypeRules.new()
+	rules.from_json_array(json)

--- a/project/src/test/puzzle/level/test-rank-rules.gd
+++ b/project/src/test/puzzle/level/test-rank-rules.gd
@@ -1,0 +1,64 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests for tweaks to rank calculation.
+"""
+
+var rules: RankRules
+
+func before_each() -> void:
+	rules = RankRules.new()
+
+
+func test_is_default() -> void:
+	assert_eq(rules.is_default(), true)
+	rules.box_factor = 2.0
+	assert_eq(rules.is_default(), false)
+
+
+func test_to_json_empty() -> void:
+	assert_eq(rules.to_json_array(), [])
+
+
+func test_convert_to_json_and_back() -> void:
+	rules.box_factor = 2.3
+	rules.combo_factor = 3.4
+	rules.customer_combo = 4
+	rules.extra_seconds_per_piece = 5.6
+	rules.leftover_lines = 6
+	rules.master_pickup_score = 7.8
+	rules.master_pickup_score_per_line = 8.9
+	rules.show_boxes_rank = RankRules.ShowRank.SHOW
+	rules.show_combos_rank = RankRules.ShowRank.HIDE
+	rules.show_lines_rank = RankRules.ShowRank.SHOW
+	rules.show_pickups_rank = RankRules.ShowRank.HIDE
+	rules.show_pieces_rank = RankRules.ShowRank.SHOW
+	rules.show_speed_rank = RankRules.ShowRank.HIDE
+	rules.skip_results = true
+	rules.success_bonus = 9.0
+	rules.top_out_penalty = 10
+	rules.unranked = true
+	_convert_to_json_and_back()
+	
+	assert_eq(rules.box_factor, 2.3)
+	assert_eq(rules.combo_factor, 3.4)
+	assert_eq(rules.customer_combo, 4)
+	assert_eq(rules.extra_seconds_per_piece, 5.6)
+	assert_eq(rules.leftover_lines, 6)
+	assert_eq(rules.master_pickup_score, 7.8)
+	assert_eq(rules.master_pickup_score_per_line, 8.9)
+	assert_eq(rules.show_boxes_rank, RankRules.ShowRank.SHOW)
+	assert_eq(rules.show_combos_rank, RankRules.ShowRank.HIDE)
+	assert_eq(rules.show_lines_rank, RankRules.ShowRank.SHOW)
+	assert_eq(rules.show_pickups_rank, RankRules.ShowRank.HIDE)
+	assert_eq(rules.show_pieces_rank, RankRules.ShowRank.SHOW)
+	assert_eq(rules.show_speed_rank, RankRules.ShowRank.HIDE)
+	assert_eq(rules.skip_results, true)
+	assert_eq(rules.success_bonus, 9.0)
+	assert_eq(rules.top_out_penalty, 10)
+	assert_eq(rules.unranked, true)
+
+
+func _convert_to_json_and_back() -> void:
+	var json := rules.to_json_array()
+	rules = RankRules.new()
+	rules.from_json_array(json)

--- a/project/src/test/puzzle/level/test-score-rules.gd
+++ b/project/src/test/puzzle/level/test-score-rules.gd
@@ -1,0 +1,40 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests rules for scoring points.
+"""
+
+var rules: ScoreRules
+
+func before_each() -> void:
+	rules = ScoreRules.new()
+
+
+func test_is_default() -> void:
+	assert_eq(rules.is_default(), true)
+	rules.cake_points = 0
+	assert_eq(rules.is_default(), false)
+
+
+func test_to_json_empty() -> void:
+	assert_eq(rules.to_json_array(), [])
+
+
+func test_convert_to_json_and_back() -> void:
+	rules.cake_points = 20
+	rules.snack_points = 0
+	rules.cake_pickup_points = 25
+	rules.snack_pickup_points = 15
+	rules.veg_points = 5
+	_convert_to_json_and_back()
+	
+	assert_eq(rules.cake_points, 20)
+	assert_eq(rules.snack_points, 0)
+	assert_eq(rules.cake_pickup_points, 25)
+	assert_eq(rules.snack_pickup_points, 15)
+	assert_eq(rules.veg_points, 5)
+
+
+func _convert_to_json_and_back() -> void:
+	var json := rules.to_json_array()
+	rules = ScoreRules.new()
+	rules.from_json_array(json)

--- a/project/src/test/puzzle/test-input-replay.gd
+++ b/project/src/test/puzzle/test-input-replay.gd
@@ -1,0 +1,29 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests sequences of puzzle inputs to be replayed for things such as tutorials.
+"""
+
+var replay: InputReplay
+
+func before_each() -> void:
+	replay = InputReplay.new()
+
+
+func test_is_default() -> void:
+	assert_eq(replay.is_default(), true)
+	
+	replay.action_timings = {"25 +rotate_cw": true, "33 -rotate_cw": true}
+	assert_eq(replay.is_default(), false)
+
+
+func test_convert_replay_to_json_and_back() -> void:
+	replay.action_timings = {"25 +rotate_cw": true, "33 -rotate_cw": true}
+	_convert_to_json_and_back()
+	
+	assert_eq(replay.action_timings.keys(), ["25 +rotate_cw", "33 -rotate_cw"])
+
+
+func _convert_to_json_and_back() -> void:
+	var json := replay.to_json_array()
+	replay = InputReplay.new()
+	replay.from_json_array(json)

--- a/project/src/test/puzzle/test-rank-result.gd
+++ b/project/src/test/puzzle/test-rank-result.gd
@@ -1,0 +1,28 @@
+extends "res://addons/gut/test.gd"
+"""
+Tests for rank information for a playthrough.
+"""
+
+var result: RankResult
+
+func before_each() -> void:
+	result = RankResult.new()
+
+
+func test_to_json_lost() -> void:
+	result.lost = true
+	var json1 := result.to_json_dict()
+	assert_eq(json1.get("lost"), true)
+	
+	result.lost = false
+	var json2 := result.to_json_dict()
+	assert_eq(json2.get("lost"), false)
+
+
+func test_from_json_lost() -> void:
+	result.from_json_dict({"lost": true})
+	assert_eq(result.get("lost"), true)
+	
+	result = RankResult.new()
+	result.from_json_dict({"lost": false})
+	assert_eq(result.get("lost"), false)


### PR DESCRIPTION
Expanded RuleParser to handle writing rules as json. This involved
creating an extensible framework which can handle different property
types. It can handle basic bools/ints/floats/strings which are used
throughout multiple classes, but can also handle things like the piece
lists used in PieceTypeRules and the ShowRank properties used in RankRules.

This also required changing many other classes to be serializable to
json such as milestones, triggers and phase conditions.

Boolean properties can now be specified using json strings like
'clear_on_finish false' for consistency with non-boolean properties.

Added Utils.to_bool() utility as a workaround for Godot #27529
(https://github.com/godotengine/godot/issues/27529).