### PR TITLE
Utilize ResourceCache to load creatures faster.

### DIFF
--- a/project/src/main/breadcrumb.gd
+++ b/project/src/main/breadcrumb.gd
@@ -76,13 +76,12 @@ Changes the running scene to the one at the front of the breadcrumb trail.
 """
 func _change_scene() -> void:
 	emit_signal("before_scene_changed")
+	var scene_path: String
 	if trail:
-		if ResourceCache.has_cached_resource(trail.front()):
-			get_tree().change_scene_to(ResourceCache.get_cached_resource(trail.front()))
-		else:
-			get_tree().change_scene(trail.front())
+		scene_path = trail.front()
 	else:
 		# player popped the top item off the breadcrumb trail (possibly from something like a demo)
 		# exit to loading screen and load all resources
 		ResourceCache.minimal_resources = false
-		get_tree().change_scene("res://src/main/ui/menu/LoadingScreen.tscn")
+		scene_path = "res://src/main/ui/menu/LoadingScreen.tscn"
+	get_tree().change_scene_to(ResourceCache.get_resource(scene_path))

--- a/project/src/main/puzzle/tutorial/tutorial-hud.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-hud.gd
@@ -45,7 +45,7 @@ func replace_tutorial_module() -> void:
 		module_path = "res://src/main/puzzle/tutorial/TutorialComboModule.tscn"
 	
 	if module_path:
-		var tutorial_module_scene: PackedScene = load(module_path)
+		var tutorial_module_scene: PackedScene = ResourceCache.get_resource(module_path)
 		var tutorial_module: Node = tutorial_module_scene.instance()
 		tutorial_module.hud = self
 		tutorial_module.name = "TutorialModule"

--- a/project/src/main/resource-cache.gd
+++ b/project/src/main/resource-cache.gd
@@ -158,8 +158,18 @@ func has_cached_resource(path: String) -> bool:
 	return _cache.has(path)
 
 
-func get_cached_resource(path: String) -> Resource:
-	return _cache.get(path)
+"""
+Returns the resource at the specified path, possibly from the cache.
+
+Most items will be retrieved from the cache, but especially large scenes will be loaded each time.
+"""
+func get_resource(path: String) -> Resource:
+	var result: Resource
+	if _cache.has(path):
+		result = _cache.get(path)
+	else:
+		result = load(path)
+	return result
 
 
 """

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -233,7 +233,7 @@ func _load_texture(dna: Dictionary, node_path: String, key: String, filename: St
 			# but also throws an error.
 			pass
 		else:
-			resource = load(resource_path)
+			resource = ResourceCache.get_resource(resource_path)
 	
 	if resource:
 		dna["property:%s:texture" % node_path] = resource

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -108,7 +108,7 @@ func _ready() -> void:
 	if not Engine.is_editor_hint() \
 			and SystemData.graphics_settings.creature_detail == GraphicsSettings.CreatureDetail.LOW:
 		creature_outline_scene_path = "res://src/main/world/creature/FastCreatureOutline.tscn"
-	var creature_outline_scene: PackedScene = load(creature_outline_scene_path)
+	var creature_outline_scene: PackedScene = ResourceCache.get_resource(creature_outline_scene_path)
 	_creature_outline = creature_outline_scene.instance()
 	add_child(_creature_outline)
 	


### PR DESCRIPTION
ResourceCache was previously only used for caching large scenes to
reduce load times during scene transitions. It was already caching things like
images and sounds to facilitate in the caching of scenes, but it was
never polled for these resources directly.

The CreatureLoader and Creature classes now directly consult
ResourceCache to obtain creature resources. This is much faster and
eliminates the jitter effect when creatures show up during puzzles.