### PR TITLE
Grade changes: pieces per minute, endurance/speed

### DIFF
--- a/project/assets/main/puzzle/levels/rank/10d.json
+++ b/project/assets/main/puzzle/levels/rank/10d.json
@@ -2,12 +2,12 @@
   "version": "297a",
   "success_condition": {
     "type": "time_under",
-    "value": "300"
+    "value": "360"
   },
   "start_speed": "FC",
   "finish_condition": {
     "type": "score",
-    "value": "10000"
+    "value": "7500"
   },
   "lose_condition": [
     "top_out 1"

--- a/project/assets/main/puzzle/levels/rank/4k.json
+++ b/project/assets/main/puzzle/levels/rank/4k.json
@@ -2,7 +2,7 @@
   "version": "297a",
   "success_condition": {
     "type": "score",
-    "value": "300"
+    "value": "400"
   },
   "start_speed": "4",
   "finish_condition": {

--- a/project/assets/main/puzzle/levels/rank/7d.json
+++ b/project/assets/main/puzzle/levels/rank/7d.json
@@ -2,7 +2,7 @@
   "version": "297a",
   "success_condition": {
     "type": "score",
-    "value": "4000"
+    "value": "5000"
   },
   "start_speed": "A0",
   "speed_ups": [

--- a/project/assets/main/puzzle/levels/rank/8d.json
+++ b/project/assets/main/puzzle/levels/rank/8d.json
@@ -2,12 +2,12 @@
   "version": "297a",
   "success_condition": {
     "type": "score",
-    "value": "4000"
+    "value": "3000"
   },
   "start_speed": "FA",
   "finish_condition": {
     "type": "time_over",
-    "value": "180"
+    "value": "240"
   },
   "lose_condition": [
     "top_out 1"

--- a/project/assets/main/puzzle/levels/rank/9d.json
+++ b/project/assets/main/puzzle/levels/rank/9d.json
@@ -2,7 +2,7 @@
   "version": "297a",
   "success_condition": {
     "type": "score",
-    "value": "6000"
+    "value": "5000"
   },
   "start_speed": "FB",
   "finish_condition": {

--- a/project/assets/main/puzzle/levels/rank/m.json
+++ b/project/assets/main/puzzle/levels/rank/m.json
@@ -2,7 +2,7 @@
   "version": "297a",
   "success_condition": {
     "type": "score",
-    "value": "15000"
+    "value": "10000"
   },
   "start_speed": "FA",
   "speed_ups": [

--- a/project/src/demo/puzzle/level/level-rank-demo.gd
+++ b/project/src/demo/puzzle/level/level-rank-demo.gd
@@ -58,7 +58,7 @@ func _calculate_extra_seconds_per_piece() -> void:
 	for _i in range(20):
 		CurrentLevel.settings.rank.extra_seconds_per_piece = \
 				0.5 * (extra_seconds_per_piece_min + extra_seconds_per_piece_max)
-		var lpm_for_grade := _rank_calculator.master_lpm() * pow(RankCalculator.RDF_SPEED, target_rank)
+		var lpm_for_grade := _rank_calculator.rank_lpm(target_rank)
 		if lpm_for_grade >= best_result.speed:
 			extra_seconds_per_piece_min = CurrentLevel.settings.rank.extra_seconds_per_piece
 		else:

--- a/project/src/demo/puzzle/level/rank-mode-demo.gd
+++ b/project/src/demo/puzzle/level/rank-mode-demo.gd
@@ -24,9 +24,9 @@ var _data_per_rank := {
 	"5d": ["16", "AA", "6:00"],
 	"6d": ["10", "AE", "3:00"],
 	"7d": ["10", "A0", "10:00"],
-	"8d": ["7", "FA", "3:00"],
-	"9d": ["7", "FB", "4:00"],
-	"10d": ["4", "FC", "5:00"],
+	"8d": ["10", "FA", "4:00"], # 'FA' requires much faster play than 'AA'
+	"9d": ["8", "FB", "5:00"],
+	"10d": ["6", "FC", "6:00"],
 	"M": ["4", "FA", "10:00"],
 }
 
@@ -47,7 +47,7 @@ func _ready() -> void:
 		
 		# print the resulting lines and score
 		text += "Rank %s: %s points in %s" % [data_key, target_score, duration_string]
-		text += " (%s lines, %01d bpm, %01d ppl)\n" \
+		text += " (%s lines, %01d ppm, %01d ppl)\n" \
 				% [target_lines, (2 * target_lines) / (seconds / 60.0), target_score / target_lines]
 		
 		# for marathon levels, also print a diminished score which is more realistic to reach under pressure

--- a/project/src/main/puzzle/duration-calculator.gd
+++ b/project/src/main/puzzle/duration-calculator.gd
@@ -54,7 +54,7 @@ func duration(settings: LevelSettings) -> float:
 		Milestone.CUSTOMERS:
 			var rank: float = RANKS_BY_DIFFICULTY[settings.get_difficulty()]
 			var lines_per_customer := RankCalculator.master_customer_combo(settings)
-			lines_per_customer *= pow(RankCalculator.RDF_LINES, rank)
+			lines_per_customer *= pow(RankCalculator.RDF_ENDURANCE, rank)
 			var lines := lines_per_customer * settings.finish_condition.value
 			result = _duration_for_lines(settings, lines)
 	

--- a/project/src/test/puzzle/test-duration-calculator.gd
+++ b/project/src/test/puzzle/test-duration-calculator.gd
@@ -11,93 +11,93 @@ func test_endless_level() -> void:
 	assert_almost_eq(_duration_calculator.duration(_settings), 600.0, 10.0)
 
 
-func test_score() -> void:
-	_settings.finish_condition.set_milestone(Milestone.SCORE, 200)
-	
+func test_score_high_target() -> void:
+	_settings.finish_condition.set_milestone(Milestone.SCORE, 200) # low target
 	assert_almost_eq(_duration_calculator.duration(_settings), 177.0, 10.0)
-
-
-func test_score_high_value() -> void:
-	_settings.finish_condition.set_milestone(Milestone.SCORE, 1000)
 	
+	_settings.finish_condition.set_milestone(Milestone.SCORE, 1000) # high target
 	assert_almost_eq(_duration_calculator.duration(_settings), 889.0, 10.0)
 
 
-func test_score_high_difficulty() -> void:
-	_settings.speed.set_start_speed("AA")
+func test_score_high_speed() -> void:
 	_settings.finish_condition.set_milestone(Milestone.SCORE, 200)
 	
-	assert_almost_eq(_duration_calculator.duration(_settings), 23.0, 10.0)
-
-
-func test_lines() -> void:
-	_settings.finish_condition.set_milestone(Milestone.LINES, 20)
+	_settings.speed.set_start_speed("0") # low speed
+	assert_almost_eq(_duration_calculator.duration(_settings), 178.0, 10.0)
 	
+	_settings.speed.set_start_speed("AA") # high speed
+	assert_almost_eq(_duration_calculator.duration(_settings), 30.0, 10.0)
+
+
+func test_lines_high_target() -> void:
+	_settings.finish_condition.set_milestone(Milestone.LINES, 20) # low value
 	assert_almost_eq(_duration_calculator.duration(_settings), 150.0, 10.0)
-
-
-func test_lines_high_value() -> void:
-	_settings.finish_condition.set_milestone(Milestone.LINES, 100)
 	
+	_settings.finish_condition.set_milestone(Milestone.LINES, 100) # high value
 	assert_almost_eq(_duration_calculator.duration(_settings), 750.0, 10.0)
 
 
-func test_lines_high_difficulty() -> void:
-	_settings.speed.set_start_speed("AA")
+func test_lines_high_speed() -> void:
 	_settings.finish_condition.set_milestone(Milestone.LINES, 20)
 	
-	assert_almost_eq(_duration_calculator.duration(_settings), 55.0, 10.0)
-
-
-func test_time_over() -> void:
-	_settings.finish_condition.set_milestone(Milestone.TIME_OVER, 90.0)
+	_settings.speed.set_start_speed("0") # low speed
+	assert_almost_eq(_duration_calculator.duration(_settings), 150.0, 10.0)
 	
-	assert_eq(_duration_calculator.duration(_settings), 90.0)
+	_settings.speed.set_start_speed("AA") # high speed
+	assert_almost_eq(_duration_calculator.duration(_settings), 70.0, 10.0)
 
 
-func test_time_over_high_value() -> void:
+func test_time_over_high_target() -> void:
+	_settings.finish_condition.set_milestone(Milestone.TIME_OVER, 90.0)
+	assert_eq(_duration_calculator.duration(_settings), 90.0) # low target
+	
 	_settings.finish_condition.set_milestone(Milestone.TIME_OVER, 300.0)
-	
-	assert_eq(_duration_calculator.duration(_settings), 300.0)
+	assert_eq(_duration_calculator.duration(_settings), 300.0) # high target
 
 
-func test_time_over_high_difficulty() -> void:
-	_settings.speed.set_start_speed("AA")
+func test_time_over_high_speed() -> void:
 	_settings.finish_condition.set_milestone(Milestone.TIME_OVER, 90.0)
 	
+	_settings.speed.set_start_speed("0") # low speed
+	assert_eq(_duration_calculator.duration(_settings), 90.0)
+	
+	_settings.speed.set_start_speed("AA") # high speed
 	assert_eq(_duration_calculator.duration(_settings), 90.0)
 
 
-func test_customers() -> void:
-	_settings.finish_condition.set_milestone(Milestone.CUSTOMERS, 5)
+func test_customers_high_target() -> void:
+	_settings.finish_condition.set_milestone(Milestone.CUSTOMERS, 5) # low target
+	assert_almost_eq(_duration_calculator.duration(_settings), 113.0, 10.0)
 	
-	assert_almost_eq(_duration_calculator.duration(_settings), 116.0, 10.0)
-
-
-func test_customers_high_value() -> void:
-	_settings.finish_condition.set_milestone(Milestone.CUSTOMERS, 25)
-	
+	_settings.finish_condition.set_milestone(Milestone.CUSTOMERS, 25) # high target
 	assert_almost_eq(_duration_calculator.duration(_settings), 562.5, 10.0)
 
 
-func test_customers_high_difficulty() -> void:
-	_settings.speed.set_start_speed("AA")
+func test_customers_high_speed() -> void:
 	_settings.finish_condition.set_milestone(Milestone.CUSTOMERS, 5)
 	
-	assert_almost_eq(_duration_calculator.duration(_settings), 185.0, 10.0)
+	_settings.speed.set_start_speed("0") # low speed
+	assert_almost_eq(_duration_calculator.duration(_settings), 112.0, 10.0)
+	
+	_settings.speed.set_start_speed("AA") # high speed
+	assert_almost_eq(_duration_calculator.duration(_settings), 230.0, 10.0)
 
 
 func test_master_pickup_score() -> void:
 	_settings.finish_condition.set_milestone(Milestone.SCORE, 1000)
+	
+	_settings.rank.master_pickup_score = 0 # low pickup score
 	assert_almost_eq(_duration_calculator.duration(_settings), 889.0, 10.0)
 	
-	_settings.rank.master_pickup_score = 800
+	_settings.rank.master_pickup_score = 800 # high pickup score
 	assert_almost_eq(_duration_calculator.duration(_settings), 177.0, 10.0)
 
 
 func test_master_pickup_score_per_line() -> void:
 	_settings.finish_condition.set_milestone(Milestone.SCORE, 1000)
+	
+	_settings.rank.master_pickup_score_per_line = 0 # low pickup score
 	assert_almost_eq(_duration_calculator.duration(_settings), 889.0, 10.0)
 	
-	_settings.rank.master_pickup_score_per_line = 20
+	_settings.rank.master_pickup_score_per_line = 20 # high pickup score
 	assert_almost_eq(_duration_calculator.duration(_settings), 574.0, 10.0)

--- a/project/src/test/puzzle/test-rank-calculator.gd
+++ b/project/src/test/puzzle/test-rank-calculator.gd
@@ -9,17 +9,17 @@ func before_each() -> void:
 
 func test_master_lpm_slow_marathon() -> void:
 	CurrentLevel.settings.speed.set_start_speed("0")
-	assert_almost_eq(_rank_calculator.master_lpm(), 30.77, 0.1)
+	assert_almost_eq(_rank_calculator.rank_lpm(RankResult.BEST_RANK), 30.77, 0.1)
 
 
 func test_master_lpm_medium_marathon() -> void:
 	CurrentLevel.settings.speed.set_start_speed("A0")
-	assert_almost_eq(_rank_calculator.master_lpm(), 35.64, 0.1)
+	assert_almost_eq(_rank_calculator.rank_lpm(RankResult.BEST_RANK), 35.64, 0.1)
 
 
 func test_master_lpm_fast_marathon() -> void:
 	CurrentLevel.settings.speed.set_start_speed("F0")
-	assert_almost_eq(_rank_calculator.master_lpm(), 68.90, 0.1)
+	assert_almost_eq(_rank_calculator.rank_lpm(RankResult.BEST_RANK), 65.00, 0.1)
 
 
 func test_master_lpm_mixed_marathon() -> void:
@@ -27,7 +27,7 @@ func test_master_lpm_mixed_marathon() -> void:
 	CurrentLevel.settings.speed.add_speed_up(Milestone.LINES, 30, "A0")
 	CurrentLevel.settings.speed.add_speed_up(Milestone.LINES, 60, "F0")
 	CurrentLevel.settings.set_finish_condition(Milestone.LINES, 100)
-	assert_almost_eq(_rank_calculator.master_lpm(), 46.23, 0.1)
+	assert_almost_eq(_rank_calculator.rank_lpm(RankResult.BEST_RANK), 45.27, 0.1)
 
 
 func test_master_lpm_mixed_sprint() -> void:
@@ -35,7 +35,7 @@ func test_master_lpm_mixed_sprint() -> void:
 	CurrentLevel.settings.speed.add_speed_up(Milestone.TIME_OVER, 30, "A0")
 	CurrentLevel.settings.speed.add_speed_up(Milestone.TIME_OVER, 60, "F0")
 	CurrentLevel.settings.set_finish_condition(Milestone.TIME_OVER, 90)
-	assert_almost_eq(_rank_calculator.master_lpm(), 50.98, 0.1)
+	assert_almost_eq(_rank_calculator.rank_lpm(RankResult.BEST_RANK), 49.54, 0.1)
 
 
 func test_calculate_rank_marathon_300_master() -> void:
@@ -61,7 +61,7 @@ func test_calculate_rank_marathon_300_mixed() -> void:
 	PuzzleState.level_performance.combo_score = 500
 	PuzzleState.level_performance.score = 1160
 	var rank := _rank_calculator.calculate_rank()
-	assert_eq(RankCalculator.grade(rank.speed_rank), "S")
+	assert_eq(RankCalculator.grade(rank.speed_rank), "S+")
 	assert_eq(RankCalculator.grade(rank.lines_rank), "A+")
 	assert_eq(RankCalculator.grade(rank.box_score_per_line_rank), "S+")
 	assert_eq(RankCalculator.grade(rank.combo_score_per_line_rank), "S-")
@@ -76,7 +76,7 @@ func test_calculate_rank_marathon_lenient() -> void:
 	PuzzleState.level_performance.combo_score = 500
 	PuzzleState.level_performance.score = 1160
 	var rank := _rank_calculator.calculate_rank()
-	assert_eq(RankCalculator.grade(rank.speed_rank), "S")
+	assert_eq(RankCalculator.grade(rank.speed_rank), "S+")
 	assert_eq(RankCalculator.grade(rank.lines_rank), "AA+")
 	assert_eq(RankCalculator.grade(rank.box_score_per_line_rank), "S+")
 	assert_eq(RankCalculator.grade(rank.combo_score_per_line_rank), "S-")
@@ -114,14 +114,14 @@ func test_calculate_rank_sprint_120() -> void:
 	PuzzleState.level_performance.combo_score = 570
 	PuzzleState.level_performance.score = 1012
 	var rank := _rank_calculator.calculate_rank()
-	assert_eq(RankCalculator.grade(rank.speed_rank), "S+")
-	assert_eq(RankCalculator.grade(rank.lines_rank), "S+")
+	assert_eq(RankCalculator.grade(rank.speed_rank), "SS+")
+	assert_eq(RankCalculator.grade(rank.lines_rank), "SS+")
 	assert_eq(RankCalculator.grade(rank.box_score_per_line_rank), "S")
 	assert_eq(RankCalculator.grade(rank.combo_score_per_line_rank), "SS")
 	assert_eq(RankCalculator.grade(rank.score_rank), "S+")
 
 
-func test_calculate_rank_top_out_once() -> void:
+func test_calculate_rank_sprint_120_top_out_once() -> void:
 	CurrentLevel.settings.speed.set_start_speed("A0")
 	CurrentLevel.settings.set_finish_condition(Milestone.TIME_OVER, 120)
 	PuzzleState.level_performance.seconds = 120
@@ -135,10 +135,10 @@ func test_calculate_rank_top_out_once() -> void:
 	assert_eq(RankCalculator.grade(rank.lines_rank), "S+")
 	assert_eq(RankCalculator.grade(rank.box_score_per_line_rank), "S-")
 	assert_eq(RankCalculator.grade(rank.combo_score_per_line_rank), "S+")
-	assert_eq(RankCalculator.grade(rank.score_rank), "S+")
+	assert_eq(RankCalculator.grade(rank.score_rank), "S")
 
 
-func test_calculate_rank_top_out_twice() -> void:
+func test_calculate_rank_sprint_120_top_out_twice() -> void:
 	CurrentLevel.settings.speed.set_start_speed("A0")
 	CurrentLevel.settings.set_finish_condition(Milestone.TIME_OVER, 120)
 	PuzzleState.level_performance.seconds = 120
@@ -148,11 +148,11 @@ func test_calculate_rank_top_out_twice() -> void:
 	PuzzleState.level_performance.score = 1012
 	PuzzleState.level_performance.top_out_count = 2
 	var rank := _rank_calculator.calculate_rank()
-	assert_eq(RankCalculator.grade(rank.speed_rank), "S")
-	assert_eq(RankCalculator.grade(rank.lines_rank), "S")
+	assert_eq(RankCalculator.grade(rank.speed_rank), "S+")
+	assert_eq(RankCalculator.grade(rank.lines_rank), "S+")
 	assert_eq(RankCalculator.grade(rank.box_score_per_line_rank), "AA+")
 	assert_eq(RankCalculator.grade(rank.combo_score_per_line_rank), "S")
-	assert_eq(RankCalculator.grade(rank.score_rank), "S")
+	assert_eq(RankCalculator.grade(rank.score_rank), "S-")
 
 
 func test_calculate_rank_ultra_200() -> void:
@@ -167,7 +167,7 @@ func test_calculate_rank_ultra_200() -> void:
 	assert_eq(RankCalculator.grade(rank.box_score_per_line_rank), "M")
 	assert_eq(rank.combo_score_per_line, 20.0)
 	assert_eq(RankCalculator.grade(rank.combo_score_per_line_rank), "M")
-	assert_eq(RankCalculator.grade(rank.seconds_rank), "SSS")
+	assert_eq(RankCalculator.grade(rank.seconds_rank), "SS+")
 
 
 func test_calculate_rank_ultra_200_lost() -> void:
@@ -179,7 +179,7 @@ func test_calculate_rank_ultra_200_lost() -> void:
 	PuzzleState.level_performance.score = 150
 	PuzzleState.level_performance.lost = true
 	var rank := _rank_calculator.calculate_rank()
-	assert_eq(RankCalculator.grade(rank.speed_rank), "AA+")
+	assert_eq(RankCalculator.grade(rank.speed_rank), "S-")
 	assert_eq(rank.seconds_rank, 999.0)
 	assert_eq(RankCalculator.grade(rank.box_score_per_line_rank), "S-")
 	assert_eq(RankCalculator.grade(rank.combo_score_per_line_rank), "S")
@@ -211,7 +211,7 @@ func test_calculate_rank_ultra_1() -> void:
 	PuzzleState.level_performance.lines = 1
 	PuzzleState.level_performance.score = 1
 	var rank := _rank_calculator.calculate_rank()
-	assert_eq(RankCalculator.grade(rank.seconds_rank), "SSS")
+	assert_eq(RankCalculator.grade(rank.seconds_rank), "SS+")
 
 
 func test_calculate_rank_five_creatures_good() -> void:
@@ -250,7 +250,7 @@ func test_two_rank_s() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 1000)
 	PuzzleState.level_performance.seconds = 88.55
 	var rank1 := _rank_calculator.calculate_rank()
-	assert_eq(RankCalculator.grade(rank1.seconds_rank), "SS+")
+	assert_eq(RankCalculator.grade(rank1.seconds_rank), "S+")
 
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 1000)
 	PuzzleState.level_performance.seconds = 128.616
@@ -310,7 +310,7 @@ func test_success_bonus_seconds() -> void:
 	# the player doesn't achieve the success condition; they get a worse grade
 	CurrentLevel.settings.set_success_condition(Milestone.TIME_UNDER, 180)
 	var rank1 := _rank_calculator.calculate_rank()
-	assert_eq(RankCalculator.grade(rank1.seconds_rank), "S")
+	assert_eq(RankCalculator.grade(rank1.seconds_rank), "S-")
 
 	# the player achieves the success condition; they get a better grade
 	CurrentLevel.settings.set_success_condition(Milestone.TIME_UNDER, 300)
@@ -354,8 +354,8 @@ func test_extra_seconds_per_piece() -> void:
 	PuzzleState.level_performance.lines = 60
 	PuzzleState.level_performance.score = 1160
 	var rank1 := _rank_calculator.calculate_rank()
-	assert_eq(RankCalculator.grade(rank1.speed_rank), "S+")
-	assert_eq(RankCalculator.grade(rank1.score_rank), "S+")
+	assert_eq(RankCalculator.grade(rank1.speed_rank), "SS+")
+	assert_eq(RankCalculator.grade(rank1.score_rank), "S")
 	
 	# with the 'extra_seconds_per_piece' setting enabled, the player gets a better grade
 	CurrentLevel.settings.rank.extra_seconds_per_piece = 1.2


### PR DESCRIPTION
Grade system now awards an 'M' rank for speed as long as you clear 65
lines per minute. It used to only award an 'M' rank based on the maximum
theoretical speed for each level, which was in some cases much faster
than anybody can play (yet).

Grade system now separates endurance/speed and grades them separately.
This means that clearing 90/100 lines for a Marathon course scores a
low grade, but playing at 90% speed for a Sprint course scores a high
grade.

Adjusted Rank courses to provide a more linear increase in difficulty.
There used to be a monumental jump between Rank 6d/7d which required you to
play at about 50 pieces per minute, and Rank 8d/9d which required double
that. It now gradually ramps up from 50 ppm to 110 ppm.