### PR TITLE
Added 'Open User Folder', 'Copy to Clipboard' buttons

### DIFF
--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=29 format=2]
+[gd_scene load_steps=31 format=2]
 
 [ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=2]
@@ -25,6 +25,8 @@
 [ext_resource path="res://src/main/ui/DialogBackdrop.tscn" type="PackedScene" id=23]
 [ext_resource path="res://src/main/ui/settings/settings-dialogs.gd" type="Script" id=24]
 [ext_resource path="res://src/main/ui/settings/settings-use-vsync.gd" type="Script" id=25]
+[ext_resource path="res://src/main/ui/settings/settings-open-user-folder.gd" type="Script" id=26]
+[ext_resource path="res://src/main/ui/settings/settings-copy-save-data.gd" type="Script" id=27]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 5.0
@@ -866,6 +868,82 @@ margin_bottom = 26.0
 size_flags_vertical = 4
 text = "X"
 
+[node name="Open User Folder" type="HBoxContainer" parent="Window/UiArea/TabContainer/Misc"]
+margin_top = 84.0
+margin_right = 560.0
+margin_bottom = 110.0
+rect_min_size = Vector2( 400, 26 )
+size_flags_horizontal = 3
+theme = ExtResource( 1 )
+custom_constants/separation = 20
+script = ExtResource( 26 )
+
+[node name="Spacer" type="Control" parent="Window/UiArea/TabContainer/Misc/Open User Folder"]
+margin_right = 217.0
+margin_bottom = 26.0
+rect_min_size = Vector2( 120, 0 )
+size_flags_horizontal = 3
+size_flags_vertical = 5
+size_flags_stretch_ratio = 0.74
+
+[node name="Button" type="Button" parent="Window/UiArea/TabContainer/Misc/Open User Folder"]
+margin_left = 237.0
+margin_right = 397.0
+margin_bottom = 26.0
+rect_min_size = Vector2( 160, 0 )
+size_flags_horizontal = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 1.1
+text = "Open User Folder"
+
+[node name="CopySaveData" type="HBoxContainer" parent="Window/UiArea/TabContainer/Misc"]
+margin_top = 114.0
+margin_right = 560.0
+margin_bottom = 140.0
+rect_min_size = Vector2( 400, 26 )
+size_flags_horizontal = 3
+theme = ExtResource( 1 )
+custom_constants/separation = 20
+script = ExtResource( 27 )
+_save_slot_control_path = NodePath("../SaveSlot")
+
+[node name="Spacer" type="Control" parent="Window/UiArea/TabContainer/Misc/CopySaveData"]
+margin_right = 217.0
+margin_bottom = 26.0
+rect_min_size = Vector2( 120, 0 )
+size_flags_horizontal = 3
+size_flags_vertical = 5
+size_flags_stretch_ratio = 0.74
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Window/UiArea/TabContainer/Misc/CopySaveData"]
+margin_left = 237.0
+margin_right = 521.0
+margin_bottom = 26.0
+size_flags_horizontal = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 1.1
+
+[node name="Button" type="Button" parent="Window/UiArea/TabContainer/Misc/CopySaveData/HBoxContainer"]
+margin_right = 160.0
+margin_bottom = 26.0
+rect_min_size = Vector2( 160, 0 )
+size_flags_horizontal = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 1.1
+text = "Copy to Clipboard"
+
+[node name="Copied" type="Label" parent="Window/UiArea/TabContainer/Misc/CopySaveData/HBoxContainer"]
+margin_left = 164.0
+margin_right = 284.0
+margin_bottom = 26.0
+rect_min_size = Vector2( 120, 0 )
+size_flags_vertical = 1
+size_flags_stretch_ratio = 0.74
+text = "Copied!"
+valign = 1
+
+[node name="CopiedTween" type="Tween" parent="Window/UiArea/TabContainer/Misc/CopySaveData/HBoxContainer"]
+
 [node name="Bottom" type="Control" parent="Window/UiArea"]
 margin_top = 300.0
 margin_right = 570.0
@@ -1017,7 +1095,9 @@ __meta__ = {
 [connection signal="pressed" from="Window/UiArea/Bottom/Ok" to="." method="_on_Ok_pressed"]
 [connection signal="pressed" from="Window/UiArea/Bottom/Quit" to="." method="_on_Quit_pressed"]
 [connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/GhostPiece/CheckboxButton" to="Window/UiArea/TabContainer/Gameplay/GhostPiece" method="_on_OptionButton_toggled"]
+[connection signal="pressed" from="Window/UiArea/TabContainer/Misc/CopySaveData/HBoxContainer/Button" to="Window/UiArea/TabContainer/Misc/CopySaveData" method="_on_Button_pressed"]
 [connection signal="item_selected" from="Window/UiArea/TabContainer/Misc/Language/OptionButton" to="Window/UiArea/TabContainer/Misc/Language" method="_on_OptionButton_item_selected"]
+[connection signal="pressed" from="Window/UiArea/TabContainer/Misc/Open User Folder/Button" to="Window/UiArea/TabContainer/Misc/Open User Folder" method="_on_Button_pressed"]
 [connection signal="delete_pressed" from="Window/UiArea/TabContainer/Misc/SaveSlot" to="Dialogs" method="_on_SaveSlot_delete_pressed"]
 [connection signal="pressed" from="Window/UiArea/TabContainer/Misc/SaveSlot/HBoxContainer/Delete" to="Window/UiArea/TabContainer/Misc/SaveSlot" method="_on_Delete_pressed"]
 [connection signal="item_selected" from="Window/UiArea/TabContainer/Sound + Graphics/Creature Graphics/OptionButton" to="Window/UiArea/TabContainer/Sound + Graphics/Creature Graphics" method="_on_OptionButton_item_selected"]

--- a/project/src/main/ui/settings/settings-copy-save-data.gd
+++ b/project/src/main/ui/settings/settings-copy-save-data.gd
@@ -1,0 +1,28 @@
+extends HBoxContainer
+"""
+UI component for a copying the selected save data to the clipboard
+"""
+
+export var _save_slot_control_path: NodePath
+
+# UI component for a changing the current save slot or deleting save slots
+onready var _save_slot_control: SaveSlotControl = get_node(_save_slot_control_path)
+
+onready var _copied_label: Label = $HBoxContainer/Copied
+onready var _copied_tween: Tween = $HBoxContainer/CopiedTween
+
+func _ready() -> void:
+	# hide the 'Copied!' message until we need to display it
+	_copied_label.modulate = Color.transparent
+
+
+func _on_Button_pressed() -> void:
+	# copy the contents of the selected save file to the clipboard
+	var save_filename: String = SystemSave.FILENAMES_BY_SAVE_SLOT[_save_slot_control.get_selected_save_slot()]
+	var save_text := FileUtils.get_file_as_text(save_filename)
+	OS.set_clipboard(save_text)
+	
+	# display the 'Copied!' message, and gradually fade it out
+	_copied_label.modulate = Color.white
+	_copied_tween.interpolate_property(_copied_label, "modulate", Color.white, Color.transparent, 3.0)
+	_copied_tween.start()

--- a/project/src/main/ui/settings/settings-open-user-folder.gd
+++ b/project/src/main/ui/settings/settings-open-user-folder.gd
@@ -1,0 +1,17 @@
+extends HBoxContainer
+"""
+UI component for opening the user's data folder.
+
+The user's data folder has all their save data. Accessing this folder is useful when backing up their data or changing
+PCs.
+"""
+
+onready var _button := $Button
+
+func _ready() -> void:
+	if OS.has_feature("web") or OS.has_feature("android"):
+		_button.disabled = true
+
+
+func _on_Button_pressed() -> void:
+	OS.shell_open(OS.get_user_data_dir())


### PR DESCRIPTION
When balancing the game, I'd really like to get access to other player's
play statistics (combos, boxes, pieces per minute). For players on
Windows/Linux, they can send me their 'saveslot0.json' file. For players
on the web, they can copy it to their clipboard and pastebin it.