### PR TITLE
Unused constants. top_out_penalty float. push_warning.

### DIFF
--- a/project/src/main/puzzle/level/blocks-during-rules.gd
+++ b/project/src/main/puzzle/level/blocks-during-rules.gd
@@ -15,22 +15,6 @@ enum PickupType {
 	FLOAT_REGEN, # pickups float in place and regenerate if collected
 }
 
-# key: (string) line clear type which appears in level definitions
-# value: (int) an enum from LineClearType
-const LINE_CLEAR_TYPES_BY_NAME := {
-	"default": LineClearType.DEFAULT,
-	"float": LineClearType.FLOAT,
-	"float_fall": LineClearType.FLOAT_FALL,
-}
-
-# key: (string) pickup type which appears in level definitions
-# value: (int) an enum from PickupType
-const PICKUP_TYPES_BY_NAME := {
-	"default": PickupType.DEFAULT,
-	"float": PickupType.FLOAT,
-	"float_regen": PickupType.FLOAT_REGEN,
-}
-
 # if true, the entire playfield is cleared when the player tops out
 var clear_on_top_out := false
 

--- a/project/src/main/puzzle/level/rank-rules.gd
+++ b/project/src/main/puzzle/level/rank-rules.gd
@@ -79,7 +79,7 @@ var skip_results := false
 var success_bonus := 0.0
 
 # rank penalty applied each time the player tops out
-var top_out_penalty := 4
+var top_out_penalty := 4.0
 
 # If 'true' the player is not given a rank for this level.
 var unranked := false
@@ -103,7 +103,7 @@ func _init() -> void:
 	_rule_parser.add(ShowRankPropertyParser.new(self, "show_speed_rank"))
 	_rule_parser.add_bool("skip_results")
 	_rule_parser.add_float("success_bonus")
-	_rule_parser.add_int("top_out_penalty").default(4)
+	_rule_parser.add_float("top_out_penalty").default(4.0)
 	_rule_parser.add_bool("unranked")
 
 

--- a/project/src/main/puzzle/tutorial/skill-tally-item.gd
+++ b/project/src/main/puzzle/tutorial/skill-tally-item.gd
@@ -83,15 +83,15 @@ func _refresh_puzzle() -> void:
 		if not signal_name:
 			pass
 		elif signal_name == "line_cleared":
-			_playfield.connect("line_cleared", self, "_on_Playfield_line_cleared")
+			_playfield.connect(signal_name, self, "_on_Playfield_line_cleared")
 		elif signal_name == "box_built":
-			_playfield.connect("box_built", self, "_on_Playfield_box_built")
+			_playfield.connect(signal_name, self, "_on_Playfield_box_built")
 		elif signal_name == "squish_moved":
-			_piece_manager.connect("squish_moved", self, "_on_PieceManager_squish_moved")
+			_piece_manager.connect(signal_name, self, "_on_PieceManager_squish_moved")
 		elif signal_name in _get_signal_names(_piece_manager):
 			_piece_manager.connect(signal_name, self, "_on_skill_performed")
 		else:
-			push_error("Could not find sender for signal '%s'" % signal_name)
+			push_warning("Could not find sender for signal '%s'" % signal_name)
 
 
 """

--- a/project/src/main/ui/chat/chatscript-parser.gd
+++ b/project/src/main/ui/chat/chatscript-parser.gd
@@ -226,7 +226,7 @@ class ChatState extends AbstractState:
 		who = _unalias(who)
 		if _character_aliases:
 			if not who in _character_aliases and not who in _character_aliases.values():
-				push_error("Unrecognized character name: %s" % [who])
+				push_warning("Unrecognized character name: %s" % [who])
 		_event.who = who
 		
 		_event.text = StringUtils.substring_after(line, ": ")

--- a/project/src/main/ui/settings/settings-language.gd
+++ b/project/src/main/ui/settings/settings-language.gd
@@ -17,7 +17,7 @@ func _ready() -> void:
 	if TranslationServer.get_loaded_locales().has(_current_loaded_locale()):
 		_option_button.selected = TranslationServer.get_loaded_locales().find(_current_loaded_locale())
 	else:
-		push_error("Locale '%s' was not in the list of loaded locales" % [current_loaded_locale])
+		push_warning("Locale '%s' was not in the list of loaded locales" % [current_loaded_locale])
 
 
 """

--- a/project/src/main/ui/wallpaper/sticker-row.gd
+++ b/project/src/main/ui/wallpaper/sticker-row.gd
@@ -40,9 +40,9 @@ func _physics_process(delta: float) -> void:
 	
 	# add stickers if we need more
 	if rect_size.y == 0:
-		push_warning("illegal sticker row rect size (%s)" % [rect_size])
+		push_warning("Illegal sticker row rect size (%s)" % [rect_size])
 	elif velocity.x == 0:
-		push_warning("illegal velocity (%s)" % [velocity])
+		push_warning("Illegal velocity (%s)" % [velocity])
 	else:
 		if velocity.x > 0:
 			while not _back_sticker or _back_sticker.position.x > 0:

--- a/project/src/test/puzzle/level/test-rank-rules.gd
+++ b/project/src/test/puzzle/level/test-rank-rules.gd
@@ -32,7 +32,7 @@ func test_convert_to_json_and_back() -> void:
 	rules.show_speed_rank = RankRules.ShowRank.HIDE
 	rules.skip_results = true
 	rules.success_bonus = 9.0
-	rules.top_out_penalty = 10
+	rules.top_out_penalty = 10.0
 	rules.unranked = true
 	_convert_to_json_and_back()
 	
@@ -51,7 +51,7 @@ func test_convert_to_json_and_back() -> void:
 	assert_eq(rules.show_speed_rank, RankRules.ShowRank.HIDE)
 	assert_eq(rules.skip_results, true)
 	assert_eq(rules.success_bonus, 9.0)
-	assert_eq(rules.top_out_penalty, 10)
+	assert_eq(rules.top_out_penalty, 10.0)
 	assert_eq(rules.unranked, true)
 
 

--- a/project/src/test/puzzle/piece/test-piece-kicks.gd
+++ b/project/src/test/puzzle/piece/test-piece-kicks.gd
@@ -109,7 +109,7 @@ Calculates the piece's type, position and orientation.
 func _create_active_piece(ascii_grid: Array) -> ActivePiece:
 	var piece_type := _determine_piece_type(ascii_grid)
 	if not piece_type:
-		push_error("Could not find piece type in '%s' grid" % ("from" if ascii_grid == from_grid else "to"))
+		push_warning("Could not find piece type in '%s' grid" % ("from" if ascii_grid == from_grid else "to"))
 
 	var from_shape_data := []
 	for row_index in range(from_grid.size()):
@@ -133,7 +133,7 @@ func _create_active_piece(ascii_grid: Array) -> ActivePiece:
 			_active_piece.orientation = pos_arr_index
 			break
 	if not _active_piece:
-		push_error("Could not find piece position/orientation in '%s' grid"\
+		push_warning("Could not find piece position/orientation in '%s' grid"\
 				% ("from" if ascii_grid == from_grid else "to"))
 	_active_piece.reset_target()
 	return _active_piece


### PR DESCRIPTION
Removed unused constants from blocks-during-rules script.

Changed RankRules.top_out_penalty from int to float for consistency with
RankRules.success_bonus

Replaced push_error with push_warning in non-fatal places. For recoverable
errors, like a missing locale or a background that can't scroll, push_warning
is more appropriate. push_error should be for things which prevent the game
from being playable.