### PR TITLE
Fix WalkingBuddy crash after initial tutorial. Minor bugfixes.

### DIFF
--- a/project/src/main/creature-library.gd
+++ b/project/src/main/creature-library.gd
@@ -89,6 +89,7 @@ func reset() -> void:
 	# default player appearance and name
 	var new_player_def := CreatureDef.new()
 	new_player_def.rename(CreatureDef.DEFAULT_NAME)
+	new_player_def.creature_id = PLAYER_ID
 	new_player_def.dna = CreatureDef.DEFAULT_DNA.duplicate()
 	new_player_def.min_fatness = 1.0
 	new_player_def.chat_theme_def = CreatureDef.DEFAULT_CHAT_THEME_DEF.duplicate()

--- a/project/src/main/ui/music-popup-tween.gd
+++ b/project/src/main/ui/music-popup-tween.gd
@@ -44,8 +44,10 @@ Parameters:
 """
 func pop_in_and_out(pop_in_delay: float) -> void:
 	if pop_in_delay:
-		yield(get_tree().create_timer(pop_in_delay), "timeout")
-	_pop_in()
+		# we use a one-shot listener method instead of a yield statement to avoid 'class instance is gone' errors.
+		get_tree().create_timer(pop_in_delay).connect("timeout", self, "_pop_in")
+	else:
+		_pop_in()
 
 
 func _pop_in() -> void:

--- a/project/src/test/test-system-save.gd
+++ b/project/src/test/test-system-save.gd
@@ -20,6 +20,7 @@ func before_each() -> void:
 
 func after_each() -> void:
 	var dir := Directory.new()
+	dir.open("user://")
 	dir.remove(TEMP_SYSTEM_FILENAME)
 	dir.remove(TEMP_LEGACY_FILENAME)
 	for backup in [


### PR DESCRIPTION
Fix crash which occurs launching StoryMode after the initial tutorial.
The crash occurred because the player's ID was changed from '#player#'
to 'Spira'. This edge case was overlooked when fixing issue #903.

Fixed sporadic yield error in MusicPopupTween. Godot's official tutorials
recommend `yield(get_tree().create_timer(...` for one shot timers, perhaps as a
cruel prank against novice developers. I have since learned this practice
invariably causes 'Resumed function after yield but class instance is gone'
errors unless your project has only one scene -- and possibly, even in
single-scene projects as well.

Fixed test-system-save.gd leaving behind a 'test254.save' file because
of its buggy cleanup code.