### PR TITLE
Overworld offset, collision fixes. map_to_world_centered() utility.

### DIFF
--- a/project/src/main/editor/puzzle/editor-pickups.gd
+++ b/project/src/main/editor/puzzle/editor-pickups.gd
@@ -26,8 +26,7 @@ func set_pickup(cell: Vector2, box_type: int) -> void:
 		var pickup: Pickup = PickupScene.instance()
 		pickup.food_type = _food_type_for_cell(box_type, cell)
 	
-		pickup.position = _puzzle_tile_map.map_to_world(cell)
-		pickup.position += _puzzle_tile_map.cell_size * Vector2(0.5, 0.5)
+		pickup.position = Utils.map_to_world_centered(_puzzle_tile_map, cell)
 		pickup.position *= _puzzle_tile_map.scale
 		pickup.scale = _puzzle_tile_map.scale
 		pickup.z_index = 4 # in front of the active piece

--- a/project/src/main/puzzle/combo-counters.gd
+++ b/project/src/main/puzzle/combo-counters.gd
@@ -72,8 +72,7 @@ func _on_Playfield_before_line_cleared(y: int, _total_lines: int, _remaining_lin
 	_previous_cell_x = target_cell.x
 	
 	var combo_counter: ComboCounter = ComboCounterScene.instance()
-	combo_counter.position = _playfield.tile_map.map_to_world(target_cell + Vector2(0, -3))
-	combo_counter.position += _playfield.tile_map.cell_size * Vector2(0.5, 0.5)
+	combo_counter.position = Utils.map_to_world_centered(_playfield.tile_map, target_cell + Vector2(0, -3))
 	combo_counter.position *= _playfield.tile_map.scale
 	combo_counter.combo = PuzzleState.combo
 	add_child(combo_counter)

--- a/project/src/main/puzzle/food-items.gd
+++ b/project/src/main/puzzle/food-items.gd
@@ -75,8 +75,7 @@ func add_food_item(cell: Vector2, food_type: int, remaining_food: int = 0) -> vo
 	var food_item: FoodItem = FoodScene.instance()
 	food_item.collect()
 	food_item.food_type = food_type
-	food_item.position = _puzzle_tile_map.map_to_world(cell)
-	food_item.position += _puzzle_tile_map.cell_size * Vector2(0.5, 0.5)
+	food_item.position = Utils.map_to_world_centered(_puzzle_tile_map, cell)
 	food_item.position *= _puzzle_tile_map.scale / _texture_rect.rect_scale
 	food_item.position += _puzzle_tile_map_position / _texture_rect.rect_scale
 	food_item.base_scale = _puzzle_tile_map.scale / _texture_rect.rect_scale

--- a/project/src/main/puzzle/pickups.gd
+++ b/project/src/main/puzzle/pickups.gd
@@ -58,8 +58,7 @@ func set_pickup(cell: Vector2, box_type: int) -> void:
 		var pickup: Pickup = PickupScene.instance()
 		pickup.food_type = _food_type_for_box_type(box_type, cell)
 
-		pickup.position = _puzzle_tile_map.map_to_world(cell + Vector2(0, -3))
-		pickup.position += _puzzle_tile_map.cell_size * Vector2(0.5, 0.5)
+		pickup.position = Utils.map_to_world_centered(_puzzle_tile_map, cell + Vector2(0, -3))
 		pickup.position *= _puzzle_tile_map.scale
 		pickup.scale = _puzzle_tile_map.scale
 		pickup.z_index = 4 # in front of the active piece

--- a/project/src/main/utils.gd
+++ b/project/src/main/utils.gd
@@ -300,3 +300,19 @@ static func to_bool(s: String) -> bool:
 		"False", "FALSE", "false", "0": result = false
 		_: result = false if s.empty() else true
 	return result
+
+
+"""
+Returns the local position of the center of the cell corresponding to the given tilemap (grid-based) coordinates.
+
+One might expect this could be implemented trivially by passing in something like 'map_to_world(2.5, 2.5)' to
+get the center of the cell at (2, 2). But, map_to_world does not work that way.
+
+One might also expect this could be implemented by doing something like "Get the top left corner, and shift it by half
+the cell size." But, this returns incorrect results for isometric tilemaps.
+
+For now, the nuance and complexity required in correctly implementing this trivial functionality warrants a utility
+function.
+"""
+static func map_to_world_centered(tile_map: TileMap, cell: Vector2) -> Vector2:
+	return (tile_map.map_to_world(cell) + tile_map.map_to_world(cell + Vector2(1, 1))) * 0.5

--- a/project/src/main/world/GroundMap.tscn
+++ b/project/src/main/world/GroundMap.tscn
@@ -7,7 +7,7 @@
 [sub_resource type="TileSet" id=1]
 0/name = "marsh-frosting-sheet.png 0"
 0/texture = ExtResource( 2 )
-0/tex_offset = Vector2( 0, 35 )
+0/tex_offset = Vector2( 0, 25 )
 0/modulate = Color( 1, 1, 1, 1 )
 0/region = Rect2( 0, 0, 810, 660 )
 0/tile_mode = 2

--- a/project/src/main/world/environment/ground-library.tres
+++ b/project/src/main/world/environment/ground-library.tres
@@ -5,7 +5,7 @@
 [resource]
 0/name = "marsh-frosting"
 0/texture = ExtResource( 1 )
-0/tex_offset = Vector2( 0, 35 )
+0/tex_offset = Vector2( 0, 25 )
 0/modulate = Color( 1, 1, 1, 1 )
 0/region = Rect2( 0, 0, 810, 660 )
 0/tile_mode = 1

--- a/project/src/main/world/environment/obstacle-library.tres
+++ b/project/src/main/world/environment/obstacle-library.tres
@@ -47,8 +47,8 @@ points = PoolVector2Array( -3, 80, 29, 64, 93, 96, 61, 112 )
 1/tile_mode = 0
 1/occluder_offset = Vector2( 0, 0 )
 1/navigation_offset = Vector2( 0, 0 )
-1/shape_offset = Vector2( 74, 113.5 )
-1/shape_transform = Transform2D( 1, 0, 0, 1, 74, 113.5 )
+1/shape_offset = Vector2( 74, 106 )
+1/shape_transform = Transform2D( 1, 0, 0, 1, 74, 106 )
 1/shape = SubResource( 1 )
 1/shape_one_way = false
 1/shape_one_way_margin = 1.0
@@ -57,12 +57,12 @@ points = PoolVector2Array( -3, 80, 29, 64, 93, 96, 61, 112 )
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 74, 113.5 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 74, 106 )
 } ]
 1/z_index = 0
 2/name = "marsh-frosting"
 2/texture = ExtResource( 1 )
-2/tex_offset = Vector2( 0, -47.5 )
+2/tex_offset = Vector2( 0, -52.5 )
 2/modulate = Color( 1, 1, 1, 1 )
 2/region = Rect2( 0, 0, 810, 660 )
 2/tile_mode = 1
@@ -77,8 +77,8 @@ points = PoolVector2Array( -3, 80, 29, 64, 93, 96, 61, 112 )
 2/autotile/z_index_map = [  ]
 2/occluder_offset = Vector2( 0, 0 )
 2/navigation_offset = Vector2( 0, 0 )
-2/shape_offset = Vector2( 67.5, 90 )
-2/shape_transform = Transform2D( 1, 0, 0, 1, 67.5, 90 )
+2/shape_offset = Vector2( 67, 82 )
+2/shape_transform = Transform2D( 1, 0, 0, 1, 67, 82 )
 2/shape = SubResource( 1 )
 2/shape_one_way = false
 2/shape_one_way_margin = 1.0
@@ -87,132 +87,138 @@ points = PoolVector2Array( -3, 80, 29, 64, 93, 96, 61, 112 )
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 1, 0 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 2, 0 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 3, 0 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 4, 0 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
+}, {
+"autotile_coord": Vector2( 5, 0 ),
+"one_way": false,
+"one_way_margin": 1.0,
+"shape": SubResource( 1 ),
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 0, 1 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 1, 1 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 2, 1 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 3, 1 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 4, 1 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
+}, {
+"autotile_coord": Vector2( 5, 1 ),
+"one_way": false,
+"one_way_margin": 1.0,
+"shape": SubResource( 1 ),
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 0, 2 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 1, 2 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 2, 2 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 3, 2 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 4, 2 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
+}, {
+"autotile_coord": Vector2( 5, 2 ),
+"one_way": false,
+"one_way_margin": 1.0,
+"shape": SubResource( 1 ),
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 0, 3 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 1, 3 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 2, 3 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 3, 3 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
-}, {
-"autotile_coord": Vector2( 4, 3 ),
-"one_way": false,
-"one_way_margin": 1.0,
-"shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
-}, {
-"autotile_coord": Vector2( 0, 4 ),
-"one_way": false,
-"one_way_margin": 1.0,
-"shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 } ]
 2/z_index = 0
 3/name = "marsh-block-sheet.png 3"
 3/texture = ExtResource( 4 )
-3/tex_offset = Vector2( 0, -47.5 )
+3/tex_offset = Vector2( 0, -52.5 )
 3/modulate = Color( 1, 1, 1, 1 )
 3/region = Rect2( 0, 0, 810, 990 )
 3/tile_mode = 1
@@ -227,8 +233,8 @@ points = PoolVector2Array( -3, 80, 29, 64, 93, 96, 61, 112 )
 3/autotile/z_index_map = [  ]
 3/occluder_offset = Vector2( 0, 0 )
 3/navigation_offset = Vector2( 0, 0 )
-3/shape_offset = Vector2( 67.5, 90 )
-3/shape_transform = Transform2D( 1, 0, 0, 1, 67.5, 90 )
+3/shape_offset = Vector2( 67, 82 )
+3/shape_transform = Transform2D( 1, 0, 0, 1, 67, 82 )
 3/shape = SubResource( 1 )
 3/shape_one_way = false
 3/shape_one_way_margin = 1.0
@@ -237,156 +243,198 @@ points = PoolVector2Array( -3, 80, 29, 64, 93, 96, 61, 112 )
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 1, 0 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 2, 0 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 3, 0 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 4, 0 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
+}, {
+"autotile_coord": Vector2( 5, 0 ),
+"one_way": false,
+"one_way_margin": 1.0,
+"shape": SubResource( 1 ),
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 0, 1 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 1, 1 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 2, 1 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 3, 1 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 4, 1 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
+}, {
+"autotile_coord": Vector2( 5, 1 ),
+"one_way": false,
+"one_way_margin": 1.0,
+"shape": SubResource( 1 ),
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 0, 2 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 1, 2 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 2, 2 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 3, 2 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 4, 2 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
+}, {
+"autotile_coord": Vector2( 5, 2 ),
+"one_way": false,
+"one_way_margin": 1.0,
+"shape": SubResource( 1 ),
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 0, 3 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 1, 3 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 2, 3 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 3, 3 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 4, 3 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
+}, {
+"autotile_coord": Vector2( 5, 3 ),
+"one_way": false,
+"one_way_margin": 1.0,
+"shape": SubResource( 1 ),
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 0, 4 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 1, 4 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 2, 4 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 3, 4 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 }, {
 "autotile_coord": Vector2( 4, 4 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 1 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 67.5, 90 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
+}, {
+"autotile_coord": Vector2( 5, 4 ),
+"one_way": false,
+"one_way_margin": 1.0,
+"shape": SubResource( 1 ),
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
+}, {
+"autotile_coord": Vector2( 0, 5 ),
+"one_way": false,
+"one_way_margin": 1.0,
+"shape": SubResource( 1 ),
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
+}, {
+"autotile_coord": Vector2( 1, 5 ),
+"one_way": false,
+"one_way_margin": 1.0,
+"shape": SubResource( 1 ),
+"shape_transform": Transform2D( 1, 0, 0, 1, 67, 82 )
 } ]
 3/z_index = 0
 4/name = "marsh-fence-sheet.png 4"
 4/texture = ExtResource( 5 )
-4/tex_offset = Vector2( 0, -32 )
+4/tex_offset = Vector2( 0, -28 )
 4/modulate = Color( 1, 1, 1, 1 )
 4/region = Rect2( 0, 0, 360, 360 )
 4/tile_mode = 1
@@ -401,8 +449,8 @@ points = PoolVector2Array( -3, 80, 29, 64, 93, 96, 61, 112 )
 4/autotile/z_index_map = [  ]
 4/occluder_offset = Vector2( 0, 0 )
 4/navigation_offset = Vector2( 0, 0 )
-4/shape_offset = Vector2( 0, -32 )
-4/shape_transform = Transform2D( 1, 0, 0, 1, 0, -32 )
+4/shape_offset = Vector2( 0, -28 )
+4/shape_transform = Transform2D( 1, 0, 0, 1, 0, -28 )
 4/shape = SubResource( 2 )
 4/shape_one_way = false
 4/shape_one_way_margin = 1.0
@@ -411,72 +459,72 @@ points = PoolVector2Array( -3, 80, 29, 64, 93, 96, 61, 112 )
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 2 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 0, -32 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 0, -28 )
 }, {
 "autotile_coord": Vector2( 1, 0 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 3 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 0, -32 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 0, -28 )
 }, {
 "autotile_coord": Vector2( 2, 0 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 4 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 0, -32 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 0, -28 )
 }, {
 "autotile_coord": Vector2( 3, 0 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 4 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 0, -32 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 0, -28 )
 }, {
 "autotile_coord": Vector2( 0, 1 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 5 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 0, -32 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 0, -28 )
 }, {
 "autotile_coord": Vector2( 1, 1 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 6 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 0, -32 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 0, -28 )
 }, {
 "autotile_coord": Vector2( 2, 1 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 7 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 0, -32 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 0, -28 )
 }, {
 "autotile_coord": Vector2( 3, 1 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 8 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 0, -32 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 0, -28 )
 }, {
 "autotile_coord": Vector2( 0, 2 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 9 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 0, -32 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 0, -28 )
 }, {
 "autotile_coord": Vector2( 1, 2 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 10 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 0, -32 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 0, -28 )
 }, {
 "autotile_coord": Vector2( 2, 2 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 11 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 0, -32 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 0, -28 )
 }, {
 "autotile_coord": Vector2( 3, 2 ),
 "one_way": false,
 "one_way_margin": 1.0,
 "shape": SubResource( 11 ),
-"shape_transform": Transform2D( 1, 0, 0, 1, 0, -32 )
+"shape_transform": Transform2D( 1, 0, 0, 1, 0, -28 )
 } ]
 4/z_index = 0


### PR DESCRIPTION
Minor adjustments to overworld texture and collision offsets. The
empty outer cell collisions were slightly misaligned with the obstalce
collisions. The ground and obstacle tilemaps were also not very well
aligned with the tilemap grid. This became especially apparent when
adding goop waves because they were asymmetrical on the left and right.

Fixed some overworld tilesets which did not have collision shapes
defined. This was broken when we recently got rid of the goop shader and
generated pre-colored tilesets.

Extracted Utils.map_to_world_centered() utility. We were doing this in
many traditional tilemaps, but the procedure for calculating the center of a
cell in an isometric tilemaps is more complex.