### PR TITLE
Added vsync toggle. Capped FPS to 120.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -1109,7 +1109,7 @@ _global_script_class_icons={
 config/name="Turbo Fat"
 run/main_scene="res://src/main/ui/menu/LoadingScreen.tscn"
 config/icon="res://assets/main/ui/icon.png"
-config/version="0.3000"
+config/version="0.3015"
 
 [audio]
 
@@ -1146,6 +1146,7 @@ PhaseConditions="*res://src/main/puzzle/level/phase-conditions.gd"
 
 [debug]
 
+settings/fps/force_fps=120
 gdscript/warnings/narrowing_conversion=false
 gdscript/warnings/return_value_discarded=false
 

--- a/project/src/main/settings/graphics-settings.gd
+++ b/project/src/main/settings/graphics-settings.gd
@@ -13,11 +13,18 @@ enum CreatureDetail {
 # CreatureDetail enum describing how detailed the creatures should look
 var creature_detail: int = _default_creature_detail() setget set_creature_detail
 
+var use_vsync: bool = _default_use_vsync() setget set_use_vsync
+
 func set_creature_detail(new_creature_detail: int) -> void:
 	if creature_detail == new_creature_detail:
 		return
 	creature_detail = new_creature_detail
 	emit_signal("creature_detail_changed", new_creature_detail)
+
+
+func set_use_vsync(new_use_vsync: bool) -> void:
+	use_vsync = new_use_vsync
+	OS.set_use_vsync(new_use_vsync)
 
 
 """
@@ -30,11 +37,13 @@ func reset() -> void:
 func to_json_dict() -> Dictionary:
 	return {
 		"creature_detail": creature_detail,
+		"use_vsync": use_vsync,
 	}
 
 
 func from_json_dict(json: Dictionary) -> void:
 	set_creature_detail(json.get("creature_detail", _default_creature_detail()))
+	set_use_vsync(json.get("use_vsync", _default_use_vsync()))
 
 
 """
@@ -48,3 +57,13 @@ Viewport texture utilized by creatures offers poor performance on mobile and web
 """
 func _default_creature_detail() -> int:
 	return CreatureDetail.LOW if OS.has_feature("web") or OS.has_feature("mobile") else CreatureDetail.HIGH
+
+
+"""
+Returns the default 'use vsync' value.
+
+Many platforms enforce vsync regardless of this value (such as mobile platforms and HTML5), so we default it to 'true'
+on those platforms. However, it makes stuttering more noticable during puzzles.
+"""
+func _default_use_vsync() -> bool:
+	return true if OS.has_feature("web") or OS.has_feature("mobile") else false

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=28 format=2]
+[gd_scene load_steps=29 format=2]
 
 [ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=2]
@@ -24,6 +24,7 @@
 [ext_resource path="res://src/main/ui/settings/settings-save-slot.gd" type="Script" id=22]
 [ext_resource path="res://src/main/ui/DialogBackdrop.tscn" type="PackedScene" id=23]
 [ext_resource path="res://src/main/ui/settings/settings-dialogs.gd" type="Script" id=24]
+[ext_resource path="res://src/main/ui/settings/settings-use-vsync.gd" type="Script" id=25]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 5.0
@@ -221,6 +222,39 @@ size_flags_stretch_ratio = 1.1
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
+[node name="Use Vsync" type="HBoxContainer" parent="Window/UiArea/TabContainer/Sound + Graphics"]
+margin_top = 182.0
+margin_right = 560.0
+margin_bottom = 210.0
+rect_min_size = Vector2( 400, 26 )
+size_flags_horizontal = 3
+theme = ExtResource( 1 )
+custom_constants/separation = 20
+script = ExtResource( 25 )
+
+[node name="Label" type="Label" parent="Window/UiArea/TabContainer/Sound + Graphics/Use Vsync"]
+margin_right = 217.0
+margin_bottom = 28.0
+rect_min_size = Vector2( 120, 0 )
+size_flags_horizontal = 3
+size_flags_vertical = 5
+size_flags_stretch_ratio = 0.74
+text = "Use Vsync"
+align = 2
+valign = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="CheckboxButton" type="CheckBox" parent="Window/UiArea/TabContainer/Sound + Graphics/Use Vsync"]
+margin_left = 237.0
+margin_right = 397.0
+margin_bottom = 28.0
+rect_min_size = Vector2( 160, 0 )
+size_flags_horizontal = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 1.1
 
 [node name="Gameplay" type="VBoxContainer" parent="Window/UiArea/TabContainer"]
 visible = false
@@ -987,6 +1021,7 @@ __meta__ = {
 [connection signal="delete_pressed" from="Window/UiArea/TabContainer/Misc/SaveSlot" to="Dialogs" method="_on_SaveSlot_delete_pressed"]
 [connection signal="pressed" from="Window/UiArea/TabContainer/Misc/SaveSlot/HBoxContainer/Delete" to="Window/UiArea/TabContainer/Misc/SaveSlot" method="_on_Delete_pressed"]
 [connection signal="item_selected" from="Window/UiArea/TabContainer/Sound + Graphics/Creature Graphics/OptionButton" to="Window/UiArea/TabContainer/Sound + Graphics/Creature Graphics" method="_on_OptionButton_item_selected"]
+[connection signal="pressed" from="Window/UiArea/TabContainer/Sound + Graphics/Use Vsync/CheckboxButton" to="Window/UiArea/TabContainer/Sound + Graphics/Use Vsync" method="_on_CheckboxButton_pressed"]
 [connection signal="item_selected" from="Window/UiArea/TabContainer/Touch/FatFinger/OptionButton" to="Window/UiArea/TabContainer/Touch/FatFinger" method="_on_OptionButton_item_selected"]
 [connection signal="item_selected" from="Window/UiArea/TabContainer/Touch/Scheme/OptionButton" to="Window/UiArea/TabContainer/Touch/Scheme" method="_on_OptionButton_item_selected"]
 [connection signal="value_changed" from="Window/UiArea/TabContainer/Touch/Size/Control/HSlider" to="Window/UiArea/TabContainer/Touch/Size" method="_on_HSlider_value_changed"]

--- a/project/src/main/ui/settings/settings-use-vsync.gd
+++ b/project/src/main/ui/settings/settings-use-vsync.gd
@@ -1,0 +1,13 @@
+extends HBoxContainer
+"""
+UI control for toggling vertical synchronization.
+"""
+
+onready var _checkbox_button: CheckBox = $CheckboxButton
+
+func _ready() -> void:
+	_checkbox_button.pressed = SystemData.graphics_settings.use_vsync
+
+
+func _on_CheckboxButton_pressed() -> void:
+	SystemData.graphics_settings.use_vsync = _checkbox_button.pressed


### PR DESCRIPTION
Vsync can be toggled through the settings menu. It defaults to 'true' on
mobile/web platforms, and 'false' on other platforms.

Capped FPS to 120. Discord user Amavect indicated that with VSync off, Turbo Fat
maxed out a core. Limiting the FPS should prevent this.