### PR TITLE
Move ChattableManager.player assignment inside ChattableManager.

### DIFF
--- a/project/src/main/world/chattable-manager.gd
+++ b/project/src/main/world/chattable-manager.gd
@@ -75,7 +75,12 @@ func refresh_creatures() -> void:
 	_creatures_by_id.clear()
 	for creature_obj in get_tree().get_nodes_in_group("creatures"):
 		var creature: Creature = creature_obj
-		register_creature(creature)
+		if creature.creature_id == CreatureLibrary.PLAYER_ID:
+			set_player(creature)
+		elif creature.creature_id == CreatureLibrary.SENSEI_ID:
+			set_sensei(creature)
+		else:
+			register_creature(creature)
 
 
 """

--- a/project/src/main/world/creature/player.gd
+++ b/project/src/main/world/creature/player.gd
@@ -14,7 +14,6 @@ func _ready() -> void:
 	SceneTransition.connect("fade_out_started", self, "_on_SceneTransition_fade_out_started")
 	set_creature_id(CreatureLibrary.PLAYER_ID)
 	refresh_collision_extents()
-	ChattableManager.player = self
 
 
 func _unhandled_input(_event: InputEvent) -> void:

--- a/project/src/main/world/creature/sensei.gd
+++ b/project/src/main/world/creature/sensei.gd
@@ -16,7 +16,6 @@ var movement_disabled := false
 func _ready() -> void:
 	set_creature_id(CreatureLibrary.SENSEI_ID)
 	$MoveTimer.connect("timeout", self, "_on_MoveTimer_timeout")
-	ChattableManager.sensei = self
 
 
 func _on_MoveTimer_timeout() -> void:

--- a/project/src/main/world/creature/walking-buddy.gd
+++ b/project/src/main/world/creature/walking-buddy.gd
@@ -50,13 +50,11 @@ onready var destination: Node2D = get_node(destination_path)
 # the creature reevaluates whether they should continue walking when this timer times out
 onready var _move_timer: Timer = $MoveTimer
 
+"""
+Note: Some superclass method calls are implicit in gdscript for notifications. This is planned to require explicit
+super() calls in Godot 4.0
+"""
 func _ready() -> void:
-	if creature_id == CreatureLibrary.PLAYER_ID:
-		ChattableManager.player = self
-		set_creature_def(PlayerData.creature_library.player_def)
-		creature_id = CreatureLibrary.PLAYER_ID
-	if creature_id == CreatureLibrary.SENSEI_ID:
-		ChattableManager.sensei = self
 	_move_timer.connect("timeout", self, "_on_MoveTimer_timeout")
 	set_non_iso_walk_direction(WALK_DIR)
 

--- a/project/src/main/world/overworld-walk-world.gd
+++ b/project/src/main/world/overworld-walk-world.gd
@@ -8,9 +8,8 @@ onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
 func _ready() -> void:
 	MusicPlayer.play_tutorial_bgm()
 	
-	$Camera.position = ChattableManager.player.position
 	ChattableManager.refresh_creatures()
-	
+	$Camera.position = ChattableManager.player.position
 	if CutsceneManager.is_front_chat_tree():
 		_launch_cutscene()
 

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -22,6 +22,7 @@ func _ready() -> void:
 	
 	MusicPlayer.play_chill_bgm()
 	
+	ChattableManager.refresh_creatures()
 	if CutsceneManager.is_front_chat_tree():
 		_launch_cutscene()
 	else:
@@ -32,7 +33,6 @@ func _ready() -> void:
 			move_creature_to_spawn(ChattableManager.sensei, Global.sensei_spawn_id)
 	
 	$Camera.position = ChattableManager.player.position
-	ChattableManager.refresh_creatures()
 
 
 func _launch_cutscene() -> void:


### PR DESCRIPTION
ChattableManager requires a refresh every scene change where
it steps through the entire node tree looking for Creatures.
Let's use that to discover the player and sensei,
simplifying _ready Node notifications that nonlocally set
ChattableManager.player and ChattableManager.sensei.