### PR TITLE
Fixed resource leaks introduced by RuleParser change.

### DIFF
--- a/project/src/main/puzzle/level/piece-type-rules.gd
+++ b/project/src/main/puzzle/level/piece-type-rules.gd
@@ -22,9 +22,9 @@ class PieceTypesPropertyParser extends RuleParser.PropertyParser:
 	
 	func to_json_strings() -> Array:
 		var result := []
-		for type in target.get(name):
+		for type in target().get(name):
 			result.append("piece_%s" % [type.string])
-		for type in target.get(start_name):
+		for type in target().get(start_name):
 			result.append("start_piece_%s" % [type.string])
 		return result
 	
@@ -32,16 +32,16 @@ class PieceTypesPropertyParser extends RuleParser.PropertyParser:
 	func from_json_string(json: String) -> void:
 		if json.begins_with("piece_") \
 				and PieceTypes.pieces_by_string.has(json.trim_prefix("piece_")):
-			target.get(name).append(PieceTypes.pieces_by_string[json.trim_prefix("piece_")])
+			target().get(name).append(PieceTypes.pieces_by_string[json.trim_prefix("piece_")])
 		elif json.begins_with("start_piece_") \
 				and PieceTypes.pieces_by_string.has(json.trim_prefix("start_piece_")):
-			target.get(start_name).append(PieceTypes.pieces_by_string[json.trim_prefix("start_piece_")])
+			target().get(start_name).append(PieceTypes.pieces_by_string[json.trim_prefix("start_piece_")])
 		else:
 			push_warning("Unrecognized: %s" % [json])
 	
 	
 	func is_default() -> bool:
-		return target.get(name).empty() and target.get(start_name).empty()
+		return target().get(name).empty() and target().get(start_name).empty()
 
 # if 'true', the start pieces always appear in the same order instead of being shuffled.
 var ordered_start: bool = false

--- a/project/src/main/puzzle/level/rank-rules.gd
+++ b/project/src/main/puzzle/level/rank-rules.gd
@@ -17,7 +17,7 @@ class ShowRankPropertyParser extends RuleParser.PropertyParser:
 	
 	func to_json_strings() -> Array:
 		var result := []
-		match target.get(name):
+		match target().get(name):
 			ShowRank.SHOW: result.append(name)
 			ShowRank.HIDE: result.append(_hide_string)
 		return result
@@ -25,13 +25,13 @@ class ShowRankPropertyParser extends RuleParser.PropertyParser:
 	
 	func from_json_string(json: String) -> void:
 		match json:
-			name: target.set(name, ShowRank.SHOW)
-			_hide_string: target.set(name, ShowRank.HIDE)
+			name: target().set(name, ShowRank.SHOW)
+			_hide_string: target().set(name, ShowRank.HIDE)
 			_: push_warning("Unrecognized: %s" % [json])
 	
 	
 	func is_default() -> bool:
-		return target.get(name) == ShowRank.DEFAULT
+		return target().get(name) == ShowRank.DEFAULT
 
 
 enum ShowRank {

--- a/project/src/main/puzzle/level/score-rules.gd
+++ b/project/src/main/puzzle/level/score-rules.gd
@@ -19,11 +19,11 @@ class PointsPropertyParser extends RuleParser.PropertyParser:
 	
 	
 	func to_json_strings() -> Array:
-		return ["%s %s" % [_all_string, target.get(name)]]
+		return ["%s %s" % [_all_string, target().get(name)]]
 	
 	
 	func from_json_string(json: String) -> void:
-		target.set(name, int(json.split(" ")[1]))
+		target().set(name, int(json.split(" ")[1]))
 
 
 const DEFAULT_CAKE_POINTS := 10


### PR DESCRIPTION
The recent RuleParser change introduced circular references between the
RuleParser and the different Rules classes. This prevents resources from
being released, resulting in a warning when exiting the game. I've changed
RuleParser's references to weak references to avoid leaking resources.