### PR TITLE
Disabled 2D Batching on android. Disabled vsync on all targets.

### DIFF
--- a/delint.sh
+++ b/delint.sh
@@ -109,7 +109,6 @@ fi
 # project settings which are enabled temporarily, but shouldn't be pushed
 RESULT=
 RESULT=${RESULT}$(grep "emulate_touch_from_mouse=true" project/project.godot)
-RESULT=${RESULT}$(grep "window/vsync/use_vsync=false" project/project.godot)
 if [ -n "$RESULT" ]
 then
   echo ""
@@ -119,7 +118,6 @@ then
   then
     # unset project settings
     sed -i "/emulate_touch_from_mouse=true/d" project/project.godot
-    sed -i "/window\/vsync\/use_vsync=false/d" project/project.godot
     echo "...Temporary settings reverted."
   fi
 fi

--- a/project/project.godot
+++ b/project/project.godot
@@ -1133,6 +1133,7 @@ gdscript/warnings/return_value_discarded=false
 
 [display]
 
+window/vsync/use_vsync=false
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 
@@ -1340,3 +1341,4 @@ environment/default_clear_color=Color( 0.12549, 0.12549, 0.12549, 1 )
 quality/filters/msaa=2
 quality/depth/hdr=false
 quality/2d/gles2_use_nvidia_rect_flicker_workaround=true
+batching/options/use_batching.Android=false


### PR DESCRIPTION
Disabled 2D batching for Android. Android 2D batching reduces FPS by
80%:
 * On android, with batching off, the game runs at about 60 FPS on the
   overworld, and 15 FPS for a 35 creature stress test.
 * On android, with batching on, the game runs at about 15 FPS on the
   overworld, and 3 FPS for a 35 creature stress test.
 * On windows, with batching off, the game runs at about 410 FPS on the
   overworld, and 130 FPS for a 35 creature stress test.
 * On windows, with batching on, the game runs at about 580 FPS on the
   overworld, and 160 FPS for a 35 creature stress test.

Disabled vsync. With vsync off, I don't notice stuttering during the puzzles on
desktop.