### PR TITLE
Fixed bug where inserted lines did not work.

### DIFF
--- a/project/src/main/puzzle/line-inserter.gd
+++ b/project/src/main/puzzle/line-inserter.gd
@@ -75,7 +75,7 @@ func _reset() -> void:
 	for tiles_key in CurrentLevel.settings.tiles.bunches:
 		var max_y := 0
 		for cell in CurrentLevel.settings.tiles.bunches[tiles_key].block_tiles:
-			max_y = max(max_y, cell.y)
+			max_y = int(max(max_y, cell.y))
 		_row_count_by_tiles_key[tiles_key] = max_y + 1
 	
 	# initialize _row_index_by_tiles_key


### PR DESCRIPTION
This stems from a type conversion error which affects released versions of the
game. When performing float operations, Godot will haphazardly store the result
as a float or an int depending on the circumstances. In the Godot editor, it
likes storing them as ints more often. But when exported, it likes storing them
as floats more often.