### PR TITLE
Replaced block quotes, field comments with docstring

### DIFF
--- a/project/src/demo/demo-save.gd
+++ b/project/src/demo/demo-save.gd
@@ -1,19 +1,17 @@
 extends Node
-"""
-Reads and writes data about demos from a file.
+## Reads and writes data about demos from a file.
+##
+## This allows demos to remember a developer's selections, so that they don't need to keep retyping or reselecting the
+## same choices.
+##
+## This data is stored independently of the player data to prevent demos from overwriting the developer's game data
+## with invalid data. Demos often put the game into a weird state temporarily, and we don't want to persist this weird
+## temporary data.
 
-This allows demos to remember a developer's selections, so that they don't need to keep retyping or reselecting the
-same choices.
-
-This data is stored independently of the player data to prevent demos from overwriting the developer's game data
-with invalid data. Demos often put the game into a weird state temporarily, and we don't want to persist this weird
-temporary data.
-"""
-
-# the path to the save file
+## the path to the save file
 const FILENAME := "user://demo-data.json"
 
-# the json data read from the save file
+## the json data read from the save file
 var demo_data := {}
 
 func _ready() -> void:
@@ -21,16 +19,12 @@ func _ready() -> void:
 	load_demo_data()
 
 
-"""
-Writes the developer's in-memory data to a save file.
-"""
+## Writes the developer's in-memory data to a save file.
 func save_demo_data() -> void:
 	FileUtils.write_file(FILENAME, Utils.print_json(demo_data))
 
 
-"""
-Populates the player's in-memory data based on their save files.
-"""
+## Populates the player's in-memory data based on their save files.
 func load_demo_data() -> void:
 	var file := File.new()
 	var open_result := file.open(FILENAME, File.READ)

--- a/project/src/demo/music/music-player-demo.gd
+++ b/project/src/demo/music/music-player-demo.gd
@@ -1,18 +1,16 @@
 extends Node
-"""
-Demonstrates music player capability.
-
-Shows a string with the 'staleness' of each music track. As sections of the music gets played, they get incremented.
-When playing a music track, it skips to the least stale parts of the track.
-
-Keys:
-	C: Play chill song
-	U: Play upbeat song
-	T: Play tutorial song
-	=: Fade in the current song
-	-: Fade out the current song
-	]: Skip to next checkpoint in song
-"""
+## Demonstrates music player capability.
+##
+## Shows a string with the 'staleness' of each music track. As sections of the music gets played, they get incremented.
+## When playing a music track, it skips to the least stale parts of the track.
+##
+## Keys:
+## 	C: Play chill song
+## 	U: Play upbeat song
+## 	T: Play tutorial song
+## 	=: Fade in the current song
+## 	-: Fade out the current song
+## 	]: Skip to next checkpoint in song
 
 func _ready() -> void:
 	SystemData.volume_settings.set_bus_volume_linear(VolumeSettings.MUSIC, 0.5)

--- a/project/src/demo/name-generator-demo.gd
+++ b/project/src/demo/name-generator-demo.gd
@@ -1,7 +1,5 @@
 extends Control
-"""
-Demonstrates the name generator.
-"""
+## Demonstrates the name generator.
 
 var _name_generator := NameGenerator.new()
 

--- a/project/src/demo/packed-sprite-demo.gd
+++ b/project/src/demo/packed-sprite-demo.gd
@@ -1,11 +1,9 @@
 extends Node
-"""
-Demonstrates loading and animating a packed sprite.
-
-Keys:
-	[Z]: Cycle to the next frame
-	Arrows: Move the sprite and print its offset.
-"""
+## Demonstrates loading and animating a packed sprite.
+##
+## Keys:
+## 	[Z]: Cycle to the next frame
+## 	Arrows: Move the sprite and print its offset.
 
 onready var _packed_sprite: PackedSprite = $PackedSprite
 

--- a/project/src/demo/puzzle/level/level-rank-demo-grade.gd
+++ b/project/src/demo/puzzle/level/level-rank-demo-grade.gd
@@ -1,14 +1,12 @@
 extends HBoxContainer
-"""
-UI input for specifying the target grade
-"""
+## UI input for specifying the target grade
 
-# The level to open
-# Virtual property; value is only exposed through getters/setters
+## The level to open
+## Virtual property; value is only exposed through getters/setters
 var value: String setget set_value, get_value
 
-# key: (String) letter grade such as 'SSS' or 'AA+'
-# value: (int) OptionButton index
+## key: (String) letter grade such as 'SSS' or 'AA+'
+## value: (int) OptionButton index
 var _index_by_grade := {}
 
 func _ready() -> void:

--- a/project/src/demo/puzzle/level/level-rank-demo-open.gd
+++ b/project/src/demo/puzzle/level/level-rank-demo-open.gd
@@ -1,10 +1,8 @@
 extends HBoxContainer
-"""
-UI input for specifying the level to open
-"""
+## UI input for specifying the level to open
 
-# The level to open
-# Virtual property; value is only exposed through getters/setters
+## The level to open
+## Virtual property; value is only exposed through getters/setters
 var value: String setget set_value, get_value
 
 func set_value(new_value: String) -> void:

--- a/project/src/demo/puzzle/level/level-rank-demo.gd
+++ b/project/src/demo/puzzle/level/level-rank-demo.gd
@@ -1,14 +1,13 @@
 extends Control
-"""
-A demo which calculates the necessary level metadata for the player to attain their expected grade.
+## A demo which calculates the necessary level metadata for the player to attain their expected grade.
+##
+## This demo takes the player's best performance and calculates the necessary level adjustments so that their best
+## performance will result in the specified grade. For example, a player might usually play at an 'SSS' rank, but they
+## make very few boxes on one specific level, because the level is difficult. So this demo might calculate and print
+## something like 'box_factor=0.5' indicating that the level should be more lenient for players who don't make many
+## boxes.
 
-This demo takes the player's best performance and calculates the necessary level adjustments so that their best
-performance will result in the specified grade. For example, a player might usually play at an 'SSS' rank, but they
-make very few boxes on one specific level, because the level is difficult. So this demo might calculate and print
-something like 'box_factor=0.5' indicating that the level should be more lenient for players who don't make many boxes.
-"""
-
-# property keys to use when saving/loading data
+## property keys to use when saving/loading data
 const SAVE_KEY_GRADE := "level-rank-demo.grade"
 const SAVE_KEY_OPEN := "level-rank-demo.open"
 
@@ -25,9 +24,7 @@ func _ready() -> void:
 	_load_demo_data()
 
 
-"""
-Calculates and outputs the necessary level metadata for the player to attain their expected grade.
-"""
+## Calculates and outputs the necessary level metadata for the player to attain their expected grade.
 func _calculate() -> void:
 	_text_edit.text = ""
 	
@@ -46,9 +43,7 @@ func _calculate() -> void:
 	_text_edit.text = _text_edit.text.strip_edges()
 
 
-"""
-Calculates and outputs the extra_seconds_per_piece for levels which inhibit fast players.
-"""
+## Calculates and outputs the extra_seconds_per_piece for levels which inhibit fast players.
 func _calculate_extra_seconds_per_piece() -> void:
 	var target_rank := _target_rank()
 	var best_result := _best_result()
@@ -67,9 +62,7 @@ func _calculate_extra_seconds_per_piece() -> void:
 	_text_edit.text += "\"extra_seconds_per_piece %.2f\",\n" % [CurrentLevel.settings.rank.extra_seconds_per_piece]
 
 
-"""
-Calculates and outputs the box_factor for levels which inhibit snack and cake boxes.
-"""
+## Calculates and outputs the box_factor for levels which inhibit snack and cake boxes.
 func _calculate_box_factor() -> void:
 	var target_rank := _target_rank()
 	var best_result := _best_result()
@@ -89,9 +82,7 @@ func _calculate_box_factor() -> void:
 	_text_edit.text += "\"box_factor %.2f\",\n" % [CurrentLevel.settings.rank.box_factor]
 
 
-"""
-Calculates and outputs the combo_factor for levels which inhibit combos.
-"""
+## Calculates and outputs the combo_factor for levels which inhibit combos.
 func _calculate_combo_factor() -> void:
 	var target_rank := _target_rank()
 	var best_result := _best_result()
@@ -111,9 +102,7 @@ func _calculate_combo_factor() -> void:
 	_text_edit.text += "\"combo_factor %.2f\",\n" % [CurrentLevel.settings.rank.combo_factor]
 
 
-"""
-Calculates and outputs the master_pickup_score_per_line for levels with pickups.
-"""
+## Calculates and outputs the master_pickup_score_per_line for levels with pickups.
 func _calculate_master_pickup_score_per_line() -> void:
 	var target_rank := _target_rank()
 	var best_result := _best_result()
@@ -126,25 +115,19 @@ func _calculate_master_pickup_score_per_line() -> void:
 			% [CurrentLevel.settings.rank.master_pickup_score_per_line]
 
 
-"""
-Returns the player's best result for the level selected in the demo.
-
-The player's data is loaded from the current save slot.
-"""
+## Returns the player's best result for the level selected in the demo.
+##
+## The player's data is loaded from the current save slot.
 func _best_result() -> RankResult:
 	return PlayerData.level_history.best_result(CurrentLevel.level_id)
 
 
-"""
-Returns the rank corresponding to the grade chosen in the demo.
-"""
+## Returns the rank corresponding to the grade chosen in the demo.
 func _target_rank() -> float:
 	return RankCalculator.rank(_grade_input.value)
 
 
-"""
-Reads the developer's in-memory data from a save file.
-"""
+## Reads the developer's in-memory data from a save file.
 func _load_demo_data() -> void:
 	if _demo_save.demo_data.has(SAVE_KEY_GRADE):
 		_grade_input.value = _demo_save.demo_data[SAVE_KEY_GRADE]
@@ -152,9 +135,7 @@ func _load_demo_data() -> void:
 		_open_input.value = _demo_save.demo_data[SAVE_KEY_OPEN]
 
 
-"""
-Writes the developer's in-memory data to a save file.
-"""
+## Writes the developer's in-memory data to a save file.
 func _save_demo_data() -> void:
 	_demo_save.demo_data[SAVE_KEY_GRADE] = _grade_input.value
 	_demo_save.demo_data[SAVE_KEY_OPEN] = _open_input.value

--- a/project/src/demo/puzzle/level/rank-mode-demo.gd
+++ b/project/src/demo/puzzle/level/rank-mode-demo.gd
@@ -1,13 +1,11 @@
 extends Label
-"""
-Demo which performs some complex calculations to determine how fast someone would need to play to achieve a rank on a
-particular level.
-
-For example, to get rank 28 on the '2 kyu' level, a player would need to score 432 points. This is based on the
-rank requirements, the duration of the level, the piece speed and other factors.
-
-This was used to assign a roughly increasing level of difficulty for rank levels.
-"""
+## Demo which performs some complex calculations to determine how fast someone would need to play to achieve a rank on
+## a particular level.
+##
+## For example, to get rank 28 on the '2 kyu' level, a player would need to score 432 points. This is based on the
+## rank requirements, the duration of the level, the piece speed and other factors.
+##
+## This was used to assign a roughly increasing level of difficulty for rank levels.
 
 var _data_per_rank := {
 	"7k": ["48", "1", "5:00"],
@@ -57,12 +55,10 @@ func _ready() -> void:
 				text += "  (%s marathon: %s points)\n" % [data_key, marathon_points]
 
 
-"""
-Creates a level with the specified duration.
-
-The piece speed starts at the specified start level, but might increase depending on the specified data key. The speed
-increases defined in this method should align with the speed increases of the rank levels in the game.
-"""
+## Creates a level with the specified duration.
+##
+## The piece speed starts at the specified start level, but might increase depending on the specified data key. The
+## speed increases defined in this method should align with the speed increases of the rank levels in the game.
 func _level_settings(data_key: String, start_speed: String, seconds: float) -> LevelSettings:
 	var settings := LevelSettings.new()
 	settings.id = data_key
@@ -140,11 +136,9 @@ func _level_settings(data_key: String, start_speed: String, seconds: float) -> L
 	return settings
 
 
-"""
-Binary search for how many points are needed to achieve the specified score_rank.
-
-This depends on the current level's duration and piece speed.
-"""
+## Binary search for how many points are needed to achieve the specified score_rank.
+##
+## This depends on the current level's duration and piece speed.
 func _target_score(target_rank: float) -> float:
 	var min_score := 0
 	var max_score := 50000
@@ -161,11 +155,9 @@ func _target_score(target_rank: float) -> float:
 	return (min_score + max_score) / 2.0
 
 
-"""
-Binary search for how many lines are needed to achieve the specified line_rank.
-
-This depends on the current level's duration and piece speed.
-"""
+## Binary search for how many lines are needed to achieve the specified line_rank.
+##
+## This depends on the current level's duration and piece speed.
 func _target_lines(target_rank: int) -> float:
 	var min_target_lines := 0
 	var max_target_lines := 5000

--- a/project/src/demo/puzzle/pan/frying-pans-ui-demo.gd
+++ b/project/src/demo/puzzle/pan/frying-pans-ui-demo.gd
@@ -1,17 +1,15 @@
 extends Node
-"""
-Demonstrates the 'frying pans UI' which shows the player's lives.
-"""
+## Demonstrates the 'frying pans UI' which shows the player's lives.
 
 onready var _frying_pans_ui := $FryingPansUi
 
-# UI control for the remaining frying pans
+## UI control for the remaining frying pans
 onready var _remaining_control: SpinBox = $Remaining/HBoxContainer/SpinBox
 
-# UI control for the maximum number of frying pans
+## UI control for the maximum number of frying pans
 onready var _max_control: SpinBox = $Max/HBoxContainer/SpinBox
 
-# UI control for whether or not the frying pans are gold
+## UI control for whether or not the frying pans are gold
 onready var _gold_control: CheckBox = $Gold
 
 func _ready() -> void:

--- a/project/src/demo/puzzle/playfield-demo.gd
+++ b/project/src/demo/puzzle/playfield-demo.gd
@@ -1,13 +1,11 @@
 extends Control
-"""
-Shows off the visual effects for the playfield.
-
-Keys:
-	[Q,W,E,R,T]: Build a box at different locations in the playfield
-	[A,S,D,F,G]: Change the box color to brown, pink, bread, white, cake
-	[Z,X,C,V,B]: Clear a line at different locations in the playfield
-	[.]: Place a piece without continuing the combo
-"""
+## Shows off the visual effects for the playfield.
+##
+## Keys:
+## 	[Q,W,E,R,T]: Build a box at different locations in the playfield
+## 	[A,S,D,F,G]: Change the box color to brown, pink, bread, white, cake
+## 	[Z,X,C,V,B]: Clear a line at different locations in the playfield
+## 	[.]: Place a piece without continuing the combo
 
 var _line_clear_count := 1
 var _box_type := 0

--- a/project/src/demo/puzzle/puzzle-demo.gd
+++ b/project/src/demo/puzzle/puzzle-demo.gd
@@ -1,25 +1,23 @@
 extends Node
-"""
-Shows off the visual effects for the puzzle.
-
-Keys:
-	[Q,W,E]: Build a box at different locations in the playfield
-	[T,Y]: Insert a line at different locations in the playfield
-	[A,S,D,F,G]: Change the box color to brown, pink, bread, white, cake
-	[H]: Change the cake box variation used to make cake boxes
-	[U,I,O]: Clear a line at different locations in the playfield
-	[P]: Add pickups
-	[J]: Generate a food item
-	[K]: Cycle to the next food item
-	[L]: Level up
-"""
+## Shows off the visual effects for the puzzle.
+##
+## Keys:
+## 	[Q,W,E]: Build a box at different locations in the playfield
+## 	[T,Y]: Insert a line at different locations in the playfield
+## 	[A,S,D,F,G]: Change the box color to brown, pink, bread, white, cake
+## 	[H]: Change the cake box variation used to make cake boxes
+## 	[U,I,O]: Clear a line at different locations in the playfield
+## 	[P]: Add pickups
+## 	[J]: Generate a food item
+## 	[K]: Cycle to the next food item
+## 	[L]: Level up
 
 var _line_clear_count := 1
 var _box_type := 0
 var _food_item_index := 0
 var _cake_box_type: int = Foods.BoxType.CAKE_JJO
 
-# a local path to a json level resource to demo
+## a local path to a json level resource to demo
 export (String, FILE, "*.json") var level_path: String
 
 func _ready() -> void:

--- a/project/src/demo/puzzle/results-hud-demo.gd
+++ b/project/src/demo/puzzle/results-hud-demo.gd
@@ -1,11 +1,9 @@
 extends Control
-"""
-Demonstrates the end of level results message.
-
-Keys:
-	[S]: Show message
-	[H]: Hide message
-"""
+## Demonstrates the end of level results message.
+##
+## Keys:
+## 	[S]: Show message
+## 	[H]: Hide message
 
 var _rank_result: RankResult = RankResult.new()
 var _customer_scores := [

--- a/project/src/demo/puzzle/tutorial/tutorial-hud-demo.gd
+++ b/project/src/demo/puzzle/tutorial/tutorial-hud-demo.gd
@@ -1,13 +1,11 @@
 extends Control
-"""
-Shows off the tutorial message UI.
-
-Keys:
-	[0-9]: Prints a message; 1 = short, 0 = long
-	[shift+0-9]: Enqueues a message; 1 = short, 0 = long
-	[O]: Prints a message in a big font
-	[H]: Hides the message after a short delay
-"""
+## Shows off the tutorial message UI.
+##
+## Keys:
+## 	[0-9]: Prints a message; 1 = short, 0 = long
+## 	[shift+0-9]: Enqueues a message; 1 = short, 0 = long
+## 	[O]: Prints a message in a big font
+## 	[H]: Hides the message after a short delay
 
 const TEXTS := [
 	"Oh my,/ you're not supposed to know how to do that!\n\n" \

--- a/project/src/demo/toolkit/extract-localizables-button.gd
+++ b/project/src/demo/toolkit/extract-localizables-button.gd
@@ -1,30 +1,26 @@
 extends Button
-"""
-Extracts localizable strings from levels and chats as a part of the localization process.
+## Extracts localizable strings from levels and chats as a part of the localization process.
+##
+## The pybabel tool creates a PO template file from our script and scene files. However, level and chat data is stored
+## in a proprietary JSON format which pybabel doesn't understand. This demo looks at all levels and chat in the game
+## and exports any localizable strings into a format accessible by pybabel.
 
-The pybabel tool creates a PO template file from our script and scene files. However, level and chat data is stored
-in a proprietary JSON format which pybabel doesn't understand. This demo looks at all levels and chat in the game
-and exports any localizable strings into a format accessible by pybabel.
-"""
-
-# the file where we write the localizable strings
+## the file where we write the localizable strings
 const OUTPUT_PATH := "res://assets/main/locale/localizables-extracted.py"
 const SCANCODE_OUTPUT_PATH := "res://assets/main/locale/localizables-scancodes.py"
 
 export (NodePath) var output_label_path: NodePath
 
-# localizable strings extracted from levels and chats
+## localizable strings extracted from levels and chats
 var _localizables := []
 
-# localizable strings extracted from scancodes (input keys)
+## localizable strings extracted from scancodes (input keys)
 var _scancode_localizables := []
 
-# label for outputting messages to the user
+## label for outputting messages to the user
 onready var _output_label := get_node(output_label_path)
 
-"""
-Extracts localizable strings from levels and chats and writes them to a file.
-"""
+## Extracts localizable strings from levels and chats and writes them to a file.
 func _extract_and_write_localizables() -> void:
 	_localizables.clear()
 	_scancode_localizables.clear()
@@ -45,9 +41,7 @@ func _extract_and_write_localizables() -> void:
 			OUTPUT_PATH, SCANCODE_OUTPUT_PATH]
 
 
-"""
-Extracts localizable strings from levels and adds them to the in-memory list of localizables.
-"""
+## Extracts localizable strings from levels and adds them to the in-memory list of localizables.
 func _extract_localizables_from_levels() -> void:
 	var level_ids := LevelLibrary.all_level_ids()
 	level_ids.sort()
@@ -67,9 +61,7 @@ func _extract_localizables_from_levels() -> void:
 			_extract_localizables_from_chat_tree(chat_tree)
 
 
-"""
-Extracts localizable strings from creature chats and adds them to the in-memory list of localizables.
-"""
+## Extracts localizable strings from creature chats and adds them to the in-memory list of localizables.
 func _extract_localizables_from_creatures() -> void:
 	var creature_ids := PlayerData.creature_library.creature_ids()
 	creature_ids.sort()
@@ -88,9 +80,7 @@ func _extract_localizables_from_creatures() -> void:
 			_extract_localizables_from_chat_tree(chat_tree)
 
 
-"""
-Extracts localizable strings from a chat tree and adds them to the in-memory list of localizables.
-"""
+## Extracts localizable strings from a chat tree and adds them to the in-memory list of localizables.
 func _extract_localizables_from_chat_tree(chat_tree: ChatTree) -> void:
 	for event_sequence in chat_tree.events.values():
 		for event_obj in event_sequence:
@@ -108,12 +98,10 @@ func _extract_localizables_from_chat_tree(chat_tree: ChatTree) -> void:
 					_localizables.append(link_text)
 
 
-"""
-Extract localizables from OS.get_scancode_string()
-
-This is a workaround for Godot #4140 (https://github.com/godotengine/godot/issues/4140). Because Godot does not offer
-a way to localize scancode strings, we must extract and localize them ourselves.
-"""
+## Extract localizables from OS.get_scancode_string()
+##
+## This is a workaround for Godot #4140 (https://github.com/godotengine/godot/issues/4140). Because Godot does not
+## offer a way to localize scancode strings, we must extract and localize them ourselves.
 func _extract_localizables_from_scancode_strings() -> void:
 	# ascii printable characters: space, comma, period, slash...
 	for i in range(256):
@@ -128,9 +116,7 @@ func _extract_localizables_from_scancode_strings() -> void:
 			_scancode_localizables.append(scancode_string)
 
 
-"""
-Writes the in-memory list of localizables to a file, in a format accessible by pybabel.
-"""
+## Writes the in-memory list of localizables to a file, in a format accessible by pybabel.
 func _write_localizables(output_path: String, localizables: Array) -> void:
 	var f := File.new()
 	f.open(output_path, f.WRITE)

--- a/project/src/demo/toolkit/upgrade-levels-button.gd
+++ b/project/src/demo/toolkit/upgrade-levels-button.gd
@@ -1,26 +1,22 @@
 extends Button
-"""
-Upgrades old levels to the newest format.
+## Upgrades old levels to the newest format.
+##
+## Recursively searches for levels, upgrading them if they are out of date.
 
-Recursively searches for levels, upgrading them if they are out of date.
-"""
-
-# directories containing levels which should be upgraded
+## directories containing levels which should be upgraded
 const LEVEL_DIRS := ["res://assets/main/puzzle/levels"]
 
 export (NodePath) var output_label_path: NodePath
 
 var _upgrader := LevelSettingsUpgrader.new()
 
-# string level paths which have been successfully converted to the newest version
+## string level paths which have been successfully converted to the newest version
 var _converted := []
 
-# label for outputting messages to the user
+## label for outputting messages to the user
 onready var _output_label: Label = get_node(output_label_path)
 
-"""
-Upgrades all levels to the newest version.
-"""
+## Upgrades all levels to the newest version.
 func _upgrade_levels() -> void:
 	_converted.clear()
 	
@@ -34,12 +30,10 @@ func _upgrade_levels() -> void:
 		_output_label.text = "No levels required upgrading."
 
 
-"""
-Upgrades a level to the newest version.
-
-Parameters:
-	'path': Path to a json resource containing level data to upgrade.
-"""
+## Upgrades a level to the newest version.
+##
+## Parameters:
+## 	'path': Path to a json resource containing level data to upgrade.
 func _upgrade_settings(path: String) -> void:
 	var old_text := FileUtils.get_file_as_text(path)
 	var old_json: Dictionary = parse_json(old_text)
@@ -50,12 +44,10 @@ func _upgrade_settings(path: String) -> void:
 		_converted.append(path)
 
 
-"""
-Recursively searches for levels to upgrade.
-
-Returns:
-	List of string paths to json resources containing level data to upgrade.
-"""
+## Recursively searches for levels to upgrade.
+##
+## Returns:
+## 	List of string paths to json resources containing level data to upgrade.
 func _find_level_paths() -> Array:
 	var result := []
 	

--- a/project/src/demo/ui/chat/chat-frame-demo.gd
+++ b/project/src/demo/ui/chat/chat-frame-demo.gd
@@ -1,20 +1,18 @@
 extends Control
-"""
-A demo which shows off the chat window.
-
-Keys:
-	[0-9]: Prints a chat line; 1 = short, 9 = long, 0 = longest
-	SHIFT+[0-9]: Changes the name; 1 = short, 9 = long, 0 = longest
-	'[', ']': Change the accent texture
-	Arrows: Change the color and scale
-	[A]: Make the chat window appear/disappear
-	[D]: Toggle 'dark mode' for the accent
-	[L]: Toggle 'left' and 'right' for the nametag position
-	[P]: Print the json accent definition
-	[R]: Generate a random accent definition
-	[S]: Swap the accent's colors
-	[Z]: Squish the window to the side
-"""
+## A demo which shows off the chat window.
+##
+## Keys:
+## 	[0-9]: Prints a chat line; 1 = short, 9 = long, 0 = longest
+## 	SHIFT+[0-9]: Changes the name; 1 = short, 9 = long, 0 = longest
+## 	'[', ']': Change the accent texture
+## 	Arrows: Change the color and scale
+## 	[A]: Make the chat window appear/disappear
+## 	[D]: Toggle 'dark mode' for the accent
+## 	[L]: Toggle 'left' and 'right' for the nametag position
+## 	[P]: Print the json accent definition
+## 	[R]: Generate a random accent definition
+## 	[S]: Swap the accent's colors
+## 	[Z]: Squish the window to the side
 
 const TEXTS := [
 	"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore" \
@@ -61,7 +59,7 @@ const SCALES := [
 	8.00
 ]
 
-# these fields store the results of the user's input
+## these fields store the results of the user's input
 var _name_index := 4
 var _text_index := 4
 
@@ -134,9 +132,7 @@ func _input(event: InputEvent) -> void:
 			_play_chat_event()
 
 
-"""
-Configures the chat window's appearance based on the user's input.
-"""
+## Configures the chat window's appearance based on the user's input.
 func _play_chat_event() -> void:
 	var creature_def := CreatureDef.new()
 	creature_def.creature_name = NAMES[_name_index]
@@ -149,9 +145,7 @@ func _play_chat_event() -> void:
 	$ChatFrame.play_chat_event(chat_event, _squished)
 
 
-"""
-Generates a new accent definition generated based on the user's input.
-"""
+## Generates a new accent definition generated based on the user's input.
 func _get_chat_theme_def() -> Dictionary:
 	return {
 		"accent_texture": _texture_index,

--- a/project/src/demo/ui/chat/chat-ui-demo.gd
+++ b/project/src/demo/ui/chat/chat-ui-demo.gd
@@ -1,15 +1,13 @@
 extends Control
-"""
-A demo which lets you test the chat UI by flipping through pages of a chat.
-
-Keys:
-	[0-9]: Changes chat line length; 1 = short, 9 = long, 0 = longest
-	[Control + 0-9]: Changes response length; 1 = short, 9 = long, 0 = longest
-	[Q, W, E]: Shows questions with more and more options.
-	[R]: Shows a chat tree missing a lot of chat lines.
-	[T]: Shows a chat tree showing off the different moods.
-	[A]: Shows a chat line with no choices.
-"""
+## A demo which lets you test the chat UI by flipping through pages of a chat.
+##
+## Keys:
+## 	[0-9]: Changes chat line length; 1 = short, 9 = long, 0 = longest
+## 	[Control + 0-9]: Changes response length; 1 = short, 9 = long, 0 = longest
+## 	[Q, W, E]: Shows questions with more and more options.
+## 	[R]: Shows a chat tree missing a lot of chat lines.
+## 	[T]: Shows a chat tree showing off the different moods.
+## 	[A]: Shows a chat line with no choices.
 
 const FRUITS := [
 	"Apple", "Apricot", "Banana", "Cantaloupe", "Cherry", "Grape", "Grapefruit",

--- a/project/src/demo/ui/chat/chatscript-table-demo.gd
+++ b/project/src/demo/ui/chat/chatscript-table-demo.gd
@@ -1,18 +1,16 @@
 extends Control
-"""
-Generates a BBCode Chatscript mood table for the wiki.
+## Generates a BBCode Chatscript mood table for the wiki.
+##
+## This process is automated because the list of emoticons is likely to expand or change.
 
-This process is automated because the list of emoticons is likely to expand or change.
-"""
-
-# The number of columns in the BBCode table
+## The number of columns in the BBCode table
 var _table_width := 1
 
-# key: An int corresponding to a mood from ChatEvent.Mood
-# value: An array of string chat prefixes (emoticons)
+## key: An int corresponding to a mood from ChatEvent.Mood
+## value: An array of string chat prefixes (emoticons)
 var _prefixes_by_mood := {}
 
-# TextEdit containing the BBCode table
+## TextEdit containing the BBCode table
 onready var _text_edit := $TextEdit
 
 func _ready() -> void:
@@ -70,13 +68,11 @@ func _add_mood_rows() -> void:
 		_add_table_row(table_row)
 
 
-"""
-Add a BBCode row to the TextEdit.
-
-Parameters:
-	'row': An array of strings corresponding to the row's contents. Empty columns will be filled in if the array has
-			fewer entries than the number of columns in the table.
-"""
+## Add a BBCode row to the TextEdit.
+##
+## Parameters:
+## 	'row': An array of strings corresponding to the row's contents. Empty columns will be filled in if the array has
+## 		fewer entries than the number of columns in the table.
 func _add_table_row(row: Array) -> void:
 	var pool_array := PoolStringArray(row)
 	

--- a/project/src/demo/ui/chat/mood-demo.gd
+++ b/project/src/demo/ui/chat/mood-demo.gd
@@ -1,31 +1,29 @@
 extends Node
-"""
-A demo which shows off the creature's range of emotions and idle animations
-
-Keys:
-	[1]: Default mood
-	
-	[Q, W, E, R]: Awkward0 (Uncomfortable), Awkward1 (Embarrassed), Cry0 (Disappointed), Cry1 (Distraught)
-	[T, Y, U, I, 8]: Laugh0 (Tickled), Laugh1 (Laughing), Love0 (Heart Eyes), Love1 (Dreamy Love), Love1 Forever
-	[O, P]: No0 (Head Shake), No1 (More Shakes)
-	
-	[A, S, D, F, G]: Rage0 (Annoyed), Rage1 (Angry), Rage2 (Murderous), Sigh0 (Ugh), Sigh1 (Eyeroll)
-	[H, J, K, L]: Smile0 (Happy), Smile1 (Sweet), Sweat0 (Nervous), Sweat1 (Fidgety)
-	
-	[Z, X, C, V]: Think0 (Pensive), Think1 (Confused), Wave0 (Polite), Wave1 (Friendly)
-	[B, N]: Yes0 (Nod), Yes1 (More Nods)
-	
-	[Shift + T]: Talk
-	[=]: Make the creature fat
-	[space bar]: Feed
-	[brace keys]: Change the creature's appearance
-	[Shift + /]: Print DNA
-	
-	[Shift + Q, W]: Look over shoulder
-	[Shift + E, R]: Yawn
-	[Shift + A, S]: Close eyes
-	[Shift + D, F]: Wiggle ears
-"""
+## A demo which shows off the creature's range of emotions and idle animations
+##
+## Keys:
+## 	[1]: Default mood
+##
+## 	[Q, W, E, R]: Awkward0 (Uncomfortable), Awkward1 (Embarrassed), Cry0 (Disappointed), Cry1 (Distraught)
+## 	[T, Y, U, I, 8]: Laugh0 (Tickled), Laugh1 (Laughing), Love0 (Heart Eyes), Love1 (Dreamy Love), Love1 Forever
+## 	[O, P]: No0 (Head Shake), No1 (More Shakes)
+##
+## 	[A, S, D, F, G]: Rage0 (Annoyed), Rage1 (Angry), Rage2 (Murderous), Sigh0 (Ugh), Sigh1 (Eyeroll)
+## 	[H, J, K, L]: Smile0 (Happy), Smile1 (Sweet), Sweat0 (Nervous), Sweat1 (Fidgety)
+##
+## 	[Z, X, C, V]: Think0 (Pensive), Think1 (Confused), Wave0 (Polite), Wave1 (Friendly)
+## 	[B, N]: Yes0 (Nod), Yes1 (More Nods)
+##
+## 	[Shift + T]: Talk
+## 	[=]: Make the creature fat
+## 	[space bar]: Feed
+## 	[brace keys]: Change the creature's appearance
+## 	[Shift + /]: Print DNA
+##
+## 	[Shift + Q, W]: Look over shoulder
+## 	[Shift + E, R]: Yawn
+## 	[Shift + A, S]: Close eyes
+## 	[Shift + D, F]: Wiggle ears
 
 onready var _creature_animations: CreatureAnimations = $Creature.creature_visuals.get_node("Animations")
 

--- a/project/src/demo/ui/settings/keybind/keybind-manager-demo.gd
+++ b/project/src/demo/ui/settings/keybind/keybind-manager-demo.gd
@@ -1,9 +1,7 @@
 extends Node
-"""
-Non-interactive demo which prints the currently bound keys in JSON format.
-
-Useful for saving a new keybind preset from the current InputMap.
-"""
+## Non-interactive demo which prints the currently bound keys in JSON format.
+##
+## Useful for saving a new keybind preset from the current InputMap.
 
 func _ready() -> void:
 	var json_dict := {}

--- a/project/src/demo/ui/settings/settings-menu-demo.gd
+++ b/project/src/demo/ui/settings/settings-menu-demo.gd
@@ -1,9 +1,7 @@
 extends Node
-"""
-Shows the settings menu.
-
-The settings menu is invisible by default, so a demo is necessary to view it.
-"""
+## Shows the settings menu.
+##
+## The settings menu is invisible by default, so a demo is necessary to view it.
 
 func _ready() -> void:
 	$SettingsMenu.show()

--- a/project/src/demo/ui/touch/eight-way-demo.gd
+++ b/project/src/demo/ui/touch/eight-way-demo.gd
@@ -1,12 +1,10 @@
 extends Node
-"""
-Demonstrates the eight-way touchscreen inputs.
-
-Enable emulate_desktop_from_mouse in the project settings to use this demo.
-
-Keys:
-	[+,-]: Increase/decrease the size of the EightWay
-"""
+## Demonstrates the eight-way touchscreen inputs.
+##
+## Enable emulate_desktop_from_mouse in the project settings to use this demo.
+##
+## Keys:
+## 	[+,-]: Increase/decrease the size of the EightWay
 
 var actions := [
 	"ui_up", "ui_down", "ui_left", "ui_right",

--- a/project/src/demo/world/creature/creature-palette-demo.gd
+++ b/project/src/demo/world/creature/creature-palette-demo.gd
@@ -1,11 +1,9 @@
 class_name CreaturePaletteDemo
 extends Control
-"""
-Demonstrates the creature palettes, and lets you view/edit them.
-
-This adds a third 'palette' tab to the creature editor. Clicking the themes in that tab recolors the creature. There
-are also buttons for adding themes and printing them to the console.
-"""
+## Demonstrates the creature palettes, and lets you view/edit them.
+##
+## This adds a third 'palette' tab to the creature editor. Clicking the themes in that tab recolors the creature. There
+## are also buttons for adding themes and printing them to the console.
 
 export (PackedScene) var PaletteEditorTabScene: PackedScene
 

--- a/project/src/demo/world/creature/palette-button.gd
+++ b/project/src/demo/world/creature/palette-button.gd
@@ -1,14 +1,10 @@
 class_name PaletteButton
 extends ColorRect
-"""
-Clickable control which shows a palette's colors.
-"""
+## Clickable control which shows a palette's colors.
 
 signal pressed
 
-"""
-Updates the button's colors to match the specified palette.
-"""
+## Updates the button's colors to match the specified palette.
 func set_palette(palette: Dictionary) -> void:
 	color = palette["line_rgb"]
 	$HBoxContainer/Body.color = Color(palette["body_rgb"])

--- a/project/src/demo/world/creature/palette-editor-tab.gd
+++ b/project/src/demo/world/creature/palette-editor-tab.gd
@@ -1,8 +1,6 @@
 class_name PaletteEditorTab
 extends VBoxContainer
-"""
-A tab which lets the player pick and edit different creature palettes.
-"""
+## A tab which lets the player pick and edit different creature palettes.
 
 export (PackedScene) var PaletteButtonScene: PackedScene
 export (NodePath) var creature_editor_path: NodePath setget set_creature_editor_path
@@ -35,11 +33,9 @@ func _add_palette(palette: Dictionary) -> void:
 	_creature_palettes.append(palette)
 
 
-"""
-Updates the creature's colors with the clicked palette.
-
-Rotates the creature's current color to the outer creatures, so the player can go back if they liked the old colors.
-"""
+## Updates the creature's colors with the clicked palette.
+##
+## Rotates the creature's current color to the outer creatures, so the player can go back if they liked the old colors.
 func _on_PaletteButton_pressed(palette: Dictionary) -> void:
 	# rotate the creature's current color out
 	_creature_editor.outer_creatures[0].dna = get_center_creature().dna
@@ -60,11 +56,9 @@ func _on_PaletteButton_pressed(palette: Dictionary) -> void:
 	_creature_editor.emit_signal("center_creature_changed")
 
 
-"""
-Prints a palette to the console.
-
-This printed palette is valid GDScript, and can be copy/pasted into the DnaUtils constant.
-"""
+## Prints a palette to the console.
+##
+## This printed palette is valid GDScript, and can be copy/pasted into the DnaUtils constant.
 func _print_palette(palette: Dictionary) -> void:
 	var result := ""
 	result += "\t{\"line_rgb\": \"%s\", " % palette["line_rgb"]
@@ -79,9 +73,7 @@ func _print_palette(palette: Dictionary) -> void:
 	print(result)
 
 
-"""
-Prints all palettes to the console.
-"""
+## Prints all palettes to the console.
 func _on_Print_pressed() -> void:
 	print("const CREATURE_PALETTES := [")
 	for palette in _creature_palettes:
@@ -89,9 +81,7 @@ func _on_Print_pressed() -> void:
 	print("]")
 
 
-"""
-Appends a palette and prints it to the console.
-"""
+## Appends a palette and prints it to the console.
 func _on_Add_pressed() -> void:
 	var palette := {}
 	for allele in DnaUtils.COLOR_ALLELES:

--- a/project/src/demo/world/cutscene-demo-fatness.gd
+++ b/project/src/demo/world/cutscene-demo-fatness.gd
@@ -1,7 +1,5 @@
 extends HBoxContainer
-"""
-UI control for editing the global 'forced_fatness' field.
-"""
+## UI control for editing the global 'forced_fatness' field.
 
 func _ready() -> void:
 	if PlayerData.creature_library.forced_fatness:
@@ -14,9 +12,7 @@ func _ready() -> void:
 	_refresh()
 
 
-"""
-Updates the UI controls and the global 'forced_fatness' field.
-"""
+## Updates the UI controls and the global 'forced_fatness' field.
 func _refresh() -> void:
 	$HSlider.editable = $CheckBox.pressed
 	$Value.text = "%.1f" % [$HSlider.value] if $HSlider.editable else "-"

--- a/project/src/demo/world/cutscene-demo-flags.gd
+++ b/project/src/demo/world/cutscene-demo-flags.gd
@@ -1,23 +1,19 @@
 extends VBoxContainer
-"""
-UI input for specifying flags to assign or unassign during cutscenes.
-"""
+## UI input for specifying flags to assign or unassign during cutscenes.
 
-# Describes flags to assign or unassign during cutscenes
-# Virtual property; value is only exposed through getters/setters
+## Describes flags to assign or unassign during cutscenes
+## Virtual property; value is only exposed through getters/setters
 var value: String setget set_value, get_value
 
-"""
-Applies the text contents to the player's data.
-
-This involves assigning and unassigning conversations they've had and levels they've played based on the input. The
-input field supports the following flags:
-	
-	'chat_finished foo'
-	'not chat_finished foo'
-	'level_finished foo'
-	'not level_finished foo'
-"""
+## Applies the text contents to the player's data.
+##
+## This involves assigning and unassigning conversations they've had and levels they've played based on the input. The
+## input field supports the following flags:
+##
+## 	'chat_finished foo'
+## 	'not chat_finished foo'
+## 	'level_finished foo'
+## 	'not level_finished foo'
 func apply_flags() -> void:
 	for line_obj in $TextEdit.text.split("\n"):
 		var line: String = line_obj

--- a/project/src/demo/world/cutscene-demo-long-names.gd
+++ b/project/src/demo/world/cutscene-demo-long-names.gd
@@ -1,14 +1,12 @@
 extends CheckBox
-"""
-UI control for toggling whether or not the protagonists have very long names.
+## UI control for toggling whether or not the protagonists have very long names.
+##
+## This is useful for preventing bugs where a player with a long name causes text to overrun the chat window.
 
-This is useful for preventing bugs where a player with a long name causes text to overrun the chat window.
-"""
-
-# long name to substitute for the creature_name field
+## long name to substitute for the creature_name field
 const LONG_NAME := "WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW"
 
-# long name to substitute for the creature_short_name field
+## long name to substitute for the creature_short_name field
 const LONG_SHORT_NAME := "WWWWWWWWWWWWWWW"
 
 

--- a/project/src/demo/world/cutscene-demo-open.gd
+++ b/project/src/demo/world/cutscene-demo-open.gd
@@ -1,10 +1,8 @@
 extends HBoxContainer
-"""
-UI input for specifying the cutscene to open
-"""
+## UI input for specifying the cutscene to open
 
-# The cutscene to open
-# Virtual property; value is only exposed through getters/setters
+## The cutscene to open
+## Virtual property; value is only exposed through getters/setters
 var value: String setget set_value, get_value
 
 func set_value(new_value: String) -> void:

--- a/project/src/demo/world/cutscene-demo.gd
+++ b/project/src/demo/world/cutscene-demo.gd
@@ -1,11 +1,9 @@
 extends Control
-"""
-Demonstrates cutscenes.
+## Demonstrates cutscenes.
+##
+## The user can select and launch any cutscene, and change how fat the creatures are.
 
-The user can select and launch any cutscene, and change how fat the creatures are.
-"""
-
-# property keys to use when saving/loading data
+## property keys to use when saving/loading data
 const SAVE_KEY_FLAGS := "cutscene-demo.flags"
 const SAVE_KEY_OPEN := "cutscene-demo.open"
 

--- a/project/src/demo/world/letter-shooter-demo.gd
+++ b/project/src/demo/world/letter-shooter-demo.gd
@@ -1,11 +1,9 @@
 extends Node
-"""
-Demonstrates the 'letter shooter' which launches letter projectiles.
-
-Keys:
-	]: Start shooting letters
-	[: Stop shooting letters
-"""
+## Demonstrates the 'letter shooter' which launches letter projectiles.
+##
+## Keys:
+## 	]: Start shooting letters
+## 	[: Stop shooting letters
 
 func _input(event: InputEvent) -> void:
 	match Utils.key_scancode(event):

--- a/project/src/demo/world/restaurant/restaurant-scene-demo.gd
+++ b/project/src/demo/world/restaurant/restaurant-scene-demo.gd
@@ -1,13 +1,11 @@
 extends Node2D
-"""
-A demo which shows off the restaurant scene.
-
-Keys:
-	[F]: Feed the creature
-	[1-9,0]: Change the creature's size from 10% to 100%
-	[Q,W,E]: Switch to the 1st, 2nd or 3rd creature.
-	brace keys: Change the creature's appearance
-"""
+## A demo which shows off the restaurant scene.
+##
+## Keys:
+## 	[F]: Feed the creature
+## 	[1-9,0]: Change the creature's size from 10% to 100%
+## 	[Q,W,E]: Switch to the 1st, 2nd or 3rd creature.
+## 	brace keys: Change the creature's appearance
 
 const FATNESS_KEYS = [10.0, 1.0, 1.5, 2.0, 3.0, 5.0, 6.0, 7.0, 8.0, 9.0]
 

--- a/project/src/demo/world/restaurant/restaurant-view-demo.gd
+++ b/project/src/demo/world/restaurant/restaurant-view-demo.gd
@@ -1,19 +1,17 @@
 extends Control
-"""
-A demo which shows off the restaurant view.
-
-Keys:
-	[D]: Ring the doorbell
-	[F]: Feed the creature
-	[I]: Launch an idle animation
-	[V]: Say something
-	[N]: Change the nametag names
-	[1-9,0]: Change the creature's size from 10% to 100%
-	SHIFT+[1-9,0]: Change the creature's comfort from 0.0 -> 1.0 -> -1.0
-	[Q,W,E]: Switch to the 1st, 2nd or 3rd creature.
-	arrows: Change the creature's orientation
-	brace keys: Change the creature's appearance
-"""
+## A demo which shows off the restaurant view.
+##
+## Keys:
+## 	[D]: Ring the doorbell
+## 	[F]: Feed the creature
+## 	[I]: Launch an idle animation
+## 	[V]: Say something
+## 	[N]: Change the nametag names
+## 	[1-9,0]: Change the creature's size from 10% to 100%
+## 	SHIFT+[1-9,0]: Change the creature's comfort from 0.0 -> 1.0 -> -1.0
+## 	[Q,W,E]: Switch to the 1st, 2nd or 3rd creature.
+## 	arrows: Change the creature's orientation
+## 	brace keys: Change the creature's appearance
 
 const FATNESS_KEYS = [10.0, 1.0, 1.5, 2.0, 3.0, 5.0, 6.0, 7.0, 8.0, 9.0]
 const NAMES = [

--- a/project/src/main/breadcrumb.gd
+++ b/project/src/main/breadcrumb.gd
@@ -1,39 +1,31 @@
 extends Node
-"""
-List of paths representing the current scene and its ancestors, leading back to the main menu.
+## List of paths representing the current scene and its ancestors, leading back to the main menu.
+##
+## This breadcrumb trail is used for navigation. It keeps track of which scene the user should go back to when they
+## press the various 'Quit' buttons throughout the game.
 
-This breadcrumb trail is used for navigation. It keeps track of which scene the user should go back to when they press
-the various 'Quit' buttons throughout the game.
-"""
-
-"""
-Emitted when the user goes back, popping the front item off of the breadcrumb trail
-
-Parameters:
-	'prev_path': The path item which was just popped from the breadcrumb trail
-"""
+## Emitted when the user goes back, popping the front item off of the breadcrumb trail
+##
+## Parameters:
+## 	'prev_path': The path item which was just popped from the breadcrumb trail
 signal trail_popped(prev_path)
 
-# Emitted before this class changes the running scene.
+## Emitted before this class changes the running scene.
 signal before_scene_changed
 
 var trail := []
 
-"""
-Initializes the trail to be empty except for the current scene.
-
-This is useful for demos and development where having an empty breadcrumb trail causes bugs. During regular play the
-breadcrumb trail should be initialized conventionally in the splash screen or menus.
-"""
+## Initializes the trail to be empty except for the current scene.
+##
+## This is useful for demos and development where having an empty breadcrumb trail causes bugs. During regular play the
+## breadcrumb trail should be initialized conventionally in the splash screen or menus.
 func initialize_trail() -> void:
 	trail = [get_tree().current_scene.filename]
 
 
-"""
-Navigates back one level in the breadcrumb trail.
-
-Pops the front path off of the breadcrumb trail. Emits a signal and changes the current scene.
-"""
+## Navigates back one level in the breadcrumb trail.
+##
+## Pops the front path off of the breadcrumb trail. Emits a signal and changes the current scene.
 func pop_trail() -> void:
 	var prev_path: String
 	if trail:
@@ -44,26 +36,22 @@ func pop_trail() -> void:
 		_change_scene()
 
 
-"""
-Navigates forward one level, appending the new path to the breadcrumb trail.
-
-Parameters:
-	'path': The path to append to the breadcrumb trail. This is usually a scene path such as 'res://MyScene.tscn', but
-		it can also include a '::foo' suffix for navigation paths which do not result in a scene change.
-"""
+## Navigates forward one level, appending the new path to the breadcrumb trail.
+##
+## Parameters:
+## 	'path': The path to append to the breadcrumb trail. This is usually a scene path such as 'res://MyScene.tscn', but
+## 		it can also include a '::foo' suffix for navigation paths which do not result in a scene change.
 func push_trail(path: String) -> void:
 	trail.push_front(path)
 	if not "::" in path:
 		_change_scene()
 
 
-"""
-Stays at the current level in the breadcrumb trail, but replaces the current navigation path.
-
-Parameters:
-	'path': The path to append to the breadcrumb trail. This is usually a scene path such as 'res://MyScene.tscn', but
-		it can also include a '::foo' suffix for navigation paths which do not result in a scene change.
-"""
+## Stays at the current level in the breadcrumb trail, but replaces the current navigation path.
+##
+## Parameters:
+## 	'path': The path to append to the breadcrumb trail. This is usually a scene path such as 'res://MyScene.tscn', but
+## 		it can also include a '::foo' suffix for navigation paths which do not result in a scene change.
 func replace_trail(path: String) -> void:
 	trail.pop_front()
 	trail.push_front(path)
@@ -71,9 +59,7 @@ func replace_trail(path: String) -> void:
 		_change_scene()
 
 
-"""
-Changes the running scene to the one at the front of the breadcrumb trail.
-"""
+## Changes the running scene to the one at the front of the breadcrumb trail.
 func _change_scene() -> void:
 	emit_signal("before_scene_changed")
 	var scene_path: String

--- a/project/src/main/creature-library.gd
+++ b/project/src/main/creature-library.gd
@@ -1,48 +1,46 @@
 class_name CreatureLibrary
-"""
-Manages data for all creatures in the world, including the player.
+## Manages data for all creatures in the world, including the player.
+##
+## This includes their appearance, name and weight.
 
-This includes their appearance, name and weight.
-"""
-
-# unique creature ids
+## unique creature ids
 const SENSEI_ID := "#sensei#"
 const PLAYER_ID := "#player#"
 const NARRATOR_ID := "#narrator#"
 
-# How many randomly generated filler creatures have their fatness tracked
+## How many randomly generated filler creatures have their fatness tracked
 const GENERIC_FATNESS_COUNT := 150
 
-# The maximum fatness we'll save for a randomly generated filler creature. We don't want a random creature the player
-# has never seen who weighs 10,000 pounds; it would sort of break immersion as they'd wonder "who fed this person!? it
-# wasn't me"
+## The maximum fatness we'll save for a randomly generated filler creature. We don't want a random creature the player
+## has never seen who weighs 10,000 pounds; it would sort of break immersion as they'd wonder "who fed this person!? it
+## wasn't me"
 const MAX_FILLER_FATNESS := 2.5
 
-# If set, all creatures will have a specific fatness. Used for testing cutscenes.
+## If set, all creatures will have a specific fatness. Used for testing cutscenes.
 var forced_fatness := 0.0
 
-# Virtual properties; values are only exposed through getters/setters
+## Virtual properties; values are only exposed through getters/setters
 var player_def: CreatureDef setget set_player_def, get_player_def
 var sensei_def: CreatureDef setget set_sensei_def, get_sensei_def
 
-# fatnesses by creature id
+## fatnesses by creature id
 var _fatnesses: Dictionary
 
-# fatnesses saved to roll the tilemap back to a previous state
+## fatnesses saved to roll the tilemap back to a previous state
 var _saved_fatnesses: Dictionary
 
-# In addition to storing known fatness attributes like "Ebe's weight is 2.5", we store fatnesses for randomly
-# generated filler creatures. We rotate their IDs to avoid edge cases where two creatures have the same ID.
+## In addition to storing known fatness attributes like "Ebe's weight is 2.5", we store fatnesses for randomly
+## generated filler creatures. We rotate their IDs to avoid edge cases where two creatures have the same ID.
 var _filler_ids: Array
 
-# Cached creature definitions. This includes all primary and creature json definitions loaded from static json files,
-# as well as the player and sensei's definitions.
+## Cached creature definitions. This includes all primary and creature json definitions loaded from static json files,
+## as well as the player and sensei's definitions.
 #
-# This is a transient field which is populated on startup, but is not saved anywhere. As its contents not written to
-# disk, it should not be modified with the intent of permanently changing a creature's appearance.
+## This is a transient field which is populated on startup, but is not saved anywhere. As its contents not written to
+## disk, it should not be modified with the intent of permanently changing a creature's appearance.
 #
-# key: creature_id
-# value: CreatureDef instance with the specified id
+## key: creature_id
+## value: CreatureDef instance with the specified id
 var _creature_defs_by_id: Dictionary
 
 func _init() -> void:
@@ -53,12 +51,10 @@ func creature_ids() -> Array:
 	return _creature_defs_by_id.keys()
 
 
-"""
-Returns a filler ID.
-
-Pushes the filler ID somewhere toward the back of the queue. The position is slightly randomized to prevent cycles
-from emerging.
-"""
+## Returns a filler ID.
+##
+## Pushes the filler ID somewhere toward the back of the queue. The position is slightly randomized to prevent cycles
+## from emerging.
 func next_filler_id() -> String:
 	var filler_id: String = _filler_ids.pop_front()
 	# warning-ignore:integer_division
@@ -111,19 +107,15 @@ func reset() -> void:
 		_creature_defs_by_id[creature_def.creature_id] = creature_def
 
 
-"""
-Saves the current fatness state so that we can roll back later.
-"""
+## Saves the current fatness state so that we can roll back later.
 func save_fatness_state() -> void:
 	_saved_fatnesses = _fatnesses.duplicate()
 
 
-"""
-Restores the previously saved fatness state.
-
-This prevents a creature from gaining weight when retrying a level over and over.
-Thematically, we're turning back time.
-"""
+## Restores the previously saved fatness state.
+##
+## This prevents a creature from gaining weight when retrying a level over and over.
+## Thematically, we're turning back time.
 func restore_fatness_state() -> void:
 	_fatnesses = _saved_fatnesses.duplicate()
 
@@ -184,9 +176,7 @@ func set_creature_def(creature_id: String, creature_def: CreatureDef) -> void:
 	_creature_defs_by_id[creature_id] = creature_def
 
 
-"""
-Populates the fatness for randomly generated filler creatures.
-"""
+## Populates the fatness for randomly generated filler creatures.
 func _normalize_filler_fatnesses() -> void:
 	for i in range(GENERIC_FATNESS_COUNT):
 		var filler_id := "#filler_%03d#" % i
@@ -199,16 +189,14 @@ func _normalize_filler_fatnesses() -> void:
 	_filler_ids.shuffle()
 
 
-"""
-Returns a list of file paths in the specified directory.
-
-This only returns the directory's immediate children, and does not perform a tree traversal.
-
-Parameters:
-	'dir_path': The path of the directory to scan
-	
-	'file_suffix': (Optional) A suffix to append to each returned file path.
-"""
+## Returns a list of file paths in the specified directory.
+##
+## This only returns the directory's immediate children, and does not perform a tree traversal.
+##
+## Parameters:
+## 	'dir_path': The path of the directory to scan
+##
+## 	'file_suffix': (Optional) A suffix to append to each returned file path.
 func _file_paths(dir_path: String, file_suffix: String = "") -> Array:
 	var result := []
 	var dir := Directory.new()

--- a/project/src/main/creature-queue.gd
+++ b/project/src/main/creature-queue.gd
@@ -1,16 +1,14 @@
 class_name CreatureQueue
-"""
-Queue of creatures who appear when the player solves puzzles.
+## Queue of creatures who appear when the player solves puzzles.
+##
+## This includes a 'primary queue' of creatures guaranteed to show up at the start of a puzzle, and a 'secondary queue'
+## of creatures who randomly show up during a puzzle.
 
-This includes a 'primary queue' of creatures guaranteed to show up at the start of a puzzle, and a 'secondary queue'
-of creatures who randomly show up during a puzzle.
-"""
-
-# Queue of creatures who show up at the start of a puzzle.
+## Queue of creatures who show up at the start of a puzzle.
 var primary_queue := []
 var primary_index: int
 
-# Queue of creatures who randomly show up during a puzzle.
+## Queue of creatures who randomly show up during a puzzle.
 var secondary_queue: Array
 var secondary_index := 0
 
@@ -18,16 +16,12 @@ func _init() -> void:
 	_load_secondary_creatures()
 
 
-"""
-Returns 'true' if the primary creature queue has any creatures left.
-"""
+## Returns 'true' if the primary creature queue has any creatures left.
 func has_primary_creature() -> bool:
 	return primary_index < primary_queue.size()
 
 
-"""
-Returns the next creature in the primary creature queue, and advances the queue.
-"""
+## Returns the next creature in the primary creature queue, and advances the queue.
 func pop_primary_creature() -> CreatureDef:
 	var creature_def: CreatureDef
 	if has_primary_creature():
@@ -36,16 +30,12 @@ func pop_primary_creature() -> CreatureDef:
 	return creature_def
 
 
-"""
-Returns 'true' if the secondary creature queue has any creatures left.
-"""
+## Returns 'true' if the secondary creature queue has any creatures left.
 func has_secondary_creature() -> bool:
 	return secondary_index < secondary_queue.size()
 
 
-"""
-Returns the next creature in the secondary creature queue, and advances the queue.
-"""
+## Returns the next creature in the secondary creature queue, and advances the queue.
 func pop_secondary_creature() -> CreatureDef:
 	var creature_def: CreatureDef
 	if has_secondary_creature():
@@ -55,23 +45,19 @@ func pop_secondary_creature() -> CreatureDef:
 	return creature_def
 
 
-"""
-Empties the queue of creatures who will show up at the start of the next puzzle.
-
-Also rotates the secondary creatures so the same creatures don't show up over and over.
-"""
+## Empties the queue of creatures who will show up at the start of the next puzzle.
+##
+## Also rotates the secondary creatures so the same creatures don't show up over and over.
 func clear() -> void:
 	primary_queue = []
 	primary_index = 0
 	reset_secondary_creature_queue()
 
 
-"""
-Resets the queue of secondary creatures; recognizable characters who show up now and then, but don't have any chats or
-levels
-
-This resets the queue_index to 0, and moves the beginning of the queue to the end.
-"""
+## Resets the queue of secondary creatures; recognizable characters who show up now and then, but don't have any chats
+## or levels
+##
+## This resets the queue_index to 0, and moves the beginning of the queue to the end.
 func reset_secondary_creature_queue() -> void:
 	if secondary_queue and secondary_index > 0:
 		var new_queue := []
@@ -82,9 +68,7 @@ func reset_secondary_creature_queue() -> void:
 		secondary_index = 0
 
 
-"""
-Loads all secondary creature data from a directory of json files.
-"""
+## Loads all secondary creature data from a directory of json files.
 func _load_secondary_creatures() -> void:
 	var dir := Directory.new()
 	dir.open("res://assets/main/creatures/secondary")

--- a/project/src/main/editor/creature/creature-editor-nametags.gd
+++ b/project/src/main/editor/creature/creature-editor-nametags.gd
@@ -1,17 +1,15 @@
 extends Node
-"""
-Manages nametags which label creatures in the creature editor.
+## Manages nametags which label creatures in the creature editor.
+##
+## Creates a nametag for each creature in the scene.
 
-Creates a nametag for each creature in the scene.
-"""
-
-# nametag colors for focused/unfocused creatures
+## nametag colors for focused/unfocused creatures
 const NAMETAG_HIGHLIGHT = Color("303060")
 const NAMETAG_LOWLIGHT = Color.darkgray
 
 export (PackedScene) var HookableNametagScene: PackedScene
 
-# mapping from Creatures to NametagPanels
+## mapping from Creatures to NametagPanels
 var _creature_to_nametag: Dictionary
 
 func _ready() -> void:
@@ -26,9 +24,7 @@ func _ready() -> void:
 		_creature_to_nametag[creature] = nametag
 
 
-"""
-When a creature is renamed, the corresponding nametag changes its text and position.
-"""
+## When a creature is renamed, the corresponding nametag changes its text and position.
 func _on_Creature_creature_name_changed(creature: Creature, nametag: Panel) -> void:
 	nametag.set_nametag_text(StringUtils.default_if_empty(creature.creature_name, "(unnamed)"))
 	nametag.rect_scale = Vector2(0.6, 0.6) if creature.has_meta("main_creature") else Vector2(0.4, 0.4)
@@ -39,9 +35,7 @@ func _on_Creature_creature_name_changed(creature: Creature, nametag: Panel) -> v
 	nametag.rect_position.y = -nametag.rect_size.y * nametag.rect_scale.y + 20
 
 
-"""
-When a creature is hovered, the nametag colors change.
-"""
+## When a creature is hovered, the nametag colors change.
 func _on_CreatureSelector_hovered_creature_changed(value: Creature) -> void:
 	if value:
 		# creature is highlighted; their nametag is blue, others are gray

--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -1,10 +1,8 @@
 class_name CreatureEditor
 extends Node
-"""
-A graphical creature editor which lets players design their own creatures.
-"""
+## A graphical creature editor which lets players design their own creatures.
 
-# emitted when the center creature is first initialized, and later when it is swapped out
+## emitted when the center creature is first initialized, and later when it is swapped out
 signal center_creature_changed
 
 enum ColorMode {
@@ -20,17 +18,17 @@ const SIMILAR_COLORS := ColorMode.SIMILAR_COLORS
 var _rng := RandomNumberGenerator.new()
 var _next_line_color_index := 0
 
-# key: allele
-# value: values which have been randomly chosen by the 'tweak dna' button
+## key: allele
+## value: values which have been randomly chosen by the 'tweak dna' button
 var _recent_tweaked_allele_values := {}
 
-# generates random names
+## generates random names
 var _name_generator: NameGenerator
 
-# the creature the player is editing
+## the creature the player is editing
 onready var center_creature: Creature = $World/Creatures/CenterCreature
 
-# alternative creatures the player can choose
+## alternative creatures the player can choose
 onready var outer_creatures := [
 	$World/Creatures/NwCreature,
 	$World/Creatures/NeCreature,
@@ -40,7 +38,7 @@ onready var outer_creatures := [
 	$World/Creatures/SeCreature,
 ]
 
-# the UI which tracks things like mutagen level and locked/unlocked alleles
+## the UI which tracks things like mutagen level and locked/unlocked alleles
 onready var _mutate_ui := $Ui/TabContainer/Mutate
 onready var _reroll_ui := $Ui/Reroll
 
@@ -63,22 +61,18 @@ func _ready() -> void:
 	mutate_all_creatures()
 
 
-"""
-Regenerates all of the outer creatures to be variations of the center creature.
-
-Any number of aspects of the creature are changed.
-"""
+## Regenerates all of the outer creatures to be variations of the center creature.
+##
+## Any number of aspects of the creature are changed.
 func mutate_all_creatures() -> void:
 	for creature_obj in outer_creatures:
 		_mutate_creature(creature_obj)
 
 
-"""
-Regenerates a creature to be a variation of the center creature.
-
-The amount of variance depends on the 'mutagen' level. The mutated alleles are randomly chosen depend on the player's
-locked/unlocked alleles.
-"""
+## Regenerates a creature to be a variation of the center creature.
+##
+## The amount of variance depends on the 'mutagen' level. The mutated alleles are randomly chosen depend on the
+## player's locked/unlocked alleles.
 func _mutate_creature(creature: Creature) -> void:
 	var new_palette: Dictionary = _palette()
 	
@@ -97,21 +91,19 @@ func _mutate_creature(creature: Creature) -> void:
 	creature.chat_theme_def = CreatureLoader.chat_theme_def(dna)
 
 
-"""
-Mutate a single allele.
-
-Picks a new value for the specified allele, weighted to pick more common/appealing attributes more frequently, and to
-avoid illegal allele combinations.
-
-Parameters:
-	'creature': The creature to modify for non-DNA attributes, such as fatness and name.
-	
-	'dna': The dna dictionary to modify.
-	
-	'new_palette': The palette to use for any new colors.
-	
-	'property': The allele property to mutate.
-"""
+## Mutate a single allele.
+##
+## Picks a new value for the specified allele, weighted to pick more common/appealing attributes more frequently, and
+## to avoid illegal allele combinations.
+##
+## Parameters:
+## 	'creature': The creature to modify for non-DNA attributes, such as fatness and name.
+##
+## 	'dna': The dna dictionary to modify.
+##
+## 	'new_palette': The palette to use for any new colors.
+##
+## 	'property': The allele property to mutate.
 func _mutate_allele(creature: Creature, dna: Dictionary, new_palette: Dictionary, property: String) -> void:
 	match property:
 		"name":
@@ -148,12 +140,10 @@ func _mutate_allele(creature: Creature, dna: Dictionary, new_palette: Dictionary
 				dna[property] = Utils.weighted_rand_value(new_alleles)
 
 
-"""
-Regenerates all of the outer creatures to be variations of the center creature.
-
-Only one aspect of the creature is changed. We select a value which is different from the creature's current value, and
-which hasn't been selected recently.
-"""
+## Regenerates all of the outer creatures to be variations of the center creature.
+##
+## Only one aspect of the creature is changed. We select a value which is different from the creature's current value,
+## and which hasn't been selected recently.
 func tweak_all_creatures(allele: String, color_mode: int = THEME_COLORS) -> void:
 	for creature_obj in outer_creatures:
 		_tweak_creature(creature_obj, allele, color_mode)
@@ -164,12 +154,10 @@ func set_center_creature_def(creature_def: CreatureDef) -> void:
 	emit_signal("center_creature_changed")
 
 
-"""
-Generates a palette.
-
-Depending on the specified color mode, the new palette is either loaded from a preset, or generated with completely
-random colors, or derived from the current palette.
-"""
+## Generates a palette.
+##
+## Depending on the specified color mode, the new palette is either loaded from a preset, or generated with completely
+## random colors, or derived from the current palette.
 func _palette(color_mode: int = THEME_COLORS) -> Dictionary:
 	var result := {}
 	if color_mode == THEME_COLORS:
@@ -230,12 +218,10 @@ func _palette(color_mode: int = THEME_COLORS) -> Dictionary:
 	return result
 
 
-"""
-Regenerates a creature to be a variation of the center creature.
-
-Only one aspect of the creature is changed. We select a value which is different from the creature's current value, and
-which hasn't been selected recently.
-"""
+## Regenerates a creature to be a variation of the center creature.
+##
+## Only one aspect of the creature is changed. We select a value which is different from the creature's current value,
+## and which hasn't been selected recently.
 func _tweak_creature(creature: Creature, allele: String, color_mode: int) -> void:
 	var palette: Dictionary = _palette(color_mode)
 	if allele == "line_rgb":
@@ -307,14 +293,13 @@ func _tweak_creature(creature: Creature, allele: String, color_mode: int) -> voi
 	creature.chat_theme_def = CreatureLoader.chat_theme_def(dna)
 
 
-"""
-Randomly calculates a set of alleles to mutate.
-
-These alleles are randomly selected based on the player's locked/unlocked selections.
-
-Unlocked alleles are always returned. Locked alleles are never returned. Alleles which are neither locked nor unlocked
-are randomly returned depending on the 'mutagen' value; a higher mutagen value results in more alleles being returned.
-"""
+## Randomly calculates a set of alleles to mutate.
+##
+## These alleles are randomly selected based on the player's locked/unlocked selections.
+##
+## Unlocked alleles are always returned. Locked alleles are never returned. Alleles which are neither locked nor
+## unlocked are randomly returned depending on the 'mutagen' value; a higher mutagen value results in more alleles
+## being returned.
 func _alleles_to_mutate() -> Array:
 	var result := []
 	result += _mutate_ui.get_unlocked_alleles()
@@ -365,9 +350,7 @@ func _alleles_to_mutate() -> Array:
 	return result
 
 
-"""
-Randomly generates a color with a similar HSV to the specified color.
-"""
+## Randomly generates a color with a similar HSV to the specified color.
 func _random_similar_color(color: Color) -> Color:
 	var new_color := color
 	new_color.h = new_color.h + _rng.randfn(0.0, 0.06)
@@ -376,9 +359,7 @@ func _random_similar_color(color: Color) -> Color:
 	return new_color
 
 
-"""
-Randomly generates a brighter version of the specified color.
-"""
+## Randomly generates a brighter version of the specified color.
 func _random_highlight_color(color: Color) -> Color:
 	var new_color := color
 	new_color.h = color.h + _rng.randfn(+0.00, 0.03)
@@ -395,10 +376,7 @@ func _on_Reroll_pressed() -> void:
 	mutate_all_creatures()
 	_reroll_ui.mutagen *= 0.84
 
-
-"""
-Swap the clicked creature with the center creature.
-"""
+## Swap the clicked creature with the center creature.
 func _on_CreatureSelector_creature_clicked(creature: Creature) -> void:
 	if creature == center_creature:
 		return

--- a/project/src/main/editor/creature/creature-selector.gd
+++ b/project/src/main/editor/creature/creature-selector.gd
@@ -1,17 +1,15 @@
 extends Control
-"""
-Emits signals as the player interacts with creatures in the creature editor.
-"""
+## Emits signals as the player interacts with creatures in the creature editor.
 
-# how far away you can click and still trigger an event
+## how far away you can click and still trigger an event
 const MAX_MOUSE_DISTANCE := 120
 
-# emitted when the player moves their mouse over a new creature
+## emitted when the player moves their mouse over a new creature
 signal hovered_creature_changed(value)
 
 signal creature_clicked(value)
 
-# cache the list of creatures; we don't want to call `get_nodes_in_group` every frame for mouseover events
+## cache the list of creatures; we don't want to call `get_nodes_in_group` every frame for mouseover events
 onready var creatures: Array = get_tree().get_nodes_in_group("creatures")
 
 var hovered_creature: Creature setget set_hovered_creature
@@ -36,9 +34,7 @@ func _input(event: InputEvent) -> void:
 			set_hovered_creature(closest_creature)
 
 
-"""
-Changes the hovered creature (the creature beneath the mouse)
-"""
+## Changes the hovered creature (the creature beneath the mouse)
 func set_hovered_creature(new_hovered_creature: Creature) -> void:
 	hovered_creature = new_hovered_creature
 	if hovered_creature:
@@ -50,9 +46,7 @@ func set_hovered_creature(new_hovered_creature: Creature) -> void:
 	emit_signal("hovered_creature_changed", hovered_creature)
 
 
-"""
-Finds the creature closest to the mouse.
-"""
+## Finds the creature closest to the mouse.
 func _find_closest_creature(mouse_event_position: Vector2) -> Creature:
 	var closest_creature: Creature
 	var closest_distance := MAX_MOUSE_DISTANCE

--- a/project/src/main/editor/creature/creature-shadows.gd
+++ b/project/src/main/editor/creature/creature-shadows.gd
@@ -1,8 +1,6 @@
 class_name CreatureShadows
 extends Node2D
-"""
-Manages shadows for all creatures in a scene.
-"""
+## Manages shadows for all creatures in a scene.
 
 export (PackedScene) var CreatureShadowScene: PackedScene
 

--- a/project/src/main/editor/creature/dialog-backdrop.gd
+++ b/project/src/main/editor/creature/dialog-backdrop.gd
@@ -1,9 +1,7 @@
 extends ColorRect
-"""
-Darkens and pauses the game while a popup dialog is displayed.
-"""
+## Darkens and pauses the game while a popup dialog is displayed.
 
-# number of dialogs currently shown; we unpause when this decrements to zero
+## number of dialogs currently shown; we unpause when this decrements to zero
 var _shown_dialogs := 0
 
 func _on_Dialog_about_to_show() -> void:

--- a/project/src/main/editor/creature/dialogs.gd
+++ b/project/src/main/editor/creature/dialogs.gd
@@ -1,7 +1,5 @@
 extends Control
-"""
-Shows popup dialogs for the creature editor.
-"""
+## Shows popup dialogs for the creature editor.
 
 export (NodePath) var creature_editor_path: NodePath
 
@@ -31,9 +29,7 @@ func _on_ImportButton_pressed() -> void:
 	_import_dialog.popup_centered()
 
 
-"""
-Imports the specified creature into the editor.
-"""
+## Imports the specified creature into the editor.
 func _on_ImportDialog_file_selected(path: String) -> void:
 	var loaded_def: CreatureDef = CreatureDef.new().from_json_path(path)
 	if loaded_def:
@@ -57,9 +53,7 @@ func _on_ExportButton_pressed() -> void:
 	_export_dialog.popup_centered()
 
 
-"""
-Imports the currently edited creature to a file.
-"""
+## Imports the currently edited creature to a file.
 func _on_ExportDialog_file_selected(path: String) -> void:
 	var exported_creature: Creature = _creature_editor.center_creature
 	var exported_json := exported_creature.creature_def.to_json_dict()
@@ -71,9 +65,7 @@ func _on_SaveButton_pressed() -> void:
 	_save_confirmation.popup_centered()
 
 
-"""
-Updates the player character and writes it to their save file.
-"""
+## Updates the player character and writes it to their save file.
 func _on_SaveConfirmation_confirmed() -> void:
 	PlayerData.creature_library.player_def = _creature_editor.center_creature.creature_def
 	PlayerSave.save_player_data()

--- a/project/src/main/editor/creature/mutate-allele-button.gd
+++ b/project/src/main/editor/creature/mutate-allele-button.gd
@@ -1,23 +1,21 @@
 class_name LockAlleleButton
 extends Button
-"""
-A button which can lock/unlock an allele.
+## A button which can lock/unlock an allele.
+##
+## Unlocked alleles always mutate. Locked alleles never mutate. Alleles which are neither locked nor unlocked mutate
+## sometimes.
 
-Unlocked alleles always mutate. Locked alleles never mutate. Alleles which are neither locked nor unlocked mutate
-sometimes.
-"""
-
-# icon which appears next to the button text when the allele is locked
+## icon which appears next to the button text when the allele is locked
 export (Texture) var locked_texture: Texture
 
-# icon which appears next to the button text when the allele is unlocked
+## icon which appears next to the button text when the allele is unlocked
 export (Texture) var unlocked_texture: Texture
 
-# An allele property used internally when updating the creature. Not shown to the player
+## An allele property used internally when updating the creature. Not shown to the player
 export (String) var allele: String
 
-# By default the button toggles between three states: locked/unlocked/flexible. The 'two_states' property can be
-# enabled to make the button toggle between locked/unlocked instead.
+## By default the button toggles between three states: locked/unlocked/flexible. The 'two_states' property can be
+## enabled to make the button toggle between locked/unlocked instead.
 export (bool) var two_states: bool = false
 
 func is_locked() -> bool:
@@ -28,9 +26,7 @@ func is_unlocked() -> bool:
 	return icon == unlocked_texture
 
 
-"""
-When the button is pressed, it cycles between three states (Or two states if the 'two_states' property is set)
-"""
+## When the button is pressed, it cycles between three states (Or two states if the 'two_states' property is set)
 func _on_pressed() -> void:
 	if not icon or (icon != locked_texture and two_states):
 		icon = locked_texture

--- a/project/src/main/editor/creature/mutate-ui.gd
+++ b/project/src/main/editor/creature/mutate-ui.gd
@@ -1,14 +1,10 @@
 class_name MutateUi
 extends Panel
-"""
-Provides buttons/sliders for the player to control how the creatures mutate.
-"""
+## Provides buttons/sliders for the player to control how the creatures mutate.
 
-"""
-Returns a list of alleles which are neither locked nor unlocked.
-
-These alleles might change when the creature mutates, it's up to chance.
-"""
+## Returns a list of alleles which are neither locked nor unlocked.
+##
+## These alleles might change when the creature mutates, it's up to chance.
 func get_flexible_alleles() -> Array:
 	var alleles := []
 	for button_obj in get_tree().get_nodes_in_group("lock_allele_buttons"):
@@ -18,11 +14,9 @@ func get_flexible_alleles() -> Array:
 	return alleles
 
 
-"""
-Returns a list of alleles which are unlocked.
-
-These alleles always change when the creature mutates.
-"""
+## Returns a list of alleles which are unlocked.
+##
+## These alleles always change when the creature mutates.
 func get_unlocked_alleles() -> Array:
 	var alleles := []
 	for button_obj in get_tree().get_nodes_in_group("lock_allele_buttons"):
@@ -32,11 +26,9 @@ func get_unlocked_alleles() -> Array:
 	return alleles
 
 
-"""
-Returns a list of alleles which are locked.
-
-These alleles never change when the creature mutates.
-"""
+## Returns a list of alleles which are locked.
+##
+## These alleles never change when the creature mutates.
 func get_locked_alleles() -> Array:
 	var alleles := []
 	for button_obj in get_tree().get_nodes_in_group("lock_allele_buttons"):

--- a/project/src/main/editor/creature/reroll-ui.gd
+++ b/project/src/main/editor/creature/reroll-ui.gd
@@ -1,15 +1,13 @@
 extends Control
-"""
-UI control for rerolling and controlling the mutagen level.
+## UI control for rerolling and controlling the mutagen level.
+##
+## A higher mutagen level means more alleles will be mutated.
 
-A higher mutagen level means more alleles will be mutated.
-"""
-
-# default mutagen level when launching the scene
+## default mutagen level when launching the scene
 const DEFAULT_MUTAGEN := 1.00
 
-# A higher mutagen level means more alleles will be mutated.
-# Virtual property; value is only exposed through getters/setters
+## A higher mutagen level means more alleles will be mutated.
+## Virtual property; value is only exposed through getters/setters
 var mutagen: float setget set_mutagen, get_mutagen
 
 func _ready() -> void:

--- a/project/src/main/editor/creature/tweak-allele-row.gd
+++ b/project/src/main/editor/creature/tweak-allele-row.gd
@@ -1,19 +1,17 @@
 extends HBoxContainer
-"""
-UI control for editing a creature's allele, such their nose or mouth.
-"""
+## UI control for editing a creature's allele, such their nose or mouth.
 
-# An allele property used internally when updating the creature. Not shown to the player
+## An allele property used internally when updating the creature. Not shown to the player
 export (String) var allele: String
 
-# An allele property used internally when updating the creature. Not shown to the player
+## An allele property used internally when updating the creature. Not shown to the player
 export (String) var text: String
 
 export (NodePath) var creature_editor_path: NodePath
 
 onready var _creature_editor: CreatureEditor = get_node(creature_editor_path)
 
-# Allele values corresponding to the option button items. Used when updating the creature, not shown to the player.
+## Allele values corresponding to the option button items. Used when updating the creature, not shown to the player.
 var _allele_values: Array
 
 func _ready() -> void:
@@ -21,17 +19,13 @@ func _ready() -> void:
 	_creature_editor.connect("center_creature_changed", self, "_on_CreatureEditor_center_creature_changed")
 
 
-"""
-Update the creature with the player's chosen allele value.
-"""
+## Update the creature with the player's chosen allele value.
 func _select_allele(index: int) -> void:
 	_creature_editor.center_creature.dna[allele] = _allele_values[index]
 	_creature_editor.center_creature.refresh_dna()
 
 
-"""
-Populate the option button with the available allele values.
-"""
+## Populate the option button with the available allele values.
 func _on_Edit_pressed() -> void:
 	_allele_values = DnaUtils.unique_allele_values(allele)
 	
@@ -61,9 +55,7 @@ func _on_Dna_pressed() -> void:
 	_creature_editor.tweak_all_creatures(allele)
 
 
-"""
-Update the option button with the creature's allele value.
-"""
+## Update the option button with the creature's allele value.
 func _on_CreatureEditor_center_creature_changed() -> void:
 	if _creature_editor.center_creature.dna[allele]:
 		$Edit.text = DnaUtils.allele_name(allele, _creature_editor.center_creature.dna[allele])

--- a/project/src/main/editor/creature/tweak-color-row.gd
+++ b/project/src/main/editor/creature/tweak-color-row.gd
@@ -1,12 +1,10 @@
 extends HBoxContainer
-"""
-UI control for editing one of a creature's colors.
-"""
+## UI control for editing one of a creature's colors.
 
-# An allele property used internally when updating the creature. Not shown to the player
+## An allele property used internally when updating the creature. Not shown to the player
 export (String) var allele: String
 
-# An allele property used internally when updating the creature. Not shown to the player
+## An allele property used internally when updating the creature. Not shown to the player
 export (String) var text: String
 
 export (NodePath) var creature_editor_path: NodePath
@@ -20,9 +18,7 @@ func _ready() -> void:
 		$Edit.visible = false
 
 
-"""
-Update the creature with the player's chosen color.
-"""
+## Update the creature with the player's chosen color.
 func _on_Edit_color_changed(_color: Color) -> void:
 	_creature_editor.center_creature.dna[allele] = $Edit.color.to_html(false).to_lower()
 	_creature_editor.center_creature.refresh_dna()
@@ -48,9 +44,7 @@ func _on_GreyDna_pressed() -> void:
 	_creature_editor.tweak_all_creatures(allele, CreatureEditor.SIMILAR_COLORS)
 
 
-"""
-Update the color picker button with the creature's color.
-"""
+## Update the color picker button with the creature's color.
 func _on_CreatureEditor_center_creature_changed() -> void:
 	if allele != "all_rgb":
 		$Edit.color = Color(_creature_editor.center_creature.dna[allele])

--- a/project/src/main/editor/creature/tweak-dna-button.gd
+++ b/project/src/main/editor/creature/tweak-dna-button.gd
@@ -1,7 +1,5 @@
 extends Button
-"""
-A button with a DNA symbol on it.
-"""
+## A button with a DNA symbol on it.
 
 func _on_button_down() -> void:
 	$TextureRect.modulate.a = 0.6

--- a/project/src/main/editor/creature/tweak-eye-row.gd
+++ b/project/src/main/editor/creature/tweak-eye-row.gd
@@ -1,11 +1,9 @@
 extends HBoxContainer
-"""
-UI control for tweaking a creature's eye color.
+## UI control for tweaking a creature's eye color.
+##
+## The eye uses two different colors, and requires a specialized tool.
 
-The eye uses two different colors, and requires a specialized tool.
-"""
-
-# An allele property used internally when updating the creature. Not shown to the player
+## An allele property used internally when updating the creature. Not shown to the player
 var _allele := "eye_rgb"
 
 export (NodePath) var creature_editor_path: NodePath
@@ -16,9 +14,7 @@ func _ready() -> void:
 	_creature_editor.connect("center_creature_changed", self, "_on_CreatureEditor_center_creature_changed")
 
 
-"""
-Update the creature with the player's chosen eye color.
-"""
+## Update the creature with the player's chosen eye color.
 func _on_Edit_color_changed(_color: Color) -> void:
 	var color_string := "%s %s" % [$Edit1.color.to_html(false).to_lower(), $Edit2.color.to_html(false).to_lower()]
 	_creature_editor.center_creature.dna[_allele] = color_string
@@ -45,9 +41,7 @@ func _on_RainbowDna_pressed() -> void:
 	_creature_editor.tweak_all_creatures(_allele, CreatureEditor.RANDOM_COLORS)
 
 
-"""
-Update the color picker buttons with the creature's eye color.
-"""
+## Update the color picker buttons with the creature's eye color.
 func _on_CreatureEditor_center_creature_changed() -> void:
 	var rgb_split: Array = _creature_editor.center_creature.dna[_allele].split(" ")
 	$Edit1.color = Color(rgb_split[0])

--- a/project/src/main/editor/creature/tweak-name-row.gd
+++ b/project/src/main/editor/creature/tweak-name-row.gd
@@ -1,7 +1,5 @@
 extends HBoxContainer
-"""
-UI control for editing a creature's name.
-"""
+## UI control for editing a creature's name.
 
 export (NodePath) var creature_editor_path: NodePath
 
@@ -13,18 +11,14 @@ func _ready() -> void:
 	$Edit/ShortName.max_length = NameUtils.MAX_CREATURE_SHORT_NAME_LENGTH
 
 
-"""
-Update the creature's name and short name.
-"""
+## Update the creature's name and short name.
 func _finish_name_edit(text: String) -> void:
 	var new_name: String = NameUtils.sanitize_name(text)
 	_creature_editor.center_creature.rename(new_name)
 	_refresh_name_ui()
 
 
-"""
-Update the creature's short name.
-"""
+## Update the creature's short name.
 func _finish_short_name_edit(text: String) -> void:
 	var new_name: String = NameUtils.sanitize_short_name(text)
 	var creature: Creature = _creature_editor.center_creature
@@ -33,11 +27,9 @@ func _finish_short_name_edit(text: String) -> void:
 	_refresh_name_ui()
 
 
-"""
-Update the name text boxes with the creature's name.
-
-The short name is only shown if it differs from the creature's name.
-"""
+## Update the name text boxes with the creature's name.
+##
+## The short name is only shown if it differs from the creature's name.
 func _refresh_name_ui() -> void:
 	var creature := _creature_editor.center_creature
 	if $Edit/Name.text != creature.creature_name:
@@ -47,12 +39,10 @@ func _refresh_name_ui() -> void:
 	$Edit/ShortName.visible = creature.creature_short_name != creature.creature_name
 
 
-"""
-If the user's typed a valid name, we update the name immediately.
-
-We don't update if the user's typed an invalid name (e.g 'Tom ') because otherwise it's aggravating erasing the name or
-appending punctuation/spaces, as the text box is constantly updated.
-"""
+## If the user's typed a valid name, we update the name immediately.
+##
+## We don't update if the user's typed an invalid name (e.g 'Tom ') because otherwise it's aggravating erasing the name
+## or appending punctuation/spaces, as the text box is constantly updated.
 func _on_Edit_text_changed(text: String) -> void:
 	if text == NameUtils.sanitize_name(text):
 		_finish_name_edit(text)
@@ -66,12 +56,10 @@ func _on_Edit_focus_exited() -> void:
 	_finish_name_edit($Edit/Name.text)
 
 
-"""
-If the user's typed a valid short name, we update the name immediately.
-
-We don't update if the user's typed an invalid name (e.g 'Tom ') because otherwise it's aggravating erasing the name or
-appending punctuation/spaces, as the text box is constantly updated.
-"""
+## If the user's typed a valid short name, we update the name immediately.
+##
+## We don't update if the user's typed an invalid name (e.g 'Tom ') because otherwise it's aggravating erasing the name
+## or appending punctuation/spaces, as the text box is constantly updated.
 func _on_ShortName_text_changed(text: String) -> void:
 	if text == NameUtils.sanitize_short_name(text):
 		_finish_short_name_edit(text)

--- a/project/src/main/editor/creature/tweak-size-row.gd
+++ b/project/src/main/editor/creature/tweak-size-row.gd
@@ -1,7 +1,5 @@
 extends HBoxContainer
-"""
-UI control for editing a creature's size.
-"""
+## UI control for editing a creature's size.
 
 export (NodePath) var creature_editor_path: NodePath
 
@@ -11,17 +9,13 @@ func _ready() -> void:
 	_creature_editor.connect("center_creature_changed", self, "_on_CreatureEditor_center_creature_changed")
 
 
-"""
-Update the creature's size.
-"""
+## Update the creature's size.
 func _on_Edit_value_changed(value: float) -> void:
 	_creature_editor.center_creature.min_fatness = value
 	_creature_editor.center_creature.set_fatness(value)
 
 
-"""
-Update the slider with the creature's size.
-"""
+## Update the slider with the creature's size.
 func _on_CreatureEditor_center_creature_changed() -> void:
 	$Edit.value = _creature_editor.center_creature.get_fatness()
 

--- a/project/src/main/editor/puzzle/block-level-chunk-control.gd
+++ b/project/src/main/editor/puzzle/block-level-chunk-control.gd
@@ -1,8 +1,6 @@
 class_name BlockLevelChunkControl
 extends Control
-"""
-UI component for a draggable chunk of level editor data made up of playfield blocks.
-"""
+## UI component for a draggable chunk of level editor data made up of playfield blocks.
 
 func _ready() -> void:
 	_refresh_tile_map()
@@ -19,9 +17,7 @@ func get_drag_data(_pos: Vector2) -> Object:
 	return data
 
 
-"""
-Calculates the extents of the tilemap's used cells.
-"""
+## Calculates the extents of the tilemap's used cells.
 func _tile_map_extents() -> Rect2:
 	var extents := Rect2(Vector2.ZERO, Vector2.ZERO)
 	if $TileMap.get_used_cells():
@@ -31,16 +27,12 @@ func _tile_map_extents() -> Rect2:
 	return extents
 
 
-"""
-Overridden by child classes, which use this method to populate the contents of the tilemap.
-"""
+## Overridden by child classes, which use this method to populate the contents of the tilemap.
 func _refresh_tile_map() -> void:
 	pass
 
 
-"""
-Refreshes the scale to ensure the contents of the tilemap fit inside an item in the palette.
-"""
+## Refreshes the scale to ensure the contents of the tilemap fit inside an item in the palette.
 func _refresh_scale() -> void:
 	var extents := _tile_map_extents()
 	$TileMap.scale.x = 1.00 / (1 + max(extents.end.x, extents.end.y))

--- a/project/src/main/editor/puzzle/block-level-chunk.gd
+++ b/project/src/main/editor/puzzle/block-level-chunk.gd
@@ -1,7 +1,5 @@
 class_name BlockLevelChunk
-"""
-Draggable chunk of level editor data made up of playfield blocks.
-"""
+## Draggable chunk of level editor data made up of playfield blocks.
 
 var used_cells := []
 var tiles := {}

--- a/project/src/main/editor/puzzle/box-level-chunk-control.gd
+++ b/project/src/main/editor/puzzle/box-level-chunk-control.gd
@@ -1,7 +1,5 @@
 extends BlockLevelChunkControl
-"""
-A level editor chunk which contains a snack/cake box.
-"""
+## A level editor chunk which contains a snack/cake box.
 
 export (Foods.BoxType) var box_type: int setget set_box_type
 

--- a/project/src/main/editor/puzzle/dialogs.gd
+++ b/project/src/main/editor/puzzle/dialogs.gd
@@ -1,7 +1,5 @@
 extends Control
-"""
-Shows popup dialogs for the level editor.
-"""
+## Shows popup dialogs for the level editor.
 
 export (NodePath) var _level_editor_path: NodePath
 

--- a/project/src/main/editor/puzzle/editor-json.gd
+++ b/project/src/main/editor/puzzle/editor-json.gd
@@ -1,11 +1,9 @@
 extends TextEdit
-"""
-A text editor window which shows the current level's json representation.
+## A text editor window which shows the current level's json representation.
+##
+## This script includes logic for populating the json model from the level editor, and vice-versa.
 
-This script includes logic for populating the json model from the level editor, and vice-versa.
-"""
-
-# these fields store different parts of the parsed json
+## these fields store different parts of the parsed json
 var _json_tree: Dictionary
 
 export (NodePath) var playfield_editor_path: NodePath
@@ -14,7 +12,7 @@ export (NodePath) var properties_editor_path: NodePath
 var _tile_map: PuzzleTileMap
 var _pickups: EditorPickups
 
-# cached values used for calculating pickup properties
+## cached values used for calculating pickup properties
 var _score_rules := ScoreRules.new()
 var _calculated_pickup_score := 0
 
@@ -26,20 +24,16 @@ func _ready() -> void:
 	_pickups = _playfield_editor.get_pickups()
 
 
-"""
-Parses our text as json, storing the results in the various _json properties.
-
-Returns 'false' if the json cannot be parsed.
-"""
+## Parses our text as json, storing the results in the various _json properties.
+##
+## Returns 'false' if the json cannot be parsed.
 func can_parse_json() -> bool:
 	var parsed = parse_json(text)
 	_json_tree = parsed if typeof(parsed) == TYPE_DICTIONARY else {}
 	return not _json_tree.empty()
 
 
-"""
-Refreshes the playfield editor based on our json text.
-"""
+## Refreshes the playfield editor based on our json text.
 func refresh_playfield_editor() -> void:
 	if not can_parse_json():
 		return
@@ -54,9 +48,7 @@ func refresh_playfield_editor() -> void:
 	PuzzleTileMapReader.read(json_tiles_set, funcref(_tile_map, "set_block"), funcref(_pickups, "set_pickup"))
 
 
-"""
-Refreshes the properties editor based on our json text.
-"""
+## Refreshes the properties editor based on our json text.
 func refresh_properties_editor() -> void:
 	if not can_parse_json():
 		return
@@ -73,11 +65,9 @@ func reset_editors() -> void:
 	refresh_properties_editor()
 
 
-"""
-Refreshes our json text based on the tiles keys.
-
-This occurs when new tiles keys are added or removed.
-"""
+## Refreshes our json text based on the tiles keys.
+##
+## This occurs when new tiles keys are added or removed.
 func _refresh_json_tiles_keys() -> void:
 	if not can_parse_json():
 		return
@@ -110,11 +100,9 @@ func _refresh_json_tiles_keys() -> void:
 	_refresh_text_from_json_tree()
 
 
-"""
-Refreshes our json text based on the tilemap.
-
-This occurs when new blocks are added or removed from the tilemap.
-"""
+## Refreshes our json text based on the tilemap.
+##
+## This occurs when new blocks are added or removed from the tilemap.
 func _refresh_json_tile_map() -> void:
 	if not can_parse_json():
 		return
@@ -153,9 +141,7 @@ func _refresh_text_from_json_tree() -> void:
 	text = Utils.print_json(_json_tree)
 
 
-"""
-Refreshes our json tree based on the data from the properties editor.
-"""
+## Refreshes our json tree based on the data from the properties editor.
 func _refresh_json_tree_from_properties() -> void:
 	if not can_parse_json():
 		return
@@ -191,9 +177,7 @@ func _refresh_json_tree_from_properties() -> void:
 	_refresh_text_from_json_tree()
 
 
-"""
-Recalculates the master pickup score and updates the properties editor.
-"""
+## Recalculates the master pickup score and updates the properties editor.
 func _update_properties_master_pickup_score_with_calculated_value() -> void:
 	# reset previously parsed json data
 	_calculated_pickup_score = 0
@@ -210,11 +194,9 @@ func _update_properties_master_pickup_score_with_calculated_value() -> void:
 	_properties_editor.set_master_pickup_score(_calculated_pickup_score)
 
 
-"""
-Returns a sorted list of used cells in the playfield editor.
-
-This includes cells containing blocks and pickups. The result is sorted first by Y ascending, then by X ascending.
-"""
+## Returns a sorted list of used cells in the playfield editor.
+##
+## This includes cells containing blocks and pickups. The result is sorted first by Y ascending, then by X ascending.
 func _playfield_editor_used_cells() -> Array:
 	var used_cells := {
 	}
@@ -235,9 +217,7 @@ func _compare_by_y(a: Vector2, b: Vector2) -> bool:
 	return b.x > a.x
 
 
-"""
-Callback function which increments the pickup score for each playfield pickup.
-"""
+## Callback function which increments the pickup score for each playfield pickup.
 func _increment_calculated_pickup_score(_pos: Vector2, box_type: int) -> void:
 	if Foods.is_snack_box(box_type):
 		_calculated_pickup_score += _score_rules.snack_pickup_points

--- a/project/src/main/editor/puzzle/editor-pickups.gd
+++ b/project/src/main/editor/puzzle/editor-pickups.gd
@@ -1,24 +1,20 @@
 class_name EditorPickups
 extends Control
-"""
-Pickups for use in the level editor.
-
-This stripped down class excludes gameplay code for sound effects and scoring. It only includes logic required for the
-level editor.
-"""
+## Pickups for use in the level editor.
+##
+## This stripped down class excludes gameplay code for sound effects and scoring. It only includes logic required for
+## the level editor.
 
 export (PackedScene) var PickupScene: PackedScene
 export (NodePath) var _puzzle_tile_map_path: NodePath
 
-# key: Vector2 playfield cell positions
-# value: Pickup node contained within that cell
+## key: Vector2 playfield cell positions
+## value: Pickup node contained within that cell
 var _pickups_by_cell: Dictionary
 
 onready var _puzzle_tile_map: PuzzleTileMap = get_node(_puzzle_tile_map_path)
 
-"""
-Adds or replaces a pickup in a playfield cell.
-"""
+## Adds or replaces a pickup in a playfield cell.
 func set_pickup(cell: Vector2, box_type: int) -> void:
 	remove_pickup(cell)
 	
@@ -35,12 +31,10 @@ func set_pickup(cell: Vector2, box_type: int) -> void:
 		add_child(pickup)
 
 
-"""
-Returns the food type for the pickup at the specified cell.
-
-Returns:
-	An enum from Foods.FoodType for the pickup at the specified cell, or -1 if the cell is empty.
-"""
+## Returns the food type for the pickup at the specified cell.
+##
+## Returns:
+## 	An enum from Foods.FoodType for the pickup at the specified cell, or -1 if the cell is empty.
 func get_food_type(cell: Vector2) -> int:
 	var result := -1
 	if _pickups_by_cell.has(cell):
@@ -49,9 +43,7 @@ func get_food_type(cell: Vector2) -> int:
 	return result
 
 
-"""
-Removes a pickup from a playfield cell.
-"""
+## Removes a pickup from a playfield cell.
 func remove_pickup(cell: Vector2) -> void:
 	if not _pickups_by_cell.has(cell):
 		return
@@ -60,9 +52,7 @@ func remove_pickup(cell: Vector2) -> void:
 	_pickups_by_cell.erase(cell)
 
 
-"""
-Removes all pickups from all playfield cells.
-"""
+## Removes all pickups from all playfield cells.
 func clear() -> void:
 	for pickup in get_children():
 		pickup.queue_free()
@@ -73,11 +63,10 @@ func get_used_cells() -> Array:
 	return _pickups_by_cell.keys()
 
 
-"""
-Return the food type for the specified cell.
-
-The food type corresponds to the box type, although we alternate identical snack box pickups in a checkerboard pattern.
-"""
+## Return the food type for the specified cell.
+##
+## The food type corresponds to the box type, although we alternate identical snack box pickups in a checkerboard
+## pattern.
 func _food_type_for_cell(box_type: int, cell: Vector2) -> int:
 	var food_types: Array = Foods.FOOD_TYPES_BY_BOX_TYPES[box_type]
 	return food_types[(int(cell.x + cell.y) % food_types.size())]

--- a/project/src/main/editor/puzzle/editor-playfield-nav.gd
+++ b/project/src/main/editor/puzzle/editor-playfield-nav.gd
@@ -1,19 +1,17 @@
 class_name PlayfieldNav
 extends VBoxContainer
-"""
-UI control for adding, removing and selecting different groups of level tiles.
-"""
+## UI control for adding, removing and selecting different groups of level tiles.
 
-# emitted when the 'prev tiles key' button is pressed
+## emitted when the 'prev tiles key' button is pressed
 signal prev_tiles_key_pressed
 
-# emitted when the 'next tiles key' button is pressed
+## emitted when the 'next tiles key' button is pressed
 signal next_tiles_key_pressed
 
-# emitted when the 'remove tiles key' button is pressed
+## emitted when the 'remove tiles key' button is pressed
 signal remove_tiles_key_pressed
 
-# emitted when the 'add tiles key' button is pressed
+## emitted when the 'add tiles key' button is pressed
 signal add_tiles_key_pressed
 
 onready var next_button := $NextPrev/Next
@@ -26,9 +24,7 @@ func _ready() -> void:
 	_refresh_buttons(["start"], "start")
 
 
-"""
-Enables/disables the buttons based on the available groups of tiles.
-"""
+## Enables/disables the buttons based on the available groups of tiles.
 func _refresh_buttons(tiles_keys: Array, current_tiles_key: String) -> void:
 	# add button: enabled if there are fewer than 3 tiles keys
 	add_button.disabled = tiles_keys.size() >= 3

--- a/project/src/main/editor/puzzle/editor-playfield.gd
+++ b/project/src/main/editor/puzzle/editor-playfield.gd
@@ -1,28 +1,26 @@
 class_name EditorPlayfield
 extends Control
-"""
-Playfield for use in the level editor.
+## Playfield for use in the level editor.
+##
+## This script provides drag/drop logic and other things specific to the level editor.
 
-This script provides drag/drop logic and other things specific to the level editor.
-"""
-
-# emitted when the player changes the tilemap's contents. This signal is not emitted when set_cell is called to
-# prevent infinite recursion when populated by editor-json.gd.
+## emitted when the player changes the tilemap's contents. This signal is not emitted when set_cell is called to
+## prevent infinite recursion when populated by editor-json.gd.
 signal tile_map_changed
 
-# emitted when the player changes the pickups. This signal is not emitted set_pickup is called to
-# prevent infinite recursion when populated by editor-json.gd.
+## emitted when the player changes the pickups. This signal is not emitted set_pickup is called to
+## prevent infinite recursion when populated by editor-json.gd.
 signal pickups_changed
 
 var _dragging_right_mouse := false
 
-# The 'pos' parameter for the previous call to 'can_drop_data'
+## The 'pos' parameter for the previous call to 'can_drop_data'
 var _prev_can_drop_pos: Vector2
 
-# The 'data' parameter for the previous call to 'can_drop_data'
+## The 'data' parameter for the previous call to 'can_drop_data'
 var _prev_can_drop_data: Object
 
-# The data previously dropped on this panel. New drag events originating from this panel reuse the dropped data.
+## The data previously dropped on this panel. New drag events originating from this panel reuse the dropped data.
 var _prev_dropped_data: Object
 
 onready var _tile_map := $Bg/TileMap
@@ -99,52 +97,44 @@ func drop_data(pos: Vector2, data: Object) -> void:
 				_prev_dropped_data.autotile_coords[cell] = Vector2(randi() % 18, randi() % 4)
 
 
-"""
-If the user clicks and drags on the playfield, we reuse the previously dropped data.
-
-This makes it easier to populate a playfield with lots of vegetables or pickups.
-"""
+## If the user clicks and drags on the playfield, we reuse the previously dropped data.
+##
+## This makes it easier to populate a playfield with lots of vegetables or pickups.
 func get_drag_data(_pos: Vector2) -> Object:
 	return _prev_dropped_data
 
 
-"""
-Adds a dragged chunk of blocks to a tile map.
-
-Parameters:
-	'target_tile_map': The tile map to modify
-	
-	'pos': An x/y control coordinate like '58, 132'
-	
-	'data': The data to apply to the tile map
-"""
+## Adds a dragged chunk of blocks to a tile map.
+##
+## Parameters:
+## 	'target_tile_map': The tile map to modify
+##
+## 	'pos': An x/y control coordinate like '58, 132'
+##
+## 	'data': The data to apply to the tile map
 func _store_block_level_chunk(target_tile_map: PuzzleTileMap, pos: Vector2, data: BlockLevelChunk) -> void:
 	for cell in data.used_cells:
 		var target_pos: Vector2 = _cell_pos(pos) + cell
 		_set_tile_map_block(target_tile_map, target_pos, data.tiles[cell], data.autotile_coords[cell])
 
 
-"""
-Adds a dragged pickup to a set of pickups.
-
-Parameters:
-	'target_pickups': The set of pickups to modify
-	
-	'pos': An x/y control coordinate like '58, 132'
-	
-	'data': The pickup to add to the set of pickups
-"""
+## Adds a dragged pickup to a set of pickups.
+##
+## Parameters:
+## 	'target_pickups': The set of pickups to modify
+##
+## 	'pos': An x/y control coordinate like '58, 132'
+##
+## 	'data': The pickup to add to the set of pickups
 func _store_pickup_level_chunk(target_pickups: EditorPickups, pos: Vector2, data: PickupLevelChunk) -> void:
 	var target_pos: Vector2 = _cell_pos(pos)
 	target_pickups.set_pickup(target_pos, data.box_type)
 
 
-"""
-Clears all of the drop previews.
-
-When dragging/dropping items in the editor, we show translucent previews where the items will drop. These previews are
-cleared following a successful drop, or if the mouse exits the control.
-"""
+## Clears all of the drop previews.
+##
+## When dragging/dropping items in the editor, we show translucent previews where the items will drop. These previews
+## are cleared following a successful drop, or if the mouse exits the control.
 func _clear_previews() -> void:
 	_tile_map_drop_preview.clear()
 	_pickups_drop_preview.clear()
@@ -168,9 +158,7 @@ func get_pickups() -> EditorPickups:
 	return $Bg/Pickups as EditorPickups
 
 
-"""
-Converts an x/y control coordinate like '58, 132' into a tile_map coordinate like '3, 2'
-"""
+## Converts an x/y control coordinate like '58, 132' into a tile_map coordinate like '3, 2'
 func _cell_pos(pos: Vector2) -> Vector2:
 	var result := pos * Vector2(PuzzleTileMap.COL_COUNT, PuzzleTileMap.ROW_COUNT) / rect_size
 	return result.floor()

--- a/project/src/main/editor/puzzle/level-editor.gd
+++ b/project/src/main/editor/puzzle/level-editor.gd
@@ -1,17 +1,15 @@
 class_name LevelEditor
 extends Control
-"""
-A graphical level editor which lets players create, load and save levels.
+## A graphical level editor which lets players create, load and save levels.
+##
+## Full instructions are available at https://github.com/Poobslag/turbofat/wiki/level-editor
 
-Full instructions are available at https://github.com/Poobslag/turbofat/wiki/level-editor
-"""
-
-# default to an empty level; players may be confused if it's not empty
+## default to an empty level; players may be confused if it's not empty
 const DEFAULT_LEVEL_ID := "practice/ultra_normal"
 
 export (PackedScene) var PuzzleScene: PackedScene
 
-# level scene currently being tested
+## level scene currently being tested
 var _test_scene: Node
 
 onready var level_id_label := $HBoxContainer/SideButtons/LevelId

--- a/project/src/main/editor/puzzle/pickup-level-chunk-control.gd
+++ b/project/src/main/editor/puzzle/pickup-level-chunk-control.gd
@@ -1,8 +1,6 @@
 class_name PickupLevelChunkControl
 extends Control
-"""
-UI component for a draggable chunk of level editor data containing a pickup.
-"""
+## UI component for a draggable chunk of level editor data containing a pickup.
 
 export (Foods.BoxType) var box_type: int setget set_box_type
 

--- a/project/src/main/editor/puzzle/pickup-level-chunk.gd
+++ b/project/src/main/editor/puzzle/pickup-level-chunk.gd
@@ -1,6 +1,4 @@
 class_name PickupLevelChunk
-"""
-Draggable chunk of level editor data containing a pickup.
-"""
+## Draggable chunk of level editor data containing a pickup.
 
 var box_type: int

--- a/project/src/main/editor/puzzle/piece-level-chunk-control.gd
+++ b/project/src/main/editor/puzzle/piece-level-chunk-control.gd
@@ -1,7 +1,5 @@
 extends BlockLevelChunkControl
-"""
-A level editor chunk which contains several blocks which make up a single piece, such as a t-piece.
-"""
+## A level editor chunk which contains several blocks which make up a single piece, such as a t-piece.
 
 enum EditorPiece {
 	PIECE_J, PIECE_L, PIECE_O, PIECE_P, PIECE_Q, PIECE_T, PIECE_U, PIECE_V,
@@ -34,9 +32,7 @@ func set_editor_piece(new_editor_piece: int) -> void:
 	_refresh_scale()
 
 
-"""
-Calculates the extents of the piece's used cells.
-"""
+## Calculates the extents of the piece's used cells.
 func _piece_extents() -> Rect2:
 	var extents := Rect2(Vector2.ZERO, Vector2.ZERO)
 	extents.position = _type.get_cell_position(_orientation, 0)

--- a/project/src/main/editor/puzzle/playfield-editor-control.gd
+++ b/project/src/main/editor/puzzle/playfield-editor-control.gd
@@ -1,31 +1,27 @@
 class_name PlayfieldEditorControl
 extends HBoxContainer
-"""
-UI control for editing the playfield.
+## UI control for editing the playfield.
+##
+## This includes adding/removing blocks to the playfield. It also includes adding, removing and selecting different
+## groups of level tiles.
 
-This includes adding/removing blocks to the playfield. It also includes adding, removing and selecting different groups
-of level tiles.
-"""
-
-# emitted when a group of level tiles is added, removed, or selected
+## emitted when a group of level tiles is added, removed, or selected
 signal tiles_keys_changed(tiles_keys, tiles_key)
-# emitted when the playfield's contents change, such as when blocks are added or removed
+## emitted when the playfield's contents change, such as when blocks are added or removed
 signal tile_map_changed
-# emitted when the playfield's pickups change
+## emitted when the playfield's pickups change
 signal pickups_changed
 
-# tiles keys which can be selected. 'start' is always the first item in this array
+## tiles keys which can be selected. 'start' is always the first item in this array
 var tiles_keys := ["start"] setget set_tiles_keys
-# the currently selected tiles key
+## the currently selected tiles key
 var tiles_key := "start" setget set_tiles_key
 
 onready var _playfield_nav := $PlayfieldNav
 
-"""
-Updates the list of selectable tiles keys.
-
-The incoming tiles keys are sanitized to ensure they are sorted, and that they always include a 'start' key.
-"""
+## Updates the list of selectable tiles keys.
+##
+## The incoming tiles keys are sanitized to ensure they are sorted, and that they always include a 'start' key.
 func set_tiles_keys(new_tiles_keys: Array) -> void:
 	var new_normalized_tile_keys := _normalize_tiles_keys(new_tiles_keys)
 	if tiles_keys == new_normalized_tile_keys:
@@ -51,9 +47,7 @@ func get_pickups() -> EditorPickups:
 	return $CenterPanel/Playfield.get_pickups()
 
 
-"""
-Ensure the tiles keys are sorted, and that they always include a 'start' key.
-"""
+## Ensure the tiles keys are sorted, and that they always include a 'start' key.
 func _normalize_tiles_keys(keys: Array) -> Array:
 	var new_keys := keys.duplicate()
 	new_keys.sort()
@@ -71,9 +65,7 @@ func _on_Playfield_pickups_changed() -> void:
 	emit_signal("pickups_changed")
 
 
-"""
-When the player presses the 'add tiles' button, we append and select a new tiles key.
-"""
+## When the player presses the 'add tiles' button, we append and select a new tiles key.
 func _on_PlayfieldNav_add_tiles_key_pressed() -> void:
 	var new_key: String
 	for potential_new_key in ["0", "1"]:
@@ -92,9 +84,7 @@ func _on_PlayfieldNav_add_tiles_key_pressed() -> void:
 	emit_signal("tiles_keys_changed", tiles_keys, tiles_key)
 
 
-"""
-When the player presses the 'remove tiles' button, we remove the current tiles key and select the previous one.
-"""
+## When the player presses the 'remove tiles' button, we remove the current tiles key and select the previous one.
 func _on_PlayfieldNav_remove_tiles_key_pressed() -> void:
 	var old_tiles_key_index := tiles_keys.find(tiles_key)
 	
@@ -113,9 +103,7 @@ func _on_PlayfieldNav_remove_tiles_key_pressed() -> void:
 	emit_signal("tiles_keys_changed", tiles_keys, tiles_key)
 
 
-"""
-When the player presses the 'next tiles' button, we select the next tiles key.
-"""
+## When the player presses the 'next tiles' button, we select the next tiles key.
 func _on_PlayfieldNav_next_tiles_key_pressed() -> void:
 	var new_tiles_key_index := tiles_keys.find(tiles_key) + 1
 	
@@ -126,9 +114,7 @@ func _on_PlayfieldNav_next_tiles_key_pressed() -> void:
 	set_tiles_key(tiles_keys[new_tiles_key_index])
 
 
-"""
-When the player presses the 'previous tiles' button, we select the previous tiles key.
-"""
+## When the player presses the 'previous tiles' button, we select the previous tiles key.
 func _on_PlayfieldNav_prev_tiles_key_pressed() -> void:
 	var old_tiles_key_index := tiles_keys.find(tiles_key)
 	var new_tiles_key_index := old_tiles_key_index - 1 if old_tiles_key_index != -1 else tiles_keys.size()

--- a/project/src/main/editor/puzzle/properties-editor-control.gd
+++ b/project/src/main/editor/puzzle/properties-editor-control.gd
@@ -1,10 +1,8 @@
 class_name PropertiesEditorControl
 extends Control
-"""
-UI control for editing level properties.
-"""
+## UI control for editing level properties.
 
-# emitted when the user edits level property values using the UI.
+## emitted when the user edits level property values using the UI.
 signal properties_changed
 
 onready var _button: Button = $Pickups/Button

--- a/project/src/main/editor/puzzle/veg-level-chunk-control.gd
+++ b/project/src/main/editor/puzzle/veg-level-chunk-control.gd
@@ -1,9 +1,7 @@
 extends BlockLevelChunkControl
-"""
-A level editor chunk which contains a vegetable block.
-"""
+## A level editor chunk which contains a vegetable block.
 
-# Increasing this size allows you to draw vegetable blocks as a cluster, instead of one at a time.
+## Increasing this size allows you to draw vegetable blocks as a cluster, instead of one at a time.
 export (Vector2) var veg_size: Vector2 = Vector2(1, 1) setget set_veg_size
 
 func _ready() -> void:

--- a/project/src/main/file-utils.gd
+++ b/project/src/main/file-utils.gd
@@ -1,10 +1,7 @@
 class_name FileUtils
-"""
-Utility class for file operations.
-
-Many of these were adopted from the Gut library.
-"""
-
+## Utility class for file operations.
+##
+## Many of these were adopted from the Gut library.
 
 static func file_exists(path: String) -> bool:
 	var f := File.new()

--- a/project/src/main/global.gd
+++ b/project/src/main/global.gd
@@ -1,50 +1,48 @@
 extends Node
-"""
-Contains variables for preserving state when loading different scenes.
-"""
+## Contains variables for preserving state when loading different scenes.
 
-# splash screen which precedes the main menu.
+## splash screen which precedes the main menu.
 const SCENE_SPLASH := "res://src/main/ui/menu/SplashScreen.tscn"
 
-# menu the user sees after starting the game.
+## menu the user sees after starting the game.
 const SCENE_MAIN_MENU := "res://src/main/ui/menu/MainMenu.tscn"
 
-# overworld which the player character can run around on and talk to other creatures.
+## overworld which the player character can run around on and talk to other creatures.
 const SCENE_OVERWORLD := "res://src/main/world/Overworld.tscn"
 
-# puzzle where a player drops pieces into a playfield of blocks.
+## puzzle where a player drops pieces into a playfield of blocks.
 const SCENE_PUZZLE := "res://src/main/puzzle/Puzzle.tscn"
 
-# cutscene demo; only used during development
+## cutscene demo; only used during development
 const SCENE_CUTSCENE_DEMO := "res://src/demo/world/CutsceneDemo.tscn"
 
-# The scale of the TextureRect the creature is rendered to
+## The scale of the TextureRect the creature is rendered to
 const CREATURE_SCALE := 0.4
 
-# weighted distribution of 'fatnesses' in the range [1.0, 10.0]. most creatures are skinny.
+## weighted distribution of 'fatnesses' in the range [1.0, 10.0]. most creatures are skinny.
 const FATNESSES := [
 	1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
 	1.1, 1.2, 1.3, 1.5,
 	1.8, 2.3,
 ]
 
-# The factor to multiply by to convert non-isometric coordinates into isometric coordinates
+## The factor to multiply by to convert non-isometric coordinates into isometric coordinates
 const ISO_FACTOR := Vector2(1.0, 0.5)
 
-# Target number of creature greetings (hello, goodbye) per minute
+## Target number of creature greetings (hello, goodbye) per minute
 const GREETINGS_PER_MINUTE := 3.0
 
-# Stores all of the benchmarks which have been started
+## Stores all of the benchmarks which have been started
 var _benchmark_start_times := Dictionary()
 
-# A number in the range [-1, 1] which corresponds to how many greetings we've given recently. If it's close to 1,
-# we're very unlikely to receive a greeting. If it's close to -1, we're very likely to receive a greeting.
+## A number in the range [-1, 1] which corresponds to how many greetings we've given recently. If it's close to 1,
+## we're very unlikely to receive a greeting. If it's close to -1, we're very likely to receive a greeting.
 var greetiness := 0.0
 
-# the id of the spawn where the player appears on the overworld
+## the id of the spawn where the player appears on the overworld
 var player_spawn_id: String
 
-# the id of the spawn where the sensei appears on the overworld
+## the id of the spawn where the sensei appears on the overworld
 var sensei_spawn_id: String
 
 func _init() -> void:
@@ -56,32 +54,24 @@ func _process(delta: float) -> void:
 	greetiness = clamp(greetiness + delta * GREETINGS_PER_MINUTE / 60, -1.0, 1.0)
 
 
-"""
-Convert a coordinate from global coordinates to isometric (squashed) coordinates
-"""
+## Convert a coordinate from global coordinates to isometric (squashed) coordinates
 static func to_iso(vector: Vector2) -> Vector2:
 	return vector * ISO_FACTOR
 
 
-"""
-Convert a coordinate from isometric coordinates to global (unsquashed) coordinates
-"""
+## Convert a coordinate from isometric coordinates to global (unsquashed) coordinates
 static func from_iso(vector: Vector2) -> Vector2:
 	return vector / ISO_FACTOR
 
 
-"""
-Sets the start time for a benchmark. Calling 'benchmark_start(foo)' and 'benchmark_finish(foo)' will display a message
-like 'foo took 123 milliseconds'.
-"""
+## Sets the start time for a benchmark. Calling 'benchmark_start(foo)' and 'benchmark_finish(foo)' will display a
+## message like 'foo took 123 milliseconds'.
 func benchmark_start(key: String = "") -> void:
 	_benchmark_start_times[key] = OS.get_ticks_msec()
 
 
-"""
-Prints the amount of time which has passed since a benchmark was started. Calling 'benchmark_start(foo)' and
-'benchmark_finish(foo)' will display a message like 'foo took 123 milliseconds'.
-"""
+## Prints the amount of time which has passed since a benchmark was started. Calling 'benchmark_start(foo)' and
+## 'benchmark_finish(foo)' will display a message like 'foo took 123 milliseconds'.
 func benchmark_end(key: String = "") -> void:
 	if not _benchmark_start_times.has(key):
 		print("Invalid benchmark: %s" % key)
@@ -89,13 +79,12 @@ func benchmark_end(key: String = "") -> void:
 	print("benchmark %s: %.3f msec" % [key, (OS.get_ticks_msec() - _benchmark_start_times[key])])
 
 
-"""
-Returns 'true' if the creature should greet us. We calculate this based on how many times we've been greeted recently.
-
-Novice players or fast players won't mind receiving a lot of sounds related to combos because those sounds are
-associated with positive reinforcement (big combos), but they could get annoyed if creatures say hello/goodbye too
-frequently because those sounds are associated with negative reinforcement (broken combos).
-"""
+## Returns 'true' if the creature should greet us. We calculate this based on how many times we've been greeted
+## recently.
+##
+## Novice players or fast players won't mind receiving a lot of sounds related to combos because those sounds are
+## associated with positive reinforcement (big combos), but they could get annoyed if creatures say hello/goodbye too
+## frequently because those sounds are associated with negative reinforcement (broken combos).
 func should_chat() -> bool:
 	var should_chat := true
 	if greetiness + randf() > 1.0:

--- a/project/src/main/markov-model.gd
+++ b/project/src/main/markov-model.gd
@@ -1,23 +1,21 @@
 class_name MarkovModel
-"""
-A model for markov chains.
-
-Maintains a list of letter sequences and letters which can follow them.
-"""
+## A model for markov chains.
+##
+## Maintains a list of letter sequences and letters which can follow them.
 
 var min_length := 3
 var max_length := 15
 
-# The smallest cluster of letters which are guaranteed to stay together. A fractional value will randomly alternate
-# between the lower and higher values while generating words.
+## The smallest cluster of letters which are guaranteed to stay together. A fractional value will randomly alternate
+## between the lower and higher values while generating words.
 var order := 2.5
 
-# Key: Letter cluster, newline-terminated for the word's end
-# Value: Number of times the cluster appeared in the input data
+## key: Letter cluster, newline-terminated for the word's end
+## value: Number of times the cluster appeared in the input data
 var frequency := {}
 
-# Key: Letter cluster
-# Value: Dictionary of continuation clusters
+## key: Letter cluster
+## value: Dictionary of continuation clusters
 var connections := {}
 
 func clear() -> void:
@@ -25,9 +23,7 @@ func clear() -> void:
 	connections.clear()
 
 
-"""
-Adds an input word to use when generating new words.
-"""
+## Adds an input word to use when generating new words.
 func add_word(word: String) -> void:
 	if word.length() <= 1:
 		return
@@ -44,15 +40,13 @@ func add_word(word: String) -> void:
 			_add_cluster(cluster)
 
 
-"""
-Generates a new word similar to the input words.
-
-Generation can fail for a few reasons, such as if the generated word is too long, too short, or if the model is
-flawed. In those cases this method will return an empty string.
-
-Returns:
-	A generated word, or an empty string if generation fails.
-"""
+## Generates a new word similar to the input words.
+##
+## Generation can fail for a few reasons, such as if the generated word is too long, too short, or if the model is
+## flawed. In those cases this method will return an empty string.
+##
+## Returns:
+## 	A generated word, or an empty string if generation fails.
 func generate_word() -> String:
 	var word := ""
 	while true:
@@ -73,17 +67,15 @@ func generate_word() -> String:
 	return word
 
 
-"""
-Appends a new letter to a letter cluster, returning the result.
-
-Parameters:
-	'cluster_in': A cluster of letters.
-	
-	'may_end': True if this method is allowed to end the word.
-
-Returns:
-	The input letter cluster with a new letter added at the end.
-"""
+## Appends a new letter to a letter cluster, returning the result.
+##
+## Parameters:
+## 	'cluster_in': A cluster of letters.
+##
+## 	'may_end': True if this method is allowed to end the word.
+##
+## Returns:
+## 	The input letter cluster with a new letter added at the end.
 func _get_cluster(cluster_in: String, may_end: bool) -> String:
 	# calculate the total number of connections
 	var total := 0
@@ -108,9 +100,7 @@ func _get_cluster(cluster_in: String, may_end: bool) -> String:
 	return result
 
 
-"""
-Adds a cluster to the markov model.
-"""
+## Adds a cluster to the markov model.
 func _add_cluster(cluster: String) -> void:
 	if not frequency.has(cluster):
 		frequency[cluster] = 0

--- a/project/src/main/music/checkpoint-song.gd
+++ b/project/src/main/music/checkpoint-song.gd
@@ -1,26 +1,25 @@
 class_name CheckpointSong
 extends AudioStreamPlayer
-"""
-Plays a music track from different checkpoints to avoid playing the beginning of the song too much.
+## Plays a music track from different checkpoints to avoid playing the beginning of the song too much.
+##
+## If looped songs always played from the start, players would hear the beginning more than the ending. This class
+## tracks which parts of the song have been played so the MusicPlayer can skip to the parts which have been played the
+## least.
 
-If looped songs always played from the start, players would hear the beginning more than the ending. This class tracks
-which parts of the song have been played so the MusicPlayer can skip to the parts which have been played the least.
-"""
-
-# we measure which 'chunks' of music have been _played the least, this defines the chunk size
+## we measure which 'chunks' of music have been _played the least, this defines the chunk size
 const CHUNK_SIZE := 6.0
 
-# array of floats corresponding to good start positions in each song
+## array of floats corresponding to good start positions in each song
 export (Array, float) var checkpoints: Array = []
 
-# the song title and color shown in the toaster popup
+## the song title and color shown in the toaster popup
 export var song_title: String
 export var song_color: Color
 
-# array of ints corresponding to how much each 'chunk' of music has been _played
+## array of ints corresponding to how much each 'chunk' of music has been _played
 var _staleness_record: Array
 
-# value: 'true' if the BGM node has been _played
+## value: 'true' if the BGM node has been _played
 var _played: bool
 
 func _ready() -> void:
@@ -31,13 +30,11 @@ func _ready() -> void:
 		push_warning("CheckpointSong %s checkpoints=%s" % [name, checkpoints])
 
 
-"""
-Plays this song from the specified position, or somewhere in the middle.
-
-Parameters:
-	'from_position': If 0 or greater, the song will begin playing from the specified position. If unspecified or
-		negative, the song will start somewhere in the middle based on an algorithm.
-"""
+## Plays this song from the specified position, or somewhere in the middle.
+##
+## Parameters:
+## 	'from_position': If 0 or greater, the song will begin playing from the specified position. If unspecified or
+## 		negative, the song will start somewhere in the middle based on an algorithm.
 func play(from_position: float = -1.0) -> void:
 	if from_position < 0:
 		# calculate the start position based on an algorithm
@@ -60,22 +57,18 @@ func get_nearest_checkpoint(start: float) -> float:
 	return result
 
 
-"""
-Increases the staleness of the part of the song currently playing.
-"""
+## Increases the staleness of the part of the song currently playing.
 func _increase_staleness() -> void:
 	if playing:
 		_played = true
 		_staleness_record[int(get_playback_position() / CHUNK_SIZE)] += 1
 
 
-"""
-Calculates the ideal position to start playing the specified song.
-
-The algorithm we follow is to create a window with the left half of the 'freshness record'. We gradually advance it
-through the entire song, and figure out which half of the song has been played the least. We return the position of
-the song at the start of that half.
-"""
+## Calculates the ideal position to start playing the specified song.
+##
+## The algorithm we follow is to create a window with the left half of the 'freshness record'. We gradually advance it
+## through the entire song, and figure out which half of the song has been played the least. We return the position of
+## the song at the start of that half.
 func _freshest_start() -> float:
 	var freshest_start_index := 0
 	var min_staleness: int = 0

--- a/project/src/main/music/music-player.gd
+++ b/project/src/main/music/music-player.gd
@@ -1,25 +1,23 @@
 extends Node
-"""
-Plays music.
-
-Ensures only one music track is playing at once. Organizes music by category and fades music in and out.
-"""
+## Plays music.
+##
+## Ensures only one music track is playing at once. Organizes music by category and fades music in and out.
 
 signal current_bgm_changed(value)
 
-# volume to fade out to; once the music reaches this volume, it's stopped
+## volume to fade out to; once the music reaches this volume, it's stopped
 const MIN_VOLUME := -40.0
 
-# volume to fade in to
+## volume to fade in to
 const MAX_VOLUME := 0.0
 
-# the music currently playing
+## the music currently playing
 var current_bgm: CheckpointSong
 
-# volume_db changes when we fade in/fade out so we cache the original value.
+## volume_db changes when we fade in/fade out so we cache the original value.
 #
-# key: bgm node name
-# value: desired volume_db for playing music
+## key: bgm node name
+## value: desired volume_db for playing music
 var _max_volume_db_by_bgm := {}
 
 var all_bgms: Array
@@ -45,39 +43,31 @@ func _ready() -> void:
 		_max_volume_db_by_bgm[bgm.name] = bgm.volume_db
 
 
-"""
-Plays a 'chill' song; something suitable for background music when the player's navigating menus or wandering the
-overworld.
-
-If a chill song is already playing, this method has no effect.
-"""
+## Plays a 'chill' song; something suitable for background music when the player's navigating menus or wandering the
+## overworld.
+##
+## If a chill song is already playing, this method has no effect.
 func play_chill_bgm(fade_in: bool = true) -> void:
 	_play_next_bgm(_chill_bgms, fade_in)
 
 
-"""
-Plays an 'upbeat' song; something suitable when the player's playing a puzzle level.
-
-If an upbeat song is already playing, this method has no effect.
-"""
+## Plays an 'upbeat' song; something suitable when the player's playing a puzzle level.
+##
+## If an upbeat song is already playing, this method has no effect.
 func play_upbeat_bgm(fade_in: bool = true) -> void:
 	_play_next_bgm(_upbeat_bgms, fade_in)
 
 
-"""
-Plays a 'tutorial song'; something suitable when the player is following a puzzle tutorial.
-
-If a tutorial song is already playing, this method has no effect.
-"""
+## Plays a 'tutorial song'; something suitable when the player is following a puzzle tutorial.
+##
+## If a tutorial song is already playing, this method has no effect.
 func play_tutorial_bgm(fade_in: bool = true) -> void:
 	_play_next_bgm(_tutorial_bgms, fade_in)
 
 
-"""
-Gradually fades a track in.
-
-Usually it's OK for a track to start abrubtly, but sometimes we want to fade music in more gradually.
-"""
+## Gradually fades a track in.
+##
+## Usually it's OK for a track to start abrubtly, but sometimes we want to fade music in more gradually.
 func fade_in(duration: float = MusicTween.FADE_IN_DURATION) -> void:
 	current_bgm.volume_db = MIN_VOLUME
 	_music_tween.fade_in(current_bgm, _max_volume_db_by_bgm[current_bgm.name], duration)
@@ -87,9 +77,7 @@ func is_fading_in() -> bool:
 	return _music_tween.fading_state == MusicTween.FADING_IN
 
 
-"""
-Fades out the currently playing track.
-"""
+## Fades out the currently playing track.
 func stop(duration: float = MusicTween.FADE_OUT_DURATION) -> void:
 	if current_bgm == null:
 		return
@@ -98,15 +86,13 @@ func stop(duration: float = MusicTween.FADE_OUT_DURATION) -> void:
 	current_bgm = null
 
 
-"""
-Plays the specified song.
-
-Any currently playing song is faded out.
-
-Parameters:
-	'from_position': If 0 or greater, the song will begin playing from the specified position. If unspecified or
-		negative, the song will start somewhere in the middle based on an algorithm.
-"""
+## Plays the specified song.
+##
+## Any currently playing song is faded out.
+##
+## Parameters:
+## 	'from_position': If 0 or greater, the song will begin playing from the specified position. If unspecified or
+## 		negative, the song will start somewhere in the middle based on an algorithm.
 func play_bgm(new_bgm: CheckpointSong, from_position: float = -1.0) -> void:
 	var old_bgm := current_bgm
 	if old_bgm == new_bgm:
@@ -120,17 +106,15 @@ func play_bgm(new_bgm: CheckpointSong, from_position: float = -1.0) -> void:
 	emit_signal("current_bgm_changed", current_bgm)
 
 
-"""
-Plays the first song from the specified list, and reorders the songs.
-
-If a song from the specified list is already playing, this method has no effect. Otherwise, any currently playing song
-is faded out.
-
-Parameters:
-	'bgms': Array of CheckpointSong instances to play
-	
-	'fade_in': 'true' if the music should fade in
-"""
+## Plays the first song from the specified list, and reorders the songs.
+##
+## If a song from the specified list is already playing, this method has no effect. Otherwise, any currently playing
+## song is faded out.
+##
+## Parameters:
+## 	'bgms': Array of CheckpointSong instances to play
+##
+## 	'fade_in': 'true' if the music should fade in
 func _play_next_bgm(bgms: Array, fade_in: bool) -> void:
 	if current_bgm in bgms:
 		# a song from the specified list is already playing; don't interrupt it

--- a/project/src/main/music/music-transition.gd
+++ b/project/src/main/music/music-transition.gd
@@ -1,10 +1,8 @@
 extends Node
-"""
-Transitions the music for web targets when the scene fades in and out.
-
-On web targets, the music sounds choppy and bad if we leave it running during scene transitions, so we fade out the
-music. On other targets, the music sounds fine.
-"""
+## Transitions the music for web targets when the scene fades in and out.
+##
+## On web targets, the music sounds choppy and bad if we leave it running during scene transitions, so we fade out the
+## music. On other targets, the music sounds fine.
 
 var _faded_bgm: CheckpointSong
 
@@ -13,9 +11,7 @@ func _ready() -> void:
 	SceneTransition.connect("fade_in_started", self, "_on_SceneTransition_fade_in_started")
 
 
-"""
-When the scene fades back in, we un-fade any music we previously faded out.
-"""
+## When the scene fades back in, we un-fade any music we previously faded out.
 func _on_SceneTransition_fade_in_started() -> void:
 	if _faded_bgm:
 		# If we faded the music out, we fade it back in
@@ -26,11 +22,9 @@ func _on_SceneTransition_fade_in_started() -> void:
 		_faded_bgm = null
 
 
-"""
-When fading out the scene, we fade out the music for web targets.
-
-On web targets, the music sounds choppy and bad if we leave it running during scene transitions.
-"""
+## When fading out the scene, we fade out the music for web targets.
+##
+## On web targets, the music sounds choppy and bad if we leave it running during scene transitions.
 func _on_SceneTransition_fade_out_started() -> void:
 	if OS.has_feature("web"):
 		_faded_bgm = MusicPlayer.current_bgm

--- a/project/src/main/music/music-tween.gd
+++ b/project/src/main/music/music-tween.gd
@@ -1,8 +1,6 @@
 class_name MusicTween
 extends Tween
-"""
-Tweens the volumes of music tracks.
-"""
+## Tweens the volumes of music tracks.
 
 enum FadingState {
 	FADING_NONE,
@@ -17,12 +15,10 @@ const FADING_OUT := FadingState.FADING_OUT
 const FADE_OUT_DURATION := 0.4
 const FADE_IN_DURATION := 2.5
 
-# a FadingState enum representing whether the music is fading in or out
+## a FadingState enum representing whether the music is fading in or out
 var fading_state: int = FADING_NONE
 
-"""
-Gradually silences a music track.
-"""
+## Gradually silences a music track.
 func fade_out(player: AudioStreamPlayer, min_volume: float, duration: float = FADE_OUT_DURATION) -> void:
 	fading_state = FADING_OUT
 	stop(player, "volume_db")
@@ -31,9 +27,7 @@ func fade_out(player: AudioStreamPlayer, min_volume: float, duration: float = FA
 	start()
 
 
-"""
-Gradually raises a music track to full volume.
-"""
+## Gradually raises a music track to full volume.
 func fade_in(player: AudioStreamPlayer, max_volume: float, duration: float = FADE_IN_DURATION) -> void:
 	fading_state = FADING_IN
 	stop(player, "volume_db")
@@ -42,9 +36,7 @@ func fade_in(player: AudioStreamPlayer, max_volume: float, duration: float = FAD
 	start()
 
 
-"""
-When a music track is faded out, we stop it from playing.
-"""
+## When a music track is faded out, we stop it from playing.
 func _on_tween_completed(object: Object, _key: String) -> void:
 	fading_state = FADING_NONE
 	if object is AudioStreamPlayer:

--- a/project/src/main/name-generator.gd
+++ b/project/src/main/name-generator.gd
@@ -1,33 +1,29 @@
 class_name NameGenerator
-"""
-Markov chain name generation algorithm.
-
-Accepts as input a list of words like 'banana' and 'anabelle', and mixes them into new words like 'banabelle'.
-"""
+## Markov chain name generation algorithm.
+##
+## Accepts as input a list of words like 'banana' and 'anabelle', and mixes them into new words like 'banabelle'.
 
 var markov_model := MarkovModel.new()
 var min_length: int setget set_min_length
 var max_length: int setget set_max_length
 var order: float setget set_order
 
-# Key: Word from the source material
-# Value: true
+## Key: Word from the source material
+## Value: true
 var _seed_words := {}
 
-# cached list of generated names; we generate many names at once at cache them
+## cached list of generated names; we generate many names at once at cache them
 var _generated_names := []
 
-# resource paths containing input names (one word per line)
+## resource paths containing input names (one word per line)
 var _seed_paths := []
 
-# seed names loaded from the resource files
+## seed names loaded from the resource files
 var _seed_word_lists := []
 
-"""
-Configures the name generator with 'American given names' and 'animals'.
-
-This generates names like 'Boala', 'Badgehog' and 'Coyce'.
-"""
+## Configures the name generator with 'American given names' and 'animals'.
+##
+## This generates names like 'Boala', 'Badgehog' and 'Coyce'.
 func load_american_animals() -> void:
 	add_seed_resource("res://assets/main/editor/creature/animals.txt")
 	add_seed_resource("res://assets/main/editor/creature/american-male-given-names.txt")
@@ -56,9 +52,7 @@ func set_order(new_order: float) -> void:
 	markov_model.order = new_order
 
 
-"""
-Add a resource file to load words from.
-"""
+## Add a resource file to load words from.
 func add_seed_resource(path: String) -> void:
 	var words: Array = FileUtils.get_file_as_text(path).split("\n")
 	_seed_word_lists.append(words)
@@ -67,12 +61,10 @@ func add_seed_resource(path: String) -> void:
 	_seed_paths.append(path)
 
 
-"""
-Generates a name based on the seed resources.
-
-This method regenerates the markov chain connection data and generates several names all at once. It then returns
-those cached names each time it's called until the cache is exhausted.
-"""
+## Generates a name based on the seed resources.
+##
+## This method regenerates the markov chain connection data and generates several names all at once. It then returns
+## those cached names each time it's called until the cache is exhausted.
 func generate_name() -> String:
 	if not _generated_names:
 		# repopulate the list of generated words
@@ -89,12 +81,10 @@ func generate_name() -> String:
 	return _generated_names.pop_front()
 
 
-"""
-Mixes a few seed word lists into a single list of words.
-
-This takes the same amount of words from each list, so a list of 100 words won't get drowned out by a list of 500
-words.
-"""
+## Mixes a few seed word lists into a single list of words.
+##
+## This takes the same amount of words from each list, so a list of 100 words won't get drowned out by a list of 500
+## words.
 func _mix_seed_lists() -> Array:
 	var words := []
 	var word_count: int = _seed_word_lists[0].size()

--- a/project/src/main/name-utils.gd
+++ b/project/src/main/name-utils.gd
@@ -1,17 +1,13 @@
 class_name NameUtils
-"""
-Utility class for creature names.
-"""
+## Utility class for creature names.
 
 const MAX_CREATURE_NAME_LENGTH := 63
 const MAX_CREATURE_SHORT_NAME_LENGTH := 15
 
-"""
-Sanitizes a creatures name.
-
-Removes any illegal characters, and any leading/trailing punctuation. Excessively short names are padded, and
-excessively long names are truncated.
-"""
+## Sanitizes a creatures name.
+##
+## Removes any illegal characters, and any leading/trailing punctuation. Excessively short names are padded, and
+## excessively long names are truncated.
 static func sanitize_name(name: String) -> String:
 	var result := ""
 	var utf8 := name.to_lower().to_utf8()
@@ -32,11 +28,9 @@ static func sanitize_name(name: String) -> String:
 	return result.substr(0, MAX_CREATURE_NAME_LENGTH)
 
 
-"""
-Sorts an array of strings by length.
-
-In GDScript this requires an internal class because of Godot #30668.
-"""
+## Sorts an array of strings by length.
+##
+## In GDScript this requires an internal class because of Godot #30668.
 static func sort_by_length(strings: Array) -> void:
 	strings.sort_custom(LengthSorter, '_compare_by_length')
 
@@ -46,12 +40,10 @@ class LengthSorter:
 		return a.length() > b.length()
 
 
-"""
-Sanitizes a creatures short name.
-
-Removes any illegal characters, and any leading/trailing punctuation. Excessively short names are padded, and
-excessively long names are shortened using a complex name shortening algorithm.
-"""
+## Sanitizes a creatures short name.
+##
+## Removes any illegal characters, and any leading/trailing punctuation. Excessively short names are padded, and
+## excessively long names are shortened using a complex name shortening algorithm.
 static func sanitize_short_name(name: String) -> String:
 	var result := sanitize_name(name)
 	if result.length() <= MAX_CREATURE_SHORT_NAME_LENGTH:
@@ -69,14 +61,12 @@ static func sanitize_short_name(name: String) -> String:
 	return result
 
 
-"""
-Returns 'true' if the specified letter is a consonant.
-
-Parameters:
-	'character': An upper-case or lower-case letter.
-	
-	'y': True if 'y' counts as a consonant.
-"""
+## Returns 'true' if the specified letter is a consonant.
+##
+## Parameters:
+## 	'character': An upper-case or lower-case letter.
+##
+## 	'y': True if 'y' counts as a consonant.
 static func is_consonant(character: String, y: bool = false) -> bool:
 	var result: bool
 	match character.to_lower():
@@ -86,14 +76,12 @@ static func is_consonant(character: String, y: bool = false) -> bool:
 	return result
 
 
-"""
-Returns 'true' if the specified letter is a vowel.
-
-Parameters:
-	'character': An upper-case or lower-case letter.
-	
-	'y': True if 'y' counts as a vowel.
-"""
+## Returns 'true' if the specified letter is a vowel.
+##
+## Parameters:
+## 	'character': An upper-case or lower-case letter.
+##
+## 	'y': True if 'y' counts as a vowel.
 static func is_vowel(character: String, y: bool = true) -> bool:
 	var result: bool
 	match character.to_lower():
@@ -103,15 +91,13 @@ static func is_vowel(character: String, y: bool = true) -> bool:
 	return result
 
 
-"""
-Shortens a name using a complex name shortening algorithm.
-
-Instead of shortening names like 'Francoisensellensoile' into awkwardly truncated names like 'Francoi', this analyzes
-vowel/consonant patterns to come up with nicknames like 'Franny'.
-
-Parameters:
-	'name': A single-word name which should be shortened.
-"""
+## Shortens a name using a complex name shortening algorithm.
+##
+## Instead of shortening names like 'Francoisensellensoile' into awkwardly truncated names like 'Francoi', this
+## analyzes vowel/consonant patterns to come up with nicknames like 'Franny'.
+##
+## Parameters:
+## 	'name': A single-word name which should be shortened.
 static func shorten_name(name: String) -> String:
 	var result := name.substr(0, 5)
 	
@@ -152,12 +138,10 @@ static func shorten_name(name: String) -> String:
 	return result
 
 
-"""
-Converts a short name like 'Dr. Smiles' into a creature ID like 'dr_smiles'.
-
-The creature editor converts creature IDs to snake case and strips any diacritical marks or upper ascii. The game
-should work fine even if the IDs have upper ascii and spaces, they'll just be more annoying to type in.
-"""
+## Converts a short name like 'Dr. Smiles' into a creature ID like 'dr_smiles'.
+##
+## The creature editor converts creature IDs to snake case and strips any diacritical marks or upper ascii. The game
+## should work fine even if the IDs have upper ascii and spaces, they'll just be more annoying to type in.
 static func short_name_to_id(short_name: String) -> String:
 	var transformer := StringTransformer.new(short_name)
 	

--- a/project/src/main/nearest-sorter.gd
+++ b/project/src/main/nearest-sorter.gd
@@ -1,18 +1,14 @@
 class_name NearestSorter
-"""
-Sorts an array's values by proximity to a specified value.
-"""
+## Sorts an array's values by proximity to a specified value.
 
 var _target_value
 
-"""
-Sorts an array's values by proximity to a specified value.
-
-Example:
-	input: [1, 2, 4, 5, 7, 8, 10]
-	target_value: [4]
-	result: [4, 5, 2, 1, 7, 8, 10]
-"""
+## Sorts an array's values by proximity to a specified value.
+##
+## Example:
+## 	input: [1, 2, 4, 5, 7, 8, 10]
+## 	target_value: [4]
+## 	result: [4, 5, 2, 1, 7, 8, 10]
 func sort(values: Array, target_value: float) -> void:
 	_target_value = target_value
 	values.sort_custom(self, "compare")

--- a/project/src/main/packed-sprite.gd
+++ b/project/src/main/packed-sprite.gd
@@ -1,24 +1,22 @@
 tool
 class_name PackedSprite
 extends Node2D
-"""
-A sprite whose contents are packed with Aseprite.
-
-Aseprite can export packed and trimmed sprite sheets. These sprite sheets are much smaller than grid-based sheets
-because they remove the whitespace for each frame. However, they require spatial data indicating the position of each
-frame within the sprite sheet, as well as the position where it should be drawn.
-
-This spatial data is available in a separate Aseprite json file.
-"""
+## A sprite whose contents are packed with Aseprite.
+##
+## Aseprite can export packed and trimmed sprite sheets. These sprite sheets are much smaller than grid-based sheets
+## because they remove the whitespace for each frame. However, they require spatial data indicating the position of
+## each frame within the sprite sheet, as well as the position where it should be drawn.
+##
+## This spatial data is available in a separate Aseprite json file.
 
 signal frame_changed
 
 export (Texture) var texture: Texture
 
-# the path of the Aseprite json file containing spatial data for the packed texture
+## the path of the Aseprite json file containing spatial data for the packed texture
 export (String, FILE) var frame_data setget set_frame_data
 
-# our width/height. affects our position when we're centered
+## our width/height. affects our position when we're centered
 export (Vector2) var rect_size := Vector2(100, 100) setget set_rect_size
 
 export (int) var frame: int setget set_frame
@@ -27,20 +25,18 @@ export (bool) var centered: bool = true setget set_centered
 
 export (Vector2) var offset: Vector2 setget set_offset
 
-# the number of animation frames parsed from the Aseprite json file.
+## the number of animation frames parsed from the Aseprite json file.
 var frame_count setget ,get_frame_count
 
-# Rect2 instances representing sprite sheet regions where each frame can be read
+## Rect2 instances representing sprite sheet regions where each frame can be read
 var _frame_src_rects := []
 
-# Rect2 instances representing screen regions where each frame should be drawn
+## Rect2 instances representing screen regions where each frame should be drawn
 var _frame_dest_rects := []
 
-"""
-Sets the path of the Aseprite json file.
-
-Loads the file and recalculates the frame data. Updates our region and offset based on the file contents.
-"""
+## Sets the path of the Aseprite json file.
+##
+## Loads the file and recalculates the frame data. Updates our region and offset based on the file contents.
 func set_frame_data(new_frame_data: String) -> void:
 	frame_data = new_frame_data
 	if Engine.editor_hint:
@@ -103,11 +99,9 @@ func _draw() -> void:
 		draw_texture_rect_region(texture, rect, _frame_src_rects[frame])
 
 
-"""
-Loads sprite sheet regions and screen regions from a json file.
-
-This is slow and should only be used for editor tools where the ResourceCache is inaccessible.
-"""
+## Loads sprite sheet regions and screen regions from a json file.
+##
+## This is slow and should only be used for editor tools where the ResourceCache is inaccessible.
 func _load_rects_from_json() -> void:
 	if not frame_data:
 		return

--- a/project/src/main/pauser.gd
+++ b/project/src/main/pauser.gd
@@ -1,9 +1,7 @@
 extends Node
-"""
-Emits signals when the scene tree is paused or unpaused.
-"""
+## Emits signals when the scene tree is paused or unpaused.
 
-# emitted when the scene tree is paused or unpaused
+## emitted when the scene tree is paused or unpaused
 signal paused_changed(value)
 
 var _paused: bool

--- a/project/src/main/player-data.gd
+++ b/project/src/main/player-data.gd
@@ -1,18 +1,16 @@
 extends Node
-"""
-Stores data about the player's progress.
-
-This data includes how well they've done on each level and how much money they've earned.
-
-Configuration data like the graphics and keybindings is stored in the SystemData class, not here.
-"""
+## Stores data about the player's progress.
+##
+## This data includes how well they've done on each level and how much money they've earned.
+##
+## Configuration data like the graphics and keybindings is stored in the SystemData class, not here.
 
 signal money_changed(value)
 
-# emitted when the player beats a level, or when the level history is reset or reloaded
+## emitted when the player beats a level, or when the level history is reset or reloaded
 signal level_history_changed
 
-# how often in seconds to increment the 'seconds_played' value
+## how often in seconds to increment the 'seconds_played' value
 const SECONDS_PLAYED_INCREMENT := 0.619
 
 var level_history := LevelHistory.new()
@@ -23,10 +21,10 @@ var creature_queue := CreatureQueue.new()
 
 var money := 0 setget set_money
 
-# the player's playtime in seconds
+## the player's playtime in seconds
 var seconds_played := 0.0
 
-# periodically increments the 'seconds_played' value
+## periodically increments the 'seconds_played' value
 var seconds_played_timer: Timer
 
 func _ready() -> void:
@@ -37,9 +35,7 @@ func _ready() -> void:
 	seconds_played_timer.start()
 
 
-"""
-Resets the player's in-memory data to a default state.
-"""
+## Resets the player's in-memory data to a default state.
 func reset() -> void:
 	level_history.reset()
 	chat_history.reset()

--- a/project/src/main/player-save-upgrader.gd
+++ b/project/src/main/player-save-upgrader.gd
@@ -1,14 +1,12 @@
 class_name PlayerSaveUpgrader
-"""
-Provides backwards compatibility with older player save formats.
+## Provides backwards compatibility with older player save formats.
+##
+## This class will grow with each change to our save system. Once it gets too large (600 lines or so) we should drop
+## backwards compatibility for older versions.
 
-This class will grow with each change to our save system. Once it gets too large (600 lines or so) we should drop
-backwards compatibility for older versions.
-"""
-
-# chat history prefixes to replace when upgrading from version 2743
-# key: old string prefix to be replaced
-# value: new string prefix
+## chat history prefixes to replace when upgrading from version 2743
+## key: old string prefix to be replaced
+## value: new string prefix
 const PREFIX_REPLACEMENTS_2743 := {
 	"chat/bones": "creature/bones",
 	"chat/skins": "creature/skins",
@@ -22,9 +20,7 @@ const PREFIX_REPLACEMENTS_2743 := {
 }
 
 
-"""
-Creates and configures a SaveItemUpgrader capable of upgrading older player save formats.
-"""
+## Creates and configures a SaveItemUpgrader capable of upgrading older player save formats.
 func new_save_item_upgrader() -> SaveItemUpgrader:
 	var upgrader := SaveItemUpgrader.new()
 	upgrader.add_upgrade_method(self, "_upgrade_2783", "2783", "27bb")
@@ -67,9 +63,7 @@ func _upgrade_2743(save_item: SaveItem) -> SaveItem:
 	return save_item
 
 
-"""
-Replace chat keys like 'chat/richie/filler_000' with 'creature/richie/filler_000'
-"""
+## Replace chat keys like 'chat/richie/filler_000' with 'creature/richie/filler_000'
 func _replace_chat_history_prefixes_for_2743(dict: Dictionary) -> void:
 	for sub_dict in dict.values():
 		for key in sub_dict.keys():
@@ -86,9 +80,7 @@ func _replace_chat_history_prefixes_for_2743(dict: Dictionary) -> void:
 				sub_dict.erase(key)
 
 
-"""
-Replace hyphens with underscores in fatness keys like '#filler-033#'
-"""
+## Replace hyphens with underscores in fatness keys like '#filler-033#'
 func _replace_fatness_keys_for_2743(dict: Dictionary) -> void:
 	for key in dict.keys():
 		var new_key: String = key
@@ -269,11 +261,9 @@ func _upgrade_15d2(save_item: SaveItem) -> SaveItem:
 	return save_item
 
 
-"""
-Adds a 'success' key for a RankResult if the player met a target score and didn't lose.
-
-Provides backwards compatibility with 15d2, which did not include 'success' keys in rank results.
-"""
+## Adds a 'success' key for a RankResult if the player met a target score and didn't lose.
+##
+## Provides backwards compatibility with 15d2, which did not include 'success' keys in rank results.
 func _append_score_success_for_15d2(save_item: SaveItem, target_score: int) -> void:
 	for rank_result_obj in save_item.value:
 		var rank_result_dict: Dictionary = rank_result_obj
@@ -281,11 +271,9 @@ func _append_score_success_for_15d2(save_item: SaveItem, target_score: int) -> v
 				and rank_result_dict.get("score", 0) >= target_score
 
 
-"""
-Adds a 'success' key for a RankResult if the player met a target time and didn't lose
-
-Provides backwards compatibility with 15d2, which did not include 'success' keys in rank results.
-"""
+## Adds a 'success' key for a RankResult if the player met a target time and didn't lose
+##
+## Provides backwards compatibility with 15d2, which did not include 'success' keys in rank results.
 func _append_time_success_for_15d2(save_item: SaveItem, target_time: float) -> void:
 	for rank_result_obj in save_item.value:
 		var rank_result_dict: Dictionary = rank_result_obj

--- a/project/src/main/player-save.gd
+++ b/project/src/main/player-save.gd
@@ -1,31 +1,29 @@
 extends Node
-"""
-Reads and writes data about the player's progress from a file.
+## Reads and writes data about the player's progress from a file.
+##
+## This data includes how well they've done on each level and how much money they've earned.
 
-This data includes how well they've done on each level and how much money they've earned.
-"""
-
-# Current version for saved player data. Should be updated if and only if the player format changes.
-# This version number follows a 'ymdh' hex date format which is documented in issue #234.
+## Current version for saved player data. Should be updated if and only if the player format changes.
+## This version number follows a 'ymdh' hex date format which is documented in issue #234.
 const PLAYER_DATA_VERSION := "27bb"
 
 var rolling_backups := RollingBackups.new()
 
-# Enum value for the backup was successfully loaded. 'RollingBackups.CURRENT' if the current file worked.
-# Virtual property; value is only exposed through getters/setters
+## Enum value for the backup was successfully loaded. 'RollingBackups.CURRENT' if the current file worked.
+## Virtual property; value is only exposed through getters/setters
 var loaded_backup: int setget ,get_loaded_backup
 
-# Newly renamed save files which couldn't be loaded
-# Virtual property; value is only exposed through getters/setters
+## Newly renamed save files which couldn't be loaded
+## Virtual property; value is only exposed through getters/setters
 var corrupt_filenames: Array setget ,get_corrupt_filenames
 
-# Filename for saving/loading player data. Can be changed for tests
+## Filename for saving/loading player data. Can be changed for tests
 var data_filename := "user://saveslot0.json" setget set_data_filename
 
-# Filename for loading data older than July 2021. Can be changed for tests
+## Filename for loading data older than July 2021. Can be changed for tests
 var legacy_filename := "user://turbofat0.save" setget set_legacy_filename
 
-# Provides backwards compatibility with older save formats
+## Provides backwards compatibility with older save formats
 var _upgrader := PlayerSaveUpgrader.new().new_save_item_upgrader()
 
 func _ready() -> void:
@@ -51,9 +49,7 @@ func set_legacy_filename(new_legacy_filename: String) -> void:
 	rolling_backups.legacy_filename = legacy_filename
 
 
-"""
-Writes the player's in-memory data to a save file.
-"""
+## Writes the player's in-memory data to a save file.
 func save_player_data() -> void:
 	var save_json := []
 	save_json.append(_save_item("version", PLAYER_DATA_VERSION).to_json_dict())
@@ -76,17 +72,13 @@ func save_player_data() -> void:
 	rolling_backups.rotate_backups()
 
 
-"""
-Populates the player's in-memory data based on their save files.
-"""
+## Populates the player's in-memory data based on their save files.
 func load_player_data() -> void:
 	PlayerData.reset()
 	rolling_backups.load_newest_save(self, "_load_player_data_from_file")
 
 
-"""
-Returns the playtime in seconds from the specified save file.
-"""
+## Returns the playtime in seconds from the specified save file.
 func get_save_slot_playtime(filename: String) -> float:
 	var json_save_items := _save_items_from_file(filename)
 	var seconds_played := 0.0
@@ -102,9 +94,7 @@ func get_save_slot_playtime(filename: String) -> float:
 	return seconds_played
 
 
-"""
-Returns the player's short name from the specified save file.
-"""
+## Returns the player's short name from the specified save file.
 func get_save_slot_player_short_name(filename: String) -> String:
 	var json_save_items := _save_items_from_file(filename)
 	var player_short_name := ""
@@ -121,12 +111,10 @@ func get_save_slot_player_short_name(filename: String) -> String:
 	return player_short_name
 
 
-"""
-Creates a granular save item. The player's save data includes many of these.
-
-Note: Intuitively this method would be a static factory method on the SaveItem class, but that causes console errors
-due to Godot #30668 (https://github.com/godotengine/godot/issues/30668)
-"""
+## Creates a granular save item. The player's save data includes many of these.
+##
+## Note: Intuitively this method would be a static factory method on the SaveItem class, but that causes console errors
+## due to Godot #30668 (https://github.com/godotengine/godot/issues/30668)
 func _save_item(type: String, value, key: String = "") -> SaveItem:
 	var save_item := SaveItem.new()
 	save_item.type = type
@@ -135,11 +123,9 @@ func _save_item(type: String, value, key: String = "") -> SaveItem:
 	return save_item
 
 
-"""
-Populates the player's in-memory data based on a save file.
-
-Returns 'true' if the data is loaded successfully.
-"""
+## Populates the player's in-memory data based on a save file.
+##
+## Returns 'true' if the data is loaded successfully.
 func _load_player_data_from_file(filename: String) -> bool:
 	var json_save_items := _save_items_from_file(filename)
 	if not json_save_items:
@@ -155,13 +141,11 @@ func _load_player_data_from_file(filename: String) -> bool:
 	return true
 
 
-"""
-Loads a list of SaveItems from the specified save file.
-
-Returns:
-	A list of SaveItem instances from the specified save file. Returns an empty array if there is an error reading the
-	file.
-"""
+## Loads a list of SaveItems from the specified save file.
+##
+## Returns:
+## 	A list of SaveItem instances from the specified save file. Returns an empty array if there is an error reading the
+## 	file.
 func _save_items_from_file(filename: String) -> Array:
 	var file := File.new()
 	var open_result := file.open(filename, File.READ)
@@ -185,14 +169,12 @@ func _save_items_from_file(filename: String) -> Array:
 	return json_save_items
 
 
-"""
-Populates the player's in-memory data based on a single line from their save file.
-
-Parameters:
-	'type': A string unique to each type of data (level-data, player-data)
-	'key': A string identifying a specific data item (sophie, marathon-normal)
-	'json_value': The value object (array, dictionary, string) containing the data
-"""
+## Populates the player's in-memory data based on a single line from their save file.
+##
+## Parameters:
+## 	'type': A string unique to each type of data (level-data, player-data)
+## 	'key': A string identifying a specific data item (sophie, marathon-normal)
+## 	'json_value': The value object (array, dictionary, string) containing the data
 func _load_line(type: String, key: String, json_value) -> void:
 	match type:
 		"version":

--- a/project/src/main/puzzle-connect.gd
+++ b/project/src/main/puzzle-connect.gd
@@ -1,32 +1,30 @@
 class_name PuzzleConnect
-"""
-Map integers such as '14' to puzzle autotile coordinates such as 'LEFT | RIGHT | DOWN'
+## Map integers such as '14' to puzzle autotile coordinates such as 'LEFT | RIGHT | DOWN'
+##
+## This is useful for tiles which are arranged so that the X coordinates of the tiles correspond to the directions
+## they're connected. This type of tilemap is used for puzzle pieces.
 
-This is useful for tiles which are arranged so that the X coordinates of the tiles correspond to the directions they're
-connected. This type of tilemap is used for puzzle pieces.
-"""
-
-# Constants used when drawing tiles which are connected to other tiles. These serve a similar purpose to the
-# TileSet.BIND_TOP constants, but with smaller values.
+## Constants used when drawing tiles which are connected to other tiles. These serve a similar purpose to the
+## TileSet.BIND_TOP constants, but with smaller values.
 const UP := 1
 const DOWN := 2
 const LEFT := 4
 const RIGHT := 8
 
-# functions which return true if a specific directional bitmask is set
+## functions which return true if a specific directional bitmask is set
 static func is_u(input: int) -> bool: return input & UP > 0
 static func is_d(input: int) -> bool: return input & DOWN > 0
 static func is_l(input: int) -> bool: return input & LEFT > 0
 static func is_r(input: int) -> bool: return input & RIGHT > 0
 
-# functions which enable a specific directional bitmask
+## functions which enable a specific directional bitmask
 static func set_u(input: int) -> int: return input | UP
 static func set_d(input: int) -> int: return input | DOWN
 static func set_l(input: int) -> int: return input | LEFT
 static func set_r(input: int) -> int: return input | RIGHT
 static func set_dirs(input: int, bitmask: int) -> int: return input | bitmask
 
-# functions which disable a specific directional bitmask
+## functions which disable a specific directional bitmask
 static func unset_u(input: int) -> int: return input & ~UP
 static func unset_d(input: int) -> int: return input & ~DOWN
 static func unset_l(input: int) -> int: return input & ~LEFT

--- a/project/src/main/puzzle/box-builder.gd
+++ b/project/src/main/puzzle/box-builder.gd
@@ -1,33 +1,30 @@
 class_name BoxBuilder
 extends Node
-"""
-Builds boxes in a tilemap as new pieces are placed.
-"""
+## Builds boxes in a tilemap as new pieces are placed.
 
-# emitted after all boxes are built, when the builder stops processing and passes control back to the playfield
+## emitted after all boxes are built, when the builder stops processing and passes control back to the playfield
 signal after_boxes_built
 
-# emitted when a new box is built
+## emitted when a new box is built
 signal box_built(rect, box_type)
 
 export (NodePath) var tile_map_path: NodePath
 
-# remaining frames to wait for making the current box
+## remaining frames to wait for making the current box
 var remaining_box_build_frames := 0
 
 onready var _tile_map: PuzzleTileMap = get_node(tile_map_path)
 
-"""
-Maps 'ingredient strings' to box colors. This lets us calculate which snack/cake tiles should be used for a box with
-certain pieces.
-
-An ingredient string looks like 's13'. It starts with an 's' for a 3x3 or 4x3 box, and 'l' for a 5x3 box. It ends with
-the box's piece color ints in ascending numerical order (brown=0, pink=1...). For example 's13' is a 4x3 box with pink
-and white pieces, where 'l123' is a 5x3 box with pink, bread and white pieces. 's0' is a 3x3 box with brown pieces.
-
-Key: Ingredient string describing the box's size and color
-Value: BoxType for the resulting snack/cake
-"""
+## Maps 'ingredient strings' to box colors. This lets us calculate which snack/cake tiles should be used for a box with
+## certain pieces.
+##
+## An ingredient string looks like 's13'. It starts with an 's' for a 3x3 or 4x3 box, and 'l' for a 5x3 box. It ends
+## with the box's piece color ints in ascending numerical order (brown=0, pink=1...). For example 's13' is a 4x3 box
+## with pink and white pieces, where 'l123' is a 5x3 box with pink, bread and white pieces. 's0' is a 3x3 box with
+## brown pieces.
+##
+## key: Ingredient string describing the box's size and color
+## value: BoxType for the resulting snack/cake
 const BOX_TYPES_BY_INGREDIENTS := {
 	# 3x3
 	"s0": Foods.BoxType.BROWN,
@@ -60,11 +57,9 @@ func _physics_process(_delta: float) -> void:
 		emit_signal("after_boxes_built")
 
 
-"""
-Builds a box with the specified location and size.
-
-Boxes are built when the player forms a 3x3, 3x4, 3x5 rectangle from intact pieces.
-"""
+## Builds a box with the specified location and size.
+##
+## Boxes are built when the player forms a 3x3, 3x4, 3x5 rectangle from intact pieces.
 func build_box(rect: Rect2, box_type: int) -> void:
 	# set at least 1 box build frame; processing occurs when the frame goes from 1 -> 0
 	remaining_box_build_frames = max(1, PieceSpeeds.current_speed.box_delay)
@@ -72,9 +67,7 @@ func build_box(rect: Rect2, box_type: int) -> void:
 	emit_signal("box_built", rect, box_type)
 
 
-"""
-Creates a new integer matrix of the same dimensions as the playfield.
-"""
+## Creates a new integer matrix of the same dimensions as the playfield.
 func _int_matrix() -> Array:
 	var matrix := []
 	for y in range(PuzzleTileMap.ROW_COUNT):
@@ -84,11 +77,9 @@ func _int_matrix() -> Array:
 	return matrix
 
 
-"""
-Calculates the possible locations for a (width x height) rectangle in the playfield, given an integer matrix with the
-possible locations for a (1 x height) rectangle in the playfield. These rectangles must consist of dropped pieces which
-haven't been split apart by lines. They can't consist of any empty cells or any previously built boxes.
-"""
+## Calculates the possible locations for a (width x height) rectangle in the playfield, given an integer matrix with
+## the possible locations for a (1 x height) rectangle in the playfield. These rectangles must consist of dropped
+## pieces which haven't been split apart by lines. They can't consist of any empty cells or any previously built boxes.
 func _filled_rectangles(db: Array, box_height: int) -> Array:
 	var dt := _int_matrix()
 	for y in range(PuzzleTileMap.ROW_COUNT):
@@ -100,11 +91,9 @@ func _filled_rectangles(db: Array, box_height: int) -> Array:
 	return dt
 
 
-"""
-Calculates the possible locations for a (1 x height) rectangle in the playfield, capable of being a part of a 3x3,
-3x4, or 3x5 'box'. These rectangles must consist of dropped pieces which haven't been split apart by lines. They can't
-consist of any empty cells or any previously built boxes.
-"""
+## Calculates the possible locations for a (1 x height) rectangle in the playfield, capable of being a part of a 3x3,
+## 3x4, or 3x5 'box'. These rectangles must consist of dropped pieces which haven't been split apart by lines. They
+## can't consist of any empty cells or any previously built boxes.
 func _filled_columns() -> Array:
 	var db := _int_matrix()
 	for y in range(PuzzleTileMap.ROW_COUNT):
@@ -124,9 +113,7 @@ func _filled_columns() -> Array:
 	return db
 
 
-"""
-Builds any possible 3x3, 3x4 or 3x5 'boxes' in the playfield, returning 'true' if a box was built.
-"""
+## Builds any possible 3x3, 3x4 or 3x5 'boxes' in the playfield, returning 'true' if a box was built.
 func process_boxes() -> bool:
 	if CurrentLevel.settings.other.tile_set == PuzzleTileMap.TileSetType.VEGGIE:
 		# veggie blocks cannot make boxes
@@ -148,20 +135,19 @@ func process_boxes() -> bool:
 	return false
 
 
-"""
-Calculates an 'ingredient string' for a specific box.
-
-An ingredient string looks like 's13'. It starts with an 's' for a 3x3 or 4x3 box, and 'l' for a 5x3 box. It ends with
-the box's piece color ints in ascending numerical order (brown=0, pink=1...). For example 's13' is a 4x3 box with pink
-and white pieces, where 'l123' is a 5x3 box with pink, bread and white pieces. 's0' is a 3x3 box with brown pieces.
-
-Parameters:
-	'width': The box width
-	
-	'height': The box height
-	
-	'piece_box_types': An array of ints corresponding to different piece colors (brown=0, pink=1...)
-"""
+## Calculates an 'ingredient string' for a specific box.
+##
+## An ingredient string looks like 's13'. It starts with an 's' for a 3x3 or 4x3 box, and 'l' for a 5x3 box. It ends
+## with the box's piece color ints in ascending numerical order (brown=0, pink=1...). For example 's13' is a 4x3 box
+## with pink and white pieces, where 'l123' is a 5x3 box with pink, bread and white pieces. 's0' is a 3x3 box with
+## brown pieces.
+##
+## Parameters:
+## 	'width': The box width
+##
+## 	'height': The box height
+##
+## 	'piece_box_types': An array of ints corresponding to different piece colors (brown=0, pink=1...)
 func _box_ingredients(width: int, height: int, piece_box_types: Array) -> String:
 	piece_box_types.sort()
 	var result := "s" if width <= 4 and height <= 4 else "l"
@@ -170,13 +156,11 @@ func _box_ingredients(width: int, height: int, piece_box_types: Array) -> String
 	return result
 
 
-"""
-Checks whether the specified rectangle represents an enclosed box. An enclosed box must not connect to any pieces
-outside the box.
-
-It's assumed the rectangle's coordinates contain only dropped pieces which haven't been split apart by lines, and
-no empty/vegetable/box cells.
-"""
+## Checks whether the specified rectangle represents an enclosed box. An enclosed box must not connect to any pieces
+## outside the box.
+##
+## It's assumed the rectangle's coordinates contain only dropped pieces which haven't been split apart by lines, and
+## no empty/vegetable/box cells.
 func _process_box(end_x: int, end_y: int, width: int, height: int) -> bool:
 	var start_x := end_x - (width - 1)
 	var start_y := end_y - (height - 1)

--- a/project/src/main/puzzle/build-box-sfx.gd
+++ b/project/src/main/puzzle/build-box-sfx.gd
@@ -1,7 +1,5 @@
 extends Node
-"""
-Plays sound effects when boxes are built.
-"""
+## Plays sound effects when boxes are built.
 
 onready var _build_snack_box_sounds := [
 		preload("res://assets/main/puzzle/build-snack-box0.wav"),

--- a/project/src/main/puzzle/chalkboard.gd
+++ b/project/src/main/puzzle/chalkboard.gd
@@ -1,7 +1,5 @@
 extends TextureRect
-"""
-Chalkboard which displays the player's score and progress during a puzzle.
-"""
+## Chalkboard which displays the player's score and progress during a puzzle.
 
 func _ready() -> void:
 	CurrentLevel.connect("settings_changed", self, "_on_Level_settings_changed")

--- a/project/src/main/puzzle/chef-view.gd
+++ b/project/src/main/puzzle/chef-view.gd
@@ -1,7 +1,5 @@
 extends ViewportContainer
-"""
-Shows the player's chef character in the restaurant scene.
-"""
+## Shows the player's chef character in the restaurant scene.
 
 export (NodePath) var restaurant_viewport_path: NodePath
 

--- a/project/src/main/puzzle/combo-counter.gd
+++ b/project/src/main/puzzle/combo-counter.gd
@@ -1,12 +1,10 @@
 class_name ComboCounter
 extends Node2D
-"""
-A combo indicator which appears when the player clears a line in puzzle mode.
+## A combo indicator which appears when the player clears a line in puzzle mode.
+##
+## The indicator includes some colorful stylized text with an accent shape behind it.
 
-The indicator includes some colorful stylized text with an accent shape behind it.
-"""
-
-# When the combo exceeds these values, the indicator changes its appearance
+## When the combo exceeds these values, the indicator changes its appearance
 const COMBO_THRESHOLD_0 := 5
 const COMBO_THRESHOLD_1 := 10
 const COMBO_THRESHOLD_2 := 20
@@ -15,22 +13,22 @@ const COMBO_THRESHOLD_4 := 50
 
 export (Vector2) var velocity: Vector2
 
-# The combo to display. This controls our text, color and particle properties.
+## The combo to display. This controls our text, color and particle properties.
 var combo: int setget set_combo
 
-# Colors to use; these are automatically assigned based on the combo value
+## Colors to use; these are automatically assigned based on the combo value
 var _font_color: Color
 var _accent_color: Color # darker version of the font color
 var _particle_color: Color # lighter version of the font color
 
-# particles which explode from the center of the combo
+## particles which explode from the center of the combo
 onready var _particles: Particles2D = $Particles2D
 onready var _particles_material: ParticlesMaterial = $Particles2D.process_material
 
-# text showing the current combo, like '12x'
+## text showing the current combo, like '12x'
 onready var _label: Label = $Label
 
-# colorful shape which goes behind the text
+## colorful shape which goes behind the text
 onready var _accent: PackedSprite = $Accent
 
 func _ready() -> void:

--- a/project/src/main/puzzle/combo-counters.gd
+++ b/project/src/main/puzzle/combo-counters.gd
@@ -1,18 +1,16 @@
 extends Node2D
-"""
-Combo indicators which appear when the player clears a line in puzzle mode.
-"""
+## Combo indicators which appear when the player clears a line in puzzle mode.
 
 export (NodePath) var piece_manager_path: NodePath
 export (NodePath) var playfield_path: NodePath
 export (PackedScene) var ComboCounterScene: PackedScene
 
-# Stores the x position of the previous combo counter to ensure consecutive counters aren't vertically aligned
+## Stores the x position of the previous combo counter to ensure consecutive counters aren't vertically aligned
 var _previous_cell_x := -1
 
-# Tracke the most x position of the most recent piece placed in each row
-# key: y value of a recently dropped piece
-# value: average x position of the piece's blocks in that row
+## Tracke the most x position of the most recent piece placed in each row
+## key: y value of a recently dropped piece
+## value: average x position of the piece's blocks in that row
 var _piece_x_by_y: Dictionary
 
 onready var _piece_manager: PieceManager = get_node(piece_manager_path)
@@ -22,11 +20,9 @@ func _ready() -> void:
 	PuzzleState.connect("before_piece_written", self, "_on_PuzzleState_before_piece_written")
 
 
-"""
-When the player places a piece, we store the piece's position in _piece_x_by_y
-
-This allows combo counters to appear horizontally aligned with the most recent piece.
-"""
+## When the player places a piece, we store the piece's position in _piece_x_by_y
+##
+## This allows combo counters to appear horizontally aligned with the most recent piece.
 func _on_PuzzleState_before_piece_written() -> void:
 	var piece_min_x_by_y := {}
 	var piece_max_x_by_y := {}
@@ -43,9 +39,7 @@ func _on_PuzzleState_before_piece_written() -> void:
 		_piece_x_by_y[int(y)] = (piece_min_x_by_y[y] + piece_max_x_by_y[y]) / 2
 
 
-"""
-When a line is cleared we add a new combo counter.
-"""
+## When a line is cleared we add a new combo counter.
 func _on_Playfield_before_line_cleared(y: int, _total_lines: int, _remaining_lines: int, _box_ints: Array) -> void:
 	if PuzzleState.combo < 3:
 		# no combo counters below 3x

--- a/project/src/main/puzzle/combo-score-value-label.gd
+++ b/project/src/main/puzzle/combo-score-value-label.gd
@@ -1,9 +1,7 @@
 extends Label
-"""
-Displays bonus points awarded during the current combo.
-
-This only includes bonuses and should be a round number like +55 or +130 for visual aesthetics.
-"""
+## Displays bonus points awarded during the current combo.
+##
+## This only includes bonuses and should be a round number like +55 or +130 for visual aesthetics.
 
 func _ready() -> void:
 	PuzzleState.connect("score_changed", self, "_on_PuzzleState_score_changed")

--- a/project/src/main/puzzle/combo-tracker.gd
+++ b/project/src/main/puzzle/combo-tracker.gd
@@ -1,24 +1,22 @@
 class_name ComboTracker
 extends Node
-"""
-Keeps track of the player's combo.
-
-Increments the combo when the player does well, breaks the combo when the player messes up.
-"""
+## Keeps track of the player's combo.
+##
+## Increments the combo when the player does well, breaks the combo when the player messes up.
 
 signal combo_break_changed(value)
 
-# bonus points which are awarded as the player continues a combo
+## bonus points which are awarded as the player continues a combo
 const COMBO_SCORE_ARR = [0, 0, 5, 5, 10, 10, 15, 15, 20]
 
-# The number of pieces the player has dropped without clearing a line or making a box.
+## The number of pieces the player has dropped without clearing a line or making a box.
 var combo_break := 0 setget set_combo_break
 
-# 'true' if the player drops a piece which continues the combo (typically, making a box or clearing a line)
+## 'true' if the player drops a piece which continues the combo (typically, making a box or clearing a line)
 var piece_continued_combo := false
 
-# 'true' if the player drops a piece which discontinues the combo.
-# Some levels might break your combo if you clear a vegetable line, for example.
+## 'true' if the player drops a piece which discontinues the combo.
+## Some levels might break your combo if you clear a vegetable line, for example.
 var piece_broke_combo := false
 
 func _ready() -> void:
@@ -101,9 +99,7 @@ func _on_PuzzleState_game_ended() -> void:
 	PuzzleState.end_combo()
 
 
-"""
-Increments the combo and score for the specified line clear.
-"""
+## Increments the combo and score for the specified line clear.
 func _on_Playfield_before_line_cleared(_y: int, _total_lines: int, _remaining_lines: int, box_ints: Array) -> void:
 	var combo_score: int = COMBO_SCORE_ARR[clamp(PuzzleState.combo, 0, COMBO_SCORE_ARR.size() - 1)]
 	var box_score := 0

--- a/project/src/main/puzzle/crumb-cluster.gd
+++ b/project/src/main/puzzle/crumb-cluster.gd
@@ -1,19 +1,17 @@
 class_name CrumbCluster
 extends Node2D
-"""
-A cluster of crumbs which appears when the customer eats.
-"""
+## A cluster of crumbs which appears when the customer eats.
 
-# The lifetime of the particles in seconds. The CrumbCluster also deletes itself after this duration.
+## The lifetime of the particles in seconds. The CrumbCluster also deletes itself after this duration.
 export (float) var lifetime := 1.0
 
-# An int corresponding to a FoodItem frame
+## An int corresponding to a FoodItem frame
 var food_type setget set_food_type
 
-# Timer which causes the CrumbCluster to free itself
+## Timer which causes the CrumbCluster to free itself
 onready var _timer := $Timer
 
-# This cluster is made up of multiple CPUParticles2D instances so that multiple colors can be shown.
+## This cluster is made up of multiple CPUParticles2D instances so that multiple colors can be shown.
 onready var _particles := [$Particles0, $Particles1, $Particles2]
 
 func _ready() -> void:
@@ -29,9 +27,7 @@ func set_food_type(new_food_type: int) -> void:
 	_refresh_food_type()
 
 
-"""
-Updates the crumb count and colors based on the food type.
-"""
+## Updates the crumb count and colors based on the food type.
 func _refresh_food_type() -> void:
 	if not is_inside_tree():
 		return
@@ -47,8 +43,6 @@ func _refresh_food_type() -> void:
 		particles.modulate = crumb_colors[i % crumb_colors.size()]
 
 
-"""
-Frees the CrumbCluster instance after the particles expire.
-"""
+## Frees the CrumbCluster instance after the particles expire.
 func _on_Timer_timeout() -> void:
 	queue_free()

--- a/project/src/main/puzzle/crumb-definitions.gd
+++ b/project/src/main/puzzle/crumb-definitions.gd
@@ -1,24 +1,20 @@
 extends Node
-"""
-Defines the color and density of crumbs when different foods are eaten.
-"""
+## Defines the color and density of crumbs when different foods are eaten.
 
-"""
-Defines the color and density of crumbs when a specific food is eaten.
-"""
+## Defines the color and density of crumbs when a specific food is eaten.
 class CrumbDefinition:
-	# The number of crumbs which appear when the food is eaten. Cakes produce more crumbs than snacks.
+	## The number of crumbs which appear when the food is eaten. Cakes produce more crumbs than snacks.
 	var max_crumb_count: int
 	
-	# Up to three colors of crumbs which appear when the food is eaten.
+	## Up to three colors of crumbs which appear when the food is eaten.
 	var crumb_colors: Array
 	
 	func _init(init_max_crumb_count: int, init_crumb_colors: Array):
 		max_crumb_count = init_max_crumb_count
 		crumb_colors = init_crumb_colors
 
-# key: an enum from Foods.FoodType defining the food being eaten
-# value: CrumbDefinition defining the color and density of crumbs
+## key: an enum from Foods.FoodType defining the food being eaten
+## value: CrumbDefinition defining the color and density of crumbs
 var crumb_definitions := {
 }
 
@@ -30,14 +26,12 @@ func _ready() -> void:
 		crumb_definitions[food_type] = CrumbDefinition.new(max_crumb_count, colors)
 
 
-"""
-Returns a crumb definition for the specified food type.
-
-Parameters:
-	'food_type': An enum from Foods.FoodType defining the food being eaten
-
-Returns:
-	A CrumbDefinition instance defining the color and density of crumbs when the specified food is eaten.
-"""
+## Returns a crumb definition for the specified food type.
+##
+## Parameters:
+## 	'food_type': An enum from Foods.FoodType defining the food being eaten
+##
+## Returns:
+## 	A CrumbDefinition instance defining the color and density of crumbs when the specified food is eaten.
 func get_definition(food_type: int) -> CrumbDefinition:
 	return crumb_definitions[food_type]

--- a/project/src/main/puzzle/customer-view.gd
+++ b/project/src/main/puzzle/customer-view.gd
@@ -1,7 +1,5 @@
 extends ViewportContainer
-"""
-Shows the active customer in the restaurant scene.
-"""
+## Shows the active customer in the restaurant scene.
 
 export (NodePath) var restaurant_viewport_path: NodePath
 

--- a/project/src/main/puzzle/duration-calculator.gd
+++ b/project/src/main/puzzle/duration-calculator.gd
@@ -1,16 +1,14 @@
 class_name DurationCalculator
-"""
-Estimates the duration of a puzzle.
+## Estimates the duration of a puzzle.
+##
+## This is shown to the user on the level select screen, and also affects the relative sizes of the level buttons.
 
-This is shown to the user on the level select screen, and also affects the relative sizes of the level buttons.
-"""
-
-# While rank 48 only requires a player to clear 3-4 lines per minute, it's unreasonable to predict that a level that
-# requiring 12 line clears will take 3-4 minutes. This constant stores the expected lines per minute for a novice
-# player.
+## While rank 48 only requires a player to clear 3-4 lines per minute, it's unreasonable to predict that a level that
+## requiring 12 line clears will take 3-4 minutes. This constant stores the expected lines per minute for a novice
+## player.
 const MIN_LINES_PER_MINUTE := 8.0
 
-# Estimated rank for each difficulty based on the various rank levels
+## Estimated rank for each difficulty based on the various rank levels
 const RANKS_BY_DIFFICULTY := {
 	# beginner; 10-30 blocks per minute
 	"T": 48.0,
@@ -29,12 +27,10 @@ const RANKS_BY_DIFFICULTY := {
 	"FD": 3.0, "FE": 2.5, "FF": 2.0, "FFF": 1.5,
 }
 
-"""
-Returns the estimated duration for the specified level.
-
-We calculate an approprate rank based on the level difficulty, and then estimate how long a player of that rank
-would take to achieve the clear condition.
-"""
+## Returns the estimated duration for the specified level.
+##
+## We calculate an approprate rank based on the level difficulty, and then estimate how long a player of that rank
+## would take to achieve the clear condition.
 func duration(settings: LevelSettings) -> float:
 	var result := 600.0
 	
@@ -61,9 +57,7 @@ func duration(settings: LevelSettings) -> float:
 	return result
 
 
-"""
-Returns the estimated time to clear the specified number of lines.
-"""
+## Returns the estimated time to clear the specified number of lines.
 func _duration_for_lines(settings: LevelSettings, lines: float) -> float:
 	var min_frames_per_line := RankCalculator.min_frames_per_line(PieceSpeeds.speed(settings.difficulty))
 	var min_lines_per_frame := 1 / min_frames_per_line
@@ -75,19 +69,15 @@ func _duration_for_lines(settings: LevelSettings, lines: float) -> float:
 	return 60 * lines / master_lines_per_minute
 
 
-"""
-Returns the rank the player is expected to perform at for the specified level.
-"""
+## Returns the rank the player is expected to perform at for the specified level.
 func _rank(settings: LevelSettings) -> float:
 	return RANKS_BY_DIFFICULTY[settings.get_difficulty()]
 
 
-"""
-Returns the estimated score per line for the specified level.
-
-We calculate an approprate rank based on the level difficulty, and then estimate how many bonus points a player of
-that rank would achieve from combos and boxes.
-"""
+## Returns the estimated score per line for the specified level.
+##
+## We calculate an approprate rank based on the level difficulty, and then estimate how many bonus points a player of
+## that rank would achieve from combos and boxes.
 func _score_per_line(settings: LevelSettings) -> float:
 	var combo_score_per_line := RankCalculator.master_combo_score(settings)
 	combo_score_per_line *= pow(RankCalculator.RDF_COMBO_SCORE_PER_LINE, _rank(settings))

--- a/project/src/main/puzzle/food-crumbs.gd
+++ b/project/src/main/puzzle/food-crumbs.gd
@@ -1,20 +1,18 @@
 extends Node2D
-"""
-Spawns food crumbs near the customer's mouth when they eat.
-"""
+## Spawns food crumbs near the customer's mouth when they eat.
 
 export (NodePath) var restaurant_view_path: NodePath
 
-# A cluster of crumbs which appears when the customer eats.
+## A cluster of crumbs which appears when the customer eats.
 export (PackedScene) var CrumbClusterScene: PackedScene
 
 onready var _restaurant_view: RestaurantView = get_node(restaurant_view_path)
 
-# Crumb clusters are pooled for performance reasons. Spawning the first crumb cluster sometimes causes a performance
-# hiccup, and it's better for this to happen on load rather than during gameplay.
+## Crumb clusters are pooled for performance reasons. Spawning the first crumb cluster sometimes causes a performance
+## hiccup, and it's better for this to happen on load rather than during gameplay.
 var _crumb_cluster_pool := []
 
-# Called when the node enters the scene tree for the first time.
+## Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	for customer_obj in _restaurant_view.get_customers():
 		var customer: Creature = customer_obj
@@ -32,9 +30,7 @@ func _exit_tree() -> void:
 		crumb_cluster.free()
 
 
-"""
-When the customer eats, we spawn crumbs near their mouth.
-"""
+## When the customer eats, we spawn crumbs near their mouth.
 func _on_Creature_food_eaten(food_type: int, customer: Creature) -> void:
 	var target_pos := _restaurant_view.get_customer_mouth_position(customer)
 	# calculate the position within the global viewport

--- a/project/src/main/puzzle/food-item.gd
+++ b/project/src/main/puzzle/food-item.gd
@@ -1,60 +1,58 @@
 tool
 class_name FoodItem
 extends PackedSprite
-"""
-A food item which appears when the player clears a box in puzzle mode.
-"""
+## A food item which appears when the player clears a box in puzzle mode.
 
 # warning-ignore:unused_signal
-# Emitted when the food item has floated for long enough and fly_to_target can be called. Emitted by food-items.gd
+## Emitted when the food item has floated for long enough and fly_to_target can be called. Emitted by food-items.gd
 signal ready_to_fly
 
-# Scale/rotation modifiers applied by our animation
+## Scale/rotation modifiers applied by our animation
 export (Vector2) var scale_modifier := Vector2(1.0, 1.0)
 export (float) var rotation_modifier := 0.0
 
-# The unmodified scale/rotation before pulsing/spinning
+## The unmodified scale/rotation before pulsing/spinning
 var base_scale := Vector2(1.0, 1.0) setget set_base_scale
 var base_rotation := 0.0 setget set_base_rotation
 
-# The velocity applied to the food when in the 'floating' state
+## The velocity applied to the food when in the 'floating' state
 var velocity := Vector2(0, -25)
 
-# The creature who this food will fly towards
+## The creature who this food will fly towards
 var customer: Creature
 
-# Incremented as the customer changes to track the intended recipient of each food item.
+## Incremented as the customer changes to track the intended recipient of each food item.
 var customer_index: int
 
-# An enum from FoodType corresponding to the food to show
+## An enum from FoodType corresponding to the food to show
 var food_type: int setget set_food_type
 
-# Food items pulse and rotate. This field is used to calculate the pulse/rotation amount
+## Food items pulse and rotate. This field is used to calculate the pulse/rotation amount
 var _total_time := 0.0
 
-# Tweens the food's position to fly into the customer's mouth.
+## Tweens the food's position to fly into the customer's mouth.
 var _flying_tween: Tween
 
-# This func ref and array correspond to a callback which return the position of the customer's mouth.
+## This func ref and array correspond to a callback which return the position of the customer's mouth.
 var _get_target_pos: FuncRef
 var _target_pos_arg_array: Array
 
-# The position the food is flying from
+## The position the food is flying from
 var _source_pos: Vector2
 
-# The position the food is flying toward
+## The position the food is flying toward
 var _target_pos: Vector2
 
-# A number in the range [0.0, 1.0] corresponding to where the food is positioned between its source and target
+## A number in the range [0.0, 1.0] corresponding to where the food is positioned between its source and target
 var _flight_percent := 0.0
 
-# 'true' of the food item has been collected and should slowly float upward
+## 'true' of the food item has been collected and should slowly float upward
 var _floating_upward := false
 
-# How far the sprite should rotate; 1.0 = one full circle forward and backward
+## How far the sprite should rotate; 1.0 = one full circle forward and backward
 onready var _spin_amount := 0.08 * rand_range(0.8, 1.2)
 
-# How many seconds the sprite should take to rotate back and forth once
+## How many seconds the sprite should take to rotate back and forth once
 onready var _spin_period := 2.50 * rand_range(0.8, 1.2)
 
 func _ready() -> void:
@@ -92,10 +90,7 @@ func _physics_process(delta: float) -> void:
 	_refresh_scale()
 	_refresh_rotation()
 
-
-"""
-Makes the food jiggle briefly.
-"""
+## Makes the food jiggle briefly.
 func jiggle() -> void:
 	# restart the jiggle animation if the item was already jiggling
 	$AnimationPlayer.stop()
@@ -103,11 +98,9 @@ func jiggle() -> void:
 	$AnimationPlayer.play("jiggle", -1, rand_range(0.5, 1.5))
 
 
-"""
-Launches the 'food was collected' animation.
-
-This makes the food jiggle and float upward.
-"""
+## Launches the 'food was collected' animation.
+##
+## This makes the food jiggle and float upward.
 func collect() -> void:
 	_floating_upward = true
 	jiggle()
@@ -128,17 +121,15 @@ func set_base_rotation(new_base_rotation: float) -> void:
 	_refresh_rotation()
 
 
-"""
-Makes the food item start flying towards the customer's mouth.
-
-The object, method and arg_array parameters correspond to a callback which returns the position of the customer's
-mouth. The callback function can also return Vector2.INF if the customer is no longer present.
-
-Parameters:
-	'new_get_target_pos': The callback function which returns the position of the customer's mouth.
-	
-	'target_pos_arg_array': The parameters of the callback function which returns the position of the customer's mouth.
-"""
+## Makes the food item start flying towards the customer's mouth.
+##
+## The object, method and arg_array parameters correspond to a callback which returns the position of the customer's
+## mouth. The callback function can also return Vector2.INF if the customer is no longer present.
+##
+## Parameters:
+## 	'new_get_target_pos': The callback function which returns the position of the customer's mouth.
+##
+## 	'target_pos_arg_array': The parameters of the callback function which returns the position of the customer's mouth.
 func fly_to_target(new_get_target_pos: FuncRef, target_pos_arg_array: Array,
 			duration: float) -> void:
 	_get_target_pos = new_get_target_pos

--- a/project/src/main/puzzle/food-items.gd
+++ b/project/src/main/puzzle/food-items.gd
@@ -1,52 +1,50 @@
 extends Node2D
-"""
-Food items which appear when the player clears boxes in puzzle mode.
-"""
+## Food items which appear when the player clears boxes in puzzle mode.
 
 export (NodePath) var puzzle_path: NodePath
 export (NodePath) var restaurant_view_path: NodePath
 export (PackedScene) var FoodScene: PackedScene
 
-# Array of floats corresponding to how fat the creature should become after eating each upcoming food item.
+## Array of floats corresponding to how fat the creature should become after eating each upcoming food item.
 var _pending_food_fatness := []
 
-# Increments as the customer changes to track the intended recipient of each food item.
+## Increments as the customer changes to track the intended recipient of each food item.
 var _customer_index := 0
 
-# Queue of FoodItem objects which have floated awhile, and can now fly into a customer's mouth.
+## Queue of FoodItem objects which have floated awhile, and can now fly into a customer's mouth.
 var _food_waiting_to_fly := []
 
 var _window_width: float = ProjectSettings.get_setting("display/window/size/width")
 
-# Minimum duration in seconds that food should float before flying into a customer's mouth.
+## Minimum duration in seconds that food should float before flying into a customer's mouth.
 var _food_float_duration := 1.0
 
-# Duration in seconds that food should fly into a customer's mouth.
+## Duration in seconds that food should fly into a customer's mouth.
 var _food_flight_duration := 1.0
 
-# Maximum time in seconds between eaten food
+## Maximum time in seconds between eaten food
 var _max_food_repeat_delay := 1.0
 
-# Caches the coordinate of the customer's mouth relative to the FoodItems viewport
+## Caches the coordinate of the customer's mouth relative to the FoodItems viewport
 var _target_pos_cache := {}
 
 onready var _puzzle: Puzzle = get_node(puzzle_path)
 onready var _puzzle_tile_map: PuzzleTileMap = _puzzle.get_playfield().tile_map
 
-# relative position of the PuzzleTileMap, used for positioning food
+## relative position of the PuzzleTileMap, used for positioning food
 onready var _puzzle_tile_map_position: Vector2 = _puzzle_tile_map.get_global_transform().origin \
 		- get_global_transform().origin
 
 onready var _restaurant_view: RestaurantView = get_node(restaurant_view_path)
 
-# Food items are rendered in a Viewport and TextureRect so that they can use an outline shader.
+## Food items are rendered in a Viewport and TextureRect so that they can use an outline shader.
 onready var _viewport := $Viewport
 onready var _texture_rect := $TextureRect
 
-# Timer which causes food items to be repeatedly launched.
+## Timer which causes food items to be repeatedly launched.
 onready var _food_flight_timer := $FoodFlightTimer
 
-# Timer which starts decrementing after a customer change.
+## Timer which starts decrementing after a customer change.
 onready var _customer_change_timer := $CustomerChangeTimer
 
 func _ready() -> void:
@@ -59,9 +57,7 @@ func _physics_process(_delta: float) -> void:
 		_target_pos_cache.clear()
 
 
-"""
-Adds a food item in the specified cell.
-"""
+## Adds a food item in the specified cell.
 func add_food_item(cell: Vector2, food_type: int, remaining_food: int = 0) -> void:
 	# calculate and store 'food fatness' for customer; how fat the customer will be after eating each item
 	var customer := _puzzle.get_customer()
@@ -89,13 +85,11 @@ func add_food_item(cell: Vector2, food_type: int, remaining_food: int = 0) -> vo
 	get_tree().create_timer(_food_float_duration).connect("timeout", self, "_on_FoodItem_float_done", [food_item])
 
 
-"""
-Callback function which returns the coordinate of the customer's mouth relative to the FoodItems viewport.
-
-Returns Vector2.INF if the customer is replaced, and food should no longer fly towards their mouth.
-
-This is an expensive calculation which is needed once per frame per food item, so we employ a cache.
-"""
+## Callback function which returns the coordinate of the customer's mouth relative to the FoodItems viewport.
+##
+## Returns Vector2.INF if the customer is replaced, and food should no longer fly towards their mouth.
+##
+## This is an expensive calculation which is needed once per frame per food item, so we employ a cache.
 func get_target_pos(target_customer: Creature, target_customer_index: int) -> Vector2:
 	if not _target_pos_cache.has(target_customer):
 		var target_pos: Vector2 = _restaurant_view.get_customer_mouth_position(target_customer)
@@ -125,11 +119,9 @@ func get_target_pos(target_customer: Creature, target_customer_index: int) -> Ve
 	return _target_pos_cache[target_customer]
 
 
-"""
-Recalculates the food speed fields based on the speed of the current level.
-
-Faster levels cause the foods to fly around faster.
-"""
+## Recalculates the food speed fields based on the speed of the current level.
+##
+## Faster levels cause the foods to fly around faster.
 func _update_food_speed() -> void:
 	# calculate the 'speed factor': a number from 0.0 to 1.0 corresponding to
 	# how quickly the player can drop pieces
@@ -177,10 +169,8 @@ func _on_Playfield_food_spawned(cell, remaining_food, food_type) -> void:
 	add_food_item(cell, food_type, remaining_food)
 
 
-"""
-When the FoodFlightTimer times out, we check the queue for the next food item which should fly into the customer's
-mouth.
-"""
+## When the FoodFlightTimer times out, we check the queue for the next food item which should fly into the customer's
+## mouth.
 func _on_FoodFlightTimer_timeout() -> void:
 	if not _food_waiting_to_fly:
 		return
@@ -190,10 +180,8 @@ func _on_FoodFlightTimer_timeout() -> void:
 	food_item.emit_signal("ready_to_fly")
 
 
-"""
-We track when the customer changes to ensure food goes to the proper place, and that it doesn't get eaten by the wrong
-customer.
-"""
+## We track when the customer changes to ensure food goes to the proper place, and that it doesn't get eaten by the
+## wrong customer.
 func _on_RestaurantView_customer_changed() -> void:
 	_customer_change_timer.start()
 	# increment the customer index; wrap it to avoid an overflow error

--- a/project/src/main/puzzle/foods.gd
+++ b/project/src/main/puzzle/foods.gd
@@ -1,11 +1,7 @@
 class_name Foods
-"""
-Enums, constants and utilities for the food which gets fed to the customers.
-"""
+## Enums, constants and utilities for the food which gets fed to the customers.
 
-"""
-Different box varieties. Boxes have different graphics based on their ingredients.
-"""
+## Different box varieties. Boxes have different graphics based on their ingredients.
 enum BoxType {
 	BROWN,
 	PINK,
@@ -21,11 +17,9 @@ enum BoxType {
 	CAKE_QUV,
 }
 
-"""
-Different food varieties.
-
-There are more food types than box types, because snack boxes of one color produce two different foods.
-"""
+## Different food varieties.
+##
+## There are more food types than box types, because snack boxes of one color produce two different foods.
 enum FoodType {
 	BROWN_0,
 	BROWN_1,
@@ -45,9 +39,7 @@ enum FoodType {
 	CAKE_QUV,
 }
 
-"""
-Food colors for the food which gets hurled into the creature's mouth.
-"""
+## Food colors for the food which gets hurled into the creature's mouth.
 const COLOR_VEGETABLE := Color("335320")
 const COLOR_BROWN := Color("a4470b")
 const COLOR_PINK := Color("ff5d68")
@@ -55,8 +47,8 @@ const COLOR_BREAD := Color("ffa357")
 const COLOR_WHITE := Color("fff6eb")
 const COLORS_ALL := [COLOR_BROWN, COLOR_PINK, COLOR_BREAD, COLOR_WHITE ]
 
-# key: an enum from FoodType
-# value: an enum from BoxType for the corresponding box
+## key: an enum from FoodType
+## value: an enum from BoxType for the corresponding box
 const BOX_TYPE_BY_FOOD_TYPE := {
 	FoodType.BROWN_0: BoxType.BROWN,
 	FoodType.BROWN_1: BoxType.BROWN,
@@ -95,8 +87,8 @@ const COLORS_BY_FOOD_TYPE := {
 	FoodType.CAKE_QUV: [COLOR_BROWN, COLOR_BREAD, COLOR_WHITE],
 }
 
-# key: an enum from BoxType
-# value: array of enums from FoodType for the corresponding food items
+## key: an enum from BoxType
+## value: array of enums from FoodType for the corresponding food items
 const FOOD_TYPES_BY_BOX_TYPES := {
 	BoxType.BROWN: [FoodType.BROWN_0, FoodType.BROWN_1],
 	BoxType.PINK: [FoodType.PINK_0, FoodType.PINK_1],
@@ -112,37 +104,29 @@ const FOOD_TYPES_BY_BOX_TYPES := {
 	BoxType.CAKE_QUV: [FoodType.CAKE_QUV],
 }
 
-"""
-Returns 'true' if the specified box type corresponds to a snack box.
-
-There are four snack box colors; brown, pink, bread and white.
-"""
+## Returns 'true' if the specified box type corresponds to a snack box.
+##
+## There are four snack box colors; brown, pink, bread and white.
 static func is_snack_box(box_type: int) -> bool:
 	return box_type <= BoxType.WHITE
 
 
-"""
-Returns 'true' if the specified box type corresponds to a cake box.
-
-There are eight cake box colors; one for each combination of three pieces which forms a rectangle.
-"""
+## Returns 'true' if the specified box type corresponds to a cake box.
+##
+## There are eight cake box colors; one for each combination of three pieces which forms a rectangle.
 static func is_cake_box(box_type: int) -> bool:
 	return box_type >= BoxType.CAKE_JJO
 
 
-"""
-Returns 'true' if the specified food type corresponds to a snack food.
-
-There are eight snack food types; two each of brown, pink, bread and white.
-"""
+## Returns 'true' if the specified food type corresponds to a snack food.
+##
+## There are eight snack food types; two each of brown, pink, bread and white.
 static func is_snack_food(food_type: int) -> bool:
 	return food_type <= FoodType.WHITE
 
 
-"""
-Returns 'true' if the specified food type corresponds to a cake food.
-
-There are eight cake box colors; one for each combination of three pieces which forms a rectangle.
-"""
+## Returns 'true' if the specified food type corresponds to a cake food.
+##
+## There are eight cake box colors; one for each combination of three pieces which forms a rectangle.
 static func is_cake_food(food_type: int) -> bool:
 	return food_type >= FoodType.CAKE_JJO

--- a/project/src/main/puzzle/frame-drops-label.gd
+++ b/project/src/main/puzzle/frame-drops-label.gd
@@ -1,29 +1,27 @@
 extends Label
-"""
-Renders to screen debug information about dropped frames or dropped physics steps.
+## Renders to screen debug information about dropped frames or dropped physics steps.
+##
+## A 'dropped frame' occurs when the _process() function isn't called 60 times per second. This coincides with a visual
+## hiccup in the game where the graphics don't update for a few frames.
+##
+## A 'dropped physics step' occurs when the _physics_process() function isn't called 60 times per second. This
+## coincides in a gameplay hiccup where the game ignores the player's input for a few frames.
 
-A 'dropped frame' occurs when the _process() function isn't called 60 times per second. This coincides with a visual
-hiccup in the game where the graphics don't update for a few frames.
-
-A 'dropped physics step' occurs when the _physics_process() function isn't called 60 times per second. This coincides
-in a gameplay hiccup where the game ignores the player's input for a few frames.
-"""
-
-# expected seconds per frame; 0.01667 if physics_fps is set to 60 FPS
+## expected seconds per frame; 0.01667 if physics_fps is set to 60 FPS
 var _seconds_per_frame: float
 
-# expected system clock for the previous _physics_process() call
+## expected system clock for the previous _physics_process() call
 var _expected_physics_msec := 0.0
-# actual system clock for the previous _physics_process() call
+## actual system clock for the previous _physics_process() call
 var _actual_physics_msec := 0.0
-# increments when the system clock falls behind the expected value
+## increments when the system clock falls behind the expected value
 var _physics_step_drops := 0
 
-# expected system clock for the previous _process() call
+## expected system clock for the previous _process() call
 var _expected_visual_msec := 0.0
-# actual system clock for the previous _process() call
+## actual system clock for the previous _process() call
 var _actual_visual_msec := 0.0
-# increments when the system clock falls behind the expected value
+## increments when the system clock falls behind the expected value
 var _visual_frame_drops := 0
 
 func _ready() -> void:

--- a/project/src/main/puzzle/frosting-glob.gd
+++ b/project/src/main/puzzle/frosting-glob.gd
@@ -1,61 +1,57 @@
 class_name FrostingGlob
 extends Sprite
-"""
-A frosting glob which appears when the player clears a line or builds a box.
-"""
+## A frosting glob which appears when the player clears a line or builds a box.
 
-# emitted when the glob collides with one of the four outer walls
+## emitted when the glob collides with one of the four outer walls
 signal hit_wall(glob)
 
-# emitted when the glob smears against the playfield area behind the blocks
+## emitted when the glob smears against the playfield area behind the blocks
 signal hit_playfield(glob)
 
-# emitted when the glob smears against the next piece area
+## emitted when the glob smears against the next piece area
 signal hit_next_pieces(glob)
 
 const MAX_INITIAL_VELOCITY := Vector2(600, -500)
 const GRAVITY := 2400
 
-# how long globs are visible while falling
+## how long globs are visible while falling
 const FALL_DURATION := 0.6
 
-# how long it takes for globs to start fading after stuck to walls
+## how long it takes for globs to start fading after stuck to walls
 const FADE_DELAY := 4.5
 
-# how long it takes globs fade completely after stuck to walls
+## how long it takes globs fade completely after stuck to walls
 const FADE_DURATION := 1.5
 
-# the duration when a glob should be recycled, even if it's somehow still visible
+## the duration when a glob should be recycled, even if it's somehow still visible
 const MAX_AGE := 7.0
 
 var puzzle_areas: PuzzleAreas
 
-# the PuzzleTileMap food color index for this glob (brown, pink, bread, white, cake)
+## the PuzzleTileMap food color index for this glob (brown, pink, bread, white, cake)
 var box_type := -1
 
-# remaining time in seconds before this glob will smear against the background
+## remaining time in seconds before this glob will smear against the background
 var smear_time := 0.0
 
-# true if this glob is being affected by gravity
+## true if this glob is being affected by gravity
 var falling := false
 
 var velocity := Vector2.ZERO
 
-# time in milliseconds between the engine starting and this node being initialized
+## time in milliseconds between the engine starting and this node being initialized
 var _creation_time := 0.0
 
 onready var _tween: Tween = $Tween
 onready var _fade_timer: Timer = $FadeTimer
 
-"""
-Populates this object from another FrostingGlob instance.
-
-Note: While the 'glob' parameter should always be a FrostingGlob object, statically typing it as such causes errors at
-game close due to Godot #30668 (https://github.com/godotengine/godot/issues/30668)
-
-Parameters:
-	'glob': The FrostingGlob instance to copy from.
-"""
+## Populates this object from another FrostingGlob instance.
+##
+## Note: While the 'glob' parameter should always be a FrostingGlob object, statically typing it as such causes errors
+## at game close due to Godot #30668 (https://github.com/godotengine/godot/issues/30668)
+##
+## Parameters:
+## 	'glob': The FrostingGlob instance to copy from.
 func copy_from(glob: Node) -> void:
 	initialize(glob.box_type, glob.position)
 	puzzle_areas = glob.puzzle_areas
@@ -65,9 +61,7 @@ func copy_from(glob: Node) -> void:
 	modulate = glob.modulate
 
 
-"""
-Returns the time in seconds since this glob was initialized.
-"""
+## Returns the time in seconds since this glob was initialized.
 func get_age() -> float:
 	return (OS.get_ticks_msec() - _creation_time) / 1000
 
@@ -76,9 +70,7 @@ func is_rainbow() -> bool:
 	return Foods.is_cake_box(box_type)
 
 
-"""
-Resets this frosting glob's state, including its color and position.
-"""
+## Resets this frosting glob's state, including its color and position.
 func initialize(new_box_type: int, new_position: Vector2) -> void:
 	_creation_time = OS.get_ticks_msec()
 	box_type = new_box_type
@@ -108,11 +100,9 @@ func initialize(new_box_type: int, new_position: Vector2) -> void:
 		scale *= Vector2(1.0, -1.0)
 
 
-"""
-Makes this frosting glob fall and disappear.
-
-Called when a frosting glob is first spawned.
-"""
+## Makes this frosting glob fall and disappear.
+##
+## Called when a frosting glob is first spawned.
 func fall() -> void:
 	falling = true
 	smear_time = min(rand_range(0.0, FALL_DURATION * 0.7), rand_range(0.0, FALL_DURATION * 1.2))
@@ -123,11 +113,9 @@ func fall() -> void:
 	_tween.start()
 
 
-"""
-Makes this frosting glob fade away and disappear.
-
-Called when a frosting glob hits a wall or smears against the background.
-"""
+## Makes this frosting glob fade away and disappear.
+##
+## Called when a frosting glob hits a wall or smears against the background.
 func fade() -> void:
 	falling = false
 	_fade_timer.start(FADE_DELAY * rand_range(0.8, 1.2))
@@ -138,9 +126,7 @@ func fade() -> void:
 			FADE_DURATION * rand_range(0.8, 1.2), Tween.TRANS_LINEAR, Tween.EASE_IN)
 
 
-"""
-Applies gravity and checks for collisions.
-"""
+## Applies gravity and checks for collisions.
 func _process(delta: float) -> void:
 	if not falling:
 		return

--- a/project/src/main/puzzle/frosting-globs.gd
+++ b/project/src/main/puzzle/frosting-globs.gd
@@ -1,14 +1,12 @@
 extends Node2D
-"""
-Creates frosting globs on the playfield when the player does well.
+## Creates frosting globs on the playfield when the player does well.
+##
+## These frosting globs are initialized to a specific color and position and launched in a random direction.
 
-These frosting globs are initialized to a specific color and position and launched in a random direction.
-"""
-
-# emitted when a frosting glob hits a wall
+## emitted when a frosting glob hits a wall
 signal hit_wall(glob)
 
-# emitted when a frosting glob smears against the playfield or next piece area
+## emitted when a frosting glob smears against the playfield or next piece area
 signal hit_playfield(glob)
 signal hit_next_pieces(glob)
 
@@ -20,7 +18,7 @@ export (PackedScene) var FrostingGlobScene: PackedScene
 onready var _puzzle_tile_map: PuzzleTileMap = get_node(puzzle_tile_map_path)
 onready var _puzzle_areas: PuzzleAreas
 
-# relative position of the PuzzleTileMap, used for positioning frosting
+## relative position of the PuzzleTileMap, used for positioning frosting
 onready var _puzzle_tile_map_position: Vector2 = _puzzle_tile_map.get_global_transform().origin \
 		- get_global_transform().origin
 
@@ -31,15 +29,13 @@ func _ready() -> void:
 	_puzzle_areas.walled_area = _puzzle_areas.playfield_area.merge(_puzzle_areas.next_pieces_area)
 
 
-"""
-Launches new frosting globs from the specified tile.
-
-Parameters:
-	'cell_pos': An (x, y) position in the TileMap containing the playfield blocks
-	'box_type': An enum from Foods.BoxType defining the glob's color
-	'glob_count': The number of frosting globs to launch
-	'glob_alpha': The initial alpha component of the globs. Affects their size and duration
-"""
+## Launches new frosting globs from the specified tile.
+##
+## Parameters:
+## 	'cell_pos': An (x, y) position in the TileMap containing the playfield blocks
+## 	'box_type': An enum from Foods.BoxType defining the glob's color
+## 	'glob_count': The number of frosting globs to launch
+## 	'glob_alpha': The initial alpha component of the globs. Affects their size and duration
 func _spawn_globs(cell_pos: Vector2, box_type: int, glob_count: int, glob_alpha: float = 1.0) -> void:
 	var viewport: Viewport
 	if Foods.is_cake_box(box_type):
@@ -65,11 +61,9 @@ func _instance_glob(new_parent: Node = null) -> FrostingGlob:
 	return glob
 
 
-"""
-When a line is cleared, we generate frosting globs for any boxes involved in the line clear.
-
-This must be called before the line is cleared so that we can evaluate the food blocks before they're erased.
-"""
+## When a line is cleared, we generate frosting globs for any boxes involved in the line clear.
+##
+## This must be called before the line is cleared so that we can evaluate the food blocks before they're erased.
 func _on_Playfield_before_line_cleared(y: int, _total_lines: int, _remaining_lines: int, _box_ints: Array) -> void:
 	for x in range(PuzzleTileMap.COL_COUNT):
 		var box_type: int
@@ -83,9 +77,7 @@ func _on_Playfield_before_line_cleared(y: int, _total_lines: int, _remaining_lin
 		_spawn_globs(Vector2(x, y), box_type, glob_count)
 
 
-"""
-When a box is built, we generate frosting globs on the inside of the box.
-"""
+## When a box is built, we generate frosting globs on the inside of the box.
 func _on_Playfield_box_built(rect: Rect2, box_type: int) -> void:
 	for y in range(rect.position.y, rect.end.y):
 		for x in range(rect.position.x, rect.end.x):
@@ -97,9 +89,7 @@ func _on_Playfield_box_built(rect: Rect2, box_type: int) -> void:
 			_spawn_globs(Vector2(x, y), box_type, glob_count)
 
 
-"""
-When a squish move is performed, we generate frosting globs around the old and new piece position.
-"""
+## When a squish move is performed, we generate frosting globs around the old and new piece position.
 func _on_PieceManager_squish_moved(piece: ActivePiece, old_pos: Vector2) -> void:
 	if CurrentLevel.settings.other.tile_set == PuzzleTileMap.TileSetType.VEGGIE:
 		# veggie pieces don't spawn frosting

--- a/project/src/main/puzzle/frosting-viewports.gd
+++ b/project/src/main/puzzle/frosting-viewports.gd
@@ -1,13 +1,11 @@
 class_name FrostingViewports
 extends Control
-"""
-Maintains viewports for drawing smeared snack/cake frosting globs.
-"""
+## Maintains viewports for drawing smeared snack/cake frosting globs.
 
-# the minimum smear size for globs which are smeared slowly.
+## the minimum smear size for globs which are smeared slowly.
 export (float) var glob_min_scale := 1.0
 
-# the maximum smear size for globs which are smeared quickly.
+## the maximum smear size for globs which are smeared quickly.
 export (float) var glob_max_scale := 1.0
 
 export (PackedScene) var FrostingGlobScene: PackedScene
@@ -17,11 +15,9 @@ func _ready() -> void:
 	$RainbowViewport.size = rect_size
 
 
-"""
-Adds a frosting smear.
-
-The glob is added to the appropriate viewport and stretched in the direction of its movement.
-"""
+## Adds a frosting smear.
+##
+## The glob is added to the appropriate viewport and stretched in the direction of its movement.
 func add_smear(glob: FrostingGlob) -> void:
 	var new_glob: FrostingGlob = FrostingGlobScene.instance()
 	new_glob.copy_from(glob)

--- a/project/src/main/puzzle/input-replay.gd
+++ b/project/src/main/puzzle/input-replay.gd
@@ -1,38 +1,30 @@
 class_name InputReplay
-"""
-Stores a sequence of puzzle inputs to be replayed for things such as tutorials.
-"""
+## Stores a sequence of puzzle inputs to be replayed for things such as tutorials.
 
-# set of actions which are currently in the 'pressed' state
-# key: action name
-# value: true
+## set of actions which are currently in the 'pressed' state
+## key: action name
+## value: true
 var _pressed_actions: Dictionary
 
-# set of frames when different actions are pressed/released
-# key: action key containing the frame number and action, '46 +ui_right'
-# value: true
+## set of frames when different actions are pressed/released
+## key: action key containing the frame number and action, '46 +ui_right'
+## value: true
 var action_timings: Dictionary
 
-"""
-Returns true if there is no replay data.
-"""
+## Returns true if there is no replay data.
 func empty() -> bool:
 	return action_timings.empty()
 
 
-"""
-Clears the replay data, removing all action timings.
-"""
+## Clears the replay data, removing all action timings.
 func clear() -> void:
 	_pressed_actions.clear()
 	action_timings.clear()
 
 
-"""
-Returns 'true' if the replay data specifies that the action was pressed on the current input frame.
-
-This only true for the exact frame when the press is first triggered.
-"""
+## Returns 'true' if the replay data specifies that the action was pressed on the current input frame.
+##
+## This only true for the exact frame when the press is first triggered.
 func is_action_pressed(action: String) -> bool:
 	var action_frame_key := "%s +%s" % [PuzzleState.input_frame, action]
 	var pressed := action_timings.has(action_frame_key)
@@ -41,11 +33,9 @@ func is_action_pressed(action: String) -> bool:
 	return pressed
 
 
-"""
-Returns 'true' if the replay data specifies that the action was released on the current input frame.
-
-This only true for the exact frame when the release is first triggered.
-"""
+## Returns 'true' if the replay data specifies that the action was released on the current input frame.
+##
+## This only true for the exact frame when the release is first triggered.
 func is_action_released(action: String) -> bool:
 	var action_frame_key := "%s -%s" % [PuzzleState.input_frame, action]
 	var released := action_timings.has(action_frame_key)
@@ -54,13 +44,11 @@ func is_action_released(action: String) -> bool:
 	return released
 
 
-"""
-Returns 'true' if the replay data specifies that the action was held down on the current input frame.
-
-This returns true once the action is pressed, and returns false once the action is released. It assumes the pressed
-and released functions are being called sequentially on every frame; it does not traverse the input history to find
-the previous press/release event.
-"""
+## Returns 'true' if the replay data specifies that the action was held down on the current input frame.
+##
+## This returns true once the action is pressed, and returns false once the action is released. It assumes the pressed
+## and released functions are being called sequentially on every frame; it does not traverse the input history to find
+## the previous press/release event.
 func is_action_held(action: String) -> bool:
 	return _pressed_actions.get(action, false)
 
@@ -74,10 +62,8 @@ func to_json_array() -> Array:
 	return action_timings.keys()
 
 
-"""
-Returns 'true' if the input replay is empty. Empty replays are omitted from our json output.
-
-Note: This method is called 'is_default' for consistency with other similar methods related to LevelSettings.
-"""
+## Returns 'true' if the input replay is empty. Empty replays are omitted from our json output.
+##
+## Note: This method is called 'is_default' for consistency with other similar methods related to LevelSettings.
 func is_default() -> bool:
 	return action_timings.empty()

--- a/project/src/main/puzzle/leaf-poof.gd
+++ b/project/src/main/puzzle/leaf-poof.gd
@@ -1,22 +1,20 @@
 class_name LeafPoof
 extends Sprite
-"""
-A leaf poof spawned when the player clears a row containing vegetables.
-"""
+## A leaf poof spawned when the player clears a row containing vegetables.
 
-# the duration the leaf poof remains visible.
+## the duration the leaf poof remains visible.
 const LIFETIME := 1.5
 
-# leaf animations alternate between two frames; leaf_frame is always 0 or 1
+## leaf animations alternate between two frames; leaf_frame is always 0 or 1
 var leaf_frame: int setget set_leaf_frame
 
-# leaf_type controls which pair of frames are selected from the sprite sheet
+## leaf_type controls which pair of frames are selected from the sprite sheet
 var leaf_type: int
 
-# turns the leaf invisible
+## turns the leaf invisible
 onready var _tween: Tween = $Tween
 
-# animates and flips the leaf
+## animates and flips the leaf
 onready var _animation_player: AnimationPlayer = $AnimationPlayer
 
 func _ready() -> void:
@@ -26,11 +24,9 @@ func _ready() -> void:
 	_update_tween_and_animation()
 
 
-"""
-Makes the leaf poof visible and enables its physics processing.
-
-The leaf poof appears at the specified location, falls and sways back and forth, fades out and disables itself.
-"""
+## Makes the leaf poof visible and enables its physics processing.
+##
+## The leaf poof appears at the specified location, falls and sways back and forth, fades out and disables itself.
 func initialize(init_leaf_type: int, init_position: Vector2) -> void:
 	visible = true
 	modulate = Color.white

--- a/project/src/main/puzzle/leaf-poofs.gd
+++ b/project/src/main/puzzle/leaf-poofs.gd
@@ -1,10 +1,8 @@
 extends Node2D
-"""
-Spawns leaf poofs when the player clears a row containing vegetables.
-
-Any occupied cell which isn't used in a box risks spawning a leaf poof. The more unused cells there are, the greater
-the chance of a poof.
-"""
+## Spawns leaf poofs when the player clears a row containing vegetables.
+##
+## Any occupied cell which isn't used in a box risks spawning a leaf poof. The more unused cells there are, the greater
+## the chance of a poof.
 
 export (PackedScene) var LeafPoofScene: PackedScene
 
@@ -12,9 +10,7 @@ export (NodePath) var puzzle_tile_map_path: NodePath
 
 onready var _puzzle_tile_map: PuzzleTileMap = get_node(puzzle_tile_map_path)
 
-"""
-Spawns a single leaf poof near the specified cell.
-"""
+## Spawns a single leaf poof near the specified cell.
 func _spawn_poof(type: int, cell_x: int, cell_y: int) -> void:
 	# poof can appear half-way into horizontally adjacent cells, or in the cell above this one
 	var cell_offset := Vector2(rand_range(-0.5, 1.5), rand_range(-1.0, 1.0))
@@ -24,9 +20,7 @@ func _spawn_poof(type: int, cell_x: int, cell_y: int) -> void:
 	poof.initialize(type, poof_position)
 
 
-"""
-Spawns multiple leaf poofs near vegetable cells in the specified row.
-"""
+## Spawns multiple leaf poofs near vegetable cells in the specified row.
 func _spawn_poofs(y: int, veg_columns: Array, poof_count: int) -> void:
 	if poof_count <= 0:
 		return
@@ -59,9 +53,7 @@ func _poof_count(veg_cell_count: int) -> int:
 	return poof_count
 
 
-"""
-If the specified row includes enough vegetable cells, we spawn leaf poofs nearby.
-"""
+## If the specified row includes enough vegetable cells, we spawn leaf poofs nearby.
 func _on_Playfield_before_line_cleared(y: int, _total_lines: int, _remaining_lines: int, _box_ints: Array) -> void:
 	var veg_columns := []
 	for x in range(PuzzleTileMap.COL_COUNT):

--- a/project/src/main/puzzle/level-timer-manager.gd
+++ b/project/src/main/puzzle/level-timer-manager.gd
@@ -1,16 +1,14 @@
 extends Node
-"""
-Starts and stops level-specific timers during a puzzle.
+## Starts and stops level-specific timers during a puzzle.
+##
+## Some levels define behavior where something happens every 5 seconds. These timer definitions are kept in the
+## LevelTimers script, but the actual timer objects which count down are kept here.
 
-Some levels define behavior where something happens every 5 seconds. These timer definitions are kept in the
-LevelTimers script, but the actual timer objects which count down are kept here.
-"""
-
-# The maximum amount of timers which a level can define
+## The maximum amount of timers which a level can define
 const MAX_TIMER_COUNT := 1
 
-# key: timer index
-# value: an enum from LevelTriggerPhase for the timer's trigger
+## key: timer index
+## value: an enum from LevelTriggerPhase for the timer's trigger
 const PHASES_BY_TIMER_INDEX := {
 	0: LevelTrigger.TIMER_0,
 }
@@ -26,26 +24,20 @@ func _ready() -> void:
 		add_child(timer)
 
 
-"""
-Starts any timers needed for the current level.
-"""
+## Starts any timers needed for the current level.
 func _on_PuzzleState_game_started() -> void:
 	for timer_index in range(CurrentLevel.settings.timers.get_timer_count()):
 		var timer: Timer = get_child(timer_index)
 		timer.start(CurrentLevel.settings.timers.get_timer_interval(timer_index))
 
 
-"""
-Stops any timers needed for the current level.
-"""
+## Stops any timers needed for the current level.
 func _on_PuzzleState_game_ended() -> void:
 	for i in range(MAX_TIMER_COUNT):
 		var timer: Timer = get_child(i)
 		timer.stop()
 
 
-"""
-Runs all triggers for the specified timer.
-"""
+## Runs all triggers for the specified timer.
 func _on_Timer_timeout(timer_index: int) -> void:
 	CurrentLevel.settings.triggers.run_triggers(PHASES_BY_TIMER_INDEX[timer_index])

--- a/project/src/main/puzzle/level/blocks-during-rules.gd
+++ b/project/src/main/puzzle/level/blocks-during-rules.gd
@@ -1,7 +1,5 @@
 class_name BlocksDuringRules
-"""
-Blocks/boxes/pickups which appear or disappear while the game is going on.
-"""
+## Blocks/boxes/pickups which appear or disappear while the game is going on.
 
 enum LineClearType {
 	DEFAULT, # lines drop normally following line clears
@@ -15,16 +13,16 @@ enum PickupType {
 	FLOAT_REGEN, # pickups float in place and regenerate if collected
 }
 
-# if true, the entire playfield is cleared when the player tops out
+## if true, the entire playfield is cleared when the player tops out
 var clear_on_top_out := false
 
-# whether blocks drop following a line clear
+## whether blocks drop following a line clear
 var line_clear_type: int = LineClearType.DEFAULT
 
-# whether pickups move with the playfield blocks
+## whether pickups move with the playfield blocks
 var pickup_type: int = PickupType.DEFAULT
 
-# whether inserted rows should start from a random row in the source tiles instead of starting from the top
+## whether inserted rows should start from a random row in the source tiles instead of starting from the top
 var random_tiles_start: bool = false
 
 var _rule_parser: RuleParser

--- a/project/src/main/puzzle/level/combo-break-rules.gd
+++ b/project/src/main/puzzle/level/combo-break-rules.gd
@@ -1,15 +1,13 @@
 class_name ComboBreakRules
-"""
-Things that disrupt the player's combo.
-"""
+## Things that disrupt the player's combo.
 
-# a magic number for the 'pieces' combo break rule where the combo will never break
+## a magic number for the 'pieces' combo break rule where the combo will never break
 const UNLIMITED_PIECES := 999999
 
-# by default, dropping 2 pieces breaks their combo
+## by default, dropping 2 pieces breaks their combo
 var pieces := 2
 
-# 'true' if clearing a vegetable row (a row with no snack/cake blocks) breaks their combo
+## 'true' if clearing a vegetable row (a row with no snack/cake blocks) breaks their combo
 var veg_row := false
 
 var _rule_parser: RuleParser

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -1,65 +1,59 @@
 extends Node
-"""
-Stores information about the current level.
-"""
+## Stores information about the current level.
 
-# emitted after the level has customized the puzzle's settings.
+## emitted after the level has customized the puzzle's settings.
 signal settings_changed
 
-# emitted when the 'best_result' field changes, such as when starting or clearing a level.
+## emitted when the 'best_result' field changes, such as when starting or clearing a level.
 signal best_result_changed
 
-# If 'true' then the level is one which the player might keep retrying, even after clearing it.
-# This is especially true for practice levels such as the 3 minute sprint level.
+## If 'true' then the level is one which the player might keep retrying, even after clearing it.
+## This is especially true for practice levels such as the 3 minute sprint level.
 var keep_retrying := false
 
-# The settings for the level currently being launched or played
+## The settings for the level currently being launched or played
 var settings := LevelSettings.new() setget switch_level
 
-# The puzzle scene
+## The puzzle scene
 var puzzle: Puzzle
 
-# The level which was originally launched. Some tutorial levels transition
-# into other levels, so this keeps track of the original.
+## The level which was originally launched. Some tutorial levels transition
+## into other levels, so this keeps track of the original.
 var level_id: String
 
-# The creature who launched the level.
+## The creature who launched the level.
 var creature_id: String
 
-# The customers to queue up at the start of the level. If absent, random customers will be queued.
+## The customers to queue up at the start of the level. If absent, random customers will be queued.
 var customer_ids: Array
 
-# The creature who will be the chef for the level. If absent, the player will be the chef.
+## The creature who will be the chef for the level. If absent, the player will be the chef.
 var chef_id: String
 
-# Tracks when the player finishes a level.
+## Tracks when the player finishes a level.
 var best_result: int = Levels.Result.NONE setget set_best_result
 
-# Tracks whether or not the player wants to play/skip this level's cutscene.
+## Tracks whether or not the player wants to play/skip this level's cutscene.
 var cutscene_force: int = Levels.CutsceneForce.NONE
 
 func _ready() -> void:
 	Breadcrumb.connect("before_scene_changed", self, "_on_Breadcrumb_before_scene_changed")
 
 
-"""
-Unsets all of the 'launched level' data.
-
-This ensures the overworld will allow free roam and not try to play a cutscene.
-"""
+## Unsets all of the 'launched level' data.
+##
+## This ensures the overworld will allow free roam and not try to play a cutscene.
 func clear_launched_level() -> void:
 	set_launched_level("")
 
 
-"""
-Sets the launched level data.
-
-Some tutorial levels transition into other levels, so this keeps track of the original. These properties also
-used on the overworld to track whether or not it should play a cutscene or allow free roam.
-
-Parameters:
-	'level_id': The level to launch
-"""
+## Sets the launched level data.
+##
+## Some tutorial levels transition into other levels, so this keeps track of the original. These properties also
+## used on the overworld to track whether or not it should play a cutscene or allow free roam.
+##
+## Parameters:
+## 	'level_id': The level to launch
 func set_launched_level(new_level_id: String) -> void:
 	level_id = new_level_id
 	var level_lock: LevelLock
@@ -90,18 +84,16 @@ func switch_level(new_settings: LevelSettings) -> void:
 	emit_signal("settings_changed")
 
 
-"""
-Returns 'true' if the specified cutscene should be played.
-
-We skip cutscenes if the player's seen them already, or if its 'skip_if' condition is met. This can be overridden with
-the 'cutscene_force' field which the player can configure on the level select screen.
-
-Parameters:
-	'chat_tree': The cutscene to evaluate.
-	
-	'ignore_player_preferences': If 'true', the player's preferences will be ignored, and the method will only
-		check whether the player's seen the cutscene and whether its 'skip_if' condition is met.
-"""
+## Returns 'true' if the specified cutscene should be played.
+##
+## We skip cutscenes if the player's seen them already, or if its 'skip_if' condition is met. This can be overridden
+## with the 'cutscene_force' field which the player can configure on the level select screen.
+##
+## Parameters:
+## 	'chat_tree': The cutscene to evaluate.
+##
+## 	'ignore_player_preferences': If 'true', the player's preferences will be ignored, and the method will only
+## 		check whether the player's seen the cutscene and whether its 'skip_if' condition is met.
 func should_play_cutscene(chat_tree: ChatTree, ignore_player_preferences = false) -> bool:
 	var result := true
 	if not chat_tree:
@@ -123,9 +115,7 @@ func should_play_cutscene(chat_tree: ChatTree, ignore_player_preferences = false
 	return result
 
 
-"""
-Launches a puzzle scene with the previously specified 'launched level' settings.
-"""
+## Launches a puzzle scene with the previously specified 'launched level' settings.
 func push_level_trail() -> void:
 	var level_settings := LevelSettings.new()
 	level_settings.load_from_resource(level_id)
@@ -148,11 +138,9 @@ func set_best_result(new_best_result: int) -> void:
 	emit_signal("best_result_changed")
 
 
-"""
-Purges all node instances from the singleton.
-
-Because CurrentLevel is a singleton, node instances should be purged before changing scenes. Otherwise they'll
-continue consuming resources and could cause side effects.
-"""
+## Purges all node instances from the singleton.
+##
+## Because CurrentLevel is a singleton, node instances should be purged before changing scenes. Otherwise they'll
+## continue consuming resources and could cause side effects.
 func _on_Breadcrumb_before_scene_changed() -> void:
 	puzzle = null

--- a/project/src/main/puzzle/level/level-history.gd
+++ b/project/src/main/puzzle/level/level-history.gd
@@ -1,52 +1,44 @@
 class_name LevelHistory
-"""
-Stores the best results the player has achieved for different levels. This is currently used for calculating high
-scores, but could eventually be used for displaying statistics or calculating rewards.
-"""
+## Stores the best results the player has achieved for different levels. This is currently used for calculating high
+## scores, but could eventually be used for displaying statistics or calculating rewards.
 
-# how many daily and all-time records we can store before we start deleting old ones
+## how many daily and all-time records we can store before we start deleting old ones
 var max_size := 3
 
-# key: level name
-# value: array of RankResults for the specified level
+## key: level name
+## value: array of RankResults for the specified level
 var rank_results := {}
 
-# key: level name
-# value: date when the player was first successful at the level
+## key: level name
+## value: date when the player was first successful at the level
 var successful_levels := {}
 
-# key: level name
-# value: date when the player first finished the level
+## key: level name
+## value: date when the player first finished the level
 var finished_levels := {}
 
 func level_names() -> Array:
 	return rank_results.keys()
 
 
-"""
-Resets the level history to its default empty state.
-"""
+## Resets the level history to its default empty state.
 func reset() -> void:
 	rank_results.clear()
 	successful_levels.clear()
 	finished_levels.clear()
 
 
-"""
-Returns a player's performances for a specific level.
-"""
+## Returns a player's performances for a specific level.
 func results(level_id: String) -> Array:
 	return rank_results.get(level_id, [])
 
 
-"""
-Returns a player's best performance for a specific level.
-
-Parameters:
-	'level_id': The id of the level to evaluate
-	
-	'daily': (Optional) If true, only performances with today's date are included
-"""
+## Returns a player's best performance for a specific level.
+##
+## Parameters:
+## 	'level_id': The id of the level to evaluate
+##
+## 	'daily': (Optional) If true, only performances with today's date are included
 func best_result(level_id: String, daily: bool = false) -> RankResult:
 	var best_result: RankResult
 	var best_results := best_results(level_id, daily)
@@ -55,14 +47,12 @@ func best_result(level_id: String, daily: bool = false) -> RankResult:
 	return best_result
 
 
-"""
-Returns a player's best performances for a specific level.
-
-Parameters:
-	'level_id': The id of the level to evaluate
-	
-	'daily': (Optional) If true, only performances with today's date are included
-"""
+## Returns a player's best performances for a specific level.
+##
+## Parameters:
+## 	'level_id': The id of the level to evaluate
+##
+## 	'daily': (Optional) If true, only performances with today's date are included
 func best_results(level_id: String, daily: bool = false) -> Array:
 	if not rank_results.has(level_id):
 		return []
@@ -97,11 +87,9 @@ func prev_result(level_id: String) -> RankResult:
 	return rank_results[level_id][0]
 
 
-"""
-Records the current level performance to the player's history.
-
-'add' should be followed by 'prune' to ensure the history does not grow too large.
-"""
+## Records the current level performance to the player's history.
+##
+## 'add' should be followed by 'prune' to ensure the history does not grow too large.
 func add(level_id: String, rank_result: RankResult) -> void:
 	if not level_id:
 		# can't store history without a level id
@@ -120,9 +108,7 @@ func has(level_id: String) -> bool:
 	return rank_results.has(level_id) and rank_results.get(level_id).size() >= 1
 
 
-"""
-Prunes the history down to only the best daily results, best all-time results, and the most recent result.
-"""
+## Prunes the history down to only the best daily results, best all-time results, and the most recent result.
 func prune(level_id: String) -> void:
 	if not has(level_id):
 		return

--- a/project/src/main/puzzle/level/level-settings-upgrader.gd
+++ b/project/src/main/puzzle/level/level-settings-upgrader.gd
@@ -1,16 +1,19 @@
 class_name LevelSettingsUpgrader
 
-"""
-An externally defined method which provides version-specific updates.
-"""
+## An externally defined method which provides version-specific updates.
 class UpgradeMethod:
-	var method: String # The name of the method which performs the upgrade
-	var old_version: String # The old save data version which the method upgrades from
-	var new_version: String # The new save data version which the method upgrades to
+	## The name of the method which performs the upgrade
+	var method: String
+	
+	## The old save data version which the method upgrades from
+	var old_version: String
+	
+	## The new save data version which the method upgrades to
+	var new_version: String
 
-# Internally defined methods which provide version-specific updates.
-# key: old save data version from which the method upgrades
-# value: a UpgradeMethod corresponding to the method to call
+## Internally defined methods which provide version-specific updates.
+## key: old save data version from which the method upgrades
+## value: a UpgradeMethod corresponding to the method to call
 var _upgrade_methods := {}
 
 func _init() -> void:
@@ -18,9 +21,7 @@ func _init() -> void:
 	_add_upgrade_method("_upgrade_1922", "1922", "19c5")
 
 
-"""
-Upgrades the specified json settings to the newest format.
-"""
+## Upgrades the specified json settings to the newest format.
 func upgrade(json_settings: Dictionary) -> Dictionary:
 	var new_json := json_settings
 	while needs_upgrade(new_json):
@@ -49,9 +50,7 @@ func upgrade(json_settings: Dictionary) -> Dictionary:
 	return new_json
 
 
-"""
-Returns 'true' if the specified json settings are from an older version of the game.
-"""
+## Returns 'true' if the specified json settings are from an older version of the game.
 func needs_upgrade(json_settings: Dictionary) -> bool:
 	var result: bool = false
 	var version := _get_version_string(json_settings)
@@ -64,23 +63,21 @@ func needs_upgrade(json_settings: Dictionary) -> bool:
 	return result
 
 
-"""
-Adds a new internally defined method which provides version-specific updates.
-
-Upgrade methods include three parameters:
-	'old_json': (Dictionary) Old parsed level settings from which data should be upgraded
-	
-	'old_key': (String) A key corresponding to a key/value pair in the old_json dictionary which should be upgraded
-	
-	'new_json': (Dictionary) Destination dictionary to which upgraded data should be written
-
-Parameters:
-	'method': The name of the method which performs the upgrade.
-	
-	'old_version': The old settings version which the method upgrades from
-	
-	'new_version': The new settings version which the method upgrades to
-"""
+## Adds a new internally defined method which provides version-specific updates.
+##
+## Upgrade methods include three parameters:
+## 	'old_json': (Dictionary) Old parsed level settings from which data should be upgraded
+##
+## 	'old_key': (String) A key corresponding to a key/value pair in the old_json dictionary which should be upgraded
+##
+## 	'new_json': (Dictionary) Destination dictionary to which upgraded data should be written
+##
+## Parameters:
+## 	'method': The name of the method which performs the upgrade.
+##
+## 	'old_version': The old settings version which the method upgrades from
+##
+## 	'new_version': The new settings version which the method upgrades to
 func _add_upgrade_method(method: String, old_version: String, new_version: String) -> void:
 	var upgrade_method: UpgradeMethod = UpgradeMethod.new()
 	upgrade_method.method = method
@@ -115,8 +112,6 @@ func _upgrade_1922(old_json: Dictionary, old_key: String, new_json: Dictionary) 
 	return new_json
 
 
-"""
-Extracts a version string from the specified json settings.
-"""
+## Extracts a version string from the specified json settings.
 static func _get_version_string(json_settings: Dictionary) -> String:
 	return json_settings.get("version")

--- a/project/src/main/puzzle/level/level-settings.gd
+++ b/project/src/main/puzzle/level/level-settings.gd
@@ -1,73 +1,69 @@
 class_name LevelSettings
-"""
-Contains settings for a level.
+## Contains settings for a level.
+##
+## This includes information about how the player loses/wins, what kind of pieces they're given, whether they're given
+## a time limit, and any other special rules.
 
-This includes information about how the player loses/wins, what kind of pieces they're given, whether they're given a
-time limit, and any other special rules.
-"""
-
-# The level description shown when selecting a level.
+## The level description shown when selecting a level.
 var description := ""
 
-# (optional) The level difficulty shown when selecting a level.
+## (optional) The level difficulty shown when selecting a level.
 var difficulty := "" setget ,get_difficulty
 
-# Blocks/boxes which appear or disappear while the game is going on.
+## Blocks/boxes which appear or disappear while the game is going on.
 var blocks_during := BlocksDuringRules.new()
 
-# Things that disrupt the player's combo.
+## Things that disrupt the player's combo.
 var combo_break := ComboBreakRules.new()
 
-# How the player finishes. When the player finishes, they can't play anymore, and the level just ends. It should be
-# used for limits such as serving 5 creatures or clearing 10 lines.
+## How the player finishes. When the player finishes, they can't play anymore, and the level just ends. It should be
+## used for limits such as serving 5 creatures or clearing 10 lines.
 var finish_condition := Milestone.new()
 
-# The level id used for saving/loading data.
+## The level id used for saving/loading data.
 var id := ""
 
-# Sequence of puzzle inputs to be replayed for things such as tutorials.
+## Sequence of puzzle inputs to be replayed for things such as tutorials.
 var input_replay := InputReplay.new()
 
-# How the player loses. The player usually loses if they top out a certain number of times, but some levels might
-# have different rules.
+## How the player loses. The player usually loses if they top out a certain number of times, but some levels might
+## have different rules.
 var lose_condition := LoseConditionRules.new()
 
-# Rules which are unique enough that it doesn't make sense to put them in their own groups.
+## Rules which are unique enough that it doesn't make sense to put them in their own groups.
 var other := OtherRules.new()
 
-# The selection of pieces provided to the player.
+## The selection of pieces provided to the player.
 var piece_types := PieceTypeRules.new()
 
-# Tweaks to rank calculation.
+## Tweaks to rank calculation.
 var rank := RankRules.new()
 
-# Rules for scoring points.
+## Rules for scoring points.
 var score := ScoreRules.new()
 
 var speed := SpeedRules.new()
 
-# How the player succeeds. When the player succeeds, there's a big fanfare and celebration, it should be used for
-# accomplishments such as surviving 10 minutes or getting 1,000 points.
+## How the player succeeds. When the player succeeds, there's a big fanfare and celebration, it should be used for
+## accomplishments such as surviving 10 minutes or getting 1,000 points.
 var success_condition := Milestone.new()
 
-# Sets of blocks which are shown initially, or appear during the game.
+## Sets of blocks which are shown initially, or appear during the game.
 var tiles := LevelTiles.new()
 
-# Timers which cause strange things to happen during a level.
+## Timers which cause strange things to happen during a level.
 var timers := LevelTimers.new()
 
-# The level title shown in menus.
+## The level title shown in menus.
 var title := ""
 
-# Triggers which cause strange things to happen during a level.
+## Triggers which cause strange things to happen during a level.
 var triggers := LevelTriggers.new()
 
 var _upgrader := LevelSettingsUpgrader.new()
 
 
-"""
-Sets the criteria for finishing the level, such as a time, score, or line goal.
-"""
+## Sets the criteria for finishing the level, such as a time, score, or line goal.
 func set_finish_condition(type: int, value: int, lenient_value: int = -1) -> void:
 	finish_condition = Milestone.new()
 	finish_condition.set_milestone(type, value)
@@ -75,20 +71,16 @@ func set_finish_condition(type: int, value: int, lenient_value: int = -1) -> voi
 		finish_condition.set_meta("lenient_value", lenient_value)
 
 
-"""
-Sets the criteria for succeeding, such as a time or score goal.
-"""
+## Sets the criteria for succeeding, such as a time or score goal.
 func set_success_condition(type: int, value: int) -> void:
 	success_condition = Milestone.new()
 	success_condition.set_milestone(type, value)
 
 
-"""
-Populates this object with json data.
-
-Parameters:
-	'new_id': The level id used for saving statistics.
-"""
+## Populates this object with json data.
+##
+## Parameters:
+## 	'new_id': The level id used for saving statistics.
 func from_json_dict(new_id: String, json: Dictionary) -> void:
 	id = new_id
 	

--- a/project/src/main/puzzle/level/level-tiles.gd
+++ b/project/src/main/puzzle/level/level-tiles.gd
@@ -1,54 +1,45 @@
 class_name LevelTiles
-"""
-Sets of blocks which are shown initially, or appear during the game
-"""
+## Sets of blocks which are shown initially, or appear during the game
 
+## A set of blocks which is shown initially, or appears during the game
 class BlockBunch:
-	"""
-	A set of blocks which is shown initially, or appears during the game
-	"""
-
-	# key: (Vector2) positions of cells containing a tile
-	# value: (int) tile indexes of each cell
+	## key: (Vector2) positions of cells containing a tile
+	## value: (int) tile indexes of each cell
 	var block_tiles := {}
 
-	# key: (Vector2) positions of cells containing a tile
-	# value: (Vector2) coordinate of the autotile variation in the tileset
+	## key: (Vector2) positions of cells containing a tile
+	## value: (Vector2) coordinate of the autotile variation in the tileset
 	var block_autotile_coords := {}
 	
-	# key: (Vector2) positions of cells containing a pickup
-	# value: (int) an enum from Foods.BoxType defining the pickup's color
+	## key: (Vector2) positions of cells containing a pickup
+	## value: (int) an enum from Foods.BoxType defining the pickup's color
 	var pickups := {}
 
-	"""
-	Defines a block which will appear on the playfield.
-
-	Parameters:
-		'pos': Position of the cell
-		
-		'tile': Tile index of the cell
-		
-		'autotile_coord': Coordinate of the autotile variation in the tileset
-	"""
+	## Defines a block which will appear on the playfield.
+	##
+	## Parameters:
+	## 	'pos': Position of the cell
+	##
+	## 	'tile': Tile index of the cell
+	##
+	## 	'autotile_coord': Coordinate of the autotile variation in the tileset
 	func set_block(pos: Vector2, tile: int, autotile_coord: Vector2) -> void:
 		block_tiles[pos] = tile
 		block_autotile_coords[pos] = autotile_coord
 	
 	
-	"""
-	Defines a pickup which will appear on the playfield.
-	
-	Parameters:
-		'pos': Position of the cell
-		
-		'box_type': An enum from Foods.BoxType defining the pickup's color
-	"""
+	## Defines a pickup which will appear on the playfield.
+	##
+	## Parameters:
+	## 	'pos': Position of the cell
+	##
+	## 	'box_type': An enum from Foods.BoxType defining the pickup's color
 	func set_pickup(pos: Vector2, box_type: int) -> void:
 		pickups[pos] = box_type
 
 
-# key: a tiles key for tiles referenced by level rules, or the string 'start' for the initial set of tiles
-# value: a BlockBunch instance
+## key: a tiles key for tiles referenced by level rules, or the string 'start' for the initial set of tiles
+## value: a BlockBunch instance
 var bunches: Dictionary = {}
 
 func from_json_dict(json: Dictionary) -> void:
@@ -87,22 +78,18 @@ func is_default() -> bool:
 	return bunches.empty()
 
 
-"""
-Returns the initial set of tiles.
-"""
+## Returns the initial set of tiles.
 func blocks_start() -> BlockBunch:
 	return get_tiles("start")
 
 
-"""
-Returns a set of tiles referenced by level rules.
-
-Parameters:
-	'tiles_key': a key for tiles referenced by level rules, or the string 'start' for the initial set of tiles
-
-Returns:
-	A set of tiles for the specified key, or an empty BlockBunch if the key is not found.
-"""
+## Returns a set of tiles referenced by level rules.
+##
+## Parameters:
+## 	'tiles_key': a key for tiles referenced by level rules, or the string 'start' for the initial set of tiles
+##
+## Returns:
+## 	A set of tiles for the specified key, or an empty BlockBunch if the key is not found.
 func get_tiles(tiles_key: String) -> BlockBunch:
 	var result: BlockBunch
 	if bunches.has(tiles_key):

--- a/project/src/main/puzzle/level/level-timers.gd
+++ b/project/src/main/puzzle/level/level-timers.gd
@@ -1,25 +1,19 @@
 class_name LevelTimers
-"""
-Timers which cause strange things to happen during a level.
+## Timers which cause strange things to happen during a level.
+##
+## A level can contain several timers, and each timer can activate a trigger to cause different unique effects.
 
-A level can contain several timers, and each timer can activate a trigger to cause different unique effects.
-"""
-
-# array of dictionary timer definitions
+## array of dictionary timer definitions
 var timers := []
 
-"""
-Returns how frequently the timer should fire, measured in seconds.
-"""
+## Returns how frequently the timer should fire, measured in seconds.
 func get_timer_interval(timer_index: int) -> float:
 	return timers[timer_index].get("interval")
 
 
-"""
-Returns the number of timers used by this level.
-
-For most levels, this will be zero.
-"""
+## Returns the number of timers used by this level.
+##
+## For most levels, this will be zero.
 func get_timer_count() -> int:
 	return timers.size()
 

--- a/project/src/main/puzzle/level/level-trigger-effect.gd
+++ b/project/src/main/puzzle/level/level-trigger-effect.gd
@@ -1,37 +1,29 @@
 class_name LevelTriggerEffect
-"""
-An abstract class describing the effect of a level trigger.
+## An abstract class describing the effect of a level trigger.
+##
+## A LevelTriggerEffect might subtract points from the player's score, rotate a piece or turn the playfield invisible.
 
-A LevelTriggerEffect might subtract points from the player's score, rotate a piece or turn the playfield invisible.
-"""
-
-"""
-Executes this level trigger effect.
-"""
+## Executes this level trigger effect.
 func run() -> void:
 	pass
 
 
-"""
-Populates this level trigger with the specified string parameters.
-
-Parameters:
-	'new_config': A dictionary of string parameters parsed from json. For example, a level trigger effect which
-		rotates the piece could pass in parameters specifying the direction to rotate.
-"""
+## Populates this level trigger with the specified string parameters.
+##
+## Parameters:
+## 	'new_config': A dictionary of string parameters parsed from json. For example, a level trigger effect which
+## 		rotates the piece could pass in parameters specifying the direction to rotate.
 func set_config(_new_config: Dictionary = {}) -> void:
 	pass
 
 
-"""
-Extracts a dictionary of string parameters from this level trigger.
-
-This performs the inverse of the 'set_config' function, extracting values from the trigger's properties and using them
-to populate a dictionary.
-
-Returns:
-	A dictionary of string parameters parsed from json. For example, a level trigger effect which rotates the piece
-		could pass in parameters specifying the direction to rotate.
-"""
+## Extracts a dictionary of string parameters from this level trigger.
+##
+## This performs the inverse of the 'set_config' function, extracting values from the trigger's properties and using
+## them to populate a dictionary.
+##
+## Returns:
+## 	A dictionary of string parameters parsed from json. For example, a level trigger effect which rotates the piece
+## 		could pass in parameters specifying the direction to rotate.
 func get_config() -> Dictionary:
 	return {}

--- a/project/src/main/puzzle/level/level-trigger-effects.gd
+++ b/project/src/main/puzzle/level/level-trigger-effects.gd
@@ -1,38 +1,32 @@
 extends Node
-"""
-A library of level trigger effects.
+## A library of level trigger effects.
+##
+## These effects are each mapped to a unique string so that they can be referenced from json.
 
-These effects are each mapped to a unique string so that they can be referenced from json.
-"""
-
-"""
-Rotates one or more pieces in the piece queue.
-"""
+## Rotates one or more pieces in the piece queue.
 class RotateNextPiecesEffect extends LevelTriggerEffect:
 	enum Rotation {
 		NONE, CW, CCW, FLIP
 	}
 	
-	# an enum in Rotation corresponding to the direction to rotate
+	## an enum in Rotation corresponding to the direction to rotate
 	var rotate_dir: int = Rotation.NONE
 	
-	# The first piece index in the queue to rotate, inclusive
+	## The first piece index in the queue to rotate, inclusive
 	var next_piece_from_index: int = 0
 	
-	# The last piece index in the queue to rotate, inclusive
+	## The last piece index in the queue to rotate, inclusive
 	var next_piece_to_index: int = 999999
 	
-	"""
-	Updates the effect's configuration.
-	
-	This effect's configuration accepts the following parameters:
-	
-	[0]: (Optional) The direction to rotate, 'cw', 'ccw', '180' or 'none'. Defaults to 'none'.
-	[1]: (Optional) The first piece index in the queue to rotate. Defaults to 0.
-	[2]: (Optional) The last piece index in the queue to rotate. Defaults to 999999.
-	
-	Example: ["cw", "0", "0"]
-	"""
+	## Updates the effect's configuration.
+	##
+	## This effect's configuration accepts the following parameters:
+	##
+	## [0]: (Optional) The direction to rotate, 'cw', 'ccw', '180' or 'none'. Defaults to 'none'.
+	## [1]: (Optional) The first piece index in the queue to rotate. Defaults to 0.
+	## [2]: (Optional) The last piece index in the queue to rotate. Defaults to 999999.
+	##
+	## Example: ["cw", "0", "0"]
 	func set_config(new_config: Dictionary = {}) -> void:
 		if new_config.has("0"):
 			match new_config["0"]:
@@ -48,9 +42,7 @@ class RotateNextPiecesEffect extends LevelTriggerEffect:
 			next_piece_to_index = new_config["2"].to_int()
 	
 	
-	"""
-	Rotates one or more pieces in the piece queue.
-	"""
+	## Rotates one or more pieces in the piece queue.
 	func run() -> void:
 		var pieces: Array = CurrentLevel.puzzle.get_piece_queue().pieces
 		for i in range(next_piece_from_index, next_piece_to_index + 1):
@@ -80,29 +72,23 @@ class RotateNextPiecesEffect extends LevelTriggerEffect:
 		return result
 
 
-"""
-Inserts a new line at the bottom of the playfield.
-"""
+## Inserts a new line at the bottom of the playfield.
 class InsertLineEffect extends LevelTriggerEffect:
-	# (Optional) a key corresponding to a set of tiles in LevelTiles for the tiles to insert
+	## (Optional) a key corresponding to a set of tiles in LevelTiles for the tiles to insert
 	var tiles_key: String
 	
-	"""
-	Updates the effect's configuration.
-	
-	This effect's configuration accepts the following parameters:
-	
-	[tiles_key]: (Optional) A key corresponding to a set of tiles in LevelTiles for the tiles to insert.
-	
-	Example: ["tiles_key=0"]
-	"""
+	## Updates the effect's configuration.
+	##
+	## This effect's configuration accepts the following parameters:
+	##
+	## [tiles_key]: (Optional) A key corresponding to a set of tiles in LevelTiles for the tiles to insert.
+	##
+	## Example: ["tiles_key=0"]
 	func set_config(new_config: Dictionary = {}) -> void:
 		tiles_key = new_config.get("tiles_key", "")
 	
 	
-	"""
-	Inserts a new line at the bottom of the playfield.
-	"""
+	## Inserts a new line at the bottom of the playfield.
 	func run() -> void:
 		CurrentLevel.puzzle.get_playfield().line_inserter.insert_line(tiles_key)
 	
@@ -119,14 +105,12 @@ var effects_by_string := {
 	"insert_line": InsertLineEffect,
 }
 
-"""
-Creates a new LevelTriggerEffect instance.
-
-Parameters:
-	'effect_key': A string key corresponding to the level trigger effect, such as 'insert_line'.
-	
-	'effect_config': (Optional) An array of strings defining the effect's behavior.
-"""
+## Creates a new LevelTriggerEffect instance.
+##
+## Parameters:
+## 	'effect_key': A string key corresponding to the level trigger effect, such as 'insert_line'.
+##
+## 	'effect_config': (Optional) An array of strings defining the effect's behavior.
 func create(effect_key: String, effect_config: Dictionary = {}) -> LevelTriggerEffect:
 	if not effects_by_string.has(effect_key):
 		push_warning("Unrecognized effect: %s" % [effect_key])

--- a/project/src/main/puzzle/level/level-trigger.gd
+++ b/project/src/main/puzzle/level/level-trigger.gd
@@ -1,13 +1,11 @@
 class_name LevelTrigger
-"""
-A trigger which causes strange things to happen during a level.
+## A trigger which causes strange things to happen during a level.
+##
+## A level can contain any number of triggers, and each trigger makes something happen at a specific time. For example,
+## a trigger might rotate the pieces in the piece queue every 2 seconds, or a trigger might toggle the playfield
+## invisible every time the player places a piece.
 
-A level can contain any number of triggers, and each trigger makes something happen at a specific time. For example, a
-trigger might rotate the pieces in the piece queue every 2 seconds, or a trigger might toggle the playfield invisible
-every time the player places a piece.
-"""
-
-# phases when a level trigger can fire
+## phases when a level trigger can fire
 enum LevelTriggerPhase {
 	AFTER_LINE_CLEARED,
 	INITIAL_ROTATED_CW, # when the piece is rotated clockwise using initial DAS
@@ -28,21 +26,19 @@ const ROTATED_CCW := LevelTriggerPhase.ROTATED_CCW
 const ROTATED_180 := LevelTriggerPhase.ROTATED_180
 const TIMER_0 := LevelTriggerPhase.TIMER_0
 
-# key: an enum from LevelTriggerPhase
-# value: array of PhaseCondition instances defining whether the trigger should fire
+## key: an enum from LevelTriggerPhase
+## value: array of PhaseCondition instances defining whether the trigger should fire
 var phases := {}
 
-# the effect caused by this level trigger
+## the effect caused by this level trigger
 var effect: LevelTriggerEffect
 
-"""
-Returns 'true' if this trigger should run during the specified phase.
-
-Parameters:
-	'phase': An enum from LevelTriggerPhase
-	
-	'event_params': (Optional) Phase-specific metadata used to decide whether the trigger should fire
-"""
+## Returns 'true' if this trigger should run during the specified phase.
+##
+## Parameters:
+## 	'phase': An enum from LevelTriggerPhase
+##
+## 	'event_params': (Optional) Phase-specific metadata used to decide whether the trigger should fire
 func should_run(phase: int, event_params: Dictionary = {}) -> bool:
 	var result := true
 	var phase_conditions: Array = phases.get(phase, [])
@@ -57,9 +53,7 @@ func should_run(phase: int, event_params: Dictionary = {}) -> bool:
 	return result
 
 
-"""
-Executes this level trigger's effect.
-"""
+## Executes this level trigger's effect.
 func run() -> void:
 	effect.run()
 
@@ -110,14 +104,12 @@ func to_json_dict() -> Dictionary:
 	return result
 
 
-"""
-Enables this trigger for the specified phase.
-
-Parameters:
-	'phase_key': A string key corresponding to the phase, such as 'after_line_cleared'.
-	
-	'phase_config': A dictionary of strings defining any special conditions for the phase.
-"""
+## Enables this trigger for the specified phase.
+##
+## Parameters:
+## 	'phase_key': A string key corresponding to the phase, such as 'after_line_cleared'.
+##
+## 	'phase_config': A dictionary of strings defining any special conditions for the phase.
 func _add_phase(phase_key: String, phase_config: Dictionary) -> void:
 	if not LevelTriggerPhase.has(phase_key.to_upper()):
 		push_warning("Unrecognized phase: %s" % [phase_key])
@@ -128,19 +120,17 @@ func _add_phase(phase_key: String, phase_config: Dictionary) -> void:
 	phases[phase].append(phase_condition)
 
 
-"""
-Parses an array of configuration strings into a set of key/value pairs.
-
-Keyed values like "foo=bar" are added to the resulting dictionary as {"foo": "bar"}
-
-Unkeyed values like "foo" and "bar" are added to the dictionary as {"0": "foo", "1": "bar"}
-
-Parameters:
-	'param_array': An array of configuration strings.
-
-Returns:
-	A dictionary of configuration strings organized as key/value pairs.
-"""
+## Parses an array of configuration strings into a set of key/value pairs.
+##
+## Keyed values like "foo=bar" are added to the resulting dictionary as {"foo": "bar"}
+##
+## Unkeyed values like "foo" and "bar" are added to the dictionary as {"0": "foo", "1": "bar"}
+##
+## Parameters:
+## 	'param_array': An array of configuration strings.
+##
+## Returns:
+## 	A dictionary of configuration strings organized as key/value pairs.
 static func dict_config_from_array(param_array: Array) -> Dictionary:
 	var result := {}
 	var param_index := 0
@@ -155,19 +145,17 @@ static func dict_config_from_array(param_array: Array) -> Dictionary:
 	return result
 
 
-"""
-Converts a set of key/value pairs into an array of configuration strings.
-
-Keyed entries like {"foo": "bar"} are added to the resulting array as ["foo=bar"]
-
-Unkeyed entries like {"0": "foo", "1": "bar"} are added to the array as ["foo", "bar"]
-
-Parameters:
-	'param_array': A dictionary of configuration strings organized as key/value pairs.
-
-Returns:
-	An array of configuration strings.
-"""
+## Converts a set of key/value pairs into an array of configuration strings.
+##
+## Keyed entries like {"foo": "bar"} are added to the resulting array as ["foo=bar"]
+##
+## Unkeyed entries like {"0": "foo", "1": "bar"} are added to the array as ["foo", "bar"]
+##
+## Parameters:
+## 	'param_array': A dictionary of configuration strings organized as key/value pairs.
+##
+## Returns:
+## 	An array of configuration strings.
 static func dict_config_to_array(dict_config: Dictionary) -> Array:
 	var result := []
 	var remaining_config := dict_config.duplicate()

--- a/project/src/main/puzzle/level/level-triggers.gd
+++ b/project/src/main/puzzle/level/level-triggers.gd
@@ -1,24 +1,20 @@
 class_name LevelTriggers
-"""
-Triggers which cause strange things to happen during a level.
+## Triggers which cause strange things to happen during a level.
+##
+## A level can contain any number of triggers, and each trigger makes something happen at a specific time. For example,
+## a trigger might rotate the pieces in the piece queue every 2 seconds, or a trigger might toggle the playfield
+## invisible every time the player places a piece.
 
-A level can contain any number of triggers, and each trigger makes something happen at a specific time. For example, a
-trigger might rotate the pieces in the piece queue every 2 seconds, or a trigger might toggle the playfield invisible
-every time the player places a piece.
-"""
-
-# key: An enum from LevelTrigger.LevelTriggerPhase
-# value: An array of LevelTriggers which should happen during that phase
+## key: An enum from LevelTrigger.LevelTriggerPhase
+## value: An array of LevelTriggers which should happen during that phase
 var triggers := {}
 
-"""
-Runs all triggers for the specified phase.
-
-Parameters:
-	'phase': An enum from LevelTrigger.LevelTriggerPhase corresponding to the triggers to run.
-	
-	'event_params': (Optional) Phase-specific metadata used to decide whether the trigger should fire
-"""
+## Runs all triggers for the specified phase.
+##
+## Parameters:
+## 	'phase': An enum from LevelTrigger.LevelTriggerPhase corresponding to the triggers to run.
+##
+## 	'event_params': (Optional) Phase-specific metadata used to decide whether the trigger should fire
 func run_triggers(phase: int, event_params: Dictionary = {}) -> void:
 	if not triggers.has(phase):
 		return

--- a/project/src/main/puzzle/level/levels.gd
+++ b/project/src/main/puzzle/level/levels.gd
@@ -1,9 +1,8 @@
 class_name Levels
-"""
-This script consists exclusively of constants and enums related to levels.
-
-This prevents cyclic dependency errors which arise if these constants and enums are pushed down to individual scripts.
-"""
+## This script consists exclusively of constants and enums related to levels.
+##
+## This prevents cyclic dependency errors which arise if these constants and enums are pushed down to individual
+## scripts.
 
 enum CutsceneForce {
 	NONE, # do not force the cutscene to play or skip
@@ -11,8 +10,8 @@ enum CutsceneForce {
 	SKIP, # force the cutscene to skip, even if it has never been seen
 }
 
-# Tracks whether the player has lost, finished, or met a success condition. These enums should be ordered from worst to
-# best so that we can calculate the player's best result by comparing enums numerically.
+## Tracks whether the player has lost, finished, or met a success condition. These enums should be ordered from worst
+## to best so that we can calculate the player's best result by comparing enums numerically.
 enum Result {
 	NONE, # The player didn't place any pieces.
 	LOST, # The player gave up or failed.
@@ -20,6 +19,6 @@ enum Result {
 	WON, # The player was successful.
 }
 
-# Current version for saved level data. Should be updated if and only if the level format changes.
-# This version number follows a 'ymdh' hex date format which is documented in issue #234.
+## Current version for saved level data. Should be updated if and only if the level format changes.
+## This version number follows a 'ymdh' hex date format which is documented in issue #234.
 const LEVEL_DATA_VERSION := "297a"

--- a/project/src/main/puzzle/level/lose-condition-rules.gd
+++ b/project/src/main/puzzle/level/lose-condition-rules.gd
@@ -1,13 +1,11 @@
 class_name LoseConditionRules
-"""
-How the player loses. The player usually loses if they top out a certain number of times, but some levels might
-have different rules.
-"""
+## How the player loses. The player usually loses if they top out a certain number of times, but some levels might
+## have different rules.
 
-# if 'true', the finish screen is shown when the player loses
+## if 'true', the finish screen is shown when the player loses
 var finish_on_lose := false
 
-# by default, the player loses if they top out three times
+## by default, the player loses if they top out three times
 var top_out := 3
 
 var _rule_parser: RuleParser

--- a/project/src/main/puzzle/level/milestone.gd
+++ b/project/src/main/puzzle/level/milestone.gd
@@ -1,10 +1,8 @@
 class_name Milestone
-"""
-Defines a goal or milestone for a puzzle, such as reaching a certain score, clearing a certain
-number of lines or surviving a certain number of seconds.
-
-Additional details are stored in the 'meta' property.
-"""
+## Defines a goal or milestone for a puzzle, such as reaching a certain score, clearing a certain
+## number of lines or surviving a certain number of seconds.
+##
+## Additional details are stored in the 'meta' property.
 
 enum MilestoneType {
 	NONE,
@@ -24,20 +22,18 @@ const SCORE := MilestoneType.SCORE
 const TIME_OVER := MilestoneType.TIME_OVER
 const TIME_UNDER := MilestoneType.TIME_UNDER
 
-# an enum from Milestone.MilestoneType describing the milestone criteria (lines, score, time)
+## an enum from Milestone.MilestoneType describing the milestone criteria (lines, score, time)
 var type: int = MilestoneType.NONE
 
-# an value describing the milestone criteria (number of lines, points, seconds)
+## an value describing the milestone criteria (number of lines, points, seconds)
 var value := 0
 
-"""
-Initializes the milestone with a MilestoneType and value to reach, such as scoring 50 points or clearing 10 lines.
-
-Parameters:
-	'new_type': an enum from Milestone.MilestoneType describing the milestone criteria (lines, score, time)
-	
-	'new_value': an value describing the milestone criteria (number of lines, points, seconds)
-"""
+## Initializes the milestone with a MilestoneType and value to reach, such as scoring 50 points or clearing 10 lines.
+##
+## Parameters:
+## 	'new_type': an enum from Milestone.MilestoneType describing the milestone criteria (lines, score, time)
+##
+## 	'new_value': an value describing the milestone criteria (number of lines, points, seconds)
 func set_milestone(new_type: int, new_value: int) -> void:
 	type = new_type
 	value = new_value
@@ -61,11 +57,9 @@ func to_json_dict() -> Dictionary:
 	return result
 
 
-"""
-Returns 'true' if all of the milestone's properties are currently set to their default values.
-
-Milestones whose properties are set to their default values are omitted from our json output.
-"""
+## Returns 'true' if all of the milestone's properties are currently set to their default values.
+##
+## Milestones whose properties are set to their default values are omitted from our json output.
 func is_default() -> bool:
 	var result := true
 	result = result && (type == MilestoneType.NONE)

--- a/project/src/main/puzzle/level/other-rules.gd
+++ b/project/src/main/puzzle/level/other-rules.gd
@@ -1,7 +1,5 @@
 class_name OtherRules
-"""
-Rules which are unique enough that it doesn't make sense to put them in their own groups.
-"""
+## Rules which are unique enough that it doesn't make sense to put them in their own groups.
 
 enum SuppressPieceRotation {
 	NONE, # piece rotation is not suppressed
@@ -9,34 +7,34 @@ enum SuppressPieceRotation {
 	ROTATION_AND_SIGNALS # piece rotation is suppressed, no rotation signals fire for things like sfx
 }
 
-# 'true' for levels which follow tutorial levels
+## 'true' for levels which follow tutorial levels
 var after_tutorial := false
 
-# When the player finishes the level, all lines are cleared
+## When the player finishes the level, all lines are cleared
 var clear_on_finish := true
 
-# 'true' to make the visual combo indicators easier to see
+## 'true' to make the visual combo indicators easier to see
 var enhance_combo_fx := false
 
-# 'true' for non-interactive tutorial levels which don't let the player do anything
+## 'true' for non-interactive tutorial levels which don't let the player do anything
 var non_interactive := false
 
-# an enum from SuppressPieceRotation for whether pieces can rotate
+## an enum from SuppressPieceRotation for whether pieces can rotate
 var suppress_piece_rotation: int = SuppressPieceRotation.NONE
 
-# an enum from SuppressPieceRotation for whether pieces can be initially rotated by holding a rotate key
+## an enum from SuppressPieceRotation for whether pieces can be initially rotated by holding a rotate key
 var suppress_piece_initial_rotation: int = SuppressPieceRotation.NONE
 
-# When the player first launches the game and does the tutorial, we skip the start button and countdown.
+## When the player first launches the game and does the tutorial, we skip the start button and countdown.
 var skip_intro := false
 
-# If the player restarts, they restart from this level (used for tutorials)
+## If the player restarts, they restart from this level (used for tutorials)
 var start_level: String
 
-# an enum from PuzzleTileMap.TileSetType which affects the blocks' appearance (and sometimes behavior)
+## an enum from PuzzleTileMap.TileSetType which affects the blocks' appearance (and sometimes behavior)
 var tile_set: int = PuzzleTileMap.TileSetType.DEFAULT
 
-# 'true' for tutorial levels which are led by Turbo
+## 'true' for tutorial levels which are led by Turbo
 var tutorial := false
 
 var _rule_parser: RuleParser

--- a/project/src/main/puzzle/level/phase-condition.gd
+++ b/project/src/main/puzzle/level/phase-condition.gd
@@ -1,45 +1,38 @@
 class_name PhaseCondition
-"""
-Defines the conditions under which a level trigger should fire.
+## Defines the conditions under which a level trigger should fire.
+##
+## A level can contain triggers which make something happen at a specific time, such as 'add a row of blocks if the
+## player clears one of the bottom three lines'. A PhaseCondition encapsulates the concept of 'the player clears one of
+## the bottom three lines', defining what 'the bottom three lines' means and that the check should happen during a line
+## clear.
 
-A level can contain triggers which make something happen at a specific time, such as 'add a row of blocks if the player
-clears one of the bottom three lines'. A PhaseCondition encapsulates the concept of 'the player clears one of the
-bottom three lines', defining what 'the bottom three lines' means and that the check should happen during a line clear.
-"""
-
-"""
-Creates a new PhaseCondition instance.
-
-The default implementation ignores the '_definition_params' array, but this can be overridden to parse or store the
-parameters.
-
-Parameters:
-	'_phase_config': (Optional) A set of phase configuration strings defining criteria for a phase condition.
-"""
+## Creates a new PhaseCondition instance.
+##
+## The default implementation ignores the '_definition_params' array, but this can be overridden to parse or store the
+## parameters.
+##
+## Parameters:
+## 	'_phase_config': (Optional) A set of phase configuration strings defining criteria for a phase condition.
 func _init(_phase_config: Dictionary) -> void:
 	pass
 
 
-"""
-Extracts a set of phase configuration strings from this phase condition.
-
-This performs the inverse of the configuration part of the _init() function, extracting values from the phase
-condition's properties and using them to populate a dictionary.
-
-Returns:
-	A set of phase configuration strings defining criteria for this phase condition.
-"""
+## Extracts a set of phase configuration strings from this phase condition.
+##
+## This performs the inverse of the configuration part of the _init() function, extracting values from the phase
+## condition's properties and using them to populate a dictionary.
+##
+## Returns:
+## 	A set of phase configuration strings defining criteria for this phase condition.
 func get_phase_config() -> Dictionary:
 	return {}
 
 
-"""
-Can be overridden to return 'true' if a trigger should run during this phase.
-
-The default implementation always returns true, but subclasses can override this behavior.
-
-Parameters:
-	'_event_params': (Optional) Phase-specific metadata used to decide whether the trigger should fire
-"""
+## Can be overridden to return 'true' if a trigger should run during this phase.
+##
+## The default implementation always returns true, but subclasses can override this behavior.
+##
+## Parameters:
+## 	'_event_params': (Optional) Phase-specific metadata used to decide whether the trigger should fire
 func should_run(_event_params: Dictionary) -> bool:
 	return true

--- a/project/src/main/puzzle/level/phase-conditions.gd
+++ b/project/src/main/puzzle/level/phase-conditions.gd
@@ -1,33 +1,29 @@
 extends Node
-"""
-A library of phase conditions for level triggers.
-
-These conditions are each mapped to a unique string so that they can be referenced from json.
-"""
+## A library of phase conditions for level triggers.
+##
+## These conditions are each mapped to a unique string so that they can be referenced from json.
 
 class AfterLinesClearedPhaseCondition extends PhaseCondition:
-	# key: (int) a line which causes the trigger to fire when cleared. 0 is the highest line in the playfield.
-	# value: true
+	## key: (int) a line which causes the trigger to fire when cleared. 0 is the highest line in the playfield.
+	## value: true
 	var which_lines := {}
 	
-	"""
-	Creates a new AfterLinesClearedPhaseCondition instance with the specified configuration.
-	
-	The phase_config parameter accepts an optional 'y' expression defining which line clears will fire this trigger.
-	Commas and hyphens are accepted, 0 is the lowest line in the playfield.
-	
-		{"y": "2"}: The trigger will fire if the third row from the bottom is cleared.
-		
-		{"y": "1,3,5"}: The trigger will fire if the second, fourth, or sixth row from the bottom is cleared.
-		
-		{"y": "0-3"}: The trigger will fire if any of the bottom for rows from the bottom are cleared.
-		
-		{"y": "0,4-6"}: The trigger will fire if the bottom row, or the fifth through seventh rows from the bottom are
-			cleared.
-	
-	Parameters:
-		'phase_config.y': (Optional) An expression defining which line clears will fire this trigger.
-	"""
+	## Creates a new AfterLinesClearedPhaseCondition instance with the specified configuration.
+	##
+	## The phase_config parameter accepts an optional 'y' expression defining which line clears will fire this trigger.
+	## Commas and hyphens are accepted, 0 is the lowest line in the playfield.
+	##
+	## 	{"y": "2"}: The trigger will fire if the third row from the bottom is cleared.
+	##
+	## 	{"y": "1,3,5"}: The trigger will fire if the second, fourth, or sixth row from the bottom is cleared.
+	##
+	## 	{"y": "0-3"}: The trigger will fire if any of the bottom for rows from the bottom are cleared.
+	##
+	## 	{"y": "0,4-6"}: The trigger will fire if the bottom row, or the fifth through seventh rows from the bottom are
+	## 		cleared.
+	##
+	## Parameters:
+	## 	'phase_config.y': (Optional) An expression defining which line clears will fire this trigger.
 	func _init(_phase_config: Dictionary).(_phase_config) -> void:
 		var y_expression: String = _phase_config.get("y")
 		var lo := 0
@@ -44,24 +40,20 @@ class AfterLinesClearedPhaseCondition extends PhaseCondition:
 					which_lines[PuzzleTileMap.ROW_COUNT - y - 1] = true
 	
 	
-	"""
-	Returns 'true' if a trigger should run during this phase, based on the specified metadata.
-
-	Parameters:
-		'event_params': 'y' specifies which line was cleared, 0 is the highest line in the playfield.
-	"""
+	## Returns 'true' if a trigger should run during this phase, based on the specified metadata.
+	##
+	## Parameters:
+	## 	'event_params': 'y' specifies which line was cleared, 0 is the highest line in the playfield.
 	func should_run(event_params: Dictionary) -> bool:
 		return which_lines.has(event_params["y"])
 	
 	
-	"""
-	Extracts a set of phase configuration strings from this phase condition.
-	
-	Reverse-engineers a 'y' expression like {"y": "0,4-6"} based on the `which_lines` property.
-	
-	Returns:
-		A set of phase configuration strings defining criteria for this phase condition.
-	"""
+	## Extracts a set of phase configuration strings from this phase condition.
+	##
+	## Reverse-engineers a 'y' expression like {"y": "0,4-6"} based on the `which_lines` property.
+	##
+	## Returns:
+	## 	A set of phase configuration strings defining criteria for this phase condition.
 	func get_phase_config() -> Dictionary:
 		var y_expression: String = ""
 		
@@ -90,14 +82,12 @@ var phase_conditions_by_string := {
 	"after_line_cleared": AfterLinesClearedPhaseCondition,
 }
 
-"""
-Creates a new PhaseCondition instance.
-
-Parameters:
-	'phase_key': A string key corresponding to the phase, such as 'after_line_cleared'.
-	
-	'phase_config': (Optional) A dictionary of strings defining any special conditions for the phase.
-"""
+## Creates a new PhaseCondition instance.
+##
+## Parameters:
+## 	'phase_key': A string key corresponding to the phase, such as 'after_line_cleared'.
+##
+## 	'phase_config': (Optional) A dictionary of strings defining any special conditions for the phase.
 func create(phase_key: String, phase_config: Dictionary) -> PhaseCondition:
 	var phase_condition_type: GDScript = phase_conditions_by_string.get(phase_key, PhaseCondition)
 	var phase_condition: PhaseCondition = phase_condition_type.new(phase_config)

--- a/project/src/main/puzzle/level/piece-type-rules.gd
+++ b/project/src/main/puzzle/level/piece-type-rules.gd
@@ -1,14 +1,10 @@
 class_name PieceTypeRules
-"""
-Pieces the player is given.
-"""
+## Pieces the player is given.
 
-"""
-Parses json strings like 'piece_j' into enums like PieceTypes.piece_j.
-
-Unlike most property parsers which only populate a single property, this parser populates both the 'types' and
-'start_types' fields.
-"""
+## Parses json strings like 'piece_j' into enums like PieceTypes.piece_j.
+##
+## Unlike most property parsers which only populate a single property, this parser populates both the 'types' and
+## 'start_types' fields.
 class PieceTypesPropertyParser extends RuleParser.PropertyParser:
 	var start_name: String = "start_types"
 	
@@ -43,13 +39,13 @@ class PieceTypesPropertyParser extends RuleParser.PropertyParser:
 	func is_default() -> bool:
 		return target().get(name).empty() and target().get(start_name).empty()
 
-# if 'true', the start pieces always appear in the same order instead of being shuffled.
+## if 'true', the start pieces always appear in the same order instead of being shuffled.
 var ordered_start: bool = false
 
-# list of PieceTypes to prepend to the piece queue before a game begins. these pieces are shuffled
+## list of PieceTypes to prepend to the piece queue before a game begins. these pieces are shuffled
 var start_types := []
 
-# list of PieceTypes to choose from. if empty, defaults to the basic 8 types (jlopqtuv)
+## list of PieceTypes to choose from. if empty, defaults to the basic 8 types (jlopqtuv)
 var types := []
 
 var _rule_parser: RuleParser

--- a/project/src/main/puzzle/level/rank-rules.gd
+++ b/project/src/main/puzzle/level/rank-rules.gd
@@ -1,11 +1,7 @@
 class_name RankRules
-"""
-Tweaks to rank calculation.
-"""
+## Tweaks to rank calculation.
 
-"""
-Parses a json string like 'hide_combos_rank' into an enum like 'ShowRank.HIDE'
-"""
+## Parses a json string like 'hide_combos_rank' into an enum like 'ShowRank.HIDE'
 class ShowRankPropertyParser extends RuleParser.PropertyParser:
 	var _hide_string: String
 	
@@ -40,27 +36,27 @@ enum ShowRank {
 	HIDE, # rank should be hidden
 }
 
-# multiplier for the expected box_score_per_line. '3.0' means the player
-# needs 3x the usual box points per line to get a good rank
+## multiplier for the expected box_score_per_line. '3.0' means the player
+## needs 3x the usual box points per line to get a good rank
 var box_factor := 1.0
 
-# multiplier for the expected combo_score_per_line. '3.0' means the player
-# needs 3x the usual combo points per line to get a good rank
+## multiplier for the expected combo_score_per_line. '3.0' means the player
+## needs 3x the usual combo points per line to get a good rank
 var combo_factor := 1.0
 
-# expected combo per customer
+## expected combo per customer
 var customer_combo := 0
 
-# extra time it takes an expert to move the piece where it belongs
+## extra time it takes an expert to move the piece where it belongs
 var extra_seconds_per_piece := 0.0
 
-# expected leftover lines
+## expected leftover lines
 var leftover_lines := 0
 
-# expected bonus points for pickups
+## expected bonus points for pickups
 var master_pickup_score := 0.0
 
-# expected bonus points per line awarded for pickups
+## expected bonus points per line awarded for pickups
 var master_pickup_score_per_line := 0.0
 
 var show_boxes_rank: int = ShowRank.DEFAULT
@@ -70,18 +66,18 @@ var show_pickups_rank: int = ShowRank.DEFAULT
 var show_pieces_rank: int = ShowRank.DEFAULT
 var show_speed_rank: int = ShowRank.DEFAULT
 
-# 'true' if the results screen should be skipped. Used for tutorials.
+## 'true' if the results screen should be skipped. Used for tutorials.
 var skip_results := false
 
-# Bonus rank given if the player achieves the level's success condition. Useful when designing levels where
-# achieving a target score of 1,000 is an A grade, but failing with a score of 999 is also an A grade. This property
-# gives the player a little bump in rank so achieving the target score will always result in a higher grade.
+## Bonus rank given if the player achieves the level's success condition. Useful when designing levels where
+## achieving a target score of 1,000 is an A grade, but failing with a score of 999 is also an A grade. This property
+## gives the player a little bump in rank so achieving the target score will always result in a higher grade.
 var success_bonus := 0.0
 
-# rank penalty applied each time the player tops out
+## rank penalty applied each time the player tops out
 var top_out_penalty := 4.0
 
-# If 'true' the player is not given a rank for this level.
+## If 'true' the player is not given a rank for this level.
 var unranked := false
 
 var _rule_parser: RuleParser

--- a/project/src/main/puzzle/level/rule-parser.gd
+++ b/project/src/main/puzzle/level/rule-parser.gd
@@ -1,72 +1,62 @@
 class_name RuleParser
-"""
-Serializes and deserializes level rules as json.
+## Serializes and deserializes level rules as json.
+##
+## Level rules are defined in json with lists of strings like 'tile_set veggie' or 'skip_intro'. This parses those into
+## values like 'tile_set=TileSetType.VEGGIE' or 'skip_intro=true'.
 
-Level rules are defined in json with lists of strings like 'tile_set veggie' or 'skip_intro'. This parses those into
-values like 'tile_set=TileSetType.VEGGIE' or 'skip_intro=true'.
-"""
-
-"""
-Abstract class which provides a framework for parsing and formatting json strings.
-
-Subclasses can override methods to define their own specialized behavior. A single property parser typically
-corresponds to a single property, although some parsers can populate many properties.
-"""
+## Abstract class which provides a framework for parsing and formatting json strings.
+##
+## Subclasses can override methods to define their own specialized behavior. A single property parser typically
+## corresponds to a single property, although some parsers can populate many properties.
 class PropertyParser:
-	# The rules class which contains one or more properties to parse.
-	# This must be a weak reference to avoid 'ObjectDB instances leaked at exit' warnings.
+	## The rules class which contains one or more properties to parse.
+	## This must be a weak reference to avoid 'ObjectDB instances leaked at exit' warnings.
 	var _target: WeakRef
 	
-	# The name of the property and json key to parse. This is useful for the most common scenario where a single json
-	# key maps to a single property. Subclasses can ignore this property if they are doing something unusual.
+	## The name of the property and json key to parse. This is useful for the most common scenario where a single json
+	## key maps to a single property. Subclasses can ignore this property if they are doing something unusual.
 	var name: String
 	
-	# The json keys which are handled by this property parser. The RuleParser uses this to decide which PropertyParser
-	# to activate.
+	## The json keys which are handled by this property parser. The RuleParser uses this to decide which PropertyParser
+	## to activate.
 	var keys := []
 	
-	# Default value if the json property is omitted.
+	## Default value if the json property is omitted.
 	var default
 	
-	# Default value if the json property is specified without a value. For example, a json string like 'skip_intro'
-	# might imply a value of 'skip_intro=true' for example.
+	## Default value if the json property is specified without a value. For example, a json string like 'skip_intro'
+	## might imply a value of 'skip_intro=true' for example.
 	var implied
 	
-	"""
-	Parameters:
-		'init_target': The rules object with properties to parse.
-			
-		'init_name': The name of the property and json key to parse.
-	"""
+	## Parameters:
+	## 	'init_target': The rules object with properties to parse.
+	##
+	## 	'init_name': The name of the property and json key to parse.
 	func _init(init_target: Object, init_name: String) -> void:
 		_target = weakref(init_target)
 		name = init_name
 		keys = [name]
 	
 	
-	"""
-	Returns the rules class which contains one or more properties to parse.
-	
-	Note: This must be a stored as weak reference and exposed with a function to avoid 'ObjectDB instances leaked at
-	exit' warnings.
-	"""
+	## Returns the rules class which contains one or more properties to parse.
+	##
+	## Note: This must be a stored as weak reference and exposed with a function to avoid 'ObjectDB instances leaked at
+	## exit' warnings.
 	func target() -> Object:
 		return _target.get_ref()
 	
 	
-	"""
-	Returns one or more json strings corresponding to the rule's current values.
-	
-	This will typically return an array with a single value. However some parsers can populate many properties, in
-	which case they would return multiple values.
-	
-	The default implementation returns a string like 'veg_points 15' with a string representation of the rule's
-	current value. This can be overridden for custom behavior, for example an enum serializer might prefer to write
-	'tile_set veggie' instead of the default 'tile_set 1'.
-	
-	Returns:
-		One or more json strings corresponding to the rule's current values.
-	"""
+	## Returns one or more json strings corresponding to the rule's current values.
+	##
+	## This will typically return an array with a single value. However some parsers can populate many properties, in
+	## which case they would return multiple values.
+	##
+	## The default implementation returns a string like 'veg_points 15' with a string representation of the rule's
+	## current value. This can be overridden for custom behavior, for example an enum serializer might prefer to write
+	## 'tile_set veggie' instead of the default 'tile_set 1'.
+	##
+	## Returns:
+	## 	One or more json strings corresponding to the rule's current values.
 	func to_json_strings() -> Array:
 		var result: String
 		if target().get(name) == implied:
@@ -76,14 +66,12 @@ class PropertyParser:
 		return [result]
 	
 	
-	"""
-	Updates the rule's properties based on the specified json string.
-	
-	The default implementation only works for string fields, and must be overridden to avoid type conversion errors.
-	
-	Parameters:
-		'json': The full json string being parsed, such as 'tile_set veggie'.
-	"""
+	## Updates the rule's properties based on the specified json string.
+	##
+	## The default implementation only works for string fields, and must be overridden to avoid type conversion errors.
+	##
+	## Parameters:
+	## 	'json': The full json string being parsed, such as 'tile_set veggie'.
 	func from_json_string(json: String) -> void:
 		var split := json.split(" ")
 		match split.size():
@@ -93,32 +81,26 @@ class PropertyParser:
 				target().set(name, json.split(" ")[1])
 	
 	
-	"""
-	Returns 'true' if the rule's property is currently set to the default value.
-	
-	Properties currently set to the default value are omitted from our json output.
-	"""
+	## Returns 'true' if the rule's property is currently set to the default value.
+	##
+	## Properties currently set to the default value are omitted from our json output.
 	func is_default() -> bool:
 		return default == target().get(name)
 
 
-"""
-Parses a json string like 'skip_intro' into a bool.
-"""
+## Parses a json string like 'skip_intro' into a bool.
 class BoolPropertyParser extends PropertyParser:
-	# A json string corresponding to a value of 'false', such as 'no_clear_on_finish'
+	## A json string corresponding to a value of 'false', such as 'no_clear_on_finish'
 	var _false_string: String
 	
-	"""
-	Parameters:
-		'init_target': The rules object with properties to parse.
-			
-		'init_name': The name of the property and json key to parse. This json key should correspond to a value of
-			'true'.
-		
-		'init_false_string': (Optional) A json string corresponding to a value of 'false', such as
-			'no_clear_on_finish'
-	"""
+	## Parameters:
+	## 	'init_target': The rules object with properties to parse.
+	##
+	## 	'init_name': The name of the property and json key to parse. This json key should correspond to a value of
+	## 		'true'.
+	##
+	## 	'init_false_string': (Optional) A json string corresponding to a value of 'false', such as
+	## 		'no_clear_on_finish'
 	func _init(init_target: Object, init_name: String, init_false_string: String = "").(init_target, init_name) -> void:
 		default = false
 		implied = true
@@ -126,23 +108,21 @@ class BoolPropertyParser extends PropertyParser:
 		if _false_string: keys = [name, _false_string]
 	
 	
-	"""
-	Parses a json string into a boolean value.
-	
-	This covers many use cases:
-		'clear': Assigns a value 'clear' to true
-		'clear true': Assigns a value 'clear' to true
-		'clear false': Assigns a value 'clear' to false
-		'no_clear': assigns a value 'clear' to false
-		'no_clear true': assigns a value 'clear' to false
-		'no_clear false': assigns a value 'clear' to true
-	
-	The values "True", "TRUE", "true" or "1" are treated as true. The values "False", "FALSE", "false" or "0" are
-	treated as false.
-	
-	Parameters:
-		'json': The full json string being parsed, such as 'clear' or 'no_clear true'.
-	"""
+	## Parses a json string into a boolean value.
+	##
+	## This covers many use cases:
+	## 	'clear': Assigns a value 'clear' to true
+	## 	'clear true': Assigns a value 'clear' to true
+	## 	'clear false': Assigns a value 'clear' to false
+	## 	'no_clear': assigns a value 'clear' to false
+	## 	'no_clear true': assigns a value 'clear' to false
+	## 	'no_clear false': assigns a value 'clear' to true
+	##
+	## The values "True", "TRUE", "true" or "1" are treated as true. The values "False", "FALSE", "false" or "0" are
+	## treated as false.
+	##
+	## Parameters:
+	## 	'json': The full json string being parsed, such as 'clear' or 'no_clear true'.
 	func from_json_string(json: String) -> void:
 		var split := json.split(" ")
 		match split.size():
@@ -168,15 +148,13 @@ class BoolPropertyParser extends PropertyParser:
 						push_warning("Unrecognized: %s" % [split[0]])
 	
 	
-	"""
-	Returns an array with a json string like 'clear' corresponding to the rule's current value.
-	
-	This returns a short value like 'clear' or 'no_clear' if possible, or a verbose value like 'clear false' if no
-	false string is defined.
-	
-	Returns:
-		An array with a json string like 'clear' corresponding to the rule's current value.
-	"""
+	## Returns an array with a json string like 'clear' corresponding to the rule's current value.
+	##
+	## This returns a short value like 'clear' or 'no_clear' if possible, or a verbose value like 'clear false' if no
+	## false string is defined.
+	##
+	## Returns:
+	## 	An array with a json string like 'clear' corresponding to the rule's current value.
 	func to_json_strings() -> Array:
 		var result: String
 		if target().get(name) == true:
@@ -191,9 +169,7 @@ class BoolPropertyParser extends PropertyParser:
 		return [result]
 
 
-"""
-Parses a json string like 'box_factor 0.5' into a float.
-"""
+## Parses a json string like 'box_factor 0.5' into a float.
 class FloatPropertyParser extends PropertyParser:
 	func _init(init_target: Object, init_name: String).(init_target, init_name) -> void:
 		default = 0.0
@@ -212,9 +188,7 @@ class FloatPropertyParser extends PropertyParser:
 		return is_equal_approx(default, target().get(name))
 
 
-"""
-Parses a json string like 'veg_points 10' into an int.
-"""
+## Parses a json string like 'veg_points 10' into an int.
 class IntPropertyParser extends PropertyParser:
 	func _init(init_target: Object, init_name: String).(init_target, init_name) -> void:
 		default = 0
@@ -229,33 +203,27 @@ class IntPropertyParser extends PropertyParser:
 				target().set(name, int(json.split(" ")[1]))
 
 
-"""
-Parses a json string like 'start_level level_10' into a string like "level_10".
-"""
+## Parses a json string like 'start_level level_10' into a string like "level_10".
 class StringPropertyParser extends PropertyParser:
 	func _init(init_target: Object, init_name: String).(init_target, init_name) -> void:
 		default = ""
 
 
-"""
-Parses a json string like 'tile_set veggie' into an enum like 'TileSetType.VEGGIE'
-
-This parser assumes all json strings are lower case snake case strings like 'time_over', and all enum values are upper
-case snake case strings like 'TIME_OVER'.
-"""
+## Parses a json string like 'tile_set veggie' into an enum like 'TileSetType.VEGGIE'
+##
+## This parser assumes all json strings are lower case snake case strings like 'time_over', and all enum values are
+## upper case snake case strings like 'TIME_OVER'.
 class EnumPropertyParser extends PropertyParser:
-	# key: (String) upper case snake case enum key
-	# value: (int) enum index
+	## key: (String) upper case snake case enum key
+	## value: (int) enum index
 	var _enum_dict: Dictionary
 	
-	"""
-	Parameters:
-		'init_target': The rules object with properties to parse.
-			
-		'init_name': The name of the property and json key to parse.
-		
-		'init_enum_dict': The property's enum type, such as 'PuzzleTileMap.TileSetType'
-	"""
+	## Parameters:
+	## 	'init_target': The rules object with properties to parse.
+	##
+	## 	'init_name': The name of the property and json key to parse.
+	##
+	## 	'init_enum_dict': The property's enum type, such as 'PuzzleTileMap.TileSetType'
 	func _init(init_target: Object, init_name: String, init_enum_dict).(init_target, init_name) -> void:
 		_enum_dict = init_enum_dict
 		default = 0
@@ -284,9 +252,7 @@ class EnumPropertyParser extends PropertyParser:
 		return [result]
 
 
-"""
-Allows for extended configuration of properties.
-"""
+## Allows for extended configuration of properties.
 class OngoingPropertyDefinition:
 	var _property_parser: PropertyParser
 	
@@ -294,101 +260,85 @@ class OngoingPropertyDefinition:
 		_property_parser = init_property_parser
 	
 	
-	"""
-	Sets the default value to use when the json property is omitted.
-	
-	Parameters:
-		'new_default': A default value, such as 'true', '0.0', or TileSetType.DEFAULT
-	"""
+	## Sets the default value to use when the json property is omitted.
+	##
+	## Parameters:
+	## 	'new_default': A default value, such as 'true', '0.0', or TileSetType.DEFAULT
 	func default(new_default) -> void:
 		_property_parser.default = new_default
 	
 	
-	"""
-	Sets the implied value to use when the json property is specified without a value.
-	
-	Parameters:
-		'new_default': An implied value, such as 'true', '0.0', or TileSetType.DEFAULT
-	"""
+	## Sets the implied value to use when the json property is specified without a value.
+	##
+	## Parameters:
+	## 	'new_default': An implied value, such as 'true', '0.0', or TileSetType.DEFAULT
 	func implied(new_implied) -> void:
 		_property_parser.implied = new_implied
 
-# The rules class which contains one or more properties to parse.
-# This must be a weak reference to avoid 'ObjectDB instances leaked at exit' warnings.
+## The rules class which contains one or more properties to parse.
+## This must be a weak reference to avoid 'ObjectDB instances leaked at exit' warnings.
 var _target: WeakRef
 
-# List of PropertyParser instances for serializing and deserializing json. This array's order dictates the order the
-# properties will be written to the json file.
+## List of PropertyParser instances for serializing and deserializing json. This array's order dictates the order the
+## properties will be written to the json file.
 var _property_parsers := []
 
-# key: (String) json key such as 'clear_on_finish' or 'piece_j'
-# value: (PropertyParser) PropertyParser instance which is activated for the specified key
+## key: (String) json key such as 'clear_on_finish' or 'piece_j'
+## value: (PropertyParser) PropertyParser instance which is activated for the specified key
 var _property_parsers_by_key := {}
 
 func _init(init_target: Object) -> void:
 	_target = weakref(init_target)
 
 
-"""
-Adds a boolean property parser.
-
-Parameters:
-	'name': The name of the property and json key to parse. This json key should correspond to a value of 'true'.
-	
-	'false_string': (Optional) A json string corresponding to a value of 'false', such as 'no_clear_on_finish'
-"""
+## Adds a boolean property parser.
+##
+## Parameters:
+## 	'name': The name of the property and json key to parse. This json key should correspond to a value of 'true'.
+##
+## 	'false_string': (Optional) A json string corresponding to a value of 'false', such as 'no_clear_on_finish'
 func add_bool(name: String, false_string: String = "") -> OngoingPropertyDefinition:
 	return add(BoolPropertyParser.new(_target.get_ref(), name, false_string))
 
 
-"""
-Adds an enum property parser.
-
-Parameters:
-	'name': The name of the property and json key to parse.
-	
-	'enum_dict': The property's enum type, such as 'PuzzleTileMap.TileSetType'
-"""
+## Adds an enum property parser.
+##
+## Parameters:
+## 	'name': The name of the property and json key to parse.
+##
+## 	'enum_dict': The property's enum type, such as 'PuzzleTileMap.TileSetType'
 func add_enum(name: String, enum_dict: Dictionary) -> OngoingPropertyDefinition:
 	return add(EnumPropertyParser.new(_target.get_ref(), name, enum_dict))
 
 
-"""
-Adds a float property parser.
-
-Parameters:
-	'name': The name of the property and json key to parse.
-"""
+## Adds a float property parser.
+##
+## Parameters:
+## 	'name': The name of the property and json key to parse.
 func add_float(name: String) -> OngoingPropertyDefinition:
 	return add(FloatPropertyParser.new(_target.get_ref(), name))
 
 
-"""
-Adds an int property parser.
-
-Parameters:
-	'name': The name of the property and json key to parse.
-"""
+## Adds an int property parser.
+##
+## Parameters:
+## 	'name': The name of the property and json key to parse.
 func add_int(name: String) -> OngoingPropertyDefinition:
 	return add(IntPropertyParser.new(_target.get_ref(), name))
 
 
-"""
-Adds a string property parser.
-
-Parameters:
-	'name': The name of the property and json key to parse.
-"""
+## Adds a string property parser.
+##
+## Parameters:
+## 	'name': The name of the property and json key to parse.
 func add_string(name: String) -> OngoingPropertyDefinition:
 	return add(StringPropertyParser.new(_target.get_ref(), name))
 
 
-"""
-Adds a custom property parser.
-
-Parameters:
-	'property_parser': Defines behavior for parsing and formatting json strings.
-"""
+## Adds a custom property parser.
+##
+## Parameters:
+## 	'property_parser': Defines behavior for parsing and formatting json strings.
 func add(property_parser: PropertyParser) -> OngoingPropertyDefinition:
 	_property_parsers.append(property_parser)
 	for rule_key in property_parser.keys:
@@ -397,12 +347,10 @@ func add(property_parser: PropertyParser) -> OngoingPropertyDefinition:
 	return ongoing_rule_definition
 
 
-"""
-Updates the rule's properties based on the specified json strings.
-
-Parameters:
-	'json': An array of json strings to parse, such as 'tile_set veggie'.
-"""
+## Updates the rule's properties based on the specified json strings.
+##
+## Parameters:
+## 	'json': An array of json strings to parse, such as 'tile_set veggie'.
 func from_json_array(json: Array) -> void:
 	for json_string in json:
 		var split: Array = json_string.split(" ")
@@ -413,12 +361,10 @@ func from_json_array(json: Array) -> void:
 		property_parser.from_json_string(json_string)
 
 
-"""
-Returns a minimal list of json strings corresponding to the rule's current values.
-
-Properties which are set to their default value are omitted from the resulting list. If all properties are assigned to
-their default value, the list will be empty.
-"""
+## Returns a minimal list of json strings corresponding to the rule's current values.
+##
+## Properties which are set to their default value are omitted from the resulting list. If all properties are assigned
+## to their default value, the list will be empty.
 func to_json_array() -> Array:
 	var result := []
 	for property_parser in _property_parsers:
@@ -427,11 +373,9 @@ func to_json_array() -> Array:
 	return result
 
 
-"""
-Returns 'true' if all of the rule's properties are currently set to their default values.
-
-Rules whose properties are set to their default values are omitted from our json output.
-"""
+## Returns 'true' if all of the rule's properties are currently set to their default values.
+##
+## Rules whose properties are set to their default values are omitted from our json output.
 func is_default() -> bool:
 	var result := true
 	for property_parser in _property_parsers:

--- a/project/src/main/puzzle/level/score-rules.gd
+++ b/project/src/main/puzzle/level/score-rules.gd
@@ -1,14 +1,10 @@
 class_name ScoreRules
-"""
-Rules for scoring points.
-"""
+## Rules for scoring points.
 
-"""
-Parses a json string like 'cake_all 15' into an int.
-
-This is distinct from IntPropertyParser because json values like 'cake_all' are not directly stored into a 'cake_all'
-property, there is some translation logic.
-"""
+## Parses a json string like 'cake_all 15' into an int.
+##
+## This is distinct from IntPropertyParser because json values like 'cake_all' are not directly stored into a
+## 'cake_all' property, there is some translation logic.
 class PointsPropertyParser extends RuleParser.PropertyParser:
 	var _all_string: String
 	
@@ -29,19 +25,19 @@ class PointsPropertyParser extends RuleParser.PropertyParser:
 const DEFAULT_CAKE_POINTS := 10
 const DEFAULT_SNACK_POINTS := 5
 
-# box points for clearing a row of a cake box.
+## box points for clearing a row of a cake box.
 var cake_points := DEFAULT_CAKE_POINTS
 
-# box points for clearing a row of a snack box.
+## box points for clearing a row of a snack box.
 var snack_points := DEFAULT_SNACK_POINTS
 
-# box points for collecting a cake pickup.
+## box points for collecting a cake pickup.
 var cake_pickup_points := 20
 
-# box points for collecting a snack pickup.
+## box points for collecting a snack pickup.
 var snack_pickup_points := 10
 
-# box points awarded for clearing a row with no boxes, a vegetable row.
+## box points awarded for clearing a row with no boxes, a vegetable row.
 var veg_points := 0
 
 var _rule_parser: RuleParser

--- a/project/src/main/puzzle/level/speed-rules.gd
+++ b/project/src/main/puzzle/level/speed-rules.gd
@@ -1,10 +1,8 @@
 class_name SpeedRules
-"""
-Rules for how fast pieces should move.
-"""
+## Rules for how fast pieces should move.
 
-# Array of Milestone objects representing the requirements to speed up. This mostly applies to 'Marathon Mode' where
-# clearing lines makes you speed up.
+## Array of Milestone objects representing the requirements to speed up. This mostly applies to 'Marathon Mode' where
+## clearing lines makes you speed up.
 var speed_ups := []
 
 func _init() -> void:
@@ -12,16 +10,14 @@ func _init() -> void:
 	add_speed_up(Milestone.LINES, 0, "0")
 
 
-"""
-Adds criteria for speeding up, such as a time, score, or line limit.
-
-Parameters:
-	'type': an enum from Milestone.MilestoneType describing the milestone criteria (lines, score, time)
-	
-	'value': an value describing the milestone criteria (number of lines, points, seconds)
-	
-	'speed_id': a string from PieceSpeeds defining the new speed
-"""
+## Adds criteria for speeding up, such as a time, score, or line limit.
+##
+## Parameters:
+## 	'type': an enum from Milestone.MilestoneType describing the milestone criteria (lines, score, time)
+##
+## 	'value': an value describing the milestone criteria (number of lines, points, seconds)
+##
+## 	'speed_id': a string from PieceSpeeds defining the new speed
 func add_speed_up(type: int, value: int, speed_id: String) -> void:
 	var speed_up := Milestone.new()
 	speed_up.set_milestone(type, value)

--- a/project/src/main/puzzle/line-clear-sfx.gd
+++ b/project/src/main/puzzle/line-clear-sfx.gd
@@ -1,7 +1,5 @@
 extends Node
-"""
-Plays sound effects when lines are cleared.
-"""
+## Plays sound effects when lines are cleared.
 
 onready var _combo_sounds := [null, null, # no combo sfx for the first two lines
 		preload("res://assets/main/puzzle/combo-00.wav"),
@@ -61,12 +59,10 @@ func _play_thump_sound(_y: int, total_lines: int, remaining_lines: int, box_ints
 		sound.play()
 
 
-"""
-Plays an escalating sound for the current combo.
-
-For smaller combos this goes through a list of sound effects with higher pitches. For larger combos this loops through
-a repeating list where the repetition is concealed using a shepard tone.
-"""
+## Plays an escalating sound for the current combo.
+##
+## For smaller combos this goes through a list of sound effects with higher pitches. For larger combos this loops
+## through a repeating list where the repetition is concealed using a shepard tone.
 func _play_combo_sound(_y: int, _total_lines: int, _remaining_lines: int, _box_ints: Array) -> void:
 	var sound: AudioStream
 	if PuzzleState.combo <= 0:
@@ -90,12 +86,10 @@ func _play_box_sound(_y: int, _total_lines: int, _remaining_lines: int, box_ints
 	if sound: sound.play()
 
 
-"""
-Clearing a line results in three overlapping sounds:
-	1. A 'thump' sound
-	2. A 'ding' sound for continuing a combo
-	3. A 'glorp' sound when clearing a snack/cake box
-"""
+## Clearing a line results in three overlapping sounds:
+## 	1. A 'thump' sound
+## 	2. A 'ding' sound for continuing a combo
+## 	3. A 'glorp' sound when clearing a snack/cake box
 func _on_Playfield_before_line_cleared(y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:
 	_play_combo_sound(y, total_lines, remaining_lines, box_ints)
 	_play_box_sound(y, total_lines, remaining_lines, box_ints)

--- a/project/src/main/puzzle/line-inserter.gd
+++ b/project/src/main/puzzle/line-inserter.gd
@@ -1,21 +1,19 @@
 extends Node
-"""
-Inserts lines in a puzzle tilemap.
+## Inserts lines in a puzzle tilemap.
+##
+## Most levels don't insert lines, but this script handles it for the levels that do.
 
-Most levels don't insert lines, but this script handles it for the levels that do.
-"""
-
-# emitted after a line is inserted
+## emitted after a line is inserted
 signal line_inserted(y, tiles_key, src_y)
 
 export (NodePath) var tile_map_path: NodePath
 
-# key: a tiles key for tiles referenced by level rules
-# value: the next row to insert from the referenced tiles
+## key: a tiles key for tiles referenced by level rules
+## value: the next row to insert from the referenced tiles
 var _row_index_by_tiles_key := {}
 
-# key: a tiles key for tiles referenced by level rules
-# value: the total number of rows in the referenced tiles
+## key: a tiles key for tiles referenced by level rules
+## value: the total number of rows in the referenced tiles
 var _row_count_by_tiles_key := {}
 
 onready var _tile_map: PuzzleTileMap = get_node(tile_map_path)
@@ -26,15 +24,13 @@ func _ready() -> void:
 	CurrentLevel.connect("settings_changed", self, "_on_Level_settings_changed")
 
 
-"""
-Inserts a line into the puzzle tilemap.
-
-Parameters:
-	'tiles_key': (Optional) a key for the LevelTiles entry for the tiles to insert
-	
-	'dest_y': (Optional) The y coordinate of the line to insert. If omitted, the line will be inserted at the
-		bottom of the puzzle tilemap.
-"""
+## Inserts a line into the puzzle tilemap.
+##
+## Parameters:
+## 	'tiles_key': (Optional) a key for the LevelTiles entry for the tiles to insert
+##
+## 	'dest_y': (Optional) The y coordinate of the line to insert. If omitted, the line will be inserted at the
+## 		bottom of the puzzle tilemap.
 func insert_line(tiles_key: String = "", dest_y: int = PuzzleTileMap.ROW_COUNT - 1) -> void:
 	# shift playfield up
 	_tile_map.insert_row(dest_y)

--- a/project/src/main/puzzle/milestone-hud.gd
+++ b/project/src/main/puzzle/milestone-hud.gd
@@ -1,16 +1,14 @@
 class_name MilestoneHud
 extends Control
-"""
-Shows the user's level performance as a progress bar.
+## Shows the user's level performance as a progress bar.
+##
+## the progress bar fills up as they approach the next level up milestone. If there are no more speedups, it fills as
+## they approach the level's win/finish condition.
+##
+## A label overlaid on the progress bar shows them how much further they need to progress to reach the level's
+## win/finish condition.
 
-the progress bar fills up as they approach the next level up milestone. If there are no more speedups, it fills as they
-approach the level's win/finish condition.
-
-A label overlaid on the progress bar shows them how much further they need to progress to reach the level's
-win/finish condition.
-"""
-
-# Colors used to render the level number. Easy levels are green, and hard levels are red/purple.
+## Colors used to render the level number. Easy levels are green, and hard levels are red/purple.
 const LEVEL_COLOR_0 := Color("48b968")
 const LEVEL_COLOR_1 := Color("78b948")
 const LEVEL_COLOR_2 := Color("b9b948")
@@ -45,9 +43,7 @@ func _process(_delta: float) -> void:
 	update_milebar()
 
 
-"""
-Updates the milestone progress bar's value and boundaries.
-"""
+## Updates the milestone progress bar's value and boundaries.
 func update_milebar_values() -> void:
 	_progress_bar.min_value = MilestoneManager.prev_milestone().value
 	var next_milestone := MilestoneManager.next_milestone()
@@ -59,9 +55,7 @@ func update_milebar_values() -> void:
 	_progress_bar.value = MilestoneManager.milestone_progress(next_milestone)
 
 
-"""
-Updates the milestone progress bar text.
-"""
+## Updates the milestone progress bar text.
 func update_milebar_text() -> void:
 	var milestone := CurrentLevel.settings.finish_condition
 	var remaining: int = max(0, ceil(milestone.value - MilestoneManager.milestone_progress(milestone)))
@@ -76,11 +70,9 @@ func update_milebar_text() -> void:
 			_value.text = StringUtils.format_duration(remaining)
 
 
-"""
-Updates the milestone progress bar color.
-
-Color changes from green to red to purple as difficulty increases.
-"""
+## Updates the milestone progress bar color.
+##
+## Color changes from green to red to purple as difficulty increases.
 func update_milebar_color() -> void:
 	var level_color: Color
 	if PieceSpeeds.current_speed.gravity >= 20 * PieceSpeeds.G and PieceSpeeds.current_speed.lock_delay < 20:
@@ -98,41 +90,32 @@ func update_milebar_color() -> void:
 	_progress_bar.get("custom_styles/fg").set_bg_color(Utils.to_transparent(level_color, 0.333))
 
 
-"""
-Initializes the milestone progress bar's value and boundaries, and locks in the font size.
-
-It would be distracting if the font got bigger as the player progressed, so the font size is only assigned at the
-start of each level when the text should be at its longest value.
-"""
+## Initializes the milestone progress bar's value and boundaries, and locks in the font size.
+##
+## It would be distracting if the font got bigger as the player progressed, so the font size is only assigned at the
+## start of each level when the text should be at its longest value.
 func init_milebar() -> void:
 	update_milebar()
 	_value.pick_largest_font()
 
 
-"""
-Update the milestone hud's content during a game.
-"""
+## Update the milestone hud's content during a game.
 func update_milebar() -> void:
 	update_milebar_values()
 	update_milebar_text()
 	update_milebar_color()
 
 
-"""
-Update the particle colors to match the progress bar.
-
-All of the Particles2D share the same GradientTexture so we only need to modify one.
-"""
+## Update the particle colors to match the progress bar.
+##
+## All of the Particles2D share the same GradientTexture so we only need to modify one.
 func _update_particle_colors() -> void:
 	var particles_material: ParticlesMaterial = _progress_bar_particles.get_child(0).process_material
 	var progress_bar_color: Color = _progress_bar.get("custom_styles/fg").bg_color
 	particles_material.color_ramp.gradient.colors[0] = Utils.to_transparent(progress_bar_color, 1.0)
 	particles_material.color_ramp.gradient.colors[1] = Utils.to_transparent(progress_bar_color, 0.0)
 
-
-"""
-Emit particles from the progress bar.
-"""
+## Emit particles from the progress bar.
 func _emit_particles() -> void:
 	for particles_2d_node in _progress_bar_particles.get_children():
 		var particles_2d: Particles2D = particles_2d_node
@@ -144,11 +127,9 @@ func _on_PuzzleState_game_prepared() -> void:
 	init_milebar()
 
 
-"""
-Emits particles when the player levels up.
-
-This provides visual feedback for people playing without sound.
-"""
+## Emits particles when the player levels up.
+##
+## This provides visual feedback for people playing without sound.
 func _on_PuzzleState_speed_index_changed(value: int) -> void:
 	if value == 0:
 		# initializing the level; don't emit any particles

--- a/project/src/main/puzzle/milestone-manager.gd
+++ b/project/src/main/puzzle/milestone-manager.gd
@@ -1,12 +1,10 @@
 extends Node
-"""
-Tracks the player's progress towards milestones.
-
-Milestones can involve reaching a certain score, clearing a certain number of lines or surviving a certain number of
-seconds.
-
-Reaching a milestone can increase the speed, end the level, or trigger a success condition.
-"""
+## Tracks the player's progress towards milestones.
+##
+## Milestones can involve reaching a certain score, clearing a certain number of lines or surviving a certain number of
+## seconds.
+##
+## Reaching a milestone can increase the speed, end the level, or trigger a success condition.
 
 func _ready() -> void:
 	PuzzleState.connect("before_piece_written", self, "_on_PuzzleState_before_piece_written")
@@ -34,12 +32,10 @@ func milestone_met(milestone: Milestone) -> bool:
 	return result
 
 
-"""
-Returns the player's current progress toward the specified milestone.
-
-Depending on the milestone type, the returned progress value could be the current score, number of lines cleared or
-something else.
-"""
+## Returns the player's current progress toward the specified milestone.
+##
+## Depending on the milestone type, the returned progress value could be the current score, number of lines cleared or
+## something else.
 func milestone_progress(milestone: Milestone) -> float:
 	var progress: float
 	match milestone.type:
@@ -60,21 +56,17 @@ func milestone_progress(milestone: Milestone) -> float:
 	return progress
 
 
-"""
-Returns the previously completed milestone.
-
-This controls the speed at which the pieces move.
-"""
+## Returns the previously completed milestone.
+##
+## This controls the speed at which the pieces move.
 func prev_milestone() -> Milestone:
 	return CurrentLevel.settings.speed.speed_ups[PuzzleState.speed_index]
 
 
-"""
-Returns the next upcoming milestone. This is reflected in the UI.
-
-The next upcoming milestone could be a 'speed up' if this level has multiple speeds, or it could be the level's
-finish condition.
-"""
+## Returns the next upcoming milestone. This is reflected in the UI.
+##
+## The next upcoming milestone could be a 'speed up' if this level has multiple speeds, or it could be the level's
+## finish condition.
 func next_milestone() -> Milestone:
 	var milestone: Milestone
 	if PuzzleState.speed_index + 1 < CurrentLevel.settings.speed.speed_ups.size():
@@ -84,9 +76,7 @@ func next_milestone() -> Milestone:
 	return milestone
 
 
-"""
-If the player reached a milestone, we increase the speed.
-"""
+## If the player reached a milestone, we increase the speed.
 func _check_for_speed_up() -> void:
 	var new_speed_index: int = PuzzleState.speed_index
 	
@@ -98,9 +88,7 @@ func _check_for_speed_up() -> void:
 		PuzzleState.speed_index = new_speed_index
 
 
-"""
-If the player reached the finish milestone, we end the level.
-"""
+## If the player reached the finish milestone, we end the level.
 func _check_for_finish() -> void:
 	if PuzzleState.game_active and milestone_met(CurrentLevel.settings.finish_condition):
 		PuzzleState.trigger_finish()

--- a/project/src/main/puzzle/money-label-tween.gd
+++ b/project/src/main/puzzle/money-label-tween.gd
@@ -1,7 +1,5 @@
 extends Tween
-"""
-Tween which shows/hides the money label which appears after a puzzle.
-"""
+## Tween which shows/hides the money label which appears after a puzzle.
 
 const DURATION := 0.1
 

--- a/project/src/main/puzzle/pan/frying-pan-ghost.gd
+++ b/project/src/main/puzzle/pan/frying-pan-ghost.gd
@@ -1,7 +1,5 @@
 extends Sprite
-"""
-A frying pan which vanishes when the player loses a life.
-"""
+## A frying pan which vanishes when the player loses a life.
 
 export (Vector2) var velocity: Vector2
 

--- a/project/src/main/puzzle/pan/frying-pans-ui.gd
+++ b/project/src/main/puzzle/pan/frying-pans-ui.gd
@@ -1,32 +1,30 @@
 extends Control
-"""
-UI control which shows a list of frying pans corresponding to the player's lives.
+## UI control which shows a list of frying pans corresponding to the player's lives.
+##
+## The frying pans are displayed in a tilemap. When the player tops out, the tilemap is updated and a new 'frying pan
+## ghost' is added, which animates a frying pan fading away.
 
-The frying pans are displayed in a tilemap. When the player tops out, the tilemap is updated and a new 'frying pan
-ghost' is added, which animates a frying pan fading away.
-"""
-
-# tileset index for regular pans (white)
+## tileset index for regular pans (white)
 const TILE_INDEX_PAN := 0
 
-# tileset index for gold pans (yellow with a circular mark)
+## tileset index for gold pans (yellow with a circular mark)
 const TILE_INDEX_PAN_GOLD := 1
 
-# tileset index for dead pans (red with a slash)
+## tileset index for dead pans (red with a slash)
 const TILE_INDEX_PAN_DEAD := 2
 
-# maximum number of frying pans to display (the number of lives the player starts with)
+## maximum number of frying pans to display (the number of lives the player starts with)
 export (int) var pans_max := 3 setget set_pans_max
 
-# number of remaining non-dead pans (the number of lives the player has left)
+## number of remaining non-dead pans (the number of lives the player has left)
 export (int) var pans_remaining := 3 setget set_pans_remaining
 
-# if true, the pans are shown as gold pans. golden pans are used shown if topping out clears the playfield
+## if true, the pans are shown as gold pans. golden pans are used shown if topping out clears the playfield
 export (bool) var gold := false setget set_gold
 
 export (PackedScene) var FryingPanGhostScene: PackedScene
 
-# the tilemap cell containing the upper left most dead pan
+## the tilemap cell containing the upper left most dead pan
 var _first_dead_cell: Vector2
 
 onready var _tile_map: TileMap = $TileMap
@@ -49,11 +47,9 @@ func set_pans_max(new_pans_max: int) -> void:
 	refresh_tilemap()
 
 
-"""
-Sets the number of remaining non-dead pans (the number of lives the player has left.)
-
-This refreshes the tilemap and sometimes adds a frying pan ghost.
-"""
+## Sets the number of remaining non-dead pans (the number of lives the player has left.)
+##
+## This refreshes the tilemap and sometimes adds a frying pan ghost.
 func set_pans_remaining(new_pans_remaining: int) -> void:
 	if pans_remaining == new_pans_remaining:
 		return
@@ -66,9 +62,7 @@ func set_pans_remaining(new_pans_remaining: int) -> void:
 		_add_frying_pan_ghost()
 
 
-"""
-Recalculates the tilemap cells, tilemap scale, and _first_dead_cell field.
-"""
+## Recalculates the tilemap cells, tilemap scale, and _first_dead_cell field.
 func refresh_tilemap() -> void:
 	var pan_cells := _calculate_pan_cells()
 	_tile_map.clear()
@@ -76,12 +70,10 @@ func refresh_tilemap() -> void:
 	_update_tilemap_scale()
 
 
-"""
-Calculates the position of frying pans within the tilemap.
-
-Returns:
-	An array of Vector2 coordinates in the tilemap which should contain frying pans.
-"""
+## Calculates the position of frying pans within the tilemap.
+##
+## Returns:
+## 	An array of Vector2 coordinates in the tilemap which should contain frying pans.
 func _calculate_pan_cells() -> Array:
 	var pan_cells := []
 	
@@ -109,12 +101,10 @@ func _calculate_pan_cells() -> Array:
 	return pan_cells
 
 
-"""
-Places pans in the appropriate tilemap cells.
-
-Parameters:
-	'pan_cells': An array of Vector2 coordinates in the tilemap which should contain frying pans.
-"""
+## Places pans in the appropriate tilemap cells.
+##
+## Parameters:
+## 	'pan_cells': An array of Vector2 coordinates in the tilemap which should contain frying pans.
 func _add_pans_to_tilemap(pan_cells: Array) -> void:
 	for i in range(pan_cells.size()):
 		var pan_cell: Vector2 = pan_cells[i]
@@ -131,22 +121,18 @@ func _add_pans_to_tilemap(pan_cells: Array) -> void:
 		_tile_map.set_cell(pan_cell.x, pan_cell.y, tile)
 
 
-"""
-Updates the tilemap scale based on its contents.
-
-The tilemap is rescaled so that its contents will fit into its parent control horizontally.
-"""
+## Updates the tilemap scale based on its contents.
+##
+## The tilemap is rescaled so that its contents will fit into its parent control horizontally.
 func _update_tilemap_scale() -> void:
 	var total_width := max(10, _tile_map.get_used_rect().size.x + 1) * _tile_map.cell_size.x
 	_tile_map.scale = Vector2(1, 1) * (rect_size.x / total_width)
 
 
-"""
-Animates a pan disappearing when the player loses a life.
-
-The ghost is spawned at the location of the the upper left most dead pan. It should be called immediately after the
-player loses a life and the tilemap is refreshed.
-"""
+## Animates a pan disappearing when the player loses a life.
+##
+## The ghost is spawned at the location of the the upper left most dead pan. It should be called immediately after the
+## player loses a life and the tilemap is refreshed.
 func _add_frying_pan_ghost() -> void:
 	var frying_pan_ghost: Sprite = FryingPanGhostScene.instance()
 	var tile_id := TILE_INDEX_PAN_GOLD if gold else TILE_INDEX_PAN

--- a/project/src/main/puzzle/pan/puzzle-frying-pans-ui.gd
+++ b/project/src/main/puzzle/pan/puzzle-frying-pans-ui.gd
@@ -1,7 +1,5 @@
 extends "res://src/main/puzzle/pan/frying-pans-ui.gd"
-"""
-Updates the FryingPansUi based on the level's settings and how the player is doing.
-"""
+## Updates the FryingPansUi based on the level's settings and how the player is doing.
 
 func _ready() -> void:
 	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
@@ -10,9 +8,7 @@ func _ready() -> void:
 	_refresh_lives()
 
 
-"""
-Updates the state of the FryingPansUi and refreshes the tilemap.
-"""
+## Updates the state of the FryingPansUi and refreshes the tilemap.
 func _refresh_lives() -> void:
 	pans_max = CurrentLevel.settings.lose_condition.top_out
 	if PuzzleState.level_performance.lost:
@@ -31,10 +27,8 @@ func _on_PuzzleState_game_ended() -> void:
 	_refresh_lives()
 
 
-"""
-Updates the state of the FryingPansUi when the player loses a life.
-
-We deliberately avoid calling refresh_lives because we want to trigger the animation where a frying pan fades out.
-"""
+## Updates the state of the FryingPansUi when the player loses a life.
+##
+## We deliberately avoid calling refresh_lives because we want to trigger the animation where a frying pan fades out.
 func _on_PuzzleState_topped_out() -> void:
 	set_pans_remaining(pans_remaining - 1)

--- a/project/src/main/puzzle/pickup.gd
+++ b/project/src/main/puzzle/pickup.gd
@@ -1,18 +1,16 @@
 class_name Pickup
 extends Node2D
-"""
-A pickup which spawns a food item when collected by the player.
-"""
+## A pickup which spawns a food item when collected by the player.
 
-# the duration in seconds between star color changes
+## the duration in seconds between star color changes
 const STAR_COLOR_CHANGE_DURATION := 0.8
 
 var food_type := 0 setget set_food_type
 
-# 'true' if the food item should be shown, 'false' if the star or seed should be shown
+## 'true' if the food item should be shown, 'false' if the star or seed should be shown
 var food_shown: bool = false setget set_food_shown
 
-# array of Colors the star should cycle between
+## array of Colors the star should cycle between
 var _star_colors: Array = []
 var _star_color_index := 0
 
@@ -20,7 +18,7 @@ onready var _seed := $Seed
 onready var _star := $Star
 onready var _food_item := $FoodItem
 
-# tween used to update the star's color
+## tween used to update the star's color
 onready var _star_color_tween := $StarColorTween
 
 func _ready() -> void:
@@ -40,17 +38,13 @@ func set_food_type(new_food_type: int) -> void:
 	_refresh_appearance()
 
 
-"""
-Returns 'true' if this pickup will spawn a cake when collected.
-"""
+## Returns 'true' if this pickup will spawn a cake when collected.
 func is_cake() -> bool:
 	var box_type: int = Foods.BOX_TYPE_BY_FOOD_TYPE[food_type]
 	return Foods.is_cake_box(box_type)
 
 
-"""
-Updates the status and visibility of the child components.
-"""
+## Updates the status and visibility of the child components.
 func _refresh_appearance() -> void:
 	if not (is_inside_tree() and _food_item):
 		return
@@ -80,9 +74,7 @@ func _refresh_appearance() -> void:
 		_food_item.food_type = food_type
 
 
-"""
-Gradually changes the star to a new color.
-"""
+## Gradually changes the star to a new color.
 func _launch_star_color_tween(var initial_launch := false) -> void:
 	var new_star_color_index := (_star_color_index + 1) % _star_colors.size()
 	_star_color_tween.remove_all()

--- a/project/src/main/puzzle/pickups.gd
+++ b/project/src/main/puzzle/pickups.gd
@@ -1,14 +1,12 @@
 extends Control
-"""
-Creates pickups on the playfield for certain levels.
+## Creates pickups on the playfield for certain levels.
+##
+## These pickups react to the player's piece, changing their appearance and spawning food.
 
-These pickups react to the player's piece, changing their appearance and spawning food.
-"""
-
-# emitted when a food item should be spawned because the player collects a pickup
+## emitted when a food item should be spawned because the player collects a pickup
 signal food_spawned(cell, remaining_food, food_type)
 
-# sound effect volume when the piece overlaps a pickup, temporarily turning it into a food
+## sound effect volume when the piece overlaps a pickup, temporarily turning it into a food
 const OVERLAP_VOLUME_DB := -6.0
 
 const PICKUP_DEFAULT: int = BlocksDuringRules.PickupType.DEFAULT
@@ -18,25 +16,25 @@ const PICKUP_FLOAT_REGEN: int = BlocksDuringRules.PickupType.FLOAT_REGEN
 export (NodePath) var _puzzle_tile_map_path: NodePath
 export (PackedScene) var PickupScene: PackedScene
 
-# key: Vector2 playfield cell positions
-# value: Pickup node contained within that cell
+## key: Vector2 playfield cell positions
+## value: Pickup node contained within that cell
 var _pickups_by_cell: Dictionary
 
-# the next pickup sound effect to play
+## the next pickup sound effect to play
 var _pickup_sfx_index := 0
 
-# how many more pickup sounds should play after the current one
+## how many more pickup sounds should play after the current one
 var _remaining_pickup_sfx := 0
 
 onready var _puzzle_tile_map: PuzzleTileMap = get_node(_puzzle_tile_map_path)
 
-# parent node for the pickup graphics
+## parent node for the pickup graphics
 onready var _visuals := $Visuals
 
-# timer which triggers playing consecutive pickup sounds. we don't want to play them all simultaneously
+## timer which triggers playing consecutive pickup sounds. we don't want to play them all simultaneously
 onready var _pickup_sfx_timer := $CollectSfxTimer
 
-# array of AudioStreamPlayer instances which play pickup sounds
+## array of AudioStreamPlayer instances which play pickup sounds
 onready var _pickup_sfx_players := [$PickupSfx0, $PickupSfx1, $PickupSfx2, $PickupSfx3, $PickupSfx4, $PickupSfx5]
 
 func _ready() -> void:
@@ -48,9 +46,7 @@ func _ready() -> void:
 	_prepare_pickups_for_level()
 
 
-"""
-Adds or replaces a pickup in a playfield cell.
-"""
+## Adds or replaces a pickup in a playfield cell.
 func set_pickup(cell: Vector2, box_type: int) -> void:
 	remove_pickup(cell)
 	
@@ -67,9 +63,7 @@ func set_pickup(cell: Vector2, box_type: int) -> void:
 		_visuals.add_child(pickup)
 
 
-"""
-Removes a pickup from a playfield cell.
-"""
+## Removes a pickup from a playfield cell.
 func remove_pickup(cell: Vector2) -> void:
 	if not _pickups_by_cell.has(cell):
 		return
@@ -78,18 +72,14 @@ func remove_pickup(cell: Vector2) -> void:
 	_pickups_by_cell.erase(cell)
 
 
-"""
-Removes all pickups from all playfield cells.
-"""
+## Removes all pickups from all playfield cells.
 func clear() -> void:
 	for pickup in _visuals.get_children():
 		pickup.queue_free()
 	_pickups_by_cell.clear()
 
 
-"""
-Spawns any pickups necessary for starting the current level.
-"""
+## Spawns any pickups necessary for starting the current level.
 func _prepare_pickups_for_level() -> void:
 	var src_pickups := CurrentLevel.settings.tiles.blocks_start().pickups
 	
@@ -121,19 +111,16 @@ func _prepare_pickups_for_level() -> void:
 		_pickups_by_cell[cell].food_shown = false
 
 
-"""
-Return the food type which belongs in the specified cell.
-
-The food type corresponds to the box type, although we alternate identical snack box pickups in a checkerboard pattern.
-"""
+## Return the food type which belongs in the specified cell.
+##
+## The food type corresponds to the box type, although we alternate identical snack box pickups in a checkerboard
+## pattern.
 func _food_type_for_box_type(box_type: int, cell: Vector2) -> int:
 	var food_types: Array = Foods.FOOD_TYPES_BY_BOX_TYPES[box_type]
 	return food_types[(int(cell.x + cell.y) % food_types.size())]
 
 
-"""
-Updates the overlapped pickups as the player moves their piece.
-"""
+## Updates the overlapped pickups as the player moves their piece.
 func _refresh_pickup_state(piece: ActivePiece) -> void:
 	var play_overlap_sfx := false
 	
@@ -159,22 +146,18 @@ func _refresh_pickup_state(piece: ActivePiece) -> void:
 				break
 
 
-"""
-Removes all pickups from a playfield row.
-"""
+## Removes all pickups from a playfield row.
 func _erase_row(y: int) -> void:
 	for x in range(PuzzleTileMap.COL_COUNT):
 		remove_pickup(Vector2(x, y))
 
 
-"""
-Shifts a group of pickups up or down.
-
-Parameters:
-	'bottom_row': The lowest row to shift. All pickups at or above this row will be shifted.
-	
-	'direction': The direction to shift the pickups, such as Vector2.UP or Vector2.DOWN.
-"""
+## Shifts a group of pickups up or down.
+##
+## Parameters:
+## 	'bottom_row': The lowest row to shift. All pickups at or above this row will be shifted.
+##
+## 	'direction': The direction to shift the pickups, such as Vector2.UP or Vector2.DOWN.
 func _shift_rows(bottom_row: int, direction: Vector2) -> void:
 	# First, erase and store all the old pickups which are shifting
 	var shifted := {}
@@ -194,11 +177,9 @@ func _shift_rows(bottom_row: int, direction: Vector2) -> void:
 		_pickups_by_cell[cell] = shifted[cell]
 
 
-"""
-Plays a single sound effect for the next collected pickup.
-
-Also schedules a followup sound effect if more pickup sounds need to be played.
-"""
+## Plays a single sound effect for the next collected pickup.
+##
+## Also schedules a followup sound effect if more pickup sounds need to be played.
 func _play_collect_sfx() -> void:
 	if _pickup_sfx_index < _pickup_sfx_players.size():
 		_pickup_sfx_players[_pickup_sfx_index].stop()
@@ -233,9 +214,7 @@ func _on_PieceManager_piece_disturbed(piece: ActivePiece) -> void:
 	_refresh_pickup_state(piece)
 
 
-"""
-When the piece is placed, we collect any overlapped pickups.
-"""
+## When the piece is placed, we collect any overlapped pickups.
 func _on_PuzzleState_before_piece_written() -> void:
 	# count shown pickups
 	var pickup_count := 0
@@ -331,8 +310,6 @@ func _on_PickupSfxTimer_timeout() -> void:
 	_play_collect_sfx()
 
 
-"""
-When the player pauses, we hide the playfield so they can't cheat.
-"""
+## When the player pauses, we hide the playfield so they can't cheat.
 func _on_Pauser_paused_changed(value: bool) -> void:
 	visible = not value

--- a/project/src/main/puzzle/piece-sfx.gd
+++ b/project/src/main/puzzle/piece-sfx.gd
@@ -1,7 +1,5 @@
 extends Node
-"""
-Plays sound effects when the player piece is moved.
-"""
+## Plays sound effects when the player piece is moved.
 
 func _ready() -> void:
 	PuzzleState.connect("speed_index_changed", self, "_on_PuzzleState_speed_index_changed")
@@ -24,7 +22,7 @@ func _play_das_move_sfx() -> void:
 	$MoveSound.volume_db = clamp($MoveSound.volume_db * 0.92, 0.50, 1.00)
 	$MoveSound.play()
 
-# Movement events ----------------------------------------------------------------
+## Movement events ----------------------------------------------------------------
 
 func _on_PieceManager_moved_left() -> void:
 	_play_move_sfx()
@@ -53,7 +51,7 @@ func _on_PieceManager_initial_das_moved_right() -> void:
 func _on_PieceManager_squish_moved(_piece: ActivePiece, _old_pos: Vector2) -> void:
 	$SquishSound.play()
 
-# Rotation events ----------------------------------------------------------------
+## Rotation events ----------------------------------------------------------------
 
 func _on_PieceManager_initial_rotated_ccw() -> void:
 	$Rotate0Sound.play()
@@ -78,7 +76,7 @@ func _on_PieceManager_rotated_cw() -> void:
 func _on_PieceManager_rotated_180() -> void:
 	$Rotate0Sound.play()
 
-# Other events -------------------------------------------------------------------
+## Other events -------------------------------------------------------------------
 
 func _on_PieceManager_lock_started() -> void:
 	$LockSound.play()

--- a/project/src/main/puzzle/piece/active-piece.gd
+++ b/project/src/main/puzzle/piece/active-piece.gd
@@ -1,53 +1,49 @@
 class_name ActivePiece
-"""
-Contains the settings and state for the currently active piece.
-"""
+## Contains the settings and state for the currently active piece.
 
-# The current position/orientation. For most pieces, orientation will range from
-# [0, 1, 2, 3] for [unrotated, clockwise, flipped, counterclockwise]
+## The current position/orientation. For most pieces, orientation will range from
+## [0, 1, 2, 3] for [unrotated, clockwise, flipped, counterclockwise]
 var pos := Vector2(3, 3)
 var orientation := 0
 
-# The desired position/orientation when the piece is trying to move/rotate.
+## The desired position/orientation when the piece is trying to move/rotate.
 var target_pos := Vector2(3, 3)
 var target_orientation := 0
 
-# Amount of accumulated gravity for this piece. When this number reaches 256, the piece will move down one row
+## Amount of accumulated gravity for this piece. When this number reaches 256, the piece will move down one row
 var gravity := 0
 
-# Number of frames until gravity affects this piece again. After the player does a 'squish move' the piece is
-# unaffected by gravity for a few frames.
+## Number of frames until gravity affects this piece again. After the player does a 'squish move' the piece is
+## unaffected by gravity for a few frames.
 var remaining_post_squish_frames := 0
 
-# Number of frames this piece has been locked into the playfield, or '0' if the piece is not locked
+## Number of frames this piece has been locked into the playfield, or '0' if the piece is not locked
 var lock := 0
 
-# Number of 'lock resets' which have been applied to this piece
+## Number of 'lock resets' which have been applied to this piece
 var lock_resets := 0
 
-# Number of 'floor kicks' which have been applied to this piece
+## Number of 'floor kicks' which have been applied to this piece
 var floor_kicks := 0
 
-# Number of frames to wait before spawning the piece after this one
+## Number of frames to wait before spawning the piece after this one
 var spawn_delay := 0
 
-# Piece shape, color, kick information
+## Piece shape, color, kick information
 var type: PieceType
 
-# A callback function which returns 'true' if a specified cell is blocked,
-# either because it lies outside the playfield or is obstructed by a block
+## A callback function which returns 'true' if a specified cell is blocked,
+## either because it lies outside the playfield or is obstructed by a block
 var cell_blocked_func: FuncRef
 
-# Can be enabled to trace detailed information about piece kicks
+## Can be enabled to trace detailed information about piece kicks
 var _trace_kicks := false
 
-"""
-Parameters:
-	'init_type': Piece shape, color, kick information
-	
-	'init_is_cell_blocked': A callback function which returns 'true' if a specified cell is
-		blocked, either because it lies outside the playfield or is obstructed by a block
-"""
+## Parameters:
+## 	'init_type': Piece shape, color, kick information
+##
+## 	'init_is_cell_blocked': A callback function which returns 'true' if a specified cell is
+## 		blocked, either because it lies outside the playfield or is obstructed by a block
 func _init(init_type: PieceType, init_cell_blocked_func: FuncRef) -> void:
 	type = init_type
 	cell_blocked_func = init_cell_blocked_func
@@ -55,10 +51,8 @@ func _init(init_type: PieceType, init_cell_blocked_func: FuncRef) -> void:
 	orientation %= type.pos_arr.size()
 
 
-"""
-Returns 'true' if a specified playfield cell is blocked, either
-because it lies outside the playfield or is obstructed by a block.
-"""
+## Returns 'true' if a specified playfield cell is blocked, either
+## because it lies outside the playfield or is obstructed by a block.
 func is_cell_blocked(cell_pos: Vector2) -> bool:
 	return cell_blocked_func.call_func(cell_pos)
 
@@ -68,57 +62,42 @@ func reset_target() -> void:
 	target_orientation = orientation
 
 
-"""
-Returns the orientation the piece will be in if it rotates clockwise.
-"""
+## Returns the orientation the piece will be in if it rotates clockwise.
 func get_cw_orientation() -> int:
 	return type.get_cw_orientation(orientation)
 
 
-"""
-Returns the orientation the piece will be in if it rotates counter-clockwise.
-"""
+## Returns the orientation the piece will be in if it rotates counter-clockwise.
 func get_ccw_orientation() -> int:
 	return type.get_ccw_orientation(orientation)
 
 
-"""
-Returns the orientation the piece will be in if it rotates 180 degrees.
-"""
+## Returns the orientation the piece will be in if it rotates 180 degrees.
 func get_flip_orientation() -> int:
 	return type.get_flip_orientation(orientation)
 
 
-"""
-Returns the position the piece will be in if it rotates 180 degrees.
-"""
+## Returns the position the piece will be in if it rotates 180 degrees.
 func get_flip_position() -> Vector2:
 	return pos + type.flips[orientation]
 
 
-"""
-Returns the position of the piece's used cells, factoring in orientation but not position.
-"""
+## Returns the position of the piece's used cells, factoring in orientation but not position.
 func get_pos_arr() -> Array:
 	return type.pos_arr[orientation]
 
 
-"""
-Returns the desired position of the piece's used cells, factoring in orientation but not position.
-"""
+## Returns the desired position of the piece's used cells, factoring in orientation but not position.
 func get_target_pos_arr() -> Array:
 	return type.pos_arr[target_orientation]
 
-
-"""
-Returns 'true' if the specified position and location is unobstructed, and the piece could fit there. Returns 'false'
-if parts of this piece would be out of the playfield or obstructed by blocks.
-
-Parameters:
-	'new_pos': The desired position to move the piece to
-	
-	'new_orientation': The desired orientation to rotate the piece to
-"""
+## Returns 'true' if the specified position and location is unobstructed, and the piece could fit there. Returns
+## 'false' if parts of this piece would be out of the playfield or obstructed by blocks.
+##
+## Parameters:
+## 	'new_pos': The desired position to move the piece to
+##
+## 	'new_orientation': The desired orientation to rotate the piece to
 func can_move_to(new_pos: Vector2, new_orientation: int) -> bool:
 	var valid_target_pos := true
 	if type == PieceTypes.piece_null:
@@ -130,40 +109,31 @@ func can_move_to(new_pos: Vector2, new_orientation: int) -> bool:
 	return valid_target_pos
 
 
-"""
-Returns 'true' if the target position and location is unobstructed, and the piece could fit there. Returns 'false'
-if parts of this piece would be out of the playfield or obstructed by blocks.
-"""
+## Returns 'true' if the target position and location is unobstructed, and the piece could fit there. Returns 'false'
+## if parts of this piece would be out of the playfield or obstructed by blocks.
 func can_move_to_target() -> bool:
 	return can_move_to(target_pos, target_orientation)
 
 
-"""
-Move and orient the piece to its target position and orientation.
-"""
+## Move and orient the piece to its target position and orientation.
 func move_to_target() -> void:
 	pos = target_pos
 	orientation = target_orientation
 
 
-"""
-Resets the piece's 'lock' value, preventing it from locking for a moment.
-"""
+## Resets the piece's 'lock' value, preventing it from locking for a moment.
 func perform_lock_reset() -> void:
 	if lock_resets >= PieceSpeeds.MAX_LOCK_RESETS or lock == 0:
 		return
 	lock = 0
 	lock_resets += 1
 
-
-"""
-Kicks a rotated piece into a nearby empty space.
-
-This does not attempt to preserve the original position/orientation unless explicitly given a kick of (0, 0).
-
-Parameters:
-	'kicks': A list of positions to try.
-"""
+## Kicks a rotated piece into a nearby empty space.
+##
+## This does not attempt to preserve the original position/orientation unless explicitly given a kick of (0, 0).
+##
+## Parameters:
+## 	'kicks': A list of positions to try.
 func kick_piece(kicks: Array = []) -> void:
 	if kicks == []:
 		if _trace_kicks: print("%s to %s -> %s" % [type.string, orientation, target_orientation])

--- a/project/src/main/puzzle/piece/frame-input.gd
+++ b/project/src/main/puzzle/piece/frame-input.gd
@@ -1,16 +1,14 @@
 class_name FrameInput
 extends Node
-"""
-Tracks the state of an input action over time.
+## Tracks the state of an input action over time.
+##
+## Also provides support for buffered inputs. The buffer duration is dictated by the child timer.
 
-Also provides support for buffered inputs. The buffer duration is dictated by the child timer.
-"""
-
-# The action to track
+## The action to track
 export (String) var action: String
 
-# An action which negates this one if pressed. For example if the player holds move_piece_left and presses
-# move_piece_right, move_piece_left no longer gets triggered.
+## An action which negates this one if pressed. For example if the player holds move_piece_left and presses
+## move_piece_right, move_piece_left no longer gets triggered.
 export (String) var cancel_action: String
 
 var pressed_frames: int
@@ -19,10 +17,10 @@ var _just_pressed: bool
 var _pressed: bool
 var _buffer: bool
 
-# If 'true' the inputs will be printed to the console. These printed inputs can be converted into an input replay.
+## If 'true' the inputs will be printed to the console. These printed inputs can be converted into an input replay.
 var _print_inputs := false
 
-# If this timer is active, the input was recently pressed and can be popped with pop_buffered_input
+## If this timer is active, the input was recently pressed and can be popped with pop_buffered_input
 onready var _buffer_timer: Timer = $BufferTimer
 
 func _unhandled_input(event: InputEvent) -> void:
@@ -70,16 +68,12 @@ func is_just_pressed() -> bool:
 	return _just_pressed
 
 
-"""
-Records any inputs to a buffer to be replayed later.
-"""
+## Records any inputs to a buffer to be replayed later.
 func buffer_input() -> void:
 	_buffer = true
 
 
-"""
-Replays any inputs which were pressed while buffering.
-"""
+## Replays any inputs which were pressed while buffering.
 func pop_buffered_input() -> void:
 	_buffer = false
 	if not _buffer_timer.is_stopped():
@@ -87,23 +81,17 @@ func pop_buffered_input() -> void:
 		_buffer_timer.stop()
 
 
-"""
-Marks the 'just pressed' event as handled, to avoid a buffered input from triggering two events.
-"""
+## Marks the 'just pressed' event as handled, to avoid a buffered input from triggering two events.
 func set_input_as_handled() -> void:
 	_just_pressed = false
 
 
-"""
-Returns true if the player held the input long enough to trigger DAS.
-"""
+## Returns true if the player held the input long enough to trigger DAS.
 func is_das_active() -> bool:
 	return _pressed and pressed_frames >= PieceSpeeds.current_speed.delayed_auto_shift_delay
 
 
-"""
-Applies prerecorded puzzle inputs for things such as tutorials.
-"""
+## Applies prerecorded puzzle inputs for things such as tutorials.
 func _process_input_replay() -> void:
 	if CurrentLevel.settings.input_replay.is_action_pressed(action):
 		if _print_inputs: print("\"%s +%s\"," % [PuzzleState.input_frame, action])

--- a/project/src/main/puzzle/piece/ghost-mover.gd
+++ b/project/src/main/puzzle/piece/ghost-mover.gd
@@ -1,14 +1,12 @@
 extends Node
-"""
-Moves the ghost piece when the piece or playfield changes.
-"""
+## Moves the ghost piece when the piece or playfield changes.
 
 export (NodePath) var tile_map_path: NodePath
 
-# Stores the offset used when drawing the ghost piece.
+## Stores the offset used when drawing the ghost piece.
 #
-# We calculate and store this even if the ghost piece is disabled. This allows us to properly handle enabling and
-# disabling the ghost piece during a puzzle.
+## We calculate and store this even if the ghost piece is disabled. This allows us to properly handle enabling and
+## disabling the ghost piece during a puzzle.
 var _ghost_shadow_offset := Vector2.ZERO
 
 onready var _tile_map: PuzzleTileMap = get_node(tile_map_path)

--- a/project/src/main/puzzle/piece/next-piece-display.gd
+++ b/project/src/main/puzzle/piece/next-piece-display.gd
@@ -1,13 +1,11 @@
 class_name NextPieceDisplay
 extends Node2D
-"""
-Contains logic for a single 'next piece display'. A single display might only display the piece which is coming up 3
-pieces from now. Several displays are shown at once.
-"""
+## Contains logic for a single 'next piece display'. A single display might only display the piece which is coming up 3
+## pieces from now. Several displays are shown at once.
 
 var _piece_queue: PieceQueue
 
-# how far into the future this display should look; 0 = show the next piece, 10 = show the 11th piece
+## how far into the future this display should look; 0 = show the next piece, 10 = show the 11th piece
 var _piece_index := 0
 
 var _displayed_type: PieceType

--- a/project/src/main/puzzle/piece/next-piece-displays.gd
+++ b/project/src/main/puzzle/piece/next-piece-displays.gd
@@ -1,15 +1,13 @@
 class_name NextPieceDisplays
 extends Control
-"""
-Displays upcoming pieces to the player and manages the next piece displays.
-"""
+## Displays upcoming pieces to the player and manages the next piece displays.
 
 const DISPLAY_COUNT := 9
 
 export (NodePath) var piece_queue_path: NodePath
 export (PackedScene) var NextPieceDisplayScene
 
-# array of NextPieceDisplays which are shown to the user
+## array of NextPieceDisplays which are shown to the user
 var _next_piece_displays := []
 
 onready var _piece_queue: PieceQueue = get_node(piece_queue_path)
@@ -21,9 +19,7 @@ func _ready() -> void:
 		_add_display(i, 5, 5 + i * (486.0 / (DISPLAY_COUNT - 1)), 0.5)
 
 
-"""
-Adds a new next piece display.
-"""
+## Adds a new next piece display.
 func _add_display(piece_index: int, x: float, y: float, scale: float) -> void:
 	var new_display: NextPieceDisplay = NextPieceDisplayScene.instance()
 	new_display.initialize(_piece_queue, piece_index)
@@ -34,17 +30,13 @@ func _add_display(piece_index: int, x: float, y: float, scale: float) -> void:
 	_next_piece_displays.append(new_display)
 
 
-"""
-Gets ready for a new game, randomizing the pieces and filling the piece queues.
-"""
+## Gets ready for a new game, randomizing the pieces and filling the piece queues.
 func _on_PuzzleState_game_prepared() -> void:
 	for next_piece_display in _next_piece_displays:
 		next_piece_display.show()
 
 
-"""
-When the player pauses, we hide the playfield so they can't cheat.
-"""
+## When the player pauses, we hide the playfield so they can't cheat.
 func _on_Pauser_paused_changed(value: bool) -> void:
 	for display in _next_piece_displays:
 		display.visible = not value

--- a/project/src/main/puzzle/piece/next-piece.gd
+++ b/project/src/main/puzzle/piece/next-piece.gd
@@ -1,34 +1,26 @@
 class_name NextPiece
-"""
-Contains the settings and state for an upcoming piece.
-"""
+## Contains the settings and state for an upcoming piece.
 
-# Piece shape, color, kick information
+## Piece shape, color, kick information
 var type: PieceType
 
-# The current orientation. For most pieces, orientation will range from
-# [0, 1, 2, 3] for [unrotated, clockwise, flipped, counterclockwise].
+## The current orientation. For most pieces, orientation will range from
+## [0, 1, 2, 3] for [unrotated, clockwise, flipped, counterclockwise].
 #
-# Pieces in the next queue are typically unrotated.
+## Pieces in the next queue are typically unrotated.
 var orientation := 0
 
-"""
-Returns the orientation the piece will be in if it rotates clockwise.
-"""
+## Returns the orientation the piece will be in if it rotates clockwise.
 func get_cw_orientation() -> int:
 	return type.get_cw_orientation(orientation)
 
 
-"""
-Returns the orientation the piece will be in if it rotates counter-clockwise.
-"""
+## Returns the orientation the piece will be in if it rotates counter-clockwise.
 func get_ccw_orientation() -> int:
 	return type.get_ccw_orientation(orientation)
 
 
-"""
-Returns the orientation the piece will be in if it rotates 180 degrees.
-"""
+## Returns the orientation the piece will be in if it rotates 180 degrees.
 func get_flip_orientation() -> int:
 	return type.get_flip_orientation(orientation)
 

--- a/project/src/main/puzzle/piece/piece-dropper.gd
+++ b/project/src/main/puzzle/piece/piece-dropper.gd
@@ -1,9 +1,7 @@
 extends Node
-"""
-Handles gravity, hard drops, and soft drops for the player's active piece.
-"""
+## Handles gravity, hard drops, and soft drops for the player's active piece.
 
-# Emitted when the hard drop destination for the current piece changes. Used for drawing the ghost piece.
+## Emitted when the hard drop destination for the current piece changes. Used for drawing the ghost piece.
 signal hard_drop_target_pos_changed(piece, hard_drop_target_pos)
 
 signal hard_dropped
@@ -12,10 +10,10 @@ signal soft_dropped
 export (NodePath) var input_path: NodePath
 export (NodePath) var piece_mover_path: NodePath
 
-# 'true' if the player hard dropped the piece this frame
+## 'true' if the player hard dropped the piece this frame
 var did_hard_drop: bool
 
-# The hard drop destination for the current piece. Used for drawing the ghost piece.
+## The hard drop destination for the current piece. Used for drawing the ghost piece.
 var hard_drop_target_pos: Vector2
 
 onready var input: PieceInput = get_node(input_path)
@@ -25,9 +23,7 @@ func _physics_process(_delta: float) -> void:
 	did_hard_drop = false
 
 
-"""
-Recalculates the hard drop destination for the current piece.
-"""
+## Recalculates the hard drop destination for the current piece.
 func calculate_hard_drop_target(piece: ActivePiece) -> void:
 	piece.reset_target()
 	while piece.can_move_to(piece.target_pos + Vector2(0, 1), piece.orientation):
@@ -50,9 +46,7 @@ func apply_hard_drop_input(piece: ActivePiece) -> void:
 	did_hard_drop = true
 
 
-"""
-Increments the piece's gravity. A piece will fall once its accumulated gravity exceeds a certain threshold.
-"""
+## Increments the piece's gravity. A piece will fall once its accumulated gravity exceeds a certain threshold.
 func apply_gravity(piece: ActivePiece) -> void:
 	if piece.remaining_post_squish_frames > 0:
 		piece.remaining_post_squish_frames -= 1
@@ -77,11 +71,9 @@ func apply_gravity(piece: ActivePiece) -> void:
 			piece_mover.attempt_mid_drop_movement(piece)
 
 
-"""
-Squish moving pauses gravity for a moment.
-
-This allows players to squish and slide a piece before it drops, even at 20G.
-"""
+## Squish moving pauses gravity for a moment.
+##
+## This allows players to squish and slide a piece before it drops, even at 20G.
 func _on_Squisher_squish_moved(_piece: ActivePiece, _old_pos: Vector2) -> void:
 	_piece.remaining_post_squish_frames = PieceSpeeds.POST_SQUISH_FRAMES
 

--- a/project/src/main/puzzle/piece/piece-input.gd
+++ b/project/src/main/puzzle/piece/piece-input.gd
@@ -1,8 +1,6 @@
 class_name PieceInput
 extends Node
-"""
-Handles input for controlling the player's piece.
-"""
+## Handles input for controlling the player's piece.
 
 onready var left: FrameInput = $Left
 onready var right: FrameInput = $Right
@@ -11,17 +9,13 @@ onready var ccw: FrameInput = $Ccw
 onready var soft_drop: FrameInput = $SoftDrop
 onready var hard_drop: FrameInput = $HardDrop
 
-"""
-Records any inputs to a buffer to be replayed later.
-"""
+## Records any inputs to a buffer to be replayed later.
 func buffer_inputs() -> void:
 	for child in get_children():
 		child.buffer_input()
 
 
-"""
-Replays any inputs which were pressed while buffering.
-"""
+## Replays any inputs which were pressed while buffering.
 func pop_buffered_inputs() -> void:
 	for child in get_children():
 		child.pop_buffered_input()

--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -1,25 +1,23 @@
 class_name PieceManager
 extends Control
-"""
-Contains logic for spawning new pieces, moving/rotating pieces, handling player input, and locking pieces into the
-_playfield.
-"""
+## Contains logic for spawning new pieces, moving/rotating pieces, handling player input, and locking pieces into the
+## playfield.
 
-# Emitted when the playfield changes in a way which might move the current piece or alter its behavior. For example,
-# inserting a row might bump the piece up, or erasing a row might shift the ghost piece down.
+## Emitted when the playfield changes in a way which might move the current piece or alter its behavior. For example,
+## inserting a row might bump the piece up, or erasing a row might shift the ghost piece down.
 signal playfield_disturbed(piece)
 
 signal piece_spawned
 
-# emitted when the current piece changes in some way (moved, replaced, reoriented)
+## emitted when the current piece changes in some way (moved, replaced, reoriented)
 signal piece_disturbed(piece)
 
-# emitted when the player rotates a piece
+## emitted when the player rotates a piece
 signal initial_rotated_cw
 signal initial_rotated_ccw
 signal initial_rotated_180
 
-# emitted when the player moves a piece
+## emitted when the player moves a piece
 signal initial_das_moved_left
 signal initial_das_moved_right
 signal das_moved_left
@@ -33,30 +31,30 @@ signal soft_dropped
 signal hard_dropped
 signal squish_moved(piece, old_pos)
 
-# emitted for piece locks
+## emitted for piece locks
 signal lock_cancelled
 signal lock_started
 
 signal tiles_changed(tile_map)
 
-# the z index the piece manager's tilemap defaults to
+## the z index the piece manager's tilemap defaults to
 const TILE_MAP_DEFAULT_Z_INDEX := 3
 
-# the z index the piece manager's tilemap switches to temporarily when topping out
+## the z index the piece manager's tilemap switches to temporarily when topping out
 const TILE_MAP_TOP_OUT_Z_INDEX := 4
 
 export (NodePath) var playfield_path: NodePath
 export (NodePath) var piece_queue_path: NodePath
 
-# settings and state for the currently active piece.
+## settings and state for the currently active piece.
 var piece: ActivePiece
 
-# information about the piece previously rendered to the tilemap
+## information about the piece previously rendered to the tilemap
 var drawn_piece_type: PieceType
 var drawn_piece_pos: Vector2
 var drawn_piece_orientation: int
 
-# TileMap containing the puzzle blocks which make up the active piece
+## TileMap containing the puzzle blocks which make up the active piece
 onready var tile_map: PuzzleTileMap = $TileMap
 onready var input: PieceInput = $Input
 
@@ -104,31 +102,25 @@ func is_playfield_ready_for_new_piece() -> bool:
 	return _playfield.ready_for_new_piece()
 
 
-"""
-Writes the current piece to the _playfield, checking whether it builds any boxes or clears any lines.
-
-Returns true if the newly written piece results in a line clear.
-"""
+## Writes the current piece to the _playfield, checking whether it builds any boxes or clears any lines.
+##
+## Returns true if the newly written piece results in a line clear.
 func write_piece_to_playfield() -> void:
 	_playfield.write_piece(piece.pos, piece.orientation, piece.type)
 	_clear_piece()
 
 
-"""
-Called when the player tops out, but doesn't lose.
-
-Enters a state which waits for the _playfield to make room for the current piece.
-"""
+## Called when the player tops out, but doesn't lose.
+##
+## Enters a state which waits for the _playfield to make room for the current piece.
 func enter_top_out_state(top_out_frames: int) -> void:
 	_states.set_state(_states.top_out)
 	piece.spawn_delay = top_out_frames
 
 
-"""
-Spawns a new piece at the top of the _playfield.
-
-Returns 'true' if the piece was spawned successfully, or 'false' if the player topped out.
-"""
+## Spawns a new piece at the top of the _playfield.
+##
+## Returns 'true' if the piece was spawned successfully, or 'false' if the player topped out.
 func spawn_piece() -> bool:
 	var next_piece := _piece_queue.pop_next_piece()
 	piece = ActivePiece.new(next_piece.type, funcref(_playfield.tile_map, "is_cell_blocked"))
@@ -145,31 +137,23 @@ func move_piece() -> void:
 		emit_signal("piece_disturbed", piece)
 
 
-"""
-Records any inputs to a buffer to be replayed later.
-"""
+## Records any inputs to a buffer to be replayed later.
 func buffer_inputs() -> void:
 	input.buffer_inputs()
 
 
-"""
-Replays any inputs which were pressed while buffering.
-"""
+## Replays any inputs which were pressed while buffering.
 func pop_buffered_inputs() -> void:
 	input.pop_buffered_inputs()
 
 
-"""
-Returns a number from [0, 1] for how close the piece is to squishing.
-"""
+## Returns a number from [0, 1] for how close the piece is to squishing.
 func squish_percent() -> float:
 	return _physics.squish_percent(piece)
 
 
-"""
-Increments the piece's 'lock'. A piece will become locked once its accumulated 'lock' exceeds a certain threshold,
-usually about half a second.
-"""
+## Increments the piece's 'lock'. A piece will become locked once its accumulated 'lock' exceeds a certain threshold,
+## usually about half a second.
 func apply_lock() -> void:
 	if not piece.can_move_to(Vector2(piece.pos.x, piece.pos.y + 1), piece.orientation):
 		piece.lock += 1
@@ -182,9 +166,7 @@ func is_playfield_clearing_lines() -> bool:
 	return _playfield.get_remaining_line_erase_frames() > 0
 
 
-"""
-Set the state frames so that the piece spawns immediately.
-"""
+## Set the state frames so that the piece spawns immediately.
 func skip_prespawn() -> void:
 	if CurrentLevel.settings.other.non_interactive:
 		return
@@ -202,9 +184,7 @@ func _clear_piece() -> void:
 	piece = ActivePiece.new(PieceTypes.piece_null, funcref(tile_map, "is_cell_blocked"))
 
 
-"""
-Refresh the tilemap which displays the piece, based on the current piece's position and orientation.
-"""
+## Refresh the tilemap which displays the piece, based on the current piece's position and orientation.
 func _update_tile_map() -> void:
 	tile_map.clear()
 	var pos_arr := piece.get_pos_arr()
@@ -214,9 +194,7 @@ func _update_tile_map() -> void:
 		tile_map.set_block(block_pos, 0, block_color)
 
 
-"""
-Spawns the first piece of a level.
-"""
+## Spawns the first piece of a level.
 func _start_first_piece() -> void:
 	if CurrentLevel.settings.other.non_interactive:
 		return
@@ -248,18 +226,15 @@ func _on_PuzzleState_game_started() -> void:
 	_start_first_piece()
 
 
-"""
-The player finished the level, possibly while they were still moving a piece around. We clear their piece so that it's
-not left floating.
-"""
+## The player finished the level, possibly while they were still moving a piece around. We clear their piece so that
+## it's not left floating.
 func _on_PuzzleState_finish_triggered() -> void:
 	_clear_piece()
 	_states.set_state(_states.game_ended)
 
 
-"""
-The game ended the game, possibly by a top out. We leave the piece in place so that they can see why they topped out.
-"""
+## The game ended the game, possibly by a top out. We leave the piece in place so that they can see why they topped
+## out.
 func _on_PuzzleState_game_ended() -> void:
 	_states.set_state(_states.game_ended)
 
@@ -273,16 +248,12 @@ func _on_PuzzleState_after_level_changed() -> void:
 	_start_first_piece()
 
 
-"""
-When the player pauses, we hide the playfield so they can't cheat.
-"""
+## When the player pauses, we hide the playfield so they can't cheat.
 func _on_Pauser_paused_changed(value: bool) -> void:
 	visible = not value
 
 
-"""
-When a line is inserted which intersects with the active piece, we shift it up.
-"""
+## When a line is inserted which intersects with the active piece, we shift it up.
 func _on_Playfield_line_inserted(_y: int, _tiles_key: String, _src_y: int) -> void:
 	piece.reset_target()
 	while piece.target_pos.y > 0 and not piece.can_move_to_target():

--- a/project/src/main/puzzle/piece/piece-mover.gd
+++ b/project/src/main/puzzle/piece/piece-mover.gd
@@ -1,8 +1,6 @@
 class_name PieceMover
 extends Node
-"""
-Handles horizontal movement for the player's active piece.
-"""
+## Handles horizontal movement for the player's active piece.
 
 signal initial_das_moved_left
 signal initial_das_moved_right
@@ -17,7 +15,7 @@ signal moved_right
 
 export (NodePath) var input_path: NodePath
 
-# how many times the piece has moved horizontally this frame
+## how many times the piece has moved horizontally this frame
 var _horizontal_movement_count := 0
 
 onready var input: PieceInput = get_node(input_path)
@@ -25,20 +23,20 @@ onready var input: PieceInput = get_node(input_path)
 func _physics_process(_delta: float) -> void:
 	_horizontal_movement_count = 0
 
-# locations the piece will spawn if the player holds left
+## locations the piece will spawn if the player holds left
 const SPAWN_LEFT := [
 		Vector2(-4, 0), Vector2(-4, -1), Vector2(-3, 0), Vector2(-3, -1),
 		Vector2(-2, 0), Vector2(-2, -1), Vector2(-1, 0), Vector2(-1, -1),
 		Vector2(0, 0), Vector2(0, -1), Vector2(1, 0), Vector2(1, -1),
 	]
 
-# locations the piece will spawn if the player does not hold left or right
+## locations the piece will spawn if the player does not hold left or right
 const SPAWN_CENTER := [
 		Vector2(0, 0), Vector2(0, -1), Vector2(-1, 0),
 		Vector2(-1, -1), Vector2(1, 0), Vector2(1, -1),
 	]
 
-# locations the piece will spawn if the player holds right
+## locations the piece will spawn if the player holds right
 const SPAWN_RIGHT := [
 		Vector2(4, 0), Vector2(4, -1), Vector2(3, 0), Vector2(3, -1),
 		Vector2(2, 0), Vector2(2, -1), Vector2(1, 0), Vector2(1, -1),
@@ -117,9 +115,7 @@ func apply_move_input(piece: ActivePiece) -> void:
 		input.set_right_das_active()
 
 
-"""
-Move piece once per frame to allow pieces to slide into nooks during 20G.
-"""
+## Move piece once per frame to allow pieces to slide into nooks during 20G.
 func attempt_mid_drop_movement(piece: ActivePiece) -> void:
 	if _horizontal_movement_count == 0:
 		apply_move_input(piece)

--- a/project/src/main/puzzle/piece/piece-physics.gd
+++ b/project/src/main/puzzle/piece/piece-physics.gd
@@ -1,12 +1,9 @@
 class_name PiecePhysics
 extends Node
-"""
-Handles rules for when the piece moves, rotates and locks into the place.
-
-Some of this logic is pushed out into child nodes such as Rotator and Mover. This class only contains reusable code
-and code requiring coordination from different child nodes.
-"""
-
+## Handles rules for when the piece moves, rotates and locks into the place.
+##
+## Some of this logic is pushed out into child nodes such as Rotator and Mover. This class only contains reusable code
+## and code requiring coordination from different child nodes.
 
 export (NodePath) var piece_states_path: NodePath
 
@@ -17,11 +14,9 @@ onready var squisher := $Squisher
 
 onready var _states: PieceStates = get_node(piece_states_path)
 
-"""
-Spawns a new piece at the top of the _playfield.
-
-Returns 'true' if the piece was spawned successfully, or 'false' if the player topped out.
-"""
+## Spawns a new piece at the top of the _playfield.
+##
+## Returns 'true' if the piece was spawned successfully, or 'false' if the player topped out.
 func spawn_piece(piece: ActivePiece) -> bool:
 	rotator.apply_initial_rotate_input(piece)
 	
@@ -41,14 +36,12 @@ func spawn_piece(piece: ActivePiece) -> bool:
 	return success
 
 
-"""
-Moves the piece based on player input and gravity.
-
-If any move/rotate keys were pressed, this method will move the block accordingly. Gravity will then be applied.
-
-Returns 'true' if the piece was interacted with successfully resulting in a movement change, orientation change, or
-	lock reset
-"""
+## Moves the piece based on player input and gravity.
+##
+## If any move/rotate keys were pressed, this method will move the block accordingly. Gravity will then be applied.
+##
+## Returns 'true' if the piece was interacted with successfully resulting in a movement change, orientation change, or
+## 	lock reset
 func move_piece(piece: ActivePiece) -> bool:
 	var old_piece_pos := piece.pos
 	var old_piece_orientation := piece.orientation

--- a/project/src/main/puzzle/piece/piece-queue.gd
+++ b/project/src/main/puzzle/piece/piece-queue.gd
@@ -1,20 +1,18 @@
 class_name PieceQueue
 extends Node
-"""
-Queue of upcoming randomized pieces.
+## Queue of upcoming randomized pieces.
+##
+## This queue stores the upcoming pieces so they can be displayed, and randomizes them according to some complex rules.
 
-This queue stores the upcoming pieces so they can be displayed, and randomizes them according to some complex rules.
-"""
-
-# minimum number of next pieces in the queue, before we add more
+## minimum number of next pieces in the queue, before we add more
 const MIN_SIZE := 50
 
 const UNLIMITED_PIECES := 999999
 
-# queue of upcoming NextPiece instances
+## queue of upcoming NextPiece instances
 var pieces := []
 
-# default pieces to pull from if none are provided by the level
+## default pieces to pull from if none are provided by the level
 var _default_piece_types := PieceTypes.all_types
 
 var _remaining_piece_count := UNLIMITED_PIECES
@@ -25,9 +23,7 @@ func _ready() -> void:
 	_fill()
 
 
-"""
-Clears the pieces and refills the piece queues.
-"""
+## Clears the pieces and refills the piece queues.
 func clear() -> void:
 	if CurrentLevel.settings.finish_condition.type == Milestone.PIECES:
 		_remaining_piece_count = CurrentLevel.settings.finish_condition.value
@@ -37,9 +33,7 @@ func clear() -> void:
 	_fill()
 
 
-"""
-Pops the next piece off the queue.
-"""
+## Pops the next piece off the queue.
 func pop_next_piece() -> NextPiece:
 	var next_piece_type: NextPiece = pieces.pop_front()
 	if _remaining_piece_count != UNLIMITED_PIECES:
@@ -48,9 +42,7 @@ func pop_next_piece() -> NextPiece:
 	return next_piece_type
 
 
-"""
-Returns a specific piece in the queue.
-"""
+## Returns a specific piece in the queue.
 func get_next_piece(index: int) -> NextPiece:
 	return pieces[index]
 
@@ -61,12 +53,10 @@ func _apply_piece_limit() -> void:
 			pieces[i] = _new_next_piece(PieceTypes.piece_null)
 
 
-"""
-Fills the queue with randomized pieces.
-
-The first pieces have some constraints to limit players from having especially lucky or unlucky starts. Later pieces
-have fewer constraints, but still use a bagging algorithm to ensure fairness.
-"""
+## Fills the queue with randomized pieces.
+##
+## The first pieces have some constraints to limit players from having especially lucky or unlucky starts. Later pieces
+## have fewer constraints, but still use a bagging algorithm to ensure fairness.
 func _fill() -> void:
 	if pieces.empty():
 		_fill_initial_pieces()
@@ -74,22 +64,18 @@ func _fill() -> void:
 	_apply_piece_limit()
 
 
-"""
-Initializes an empty queue with a set of starting pieces.
-"""
+## Initializes an empty queue with a set of starting pieces.
 func _fill_initial_pieces() -> void:
 	if CurrentLevel.settings.piece_types.types.empty() and CurrentLevel.settings.piece_types.start_types.empty():
-		"""
-		Default starting pieces:
-		1. Append three same-size pieces which can't build a cake box; lot, jot, jlt or pqu
-		2. Append a piece which can't build a snack box or a cake box
-		3. Append a piece which can build a snack box, but not a cake box
-		4. Append the remaining three pieces
-		5. Insert an extra piece in the last 3 positions
-		
-		These are called 'bad starts' since they avoid giving player ideal openings of 'lojpqvut' or 'lqpjutov' where
-		each piece fits with the previous piece.
-		"""
+		# Default starting pieces:
+		# 1. Append three same-size pieces which can't build a cake box; lot, jot, jlt or pqu
+		# 2. Append a piece which can't build a snack box or a cake box
+		# 3. Append a piece which can build a snack box, but not a cake box
+		# 4. Append the remaining three pieces
+		# 5. Insert an extra piece in the last 3 positions
+		#
+		# These are called 'bad starts' since they avoid giving player ideal openings of 'lojpqvut' or 'lqpjutov' where
+		# each piece fits with the previous piece.
 		var all_bad_starts := [
 			[PieceTypes.piece_l, PieceTypes.piece_o, PieceTypes.piece_t, PieceTypes.piece_p, PieceTypes.piece_q],
 			[PieceTypes.piece_l, PieceTypes.piece_o, PieceTypes.piece_t, PieceTypes.piece_p, PieceTypes.piece_v],
@@ -137,9 +123,7 @@ func _fill_initial_pieces() -> void:
 				pieces.push_front(_new_next_piece(piece_type))
 
 
-"""
-Creates a new next piece with the specified type.
-"""
+## Creates a new next piece with the specified type.
 func _new_next_piece(type: PieceType) -> NextPiece:
 	var next_piece := NextPiece.new()
 	next_piece.type = type
@@ -158,13 +142,11 @@ func shuffled_piece_types() -> Array:
 	return result
 
 
-"""
-Extends a non-empty queue by adding more pieces.
-
-The algorithm puts all 8 piece types into a bag with one extra random piece. It pulls random pieces from the bag, but
-avoids pulling the same piece back to back. With this algorithm you're always able to build four 3x3 boxes, but the
-extra piece acts as an helpful tool for 3x4 boxes and 3x5 boxes, or an annoying deterrent for 3x3 boxes.
-"""
+## Extends a non-empty queue by adding more pieces.
+##
+## The algorithm puts all 8 piece types into a bag with one extra random piece. It pulls random pieces from the bag,
+## but avoids pulling the same piece back to back. With this algorithm you're always able to build four 3x3 boxes, but
+## the extra piece acts as an helpful tool for 3x4 boxes and 3x5 boxes, or an annoying deterrent for 3x3 boxes.
 func _fill_remaining_pieces() -> void:
 	while pieces.size() < MIN_SIZE:
 		# fill a bag with one of each piece and one extra; draw them out in a random order
@@ -188,17 +170,15 @@ func _fill_remaining_pieces() -> void:
 		_insert_annoying_piece(new_piece_types.size())
 
 
-"""
-Moves a piece which appears back-to-back in the piece queue.
-
-Parameters:
-	'from_index': The index of the piece being moved
-	
-	'min_to_index': The earliest position in the queue the piece can be moved to
-
-Returns:
-	The position the piece was moved to, or 'from_index' if the piece did not move.
-"""
+## Moves a piece which appears back-to-back in the piece queue.
+##
+## Parameters:
+## 	'from_index': The index of the piece being moved
+##
+## 	'min_to_index': The earliest position in the queue the piece can be moved to
+##
+## Returns:
+## 	The position the piece was moved to, or 'from_index' if the piece did not move.
 func _move_duplicate_piece(from_index: int, min_to_index: int) -> int:
 	# remove the piece from the queue
 	var duplicate_piece: NextPiece = pieces[from_index]
@@ -215,9 +195,7 @@ func _move_duplicate_piece(from_index: int, min_to_index: int) -> int:
 	return to_index
 
 
-"""
-Returns 'true' if the specified array has the same piece back-to-back.
-"""
+## Returns 'true' if the specified array has the same piece back-to-back.
 func _has_duplicate_pieces(in_pieces: Array) -> bool:
 	var result := false
 	for i in range(in_pieces.size() - 1):
@@ -227,16 +205,14 @@ func _has_duplicate_pieces(in_pieces: Array) -> bool:
 	return result
 
 
-"""
-Inserts an extra piece into the bag.
-
-Turbo Fat's pieces fit together too well. We periodically add extra pieces to the bag to ensure the game isn't too
-easy.
-
-Parameters:
-	'max_pieces_to_right': The maximum number of pieces to the right of the new piece. '0' guarantees the new piece
-			will be appended to the end of the queue, '8' means it will be mixed in with the last eight pieces.
-"""
+## Inserts an extra piece into the bag.
+##
+## Turbo Fat's pieces fit together too well. We periodically add extra pieces to the bag to ensure the game isn't too
+## easy.
+##
+## Parameters:
+## 	'max_pieces_to_right': The maximum number of pieces to the right of the new piece. '0' guarantees the new piece
+## 			will be appended to the end of the queue, '8' means it will be mixed in with the last eight pieces.
 func _insert_annoying_piece(max_pieces_to_right: int) -> void:
 	var new_piece_index := int(rand_range(pieces.size() - max_pieces_to_right + 1, pieces.size() + 1))
 	var extra_piece_types: Array = shuffled_piece_types()
@@ -261,21 +237,20 @@ func _on_PuzzleState_game_prepared() -> void:
 	clear()
 
 
-"""
-Returns a list of of positions where a piece can be inserted without being adjacent to another piece of the same type.
-
-non_adjacent_indexes(['j', 'o'], 'j')      = [2]
-non_adjacent_indexes(['j', 'o', 't'], 't') = [0, 1]
-non_adjacent_indexes([], 't')              = [0]
-non_adjacent_indexes(['o', 'j', 'o'], 'o') = []
-
-Parameters:
-	'pieces': An array of NextPiece instances representing pieces in a queue.
-	
-	'piece_type': The type of the piece being inserted.
-	
-	'from_index': The lowest position to check in the piece queue.
-"""
+## Returns a list of of positions where a piece can be inserted without being adjacent to another piece of the same
+## type.
+##
+## non_adjacent_indexes(['j', 'o'], 'j')      = [2]
+## non_adjacent_indexes(['j', 'o', 't'], 't') = [0, 1]
+## non_adjacent_indexes([], 't')              = [0]
+## non_adjacent_indexes(['o', 'j', 'o'], 'o') = []
+##
+## Parameters:
+## 	'pieces': An array of NextPiece instances representing pieces in a queue.
+##
+## 	'piece_type': The type of the piece being inserted.
+##
+## 	'from_index': The lowest position to check in the piece queue.
 static func non_adjacent_indexes(in_pieces: Array, piece_type: PieceType, from_index: int = 0) -> Array:
 	var result := []
 	for i in range(from_index, in_pieces.size() + 1):

--- a/project/src/main/puzzle/piece/piece-rotator.gd
+++ b/project/src/main/puzzle/piece/piece-rotator.gd
@@ -1,7 +1,5 @@
 extends Node
-"""
-Handles horizontal movement for the player's active piece.
-"""
+## Handles horizontal movement for the player's active piece.
 
 # warning-ignore:unused_signal
 signal initial_rotated_ccw
@@ -117,9 +115,7 @@ func apply_rotate_input(piece: ActivePiece) -> void:
 			"rotated_180": CurrentLevel.settings.triggers.run_triggers(LevelTrigger.ROTATED_180)
 
 
-"""
-Calculates the position and orientation the player is trying to rotate the piece to.
-"""
+## Calculates the position and orientation the player is trying to rotate the piece to.
 func _calc_rotate_target(piece: ActivePiece) -> void:
 	if not input.is_cw_pressed() and not input.is_ccw_pressed():
 		return

--- a/project/src/main/puzzle/piece/piece-speed.gd
+++ b/project/src/main/puzzle/piece/piece-speed.gd
@@ -1,34 +1,32 @@
 class_name PieceSpeed
-"""
-Stores data about a specific 'speed level' such as how fast pieces should drop, how long it takes them to lock into
-the playfield, and how long to pause when clearing lines.
-"""
+## Stores data about a specific 'speed level' such as how fast pieces should drop, how long it takes them to lock into
+## the playfield, and how long to pause when clearing lines.
 
-# speed string which appears in the 'speed' panel
+## speed string which appears in the 'speed' panel
 var id: String
 
-# how fast pieces should drop, as a fraction of 256. 32 = once every 8 frames, 512 = twice a frame
+## how fast pieces should drop, as a fraction of 256. 32 = once every 8 frames, 512 = twice a frame
 var gravity: int
 
-# number of frames to pause before a new piece appears
+## number of frames to pause before a new piece appears
 var appearance_delay: int
 
-# number of frames to pause before a new piece appears, after clearing a line/making a box
+## number of frames to pause before a new piece appears, after clearing a line/making a box
 var line_appearance_delay: int
 
-# number of frames the player has to hold left/right before the piece whooshes over
+## number of frames the player has to hold left/right before the piece whooshes over
 var delayed_auto_shift_delay: int
 
-# number of frames to pause before locking a piece into the playfield
+## number of frames to pause before locking a piece into the playfield
 var lock_delay: int
 
-# number of frames to pause after locking a piece, when the player can lock cancel and squish
+## number of frames to pause after locking a piece, when the player can lock cancel and squish
 var post_lock_delay: int
 
-# number of frames to pause when clearing a line
+## number of frames to pause when clearing a line
 var line_clear_delay: int
 
-# number of frames to pause when making a box
+## number of frames to pause when making a box
 var box_delay: int
 
 func _init(init_id: String, init_gravity: int, init_appearance_delay: int, init_line_appearance_delay: int,

--- a/project/src/main/puzzle/piece/piece-speeds.gd
+++ b/project/src/main/puzzle/piece/piece-speeds.gd
@@ -1,30 +1,28 @@
 extends Node
-"""
-Stores data about the different 'piece speeds' such as how fast pieces should drop, how long it takes them to lock
-into the playfield, and how long to pause when clearing lines.
+## Stores data about the different 'piece speeds' such as how fast pieces should drop, how long it takes them to lock
+## into the playfield, and how long to pause when clearing lines.
+##
+## Much of this speed data was derived from wikis for other piece-dropping games which have the concept of a 'hold
+## piece' so it's likely it will change over time to become more lenient.
 
-Much of this speed data was derived from wikis for other piece-dropping games which have the concept of a 'hold piece'
-so it's likely it will change over time to become more lenient.
-"""
-
-# All gravity constants are integers like '16', which actually correspond to fractions like '16/256' which means the
-# piece takes 16 frames to drop one row. G is the denominator of that fraction.
+## All gravity constants are integers like '16', which actually correspond to fractions like '16/256' which means the
+## piece takes 16 frames to drop one row. G is the denominator of that fraction.
 const G := 256
 
-# The maximum number of 'lock resets' the player is allotted for a single piece. A lock reset occurs when a piece is at
-# the bottom of the screen but the player moves or rotates it to prevent from locking.
+## The maximum number of 'lock resets' the player is allotted for a single piece. A lock reset occurs when a piece is
+## at the bottom of the screen but the player moves or rotates it to prevent from locking.
 const MAX_LOCK_RESETS := 15
 
-# The gravity constant used when the player soft-drops a piece.
+## The gravity constant used when the player soft-drops a piece.
 const DROP_G := 128
 
-# After the player does a 'squish move' the piece is unaffected by gravity for this many frames.
+## After the player does a 'squish move' the piece is unaffected by gravity for this many frames.
 const POST_SQUISH_FRAMES := 4
 
-# How fast the pieces are moving right now
+## How fast the pieces are moving right now
 var current_speed: PieceSpeed
 
-# Array of speed ids in ascending order
+## Array of speed ids in ascending order
 var speed_ids := []
 
 var _speeds := {}

--- a/project/src/main/puzzle/piece/piece-squisher.gd
+++ b/project/src/main/puzzle/piece/piece-squisher.gd
@@ -1,13 +1,11 @@
 class_name PieceSquisher
 extends Node
-"""
-Handles squish moves for the player's active piece.
-"""
+## Handles squish moves for the player's active piece.
 
 signal lock_cancelled
 signal squish_moved(piece, old_pos)
 
-# state of the current squish move
+## state of the current squish move
 enum SquishState {
 	UNKNOWN, # unknown; we haven't checked yet
 	INVALID, # invalid; there's no empty space beneath the piece
@@ -20,10 +18,10 @@ const VALID = SquishState.VALID
 
 export (NodePath) var input_path: NodePath
 
-# 'true' if the player did a squish drop this frame
+## 'true' if the player did a squish drop this frame
 var did_squish_drop: bool
 
-# potential source/target for the current squish move
+## potential source/target for the current squish move
 var squish_state: int = SquishState.UNKNOWN
 var _squish_target_pos: Vector2
 
@@ -69,9 +67,7 @@ func attempt_squish(piece: ActivePiece) -> void:
 			_squish_to(piece, _squish_target_pos)
 
 
-"""
-Returns a number from [0, 1] for how close the piece is to squishing.
-"""
+## Returns a number from [0, 1] for how close the piece is to squishing.
 func squish_percent(piece: ActivePiece) -> float:
 	var result := 0.0
 	if input.is_soft_drop_pressed() and squish_state == VALID:
@@ -79,9 +75,7 @@ func squish_percent(piece: ActivePiece) -> float:
 	return result
 
 
-"""
-Squishes a piece through other blocks towards the target.
-"""
+## Squishes a piece through other blocks towards the target.
 func _squish_to(piece: ActivePiece, target_pos: Vector2) -> void:
 	var old_pos := piece.pos
 	piece.target_pos = target_pos
@@ -90,20 +84,18 @@ func _squish_to(piece: ActivePiece, target_pos: Vector2) -> void:
 	emit_signal("squish_moved", piece, old_pos)
 
 
-"""
-Calculates the position a piece can 'squish' to. This squish will be successful if there's a location below the
-piece's current location where the piece can fit, and if at least one of the piece's blocks remains unobstructed
-along its path to the target location.
-
-If a squish is possible, the piece.target_pos field will be updated. If unsuccessful, the target_pos field will be
-reset to the piece's current position.
-
-Parameters:
-	'piece': The piece to squish
-	
-	'reset_target': If true, the piece's target will be reset to its current position before starting the squish. If
-		false, the piece will be squished from its current target.
-"""
+## Calculates the position a piece can 'squish' to. This squish will be successful if there's a location below the
+## piece's current location where the piece can fit, and if at least one of the piece's blocks remains unobstructed
+## along its path to the target location.
+##
+## If a squish is possible, the piece.target_pos field will be updated. If unsuccessful, the target_pos field will be
+## reset to the piece's current position.
+##
+## Parameters:
+## 	'piece': The piece to squish
+##
+## 	'reset_target': If true, the piece's target will be reset to its current position before starting the squish. If
+## 		false, the piece will be squished from its current target.
 func _squish_target(piece: ActivePiece, reset_target: bool = true) -> Vector2:
 	if reset_target:
 		piece.reset_target()

--- a/project/src/main/puzzle/piece/piece-states.gd
+++ b/project/src/main/puzzle/piece/piece-states.gd
@@ -1,26 +1,24 @@
 class_name PieceStates
 extends StateMachine
-"""
-A state machine for the states of the active piece.
-"""
+## A state machine for the states of the active piece.
 
-# Default null state. The puzzle hasn't started yet.
+## Default null state. The puzzle hasn't started yet.
 onready var none: State = $None
 
-# The piece is waiting to spawn. Another piece has just been dropped or the puzzle is just starting.
+## The piece is waiting to spawn. Another piece has just been dropped or the puzzle is just starting.
 onready var prespawn: State = $Prespawn
 
-# The piece is able to be moved/rotated.
+## The piece is able to be moved/rotated.
 onready var move_piece: State = $MovePiece
 
-# The piece has reached the bottom of the playfield and will lock soon, unless the player performs a lock cancel.
+## The piece has reached the bottom of the playfield and will lock soon, unless the player performs a lock cancel.
 onready var prelock: State = $Prelock
 
-# The piece has locked, and the playfield is processing the locked piece by clearing lines or forming boxes.
+## The piece has locked, and the playfield is processing the locked piece by clearing lines or forming boxes.
 onready var wait_for_playfield: State = $WaitForPlayfield
 
-# The player has topped out, and the playfield is processing the top out by making room.
+## The player has topped out, and the playfield is processing the top out by making room.
 onready var top_out: State = $TopOut
 
-# The game is over. The player won, lost or gave up.
+## The game is over. The player won, lost or gave up.
 onready var game_ended: State = $GameEnded

--- a/project/src/main/puzzle/piece/piece-type.gd
+++ b/project/src/main/puzzle/piece/piece-type.gd
@@ -1,28 +1,26 @@
 class_name PieceType
-"""
-Stores information on a piece shape. This includes information on its appearance, how it rotates, and how it 'kicks'
-when it's blocked from rotating.
-"""
+## Stores information on a piece shape. This includes information on its appearance, how it rotates, and how it 'kicks'
+## when it's blocked from rotating.
 
-# string representation when debugging; 'j', 'l', etc...
+## string representation when debugging; 'j', 'l', etc...
 var string: String
 
-# array of vectors representing the position of used cells
+## array of vectors representing the position of used cells
 var pos_arr: Array
 
-# array of vectors representing the autotile coordinates of used cells
+## array of vectors representing the autotile coordinates of used cells
 var color_arr: Array
 
-# array of piece kicks to try when rotating clockwise
+## array of piece kicks to try when rotating clockwise
 var cw_kicks: Array
 
-# array of piece kicks to try when rotating counterclockwise
+## array of piece kicks to try when rotating counterclockwise
 var ccw_kicks: Array
 
-# a piece kick to attempt for each orientation when rotating 180
+## a piece kick to attempt for each orientation when rotating 180
 var flips: Array
 
-# maximum number of 'floor kicks', kicks which move the piece upward
+## maximum number of 'floor kicks', kicks which move the piece upward
 var max_floor_kicks: int
 
 func _init(init_string: String, init_pos_arr: Array, init_color_arr: Array,
@@ -51,23 +49,17 @@ func _init(init_string: String, init_pos_arr: Array, init_color_arr: Array,
 	max_floor_kicks = init_max_floor_kicks
 
 
-"""
-Returns the position of the specified cell.
-"""
+## Returns the position of the specified cell.
 func get_cell_position(orientation: int, cell_index: int) -> Vector2:
 	return pos_arr[orientation][cell_index]
 
 
-"""
-Returns the coordinate (subtile column and row) of the autotile variation for the specified cell.
-"""
+## Returns the coordinate (subtile column and row) of the autotile variation for the specified cell.
 func get_cell_color(orientation: int, cell_index: int) -> Vector2:
 	return color_arr[orientation][cell_index]
 
 
-"""
-Returns PuzzleTileMap's food color index for this piece (brown, pink, bread, white)
-"""
+## Returns PuzzleTileMap's food color index for this piece (brown, pink, bread, white)
 func get_box_type() -> int:
 	return color_arr[0][0][1]
 
@@ -76,22 +68,16 @@ func _to_string() -> String:
 	return string
 
 
-"""
-Returns the orientation the piece will be in if it rotates clockwise.
-"""
+## Returns the orientation the piece will be in if it rotates clockwise.
 func get_cw_orientation(orientation: int) -> int:
 	return (orientation + 1) % pos_arr.size()
 
 
-"""
-Returns the orientation the piece will be in if it rotates counter-clockwise.
-"""
+## Returns the orientation the piece will be in if it rotates counter-clockwise.
 func get_ccw_orientation(orientation: int) -> int:
 	return wrapi(orientation - 1, 0, pos_arr.size())
 
 
-"""
-Returns the orientation the piece will be in if it rotates 180 degrees.
-"""
+## Returns the orientation the piece will be in if it rotates 180 degrees.
 func get_flip_orientation(orientation: int) -> int:
 	return (orientation + 2) % pos_arr.size()

--- a/project/src/main/puzzle/piece/piece-types.gd
+++ b/project/src/main/puzzle/piece/piece-types.gd
@@ -1,8 +1,6 @@
 extends Node
-"""
-Stores information on the various piece shapes. This includes information on their appearance, how they rotate, and
-how they 'kick' when they're blocked from rotating.
-"""
+## Stores information on the various piece shapes. This includes information on their appearance, how they rotate, and
+## how they 'kick' when they're blocked from rotating.
 
 const KICKS_JL := [
 		[Vector2( 1,  0), Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1), Vector2( 0, -1), Vector2(-1,  1)],

--- a/project/src/main/puzzle/piece/presquish-sfx.gd
+++ b/project/src/main/puzzle/piece/presquish-sfx.gd
@@ -1,16 +1,12 @@
 class_name PresquishSfx
 extends AudioStreamPlayer
-"""
-Plays sound effects when the player starts a squish move.
-"""
+## Plays sound effects when the player starts a squish move.
 
-# 'true' if a sound effect was played for the current squish move. This seems redundant with the 'playing' property,
-# but this property stays set to true after the sound effect completes, preventing the sound from looping undesirably.
+## 'true' if a sound effect was played for the current squish move. This seems redundant with the 'playing' property,
+## but this property stays set to true after the sound effect completes, preventing the sound from looping undesirably.
 var sfx_started := false
 
-"""
-Starts playing a sound effect for a squish move.
-"""
+## Starts playing a sound effect for a squish move.
 func start_presquish_sfx() -> void:
 	sfx_started = true
 	pitch_scale = rand_range(0.8, 1.3)
@@ -18,9 +14,7 @@ func start_presquish_sfx() -> void:
 	play(rand_range(0.0, 0.2))
 
 
-"""
-Stops the current sound effect.
-"""
+## Stops the current sound effect.
 func stop_presquish_sfx() -> void:
 	sfx_started = false
 	stop()

--- a/project/src/main/puzzle/piece/puzzle-corner-map.gd
+++ b/project/src/main/puzzle/piece/puzzle-corner-map.gd
@@ -1,13 +1,11 @@
 extends TileMap
-"""
-Tilemap which covers the corners of another tilemap.
-
-Without this tilemap, a simple 16-tile autotiling would result in tiny holes at the corners of a filled in area. This
-tilemap fills in the holes.
-
-This tilemap assumes tiles are arranged so that the X coordinates of the tiles correspond to the directions they're
-connected. This type of tilemap is used for puzzle pieces.
-"""
+## Tilemap which covers the corners of another tilemap.
+##
+## Without this tilemap, a simple 16-tile autotiling would result in tiny holes at the corners of a filled in area.
+## This tilemap fills in the holes.
+##
+## This tilemap assumes tiles are arranged so that the X coordinates of the tiles correspond to the directions they're
+## connected. This type of tilemap is used for puzzle pieces.
 
 onready var _parent_map: TileMap = get_parent()
 
@@ -41,31 +39,25 @@ func _process(_delta: float) -> void:
 		dirty = false
 
 
-"""
-Sets the specified cell with the specified tile from the corner atlas tileset.
-
-Parameters:
-	'pos': Position of the cell
-	
-	'autotile_coord': Coordinate of the autotile variation in the corner atlas tileset
-"""
+## Sets the specified cell with the specified tile from the corner atlas tileset.
+##
+## Parameters:
+## 	'pos': Position of the cell
+##
+## 	'autotile_coord': Coordinate of the autotile variation in the corner atlas tileset
 func _set_corner_cell(pos: Vector2, autotile_coord: Vector2) -> void:
 	set_cell(pos.x, pos.y, PuzzleTileMap.TILE_CORNER, false, false, false, autotile_coord);
 
 
-"""
-Returns the x component of the parent autotile coordinate (PAC) for the specified cell.
-
-This function has a confusingly short name because it's referenced repetitively in some long lines of code.
-"""
+## Returns the x component of the parent autotile coordinate (PAC) for the specified cell.
+##
+## This function has a confusingly short name because it's referenced repetitively in some long lines of code.
 func _pacx(pos: Vector2) -> int:
 	return int(_parent_map.get_cell_autotile_coord(pos.x, pos.y).x)
 
 
-"""
-Returns the y component of the parent autotile coordinate (PAC) for the specified cell.
-
-This function has a confusingly short name because it's referenced repetitively in some long lines of code.
-"""
+## Returns the y component of the parent autotile coordinate (PAC) for the specified cell.
+##
+## This function has a confusingly short name because it's referenced repetitively in some long lines of code.
 func _pacy(pos: Vector2) -> int:
 	return int(_parent_map.get_cell_autotile_coord(pos.x, pos.y).y)

--- a/project/src/main/puzzle/piece/puzzle-shadow-map.gd
+++ b/project/src/main/puzzle/piece/puzzle-shadow-map.gd
@@ -1,12 +1,10 @@
 extends TileMap
-"""
-Tilemap which draws the shadows behind the blocks on the playfield, as well as the shadow behind the currently active
-piece.
-"""
+## Tilemap which draws the shadows behind the blocks on the playfield, as well as the shadow behind the currently
+## active piece.
 
 export (NodePath) var _playfield_tile_map_path: NodePath
 
-# Tilemap for the active piece
+## Tilemap for the active piece
 var piece_tile_map: TileMap
 
 onready var _playfield_tile_map := get_node(_playfield_tile_map_path)

--- a/project/src/main/puzzle/piece/squish-fx.gd
+++ b/project/src/main/puzzle/piece/squish-fx.gd
@@ -1,17 +1,15 @@
 extends Control
-"""
-Generates visual and audio effects for a squish move.
+## Generates visual and audio effects for a squish move.
+##
+## Makes the piece shake, sweat, turn white, and plays a sound effect.
 
-Makes the piece shake, sweat, turn white, and plays a sound effect.
-"""
-
-# Squished pieces blink over time. This field is used to calculate the blink amount
+## Squished pieces blink over time. This field is used to calculate the blink amount
 var _total_time: float
 
-# How much the piece should flash and shake as it's squished
+## How much the piece should flash and shake as it's squished
 var _squish_amount: float
 
-# Calculates how much the piece should flash and shake as it's squished
+## Calculates how much the piece should flash and shake as it's squished
 export (Curve) var squish_curve: Curve
 
 onready var _piece_manager: PieceManager = get_parent()
@@ -50,9 +48,7 @@ func _prepare_tileset() -> void:
 	_squish_map.puzzle_tile_set_type = CurrentLevel.settings.other.tile_set
 
 
-"""
-Makes the piece shake left and right if a squish move is in progress.
-"""
+## Makes the piece shake left and right if a squish move is in progress.
 func _handle_shake() -> void:
 	if _squish_amount > 0:
 		_piece_manager.tile_map.position.x = _squish_amount * 4 * sin(16 * _total_time * TAU)
@@ -60,9 +56,7 @@ func _handle_shake() -> void:
 		_piece_manager.tile_map.position.x = 0
 
 
-"""
-Makes the piece turn white and blink if a squish move is in progress.
-"""
+## Makes the piece turn white and blink if a squish move is in progress.
 func _handle_flash() -> void:
 	if _squish_amount > 0:
 		_piece_manager.tile_map.whiteness = lerp(0.0, 0.64 + 0.16 * sin(4 * _total_time * TAU), _squish_amount)
@@ -70,9 +64,7 @@ func _handle_flash() -> void:
 		_piece_manager.tile_map.whiteness = 0
 
 
-"""
-Makes the piece emit sweat particles if a squish move is in progress.
-"""
+## Makes the piece emit sweat particles if a squish move is in progress.
 func _handle_sweat() -> void:
 	if _squish_amount > 0.1:
 		# gradually increase speed of sweat drops
@@ -82,9 +74,7 @@ func _handle_sweat() -> void:
 		_sweat_drops.emitting = false
 
 
-"""
-Plays a sound effect if a squish move is in progress.
-"""
+## Plays a sound effect if a squish move is in progress.
 func _handle_sfx() -> void:
 	if _squish_amount > 0.1:
 		if not _presquish_sfx.sfx_started:
@@ -94,9 +84,7 @@ func _handle_sfx() -> void:
 			_presquish_sfx.stop_presquish_sfx()
 
 
-"""
-Initialize the squish animation for long squish moves
-"""
+## Initialize the squish animation for long squish moves
 func _on_PieceManager_squish_moved(piece: ActivePiece, old_pos: Vector2) -> void:
 	if piece.pos.y - old_pos.y >= 3:
 		var unblocked_blocks: Array = piece.type.pos_arr[piece.orientation].duplicate()

--- a/project/src/main/puzzle/piece/states/game-ended.gd
+++ b/project/src/main/puzzle/piece/states/game-ended.gd
@@ -1,4 +1,2 @@
 extends State
-"""
-State: The game has ended. No pieces are being managed, but the player's last piece may still be onscreen.
-"""
+## State: The game has ended. No pieces are being managed, but the player's last piece may still be onscreen.

--- a/project/src/main/puzzle/piece/states/move-piece.gd
+++ b/project/src/main/puzzle/piece/states/move-piece.gd
@@ -1,7 +1,5 @@
 extends State
-"""
-State: The player is moving the piece around the playfield.
-"""
+## State: The player is moving the piece around the playfield.
 
 func enter(piece_manager: PieceManager, prev_state_name: String) -> void:
 	if prev_state_name == "Prespawn":

--- a/project/src/main/puzzle/piece/states/none.gd
+++ b/project/src/main/puzzle/piece/states/none.gd
@@ -1,4 +1,2 @@
 extends State
-"""
-State: No piece is being managed, and no piece is onscreen.
-"""
+## State: No piece is being managed, and no piece is onscreen.

--- a/project/src/main/puzzle/piece/states/prelock.gd
+++ b/project/src/main/puzzle/piece/states/prelock.gd
@@ -1,7 +1,5 @@
 extends State
-"""
-The piece has locked into position. The player can still press 'down' to unlock it or squeeze it past other blocks.
-"""
+## The piece has locked into position. The player can still press 'down' to unlock it or squeeze it past other blocks.
 
 func update(piece_manager: PieceManager) -> String:
 	var new_state_name := ""

--- a/project/src/main/puzzle/piece/states/prespawn.gd
+++ b/project/src/main/puzzle/piece/states/prespawn.gd
@@ -1,7 +1,5 @@
 extends State
-"""
-State: The piece will spawn soon.
-"""
+## State: The piece will spawn soon.
 
 func update(piece_manager: PieceManager) -> String:
 	var new_state_name := ""

--- a/project/src/main/puzzle/piece/states/wait-for-playfield.gd
+++ b/project/src/main/puzzle/piece/states/wait-for-playfield.gd
@@ -1,8 +1,6 @@
 extends State
-"""
-State: The playfield is clearing lines or making boxes. We're waiting for these animations to complete before spawning
-a new piece.
-"""
+## State: The playfield is clearing lines or making boxes. We're waiting for these animations to complete before
+## spawning a new piece.
 
 func update(piece_manager: PieceManager) -> String:
 	var new_state := ""

--- a/project/src/main/puzzle/piece/sweat-drops.gd
+++ b/project/src/main/puzzle/piece/sweat-drops.gd
@@ -1,17 +1,13 @@
 extends Particles2D
-"""
-Emits sweat particles for a piece during a squish move.
-"""
+## Emits sweat particles for a piece during a squish move.
 
-# local coordinates to emit sweat from
+## local coordinates to emit sweat from
 var _sweat_positions: Array
 
-# the index of the local coordinate to emit sweat from
+## the index of the local coordinate to emit sweat from
 var _sweat_position_index := 0
 
-"""
-Relocates this Particles2D to a random location.
-"""
+## Relocates this Particles2D to a random location.
 func _relocate_randomly() -> void:
 	if _sweat_positions:
 		_sweat_position_index = (_sweat_position_index + 1) % _sweat_positions.size()
@@ -19,9 +15,7 @@ func _relocate_randomly() -> void:
 		position = sweat_position
 
 
-"""
-Recalculates the sweat positions based on the current piece.
-"""
+## Recalculates the sweat positions based on the current piece.
 func _on_PieceManager_tiles_changed(tile_map: PuzzleTileMap) -> void:
 	_sweat_positions.clear()
 	if tile_map.get_used_cells():

--- a/project/src/main/puzzle/playfield-fx.gd
+++ b/project/src/main/puzzle/playfield-fx.gd
@@ -1,14 +1,12 @@
 extends Node2D
-"""
-Generates visual lighting effects for the playfield.
+## Generates visual lighting effects for the playfield.
+##
+## These effects are pretty to look at, but also provide feedback if the player's combo is about to end.
 
-These effects are pretty to look at, but also provide feedback if the player's combo is about to end.
-"""
-
-# Number of hues present when displaying a rainbow
+## Number of hues present when displaying a rainbow
 const RAINBOW_COLOR_COUNT := 7
 
-# Lights change color based on the lines the player clears.
+## Lights change color based on the lines the player clears.
 const VEGETABLE_LIGHT_COLOR := Color("6074a320")
 const FOOD_LIGHT_COLORS := [
 	Color("c0f47700"), # brown
@@ -17,10 +15,10 @@ const FOOD_LIGHT_COLORS := [
 	Color("a0fff69b"), # white
 ]
 
-# Rainbows are modulated white, because the tiles themselves have a color to them.
+## Rainbows are modulated white, because the tiles themselves have a color to them.
 const RAINBOW_LIGHT_COLOR := Color("50ffffff")
 
-# Light pattern shown when the player clears a line or continues their combo.
+## Light pattern shown when the player clears a line or continues their combo.
 const ON_PATTERN := [
 	"....#....",
 	"...###...",
@@ -32,7 +30,7 @@ const ON_PATTERN := [
 	"#.......#",
 ]
 
-# Light pattern shown when the player's combo is about to end.
+## Light pattern shown when the player's combo is about to end.
 const HALF_PATTERN := [
 	"....#....",
 	"...#.#...",
@@ -44,51 +42,51 @@ const HALF_PATTERN := [
 	".........",
 ]
 
-# Light pattern shown when the player has no combo.
+## Light pattern shown when the player has no combo.
 const OFF_PATTERN := [
 	".........",
 ]
 
 export (NodePath) var combo_tracker_path: NodePath
 
-# light pattern being shown.
+## light pattern being shown.
 var _pattern := OFF_PATTERN
 
-# offset used for displaying the light pattern, as well as for rainbow colors
+## offset used for displaying the light pattern, as well as for rainbow colors
 var _pattern_y := 0
 
-# number of 'elapsed beats' used for pulsing the lights. The length of a beat varies based on the piece speed, one
-# beat is the amount of time an expert player would take to clear a line.
+## number of 'elapsed beats' used for pulsing the lights. The length of a beat varies based on the piece speed, one
+## beat is the amount of time an expert player would take to clear a line.
 var _elapsed_beats := 0.0
 
-# brightness of the background lights
+## brightness of the background lights
 var _brightness := 0.0
 
-# how much the background lights dim when pulsing.
-# 1.0 = pulsing completely on and off, 0.0 = not pulsing at all
+## how much the background lights dim when pulsing.
+## 1.0 = pulsing completely on and off, 0.0 = not pulsing at all
 var _pulse_amount := 0.0
 
-# how long the lights remain on after a line clear
+## how long the lights remain on after a line clear
 var _glow_duration := 0.0
 
-# the current background light color
+## the current background light color
 var _color := Color.transparent
 
-# tile indexes by food/vegetable color
+## tile indexes by food/vegetable color
 var _color_tile_indexes: Dictionary
 
 onready var _combo_tracker: ComboTracker = get_node(combo_tracker_path)
 
-# lights which turn on and off
+## lights which turn on and off
 onready var _light_map: TileMap = $LightMap
 
-# glowy effect around the lights
+## glowy effect around the lights
 onready var _glow_map: TileMap = $GlowMap
 
-# bright flash when the player clears a line
+## bright flash when the player clears a line
 onready var _bg_strobe: ColorRect = $BgStrobe
 
-# gradually dims the glowiness
+## gradually dims the glowiness
 onready var _glow_tween: Tween = $GlowTween
 
 func _ready() -> void:
@@ -115,9 +113,7 @@ func reset() -> void:
 	_refresh_tile_maps()
 
 
-"""
-Initializes the different colored tiles in LightMap/GlowMap.
-"""
+## Initializes the different colored tiles in LightMap/GlowMap.
 func _init_tile_set() -> void:
 	if len(_light_map.tile_set.get_tiles_ids()) > 1:
 		return
@@ -133,9 +129,7 @@ func _init_tile_set() -> void:
 		_init_tile(rainbow_color)
 
 
-"""
-Initializes the mapping of tile indexes by food/vegetable color.
-"""
+## Initializes the mapping of tile indexes by food/vegetable color.
 func _init_color_tile_indexes() -> void:
 	if _color_tile_indexes:
 		return
@@ -155,9 +149,7 @@ func _init_tile(color: Color) -> void:
 		tile_set.tile_set_texture_offset(tile_index, tile_set.tile_get_texture_offset(0))
 
 
-"""
-Starts the glow tween, causing the lights to slowly dim.
-"""
+## Starts the glow tween, causing the lights to slowly dim.
 func _start_glow_tween() -> void:
 	if _brightness > 0 and _glow_duration > 0.0:
 		_glow_tween.remove_all()
@@ -170,9 +162,7 @@ func _start_glow_tween() -> void:
 		_glow_tween.start()
 
 
-"""
-Calculates the light color for a row in the playfield.
-"""
+## Calculates the light color for a row in the playfield.
 func _calculate_line_color(box_ints: Array) -> void:
 	if box_ints.empty():
 		# vegetable
@@ -188,9 +178,7 @@ func _calculate_line_color(box_ints: Array) -> void:
 		_color = FOOD_LIGHT_COLORS[box_ints[1]]
 
 
-"""
-Calculates the brightness of the lights based on the current combo.
-"""
+## Calculates the brightness of the lights based on the current combo.
 func _calculate_brightness(combo: int) -> void:
 	_elapsed_beats = 0.0
 	
@@ -216,9 +204,7 @@ func _calculate_brightness(combo: int) -> void:
 	modulate.a = _brightness
 
 
-"""
-Calculates the new light pattern and refreshes the tile maps.
-"""
+## Calculates the new light pattern and refreshes the tile maps.
 func _refresh_tile_maps() -> void:
 	_bg_strobe.color = Utils.to_transparent(_color)
 	
@@ -263,9 +249,7 @@ func _on_PuzzleState_combo_changed(value: int) -> void:
 	_start_glow_tween()
 
 
-"""
-When the player builds a box we brighten the combo lights again.
-"""
+## When the player builds a box we brighten the combo lights again.
 func _on_Playfield_box_built(_rect: Rect2, _box_type: int) -> void:
 	_refresh_tile_maps()
 	_start_glow_tween()

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -1,37 +1,35 @@
 class_name Playfield
 extends Control
-"""
-Stores information about the game playfield: writing pieces to the playfield, calculating whether a line was cleared
-or whether a box was built, pausing and playing sound effects
-"""
+## Stores information about the game playfield: writing pieces to the playfield, calculating whether a line was cleared
+## or whether a box was built, pausing and playing sound effects
 
-# emitted when a new box is built
+## emitted when a new box is built
 signal box_built(rect, box_type)
 
-# emitted shortly before a set of lines are cleared
+## emitted shortly before a set of lines are cleared
 signal line_clears_scheduled(ys)
 
-# emitted before a 'line clear' where a line is erased and the player is rewarded
+## emitted before a 'line clear' where a line is erased and the player is rewarded
 signal before_line_cleared(y, total_lines, remaining_lines, box_ints)
 
-# emitted after a 'line clear' where a line is erased and the player is rewarded
+## emitted after a 'line clear' where a line is erased and the player is rewarded
 signal line_cleared(y, total_lines, remaining_lines, box_ints)
 
-# emitted when a line is erased. this includes line clears but also top outs and non-scoring end game rows.
+## emitted when a line is erased. this includes line clears but also top outs and non-scoring end game rows.
 signal line_erased(y, total_lines, remaining_lines, box_ints)
 
-# emitted when an erased line is deleted, causing the rows above it to drop down
+## emitted when an erased line is deleted, causing the rows above it to drop down
 signal line_deleted(y)
 
-# emitted when lines are inserted. some levels insert lines, but most do not
+## emitted when lines are inserted. some levels insert lines, but most do not
 signal line_inserted(y, tiles_key, src_y)
 
-# emitted when a food item should be spawned because the player collects a pickup
+## emitted when a food item should be spawned because the player collects a pickup
 signal food_spawned(cell, remaining_food, food_type)
 
 signal blocks_prepared
 
-# remaining frames to delay for something besides making boxes/clearing lines
+## remaining frames to delay for something besides making boxes/clearing lines
 var _remaining_misc_delay_frames := 0
 
 onready var tile_map := $TileMapClip/TileMap
@@ -81,20 +79,16 @@ func schedule_line_clears(lines_to_clear: Array, line_clear_delay: int, award_po
 	_line_clearer.schedule_line_clears(lines_to_clear, line_clear_delay, award_points)
 
 
-"""
-Returns false the playfield is paused for an of animation or delay which should prevent a new piece from appearing.
-"""
+## Returns false the playfield is paused for an of animation or delay which should prevent a new piece from appearing.
 func ready_for_new_piece() -> bool:
 	return _box_builder.remaining_box_build_frames <= 0 \
 			and _line_clearer.remaining_line_erase_frames <= 0 \
 			and _remaining_misc_delay_frames <= 0
 
 
-"""
-Writes a piece to the playfield, checking whether it builds any boxes or clears any lines.
-
-Returns true if the written piece results in a line clear.
-"""
+## Writes a piece to the playfield, checking whether it builds any boxes or clears any lines.
+##
+## Returns true if the written piece results in a line clear.
 func write_piece(pos: Vector2, orientation: int, type: PieceType, death_piece := false) -> void:
 	_box_builder.remaining_box_build_frames = 0
 	_line_clearer.remaining_line_erase_frames = 0
@@ -126,9 +120,7 @@ func _prepare_tileset() -> void:
 	tile_map.puzzle_tile_set_type = CurrentLevel.settings.other.tile_set
 
 
-"""
-Resets the playfield to the level's initial state.
-"""
+## Resets the playfield to the level's initial state.
 func _prepare_level_blocks() -> void:
 	$TutorialKeybindsLabel.visible = CurrentLevel.settings.other.tutorial and not OS.has_touchscreen_ui_hint()
 	
@@ -187,9 +179,7 @@ func _on_FrostingGlobs_hit_playfield(glob: Node) -> void:
 	_bg_glob_viewports.add_smear(glob)
 
 
-"""
-When the player pauses, we hide the playfield so they can't cheat.
-"""
+## When the player pauses, we hide the playfield so they can't cheat.
 func _on_Pauser_paused_changed(value: bool) -> void:
 	$TileMapClip.visible = not value
 	$ShadowTexture.visible = not value

--- a/project/src/main/puzzle/puzzle-areas.gd
+++ b/project/src/main/puzzle/puzzle-areas.gd
@@ -1,13 +1,11 @@
 class_name PuzzleAreas
-"""
-Positional information about the puzzle screen for frosting physics.
-"""
+## Positional information about the puzzle screen for frosting physics.
 
-# the playfield area behind the blocks
+## the playfield area behind the blocks
 var playfield_area: Rect2
 
-# the upper area behind the next pieces
+## the upper area behind the next pieces
 var next_pieces_area: Rect2
 
-# the area within the four outer walls
+## the area within the four outer walls
 var walled_area: Rect2

--- a/project/src/main/puzzle/puzzle-messages.gd
+++ b/project/src/main/puzzle/puzzle-messages.gd
@@ -1,9 +1,7 @@
 extends Control
-"""
-Contains labels and buttons which overlay the puzzle screen.
-
-This includes the countdown timer, the ending message, the controls, and the 'start' and 'exit' buttons.
-"""
+## Contains labels and buttons which overlay the puzzle screen.
+##
+## This includes the countdown timer, the ending message, the controls, and the 'start' and 'exit' buttons.
 
 signal start_button_pressed
 signal settings_button_pressed
@@ -26,9 +24,7 @@ func is_settings_button_visible() -> bool:
 	return $Buttons/Settings.is_visible_in_tree()
 
 
-"""
-Shows a succinct single-line message, like 'Game Over'
-"""
+## Shows a succinct single-line message, like 'Game Over'
 func show_message(text: String) -> void:
 	$MessageLabel.show()
 	$MessageLabel.text = text
@@ -100,9 +96,7 @@ func _on_PuzzleState_game_ended() -> void:
 	show_message(message)
 
 
-"""
-Restores the HUD elements after the player wins or loses.
-"""
+## Restores the HUD elements after the player wins or loses.
 func _on_PuzzleState_after_game_ended() -> void:
 	$MessageLabel.hide()
 	$Buttons/Settings.show()
@@ -140,9 +134,7 @@ func _on_PuzzleState_after_game_ended() -> void:
 			break
 
 
-"""
-The back buttons changes its label if the level is cleared.
-"""
+## The back buttons changes its label if the level is cleared.
 func _on_Level_best_result_changed() -> void:
 	match CurrentLevel.best_result:
 		Levels.Result.FINISHED, Levels.Result.WON:

--- a/project/src/main/puzzle/puzzle-music-manager.gd
+++ b/project/src/main/puzzle/puzzle-music-manager.gd
@@ -1,7 +1,5 @@
 extends Node
-"""
-Starts and stops music during the puzzle mode.
-"""
+## Starts and stops music during the puzzle mode.
 
 func _ready() -> void:
 	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")

--- a/project/src/main/puzzle/puzzle-performance.gd
+++ b/project/src/main/puzzle/puzzle-performance.gd
@@ -1,40 +1,38 @@
 class_name PuzzlePerformance
-"""
-Stores persistent statistics for how the did during a puzzle. This includes how long they survived, how many lines
-they cleared, and their score.
-"""
+## Stores persistent statistics for how the did during a puzzle. This includes how long they survived, how many lines
+## they cleared, and their score.
 
-# number of seconds until the player won or lost
+## number of seconds until the player won or lost
 var seconds := 0.0
 
-# raw number of cleared lines, not including bonus points
+## raw number of cleared lines, not including bonus points
 var lines := 0
 
-# number of pieces placed
+## number of pieces placed
 var pieces := 0
 
-# bonus points awarded for clearing boxes
+## bonus points awarded for clearing boxes
 var box_score := 0
 
-# bonus points awarded for combos
+## bonus points awarded for combos
 var combo_score := 0
 
-# bonus points awarded for pickups
+## bonus points awarded for pickups
 var pickup_score := 0
 
-# points awarded for lines left over at the end
+## points awarded for lines left over at the end
 var leftover_score := 0
 
-# overall score
+## overall score
 var score := 0
 
-# how many times did the player top out?
+## how many times did the player top out?
 var top_out_count := 0
 
-# did the player lose?
+## did the player lose?
 var lost := false
 
-# did the player succeed?
+## did the player succeed?
 var success := false
 
 func topped_out() -> bool:

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -1,35 +1,33 @@
 extends Node
-"""
-Stores the player's score for the current puzzle.
+## Stores the player's score for the current puzzle.
+##
+## This includes persistent data such as how long they survived, how many lines they cleared, and their score. This
+## data is written eventually to the save file.
+##
+## This also includes transient data such as the current creature/bonus score. This is used visually, but never saved.
 
-This includes persistent data such as how long they survived, how many lines they cleared, and their score. This data
-is written eventually to the save file.
-
-This also includes transient data such as the current creature/bonus score. This is used visually, but never saved.
-"""
-
-# emitted when the game will start soon. Everything should be erased and reset to zero.
+## emitted when the game will start soon. Everything should be erased and reset to zero.
 signal game_prepared
 
-# emitted after everything's been erased in preparation for a new game.
+## emitted after everything's been erased in preparation for a new game.
 signal after_game_prepared
 
-# emitter after the initial countdown finishes, when the player can start playing.
+## emitter after the initial countdown finishes, when the player can start playing.
 signal game_started
 
-# emitted during tutorials, when changing from one tutorial section to the next
+## emitted during tutorials, when changing from one tutorial section to the next
 signal before_level_changed(new_level_id)
 signal after_level_changed
 
-# emitted when the player survives until the end the level.
+## emitted when the player survives until the end the level.
 signal finish_triggered
 
-# emitted when the player reaches the end of a tutorial section
+## emitted when the player reaches the end of a tutorial section
 signal tutorial_section_finished
 
 signal game_ended
 
-# emitted several seconds after the game ends
+## emitted several seconds after the game ends
 signal after_game_ended
 
 signal speed_index_changed(value)
@@ -37,22 +35,22 @@ signal speed_index_changed(value)
 signal added_line_score(combo_score, box_score)
 signal added_pickup_score(pickup_score)
 
-# emitted on the frame that the player drops and locks a new piece
+## emitted on the frame that the player drops and locks a new piece
 signal before_piece_written
 
-# emitted after the piece is written, and all boxes are made, and all lines are cleared
+## emitted after the piece is written, and all boxes are made, and all lines are cleared
 signal after_piece_written
 
 signal score_changed
 
-# emitted when a combo value changes, when building or ending a combo
+## emitted when a combo value changes, when building or ending a combo
 signal combo_changed(value)
 
-# emitted when a combo ends -- this will usually coincide with the combo resetting to zero, but at the end of a level
-# it's possible for a combo to end without being reset to zero.
+## emitted when a combo ends -- this will usually coincide with the combo resetting to zero, but at the end of a level
+## it's possible for a combo to end without being reset to zero.
 signal combo_ended
 
-# emitted when the current piece can't be placed in the _playfield
+## emitted when the current piece can't be placed in the _playfield
 signal topped_out
 
 const DELAY_NONE := 0.00
@@ -61,37 +59,37 @@ const DELAY_LONG := 4.70
 
 const READY_DURATION := 1.4
 
-# the current input frame for recording/replaying the player's inputs. a value of '-1' indicates that no input should
-# be recorded or replayed yet.
+## the current input frame for recording/replaying the player's inputs. a value of '-1' indicates that no input should
+## be recorded or replayed yet.
 var input_frame := -1
 
-# Player's performance on the current level
+## Player's performance on the current level
 var level_performance := PuzzlePerformance.new()
 
-# The scores for each creature in the current level (bonuses and line clears)
+## The scores for each creature in the current level (bonuses and line clears)
 var customer_scores := [0]
 
-# The number of lines the player has cleared without dropping their combo
+## The number of lines the player has cleared without dropping their combo
 var combo := 0 setget set_combo
 
-# Bonus points awarded during the current combo. This only includes bonuses
-# and should be a round number like +55 or +130 for visual aesthetics.
+## Bonus points awarded during the current combo. This only includes bonuses
+## and should be a round number like +55 or +130 for visual aesthetics.
 var bonus_score := 0
 
-# 'true' if the player has started a game which is still running.
+## 'true' if the player has started a game which is still running.
 var game_active: bool
 
-# 'true' if the player survived until the end the level.
+## 'true' if the player survived until the end the level.
 var finish_triggered: bool
 
-# 'true' if the end has been triggered by dying or meeting a finish condition
+## 'true' if the end has been triggered by dying or meeting a finish condition
 var game_ended: bool
 
-# the speed the player is currently on, if the level has different speeds.
+## the speed the player is currently on, if the level has different speeds.
 var speed_index: int setget set_speed_index
 
-# This is true if the final customer has been fed and we shouldn't rotate to any other customers. It also gets used
-# for tutorials to prevent the sensei from leaving.
+## This is true if the final customer has been fed and we shouldn't rotate to any other customers. It also gets used
+## for tutorials to prevent the sensei from leaving.
 var no_more_customers: bool
 
 func _physics_process(_delta: float) -> void:
@@ -103,9 +101,7 @@ func _physics_process(_delta: float) -> void:
 		input_frame += 1
 
 
-"""
-Resets all score data, and starts a new game after a brief pause.
-"""
+## Resets all score data, and starts a new game after a brief pause.
 func prepare_and_start_game() -> void:
 	_prepare_game()
 	
@@ -177,13 +173,11 @@ func change_level(level_id: String, delay_between_levels: float = DELAY_SHORT) -
 	emit_signal("after_level_changed")
 
 
-"""
-Triggers the 'finish' phase of the game when the player clears the level.
-
-Remaining lines are cleared and the player's awarded points. These points count towards their score, but don't
-help/hurt things like their box rank or combo rank. It's mostly to put on a show and help them feel like their work
-wasn't wasted, if they built a lot of boxes they didn't clear.
-"""
+## Triggers the 'finish' phase of the game when the player clears the level.
+##
+## Remaining lines are cleared and the player's awarded points. These points count towards their score, but don't
+## help/hurt things like their box rank or combo rank. It's mostly to put on a show and help them feel like their work
+## wasn't wasted, if they built a lot of boxes they didn't clear.
 func trigger_finish() -> void:
 	if CurrentLevel.settings.other.tutorial:
 		emit_signal("tutorial_section_finished")
@@ -193,15 +187,13 @@ func trigger_finish() -> void:
 		emit_signal("finish_triggered")
 
 
-"""
-Adds points for clearing a line.
-
-Increments persistent data for the current level and transient data displayed on the screen.
-
-Parameters:
-	'combo_score': Bonus points for the current combo.
-	'box_score': Bonus points for any boxes in the line.
-"""
+## Adds points for clearing a line.
+##
+## Increments persistent data for the current level and transient data displayed on the screen.
+##
+## Parameters:
+## 	'combo_score': Bonus points for the current combo.
+## 	'box_score': Bonus points for any boxes in the line.
 func add_line_score(combo_score: int, box_score: int) -> void:
 	if game_active:
 		level_performance.combo_score += combo_score
@@ -221,11 +213,9 @@ func add_line_score(combo_score: int, box_score: int) -> void:
 	emit_signal("combo_changed", combo)
 
 
-"""
-Adds points for collecting one or more pickups.
-
-Increments persistent data for the current level and transient data displayed on the screen.
-"""
+## Adds points for collecting one or more pickups.
+##
+## Increments persistent data for the current level and transient data displayed on the screen.
 func add_pickup_score(pickup_score: int) -> void:
 	if game_active:
 		level_performance.pickup_score += pickup_score
@@ -237,9 +227,7 @@ func add_pickup_score(pickup_score: int) -> void:
 	emit_signal("score_changed")
 
 
-"""
-Ends the current combo, incrementing the score and resetting the bonus/creature scores to zero.
-"""
+## Ends the current combo, incrementing the score and resetting the bonus/creature scores to zero.
 func end_combo() -> void:
 	var old_combo := combo
 	if CurrentLevel.settings.other.tutorial:
@@ -268,9 +256,7 @@ func end_combo() -> void:
 	emit_signal("combo_ended")
 
 
-"""
-Reset all score data, such as when starting a level over.
-"""
+## Reset all score data, such as when starting a level over.
 func reset() -> void:
 	customer_scores = [0]
 	combo = 0

--- a/project/src/main/puzzle/puzzle-tile-map-reader.gd
+++ b/project/src/main/puzzle/puzzle-tile-map-reader.gd
@@ -1,22 +1,20 @@
 class_name PuzzleTileMapReader
 
-"""
-Parses a json fragment listing tiles in a puzzle tilemap.
-
-Instead of directly populating a puzzle tilemap, we invoke a callback function for greater flexibility.
-
-Parameters:
-	'json_tiles': A json fragment listing tiles in a puzzle tilemap.
-	
-	'set_block': A reference to a function which accepts three parameters:
-		'pos' (Vector2): Position of the cell
-		'tile' (int): Tile index of the cell
-		'autotile_coord' (Vector2): Coordinate of the autotile variation in the tileset
-	
-	'set_pickup': (Optional) A reference to a function which accepts two parameters:
-		'pos' (Vector2): Position of the cell
-		'box_type' (int): An enum from Foods.BoxType defining the pickup's color
-"""
+## Parses a json fragment listing tiles in a puzzle tilemap.
+##
+## Instead of directly populating a puzzle tilemap, we invoke a callback function for greater flexibility.
+##
+## Parameters:
+## 	'json_tiles': A json fragment listing tiles in a puzzle tilemap.
+##
+## 	'set_block': A reference to a function which accepts three parameters:
+## 		'pos' (Vector2): Position of the cell
+## 		'tile' (int): Tile index of the cell
+## 		'autotile_coord' (Vector2): Coordinate of the autotile variation in the tileset
+##
+## 	'set_pickup': (Optional) A reference to a function which accepts two parameters:
+## 		'pos' (Vector2): Position of the cell
+## 		'box_type' (int): An enum from Foods.BoxType defining the pickup's color
 static func read(json_tiles: Array, set_block: FuncRef, set_pickup: FuncRef = null) -> void:
 	for json_tile in json_tiles:
 		var json_pos_arr: PoolStringArray = json_tile.get("pos", "").split(" ")

--- a/project/src/main/puzzle/puzzle-tile-map.gd
+++ b/project/src/main/puzzle/puzzle-tile-map.gd
@@ -1,15 +1,13 @@
 class_name PuzzleTileMap
 extends TileMap
-"""
-TileMap containing puzzle blocks such as pieces, boxes and vegetables.
-"""
+## TileMap containing puzzle blocks such as pieces, boxes and vegetables.
 
 enum TileSetType {
 	DEFAULT,
 	VEGGIE,
 }
 
-# The highest visible playfield row. Food/wobblers/vfx should not be drawn above this row.
+## The highest visible playfield row. Food/wobblers/vfx should not be drawn above this row.
 const FIRST_VISIBLE_ROW := 3
 
 const TILE_PIECE := 0 # part of an intact piece
@@ -17,25 +15,25 @@ const TILE_BOX := 1 # part of a snack/cake box
 const TILE_VEG := 2 # vegetable created from line clears
 const TILE_CORNER := 3 # inner corner of a piece for CornerMap
 
-# playfield dimensions. the playfield extends a few rows higher than what the player can see
+## playfield dimensions. the playfield extends a few rows higher than what the player can see
 const ROW_COUNT = 20
 const COL_COUNT = 9
 
-# a number in the range [0, 1] which can be set to make the tilemap flash or blink.
+## a number in the range [0, 1] which can be set to make the tilemap flash or blink.
 var whiteness := 0.0 setget set_whiteness
 
-# offset used to draw the 'ghost piece'
+## offset used to draw the 'ghost piece'
 var ghost_shadow_offset: Vector2
 
-# an enum from TileSetType referencing the tileset used to render blocks
+## an enum from TileSetType referencing the tileset used to render blocks
 var puzzle_tile_set_type: int = TileSetType.DEFAULT setget set_puzzle_tile_set_type
 
-# fields used to roll the tilemap back to a previous state
+## fields used to roll the tilemap back to a previous state
 var _saved_used_cells := []
 var _saved_tiles := []
 var _saved_autotile_coords := []
 
-# tilemap which covers the corners of this tilemap
+## tilemap which covers the corners of this tilemap
 onready var corner_map: TileMap = $CornerMap
 
 var _puzzle_tile_sets_by_enum := {
@@ -69,11 +67,9 @@ func save_state() -> void:
 		_saved_autotile_coords.append(get_cell_autotile_coord(cell.x, cell.y))
 
 
-"""
-Rolls back the piece previously written to the tilemap.
-
-Also undoes any boxes that were built and lines that were cleared.
-"""
+## Rolls back the piece previously written to the tilemap.
+##
+## Also undoes any boxes that were built and lines that were cleared.
 func restore_state() -> void:
 	clear()
 	for i in range(_saved_used_cells.size()):
@@ -83,25 +79,21 @@ func restore_state() -> void:
 		set_block(cell, tile, autotile_coord)
 
 
-"""
-Assigns a block to a tilemap cell.
-
-Parameters:
-	'pos': Position of the cell
-	
-	'tile': Tile index of the cell
-	
-	'autotile_coord': Coordinate of the autotile variation in the tileset
-"""
+## Assigns a block to a tilemap cell.
+##
+## Parameters:
+## 	'pos': Position of the cell
+##
+## 	'tile': Tile index of the cell
+##
+## 	'autotile_coord': Coordinate of the autotile variation in the tileset
 func set_block(pos: Vector2, tile: int, autotile_coord: Vector2 = Vector2.ZERO) -> void:
 	set_cell(pos.x, pos.y, tile, false, false, false, autotile_coord)
 	if is_inside_tree():
 		corner_map.dirty = true
 
 
-"""
-Creates a snack box or cake box.
-"""
+## Creates a snack box or cake box.
 func build_box(rect: Rect2, box_type: int) -> void:
 	for curr_x in range(rect.position.x, rect.end.x):
 		for curr_y in range (rect.position.y, rect.end.y):
@@ -118,24 +110,18 @@ func build_box(rect: Rect2, box_type: int) -> void:
 		_disconnect_block(Vector2(rect.end.x - 1, curr_y), PuzzleConnect.RIGHT)
 
 
-"""
-Deletes the row at the specified location, lowering all higher rows to fill the gap.
-"""
+## Deletes the row at the specified location, lowering all higher rows to fill the gap.
 func delete_row(y: int) -> void:
 	erase_playfield_row(y)
 	_shift_rows(y - 1, Vector2.DOWN)
 
 
-"""
-Inserts a blank row at the specified location, raising all higher rows to make room.
-"""
+## Inserts a blank row at the specified location, raising all higher rows to make room.
 func insert_row(y: int) -> void:
 	_shift_rows(y, Vector2.UP)
 
 
-"""
-Deletes the specified row in the tilemap, dropping all higher rows down to fill the gap.
-"""
+## Deletes the specified row in the tilemap, dropping all higher rows down to fill the gap.
 func delete_rows(rows: Array) -> void:
 	# sort to avoid edge cases with row indexes changing during deletion
 	var rows_to_delete := rows.duplicate()
@@ -144,23 +130,17 @@ func delete_rows(rows: Array) -> void:
 		delete_row(y)
 
 
-"""
-Returns 'true' if the specified cell is within the playfield bounds and does not contain a block.
-"""
+## Returns 'true' if the specified cell is within the playfield bounds and does not contain a block.
 func is_cell_empty(pos: Vector2) -> bool:
 	return Rect2(0, 0, COL_COUNT, ROW_COUNT).has_point(pos) and get_cellv(pos) == -1
 
 
-"""
-Returns 'true' if the specified cell is outside the playfield bounds or contains a block.
-"""
+## Returns 'true' if the specified cell is outside the playfield bounds or contains a block.
 func is_cell_blocked(pos: Vector2) -> bool:
 	return not is_cell_empty(pos)
 
 
-"""
-Returns true if the specified row has no empty cells.
-"""
+## Returns true if the specified row has no empty cells.
 func playfield_row_is_full(y: int) -> bool:
 	var row_is_full := true
 	for x in range(COL_COUNT):
@@ -170,9 +150,7 @@ func playfield_row_is_full(y: int) -> bool:
 	return row_is_full
 
 
-"""
-Returns true if the specified row has only empty cells.
-"""
+## Returns true if the specified row has only empty cells.
 func playfield_row_is_empty(y: int) -> bool:
 	var row_is_empty := true
 	for x in range(COL_COUNT):
@@ -182,9 +160,7 @@ func playfield_row_is_empty(y: int) -> bool:
 	return row_is_empty
 
 
-"""
-Erases all cells in the specified row.
-"""
+## Erases all cells in the specified row.
 func erase_playfield_row(y: int) -> void:
 	for x in range(COL_COUNT):
 		if get_cellv(Vector2(x, y)) == 0:
@@ -194,10 +170,7 @@ func erase_playfield_row(y: int) -> void:
 		
 		set_block(Vector2(x, y), -1)
 
-
-"""
-Sets the whiteness property to make the tilemap flash or blink.
-"""
+## Sets the whiteness property to make the tilemap flash or blink.
 func set_whiteness(new_whiteness: float) -> void:
 	if whiteness == new_whiteness:
 		return
@@ -206,38 +179,32 @@ func set_whiteness(new_whiteness: float) -> void:
 	corner_map.material.set_shader_param("mix_color", Utils.to_transparent(Color.white, whiteness))
 
 
-"""
-Returns a position randomly near a cell.
-
-This is useful when we want visual effects to appear somewhere within the cell at (3, 6) with random variation.
-
-Parameters:
-	'cell_pos': Grid-based coordinates of a cell in the tilemap.
-	
-	'cell_offset': (Optional) Grid-based coordinates of the random offset to apply. If unspecified, the coordinate
-		will be randomly offset by a value in the range [(0, 0), (1, 1)]
-"""
+## Returns a position randomly near a cell.
+##
+## This is useful when we want visual effects to appear somewhere within the cell at (3, 6) with random variation.
+##
+## Parameters:
+## 	'cell_pos': Grid-based coordinates of a cell in the tilemap.
+##
+## 	'cell_offset': (Optional) Grid-based coordinates of the random offset to apply. If unspecified, the coordinate
+## 		will be randomly offset by a value in the range [(0, 0), (1, 1)]
 func somewhere_near_cell(cell_pos: Vector2, cell_offset: Vector2 = Vector2.ZERO) -> Vector2:
 	if not cell_offset:
 		cell_offset = Vector2(randf(), randf())
 	return (cell_pos + cell_offset) * cell_size * scale
 
 
-"""
-Updates our tile set and the tileset of the corner map.
-
-Parameters:
-	'new_puzzle_tile_set_type': an enum from TileSetType referencing the tileset used to render blocks
-"""
+## Updates our tile set and the tileset of the corner map.
+##
+## Parameters:
+## 	'new_puzzle_tile_set_type': an enum from TileSetType referencing the tileset used to render blocks
 func set_puzzle_tile_set_type(new_puzzle_tile_set_type: int) -> void:
 	puzzle_tile_set_type = new_puzzle_tile_set_type
 	tile_set = _puzzle_tile_sets_by_enum[new_puzzle_tile_set_type]
 	corner_map.tile_set = _puzzle_tile_sets_by_enum[new_puzzle_tile_set_type]
 
 
-"""
-Deconstructs the piece at the specified location into vegetable blocks.
-"""
+## Deconstructs the piece at the specified location into vegetable blocks.
 func _convert_piece_to_veg(pos: Vector2) -> void:
 	# store connections
 	var old_autotile_coord: Vector2 = get_cell_autotile_coord(pos.x, pos.y)
@@ -257,16 +224,14 @@ func _convert_piece_to_veg(pos: Vector2) -> void:
 		_convert_piece_to_veg(pos + Vector2.RIGHT)
 
 
-"""
-Disconnects the specified block, which is a part of a box, from the boxes above and below it.
-
-When clearing a line which contains a box, parts of the box can stay behind. We want to redraw those boxes so that
-they don't look chopped-off, and so that the player can still tell they're worth bonus points, so we turn them into
-smaller 2x3 and 1x3 boxes.
-
-If we didn't perform this step, the chopped-off bottom of a bread box would still just look like bread. This way, the
-bottom of a bread box looks like a delicious frosted snack and the player can tell it's special.
-"""
+## Disconnects the specified block, which is a part of a box, from the boxes above and below it.
+##
+## When clearing a line which contains a box, parts of the box can stay behind. We want to redraw those boxes so that
+## they don't look chopped-off, and so that the player can still tell they're worth bonus points, so we turn them into
+## smaller 2x3 and 1x3 boxes.
+##
+## If we didn't perform this step, the chopped-off bottom of a bread box would still just look like bread. This way,
+## the bottom of a bread box looks like a delicious frosted snack and the player can tell it's special.
 func _disconnect_box(pos: Vector2) -> void:
 	if get_cellv(pos + Vector2.UP) == TILE_BOX:
 		_disconnect_block(pos + Vector2.UP, PuzzleConnect.DOWN)
@@ -274,12 +239,10 @@ func _disconnect_box(pos: Vector2) -> void:
 		_disconnect_block(pos + Vector2.DOWN, PuzzleConnect.UP)
 
 
-"""
-Disconnects a block from its surrounding directions.
-
-Parameters:
-	'dir_mask': Directions to be disconnected. Defaults to 15 which disconnects it from all four directions.
-"""
+## Disconnects a block from its surrounding directions.
+##
+## Parameters:
+## 	'dir_mask': Directions to be disconnected. Defaults to 15 which disconnects it from all four directions.
 func _disconnect_block(pos: Vector2, dir_mask: int = 15) -> void:
 	if get_cellv(pos) == -1:
 		# empty cell; nothing to disconnect
@@ -289,14 +252,12 @@ func _disconnect_block(pos: Vector2, dir_mask: int = 15) -> void:
 	set_block(pos, get_cellv(pos), autotile_coord)
 
 
-"""
-Shifts a group of rows up or down.
-
-Parameters:
-	'bottom_row': The lowest row to shift. All rows at or above this row will be shifted.
-	
-	'direction': The direction to shift the rows, such as Vector2.UP or Vector2.DOWN.
-"""
+## Shifts a group of rows up or down.
+##
+## Parameters:
+## 	'bottom_row': The lowest row to shift. All rows at or above this row will be shifted.
+##
+## 	'direction': The direction to shift the rows, such as Vector2.UP or Vector2.DOWN.
 func _shift_rows(bottom_row: int, direction: Vector2) -> void:
 	# First, erase and store all the old cells which are shifting
 	var piece_colors_to_set := {}
@@ -317,11 +278,9 @@ func _shift_rows(bottom_row: int, direction: Vector2) -> void:
 		set_block(cell, piece_colors_to_set[cell], autotile_coords_to_set[cell])
 
 
-"""
-Returns 'true' if the specified array contains a cake box type.
-
-There are eight cake box colors; one for each combination of three pieces which forms a rectangle.
-"""
+## Returns 'true' if the specified array contains a cake box type.
+##
+## There are eight cake box colors; one for each combination of three pieces which forms a rectangle.
 static func has_cake_box(box_types: Array) -> bool:
 	var result := false
 	for box_type in box_types:

--- a/project/src/main/puzzle/puzzle-timer.gd
+++ b/project/src/main/puzzle/puzzle-timer.gd
@@ -1,7 +1,5 @@
 extends Label
-"""
-A UI component showing how long the player has spent on the current puzzle.
-"""
+## A UI component showing how long the player has spent on the current puzzle.
 
 func _ready() -> void:
 	if CurrentLevel.settings.finish_condition.type == Milestone.TIME_OVER:
@@ -16,8 +14,6 @@ func _process(_delta: float) -> void:
 	_refresh_text()
 
 
-"""
-Updates the label to show the number of seconds the player has spent on the current puzzle.
-"""
+## Updates the label to show the number of seconds the player has spent on the current puzzle.
 func _refresh_text() -> void:
 	text = StringUtils.format_duration(int(ceil(PuzzleState.level_performance.seconds)))

--- a/project/src/main/puzzle/puzzle-touch-buttons.gd
+++ b/project/src/main/puzzle/puzzle-touch-buttons.gd
@@ -1,9 +1,7 @@
 extends Control
-"""
-Manages the touchscreen buttons for puzzle mode.
-"""
+## Manages the touchscreen buttons for puzzle mode.
 
-# touchscreen control schemes the player can select in the settings menu
+## touchscreen control schemes the player can select in the settings menu
 const SCHEMES := {
 	TouchSettings.EASY_CONSOLE: {
 		"sw_actions": ["hard_drop", "soft_drop", "move_piece_left", "move_piece_right"],
@@ -43,14 +41,14 @@ const SCHEMES := {
 	},
 }
 
-# if false, pressing the buttons won't emit any actions.
+## if false, pressing the buttons won't emit any actions.
 export (bool) var emit_actions := true setget set_emit_actions
 
 onready var _close := preload("res://assets/main/ui/touch/menu.png")
 onready var _close_pressed := preload("res://assets/main/ui/touch/menu-pressed.png")
 
-# when the player is testing buttons, we replace the icon so we don't confuse users trying who are trying to quit
-# (although... there's an argument that replacing the close button with a duck might confuse them more...)
+## when the player is testing buttons, we replace the icon so we don't confuse users trying who are trying to quit
+## (although... there's an argument that replacing the close button with a duck might confuse them more...)
 onready var _duck := preload("res://assets/main/ui/touch/duck.png")
 onready var _duck_pressed := preload("res://assets/main/ui/touch/duck-pressed.png")
 
@@ -72,11 +70,9 @@ func set_emit_actions(new_emit_actions: bool) -> void:
 	_refresh_emit_actions()
 
 
-"""
-Refreshes the buttons based on the emit_actions property.
-
-Propogates the setting to the EightWay child objects.
-"""
+## Refreshes the buttons based on the emit_actions property.
+##
+## Propogates the setting to the EightWay child objects.
 func _refresh_emit_actions() -> void:
 	if not is_inside_tree():
 		return
@@ -95,11 +91,9 @@ func _refresh_emit_actions() -> void:
 		_menu_button.pressed = _duck_pressed
 
 
-"""
-Updates the buttons based on the player's settings.
-
-This updates their location and size.
-"""
+## Updates the buttons based on the player's settings.
+##
+## This updates their location and size.
 func _refresh_button_positions() -> void:
 	$ButtonsSw.rect_scale = Vector2(1.0, 1.0) * SystemData.touch_settings.size
 	$ButtonsSw.rect_position.y = rect_size.y - 10 - $ButtonsSw.rect_size.y * $ButtonsSw.rect_scale.y
@@ -112,11 +106,9 @@ func _refresh_button_positions() -> void:
 	$MenuButtonHolder.rect_position.x = rect_size.x - 20 - _menu_button.pressed.get_size().x * _menu_button.scale.x
 
 
-"""
-Updates the buttons based on the player's settings.
-
-This updates their location, size, how they're arranged and their sensitivity.
-"""
+## Updates the buttons based on the player's settings.
+##
+## This updates their location, size, how they're arranged and their sensitivity.
 func _refresh_settings() -> void:
 	# update scale/position
 	_refresh_button_positions()
@@ -147,17 +139,13 @@ func _on_TouchSettings_settings_changed() -> void:
 	_refresh_settings()
 
 
-"""
-Plays sounds when testing out controls in the 'settings' menu.
-"""
+## Plays sounds when testing out controls in the 'settings' menu.
 func _on_MenuButton_pressed() -> void:
 	if not emit_actions:
 		$DuckSound.play()
 
 
-"""
-Plays sounds when testing out controls in the 'settings' menu.
-"""
+## Plays sounds when testing out controls in the 'settings' menu.
 func _on_EightWay_pressed() -> void:
 	if not emit_actions:
 		$ButtonSound.play()

--- a/project/src/main/puzzle/puzzle-trace.gd
+++ b/project/src/main/puzzle/puzzle-trace.gd
@@ -1,7 +1,5 @@
 extends Label
-"""
-Shows diagnostics for the piece physics. Enabled with the cheat code 'delays'.
-"""
+## Shows diagnostics for the piece physics. Enabled with the cheat code 'delays'.
 
 export (NodePath) var puzzle_path: NodePath
 
@@ -38,9 +36,7 @@ func _process(_delta: float) -> void:
 		text = new_text
 
 
-"""
-Returns a FrameInput object as a single-character string.
-"""
+## Returns a FrameInput object as a single-character string.
 func input_char(frame_input: FrameInput, character: String) -> String:
 	if not frame_input.is_pressed():
 		return "-"

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -1,8 +1,6 @@
 class_name Puzzle
 extends Control
-"""
-A puzzle scene where a player drops pieces into a playfield of blocks.
-"""
+## A puzzle scene where a player drops pieces into a playfield of blocks.
 
 onready var _restaurant_view: RestaurantView = $RestaurantView
 
@@ -69,9 +67,7 @@ func scroll_to_new_creature() -> void:
 	_restaurant_view.scroll_to_new_creature()
 
 
-"""
-Start a countdown when transitioning between levels. Used during tutorials.
-"""
+## Start a countdown when transitioning between levels. Used during tutorials.
 func start_level_countdown() -> void:
 	$PieceManager.set_physics_process(false)
 	$Hud/HudUi/PuzzleMessages.show_message(tr("Ready?"))
@@ -87,28 +83,24 @@ func get_customer() -> Creature:
 	return _restaurant_view.get_customer()
 
 
-"""
-Triggers the eating animation and makes the creature fatter. Accepts a 'fatness_pct' parameter which defines how
-much fatter the creature should get. We can calculate how fat they should be, and a value of 0.4 means the creature
-should increase by 40% of the amount needed to reach that target.
-
-This 'fatness_pct' parameter is needed for the level where the player eliminates three lines at once. We don't
-want the creature to suddenly grow full size. We want it to take 3 bites.
-
-Parameters:
-	'customer': The creature to feed
-	
-	'food_type': An enum from FoodType corresponding to the food to show
-"""
+## Triggers the eating animation and makes the creature fatter. Accepts a 'fatness_pct' parameter which defines how
+## much fatter the creature should get. We can calculate how fat they should be, and a value of 0.4 means the creature
+## should increase by 40% of the amount needed to reach that target.
+##
+## This 'fatness_pct' parameter is needed for the level where the player eliminates three lines at once. We don't
+## want the creature to suddenly grow full size. We want it to take 3 bites.
+##
+## Parameters:
+## 	'customer': The creature to feed
+##
+## 	'food_type': An enum from FoodType corresponding to the food to show
 func feed_creature(customer: Creature, food_type: int) -> void:
 	var new_comfort := customer.score_to_comfort(PuzzleState.combo, PuzzleState.get_customer_score())
 	customer.set_comfort(new_comfort)
 	customer.feed(food_type)
 
 
-"""
-Starts or restarts the puzzle, loading new customers and preparing the level.
-"""
+## Starts or restarts the puzzle, loading new customers and preparing the level.
 func _start_puzzle() -> void:
 	PlayerData.creature_queue.reset_secondary_creature_queue()
 	
@@ -175,12 +167,10 @@ func _quit_puzzle() -> void:
 	SceneTransition.pop_trail()
 
 
-"""
-Returns 'true' if we should play a postroll cutscene after this level.
-
-We play a postroll cutscene if the player clears the level, although we forcibly skip the cutscene in other
-circumstances as well.
-"""
+## Returns 'true' if we should play a postroll cutscene after this level.
+##
+## We play a postroll cutscene if the player clears the level, although we forcibly skip the cutscene in other
+## circumstances as well.
 func _should_play_postroll() -> bool:
 	var result := true
 	var chat_tree := ChatLibrary.chat_tree_for_postroll(CurrentLevel.level_id)
@@ -196,12 +186,10 @@ func _should_play_postroll() -> bool:
 	return result
 
 
-"""
-Returns 'true' if we should play an epilogue after this level and its postroll cutscenes.
-
-We play an epilogue if the player's beaten the last level in the current world, and if the player hasn't seen this
-world's epilogue scene yet.
-"""
+## Returns 'true' if we should play an epilogue after this level and its postroll cutscenes.
+##
+## We play an epilogue if the player's beaten the last level in the current world, and if the player hasn't seen this
+## world's epilogue scene yet.
 func _should_play_epilogue() -> bool:
 	var result := false
 	var world_lock: WorldLock = LevelLibrary.world_lock_for_level(CurrentLevel.level_id)
@@ -222,11 +210,9 @@ func _should_play_epilogue() -> bool:
 	return result
 
 
-"""
-Enqueues a cutscene to play after this level.
-
-The specified cutscene is played after any other cutscenes.
-"""
+## Enqueues a cutscene to play after this level.
+##
+## The specified cutscene is played after any other cutscenes.
 func _enqueue_cutscene(chat_tree: ChatTree) -> void:
 	if not CutsceneManager.is_front_chat_tree():
 		# Insert the cutscene into the breadcrumb trail, so it shows up when the puzzle scene is popped
@@ -246,9 +232,7 @@ func _on_Hud_back_button_pressed() -> void:
 	_quit_puzzle()
 
 
-"""
-Triggers the 'creature feeding' animation.
-"""
+## Triggers the 'creature feeding' animation.
 func _on_Playfield_line_cleared(_y: int, total_lines: int, remaining_lines: int, _box_ints: Array) -> void:
 	var customer: Creature = get_customer()
 	
@@ -273,9 +257,7 @@ func _on_PuzzleState_game_started() -> void:
 	_settings_menu.quit_type = SettingsMenu.GIVE_UP
 
 
-"""
-Method invoked when the game ends. Stores the rank result for later.
-"""
+## Method invoked when the game ends. Stores the rank result for later.
 func _on_PuzzleState_game_ended() -> void:
 	if not CurrentLevel.level_id:
 		# null check to avoid errors when launching Puzzle.tscn standalone
@@ -297,11 +279,9 @@ func _on_PuzzleState_game_ended() -> void:
 	CurrentLevel.best_result = max(CurrentLevel.best_result, PuzzleState.end_result())
 
 
-"""
-Wait until after the game ends to save the player's data.
-
-This makes the stutter from writing to disk less noticable.
-"""
+## Wait until after the game ends to save the player's data.
+##
+## This makes the stutter from writing to disk less noticable.
 func _on_PuzzleState_after_game_ended() -> void:
 	PlayerSave.save_player_data()
 

--- a/project/src/main/puzzle/rank-calculator.gd
+++ b/project/src/main/puzzle/rank-calculator.gd
@@ -1,15 +1,13 @@
 class_name RankCalculator
-"""
-Contains logic for calculating the player's performance. This performance is stored as a series of 'ranks', where 0 is
-the best possible rank and 999 is the worst.
-"""
+## Contains logic for calculating the player's performance. This performance is stored as a series of 'ranks', where 0
+## is the best possible rank and 999 is the worst.
 
 const WORST_RANK := RankResult.WORST_RANK
 const BEST_RANK := RankResult.BEST_RANK
 
-# These RDF (rank difference factor) constants from (0.0 - 1.0) affect how far apart the ranks are. A number like 0.99
-# means the ranks are really narrow, and you can fall from rank 10 to rank 20 with only a minor mistake. A number like
-# 0.96 means the ranks are more forgiving.
+## These RDF (rank difference factor) constants from (0.0 - 1.0) affect how far apart the ranks are. A number like 0.99
+## means the ranks are really narrow, and you can fall from rank 10 to rank 20 with only a minor mistake. A number like
+## 0.96 means the ranks are more forgiving.
 const RDF_SPEED := 0.940 # 'speed' measures how fast the player can place pieces
 const RDF_ENDURANCE := 0.960 # 'endurance' measures how long the player can sustain
 const RDF_BOX_SCORE_PER_LINE := 0.970
@@ -17,34 +15,34 @@ const RDF_COMBO_SCORE_PER_LINE := 0.970
 const RDF_PICKUP_SCORE := 0.980
 const RDF_PICKUP_SCORE_PER_LINE := 0.970
 
-# Performance statistics for a perfect player. These statistics interact, as it's easier to play fast without making
-# boxes, and easier to build boxes while ignoring combos. Before increasing any of these, ensure it's feasible for a
-# theoretical player to meet all three statistics simultaneously.
+## Performance statistics for a perfect player. These statistics interact, as it's easier to play fast without making
+## boxes, and easier to build boxes while ignoring combos. Before increasing any of these, ensure it's feasible for a
+## theoretical player to meet all three statistics simultaneously.
 const MASTER_BOX_SCORE := 14.5
 const MASTER_COMBO_SCORE := 17.575
 const MASTER_CUSTOMER_COMBO := 22
 const MASTER_LEFTOVER_LINES := 12
 
-# The fastest LPM for a human player at the highest piece speeds. Theoretically this could be as high as 180 based on
-# similar records in other games.
+## The fastest LPM for a human player at the highest piece speeds. Theoretically this could be as high as 180 based on
+## similar records in other games.
 #
-# The current value of 65 is a conservative estimate extrapolated based on my own personal best of 52 lines per
-# minute.
+## The current value of 65 is a conservative estimate extrapolated based on my own personal best of 52 lines per
+## minute.
 const MASTER_LINES_PER_MINUTE := 65
 
-# The number of extra unnecessary frames a perfect player will spend moving their piece.
+## The number of extra unnecessary frames a perfect player will spend moving their piece.
 const MASTER_MVMT_FRAMES := 6
 
-# amount of points lost while starting a combo
+## amount of points lost while starting a combo
 const COMBO_DEFICIT := [0, 20, 40, 55, 70, 80, 90, 95, 100]
 
-# String to display if the player scored worse than the lowest grade
+## String to display if the player scored worse than the lowest grade
 const NO_GRADE := "-"
 
-# highest attainable grade; useful for logic which checks if the player's grade can increase
+## highest attainable grade; useful for logic which checks if the player's grade can increase
 const HIGHEST_GRADE := "M"
 
-# grades with their corresponding rank requirement
+## grades with their corresponding rank requirement
 const GRADE_RANKS := [
 	["M", 0],
 	["SSS", 4],
@@ -67,14 +65,12 @@ const GRADE_RANKS := [
 	[NO_GRADE, WORST_RANK],
 ]
 
-"""
-Calculates the player's rank.
-
-This is calculated in two steps: First, we calculate the rank for a theoretical M-rank player who plays as fast as
-possible and never dies. However, some modes such as 'marathon mode' are designed with the understanding that a
-player is not expected to actually finish them. So we also simulate a second S++ rank player who dies in the middle of
-the match, and return the better of the two ranks.
-"""
+## Calculates the player's rank.
+##
+## This is calculated in two steps: First, we calculate the rank for a theoretical M-rank player who plays as fast as
+## possible and never dies. However, some modes such as 'marathon mode' are designed with the understanding that a
+## player is not expected to actually finish them. So we also simulate a second S++ rank player who dies in the middle
+## of the match, and return the better of the two ranks.
 func calculate_rank() -> RankResult:
 	var rank_result := _unranked_result()
 	if CurrentLevel.settings.rank.unranked:
@@ -100,13 +96,11 @@ func calculate_rank() -> RankResult:
 	return rank_result
 
 
-"""
-Calculates the maximum combo score for the specified number of lines.
-
-If it only takes 3 lines to clear a stage, the most combo points you can get is 5 (0 + 0 + 5). On the surface, 5 combo
-points for 3 lines seems like a bad score, but it's actually the maximum. We calculate the maximum when figuring out
-the player's performance.
-"""
+## Calculates the maximum combo score for the specified number of lines.
+##
+## If it only takes 3 lines to clear a stage, the most combo points you can get is 5 (0 + 0 + 5). On the surface, 5
+## combo points for 3 lines seems like a bad score, but it's actually the maximum. We calculate the maximum when
+## figuring out the player's performance.
 func _max_combo_score(lines: int) -> int:
 	var result := lines * 20
 	result -= COMBO_DEFICIT[min(lines, COMBO_DEFICIT.size() - 1)]
@@ -114,12 +108,10 @@ func _max_combo_score(lines: int) -> int:
 	return result
 
 
-"""
-Calculates the minimum theoretical frames per line for a given piece speed.
-
-This assumes a perfect player who is making many boxes, clearing lines one at a time, and moving pieces with TAS level
-efficiency.
-"""
+## Calculates the minimum theoretical frames per line for a given piece speed.
+##
+## This assumes a perfect player who is making many boxes, clearing lines one at a time, and moving pieces with TAS
+## level efficiency.
 static func min_frames_per_line(piece_speed: PieceSpeed) -> float:
 	var movement_frames := 1 + MASTER_MVMT_FRAMES
 	var frames_per_line := 0.0
@@ -141,12 +133,10 @@ static func min_frames_per_line(piece_speed: PieceSpeed) -> float:
 	return frames_per_line
 
 
-"""
-Calculates the lines per minute for a specific rank.
-
-The lines per minute (lpm) and seconds per line (spl) are limited based on current level's speeds, such as its line
-clear delay and lock delay. It is also limited based on the player's expected skill level.
-"""
+## Calculates the lines per minute for a specific rank.
+##
+## The lines per minute (lpm) and seconds per line (spl) are limited based on current level's speeds, such as its line
+## clear delay and lock delay. It is also limited based on the player's expected skill level.
 func rank_lpm(rank: float) -> float:
 	var total_frames := 0.0
 	var total_lines := 0.0
@@ -203,11 +193,9 @@ func rank_lpm(rank: float) -> float:
 	return 60 * 60 * float(total_lines) / total_frames
 
 
-"""
-Populates a new RankResult object with raw statistics.
-
-This does not include any rank data, only objective information like lines cleared and time taken.
-"""
+## Populates a new RankResult object with raw statistics.
+##
+## This does not include any rank data, only objective information like lines cleared and time taken.
 func _unranked_result() -> RankResult:
 	var rank_result := RankResult.new()
 	
@@ -235,17 +223,15 @@ func _unranked_result() -> RankResult:
 	return rank_result
 
 
-"""
-Calculates the player's rank.
-
-We calculate the player's rank in various areas by comparing them to a perfect player, and diminishing the perfect
-player's abilities until they match the actual player's performance.
-
-Parameters:
-	'lenient': If false, we compare the player to a perfect M-rank player. If true, we compare the player to a very
-		good S++ rank player. This is mostly done to avoid giving the player a C+ because they 'only' survived for 150
-		lines in Marathon mode.
-"""
+## Calculates the player's rank.
+##
+## We calculate the player's rank in various areas by comparing them to a perfect player, and diminishing the perfect
+## player's abilities until they match the actual player's performance.
+##
+## Parameters:
+## 	'lenient': If false, we compare the player to a perfect M-rank player. If true, we compare the player to a very
+## 		good S++ rank player. This is mostly done to avoid giving the player a C+ because they 'only' survived for 150
+## 		lines in Marathon mode.
 func _populate_rank_fields(rank_result: RankResult, lenient: bool) -> void:
 	var target_speed: float = rank_lpm(BEST_RANK)
 	var target_box_score_per_line := master_box_score(CurrentLevel.settings)
@@ -389,15 +375,13 @@ func _populate_rank_fields(rank_result: RankResult, lenient: bool) -> void:
 	_clamp_result(rank_result, lenient)
 
 
-"""
-Reduces the player's ranks if they topped out.
-
-Each time the player tops out, all of their ranks are reduced by a certain amount.
-
-It's also possible for the player to lose without topping out, if they either met a special lose condition or hit
-'esc' to give up on the level. In this case, we still apply one top out penalty. This prevents people from losing on
-purpose to achieve a good rank.
-"""
+## Reduces the player's ranks if they topped out.
+##
+## Each time the player tops out, all of their ranks are reduced by a certain amount.
+##
+## It's also possible for the player to lose without topping out, if they either met a special lose condition or hit
+## 'esc' to give up on the level. In this case, we still apply one top out penalty. This prevents people from losing on
+## purpose to achieve a good rank.
 func _apply_top_out_penalty(rank_result: RankResult) -> void:
 	if rank_result.topped_out() or rank_result.lost:
 		var penalty_count := max(1, rank_result.top_out_count)
@@ -413,14 +397,12 @@ func _apply_top_out_penalty(rank_result: RankResult) -> void:
 		rank_result.seconds_rank = rank_result.seconds_rank + all_penalty
 
 
-"""
-Clamps the player's ranks within [0, 999] to avoid edge cases.
-
-Most importantly, this patches up cases where we've previously divided by zero or calculated the natural log of zero.
-Serializing an infinite/undefined float into JSON corrupts the player's save file.
-
-The player cannot achieve a master rank if the lenient flag is set.
-"""
+## Clamps the player's ranks within [0, 999] to avoid edge cases.
+##
+## Most importantly, this patches up cases where we've previously divided by zero or calculated the natural log of
+## zero. Serializing an infinite/undefined float into JSON corrupts the player's save file.
+##
+## The player cannot achieve a master rank if the lenient flag is set.
 func _clamp_result(rank_result: RankResult, lenient: bool) -> void:
 	var min_rank := 1.0 if lenient else BEST_RANK
 	var max_rank := WORST_RANK
@@ -434,9 +416,7 @@ func _clamp_result(rank_result: RankResult, lenient: bool) -> void:
 	rank_result.pickup_score_rank = clamp(rank_result.pickup_score_rank, min_rank, max_rank)
 
 
-"""
-Converts a numeric grade such as '12.6' into a grade string such as 'S+'.
-"""
+## Converts a numeric grade such as '12.6' into a grade string such as 'S+'.
 static func grade(rank: float) -> String:
 	var grade := NO_GRADE
 	
@@ -448,11 +428,9 @@ static func grade(rank: float) -> String:
 	return grade
 
 
-"""
-Converts a letter grade such as 'S+' into a numeric rating such as '12.6'.
-
-The resulting rating is an average rating for that grade -- not a minimum cutoff.
-"""
+## Converts a letter grade such as 'S+' into a numeric rating such as '12.6'.
+##
+## The resulting rating is an average rating for that grade -- not a minimum cutoff.
 static func rank(grade: String) -> float:
 	var rank_lo := WORST_RANK
 	var rank_hi := WORST_RANK
@@ -465,43 +443,31 @@ static func rank(grade: String) -> float:
 	return 0.5 * (rank_lo + rank_hi)
 
 
-"""
-Returns the maximum box score per line for the specified level.
-"""
+## Returns the maximum box score per line for the specified level.
 static func master_box_score(settings: LevelSettings) -> float:
 	return settings.rank.box_factor * MASTER_BOX_SCORE
 
 
-"""
-Returns the maximum combo score per line for the specified level.
-"""
+## Returns the maximum combo score per line for the specified level.
 static func master_combo_score(settings: LevelSettings) -> float:
 	return settings.rank.combo_factor * MASTER_COMBO_SCORE
 
 
-"""
-Returns the maximum pickup score per line for the specified level.
-"""
+## Returns the maximum pickup score per line for the specified level.
 static func master_pickup_score_per_line(settings: LevelSettings) -> float:
 	return settings.rank.master_pickup_score_per_line
 
 
-"""
-Returns the maximum overall pickup score for the specified level.
-"""
+## Returns the maximum overall pickup score for the specified level.
 static func master_pickup_score(settings: LevelSettings) -> float:
 	return settings.rank.master_pickup_score
 
 
-"""
-Returns the maximum combo expected for a single customer for the specified level.
-"""
+## Returns the maximum combo expected for a single customer for the specified level.
 static func master_customer_combo(settings: LevelSettings) -> int:
 	return settings.rank.customer_combo if settings.rank.customer_combo else MASTER_CUSTOMER_COMBO
 
 
-"""
-Returns the maximum number of leftover lines expected for the specified level.
-"""
+## Returns the maximum number of leftover lines expected for the specified level.
 static func master_leftover_lines(settings: LevelSettings) -> int:
 	return settings.rank.leftover_lines if settings.rank.leftover_lines else MASTER_LEFTOVER_LINES

--- a/project/src/main/puzzle/rank-result.gd
+++ b/project/src/main/puzzle/rank-result.gd
@@ -1,64 +1,62 @@
 class_name RankResult
-"""
-Contains rank information for a playthrough. This includes raw statistics such as how many lines-per-minute the player
-cleared, as well as derived statistics such as the computed lines-per-minute rank.
-"""
+## Contains rank information for a playthrough. This includes raw statistics such as how many lines-per-minute the
+## player cleared, as well as derived statistics such as the computed lines-per-minute rank.
 
 const BEST_RANK := 0.0
 const WORST_RANK := 999.0
 
 var timestamp := OS.get_datetime()
 
-# how this rank result should be compared:
-# '-seconds': lowest seconds is best
-# '+score': highest score is best (default)
+## how this rank result should be compared:
+## '-seconds': lowest seconds is best
+## '+score': highest score is best (default)
 var compare := "+score"
 
-# player's speed in lines per minute.
+## player's speed in lines per minute.
 var speed := 0.0
 var speed_rank := WORST_RANK
 
-# raw number of cleared lines, not including bonus points
+## raw number of cleared lines, not including bonus points
 var lines := 0
 var lines_rank := WORST_RANK
 
-# number of pieces placed
+## number of pieces placed
 var pieces := 0
 var pieces_rank := WORST_RANK
 
-# points awarded for lines left over at the end
+## points awarded for lines left over at the end
 var leftover_score := 0
 
-# bonus points awarded for clearing boxes
+## bonus points awarded for clearing boxes
 var box_score := 0
 var box_score_per_line := 0.0
 var box_score_per_line_rank := WORST_RANK
 
-# bonus points awarded for combos
+## bonus points awarded for combos
 var combo_score := 0
 var combo_score_per_line := 0.0
 var combo_score_per_line_rank := WORST_RANK
 
-# bonus points awarded for pickups
+## bonus points awarded for pickups
 var pickup_score := 0
 var pickup_score_per_line := 0.0
 var pickup_score_rank := WORST_RANK
 
-# number of seconds until the player won or lost
+## number of seconds until the player won or lost
 var seconds := 0.0
 var seconds_rank := WORST_RANK
 
-# overall score
+## overall score
 var score := 0
 var score_rank := WORST_RANK
 
-# how many times did the player top out?
+## how many times did the player top out?
 var top_out_count := 0
 
-# did the player lose?
+## did the player lose?
 var lost := false
 
-# did the player succeed?
+## did the player succeed?
 var success := false
 
 func to_json_dict() -> Dictionary:

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -1,10 +1,8 @@
 class_name RestaurantView
 extends Control
-"""
-Showing the chef character and active customer in a restaurant scene.
-
-As the player drops blocks and scores points, the characters animate and react.
-"""
+## Showing the chef character and active customer in a restaurant scene.
+##
+## As the player drops blocks and scores points, the characters animate and react.
 
 const MOUTH_POSITIONS_BY_ORIENTATION := {
 	Creatures.SOUTHEAST: Vector2(18, -22),
@@ -13,13 +11,13 @@ const MOUTH_POSITIONS_BY_ORIENTATION := {
 	Creatures.NORTHEAST: Vector2(28, -26),
 }
 
-# emitted when the customer changes, either because of a broken combo or because the level restarts
+## emitted when the customer changes, either because of a broken combo or because the level restarts
 signal customer_changed
 
-# virtual property; value is only exposed through getters/setters
+## virtual property; value is only exposed through getters/setters
 var current_creature_index: int setget set_current_creature_index, get_current_creature_index
 
-# bonus points scored for recent lines; used for determining when the chef should smile
+## bonus points scored for recent lines; used for determining when the chef should smile
 var _recent_bonuses := []
 
 onready var _customer_nametag_panel := $CustomerNametag/Panel
@@ -46,9 +44,7 @@ func _ready() -> void:
 	_refresh_customer_name()
 
 
-"""
-Pans the camera to a new creature. This also changes which creature will be fed.
-"""
+## Pans the camera to a new creature. This also changes which creature will be fed.
 func set_current_creature_index(new_index: int) -> void:
 	_restaurant_viewport_scene.current_creature_index = new_index
 	emit_signal("customer_changed")
@@ -66,16 +62,12 @@ func get_chef() -> Creature:
 	return _restaurant_viewport_scene.get_chef()
 
 
-"""
-Returns an array of Creature objects representing customers in the scene.
-"""
+## Returns an array of Creature objects representing customers in the scene.
 func get_customers() -> Array:
 	return _restaurant_viewport_scene.get_customers()
 
 
-"""
-Returns the position of a customer's mouth within the customer viewport texture.
-"""
+## Returns the position of a customer's mouth within the customer viewport texture.
 func get_customer_mouth_position(customer: Creature) -> Vector2:
 	var target_pos: Vector2
 	# calculate the position within the restaurant scene
@@ -89,12 +81,6 @@ func get_customer_mouth_position(customer: Creature) -> Vector2:
 	return target_pos
 
 
-"""
-Returns the creature index for the specified creature id.
-
-This is useful for determining if a creature is seated at a table, and if so, which table they're seated at. Returns
--1 if the specified creature is not a customer in the restaurant.
-"""
 func find_creature_index_with_id(creature_id: String) -> int:
 	var creature_index := -1
 	var customers := get_customers()
@@ -107,10 +93,8 @@ func find_creature_index_with_id(creature_id: String) -> int:
 	return creature_index
 
 
-"""
-Recolors the creature according to the specified creature definition. This involves updating shaders and sprite
-properties.
-"""
+## Recolors the creature according to the specified creature definition. This involves updating shaders and sprite
+## properties.
 func summon_creature(creature_index: int = -1) -> void:
 	var creature_def := CreatureDef.new()
 	if PlayerData.creature_queue.has_primary_creature():
@@ -122,9 +106,7 @@ func summon_creature(creature_index: int = -1) -> void:
 		emit_signal("customer_changed")
 
 
-"""
-Scroll to a new creature and replace the old creature.
-"""
+## Scroll to a new creature and replace the old creature.
 func scroll_to_new_creature(new_creature_index: int = -1) -> void:
 	var old_creature_index: int = get_current_creature_index()
 	if new_creature_index == -1:
@@ -135,16 +117,12 @@ func scroll_to_new_creature(new_creature_index: int = -1) -> void:
 	summon_creature(old_creature_index)
 
 
-"""
-Returns a random creature index different from the current creature index.
-"""
+## Returns a random creature index different from the current creature index.
 func next_creature_index() -> int:
 	return (get_current_creature_index() + randi() % 2 + 1) % 3
 
 
-"""
-Temporarily suppresses 'hello' and 'door chime' sounds.
-"""
+## Temporarily suppresses 'hello' and 'door chime' sounds.
 func start_suppress_sfx_timer() -> void:
 	for customer in get_customers():
 		customer.start_suppress_sfx_timer()
@@ -159,11 +137,9 @@ func _refresh_chef_name() -> void:
 	_restaurant_nametag_panel.refresh_creature(get_chef())
 
 
-"""
-Update the chef's mood based on the current bonus score.
-
-If you get a lot of bonus points, the chef gets happy.
-"""
+## Update the chef's mood based on the current bonus score.
+##
+## If you get a lot of bonus points, the chef gets happy.
 func _react_to_total_bonus() -> void:
 	var total_bonus := 0
 	for bonus in _recent_bonuses:
@@ -177,9 +153,7 @@ func _on_Chef_creature_name_changed() -> void:
 	_refresh_chef_name()
 
 
-"""
-Cycle out the customer when the combo resets to 0.
-"""
+## Cycle out the customer when the combo resets to 0.
 func _on_PuzzleState_combo_changed(value: int) -> void:
 	if value > 0:
 		# if the combo is not resetting, we ignore the change
@@ -201,9 +175,7 @@ func _on_PuzzleState_topped_out() -> void:
 	get_chef().play_mood(ChatEvent.Mood.CRY0)
 
 
-"""
-When clearing lines, the chef smiles if they're scoring a lot of bonus points.
-"""
+## When clearing lines, the chef smiles if they're scoring a lot of bonus points.
 func _on_PuzzleState_added_line_score(combo_score: int, box_score: int) -> void:
 	_recent_bonuses.append(combo_score + box_score)
 	if _recent_bonuses.size() >= 6:
@@ -211,9 +183,7 @@ func _on_PuzzleState_added_line_score(combo_score: int, box_score: int) -> void:
 	_react_to_total_bonus()
 
 
-"""
-When collecting pickups, the chef smiles if they're scoring a lot of bonus points.
-"""
+## When collecting pickups, the chef smiles if they're scoring a lot of bonus points.
 func _on_PuzzleState_added_pickup_score(pickup_score: int) -> void:
 	if not _recent_bonuses:
 		_recent_bonuses.append(0)
@@ -221,9 +191,7 @@ func _on_PuzzleState_added_pickup_score(pickup_score: int) -> void:
 	_react_to_total_bonus()
 
 
-"""
-When the game ends, the chef smiles/cries/rages based on how they did.
-"""
+## When the game ends, the chef smiles/cries/rages based on how they did.
 func _on_PuzzleState_game_ended() -> void:
 	var mood: int = ChatEvent.Mood.NONE
 	match PuzzleState.end_result():

--- a/project/src/main/puzzle/results-hud.gd
+++ b/project/src/main/puzzle/results-hud.gd
@@ -1,9 +1,7 @@
 extends Control
-"""
-Results screen shown after the player finishes a level.
-"""
+## Results screen shown after the player finishes a level.
 
-# Hints displayed after the player finishes
+## Hints displayed after the player finishes
 var _hints := [
 	tr("Build a snack box by arranging a pentomino and a tetromino into a square!"),
 	tr("Build a cake box by arranging 3 pentominos into a rectangle!"),
@@ -32,12 +30,10 @@ func hide_results_message() -> void:
 	$MoneyLabelTween.hide_money()
 
 
-"""
-Prepares a game over message to show to the player.
-
-The message is littered with lull characters, '/', which are hidden from the player but result in a brief pause when
-displayed.
-"""
+## Prepares a game over message to show to the player.
+##
+## The message is littered with lull characters, '/', which are hidden from the player but result in a brief pause when
+## displayed.
 func show_results_message(rank_result: RankResult, customer_scores: Array, finish_condition_type: int) -> void:
 	# Generate post-game message with stats, grades, and a gameplay hint
 	var text := "//////////"
@@ -182,11 +178,9 @@ func _pickups_shown() -> bool:
 	return CurrentLevel.settings.rank.show_pickups_rank in [RankRules.ShowRank.SHOW]
 
 
-"""
-Returns the string width as measured by period characters.
-
-We use this when right-justifying the dollar amounts.
-"""
+## Returns the string width as measured by period characters.
+##
+## We use this when right-justifying the dollar amounts.
 func _period_count(s: String) -> int:
 	var result := 0
 	for c in s:

--- a/project/src/main/puzzle/results-label.gd
+++ b/project/src/main/puzzle/results-label.gd
@@ -1,32 +1,28 @@
 extends RichTextLabel
-"""
-A results label which reveals its contents line by line.
-"""
+## A results label which reveals its contents line by line.
 
-# emitted when new characters appear in the window. newlines are stripped from the signal
+## emitted when new characters appear in the window. newlines are stripped from the signal
 signal text_shown(new_text)
 
-# unshown character which causes the output to pause for 0.2 beats
+## unshown character which causes the output to pause for 0.2 beats
 const LULL_CHARACTER := '/'
 
-# The delay in seconds before displaying the next character
+## The delay in seconds before displaying the next character
 var _pause := 0.0
 
-# timing at which messages appear. defaults to 136 bpm
+## timing at which messages appear. defaults to 136 bpm
 var _beat_duration := 60 / 136.0
 
-# 1.0 = normal, 2.0 = fastest, 6.0 = fastestestest, 1000000.0 = fastestest
+## 1.0 = normal, 2.0 = fastest, 6.0 = fastestestest, 1000000.0 = fastestest
 var _text_speed := 1.0
 
-"""
-These two fields are used to track unshown text which is gradually revealed. RichTextLabel defines a
-'visible_characters' field which supports this capability, but it does not mesh well with the scroll bar or the
-'scroll_following' property. So we reimplement the concept of invisible characters our own way.
-"""
+## These two fields are used to track unshown text which is gradually revealed. RichTextLabel defines a
+## 'visible_characters' field which supports this capability, but it does not mesh well with the scroll bar or the
+## 'scroll_following' property. So we reimplement the concept of invisible characters our own way.
 var _unshown_text := ""
 var _unshown_index := 0
 
-# plays a typewriter sound as text appears
+## plays a typewriter sound as text appears
 onready var _bebebe_sound: AudioStreamPlayer = $BebebeSound
 
 func _ready() -> void:
@@ -59,13 +55,11 @@ func _process(delta: float) -> void:
 		emit_signal("text_shown", new_text)
 
 
-"""
-Reveals the label and empties its contents, gradually appending text over time.
-
-The text can include lull characters, '/', which are hidden from the player but result in a brief delay to mimic
-patterns of speech:
-	'Despite the promise of info,/ I was unable to determine what,/ if anything,/ a 'butt/ onion'/ is supposed to be.'
-"""
+## Reveals the label and empties its contents, gradually appending text over time.
+##
+## The text can include lull characters, '/', which are hidden from the player but result in a brief delay to mimic
+## patterns of speech:
+## 	'Despite the promise of info,/ I was unable to determine what,/ if anything,/ a 'butt/ onion'/ is supposed to be.'
 func show_text(text_with_lulls: String) -> void:
 	# reset text state before showing new text
 	hide_text()
@@ -74,9 +68,7 @@ func show_text(text_with_lulls: String) -> void:
 	show()
 
 
-"""
-Hides the label and empties its contents.
-"""
+## Hides the label and empties its contents.
 func hide_text() -> void:
 	text = ""
 	_unshown_text = ""

--- a/project/src/main/puzzle/score-value-label.gd
+++ b/project/src/main/puzzle/score-value-label.gd
@@ -1,7 +1,5 @@
 extends Label
-"""
-Displays the player's score.
-"""
+## Displays the player's score.
 
 func _ready() -> void:
 	PuzzleState.connect("score_changed", self, "_on_PuzzleState_score_changed")

--- a/project/src/main/puzzle/squish-map.gd
+++ b/project/src/main/puzzle/squish-map.gd
@@ -1,8 +1,6 @@
 class_name SquishMap
 extends PuzzleTileMap
-"""
-This TileMap handles drawing the stretched-out piece during a squish move.
-"""
+## This TileMap handles drawing the stretched-out piece during a squish move.
 
 var squish_seconds_remaining := 0.0
 var squish_seconds_total := 0.0
@@ -49,9 +47,7 @@ func _process(delta: float) -> void:
 		set_process(false)
 
 
-"""
-Adds the specified cells to the current squish move.
-"""
+## Adds the specified cells to the current squish move.
 func stretch_to(piece_pos_arr: Array, offset: Vector2) -> void:
 	if not _is_stretched_to(piece_pos_arr, offset):
 		return
@@ -62,9 +58,7 @@ func stretch_to(piece_pos_arr: Array, offset: Vector2) -> void:
 		_stretch_pos[piece_pos.y + offset.y][piece_pos.x + offset.x] = _max_distance
 
 
-"""
-Starts a new squish move, which will make the piece appear vertically stretched for a few frames.
-"""
+## Starts a new squish move, which will make the piece appear vertically stretched for a few frames.
 func start_squish(post_squish_frames: int, new_color_y: int) -> void:
 	squish_seconds_total = post_squish_frames / 60.0
 	squish_seconds_remaining = squish_seconds_total
@@ -79,9 +73,7 @@ func start_squish(post_squish_frames: int, new_color_y: int) -> void:
 			_stretch_pos[row][col] = 0
 
 
-"""
-Returns 'true' if the piece is already stretched to the specified position.
-"""
+## Returns 'true' if the piece is already stretched to the specified position.
 func _is_stretched_to(piece_pos_arr: Array, offset: Vector2) -> bool:
 	var result := false
 	if _max_distance == 0:

--- a/project/src/main/puzzle/star-seed.gd
+++ b/project/src/main/puzzle/star-seed.gd
@@ -1,8 +1,6 @@
 class_name StarSeed
 extends Node2D
-"""
-Draws a shadowy star or seed inside a snack box or cake box.
-"""
+## Draws a shadowy star or seed inside a snack box or cake box.
 
 var food_type := 0 setget set_food_type
 
@@ -18,9 +16,7 @@ func set_food_type(new_food_type: int) -> void:
 	_refresh_appearance()
 
 
-"""
-Updates the status and visibility of the child components.
-"""
+## Updates the status and visibility of the child components.
 func _refresh_appearance() -> void:
 	if not is_inside_tree():
 		return

--- a/project/src/main/puzzle/star-seeds.gd
+++ b/project/src/main/puzzle/star-seeds.gd
@@ -1,23 +1,19 @@
 extends Control
-"""
-Draws shadowy stars and seeds inside snack boxes and cake boxes.
+## Draws shadowy stars and seeds inside snack boxes and cake boxes.
+##
+## These star and seed sprites are referred to as 'star seeds'.
 
-These star and seed sprites are referred to as 'star seeds'.
-"""
-
-"""
-Emitted when a star seed is eliminated, and a new piece of food should be spawned.
-
-Parameters:
-	'cell': A Vector2 corresponding to the tilemap cell where the food should appear
-	
-	'remaining_food': The number of remaining food items for the current set of line clears
-	
-	'food_type': An enum from Foods.FoodType corresponding to the food to spawn
-"""
+## Emitted when a star seed is eliminated, and a new piece of food should be spawned.
+##
+## Parameters:
+## 	'cell': A Vector2 corresponding to the tilemap cell where the food should appear
+##
+## 	'remaining_food': The number of remaining food items for the current set of line clears
+##
+## 	'food_type': An enum from Foods.FoodType corresponding to the food to spawn
 signal food_spawned(cell, remaining_food, food_type)
 
-# Aesthetically pleasing star seed arrangements. It looks nice if they're balanced on the left and right sides.
+## Aesthetically pleasing star seed arrangements. It looks nice if they're balanced on the left and right sides.
 const STAR_SEED_POSITIONS_BY_SIZE := {
 	Vector2(3, 3): [
 			[1, 2, 3], [1, 3, 2],
@@ -50,7 +46,7 @@ const STAR_SEED_POSITIONS_BY_SIZE := {
 		],
 }
 
-# Aesthetically pleasing star seed arrangements for levels with double snacks, double cakes.
+## Aesthetically pleasing star seed arrangements for levels with double snacks, double cakes.
 const STAR_SEED_POSITIONS_BY_SIZE_DOUBLE := {
 	Vector2(3, 3): [
 			[12, 13, 23], [12, 23, 13],
@@ -81,11 +77,11 @@ const STAR_SEED_POSITIONS_BY_SIZE_DOUBLE := {
 
 export (NodePath) var _puzzle_tile_map_path: NodePath
 
-# key: Vector2 playfield cell positions
-# value: StarSeed node contained within that cell
+## key: Vector2 playfield cell positions
+## value: StarSeed node contained within that cell
 var _star_seeds_by_cell: Dictionary
 
-# the number of remaining food items to spawn for the current sequence of line clears
+## the number of remaining food items to spawn for the current sequence of line clears
 var _remaining_food_for_line_clears := 0
 
 export (PackedScene) var StarSeedScene: PackedScene
@@ -96,9 +92,7 @@ func _ready() -> void:
 	Pauser.connect("paused_changed", self, "_on_Pauser_paused_changed")
 
 
-"""
-Detects boxes in the playfield, and places star_seeds in them.
-"""
+## Detects boxes in the playfield, and places star_seeds in them.
 func _prepare_star_seeds_for_level() -> void:
 	_clear_star_seeds()
 	for x in range(PuzzleTileMap.COL_COUNT):
@@ -118,46 +112,41 @@ func _prepare_star_seeds_for_level() -> void:
 			_add_star_seeds_for_box(rect, autotile_coord.y)
 
 
-"""
-Adds star seeds for a snack box or cake box.
-
-Parameters:
-	'rect': Cell coordinates defining the box's position and dimensions
-	
-	'box_type': An enum from Foods.BoxType defining the box's color
-"""
+## Adds star seeds for a snack box or cake box.
+##
+## Parameters:
+## 	'rect': Cell coordinates defining the box's position and dimensions
+##
+## 	'box_type': An enum from Foods.BoxType defining the box's color
 func _add_star_seeds_for_box(rect: Rect2, box_type: int) -> void:
 	_remove_star_seeds_for_box(rect)
 	var star_seed_positions := _star_seed_positions(rect, box_type)
 	_spawn_star_seeds(rect, box_type, star_seed_positions)
 
 
-"""
-Clears star seeds to make room for a new snack box or cake box.
-
-Parameters:
-	'rect': Cell coordinates defining the box's position and dimensions
-"""
+## Clears star seeds to make room for a new snack box or cake box.
+##
+## Parameters:
+## 	'rect': Cell coordinates defining the box's position and dimensions
 func _remove_star_seeds_for_box(rect: Rect2) -> void:
 	for x in range(rect.position.x, rect.end.x):
 		for y in range(rect.position.y, rect.end.y):
 			_remove_star_seed(Vector2(x, y))
 
 
-"""
-Calculates relative positions for star seeds within a snack box or cake box.
-
-Returns an array of ints representing concatenated columns within the box. For example if star seeds should be in the
-first and third column of the box the array will contain the number '13', the concatenation of the values 1 and 3.
-
-Parameters:
-	'rect': Cell coordinates defining the box's position and dimensions
-	
-	'box_type': An enum from Foods.BoxType defining the box's color
-
-Returns:
-	An array of ints representing concatenated columns within the box.
-"""
+## Calculates relative positions for star seeds within a snack box or cake box.
+##
+## Returns an array of ints representing concatenated columns within the box. For example if star seeds should be in
+## the first and third column of the box the array will contain the number '13', the concatenation of the values 1 and
+## 3.
+##
+## Parameters:
+## 	'rect': Cell coordinates defining the box's position and dimensions
+##
+## 	'box_type': An enum from Foods.BoxType defining the box's color
+##
+## Returns:
+## 	An array of ints representing concatenated columns within the box.
 func _star_seed_positions(rect: Rect2, box_type: int) -> Array:
 	var star_seed_multiplier := _star_seed_multiplier(box_type)
 	var star_seed_positions: Array
@@ -186,18 +175,16 @@ func _star_seed_positions(rect: Rect2, box_type: int) -> Array:
 	return star_seed_positions
 
 
-"""
-Calculates and returns a multiplier for boxes which should have unusual numbers of star seeds.
-
-For most boxes this multiplier will be 1, but it could be 0 for boxes with no star seeds, or 2 for boxes with extra
-star seeds.
-
-Parameters:
-	'box_type': An enum from Foods.BoxType defining the box's color
-
-Returns:
-	An int multiplier in the range [0, 2] representing how many star seeds the box should have
-"""
+## Calculates and returns a multiplier for boxes which should have unusual numbers of star seeds.
+##
+## For most boxes this multiplier will be 1, but it could be 0 for boxes with no star seeds, or 2 for boxes with extra
+## star seeds.
+##
+## Parameters:
+## 	'box_type': An enum from Foods.BoxType defining the box's color
+##
+## Returns:
+## 	An int multiplier in the range [0, 2] representing how many star seeds the box should have
 func _star_seed_multiplier(box_type: int) -> int:
 	var multiplier: float
 	if Foods.is_cake_box(box_type):
@@ -207,16 +194,14 @@ func _star_seed_multiplier(box_type: int) -> int:
 	return int(clamp(multiplier, 0, 2))
 
 
-"""
-Spawns star seeds within a snack box or cake box.
-
-Parameters:
-	'rect': Cell coordinates defining the box's position and dimensions
-	
-	'box_type': An enum from Foods.BoxType defining the box's color
-	
-	'star_seed_positions': An array of ints representing concatenated columns within the box.
-"""
+## Spawns star seeds within a snack box or cake box.
+##
+## Parameters:
+## 	'rect': Cell coordinates defining the box's position and dimensions
+##
+## 	'box_type': An enum from Foods.BoxType defining the box's color
+##
+## 	'star_seed_positions': An array of ints representing concatenated columns within the box.
 func _spawn_star_seeds(rect: Rect2, box_type: int, star_seed_positions: Array) -> void:
 	for star_seed_y in range(rect.size.y):
 		for star_seed_x in _star_seed_x_array(star_seed_positions[star_seed_y]):
@@ -240,12 +225,10 @@ func _spawn_star_seeds(rect: Rect2, box_type: int, star_seed_positions: Array) -
 			_add_star_seed(cell, star_seed)
 
 
-"""
-Converts a star seed position array into a number.
-
-StarSeed positions are stored as numbers like '235' representing the second, third and fifth horizontal position in a
-box. This method creates that kind of number from a position array like [1, 3, 4]
-"""
+## Converts a star seed position array into a number.
+##
+## StarSeed positions are stored as numbers like '235' representing the second, third and fifth horizontal position in
+## a box. This method creates that kind of number from a position array like [1, 3, 4]
 func _star_seed_x_array(x_int: int) -> Array:
 	var x_array := []
 	var x_int_tmp := x_int
@@ -255,12 +238,10 @@ func _star_seed_x_array(x_int: int) -> Array:
 	return x_array
 
 
-"""
-Converts a star seed position number into an array of x coordinates.
-
-Star seed positions are stored as numbers like '235' representing the second, third and fifth horizontal position in a
-box. This method converts those ints into a position array like [1, 3, 4].
-"""
+## Converts a star seed position number into an array of x coordinates.
+##
+## Star seed positions are stored as numbers like '235' representing the second, third and fifth horizontal position in
+## a box. This method converts those ints into a position array like [1, 3, 4].
 func _star_seed_x_int(x_array: Array) -> int:
 	var x_int := 0
 	for star_seed_x in x_array:
@@ -268,9 +249,7 @@ func _star_seed_x_int(x_array: Array) -> int:
 	return x_int
 
 
-"""
-Removes a star seed from a playfield cell.
-"""
+## Removes a star seed from a playfield cell.
 func _remove_star_seed(cell: Vector2) -> void:
 	if not _star_seeds_by_cell.has(cell):
 		return
@@ -279,40 +258,32 @@ func _remove_star_seed(cell: Vector2) -> void:
 	_star_seeds_by_cell.erase(cell)
 
 
-"""
-Adds a star seed to a playfield cell.
-"""
+## Adds a star seed to a playfield cell.
 func _add_star_seed(cell: Vector2, star_seed: StarSeed) -> void:
 	_remove_star_seed(cell)
 	_star_seeds_by_cell[cell] = star_seed
 	add_child(star_seed)
 
 
-"""
-Removes all star seeds from all playfield cells.
-"""
+## Removes all star seeds from all playfield cells.
 func _clear_star_seeds() -> void:
 	for star_seed in get_children():
 		star_seed.queue_free()
 	_star_seeds_by_cell.clear()
 
 
-"""
-Removes all star seeds from a playfield row.
-"""
+## Removes all star seeds from a playfield row.
 func _erase_row(y: int) -> void:
 	for x in range(PuzzleTileMap.COL_COUNT):
 		_remove_star_seed(Vector2(x, y))
 
 
-"""
-Shifts a group of star seeds up or down.
-
-Parameters:
-	'bottom_row': The lowest row to shift. All star seeds at or above this row will be shifted.
-	
-	'direction': The direction to shift the star seeds, such as Vector2.UP or Vector2.DOWN.
-"""
+## Shifts a group of star seeds up or down.
+##
+## Parameters:
+## 	'bottom_row': The lowest row to shift. All star seeds at or above this row will be shifted.
+##
+## 	'direction': The direction to shift the star seeds, such as Vector2.UP or Vector2.DOWN.
 func _shift_rows(bottom_row: int, direction: Vector2) -> void:
 	# First, erase and store all the old star_seeds which are shifting
 	var shifted := {}
@@ -372,9 +343,7 @@ func _on_Playfield_before_line_cleared(y: int, _total_lines: int, _remaining_lin
 					_star_seeds_by_cell[Vector2(x, y)].food_type)
 
 
-"""
-When the player pauses, we hide the playfield so they can't cheat.
-"""
+## When the player pauses, we hide the playfield so they can't cheat.
 func _on_Pauser_paused_changed(value: bool) -> void:
 	visible = not value
 

--- a/project/src/main/puzzle/start-end-sfx.gd
+++ b/project/src/main/puzzle/start-end-sfx.gd
@@ -1,7 +1,5 @@
 extends Node
-"""
-Plays sound effects at the start and end of a puzzle.
-"""
+## Plays sound effects at the start and end of a puzzle.
 
 onready var _go_voices := [$GoVoice0, $GoVoice1, $GoVoice2]
 

--- a/project/src/main/puzzle/top-out.gd
+++ b/project/src/main/puzzle/top-out.gd
@@ -1,8 +1,6 @@
 extends State
-"""
-State: The player has topped out, but the game is still running. We're waiting for the playfield to make room for the
-current piece.
-"""
+## State: The player has topped out, but the game is still running. We're waiting for the playfield to make room for
+## the current piece.
 
 func update(piece_manager: PieceManager) -> String:
 	var new_state_name := ""

--- a/project/src/main/puzzle/tutorial-keybinds-label.gd
+++ b/project/src/main/puzzle/tutorial-keybinds-label.gd
@@ -1,16 +1,12 @@
 extends RichTextLabel
-"""
-A label for tutorials which shows the keybinds.
-"""
+## A label for tutorials which shows the keybinds.
 
 func _ready() -> void:
 	SystemData.keybind_settings.connect("settings_changed", self, "_on_KeybindSettings_settings_changed")
 	_refresh_message()
 
 
-"""
-Refreshes the message based on the current InputMap.
-"""
+## Refreshes the message based on the current InputMap.
 func _refresh_message() -> void:
 	text = ""
 	_append_keybind_line(tr("Move"), ["move_piece_left", "move_piece_right"])
@@ -29,17 +25,15 @@ func _refresh_message() -> void:
 	rect_size = Vector2(238, 0)
 
 
-"""
-Appends a single keybind line to the message, like 'Move: Left, Right'
-
-The inputs such as 'Left' or 'Right' which are shown to the player are derived based on the current InputMap. If the
-InputMap's actions aren't defined, this will append a partial message or no message at all.
-
-Parameters:
-	'desc': A description of the input, such as 'Rotate'
-	
-	'action_names': One or more action names to translate for the player, such as 'rotate_cw' and 'rotate_ccw'
-"""
+## Appends a single keybind line to the message, like 'Move: Left, Right'
+##
+## The inputs such as 'Left' or 'Right' which are shown to the player are derived based on the current InputMap. If the
+## InputMap's actions aren't defined, this will append a partial message or no message at all.
+##
+## Parameters:
+## 	'desc': A description of the input, such as 'Rotate'
+##
+## 	'action_names': One or more action names to translate for the player, such as 'rotate_cw' and 'rotate_ccw'
 func _append_keybind_line(desc: String, action_names: Array) -> void:
 	var keybind_strings := _keybind_strings(action_names)
 	if keybind_strings:
@@ -49,12 +43,10 @@ func _append_keybind_line(desc: String, action_names: Array) -> void:
 			text += "%s: %s" % [desc, PoolStringArray(keybind_strings).join(", ")]
 
 
-"""
-Translates a list of action names like 'rotate_cw' and 'rotate_ccw' into human-readable inputs like 'Z' and 'X'.
-
-These inputs are derived based on the current InputMap. If the InputMap's actions aren't defined, the array may have
-fewer items in it, or even be empty.
-"""
+## Translates a list of action names like 'rotate_cw' and 'rotate_ccw' into human-readable inputs like 'Z' and 'X'.
+##
+## These inputs are derived based on the current InputMap. If the InputMap's actions aren't defined, the array may have
+## fewer items in it, or even be empty.
 func _keybind_strings(action_names: Array) -> Array:
 	var result := []
 	for action_name in action_names:
@@ -64,12 +56,10 @@ func _keybind_strings(action_names: Array) -> Array:
 	return result
 
 
-"""
-Returns a json representation of the input for the specified action name.
-
-This is derived based on the earliest translatable input in the current InputMap. If the InputMap's actions aren't
-defined this will return an empty dictionary.
-"""
+## Returns a json representation of the input for the specified action name.
+##
+## This is derived based on the earliest translatable input in the current InputMap. If the InputMap's actions aren't
+## defined this will return an empty dictionary.
 func _input_event_json(action_name: String) -> Dictionary:
 	var result := {}
 	var action_list := InputMap.get_action_list(action_name)

--- a/project/src/main/puzzle/tutorial/skill-tally-item.gd
+++ b/project/src/main/puzzle/tutorial/skill-tally-item.gd
@@ -1,28 +1,26 @@
 class_name SkillTallyItem
 extends ProgressBar
-"""
-Provides feedback to the player when they perform an action, such as rotating a piece or clearing a line.
+## Provides feedback to the player when they perform an action, such as rotating a piece or clearing a line.
+##
+## This is used during tutorials so the player can see what to do.
 
-This is used during tutorials so the player can see what to do.
-"""
-
-# if 'true' the skill tally will be shown as '58%' instead of '52/90'
+## if 'true' the skill tally will be shown as '58%' instead of '52/90'
 export (bool) var show_as_percent: bool
 
-# description of the skill being tallied such as 'Rotate Left'
+## description of the skill being tallied such as 'Rotate Left'
 export (String) var label_text: String setget set_label_text
 
-# name of the signals this skill tally monitors
+## name of the signals this skill tally monitors
 export (Array, String) var signal_names: Array
 
-# puzzle to monitor for things such as moving the piece and clearing lines
+## puzzle to monitor for things such as moving the piece and clearing lines
 var puzzle: Puzzle setget set_puzzle
 
 var _playfield: Playfield
 var _piece_manager: PieceManager
 
-# When the player performs a skill enough times, the skill tally plays a noise and lights up more brightly. This
-# property is 'true' if the skill tally is lit up brightly.
+## When the player performs a skill enough times, the skill tally plays a noise and lights up more brightly. This
+## property is 'true' if the skill tally is lit up brightly.
 var _bright_tween_active: bool
 
 func _ready() -> void:
@@ -44,17 +42,13 @@ func is_complete() -> bool:
 	return value >= max_value
 
 
-"""
-Resets the skill tally to 0 when starting/restarting a tutorial.
-"""
+## Resets the skill tally to 0 when starting/restarting a tutorial.
 func reset() -> void:
 	value = 0
 	update_label()
 
 
-"""
-When the player performs a skill we blink and increment our value.
-"""
+## When the player performs a skill we blink and increment our value.
 func increment() -> void:
 	if not is_visible_in_tree():
 		return
@@ -70,11 +64,9 @@ func increment() -> void:
 	update_label()
 
 
-"""
-Initializes this node when the puzzle field is assigned.
-
-Connects the signals in 'signal_names' to the appropriate nodes.
-"""
+## Initializes this node when the puzzle field is assigned.
+##
+## Connects the signals in 'signal_names' to the appropriate nodes.
 func _refresh_puzzle() -> void:
 	_playfield = puzzle.get_playfield()
 	_piece_manager = puzzle.get_piece_manager()
@@ -94,9 +86,7 @@ func _refresh_puzzle() -> void:
 			push_warning("Could not find sender for signal '%s'" % signal_name)
 
 
-"""
-Returns the signal names for a node.
-"""
+## Returns the signal names for a node.
 static func _get_signal_names(object: Object) -> Dictionary:
 	var result := {}
 	for signal_dict in object.get_signal_list():
@@ -104,12 +94,10 @@ static func _get_signal_names(object: Object) -> Dictionary:
 	return result
 
 
-"""
-Blinks the skill tally to catch the player's attention.
-
-Parameters:
-	'bright': If true, the skill tally will blink very brightly and play a noise.
-"""
+## Blinks the skill tally to catch the player's attention.
+##
+## Parameters:
+## 	'bright': If true, the skill tally will blink very brightly and play a noise.
 func _blink(bright: bool = false) -> void:
 	if _bright_tween_active:
 		return

--- a/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
@@ -1,18 +1,16 @@
 extends TutorialModule
-"""
-Tutorial module for the 'Basic Techniques' tutorial.
+## Tutorial module for the 'Basic Techniques' tutorial.
+##
+## Shows messages and advances the player through the tutorial as they complete tasks.
 
-Shows messages and advances the player through the tutorial as they complete tasks.
-"""
-
-# tracks what the player has done so far during this tutorial
+## tracks what the player has done so far during this tutorial
 var _line_clears := 0
 var _box_clears := 0
 var _boxes_built := 0
 var _squish_moves := 0
 var _snack_stacks := 0
 
-# tracks what the player did with the most recent piece
+## tracks what the player did with the most recent piece
 var _did_line_clear := false
 var _did_box_clear := false
 var _did_build_box := false
@@ -60,12 +58,10 @@ func prepare_tutorial_level() -> void:
 			hud.enqueue_pop_out()
 
 
-"""
-Advance to the next level in the tutorial.
-
-The level to advance to depends on what the player's accomplished so far. If they perform squish moves or snack boxes
-before they're instructed to, they can skip parts of the tutorial.
-"""
+## Advance to the next level in the tutorial.
+##
+## The level to advance to depends on what the player's accomplished so far. If they perform squish moves or snack
+## boxes before they're instructed to, they can skip parts of the tutorial.
 func _advance_level() -> void:
 	if CurrentLevel.settings.id == "tutorial/basics_0" and _did_build_cake and _did_squish_move:
 		# the player did something crazy; skip the tutorial entirely
@@ -96,12 +92,10 @@ func _handle_line_clear_message() -> void:
 		hud.set_message(tr("Well done!\n\nLine clears earn ¥1. Maybe more if you can build a combo."))
 
 
-"""
-Enqueues a message describing how to progress in the tutorial, after skipping.
-
-Skipping the tutorial shows a message like 'Wow, you did a squish move!' But if we display that forever, the player
-might forget how to progress in the tutorial. This function displays a 'how to progress' message after a delay.
-"""
+## Enqueues a message describing how to progress in the tutorial, after skipping.
+##
+## Skipping the tutorial shows a message like 'Wow, you did a squish move!' But if we display that forever, the player
+## might forget how to progress in the tutorial. This function displays a 'how to progress' message after a delay.
 func _add_post_skip_message() -> void:
 	match CurrentLevel.settings.id:
 		"tutorial/basics_0":
@@ -198,9 +192,7 @@ func _on_Playfield_line_cleared(_y: int, _total_lines: int, _remaining_lines: in
 		hud.skill_tally_item("BoxClear").increment()
 
 
-"""
-After a piece is written to the playfield, we check if the player should advance further in the tutorial.
-"""
+## After a piece is written to the playfield, we check if the player should advance further in the tutorial.
 func _on_PuzzleState_after_piece_written() -> void:
 	# print tutorial messages if the player did something noteworthy
 	_handle_line_clear_message()

--- a/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
@@ -1,26 +1,24 @@
 extends TutorialModule
-"""
-Tutorial module for the 'Build Combos' tutorial.
+## Tutorial module for the 'Build Combos' tutorial.
+##
+## Shows messages and advances the player through the tutorial as they complete tasks.
 
-Shows messages and advances the player through the tutorial as they complete tasks.
-"""
-
-# how many cakes the player has made during the current tutorial section
+## how many cakes the player has made during the current tutorial section
 var _cakes_built := 0
 
-# whether the player ended the combo with their most recent piece
+## whether the player ended the combo with their most recent piece
 var _did_end_combo := false
 
-# The number of times the diagram has been shown. We cycle through different explanations and chat choices.
+## The number of times the diagram has been shown. We cycle through different explanations and chat choices.
 var _show_diagram_count := 0
 
-# At the end of the tutorial, we show a message based on whether the player got a good combo. We only show this message
-# once.
+## At the end of the tutorial, we show a message based on whether the player got a good combo. We only show this
+## message once.
 var _showed_end_of_level_message := false
 
-# set of level IDs which the player has attempted during this tutorial
-# key: level id
-# value: true
+## set of level IDs which the player has attempted during this tutorial
+## key: level id
+## value: true
 var _prepared_levels: Dictionary
 
 var _combo_diagram := preload("res://assets/main/puzzle/tutorial/combo-diagram.png")
@@ -99,14 +97,12 @@ func prepare_tutorial_level() -> void:
 	_prepared_levels[CurrentLevel.settings.id] = true
 
 
-"""
-Initializes the combo and combo indicators to the specified values.
-
-Parameters:
-	'start': The player's current combo
-	
-	'goal': (Optional) The combo needed to complete the tutorial section
-"""
+## Initializes the combo and combo indicators to the specified values.
+##
+## Parameters:
+## 	'start': The player's current combo
+##
+## 	'goal': (Optional) The combo needed to complete the tutorial section
 func _set_combo_state(start: int, goal: int = 0) -> void:
 	PuzzleState.set_combo(start)
 	if goal:
@@ -115,9 +111,7 @@ func _set_combo_state(start: int, goal: int = 0) -> void:
 		hud.skill_tally_item("Combo").update_label()
 
 
-"""
-Advance to the next level in the tutorial.
-"""
+## Advance to the next level in the tutorial.
 func _advance_level() -> void:
 	var delay_between_levels := PuzzleState.DELAY_SHORT
 	var failed_section := false
@@ -157,9 +151,7 @@ func _advance_level() -> void:
 	PuzzleState.change_level(new_level_id, delay_between_levels)
 
 
-"""
-Shows a diagram explaining how combos moves work, with an accompanying sensei message.
-"""
+## Shows a diagram explaining how combos moves work, with an accompanying sensei message.
 func _show_next_diagram() -> void:
 	var hud_messages := []
 	if _show_diagram_count == 0:
@@ -189,11 +181,9 @@ func _on_PieceManager_piece_spawned() -> void:
 	_did_end_combo = false
 
 
-"""
-After a piece is written to the playfield, we check if the player should advance further in the tutorial.
-
-We also sometimes display messages from the sensei.
-"""
+## After a piece is written to the playfield, we check if the player should advance further in the tutorial.
+##
+## We also sometimes display messages from the sensei.
 func _on_PuzzleState_after_piece_written() -> void:
 	match CurrentLevel.settings.id:
 		"tutorial/combo_0", "tutorial/combo_2":

--- a/project/src/main/puzzle/tutorial/tutorial-diagram.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-diagram.gd
@@ -1,19 +1,17 @@
 class_name TutorialDiagram
 extends Control
-"""
-Displays a diagram during a tutorial.
+## Displays a diagram during a tutorial.
+##
+## These diagrams obstruct the playfield. They're textures which appear in a window, and the player has ok/help buttons
+## to ensure they understand the diagram.
 
-These diagrams obstruct the playfield. They're textures which appear in a window, and the player has ok/help buttons
-to ensure they understand the diagram.
-"""
-
-# Emitted when the player clicks a button indicating they understand the diagram
+## Emitted when the player clicks a button indicating they understand the diagram
 signal ok_chosen
 
-# Emitted when the player clicks a button indicating they don't understand the diagram
+## Emitted when the player clicks a button indicating they don't understand the diagram
 signal help_chosen
 
-# The number of times the diagram has been shown. We cycle through different chat choices each time.
+## The number of times the diagram has been shown. We cycle through different chat choices each time.
 var _show_diagram_count := 0
 
 onready var _hud: Node = get_parent()

--- a/project/src/main/puzzle/tutorial/tutorial-hud.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-hud.gd
@@ -1,10 +1,8 @@
 class_name TutorialHud
 extends Control
-"""
-UI items specific for puzzle tutorials.
-"""
+## UI items specific for puzzle tutorials.
 
-# emitted when the HUD should be refreshed during initial setup or for a level change.
+## emitted when the HUD should be refreshed during initial setup or for a level change.
 signal refreshed
 
 export (NodePath) var puzzle_path: NodePath
@@ -27,11 +25,9 @@ func get_tutorial_messages() -> TutorialMessages:
 	return $Messages as TutorialMessages
 
 
-"""
-Loads a new tutorial module corresponding to the current level.
-
-Tutorial modules show messages and advance the player through the tutorial as they complete tasks.
-"""
+## Loads a new tutorial module corresponding to the current level.
+##
+## Tutorial modules show messages and advance the player through the tutorial as they complete tasks.
 func replace_tutorial_module() -> void:
 	if has_node("TutorialModule"):
 		remove_child(get_node("TutorialModule"))
@@ -56,9 +52,7 @@ func replace_tutorial_module() -> void:
 	refresh()
 
 
-"""
-Shows or hides the tutorial hud based on the current level.
-"""
+## Shows or hides the tutorial hud based on the current level.
 func refresh() -> void:
 	# only visible for tutorial levels
 	visible = CurrentLevel.settings.other.tutorial or CurrentLevel.settings.other.after_tutorial
@@ -66,78 +60,58 @@ func refresh() -> void:
 	emit_signal("refreshed")
 
 
-"""
-Returns a specific SkillTallyItem instance in the panel.
-"""
+## Returns a specific SkillTallyItem instance in the panel.
 func skill_tally_item(name: String) -> SkillTallyItem:
 	return get_node("SkillTallyItems/GridContainer/%s" % name) as SkillTallyItem
 
 
-"""
-Returns all SkillTallyItem instances in the panel.
-"""
+## Returns all SkillTallyItem instances in the panel.
 func skill_tally_items() -> Array:
 	return $SkillTallyItems/GridContainer.get_children()
 
 
-"""
-Adds a new SkillTallyItem instance to the panel.
-"""
+## Adds a new SkillTallyItem instance to the panel.
 func add_skill_tally_item(item: SkillTallyItem) -> void:
 	$SkillTallyItems/GridContainer.add_child(item)
 
 
-"""
-Displays a sequence of messages from the sensei.
-"""
+## Displays a sequence of messages from the sensei.
 func set_messages(messages: Array) -> void:
 	$Messages.set_messages(messages)
 
 
-"""
-Displays a message from the sensei.
-"""
+## Displays a message from the sensei.
 func set_message(message: String) -> void:
 	$Messages.set_message(message)
 
 
-"""
-Displays a BIG message from the sensei, for use in easter eggs.
-"""
+## Displays a BIG message from the sensei, for use in easter eggs.
 func set_big_message(message: String) -> void:
 	$Messages.set_big_message(message)
 
 
-"""
-Displays a message after a short delay.
-
-If other messages are already in the queue, this message will be appended to the queue.
-"""
+## Displays a message after a short delay.
+##
+## If other messages are already in the queue, this message will be appended to the queue.
 func enqueue_message(message: String) -> void:
 	$Messages.enqueue_message(message)
 
 
-"""
-Hides the currently shown message after a short delay.
-
-If other messages are already in the queue, this operation will be appended to the queue.
-"""
+## Hides the currently shown message after a short delay.
+##
+## If other messages are already in the queue, this operation will be appended to the queue.
 func enqueue_pop_out() -> void:
 	$Messages.enqueue_pop_out()
 
 
-"""
-Shows the panel containing skill tally items.
-"""
+## Shows the panel containing skill tally items.
 func show_skill_tally_items() -> void:
 	$SkillTallyItems.show()
 	for skill_tally_item in skill_tally_items():
 		skill_tally_item.visible = true
 
 
-"""
-Pause and play a camera _flash effect for transitions.
-"""
+## Pause and play a camera _flash effect for transitions.
 func _flash() -> void:
 	puzzle.get_playfield().add_misc_delay_frames(30)
 	$ZIndex/ColorRect.modulate.a = 0.25

--- a/project/src/main/puzzle/tutorial/tutorial-messages.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-messages.gd
@@ -1,26 +1,24 @@
 class_name TutorialMessages
 extends Control
-"""
-Shows the sensei's chat during tutorials.
-"""
+## Shows the sensei's chat during tutorials.
 
-# emitted after the full chat line is typed out onscreen, and no messages remain in the queue
+## emitted after the full chat line is typed out onscreen, and no messages remain in the queue
 signal all_messages_shown
 
-# huge font used for easter eggs
+## huge font used for easter eggs
 var _huge_font := preload("res://src/main/ui/blogger-sans-bold-72.tres")
 
-# normal font used for regular chat
+## normal font used for regular chat
 var _normal_font := preload("res://src/main/ui/blogger-sans-medium-30.tres")
 
-# Queue of sensei messages which will be shown one at a time after a delay. This can also include empty strings
-# which hide the current message.
+## Queue of sensei messages which will be shown one at a time after a delay. This can also include empty strings
+## which hide the current message.
 var _message_queue := []
 
-# theme which affects the color and texture of chat messages
+## theme which affects the color and texture of chat messages
 var _sensei_chat_theme: ChatTheme
 
-# 'true' after pop_in is called, and 'false' after pop_out is called
+## 'true' after pop_in is called, and 'false' after pop_out is called
 var _popped_in: bool
 
 func _ready() -> void:
@@ -29,54 +27,42 @@ func _ready() -> void:
 	_hide_message()
 
 
-"""
-Returns 'true' if the full chat line is typed out onscreen, and no messages remain in the queue
-"""
+## Returns 'true' if the full chat line is typed out onscreen, and no messages remain in the queue
 func is_all_messages_visible() -> bool:
 	return _message_queue.empty() and $Label.is_all_text_visible()
 
 
-"""
-Displays a sequence of messages from the sensei.
-"""
+## Displays a sequence of messages from the sensei.
 func set_messages(messages: Array) -> void:
 	set_message(messages[0] if messages else "")
 	for i in range(1, messages.size()):
 		enqueue_message(messages[i])
 
 
-"""
-Displays a message from the sensei.
-"""
+## Displays a message from the sensei.
 func set_message(message: String) -> void:
 	_clear_message_queue()
 	_show_or_hide_message(message)
 
 
-"""
-Displays a BIG message from the sensei, for use in easter eggs.
-"""
+## Displays a BIG message from the sensei, for use in easter eggs.
 func set_big_message(message: String) -> void:
 	_clear_message_queue()
 	_show_or_hide_message(message, _huge_font)
 
 
-"""
-Displays a message after a short delay.
-
-If other messages are already in the queue, this message will be appended to the queue.
-"""
+## Displays a message after a short delay.
+##
+## If other messages are already in the queue, this message will be appended to the queue.
 func enqueue_message(message: String) -> void:
 	_message_queue.push_back(message)
 	if not _popped_in or $Label.is_all_text_visible():
 		_refresh_queue_timer()
 
 
-"""
-Hides the currently shown message after a short delay.
-
-If other messages are already in the queue, this operation will be appended to the queue.
-"""
+## Hides the currently shown message after a short delay.
+##
+## If other messages are already in the queue, this operation will be appended to the queue.
 func enqueue_pop_out() -> void:
 	enqueue_message("")
 
@@ -93,11 +79,9 @@ func _show_or_hide_message(message: String, font: Font = _normal_font) -> void:
 		_hide_message()
 
 
-"""
-Updates the message text and panel size to display the specified message.
-
-If no message is currently shown, we also play a sound effect and a 'pop in' animation.
-"""
+## Updates the message text and panel size to display the specified message.
+##
+## If no message is currently shown, we also play a sound effect and a 'pop in' animation.
 func _show_message(message: String, font: Font = _normal_font) -> void:
 	if not _popped_in:
 		# play a sound effect and 'pop in' animation
@@ -115,11 +99,9 @@ func _show_message(message: String, font: Font = _normal_font) -> void:
 	$Panel.update_appearance(_sensei_chat_theme, chosen_size_index)
 
 
-"""
-Updates the message text and panel size to display the specified message.
-
-If a message is currently shown, we also play a sound effect and a 'pop out' animation.
-"""
+## Updates the message text and panel size to display the specified message.
+##
+## If a message is currently shown, we also play a sound effect and a 'pop out' animation.
 func _hide_message() -> void:
 	if _popped_in:
 		# play a sound effect and 'pop out' animation
@@ -130,17 +112,13 @@ func _hide_message() -> void:
 	_refresh_queue_timer()
 
 
-"""
-If any messages are in the queue, this launches the timer so they'll be shown soon.
-"""
+## If any messages are in the queue, this launches the timer so they'll be shown soon.
 func _refresh_queue_timer() -> void:
 	if _message_queue and $QueueTimer.is_stopped():
 		$QueueTimer.start()
 
 
-"""
-When the queue timer times out, we show the next message in the queue.
-"""
+## When the queue timer times out, we show the next message in the queue.
 func _on_QueueTimer_timeout() -> void:
 	# pop and show the next message in the queue
 	if _message_queue:
@@ -152,20 +130,16 @@ func _on_QueueTimer_timeout() -> void:
 		$QueueTimer.stop()
 
 
-"""
-When the message is entirely visible, we pause for a moment and show the next message in the queue.
-"""
+## When the message is entirely visible, we pause for a moment and show the next message in the queue.
 func _on_Label_all_text_shown() -> void:
 	_refresh_queue_timer()
 	if not _message_queue:
 		emit_signal("all_messages_shown")
 
 
-"""
-After the message pops out, we hide the panel.
-
-This prevents sounds playing from a mostly-invisible panel, or other weird side effects.
-"""
+## After the message pops out, we hide the panel.
+##
+## This prevents sounds playing from a mostly-invisible panel, or other weird side effects.
 func _on_Tween_pop_out_completed() -> void:
 	$Label.hide_message()
 	$Panel.hide()

--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -1,12 +1,10 @@
 class_name TutorialModule
 extends Node
-"""
-Generic tutorial module for all tutorials.
+## Generic tutorial module for all tutorials.
+##
+## Subclasses can show messages and advances the player through the tutorial as they complete tasks.
 
-Subclasses can show messages and advances the player through the tutorial as they complete tasks.
-"""
-
-# generic nodes used by tutorial module subclasses
+## generic nodes used by tutorial module subclasses
 var hud: TutorialHud
 var puzzle: Puzzle
 var playfield: Playfield
@@ -26,23 +24,19 @@ func _ready() -> void:
 			hud.add_skill_tally_item(new_item)
 
 
-"""
-Starts a countdown and switches from tutorial music to regular music.
-
-This is used at the end of each tutorial when customers come in.
-"""
+## Starts a countdown and switches from tutorial music to regular music.
+##
+## This is used at the end of each tutorial when customers come in.
 func start_customer_countdown() -> void:
 	yield(PuzzleState, "after_level_changed")
 	MusicPlayer.play_upbeat_bgm(false)
 	puzzle.start_level_countdown()
 
 
-"""
-Prepares the next section of the tutorial.
-
-This includes resetting the combo and hiding all completed skill tally items. Subclasses can override this method to
-prepare other aspects of the level as well.
-"""
+## Prepares the next section of the tutorial.
+##
+## This includes resetting the combo and hiding all completed skill tally items. Subclasses can override this method to
+## prepare other aspects of the level as well.
 func prepare_tutorial_level() -> void:
 	# Reset the player's combo between puzzle sections. Each tutorial section should have a fresh start; We don't want
 	# them to receive a discouraging 'you broke your combo' fanfare at the start of a section.

--- a/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
@@ -1,30 +1,28 @@
 extends TutorialModule
-"""
-Tutorial module for the 'Basic Techniques' tutorial.
+## Tutorial module for the 'Basic Techniques' tutorial.
+##
+## Shows messages and advances the player through the tutorial as they complete tasks.
 
-Shows messages and advances the player through the tutorial as they complete tasks.
-"""
-
-# tracks what the player has done during the current tutorial section
+## tracks what the player has done during the current tutorial section
 var _squish_moves := 0
 var _boxes_built := 0
 
-# tracks what the player did with the most recent piece
+## tracks what the player did with the most recent piece
 var _did_squish_move := false
 var _did_build_box := false
 
-# The number of times the diagram has been shown. We cycle through different diagrams and chat choices.
+## The number of times the diagram has been shown. We cycle through different diagrams and chat choices.
 var _show_diagram_count := 0
 
-# set of level IDs which the player has attempted during this tutorial
-# key: level id
-# value: true
+## set of level IDs which the player has attempted during this tutorial
+## key: level id
+## value: true
 var _prepared_levels: Dictionary
 
 var _squish_diagram_0 := preload("res://assets/main/puzzle/tutorial/squish-diagram-0.png")
 var _squish_diagram_1 := preload("res://assets/main/puzzle/tutorial/squish-diagram-1.png")
 
-# 'true' if the player is retrying a failed tutorial section. We display different messages the second time.
+## 'true' if the player is retrying a failed tutorial section. We display different messages the second time.
 var _failed_section := false
 
 func _ready() -> void:
@@ -93,9 +91,7 @@ func prepare_tutorial_level() -> void:
 	_prepared_levels[CurrentLevel.settings.id] = true
 
 
-"""
-Advance to the next level in the tutorial.
-"""
+## Advance to the next level in the tutorial.
 func _advance_level() -> void:
 	_failed_section = false
 	var delay_between_levels := PuzzleState.DELAY_SHORT
@@ -143,9 +139,7 @@ func _handle_squish_move_message() -> void:
 		hud.set_message(tr("Good job!\n\nSquish moves help in all sorts of ways."))
 
 
-"""
-Shows a diagram explaining how squish moves work, with an accompanying sensei message.
-"""
+## Shows a diagram explaining how squish moves work, with an accompanying sensei message.
 func _show_next_diagram() -> void:
 	var hud_messages := []
 	if _show_diagram_count == 0:
@@ -188,11 +182,9 @@ func _on_Playfield_box_built(_rect: Rect2, _color: int) -> void:
 	_boxes_built += 1
 
 
-"""
-After a piece is written to the playfield, we check if the player should advance further in the tutorial.
-
-We also sometimes display messages from the sensei.
-"""
+## After a piece is written to the playfield, we check if the player should advance further in the tutorial.
+##
+## We also sometimes display messages from the sensei.
 func _on_PuzzleState_after_piece_written() -> void:
 	# print tutorial messages if the player did something noteworthy
 	_handle_squish_move_message()

--- a/project/src/main/puzzle/wall-frosting-sfx.gd
+++ b/project/src/main/puzzle/wall-frosting-sfx.gd
@@ -1,12 +1,10 @@
 extends Node
-"""
-Plays sound effects when metaballs bounce off of the environment.
+## Plays sound effects when metaballs bounce off of the environment.
+##
+## Plays loud sound effects when metaballs hit the wall, and quieter sound effects when they smear against the
+## background.
 
-Plays loud sound effects when metaballs hit the wall, and quieter sound effects when they smear against the
-background.
-"""
-
-# index of the next AudioStreamPlayer to use
+## index of the next AudioStreamPlayer to use
 var _splat_player_index := 0
 
 onready var _splat_sfx := [
@@ -18,18 +16,16 @@ onready var _splat_sfx := [
 	preload("res://assets/main/puzzle/frosting-splat5.wav"),
 ]
 
-# AudioStreamPlayers to use. We cycle between multiple players to handle concurrent sound effects
+## AudioStreamPlayers to use. We cycle between multiple players to handle concurrent sound effects
 onready var _splat_players := [
 	$SplatPlayer0,
 	$SplatPlayer1,
 	$SplatPlayer2,
 ]
 
-"""
-Play sound effects for a collision.
-
-Globs with a higher alpha component appear larger, and play louder sounds.
-"""
+## Play sound effects for a collision.
+##
+## Globs with a higher alpha component appear larger, and play louder sounds.
 func _play_sfx(glob_alpha: float, max_volume: float) -> void:
 	var player: AudioStreamPlayer = _splat_players[_splat_player_index]
 	player.stream = Utils.rand_value(_splat_sfx)

--- a/project/src/main/puzzle/wall-glob-viewports.gd
+++ b/project/src/main/puzzle/wall-glob-viewports.gd
@@ -1,7 +1,5 @@
 extends FrostingViewports
-"""
-Draws frosting smears when globs collide with the four outer walls.
-"""
+## Draws frosting smears when globs collide with the four outer walls.
 
 func _on_FrostingGlobs_hit_wall(glob: FrostingGlob) -> void:
 	add_smear(glob)

--- a/project/src/main/puzzle/wobbler.gd
+++ b/project/src/main/puzzle/wobbler.gd
@@ -1,25 +1,23 @@
 class_name Wobbler
 extends Sprite
-"""
-Sprite which wobbles and pulses.
-"""
+## Sprite which wobbles and pulses.
 
-# How far the sprite should rotate; 1.0 = one full circle forward and backward
+## How far the sprite should rotate; 1.0 = one full circle forward and backward
 export (float) var avg_spin_amount := 0.5
 
-# How many seconds the sprite should take to rotate back and forth once
+## How many seconds the sprite should take to rotate back and forth once
 export (float) var avg_spin_period := 3.0
 
-# How far the sprite should shrink; 0.21 = shrink down to 79% scale
+## How far the sprite should shrink; 0.21 = shrink down to 79% scale
 export (float) var avg_pulse_amount := 0.2
 
-# How many seconds the sprite should take to shrink to minimum/maximum scale
+## How many seconds the sprite should take to shrink to minimum/maximum scale
 export (float) var avg_pulse_period := 3.0
 
-# Stars/seeds pulse and rotate. This field is used to calculate the pulse/rotation amount
+## Stars/seeds pulse and rotate. This field is used to calculate the pulse/rotation amount
 var _total_time := 0.0
 
-# Slightly randomize inputs so each object is slightly unique
+## Slightly randomize inputs so each object is slightly unique
 onready var _spin_amount := avg_spin_amount * rand_range(0.8, 1.2)
 onready var _spin_period := avg_spin_period * rand_range(0.8, 1.2)
 onready var _pulse_amount := avg_pulse_amount * rand_range(0.8, 1.2)

--- a/project/src/main/save-item-upgrader.gd
+++ b/project/src/main/save-item-upgrader.gd
@@ -1,45 +1,46 @@
 class_name SaveItemUpgrader
-"""
-Provides backwards compatibility with older save formats.
+## Provides backwards compatibility with older save formats.
+##
+## SaveItemUpgrader can update the 'version' tag, but any other version-specific updates must be defined externally.
+## These version-specific updates can be incorporated via SaveItemUpgrader's 'add_upgrade_method' method.
 
-SaveItemUpgrader can update the 'version' tag, but any other version-specific updates must be defined externally.
-These version-specific updates can be incorporated via SaveItemUpgrader's 'add_upgrade_method' method.
-"""
-
-"""
-An externally defined method which provides version-specific updates.
-"""
+## An externally defined method which provides version-specific updates.
 class UpgradeMethod:
-	var object: Object # The object containing the method
-	var method: String # The name of the method which performs the upgrade
-	var old_version: String # The old save data version which the method upgrades from
-	var new_version: String # The new save data version which the method upgrades to
+	## The object containing the method
+	var object: Object
+	
+	## The name of the method which performs the upgrade
+	var method: String
+	
+	## The old save data version which the method upgrades from
+	var old_version: String
+	
+	## The new save data version which the method upgrades to
+	var new_version: String
 
-# Externally defined methods which provide version-specific updates.
-# key: old save data version from which the method upgrades
-# value: a UpgradeMethod corresponding to the method to call
+## Externally defined methods which provide version-specific updates.
+## key: old save data version from which the method upgrades
+## value: a UpgradeMethod corresponding to the method to call
 var _upgrade_methods := {}
 
-"""
-Adds a new externally defined method which provides version-specific updates.
-
-SaveItemUpgrader does not have logic for upgrading specific save data versions. This upgrade logic must be defined on
-an external object and incorporated via this 'add_upgrade_method' method.
-
-The specified upgrade method should accept a SaveData object and return a modified SaveData object. The upgrade method
-can also return null, in which case SaveItemUpgrader will omit the SaveData object from the list of upgraded save
-items.
-
-Parameters:
-	'object': The object containing the method
-	
-	'method': The name of the method which performs the upgrade. This method should accept a SaveData object and
-		return a modified SaveData object.
-	
-	'old_version': The old save data version which the method upgrades from
-	
-	'new_version': The new save data version which the method upgrades to
-"""
+## Adds a new externally defined method which provides version-specific updates.
+##
+## SaveItemUpgrader does not have logic for upgrading specific save data versions. This upgrade logic must be defined
+## on an external object and incorporated via this 'add_upgrade_method' method.
+##
+## The specified upgrade method should accept a SaveData object and return a modified SaveData object. The upgrade
+## method can also return null, in which case SaveItemUpgrader will omit the SaveData object from the list of upgraded
+## save items.
+##
+## Parameters:
+## 	'object': The object containing the method
+##
+## 	'method': The name of the method which performs the upgrade. This method should accept a SaveData object and
+## 		return a modified SaveData object.
+##
+## 	'old_version': The old save data version which the method upgrades from
+##
+## 	'new_version': The new save data version which the method upgrades to
 func add_upgrade_method(object: Object, method: String, old_version: String, new_version: String) -> void:
 	var upgrade_method: UpgradeMethod = UpgradeMethod.new()
 	upgrade_method.object = object
@@ -49,9 +50,7 @@ func add_upgrade_method(object: Object, method: String, old_version: String, new
 	_upgrade_methods[old_version] = upgrade_method
 
 
-"""
-Returns 'true' if the specified json save items are from an older version of the game.
-"""
+## Returns 'true' if the specified json save items are from an older version of the game.
 func needs_upgrade(json_save_items: Array) -> bool:
 	var result: bool = false
 	var version := _get_version_string(json_save_items)
@@ -64,9 +63,7 @@ func needs_upgrade(json_save_items: Array) -> bool:
 	return result
 
 
-"""
-Transforms the specified json save items to the newest format.
-"""
+## Transforms the specified json save items to the newest format.
 func upgrade(json_save_items: Array) -> Array:
 	var new_save_items := json_save_items
 	while needs_upgrade(new_save_items):
@@ -100,9 +97,7 @@ func upgrade(json_save_items: Array) -> Array:
 	return new_save_items
 
 
-"""
-Extracts a version string from the specified json save items.
-"""
+## Extracts a version string from the specified json save items.
 static func _get_version_string(json_save_items: Array) -> String:
 	var version: SaveItem
 	for json_save_item_obj in json_save_items:

--- a/project/src/main/save-item.gd
+++ b/project/src/main/save-item.gd
@@ -1,19 +1,17 @@
 class_name SaveItem
-"""
-An individual piece of save data.
+## An individual piece of save data.
+##
+## A piece of save data includes a type and value and, optionally, a key. Some data, such as the player's money, is
+## unique to the player. Other data is organized by a key field. For example, their high scores are tracked by level
+## name.
 
-A piece of save data includes a type and value and, optionally, a key. Some data, such as the player's money, is
-unique to the player. Other data is organized by a key field. For example, their high scores are tracked by level
-name.
-"""
-
-# A string unique to each type of data (level-data, player-data)
+## A string unique to each type of data (level-data, player-data)
 var type: String
 
-# A string identifying a specific data item (sophie, marathon-normal)
+## A string identifying a specific data item (sophie, marathon-normal)
 var key: String
 
-# The value object (array, dictionary, string) containing the data
+## The value object (array, dictionary, string) containing the data
 var value
 
 func from_json_dict(json: Dictionary) -> void:

--- a/project/src/main/settings/gameplay-settings.gd
+++ b/project/src/main/settings/gameplay-settings.gd
@@ -1,11 +1,9 @@
 class_name GameplaySettings
-"""
-Manages settings which control the gameplay.
-"""
+## Manages settings which control the gameplay.
 
 signal ghost_piece_changed(value)
 
-# 'true' if a ghost piece should be shown during the puzzle sections.
+## 'true' if a ghost piece should be shown during the puzzle sections.
 var ghost_piece := true setget set_ghost_piece
 
 func set_ghost_piece(new_ghost_piece: bool) -> void:
@@ -15,9 +13,7 @@ func set_ghost_piece(new_ghost_piece: bool) -> void:
 	emit_signal("ghost_piece_changed", new_ghost_piece)
 
 
-"""
-Resets the gameplay settings to their default values.
-"""
+## Resets the gameplay settings to their default values.
 func reset() -> void:
 	from_json_dict({})
 

--- a/project/src/main/settings/graphics-settings.gd
+++ b/project/src/main/settings/graphics-settings.gd
@@ -1,7 +1,5 @@
 class_name GraphicsSettings
-"""
-Manages settings which control the graphics.
-"""
+## Manages settings which control the graphics.
 
 signal creature_detail_changed(value)
 
@@ -10,7 +8,7 @@ enum CreatureDetail {
 	HIGH
 }
 
-# CreatureDetail enum describing how detailed the creatures should look
+## CreatureDetail enum describing how detailed the creatures should look
 var creature_detail: int = _default_creature_detail() setget set_creature_detail
 
 var use_vsync: bool = _default_use_vsync() setget set_use_vsync
@@ -27,9 +25,7 @@ func set_use_vsync(new_use_vsync: bool) -> void:
 	OS.set_use_vsync(new_use_vsync)
 
 
-"""
-Resets the gameplay settings to their default values.
-"""
+## Resets the gameplay settings to their default values.
 func reset() -> void:
 	from_json_dict({})
 
@@ -46,24 +42,20 @@ func from_json_dict(json: Dictionary) -> void:
 	set_use_vsync(json.get("use_vsync", _default_use_vsync()))
 
 
-"""
-Returns the default creature detail setting value. Web and mobile targets use lower detail.
-
-GPUs on mobile devices (and seemingly, web targets) work in dramatically different ways from GPUs on desktop, and often
-used tile renderers. Tile renderers split up the screen into regular-sized tiles that fit into super fast cache memory,
-which reduces the number of read/write operations to the main memory. However, tiles that rely on the results of
-rendering in different tiles or on the results of earlier operations being preserved can be very slow. As a result, the
-Viewport texture utilized by creatures offers poor performance on mobile and web targets.
-"""
+## Returns the default creature detail setting value. Web and mobile targets use lower detail.
+##
+## GPUs on mobile devices (and seemingly, web targets) work in dramatically different ways from GPUs on desktop, and
+## often used tile renderers. Tile renderers split up the screen into regular-sized tiles that fit into super fast
+## cache memory, which reduces the number of read/write operations to the main memory. However, tiles that rely on the
+## results of rendering in different tiles or on the results of earlier operations being preserved can be very slow. As
+## a result, the Viewport texture utilized by creatures offers poor performance on mobile and web targets.
 func _default_creature_detail() -> int:
 	return CreatureDetail.LOW if OS.has_feature("web") or OS.has_feature("mobile") else CreatureDetail.HIGH
 
 
-"""
-Returns the default 'use vsync' value.
-
-Many platforms enforce vsync regardless of this value (such as mobile platforms and HTML5), so we default it to 'true'
-on those platforms. However, it makes stuttering more noticable during puzzles.
-"""
+## Returns the default 'use vsync' value.
+##
+## Many platforms enforce vsync regardless of this value (such as mobile platforms and HTML5), so we default it to
+## 'true' on those platforms. However, it makes stuttering more noticable during puzzles.
 func _default_use_vsync() -> bool:
 	return true if OS.has_feature("web") or OS.has_feature("mobile") else false

--- a/project/src/main/settings/keybind-manager.gd
+++ b/project/src/main/settings/keybind-manager.gd
@@ -1,17 +1,13 @@
 extends Node
-"""
-Binds the player's input settings to the input map.
-"""
+## Binds the player's input settings to the input map.
 
 func _ready() -> void:
 	SystemData.keybind_settings.connect("settings_changed", self, "_on_KeybindSettings_settings_changed")
 
 
-"""
-Converts a json dictionary to an InputEvent instance.
-
-This supports InputEventKey and InputEventJoypadButton events. It does not support joystick, mouse or touch events.
-"""
+## Converts a json dictionary to an InputEvent instance.
+##
+## This supports InputEventKey and InputEventJoypadButton events. It does not support joystick, mouse or touch events.
 func input_event_from_json(json: Dictionary) -> InputEvent:
 	if not json:
 		return null
@@ -32,11 +28,9 @@ func input_event_from_json(json: Dictionary) -> InputEvent:
 	return input_event
 
 
-"""
-Converts an InputEvent to a json dictionary.
-
-This supports InputEventKey and InputEventJoypadButton events. It does not support joystick, mouse or touch events.
-"""
+## Converts an InputEvent to a json dictionary.
+##
+## This supports InputEventKey and InputEventJoypadButton events. It does not support joystick, mouse or touch events.
 func input_event_to_json(input_event: InputEvent) -> Dictionary:
 	var json := {}
 	if input_event is InputEventKey:
@@ -49,15 +43,13 @@ func input_event_to_json(input_event: InputEvent) -> Dictionary:
 	return json
 
 
-"""
-Returns a string representation of an input, suitable for showing to the player.
-
-Parameters:
-	'input_json': A json representation of a keyboard or joypad input
-
-Returns:
-	A short human-readable string like 'DPAD Left' or 'Escape'
-"""
+## Returns a string representation of an input, suitable for showing to the player.
+##
+## Parameters:
+## 	'input_json': A json representation of a keyboard or joypad input
+##
+## Returns:
+## 	A short human-readable string like 'DPAD Left' or 'Escape'
 func pretty_string(input_json: Dictionary) -> String:
 	var result: String
 	match input_json["type"]:
@@ -69,18 +61,14 @@ func pretty_string(input_json: Dictionary) -> String:
 	return result
 
 
-"""
-Updates the InputMap with the bindings in the specified json file
-"""
+## Updates the InputMap with the bindings in the specified json file
 func _bind_keys_from_file(path: String) -> void:
 	var json_text := FileUtils.get_file_as_text(path)
 	var json_dict: Dictionary = parse_json(json_text)
 	_bind_keys_from_json_dict(json_dict)
 
 
-"""
-Updates the InputMap with the bindings in the specified json
-"""
+## Updates the InputMap with the bindings in the specified json
 func _bind_keys_from_json_dict(json: Dictionary) -> void:
 	for action_name in json:
 		var input_events := []
@@ -92,16 +80,14 @@ func _bind_keys_from_json_dict(json: Dictionary) -> void:
 		_bind_keys(action_name, input_events)
 
 
-"""
-Updates a single InputMap action with the specified bindings
-
-This replaces all bindings for the specified action with a new set of bindings.
-
-Parameters:
-	'action_name': the action to rebind
-	
-	'input_events': the InputEvents to bind
-"""
+## Updates a single InputMap action with the specified bindings
+##
+## This replaces all bindings for the specified action with a new set of bindings.
+##
+## Parameters:
+## 	'action_name': the action to rebind
+##
+## 	'input_events': the InputEvents to bind
 func _bind_keys(action_name: String, input_events: Array) -> void:
 	if not InputMap.has_action(action_name):
 		InputMap.add_action(action_name)
@@ -110,9 +96,7 @@ func _bind_keys(action_name: String, input_events: Array) -> void:
 		InputMap.action_add_event(action_name, input_event)
 
 
-"""
-Updates the InputMap when the player's keybind settings change
-"""
+## Updates the InputMap when the player's keybind settings change
 func _on_KeybindSettings_settings_changed() -> void:
 	match SystemData.keybind_settings.preset:
 		KeybindSettings.GUIDELINE:

--- a/project/src/main/settings/keybind-settings.gd
+++ b/project/src/main/settings/keybind-settings.gd
@@ -1,12 +1,10 @@
 class_name KeybindSettings
-"""
-Manages settings which affect the keyboard/joystick input for controlling the game.
+## Manages settings which affect the keyboard/joystick input for controlling the game.
+##
+## The player can select between 'Guideline', 'WASD' or 'Custom' presets. We store a set of custom keybinds, although
+## these are ignored unless the player selects the 'Custom' preset.
 
-The player can select between 'Guideline', 'WASD' or 'Custom' presets. We store a set of custom keybinds, although
-these are ignored unless the player selects the 'Custom' preset.
-"""
-
-# emitted if new settings are loaded, or the preset changes, or the player rebinds a key
+## emitted if new settings are loaded, or the preset changes, or the player rebinds a key
 signal settings_changed
 
 enum KeybindPreset {
@@ -19,8 +17,8 @@ const GUIDELINE := KeybindPreset.GUIDELINE
 const WASD := KeybindPreset.WASD
 const CUSTOM := KeybindPreset.CUSTOM
 
-# Set of inputs accepted while playing a puzzle.
-# This includes inputs for steering the piece and bringing up a menu.
+## Set of inputs accepted while playing a puzzle.
+## This includes inputs for steering the piece and bringing up a menu.
 const PUZZLE_ACTION_NAMES := {
 	"move_piece_left": true,
 	"move_piece_right": true,
@@ -31,7 +29,7 @@ const PUZZLE_ACTION_NAMES := {
 	"ui_menu": true,
 }
 
-# Set of inputs accepted in menus.
+## Set of inputs accepted in menus.
 const MENU_ACTION_NAMES := {
 	"ui_up": true,
 	"ui_down": true,
@@ -41,8 +39,8 @@ const MENU_ACTION_NAMES := {
 	"ui_cancel": true,
 }
 
-# Set of inputs accepted on the overworld.
-# This includes inputs for walking, interacting, and bringing up a menu.
+## Set of inputs accepted on the overworld.
+## This includes inputs for walking, interacting, and bringing up a menu.
 const OVERWORLD_ACTION_NAMES := {
 	"walk_up": true,
 	"walk_down": true,
@@ -54,10 +52,10 @@ const OVERWORLD_ACTION_NAMES := {
 	"ui_menu": true,
 }
 
-# The player's selected keybind preset, or 'Custom' if they've defined their own
+## The player's selected keybind preset, or 'Custom' if they've defined their own
 var preset := GUIDELINE setget set_preset
 
-# A json representation of the player's custom keybinds
+## A json representation of the player's custom keybinds
 var custom_keybinds: Dictionary
 
 func reset() -> void:
@@ -69,21 +67,19 @@ func set_preset(new_preset: int) -> void:
 	emit_signal("settings_changed")
 
 
-"""
-Updates the custom keybind for a specific action.
-
-Unbinds any conflicting actions to avoid cases where the Left Arrow is accidentally bound to two conflicting actions.
-It's OK if the actions are in different contexts (ui_left, move_piece_left) but problematic if the actions are in the
-same context (activate, rewind_text)
-
-Parameters:
-	'action_name': The action whose keybind is being updated
-	
-	'index': A number in the range [0, 2] specifying which keybind is being updated. Each action supports up to three
-		custom keybinds.
-	
-	'json': A json representation of a keyboard or joypad input
-"""
+## Updates the custom keybind for a specific action.
+##
+## Unbinds any conflicting actions to avoid cases where the Left Arrow is accidentally bound to two conflicting
+## actions. It's OK if the actions are in different contexts (ui_left, move_piece_left) but problematic if the actions
+## are in the same context (activate, rewind_text)
+##
+## Parameters:
+## 	'action_name': The action whose keybind is being updated
+##
+## 	'index': A number in the range [0, 2] specifying which keybind is being updated. Each action supports up to three
+## 		custom keybinds.
+##
+## 	'json': A json representation of a keyboard or joypad input
 func set_custom_keybind(action_name: String, index: int, json: Dictionary) -> void:
 	_unbind_conflicting_actions(action_name, json)
 	
@@ -93,15 +89,13 @@ func set_custom_keybind(action_name: String, index: int, json: Dictionary) -> vo
 	emit_signal("settings_changed")
 
 
-"""
-Returns a json reprentation of the specified keybind.
-
-Parameters:
-	'action_name': The action whose keybind should be returned
-	
-	'index': A number in the range [0, 2] specifying which keybind should be returned. Each action supports up to three
-		custom keybinds.
-"""
+## Returns a json reprentation of the specified keybind.
+##
+## Parameters:
+## 	'action_name': The action whose keybind should be returned
+##
+## 	'index': A number in the range [0, 2] specifying which keybind should be returned. Each action supports up to three
+## 		custom keybinds.
 func get_custom_keybind(action_name: String, index: int) -> Dictionary:
 	var result := {}
 	if custom_keybinds.has(action_name):
@@ -124,9 +118,7 @@ func from_json_dict(json: Dictionary) -> void:
 	emit_signal("settings_changed")
 
 
-"""
-Resets the custom keybinds to a sensible set of defaults.
-"""
+## Resets the custom keybinds to a sensible set of defaults.
 func restore_default_custom_keybinds() -> void:
 	var json_text := FileUtils.get_file_as_text("res://assets/main/keybind/default-custom.json")
 	var json_dict: Dictionary = parse_json(json_text)
@@ -134,12 +126,10 @@ func restore_default_custom_keybinds() -> void:
 	emit_signal("settings_changed")
 
 
-"""
-Unbinds any keybinds which conflict with the specified keybind.
-
-It's OK for two actions to be bound by the same key if they're in different contexts (ui_left, move_piece_left) but
-problematic if the actions are in the same context (activate, rewind_text).
-"""
+## Unbinds any keybinds which conflict with the specified keybind.
+##
+## It's OK for two actions to be bound by the same key if they're in different contexts (ui_left, move_piece_left) but
+## problematic if the actions are in the same context (activate, rewind_text).
 func _unbind_conflicting_actions(action_name: String, json: Dictionary) -> void:
 	for other_action_name in _conflicting_action_names(action_name):
 		if not custom_keybinds.has(other_action_name):
@@ -150,23 +140,21 @@ func _unbind_conflicting_actions(action_name: String, json: Dictionary) -> void:
 				custom_keybinds[other_action_name][other_index] = {}
 
 
-"""
-Returns a list of action names which appear in the same context as the specified keybind.
-
-For example, move_piece_left and ui_menu both appear in the same context as rotate_ccw; when the player is playing a
-puzzle they might activate any of these actions. These are considered 'conflicting actions', and it is problematic for
-the same key to be bound to two of these actions.
-
-On the other hand, move_piece_left and ui_left appear in different contexts; the player would never try to move their
-piece while navigating a menu. These are not considered 'conflicting actions', and it is OK for the same key to be
-bound to two of these actions.
-
-Parameters:
-	'action_name': The action to analyze
-
-Returns:
-	An array of action names which cannot share keybinds with the specified action, including the action itself
-"""
+## Returns a list of action names which appear in the same context as the specified keybind.
+##
+## For example, move_piece_left and ui_menu both appear in the same context as rotate_ccw; when the player is playing a
+## puzzle they might activate any of these actions. These are considered 'conflicting actions', and it is problematic
+## for the same key to be bound to two of these actions.
+##
+## On the other hand, move_piece_left and ui_left appear in different contexts; the player would never try to move
+## their piece while navigating a menu. These are not considered 'conflicting actions', and it is OK for the same key
+## to be bound to two of these actions.
+##
+## Parameters:
+## 	'action_name': The action to analyze
+##
+## Returns:
+## 	An array of action names which cannot share keybinds with the specified action, including the action itself
 func _conflicting_action_names(action_name: String) -> Array:
 	var conflicting_action_names := {}
 	for other_action_names in [PUZZLE_ACTION_NAMES, MENU_ACTION_NAMES, OVERWORLD_ACTION_NAMES]:
@@ -176,9 +164,7 @@ func _conflicting_action_names(action_name: String) -> Array:
 	return conflicting_action_names.keys()
 
 
-"""
-Performs a shallow equality check for dictionaries.
-"""
+## Performs a shallow equality check for dictionaries.
 func _shallow_equal_dicts(a: Dictionary, b: Dictionary) -> bool:
 	var result := true
 	if a.size() != b.size():

--- a/project/src/main/settings/misc-settings.gd
+++ b/project/src/main/settings/misc-settings.gd
@@ -1,11 +1,9 @@
 class_name MiscSettings
-"""
-Manages miscellaneous settings such as language.
-"""
+## Manages miscellaneous settings such as language.
 
 signal save_slot_changed
 
-# Different save slots where the player can save/load their progress
+## Different save slots where the player can save/load their progress
 enum SaveSlot {
 	SLOT_A,
 	SLOT_B,
@@ -13,7 +11,7 @@ enum SaveSlot {
 	SLOT_D,
 }
 
-# Human-readable prefixes for the save slots. These are shown to the user in menus
+## Human-readable prefixes for the save slots. These are shown to the user in menus
 const SAVE_SLOT_PREFIXES := {
 	SaveSlot.SLOT_A: "A",
 	SaveSlot.SLOT_B: "B",
@@ -21,15 +19,13 @@ const SAVE_SLOT_PREFIXES := {
 	SaveSlot.SLOT_D: "D",
 }
 
-# The current save slot for saving/loading progress
+## The current save slot for saving/loading progress
 var save_slot: int = SaveSlot.SLOT_A setget set_save_slot
 
-# Whether cutscenes should play by default.
+## Whether cutscenes should play by default.
 var cutscene_force: int = Levels.CutsceneForce.NONE
 
-"""
-Resets the miscellaneous settings to their default values.
-"""
+## Resets the miscellaneous settings to their default values.
 func reset() -> void:
 	from_json_dict({})
 

--- a/project/src/main/settings/touch-settings.gd
+++ b/project/src/main/settings/touch-settings.gd
@@ -1,11 +1,9 @@
 class_name TouchSettings
-"""
-Manages settings which affect the touch controls.
-"""
+## Manages settings which affect the touch controls.
 
 signal settings_changed
 
-# control schemes that decide which buttons appear where
+## control schemes that decide which buttons appear where
 enum ControlScheme {
 	EASY_CONSOLE,
 	EASY_DESKTOP,
@@ -22,13 +20,13 @@ const AMBI_DESKTOP := ControlScheme.AMBI_DESKTOP
 const LOCO_CONSOLE := ControlScheme.LOCO_CONSOLE
 const LOCO_DESKTOP := ControlScheme.LOCO_DESKTOP
 
-# how large the buttons appear on screen
+## how large the buttons appear on screen
 var size := 1.00 setget set_size
 
-# control scheme that decides which buttons appear where
+## control scheme that decides which buttons appear where
 var scheme: int = ControlScheme.EASY_CONSOLE setget set_scheme
 
-# how easy it is to mash two buttons with one finger; 0.0 = impossible, 1.0 = very easy
+## how easy it is to mash two buttons with one finger; 0.0 = impossible, 1.0 = very easy
 var fat_finger := 0.00 setget set_fat_finger
 
 func reset() -> void:

--- a/project/src/main/settings/volume-settings.gd
+++ b/project/src/main/settings/volume-settings.gd
@@ -1,7 +1,5 @@
 class_name VolumeSettings
-"""
-Manages settings which control the game audio volume.
-"""
+## Manages settings which control the game audio volume.
 
 enum VolumeType { MASTER, MUSIC, SOUND, VOICE }
 
@@ -10,9 +8,7 @@ const MUSIC := VolumeType.MUSIC
 const SOUND := VolumeType.SOUND
 const VOICE := VolumeType.VOICE
 
-"""
-Returns the volume of the specified bus as a linear energy value.
-"""
+## Returns the volume of the specified bus as a linear energy value.
 func get_bus_volume_linear(volume_type: int) -> float:
 	var volume_linear: float
 	var bus_index := _bus_index(volume_type)
@@ -24,9 +20,7 @@ func get_bus_volume_linear(volume_type: int) -> float:
 	return volume_linear
 
 
-"""
-Sets the volume of the specified bus with a linear energy value.
-"""
+## Sets the volume of the specified bus with a linear energy value.
 func set_bus_volume_linear(volume_type: int, new_value: float) -> void:
 	var bus_index := _bus_index(volume_type)
 	AudioServer.set_bus_volume_db(bus_index, linear2db(new_value))
@@ -38,9 +32,7 @@ func is_bus_mute(volume_type: int) -> bool:
 	return AudioServer.is_bus_mute(bus_index)
 
 
-"""
-Resets the sound, music and voice volumes to their default values.
-"""
+## Resets the sound, music and voice volumes to their default values.
 func reset() -> void:
 	from_json_dict({})
 

--- a/project/src/main/state-machine.gd
+++ b/project/src/main/state-machine.gd
@@ -1,24 +1,20 @@
 class_name StateMachine
 extends Node
-"""
-An implementation of the state pattern.
+## An implementation of the state pattern.
+##
+## State nodes can be added to this node as children. This class provides logic for switching between its child states,
+## invoking their methods, and emitting signals.
 
-State nodes can be added to this node as children. This class provides logic for switching between its child states,
-invoking their methods, and emitting signals.
-"""
-
-# emitted once when a state is entered
+## emitted once when a state is entered
 signal entered_state(prev_state, state)
 
-# the currently active state
+## the currently active state
 var _state: State
 
-# the host object which is passed into each state
+## the host object which is passed into each state
 onready var _host := get_parent()
 
-"""
-Calls 'update' on the currently active state, and changes the current state if necessary.
-"""
+## Calls 'update' on the currently active state, and changes the current state if necessary.
 func update() -> void:
 	var old_state := _state
 	var new_state_name: String = _state.update(_host)
@@ -32,11 +28,9 @@ func update() -> void:
 	_state.frames += 1
 
 
-"""
-Transitions to a new state.
-
-Resets the state's internal variables and notifies any listeners.
-"""
+## Transitions to a new state.
+##
+## Resets the state's internal variables and notifies any listeners.
 func set_state(new_state: State) -> void:
 	var prev_state := _state
 	var prev_state_name := "" if _state == null else _state.name

--- a/project/src/main/state.gd
+++ b/project/src/main/state.gd
@@ -1,32 +1,26 @@
 class_name State
 extends Node
-"""
-An empty 'state' script for use in conjunction with the StateMachine class.
+## An empty 'state' script for use in conjunction with the StateMachine class.
+##
+## States should extend from this script to define functionality.
 
-States should extend from this script to define functionality.
-"""
-
-# The number of frames this state has been active for.
+## The number of frames this state has been active for.
 var frames := 0
 
-"""
-Called once when the state is first entered.
-
-Parameters:
-	'_host': The state machine's parent object.
-	
-	'_prev_state': The previous state the state machine was in.
-"""
+## Called once when the state is first entered.
+##
+## Parameters:
+## 	'_host': The state machine's parent object.
+##
+## 	'_prev_state': The previous state the state machine was in.
 func enter(_host, _prev_state_name: String) -> void:
 	pass
 
-"""
-Called once each frame to make the state update.
-
-Returns the name of the new state to transition to, or '' if the state should not change.
-
-Parameters:
-	'_host': The state machine's parent object.
-"""
+## Called once each frame to make the state update.
+##
+## Returns the name of the new state to transition to, or '' if the state should not change.
+##
+## Parameters:
+## 	'_host': The state machine's parent object.
 func update(_host) -> String:
 	return ""

--- a/project/src/main/string-transformer.gd
+++ b/project/src/main/string-transformer.gd
@@ -1,32 +1,24 @@
 class_name StringTransformer
-"""
-Applies a series of regex transformations.
-"""
+## Applies a series of regex transformations.
 
-# the transformed string
+## the transformed string
 var transformed: String
 
-# the regex instance which performs the transformations
+## the regex instance which performs the transformations
 var _regex := RegEx.new()
 
-"""
-Parameters:
-	's': The string to be transformed.
-"""
+## Parameters:
+## 	's': The string to be transformed.
 func _init(s: String) -> void:
 	transformed = s
 
-"""
-Apply a regex transformation.
-"""
+## Apply a regex transformation.
 func sub(pattern: String, replacement: String) -> void:
 	_regex.compile(pattern)
 	transformed = _regex.sub(transformed, replacement, true)
 
 
-"""
-Perform a regex search.
-"""
+## Perform a regex search.
 func search(pattern: String) -> RegExMatch:
 	_regex.compile(pattern)
 	return _regex.search(transformed)

--- a/project/src/main/string-utils.gd
+++ b/project/src/main/string-utils.gd
@@ -1,16 +1,14 @@
 class_name StringUtils
-"""
-Utility class for string operations.
+## Utility class for string operations.
+##
+## Where possible, these functions mimic the style of org.apache.commons.lang3.StringUtils.
 
-Where possible, these functions mimic the style of org.apache.commons.lang3.StringUtils.
-"""
-
-# Numeric suffixes used to represent thousands, millions, billions
+## Numeric suffixes used to represent thousands, millions, billions
 const NUM_SUFFIXES := ["", " k", " m", " b", " t"]
 
 const MAX_FILE_ROOT_LENGTH := 31
 
-# Characters to omit from the first part of a filename
+## Characters to omit from the first part of a filename
 const BAD_FILE_ROOT_CHARS := {
 	" ": true,
 	
@@ -25,11 +23,9 @@ const BAD_FILE_ROOT_CHARS := {
 	"_": true, "`": true, "{": true, "|": true, "}": true, "~": true,
 }
 
-"""
-Formats a potentially large number into a compact form like '5,982 k'.
-
-The resulting string is always seven or fewer characters, allowing for a compact UI.
-"""
+## Formats a potentially large number into a compact form like '5,982 k'.
+##
+## The resulting string is always seven or fewer characters, allowing for a compact UI.
 static func compact(n: int) -> String:
 	var suffix_index := 0
 	var i: int = n
@@ -45,9 +41,7 @@ static func compact(n: int) -> String:
 	return "%s%s" % [comma_sep(i), NUM_SUFFIXES[suffix_index]]
 
 
-"""
-Formats a number with commas like '1,234,567'.
-"""
+## Formats a number with commas like '1,234,567'.
 static func comma_sep(n: int) -> String:
 	var result := ""
 	var i: int = abs(n)
@@ -59,14 +53,12 @@ static func comma_sep(n: int) -> String:
 	return "%s%s%s" % ["-" if n < 0 else "", i, result]
 
 
-"""
-Formats a float with commas like '1,234,567.89'.
-
-Parameters:
-	'n': The number to format
-	
-	'precision': The number of decimal places to show. Rounding is used.
-"""
+## Formats a float with commas like '1,234,567.89'.
+##
+## Parameters:
+## 	'n': The number to format
+##
+## 	'precision': The number of decimal places to show. Rounding is used.
 static func comma_sep_float(n: float, precision: int) -> String:
 	var result := str(stepify(abs(n) - int(abs(n)), pow(0.1, precision))).substr(1)
 	var i: int = abs(n)
@@ -78,23 +70,17 @@ static func comma_sep_float(n: float, precision: int) -> String:
 	return "%s%s%s" % ["-" if n < 0 else "", i, result]
 
 
-"""
-Gets the substring before the first occurrence of a separator.
-"""
+## Gets the substring before the first occurrence of a separator.
 static func substring_before(s: String, sep: String) -> String:
 	return s.substr(0, s.find(sep))
 
 
-"""
-Gets the substring after the first occurrence of a separator.
-"""
+## Gets the substring after the first occurrence of a separator.
 static func substring_after(s: String, sep: String) -> String:
 	return s.substr(s.find(sep) + sep.length())
 
 
-"""
-Gets the String that is nested in between two Strings. Only the first match is returned.
-"""
+## Gets the String that is nested in between two Strings. Only the first match is returned.
 static func substring_between(s: String, open: String, close: String) -> String:
 	if not s or not open or not close:
 		return ""
@@ -108,42 +94,32 @@ static func substring_between(s: String, open: String, close: String) -> String:
 	return result
 
 
-"""
-Gets the substring after the last occurrence of a separator.
-"""
+## Gets the substring after the last occurrence of a separator.
 static func substring_after_last(s: String, sep: String) -> String:
 	return s.substr(s.find_last(sep) + sep.length())
 
 
-"""
-Gets the substring before the last occurrence of a separator.
-"""
+## Gets the substring before the last occurrence of a separator.
 static func substring_before_last(s: String, sep: String) -> String:
 	return s.substr(0, s.find_last(sep))
 
 
-"""
-Formats a duration like 63.159 into '1:03'
-"""
+## Formats a duration like 63.159 into '1:03'
 static func format_duration(seconds: float) -> String:
 	# warning-ignore:integer_division
 	return "%01d:%02d" % [int(ceil(seconds)) / 60, int(ceil(seconds)) % 60]
 
 
-"""
-Parses a duration like 1:03.159 into '63.159'
-"""
+## Parses a duration like 1:03.159 into '63.159'
 static func parse_duration(s: String) -> float:
 	var split: Array = s.split(":")
 	return int(split[0]) * 60 + float(split[1])
 
 
-"""
-Sanitizes the 'file root' to avoid creating files with unusual filenames.
-
-The file root is the part of a filename preceding the file extension. To limit bugs and user error we sanitize file
-roots to ensure they're short, lower-case, and don't include unusual characters.
-"""
+## Sanitizes the 'file root' to avoid creating files with unusual filenames.
+##
+## The file root is the part of a filename preceding the file extension. To limit bugs and user error we sanitize file
+## roots to ensure they're short, lower-case, and don't include unusual characters.
 static func sanitize_file_root(file_root: String) -> String:
 	var result := ""
 	var utf8 := file_root.to_lower().to_utf8()
@@ -164,16 +140,12 @@ static func sanitize_file_root(file_root: String) -> String:
 	return result.substr(0, MAX_FILE_ROOT_LENGTH)
 
 
-"""
-Returns true if the specified character is a letter (a-z, A-Z)
-"""
+## Returns true if the specified character is a letter (a-z, A-Z)
 static func is_letter(character: String) -> bool:
 	return character >= "A" and character <= "Z" or character >= "a" and character <= "z"
 
 
-"""
-Returns true if the specified string contains at least one letter (a-z, A-Z)
-"""
+## Returns true if the specified string contains at least one letter (a-z, A-Z)
 static func has_letter(string: String) -> bool:
 	var result := false
 	for c in string:
@@ -183,9 +155,7 @@ static func has_letter(string: String) -> bool:
 	return result
 
 
-"""
-Capitalizes all the whitespace separated words in a String.
-"""
+## Capitalizes all the whitespace separated words in a String.
 static func capitalize_words(string: String) -> String:
 	var result := string[0].to_upper()
 	for i in range(1, string.length()):
@@ -196,13 +166,11 @@ static func capitalize_words(string: String) -> String:
 	return result
 
 
-"""
-Returns an english representation of a number suitable for a message.
-
-This is useful for messages like 'You need to beat three more levels' or 'You need 3,125 more points.' We don't want to
-display messages like 'You need three thousand one hundred and twenty-five more points', so we leave larger numbers
-alone.
-"""
+## Returns an english representation of a number suitable for a message.
+##
+## This is useful for messages like 'You need to beat three more levels' or 'You need 3,125 more points.' We don't want
+## to display messages like 'You need three thousand one hundred and twenty-five more points', so we leave larger
+## numbers alone.
 static func english_number(i: int) -> String:
 	if i < 0 or i > 20:
 		return comma_sep(i)
@@ -213,26 +181,20 @@ static func english_number(i: int) -> String:
 			"sixteen", "seventeen", "eighteen", "nineteen", "twenty"][i];
 
 
-"""
-Returns either the passed in String, or if the String is empty or null, the value of 'default'.
-"""
+## Returns either the passed in String, or if the String is empty or null, the value of 'default'.
 static func default_if_empty(s: String, default: String) -> String:
 	return s if s else default
 
 
-"""
-Replaces hyphens with underscores in a string.
-
-JSON keys and values use underscores to separate words, for consistency with Python conventions.
-"""
+## Replaces hyphens with underscores in a string.
+##
+## JSON keys and values use underscores to separate words, for consistency with Python conventions.
 static func hyphens_to_underscores(s: String) -> String:
 	return s.replace("-", "_")
 
 
-"""
-Replaces underscores with hyphens in a string.
-
-Filenames use kebab-case.
-"""
+## Replaces underscores with hyphens in a string.
+##
+## Filenames use kebab-case.
 static func underscores_to_hyphens(s: String) -> String:
 	return s.replace("_", "-")

--- a/project/src/main/system-data.gd
+++ b/project/src/main/system-data.gd
@@ -1,11 +1,9 @@
 extends Node
-"""
-Stores data about the system and its configuration.
-
-This data includes configuration data like language, keybindings, and graphics settings.
-
-Data about the player's progress and high scores is stored in the PlayerData class, not here.
-"""
+## Stores data about the system and its configuration.
+##
+## This data includes configuration data like language, keybindings, and graphics settings.
+##
+## Data about the player's progress and high scores is stored in the PlayerData class, not here.
 
 var gameplay_settings := GameplaySettings.new()
 var graphics_settings := GraphicsSettings.new()
@@ -14,9 +12,7 @@ var touch_settings := TouchSettings.new()
 var keybind_settings := KeybindSettings.new()
 var misc_settings := MiscSettings.new()
 
-"""
-Resets the system's in-memory data to a default state.
-"""
+## Resets the system's in-memory data to a default state.
 func reset() -> void:
 	gameplay_settings.reset()
 	graphics_settings.reset()

--- a/project/src/main/system-save-upgrader.gd
+++ b/project/src/main/system-save-upgrader.gd
@@ -1,14 +1,10 @@
 class_name SystemSaveUpgrader
-"""
-Provides backwards compatibility with older system save formats.
+## Provides backwards compatibility with older system save formats.
+##
+## This class will grow with each change to our save system. Once it gets too large (600 lines or so) we should drop
+## backwards compatibility for older versions.
 
-This class will grow with each change to our save system. Once it gets too large (600 lines or so) we should drop
-backwards compatibility for older versions.
-"""
-
-"""
-Creates and configures a SaveItemUpgrader capable of upgrading older system save formats.
-"""
+## Creates and configures a SaveItemUpgrader capable of upgrading older system save formats.
 func new_save_item_upgrader() -> SaveItemUpgrader:
 	var upgrader := SaveItemUpgrader.new()
 	upgrader.add_upgrade_method(self, "_upgrade_2783", "2783", "27bb")

--- a/project/src/main/system-save.gd
+++ b/project/src/main/system-save.gd
@@ -1,15 +1,13 @@
 extends Node
-"""
-Reads and writes data about the system from a file.
-
-This data includes configuration data like language, keybindings, and which save slot is active.
-"""
+## Reads and writes data about the system from a file.
+##
+## This data includes configuration data like language, keybindings, and which save slot is active.
 
 signal save_slot_deleted
 
 const SYSTEM_DATA_VERSION := "27bb"
 
-# Save files older than July 2021 which should be deleted during an upgrade
+## Save files older than July 2021 which should be deleted during an upgrade
 const OLD_SAVES_TO_DELETE := [
 	"user://turbofat0.this-hour.save.bak",
 	"user://turbofat0.this-day.save.bak",
@@ -19,7 +17,7 @@ const OLD_SAVES_TO_DELETE := [
 	"user://turbofat0.prev-week.save.bak",
 ]
 
-# Player data filenames organized by save slot
+## Player data filenames organized by save slot
 const FILENAMES_BY_SAVE_SLOT: Dictionary = {
 	MiscSettings.SaveSlot.SLOT_A: "user://saveslot0.save",
 	MiscSettings.SaveSlot.SLOT_B: "user://saveslot1.save",
@@ -27,13 +25,13 @@ const FILENAMES_BY_SAVE_SLOT: Dictionary = {
 	MiscSettings.SaveSlot.SLOT_D: "user://saveslot3.save",
 }
 
-# Filename for saving/loading system data. Can be changed for tests
+## Filename for saving/loading system data. Can be changed for tests
 var data_filename := "user://config.json"
 
-# Filename for loading data older than July 2021. Can be changed for tests
+## Filename for loading data older than July 2021. Can be changed for tests
 var legacy_filename := "user://turbofat0.save"
 
-# Provides backwards compatibility with older save formats
+## Provides backwards compatibility with older save formats
 var _upgrader := SystemSaveUpgrader.new().new_save_item_upgrader()
 
 func _ready() -> void:
@@ -43,9 +41,7 @@ func _ready() -> void:
 	PlayerSave.load_player_data()
 
 
-"""
-Writes the system's in-memory data to a save file.
-"""
+## Writes the system's in-memory data to a save file.
 func save_system_data() -> void:
 	var save_json := []
 	save_json.append(_save_item("version", SYSTEM_DATA_VERSION).to_json_dict())
@@ -75,11 +71,9 @@ func save_system_data() -> void:
 			Directory.new().remove(filename)
 
 
-"""
-Populates the system's in-memory data based on a save file.
-
-Returns 'true' if the data is loaded successfully.
-"""
+## Populates the system's in-memory data based on a save file.
+##
+## Returns 'true' if the data is loaded successfully.
 func load_system_data() -> bool:
 	SystemData.reset()
 	
@@ -119,25 +113,19 @@ func load_system_data() -> bool:
 	return true
 
 
-"""
-Returns the playtime in seconds for the specified save slot.
-"""
+## Returns the playtime in seconds for the specified save slot.
 func get_save_slot_playtime(save_slot: int) -> float:
 	var filename: String = FILENAMES_BY_SAVE_SLOT[save_slot]
 	return PlayerSave.get_save_slot_playtime(filename)
 
 
-"""
-Returns the player's short name for the specified save slot.
-"""
+## Returns the player's short name for the specified save slot.
 func get_save_slot_player_short_name(save_slot: int) -> String:
 	var filename: String = FILENAMES_BY_SAVE_SLOT[save_slot]
 	return PlayerSave.get_save_slot_player_short_name(filename)
 
 
-"""
-Returns a human-readable name for the specified save slot.
-"""
+## Returns a human-readable name for the specified save slot.
 func get_save_slot_name(save_slot: int) -> String:
 	var prefix: String = MiscSettings.SAVE_SLOT_PREFIXES[save_slot]
 	var filename: String = FILENAMES_BY_SAVE_SLOT[save_slot]
@@ -150,9 +138,7 @@ func get_save_slot_name(save_slot: int) -> String:
 	return save_slot_name
 
 
-"""
-Deletes the specified save slot and all of its backups.
-"""
+## Deletes the specified save slot and all of its backups.
 func delete_save_slot(save_slot: int) -> void:
 	var filename: String = FILENAMES_BY_SAVE_SLOT[save_slot]
 	
@@ -168,12 +154,10 @@ func delete_save_slot(save_slot: int) -> void:
 	emit_signal("save_slot_deleted")
 
 
-"""
-Creates a granular save item. The system's configuration data includes many of these.
-
-Note: Intuitively this method would be a static factory method on the SaveItem class, but that causes console errors
-due to Godot #30668 (https://github.com/godotengine/godot/issues/30668)
-"""
+## Creates a granular save item. The system's configuration data includes many of these.
+##
+## Note: Intuitively this method would be a static factory method on the SaveItem class, but that causes console errors
+## due to Godot #30668 (https://github.com/godotengine/godot/issues/30668)
 func _save_item(type: String, value, key: String = "") -> SaveItem:
 	var save_item := SaveItem.new()
 	save_item.type = type
@@ -182,14 +166,12 @@ func _save_item(type: String, value, key: String = "") -> SaveItem:
 	return save_item
 
 
-"""
-Populates the player's in-memory data based on a single line from their save file.
-
-Parameters:
-	'type': A string unique to each type of data (level-data, player-data)
-	'_key': A string identifying a specific data item (sophie, marathon-normal)
-	'json_value': The value object (array, dictionary, string) containing the data
-"""
+## Populates the player's in-memory data based on a single line from their save file.
+##
+## Parameters:
+## 	'type': A string unique to each type of data (level-data, player-data)
+## 	'_key': A string identifying a specific data item (sophie, marathon-normal)
+## 	'json_value': The value object (array, dictionary, string) containing the data
 func _load_line(type: String, _key: String, json_value) -> void:
 	match type:
 		"version":

--- a/project/src/main/ui/bool-expression-evaluator.gd
+++ b/project/src/main/ui/bool-expression-evaluator.gd
@@ -1,21 +1,17 @@
 class_name BoolExpressionEvaluator
-"""
-Evaluates boolean expressions.
+## Evaluates boolean expressions.
+##
+## This includes expressions like 'not (level_finished level_001 or level_finished level_002)'.
 
-This includes expressions like 'not (level_finished level_001 or level_finished level_002)'.
-"""
-
-"""
-Evaluates the specified boolean expression based on the current game state.
-
-Parameters:
-	'string': The boolean expression to evaluate.
-	
-	'subject': The subject the specified boolean expression should be applied to.
-
-Returns:
-	'true' if the specified boolean expression is met by the current game state.
-"""
+## Evaluates the specified boolean expression based on the current game state.
+##
+## Parameters:
+## 	'string': The boolean expression to evaluate.
+##
+## 	'subject': The subject the specified boolean expression should be applied to.
+##
+## Returns:
+## 	'true' if the specified boolean expression is met by the current game state.
 static func evaluate(string: String, subject = null) -> bool:
 	var parser: BoolExpressionParser = BoolExpressionParser.new(string, subject)
 	var expression: BoolExpressionParser.BoolExpression = parser.parse()

--- a/project/src/main/ui/bool-expression-parser.gd
+++ b/project/src/main/ui/bool-expression-parser.gd
@@ -1,15 +1,11 @@
 class_name BoolExpressionParser
-"""
-Parses a string boolean expression into a tree of BoolExpressions.
+## Parses a string boolean expression into a tree of BoolExpressions.
+##
+## This is a recursive descent parser.
 
-This is a recursive descent parser.
-"""
-
-"""
-A lexical token which occurs in a boolean expression.
-
-This token represents a single word, and includes data about the occurrence of the word in the original statement.
-"""
+## A lexical token which occurs in a boolean expression.
+##
+## This token represents a single word, and includes data about the occurrence of the word in the original statement.
 class BoolToken:
 	var position: int
 	var string: String
@@ -22,11 +18,9 @@ class BoolToken:
 		return string
 
 
-"""
-An node in a tree of boolean expressions.
-
-This node includes information about how to evaluate the expression and its children.
-"""
+## An node in a tree of boolean expressions.
+##
+## This node includes information about how to evaluate the expression and its children.
 class BoolExpression:
 	var token: BoolToken
 	var args: Array
@@ -100,29 +94,27 @@ class NotableExpression extends BoolExpression:
 	func evaluate() -> bool:
 		return PlayerData.chat_history.get_filler_count(_creature_id) > 0
 
-# error encountered when parsing the boolean string
+## error encountered when parsing the boolean string
 var _parse_error: String
 
-# list of parsed BoolToken instances
+## list of parsed BoolToken instances
 var _tokens := []
 
-# the index of the next BoolToken to process in the token array
+## the index of the next BoolToken to process in the token array
 var _token_index := 0
 
-# the boolean string to parse
+## the boolean string to parse
 var _string: String
 
-# The target for which the boolean string is being evaluated, if evaluated for a specific creature or level.
+## The target for which the boolean string is being evaluated, if evaluated for a specific creature or level.
 var _subject
 
-"""
-Initializes the parser, parsing the specified string into a list of BoolTokens.
-
-Parameters:
-	'string': The boolean expression to parse.
-	
-	'subject': The subject the specified boolean expression should be applied to, such as a level or creature
-"""
+## Initializes the parser, parsing the specified string into a list of BoolTokens.
+##
+## Parameters:
+## 	'string': The boolean expression to parse.
+##
+## 	'subject': The subject the specified boolean expression should be applied to, such as a level or creature
 func _init(string: String, subject = null) -> void:
 	_string = string
 	_subject = subject
@@ -133,12 +125,10 @@ func _init(string: String, subject = null) -> void:
 		_tokens.append(chat_token)
 
 
-"""
-Parses a list of BoolTokens into a tree of BoolExpressions which can be evaluated.
-
-Returns:
-	The root of a BoolExpression tree representing the parsed boolean string.
-"""
+## Parses a list of BoolTokens into a tree of BoolExpressions which can be evaluated.
+##
+## Returns:
+## 	The root of a BoolExpression tree representing the parsed boolean string.
 func parse() -> BoolExpression:
 	var expression := _parse_or()
 	if _token_index < _tokens.size():
@@ -146,9 +136,7 @@ func parse() -> BoolExpression:
 	return expression
 
 
-"""
-Parses an 'or' chat token, as well as any tokens of higher precedence (and, not, functions, parentheses).
-"""
+## Parses an 'or' chat token, as well as any tokens of higher precedence (and, not, functions, parentheses).
 func _parse_or() -> BoolExpression:
 	if _parse_error:
 		return null
@@ -159,9 +147,7 @@ func _parse_or() -> BoolExpression:
 	return expression
 
 
-"""
-Parses an 'and' chat token, as well as any tokens of higher precedence (not, functions, parentheses).
-"""
+## Parses an 'and' chat token, as well as any tokens of higher precedence (not, functions, parentheses).
 func _parse_and() -> BoolExpression:
 	if _parse_error:
 		return null
@@ -172,9 +158,7 @@ func _parse_and() -> BoolExpression:
 	return expression
 
 
-"""
-Parses a 'not' chat token, as well as any tokens of higher precedence (functions, parentheses).
-"""
+## Parses a 'not' chat token, as well as any tokens of higher precedence (functions, parentheses).
 func _parse_not() -> BoolExpression:
 	if _parse_error:
 		return null
@@ -187,11 +171,9 @@ func _parse_not() -> BoolExpression:
 	return expression
 
 
-"""
-Parses a 'function' chat token, specifying a function to be evaluated.
-
-Also evaluates any tokens of higher precedence (parentheses).
-"""
+## Parses a 'function' chat token, specifying a function to be evaluated.
+##
+## Also evaluates any tokens of higher precedence (parentheses).
 func _parse_function() -> BoolExpression:
 	if _parse_error:
 		return null
@@ -213,11 +195,9 @@ func _parse_function() -> BoolExpression:
 	return expression
 
 
-"""
-Parses an 'atom' chat token; a series of tokens within parentheses.
-
-Reports errors if the next chat token is not an open parenthesis.
-"""
+## Parses an 'atom' chat token; a series of tokens within parentheses.
+##
+## Reports errors if the next chat token is not an open parenthesis.
 func _parse_atom() -> BoolExpression:
 	if _parse_error:
 		return null
@@ -233,9 +213,7 @@ func _parse_atom() -> BoolExpression:
 	return expression
 
 
-"""
-Advances to the next token, throwing an error if it does not match the specified token string.
-"""
+## Advances to the next token, throwing an error if it does not match the specified token string.
 func _expect_token(token_string: String) -> void:
 	var next_token := _peek_next_token()
 	if not next_token:
@@ -248,9 +226,7 @@ func _expect_token(token_string: String) -> void:
 	_get_next_token()
 
 
-"""
-Returns the next token without advancing the token index.
-"""
+## Returns the next token without advancing the token index.
 func _peek_next_token() -> BoolToken:
 	var next_token: BoolToken = null
 	if _token_index < _tokens.size():
@@ -258,17 +234,13 @@ func _peek_next_token() -> BoolToken:
 	return next_token
 
 
-"""
-Returns the next token string without advancing the token index.
-"""
+## Returns the next token string without advancing the token index.
 func _peek_next_token_string() -> String:
 	var next_token := _peek_next_token()
 	return next_token.string if next_token else ""
 
 
-"""
-Returns the next token and advances the token index.
-"""
+## Returns the next token and advances the token index.
 func _get_next_token() -> BoolToken:
 	var next_token: BoolToken = null
 	if _token_index < _tokens.size():
@@ -277,12 +249,10 @@ func _get_next_token() -> BoolToken:
 	return next_token
 
 
-"""
-Records and reports a parse error.
-
-This error is recorded to ensure the parser doesn't continue parsing and encountering further errors. It is also
-recorded for unit tests.
-"""
+## Records and reports a parse error.
+##
+## This error is recorded to ensure the parser doesn't continue parsing and encountering further errors. It is also
+## recorded for unit tests.
 func _report_error(position: int, error_description: String) -> void:
 	if _parse_error:
 		# don't report a second error. it's redundant and overwrites the first

--- a/project/src/main/ui/button-shortcut-helper.gd
+++ b/project/src/main/ui/button-shortcut-helper.gd
@@ -1,24 +1,22 @@
 extends Node
-"""
-Manages shortcuts for buttons in some weird edge cases.
+## Manages shortcuts for buttons in some weird edge cases.
+##
+## Sometimes we want two actions to activate a button, such as a menu which is launched with the start button. The
+## player would expect the 'back' button or 'menu' button to close the menu, but only one shortcut can be bound to the
+## closing of the menu. This node is capable of assigning a second shortcut to a button.
+##
+## Sometimes we want two actions assigned to the same key, such as the 'escape' key which is bound to both 'ui_back'
+## and 'ui_menu'. But, sometimes a menu might include separate cancel and menu buttons, in which case 'escape' would
+## press both. This node is capable of overriding that behavior, and pressing only one button when two actions are
+## activated simultaneously.
 
-Sometimes we want two actions to activate a button, such as a menu which is launched with the start button. The player
-would expect the 'back' button or 'menu' button to close the menu, but only one shortcut can be bound to the closing
-of the menu. This node is capable of assigning a second shortcut to a button.
-
-Sometimes we want two actions assigned to the same key, such as the 'escape' key which is bound to both 'ui_back' and
-'ui_menu'. But, sometimes a menu might include separate cancel and menu buttons, in which case 'escape' would press
-both. This node is capable of overriding that behavior, and pressing only one button when two actions are activated
-simultaneously.
-"""
-
-# the action which activates the button
+## the action which activates the button
 export (String) var action: String
 
-# (optional) a second action which is also required to activate the button
+## (optional) a second action which is also required to activate the button
 export (String) var overridden_action: String
 
-# the button this helper will activate
+## the button this helper will activate
 onready var button: Button = get_parent()
 
 func _input(event: InputEvent) -> void:

--- a/project/src/main/ui/chat/chat-advancer.gd
+++ b/project/src/main/ui/chat/chat-advancer.gd
@@ -1,23 +1,21 @@
 class_name ChatAdvancer
 extends Node
-"""
-Allows the player to advance through a chat tree, and rewind through past chat events.
-"""
+## Allows the player to advance through a chat tree, and rewind through past chat events.
 
-# tree of chat events the player can page through
+## tree of chat events the player can page through
 var chat_tree: ChatTree
 
-# historical array of ChatEvents the player can rewind through
+## historical array of ChatEvents the player can rewind through
 var _prev_chat_events := []
 var _prev_chat_event_index := 0
 
-# 'true' if the player is currently rewinding through the chat history
+## 'true' if the player is currently rewinding through the chat history
 var rewinding_text := false
 
-# emitted when a chat event (new or historical) is shown to the player
+## emitted when a chat event (new or historical) is shown to the player
 signal chat_event_shown(chat_event)
 
-# emitted when the chat sequence ends, and the window should close
+## emitted when the chat sequence ends, and the window should close
 signal chat_finished
 
 func play_chat_tree(new_chat_tree: ChatTree) -> void:
@@ -27,9 +25,7 @@ func play_chat_tree(new_chat_tree: ChatTree) -> void:
 	emit_signal("chat_event_shown", current_chat_event())
 
 
-"""
-Rewind to a previously shown chat line.
-"""
+## Rewind to a previously shown chat line.
 func rewind() -> void:
 	var did_decrement := false
 	if _prev_chat_events.size() < 2:
@@ -49,12 +45,10 @@ func rewind() -> void:
 		emit_signal("chat_event_shown", current_chat_event())
 
 
-"""
-Advance to the next chat line.
-
-This is most likely the next spoken chat line if the player is advancing chat normally. However, it can also be a
-historical chat line if the player was rewinding chat.
-"""
+## Advance to the next chat line.
+##
+## This is most likely the next spoken chat line if the player is advancing chat normally. However, it can also be a
+## historical chat line if the player was rewinding chat.
 func advance() -> void:
 	var did_increment := false
 	if rewinding_text:
@@ -80,11 +74,9 @@ func advance() -> void:
 		emit_signal("chat_finished")
 
 
-"""
-The current chat event being shown to the player.
-
-This could either be the newest chat event, or a historical one they're rewinding through.
-"""
+## The current chat event being shown to the player.
+##
+## This could either be the newest chat event, or a historical one they're rewinding through.
 func current_chat_event() -> ChatEvent:
 	var chat_event: ChatEvent
 	if rewinding_text:
@@ -94,9 +86,7 @@ func current_chat_event() -> ChatEvent:
 	return chat_event
 
 
-"""
-Returns 'true' if we're at a chat branch and should prompt the player.
-"""
+## Returns 'true' if we're at a chat branch and should prompt the player.
 func should_prompt() -> bool:
 	var result := true
 	var chat_event:ChatEvent = current_chat_event()
@@ -111,9 +101,7 @@ func should_prompt() -> bool:
 	return result
 
 
-"""
-Record the last 100 chat events so the player can review them later.
-"""
+## Record the last 100 chat events so the player can review them later.
 func _on_ChatUi_chat_event_played(chat_event: ChatEvent) -> void:
 	_prev_chat_events.append(chat_event)
 	while _prev_chat_events.size() > 100:

--- a/project/src/main/ui/chat/chat-choice-button.gd
+++ b/project/src/main/ui/chat/chat-choice-button.gd
@@ -1,13 +1,11 @@
 class_name ChatChoiceButton
 extends Button
-"""
-Shows a button corresponding to a chat branch the player can choose.
-"""
+## Shows a button corresponding to a chat branch the player can choose.
 
-# emitted after pop_choose() is invoked and the animation completes
+## emitted after pop_choose() is invoked and the animation completes
 signal pop_choose_completed
 
-# Text to show the player. We cannot use the button's text property because it does not support multiline text.
+## Text to show the player. We cannot use the button's text property because it does not support multiline text.
 export (String) var choice_text: String setget set_choice_text
 
 func _ready() -> void:
@@ -17,12 +15,10 @@ func _ready() -> void:
 	_set_pivot_to_center()
 
 
-"""
-Sets the text corresponding to the chat branch.
-
-This is distinct from the button's 'text' property. We don't use the button's 'text' property because button text
-cannot wrap.
-"""
+## Sets the text corresponding to the chat branch.
+##
+## This is distinct from the button's 'text' property. We don't use the button's 'text' property because button text
+## cannot wrap.
 func set_choice_text(new_choice_text: String) -> void:
 	choice_text = new_choice_text
 	if has_node("FontFitLabel"):
@@ -30,77 +26,57 @@ func set_choice_text(new_choice_text: String) -> void:
 		$FontFitLabel.pick_largest_font()
 
 
-"""
-Makes the chat choice appear.
-"""
+## Makes the chat choice appear.
 func pop_in() -> void:
 	$PopTween.pop_in()
 
 
-"""
-Makes the chat choice disappear.
-"""
+## Makes the chat choice disappear.
 func pop_out() -> void:
 	$PopTween.pop_out()
 
 
-"""
-Called when this chat choice is chosen by the player. Animates it and makes it disappear.
-"""
+## Called when this chat choice is chosen by the player. Animates it and makes it disappear.
 func pop_choose() -> void:
 	$PopTween.remove_all()
 	$PopAnimation.play("choose")
 	$MoodSprite/AnimationPlayer.play("choose")
 
 
-"""
-Sets the mood corresponding to the chat choice.
-"""
+## Sets the mood corresponding to the chat choice.
 func set_mood(new_mood: int) -> void:
 	$MoodSprite.set_mood(new_mood)
 
 
-"""
-Sets the location of the mood icon.
-"""
+## Sets the location of the mood icon.
 func set_mood_right(new_mood_right: bool) -> void:
 	$MoodSprite.set_mood_right(new_mood_right)
 
 
-"""
-Workaround for Godot #21789 to make get_class return class_name
-"""
+## Workaround for Godot #21789 to make get_class return class_name
 func get_class() -> String:
 	return "ChatChoiceButton"
 
 
-"""
-Workaround for Godot #21789 to make is_class match class_name
-"""
+## Workaround for Godot #21789 to make is_class match class_name
 func is_class(name: String) -> bool:
 	return name == "ChatChoiceButton" or .is_class(name)
 
 
-"""
-Centers the pivot in the button's rectangle.
-"""
+## Centers the pivot in the button's rectangle.
 func _set_pivot_to_center() -> void:
 	rect_pivot_offset = rect_size * 0.5
 
 
-"""
-When the chat choice is focused, it animates more visibly. The MoodSprite also becomes more transparent so the player
-can read the text behind it.
-"""
+## When the chat choice is focused, it animates more visibly. The MoodSprite also becomes more transparent so the
+## player can read the text behind it.
 func _on_focus_entered() -> void:
 	$FontFitLabel.set("custom_colors/font_color", Color.white)
 	$MoodSprite/AnimationPlayer.play("focus")
 	$MoodSprite/AnimationPlayer.advance(randf() * 2.5)
 
 
-"""
-When the chat choice is unfocused, its animations are subtler.
-"""
+## When the chat choice is unfocused, its animations are subtler.
 func _on_focus_exited() -> void:
 	$FontFitLabel.set("custom_colors/font_color", Color("6c4331"))
 	$MoodSprite/AnimationPlayer.play("default")

--- a/project/src/main/ui/chat/chat-choice-tween.gd
+++ b/project/src/main/ui/chat/chat-choice-tween.gd
@@ -1,6 +1,6 @@
 extends Tween
 
-# the size the chat shrinks to when it disappears
+## the size the chat shrinks to when it disappears
 const POP_OUT_SCALE := Vector2(0.5, 0.5)
 
 onready var _chat_choice := get_parent()
@@ -10,11 +10,9 @@ func _ready() -> void:
 	_reset_chat_choice()
 
 
-"""
-Makes the chat choice appear.
-
-Enlarges the chat choice in a bouncy way and makes it opaque.
-"""
+## Makes the chat choice appear.
+##
+## Enlarges the chat choice in a bouncy way and makes it opaque.
 func pop_in() -> void:
 	# All container controls in Godot reset the scale of their children to their own scale. If we don't reassign the
 	# scale before launching the tween then the rect_scale property won't be interpolated.
@@ -23,18 +21,14 @@ func pop_in() -> void:
 	_interpolate_pop(true)
 
 
-"""
-Makes the chat choice disappear.
-
-Shrinks the chat choice in a bouncy way and makes it transparent.
-"""
+## Makes the chat choice disappear.
+##
+## Shrinks the chat choice in a bouncy way and makes it transparent.
 func pop_out() -> void:
 	_interpolate_pop(false)
 
 
-"""
-Pops the chat choice in/out.
-"""
+## Pops the chat choice in/out.
 func _interpolate_pop(popping_in: bool) -> void:
 	remove(_chat_choice, "modulate")
 	remove(_chat_choice, "rect_scale:x")
@@ -52,11 +46,9 @@ func _interpolate_pop(popping_in: bool) -> void:
 	start()
 
 
-"""
-Presets the chat choice to a known invisible state.
-
-This doesn't use a tween. It's meant for setup/teardown steps the player should never see.
-"""
+## Presets the chat choice to a known invisible state.
+##
+## This doesn't use a tween. It's meant for setup/teardown steps the player should never see.
 func _reset_chat_choice() -> void:
 	remove_all()
 	_chat_choice.modulate = Color.transparent

--- a/project/src/main/ui/chat/chat-choices.gd
+++ b/project/src/main/ui/chat/chat-choices.gd
@@ -1,23 +1,21 @@
 class_name ChatChoices
 extends GridContainer
-"""
-Shows buttons corresponding to chat branches the player can choose.
-"""
+## Shows buttons corresponding to chat branches the player can choose.
 
 signal chat_choice_chosen(choice_index)
 
-# The most branches we can display at once. Branches beyond this will not be displayed.
+## The most branches we can display at once. Branches beyond this will not be displayed.
 const MAX_LABELS := 6
 
-# Time in seconds for all of the chat choices to pop up.
+## Time in seconds for all of the chat choices to pop up.
 const TOTAL_POP_IN_DELAY := 0.3
 
 export (PackedScene) var ChatChoiceButtonScene
 
-# Strings to show the player for each chat branch.
+## Strings to show the player for each chat branch.
 var _choices := []
 
-# Moods corresponding to each chat branch; -1 for branches with no mood.
+## Moods corresponding to each chat branch; -1 for branches with no mood.
 var _moods := []
 
 func _ready() -> void:
@@ -25,15 +23,13 @@ func _ready() -> void:
 	_refresh_child_buttons()
 
 
-"""
-Repositions the buttons based on the amount of chat text shown.
-
-If a lot of chat text is displayed, the buttons are flush against the right side of the window and narrow. If less chat
-is displayed, the buttons are closer to the center and wider.
-
-Parameters:
-	'chat_line_size': An enum from ChatTheme.ChatLineSize corresponding to the amount of chat text displayed.
-"""
+## Repositions the buttons based on the amount of chat text shown.
+##
+## If a lot of chat text is displayed, the buttons are flush against the right side of the window and narrow. If less
+## chat is displayed, the buttons are closer to the center and wider.
+##
+## Parameters:
+## 	'chat_line_size': An enum from ChatTheme.ChatLineSize corresponding to the amount of chat text displayed.
 func reposition(chat_line_size: int) -> void:
 	match chat_line_size:
 		ChatTheme.LINE_SMALL:
@@ -47,16 +43,14 @@ func reposition(chat_line_size: int) -> void:
 			rect_size = Vector2(200, 240)
 
 
-"""
-Displays a set of buttons corresponding to chat choices.
-
-Parameters:
-	'choices': Strings to show the player for each chat branch.
-	
-	'moods': An array of ChatEvent.Mood instances for each chat branch
-	
-	'new_columns': (Optional) The number of columns to organize the chat events into.
-"""
+## Displays a set of buttons corresponding to chat choices.
+##
+## Parameters:
+## 	'choices': Strings to show the player for each chat branch.
+##
+## 	'moods': An array of ChatEvent.Mood instances for each chat branch
+##
+## 	'new_columns': (Optional) The number of columns to organize the chat events into.
 func show_choices(choices: Array, moods: Array, new_columns: int = 0) -> void:
 	visible = true
 	_choices = choices
@@ -87,11 +81,9 @@ func is_showing_choices() -> bool:
 	return not _choices.empty()
 
 
-"""
-Makes all the chat choice buttons disappear.
-
-The chat choice buttons are immediately deleted without any sort of animation.
-"""
+## Makes all the chat choice buttons disappear.
+##
+## The chat choice buttons are immediately deleted without any sort of animation.
 func hide_choices() -> void:
 	visible = false
 	_choices = []
@@ -117,9 +109,7 @@ func _button(node: Node) -> ChatChoiceButton:
 	return result
 
 
-"""
-Removes and recreates all chat choice buttons.
-"""
+## Removes and recreates all chat choice buttons.
 func _refresh_child_buttons() -> void:
 	for child in get_tree().get_nodes_in_group("chat_choices"):
 		child.queue_free()
@@ -164,11 +154,9 @@ func _on_ChatChoiceButton_gui_input(_event: InputEvent) -> void:
 	get_tree().set_input_as_handled()
 
 
-"""
-Makes all the chat choice buttons disappear and emits a signal with the player's selected choice.
-
-The chat choice buttons remain as children of this node so they can be animated away.
-"""
+## Makes all the chat choice buttons disappear and emits a signal with the player's selected choice.
+##
+## The chat choice buttons remain as children of this node so they can be animated away.
 func _on_ChatChoiceButton_pressed() -> void:
 	if not $EnableInputTimer.is_stopped():
 		# don't let the player mash through chat choices accidentally

--- a/project/src/main/ui/chat/chat-event.gd
+++ b/project/src/main/ui/chat/chat-event.gd
@@ -1,7 +1,5 @@
 class_name ChatEvent
-"""
-Contains details for a line of spoken text shown to the player.
-"""
+## Contains details for a line of spoken text shown to the player.
 
 enum Mood {
 	NONE,
@@ -40,44 +38,42 @@ enum NametagSide {
 	RIGHT,
 }
 
-# The name of the person speaking, or blank if nobody is speaking
+## The name of the person speaking, or blank if nobody is speaking
 var who := ""
 
-# whether the chatter's nametag should be drawn on the right/left side of the frame
+## whether the chatter's nametag should be drawn on the right/left side of the frame
 var nametag_side: int = NametagSide.NO_PREFERENCE
 
-# The chat line
+## The chat line
 var text: String
 
-# The behavior the chatter should perform while saying the text (laughing, sweating, etc)
+## The behavior the chatter should perform while saying the text (laughing, sweating, etc)
 var mood: int = Mood.NONE
 
-# Metadata about the chat event, such as whether it should launch a level
+## Metadata about the chat event, such as whether it should launch a level
 var meta: Array
 
-# List of string keys corresponding to branches off of this chat event.
+## List of string keys corresponding to branches off of this chat event.
 var links: Array
 
-# List of string chat texts corresponding to branches off of this chat event.
+## List of string chat texts corresponding to branches off of this chat event.
 var link_texts: Array
 
-# List of int chat moods corresponding to branches off of this chat event.
+## List of int chat moods corresponding to branches off of this chat event.
 var link_moods: Array
 
-# List of Array metadatas about the links, such as which conditions should enable it
+## List of Array metadatas about the links, such as which conditions should enable it
 var link_metas: Array
 
-"""
-The chat window changes its appearance based on who's talking. For example, one character's speech might be blue with
-a black background, and giant blue soccer balls in the background. The 'chat_theme_def' property defines the chat
-window's appearance, such as 'blue', 'soccer balls' and 'giant'.
-
-'chat_theme_def/accent_scale': The scale of the accent's background texture
-'chat_theme_def/accent_swapped': If 'true', the accent's foreground/background colors will be swapped
-'chat_theme_def/accent_texture': A number in the range [0, 15] referring to a background texture
-'chat_theme_def/color': The color of the chat window
-'chat_theme_def/dark': True/false for whether the chat line window's background should be black/white
-"""
+## The chat window changes its appearance based on who's talking. For example, one character's speech might be blue
+## with a black background, and giant blue soccer balls in the background. The 'chat_theme_def' property defines the
+## chat window's appearance, such as 'blue', 'soccer balls' and 'giant'.
+##
+## 'chat_theme_def/accent_scale': The scale of the accent's background texture
+## 'chat_theme_def/accent_swapped': If 'true', the accent's foreground/background colors will be swapped
+## 'chat_theme_def/accent_texture': A number in the range [0, 15] referring to a background texture
+## 'chat_theme_def/color': The color of the chat window
+## 'chat_theme_def/dark': True/false for whether the chat line window's background should be black/white
 var chat_theme_def: Dictionary
 
 func add_link(link: String, link_text: String, link_mood: int) -> void:
@@ -101,9 +97,7 @@ func enabled_link_indexes() -> Array:
 	return enabled_link_indexes
 
 
-"""
-Returns 'true' if this chat event represents something the player is thinking.
-"""
+## Returns 'true' if this chat event represents something the player is thinking.
 func is_thought() -> bool:
 	return text.begins_with("(") and text.ends_with(")") and not who
 

--- a/project/src/main/ui/chat/chat-frame.gd
+++ b/project/src/main/ui/chat/chat-frame.gd
@@ -1,18 +1,16 @@
 class_name ChatFrame
 extends Control
-"""
-Window which displays a chat line.
-
-The chat window is decorated with objects in the background called 'accents'. These accents can be injected with the
-set_chat_theme_def function to configure the chat window's appearance.
-"""
+## Window which displays a chat line.
+##
+## The chat window is decorated with objects in the background called 'accents'. These accents can be injected with the
+## set_chat_theme_def function to configure the chat window's appearance.
 
 signal pop_out_completed
 
-# emitted after the full chat line is typed out onscreen
+## emitted after the full chat line is typed out onscreen
 signal all_text_shown
 
-# 'true' after pop_in is called, and 'false' after pop_out is called
+## 'true' after pop_in is called, and 'false' after pop_out is called
 var _popped_in := false
 var _squished := false
 
@@ -21,9 +19,7 @@ func _ready() -> void:
 	$ChatLinePanel/NametagPanel.hide_labels()
 
 
-"""
-Makes the chat window appear.
-"""
+## Makes the chat window appear.
 func pop_in() -> void:
 	if _popped_in:
 		# chat window is already popped in
@@ -35,9 +31,7 @@ func pop_in() -> void:
 	$PopInSound.play()
 
 
-"""
-Makes the chat window disappear.
-"""
+## Makes the chat window disappear.
 func pop_out() -> void:
 	if not _popped_in:
 		# chat window is already popped out
@@ -47,12 +41,10 @@ func pop_out() -> void:
 	$PopOutSound.play()
 
 
-"""
-Animates the chat UI to gradually reveal the specified text, mimicking speech.
-
-Also updates the chat UI's appearance based on the amount of text being displayed and the specified color and
-background texture.
-"""
+## Animates the chat UI to gradually reveal the specified text, mimicking speech.
+##
+## Also updates the chat UI's appearance based on the amount of text being displayed and the specified color and
+## background texture.
 func play_chat_event(chat_event: ChatEvent, squished: bool) -> void:
 	if not $ChatLineLabel.visible:
 		# Ensure the chat window is showing before we start changing its text and playing sounds
@@ -99,9 +91,7 @@ func make_all_text_visible() -> void:
 	$ChatLineLabel.make_all_text_visible()
 
 
-"""
-Returns the size of the chat line window needed to display the chat line text.
-"""
+## Returns the size of the chat line window needed to display the chat line text.
 func get_chat_line_size() -> int:
 	return $ChatLineLabel.chosen_size_index
 

--- a/project/src/main/ui/chat/chat-history.gd
+++ b/project/src/main/ui/chat/chat-history.gd
@@ -1,41 +1,31 @@
 class_name ChatHistory
-"""
-Stores a history of conversations the player's had.
+## Stores a history of conversations the player's had.
+##
+## Keeps track of which conversations the player's had and how long ago they've had them.
 
-Keeps track of which conversations the player's had and how long ago they've had them.
-"""
-
-"""
-Constant for the age of conversations we've never had. This is a large number so that evaluating 'have we had this
-conversation recently?' will work without requiring a third branch to handle the case where we haven't had a
-conversation before.
-"""
+## Constant for the age of conversations we've never had. This is a large number so that evaluating 'have we had this
+## conversation recently?' will work without requiring a third branch to handle the case where we haven't had a
+## conversation before.
 const CHAT_AGE_NEVER := 99999999
 
-"""
-Tracks which conversations the player has had with each creature. The value is a per-creature index which starts from
-0 and increments with each conversation with that creature.
-
-key: chat key
-value: ordering of when the chat happened (smaller is older)
-"""
+## Tracks which conversations the player has had with each creature. The value is a per-creature index which starts
+## from 0 and increments with each conversation with that creature.
+##
+## key: chat key
+## value: ordering of when the chat happened (smaller is older)
 var chat_history: Dictionary
 
-"""
-Tracks the number of conversations the player has had with each creature.
-
-key: chat key fragment
-value: int corresponding to number of chats with a character
-"""
+## Tracks the number of conversations the player has had with each creature.
+##
+## key: chat key fragment
+## value: int corresponding to number of chats with a character
 var chat_counts: Dictionary
 
-"""
-Tracks the number of consecutive filler chats for each creature. After a creature has enough filler chats, they'll
-have a more serious or interesting conversation.
-
-key: creature id
-value: number of consecutive filler chats
-"""
+## Tracks the number of consecutive filler chats for each creature. After a creature has enough filler chats, they'll
+## have a more serious or interesting conversation.
+##
+## key: creature id
+## value: number of consecutive filler chats
 var filler_counts: Dictionary
 
 func reset() -> void:
@@ -72,11 +62,9 @@ func delete_history_item(chat_key: String) -> void:
 	chat_history.erase(chat_key)
 
 
-"""
-Returns how long ago the player had the specified chat.
-
-Used to avoid repeating conversations too frequently.
-"""
+## Returns how long ago the player had the specified chat.
+##
+## Used to avoid repeating conversations too frequently.
 func get_chat_age(chat_key: String) -> int:
 	# We subtract the index assigned to the chat history from the total number
 	# of chats for that creature to calculate the entry's age.
@@ -111,12 +99,10 @@ func from_json_dict(json: Dictionary) -> void:
 	_convert_float_values_to_ints(filler_counts)
 
 
-"""
-Converts the float values in a Dictionary to int values.
-
-Godot's JSON parser converts all ints into floats, so we need to change them back. See Godot #9499
-https://github.com/godotengine/godot/issues/9499
-"""
+## Converts the float values in a Dictionary to int values.
+##
+## Godot's JSON parser converts all ints into floats, so we need to change them back. See Godot #9499
+## https://github.com/godotengine/godot/issues/9499
 func _convert_float_values_to_ints(dict: Dictionary) -> void:
 	for key in dict:
 		if dict[key] is float:

--- a/project/src/main/ui/chat/chat-library.gd
+++ b/project/src/main/ui/chat/chat-library.gd
@@ -1,30 +1,26 @@
 extends Node
-"""
-Loads chat lines from files.
-
-Chat lines are stored as a set of chatscript resources. This class loads those resources into ChatTree instances so
-they can be fed into the UI.
-"""
+## Loads chat lines from files.
+##
+## Chat lines are stored as a set of chatscript resources. This class loads those resources into ChatTree instances so
+## they can be fed into the UI.
 
 const CHAT_EXTENSION := ".chat"
 
 const PREROLL_SUFFIX := "000"
 const POSTROLL_SUFFIX := "100"
 
-"""
-Returns the chat tree for the specified creature.
-
-Each creature has a sequence of conversations defined by their 'chat selectors'. This method goes through a creature's
-chat selectors until it finds one suitable for the current game state.
-
-Returns null if the chat tree cannot be found.
-
-Parameters:
-	'creature': The creature whose conversation should be returned
-
-	'forced_level_id': (Optional) The current level being chosen. If omitted, the level_id will be calculated based on
-			the first unfinished unlocked level available.
-"""
+## Returns the chat tree for the specified creature.
+##
+## Each creature has a sequence of conversations defined by their 'chat selectors'. This method goes through a
+## creature's chat selectors until it finds one suitable for the current game state.
+##
+## Returns null if the chat tree cannot be found.
+##
+## Parameters:
+## 	'creature': The creature whose conversation should be returned
+##
+## 	'forced_level_id': (Optional) The current level being chosen. If omitted, the level_id will be calculated based on
+## 			the first unfinished unlocked level available.
 func chat_tree_for_creature(creature: Creature) -> ChatTree:
 	var filler_ids := filler_ids_for_creature(creature.creature_id)
 	var chosen_chat := select_from_chat_selectors(creature.chat_selectors, creature.creature_id, filler_ids)
@@ -36,11 +32,9 @@ func chat_tree_for_creature(creature: Creature) -> ChatTree:
 	return chat_tree
 
 
-"""
-Returns the chat tree for the specified creature and chat id.
-
-Returns null if the chat tree cannot be found.
-"""
+## Returns the chat tree for the specified creature and chat id.
+##
+## Returns null if the chat tree cannot be found.
 func chat_tree_for_creature_chat_id(creature_def: CreatureDef, chat_id: String) -> ChatTree:
 	var chat_tree: ChatTree
 	if FileUtils.file_exists(_creature_chat_path(creature_def.creature_id, chat_id)):
@@ -48,22 +42,18 @@ func chat_tree_for_creature_chat_id(creature_def: CreatureDef, chat_id: String) 
 	return chat_tree
 
 
-"""
-Returns the chat tree for the specified chat key, such as 'chat/marsh_prologue'.
-
-Parameters:
-	'chat_key': A key such as 'chat/marsh_prologue' identifying a chat resource
-"""
+## Returns the chat tree for the specified chat key, such as 'chat/marsh_prologue'.
+##
+## Parameters:
+## 	'chat_key': A key such as 'chat/marsh_prologue' identifying a chat resource
 func chat_tree_for_key(chat_key: String) -> ChatTree:
 	var path := path_from_chat_key(chat_key)
 	return chat_tree_from_file(path)
 
 
-"""
-Returns the chat tree for the cutscene which plays before the current level.
-
-Returns null if the current level does not have a preroll cutscene.
-"""
+## Returns the chat tree for the cutscene which plays before the current level.
+##
+## Returns null if the current level does not have a preroll cutscene.
 func chat_tree_for_preroll(level_id: String) -> ChatTree:
 	if not has_preroll(level_id):
 		return null
@@ -71,11 +61,9 @@ func chat_tree_for_preroll(level_id: String) -> ChatTree:
 	return chat_tree_from_file(_preroll_path(level_id))
 
 
-"""
-Returns the chat tree for the cutscene which plays after the current level.
-
-Returns null if the current level does not have a postroll cutscene.
-"""
+## Returns the chat tree for the cutscene which plays after the current level.
+##
+## Returns null if the current level does not have a postroll cutscene.
 func chat_tree_for_postroll(level_id: String) -> ChatTree:
 	if not has_postroll(level_id):
 		return null
@@ -83,23 +71,17 @@ func chat_tree_for_postroll(level_id: String) -> ChatTree:
 	return chat_tree_from_file(_postroll_path(level_id))
 
 
-"""
-Returns 'true' if the current level is preceded by a cutscene.
-"""
+## Returns 'true' if the current level is preceded by a cutscene.
 func has_preroll(level_id: String) -> bool:
 	return FileUtils.file_exists(_preroll_path(level_id))
 
 
-"""
-Returns 'true' if the current level is followed by a cutscene.
-"""
+## Returns 'true' if the current level is followed by a cutscene.
 func has_postroll(level_id: String) -> bool:
 	return FileUtils.file_exists(_postroll_path(level_id))
 
 
-"""
-Returns a ChatIcon enum representing the creature's next conversation.
-"""
+## Returns a ChatIcon enum representing the creature's next conversation.
 func chat_icon_for_creature(creature: Creature) -> int:
 	var result := ChatIcon.NONE
 	if creature == ChattableManager.sensei or creature == ChattableManager.player:
@@ -117,9 +99,7 @@ func chat_icon_for_creature(creature: Creature) -> int:
 	return result
 
 
-"""
-Loads the chat events from the specified file.
-"""
+## Loads the chat events from the specified file.
 func chat_tree_from_file(path: String) -> ChatTree:
 	var result: ChatTree
 	if path.ends_with(CHAT_EXTENSION):
@@ -129,12 +109,10 @@ func chat_tree_from_file(path: String) -> ChatTree:
 	return result
 
 
-"""
-Calculates the chat id for the current conversation.
-
-This method goes through a creature's chat selectors until it finds one suitable for the current game state. If none
-are found, it returns a filler conversation instead.
-"""
+## Calculates the chat id for the current conversation.
+##
+## This method goes through a creature's chat selectors until it finds one suitable for the current game state. If none
+## are found, it returns a filler conversation instead.
 func select_from_chat_selectors(chat_selectors: Array, creature_id: String, filler_ids: Array) -> String:
 	var result: String
 	
@@ -187,11 +165,9 @@ func select_from_chat_selectors(chat_selectors: Array, creature_id: String, fill
 	return result
 
 
-"""
-Returns the chat filler IDs for the specified creature.
-
-Examines the creature's chat and resource files, and returns any chat ids with names like 'filler_014'.
-"""
+## Returns the chat filler IDs for the specified creature.
+##
+## Examines the creature's chat and resource files, and returns any chat ids with names like 'filler_014'.
 func filler_ids_for_creature(creature_id: String) -> Array:
 	var filler_ids := []
 	for i in range(1000):
@@ -205,12 +181,10 @@ func filler_ids_for_creature(creature_id: String) -> Array:
 	return filler_ids
 
 
-"""
-Add lull characters to the specified string.
-
-Lull characters make the chat UI briefly pause at parts of the chat line. We add these after periods, commas and other
-punctuation.
-"""
+## Add lull characters to the specified string.
+##
+## Lull characters make the chat UI briefly pause at parts of the chat line. We add these after periods, commas and
+## other punctuation.
 func add_lull_characters(s: String) -> String:
 	if "/" in s:
 		# if the sentence already contains lull characters, we leave it alone
@@ -238,11 +212,9 @@ func add_lull_characters(s: String) -> String:
 	return transformer.transformed
 
 
-"""
-Add many lull characters to the specified string to make it pause after every character.
-
-This can be used for very short sentences like 'OH, MY!!!'
-"""
+## Add many lull characters to the specified string to make it pause after every character.
+##
+## This can be used for very short sentences like 'OH, MY!!!'
 func add_mega_lull_characters(s: String) -> String:
 	var transformer := StringTransformer.new(s)
 	
@@ -262,9 +234,7 @@ func _creature_chat_path(creature_id: String, chat_id: String) -> String:
 			[creature_id, StringUtils.underscores_to_hyphens(chat_id), CHAT_EXTENSION]
 
 
-"""
-Loads the chat events from the specified chatscript file.
-"""
+## Loads the chat events from the specified chatscript file.
 func _chat_tree_from_chatscript_file(path: String) -> ChatTree:
 	var chat_tree: ChatTree
 	if not FileUtils.file_exists(path):
@@ -287,18 +257,16 @@ func _postroll_path(level_id: String) -> String:
 			[StringUtils.underscores_to_hyphens(level_id), POSTROLL_SUFFIX, CHAT_EXTENSION]
 
 
-"""
-Converts a path like 'res://assets/main/creatures/primary/bones/filler-001.chat' into a chat key like
-'chat/bones/filler_001'.
-
-Using these chat keys has many benefits. Most notably they aren't invalidated if we move files or change extensions.
-
-Parameters:
-	'path': The path of a chat resource.
-
-Returns:
-	A key such as 'chat/marsh_prologue' corresponding to the specified chat resource
-"""
+## Converts a path like 'res://assets/main/creatures/primary/bones/filler-001.chat' into a chat key like
+## 'chat/bones/filler_001'.
+##
+## Using these chat keys has many benefits. Most notably they aren't invalidated if we move files or change extensions.
+##
+## Parameters:
+## 	'path': The path of a chat resource.
+##
+## Returns:
+## 	A key such as 'chat/marsh_prologue' corresponding to the specified chat resource
 static func chat_key_from_path(path: String) -> String:
 	var chat_key := path
 	chat_key = chat_key.trim_suffix(".chat")
@@ -311,16 +279,14 @@ static func chat_key_from_path(path: String) -> String:
 	return chat_key
 
 
-"""
-Converts a chat key like 'creature/bones/filler_001' into a path like
-'res://assets/main/creatures/primary/bones/filler-001.chat'
-
-Parameters:
-	'chat_key': A chat key such as 'chat/marsh_prologue'
-
-Returns:
-	The path of the resource identified by the specified chat key.
-"""
+## Converts a chat key like 'creature/bones/filler_001' into a path like
+## 'res://assets/main/creatures/primary/bones/filler-001.chat'
+##
+## Parameters:
+## 	'chat_key': A chat key such as 'chat/marsh_prologue'
+##
+## Returns:
+## 	The path of the resource identified by the specified chat key.
 static func path_from_chat_key(chat_key: String) -> String:
 	var path := chat_key
 	path = StringUtils.underscores_to_hyphens(chat_key)

--- a/project/src/main/ui/chat/chat-line-label.gd
+++ b/project/src/main/ui/chat/chat-line-label.gd
@@ -1,16 +1,14 @@
 class_name ChatLineLabel
 extends RectFitLabel
-"""
-A label which animates text in a way that mimics speech.
+## A label which animates text in a way that mimics speech.
+##
+## Text appears a letter at a time at a constant rate. Newlines cause a long pause. Slashes cause a shorter pause and
+## are hidden from the player. Slashes are referred to 'lull characters' throughout the code.
 
-Text appears a letter at a time at a constant rate. Newlines cause a long pause. Slashes cause a shorter pause and are
-hidden from the player. Slashes are referred to 'lull characters' throughout the code.
-"""
-
-# emitted after the full chat line is typed out onscreen
+## emitted after the full chat line is typed out onscreen
 signal all_text_shown
 
-# The amount of empty space between the text borders and panel borders.
+## The amount of empty space between the text borders and panel borders.
 export (Vector2) var panel_padding: Vector2
 
 export (NodePath) var chat_line_panel_path: NodePath
@@ -31,23 +29,19 @@ func _ready() -> void:
 	hide_message()
 
 
-"""
-Animates the label to gradually reveal the current text, mimicking speech.
-
-This function also calculates the duration to pause for each character. All visible characters cause a short pause.
-Newlines cause a long pause. Slashes cause a medium pause and are hidden from the player.
-
-Returns a ChatTheme.ChatLineSize corresponding to the required chat frame size.
-"""
+## Animates the label to gradually reveal the current text, mimicking speech.
+##
+## This function also calculates the duration to pause for each character. All visible characters cause a short pause.
+## Newlines cause a long pause. Slashes cause a medium pause and are hidden from the player.
+##
+## Returns a ChatTheme.ChatLineSize corresponding to the required chat frame size.
 func show_message(text_with_lulls: String, initial_pause: float = 0.0) -> int:
 	_label_typer.show_message(text_with_lulls, initial_pause)
 	pick_smallest_size()
 	return chosen_size_index
 
 
-"""
-Recolors the chat line label based on the specified chat appearance.
-"""
+## Recolors the chat line label based on the specified chat appearance.
 func update_appearance(chat_theme: ChatTheme) -> void:
 	set("custom_colors/font_color", chat_theme.border_color)
 
@@ -56,16 +50,12 @@ func hide_message() -> void:
 	_label_typer.hide_message()
 
 
-"""
-Returns 'true' if the label's visible_characters value is large enough to show all characters.
-"""
+## Returns 'true' if the label's visible_characters value is large enough to show all characters.
 func is_all_text_visible() -> bool:
 	return visible_characters >= get_total_character_count()
 
 
-"""
-Increases the label's visible_characters value to to show all characters.
-"""
+## Increases the label's visible_characters value to to show all characters.
 func make_all_text_visible() -> void:
 	_label_typer.make_all_text_visible()
 

--- a/project/src/main/ui/chat/chat-line-panel.gd
+++ b/project/src/main/ui/chat/chat-line-panel.gd
@@ -1,26 +1,24 @@
 class_name ChatLinePanel
 extends Panel
-"""
-Displays an empty frame around spoken dialog.
+## Displays an empty frame around spoken dialog.
+##
+## Note: ChatLinePanel does not contain its own chat line labels to avoid the labels being distorted as the panel
+## 	stretches and shrinks. It would make the text annoying to read.
 
-Note: ChatLinePanel does not contain its own chat line labels to avoid the labels being distorted as the panel
-	stretches and shrinks. It would make the text annoying to read.
-"""
-
-# The panel squishes over time. These two constants define the speed and squish amount
+## The panel squishes over time. These two constants define the speed and squish amount
 const PULSE_PERIOD := 5.385
 const PULSE_AMOUNT := Vector2(0.015, 0.030)
 
-# The number of available background textures
+## The number of available background textures
 const CHAT_TEXTURE_COUNT := 16
 
-# Different panel sizes to try, ordered from smallest to largest.
+## Different panel sizes to try, ordered from smallest to largest.
 export (Array, Vector2) var panel_sizes
 
-# The panel squishes over time. This field is used to calculate the squish amount
+## The panel squishes over time. This field is used to calculate the squish amount
 var _total_time := 0.0
 
-# Background textures which scroll behind the chat window
+## Background textures which scroll behind the chat window
 var _accent_textures := []
 
 func _ready() -> void:
@@ -37,13 +35,11 @@ func _process(delta: float) -> void:
 	rect_scale.y = 1.00 + PULSE_AMOUNT.y * cos((_total_time + 8.96) * TAU / PULSE_PERIOD)
 
 
-"""
-Recolors and repositions the panel based on the current chat appearance.
-
-Parameters:
-	'chat_line_size': The size of the chat line window. This is needed for the panel to update its texture to show a
-		smaller/larger window.
-"""
+## Recolors and repositions the panel based on the current chat appearance.
+##
+## Parameters:
+## 	'chat_line_size': The size of the chat line window. This is needed for the panel to update its texture to show a
+## 		smaller/larger window.
 func update_appearance(chat_theme: ChatTheme, chat_line_size: int) -> void:
 	rect_size = panel_sizes[chat_line_size]
 	rect_pivot_offset = rect_size * 0.5

--- a/project/src/main/ui/chat/chat-nametag-panel.gd
+++ b/project/src/main/ui/chat/chat-nametag-panel.gd
@@ -1,16 +1,12 @@
 extends NametagPanel
-"""
-Repositions and shows nametag labels for chat windows.
-"""
+## Repositions and shows nametag labels for chat windows.
 
-"""
-Recolors and repositions the nametag based on the current accent definition.
-
-Parameters:
-	'chat_theme': metadata about the chat window's appearance.
-	
-	'nametag_right': true/false if the nametag should be drawn on the right/left side of the frame.
-"""
+## Recolors and repositions the nametag based on the current accent definition.
+##
+## Parameters:
+## 	'chat_theme': metadata about the chat window's appearance.
+##
+## 	'nametag_right': true/false if the nametag should be drawn on the right/left side of the frame.
 func show_label(chat_theme: ChatTheme, nametag_right: bool) -> void:
 	if nametag_size == ChatTheme.NAMETAG_OFF:
 		return

--- a/project/src/main/ui/chat/chat-pop-tween.gd
+++ b/project/src/main/ui/chat/chat-pop-tween.gd
@@ -1,11 +1,9 @@
 extends Tween
-"""
-Squishes the chat frame when the chat pops in or out.
-"""
+## Squishes the chat frame when the chat pops in or out.
 
 signal pop_out_completed
 
-# the size the chat shrinks to when it disappears
+## the size the chat shrinks to when it disappears
 const POP_OUT_SCALE := Vector2(0.5, 0.5)
 
 onready var _chat_frame: Control = get_parent()
@@ -14,38 +12,30 @@ func _ready() -> void:
 	_reset_chat_frame()
 
 
-"""
-Makes the chat window appear.
-
-Enlarges the chat frame in a bouncy way and makes it opaque.
-"""
+## Makes the chat window appear.
+##
+## Enlarges the chat frame in a bouncy way and makes it opaque.
 func pop_in() -> void:
 	_interpolate_pop(true)
 
 
-"""
-Makes the chat window disappear.
-
-Shrinks the chat frame in a bouncy way and makes it transparent.
-"""
+## Makes the chat window disappear.
+##
+## Shrinks the chat frame in a bouncy way and makes it transparent.
 func pop_out() -> void:
 	_interpolate_pop(false)
 
 
-"""
-Presets the chat window to a known invisible state.
-
-This doesn't use a tween. It's meant for setup/teardown steps the player should never see.
-"""
+## Presets the chat window to a known invisible state.
+##
+## This doesn't use a tween. It's meant for setup/teardown steps the player should never see.
 func _reset_chat_frame() -> void:
 	remove_all()
 	_chat_frame.modulate = Color.transparent
 	_chat_frame.rect_scale = POP_OUT_SCALE
 
 
-"""
-Pops the chat window in/out.
-"""
+## Pops the chat window in/out.
 func _interpolate_pop(popping_in: bool) -> void:
 	remove(_chat_frame, "modulate")
 	remove(_chat_frame, "rect_scale:x")

--- a/project/src/main/ui/chat/chat-squish-tween.gd
+++ b/project/src/main/ui/chat/chat-squish-tween.gd
@@ -1,29 +1,21 @@
 extends Tween
-"""
-Squishes the chat frame when the chat pops in or out.
-"""
+## Squishes the chat frame when the chat pops in or out.
 
 onready var _chat_frame: Control = get_parent()
 
-"""
-Squishes the chat window aside to prompt the player.
-"""
+## Squishes the chat window aside to prompt the player.
 func squish() -> void:
 	_interpolate_squish(true)
 	start()
 
 
-"""
-Moves the chat window back to the center after prompting the player.
-"""
+## Moves the chat window back to the center after prompting the player.
 func unsquish() -> void:
 	_interpolate_squish(false)
 	start()
 
 
-"""
-Squishes/unsquishes the chat window when prompting the player.
-"""
+## Squishes/unsquishes the chat window when prompting the player.
 func _interpolate_squish(squished: bool) -> void:
 	remove(_chat_frame, "rect_position:x")
 	interpolate_property(_chat_frame, "rect_position:x", _chat_frame.rect_position.x,

--- a/project/src/main/ui/chat/chat-theme.gd
+++ b/project/src/main/ui/chat/chat-theme.gd
@@ -1,9 +1,7 @@
 class_name ChatTheme
-"""
-Stores metadata about the chat window's appearance.
-
-This includes the position, color and texture of the main chat window and nametag.
-"""
+## Stores metadata about the chat window's appearance.
+##
+## This includes the position, color and texture of the main chat window and nametag.
 
 enum NametagSize {
 	OFF, # 0 characters
@@ -39,14 +37,12 @@ var accent_swapped: bool
 var accent_texture_index: int
 var border_color: Color
 var dark: bool
-# virtual property; value is only exposed through getters/setters
+## virtual property; value is only exposed through getters/setters
 var nametag_font_color setget ,get_nametag_font_color
 
-"""
-Parses an chat_theme_def into properties used by the chat UI.
-
-See ChatEvent.chat_theme_def for a full description of the chat_theme_def properties.
-"""
+## Parses an chat_theme_def into properties used by the chat UI.
+##
+## See ChatEvent.chat_theme_def for a full description of the chat_theme_def properties.
 func _init(chat_theme_def: Dictionary) -> void:
 	accent_color = chat_theme_def.get("color", Color.gray)
 	accent_scale = chat_theme_def.get("accent_scale", 8.0)

--- a/project/src/main/ui/chat/chat-tree.gd
+++ b/project/src/main/ui/chat/chat-tree.gd
@@ -1,20 +1,16 @@
 class_name ChatTree
-"""
-Tree of chat events the player can page through.
-
-The tree includes a root node with one or more branches, each of which is associated with a key. Branches can redirect
-to each other by referencing these keys. Chat lines start on the '' (empty string) branch.
-"""
+## Tree of chat events the player can page through.
+##
+## The tree includes a root node with one or more branches, each of which is associated with a key. Branches can
+## redirect to each other by referencing these keys. Chat lines start on the '' (empty string) branch.
 
 class Position:
-	"""
-	Current position in a chat tree.
-	"""
+	## Current position in a chat tree.
 	
-	# The key of the chat branch being navigated.
+	## The key of the chat branch being navigated.
 	var key := ""
 	
-	# How far we are along the chat branch.
+	## How far we are along the chat branch.
 	var index := 0
 	
 	func _to_string() -> String:
@@ -25,81 +21,75 @@ class Position:
 		key = ""
 		index = 0
 
-# Current version for saved chat data. Should be updated if and only if the chat format breaks backwards
-# compatibility. This version number follows a 'ymdh' hex date format which is documented in issue #234.
+## Current version for saved chat data. Should be updated if and only if the chat format breaks backwards
+## compatibility. This version number follows a 'ymdh' hex date format which is documented in issue #234.
 const CHAT_DATA_VERSION := "1922"
 
-# Scene paths corresponding to different ChatTree.location_id values
+## Scene paths corresponding to different ChatTree.location_id values
 const LOCATION_SCENE_PATHS_BY_ID := {
 	"indoors": "res://src/main/world/OverworldIndoors.tscn",
 	"outdoors": "res://src/main/world/Overworld.tscn",
 	"outdoors_walk": "res://src/main/world/OverworldWalk.tscn",
 }
 
-# unique key to identify this conversation in the chat history
+## unique key to identify this conversation in the chat history
 var chat_key: String
 
-# metadata including whether the chat event is 'filler', 'notable' or 'inplace'
+## metadata including whether the chat event is 'filler', 'notable' or 'inplace'
 var meta: Dictionary
 
-# tree of chat event objects
-# key: chat id (String)
-# value: array of sequential ChatEvent objects for a particular chat sequence
+## tree of chat event objects
+## key: chat id (String)
+## value: array of sequential ChatEvent objects for a particular chat sequence
 var events := {}
 
-# a specific location where this conversation takes place, if any
+## a specific location where this conversation takes place, if any
 var location_id: String
 
-# a specific location where the player ends up after this conversation, if any
+## a specific location where the player ends up after this conversation, if any
 var destination_id: String
 
-# Spawn locations for different creatures, if this ChatTree represents a cutscene. Spawn locations prefixed with a '!'
-# indicate that the creature should spawn invisible.
+## Spawn locations for different creatures, if this ChatTree represents a cutscene. Spawn locations prefixed with a '!'
+## indicate that the creature should spawn invisible.
 #
-# key: creature id
-# value: spawn id
+## key: creature id
+## value: spawn id
 var spawn_locations := {}
 
-# current position in this chat tree
+## current position in this chat tree
 var _position := Position.new()
 
-# 'true' if _position has already been initialized to the first event in the chat tree
+## 'true' if _position has already been initialized to the first event in the chat tree
 var _did_prepare := false
 
-"""
-Adds a chat event to a new chat branch, or appends it to an existing branch.
-
-Parameters:
-	'key': The key of the chat branch to append to.
-	
-	'event': The chat event to append.
-"""
+## Adds a chat event to a new chat branch, or appends it to an existing branch.
+##
+## Parameters:
+## 	'key': The key of the chat branch to append to.
+##
+## 	'event': The chat event to append.
 func append(key: String, event: ChatEvent) -> void:
 	if not events.has(key):
 		events[key] = []
 	events[key].append(event)
 
 
-"""
-Returns the chat event at the current position.
-"""
+## Returns the chat event at the current position.
 func get_event() -> ChatEvent:
 	return events[_position.key][_position.index]
 
 
-"""
-Advances the chat position deeper into the tree.
-
-This can either involve navigating further down the current branch, or navigating to a new branch if any links are
-available.
-
-Returns 'true' if the position was advanced successfully, or 'false' if we hit a dead end. A dead end can indicate
-that the chat tree cannot be advanced any further and the window should close.
-
-Parameters:
-	'link_index': Which chat branch to follow. This parameter is optional, and is ignored if the chat tree does not
-		branch.
-"""
+## Advances the chat position deeper into the tree.
+##
+## This can either involve navigating further down the current branch, or navigating to a new branch if any links are
+## available.
+##
+## Returns 'true' if the position was advanced successfully, or 'false' if we hit a dead end. A dead end can indicate
+## that the chat tree cannot be advanced any further and the window should close.
+##
+## Parameters:
+## 	'link_index': Which chat branch to follow. This parameter is optional, and is ignored if the chat tree does not
+## 		branch.
 func advance(link_index := -1) -> bool:
 	var did_increment := false
 	if get_event().links and events.has(get_event().links[link_index]):
@@ -115,13 +105,11 @@ func advance(link_index := -1) -> bool:
 	return did_increment
 
 
-"""
-Relocates the position within the chat tree to start a new chat.
-
-The first time this is called, the position is relocated. The second and subsequent times, this has no effect. This
-allows subsequent overworld conversations with the same person to repeat the last line of dialog instead of repeating
-the entire dialog sequence.
-"""
+## Relocates the position within the chat tree to start a new chat.
+##
+## The first time this is called, the position is relocated. The second and subsequent times, this has no effect. This
+## allows subsequent overworld conversations with the same person to repeat the last line of dialog instead of
+## repeating the entire dialog sequence.
 func prepare_first_chat_event() -> void:
 	if _did_prepare:
 		return
@@ -131,9 +119,7 @@ func prepare_first_chat_event() -> void:
 	_did_prepare = true
 
 
-"""
-Returns 'true' if the chat position can be advanced deeper into the tree.
-"""
+## Returns 'true' if the chat position can be advanced deeper into the tree.
 func can_advance() -> bool:
 	var can_increment := false
 	if get_event().links and events.has(get_event().links[-1]):
@@ -145,18 +131,14 @@ func can_advance() -> bool:
 	return can_increment
 
 
-"""
-Returns the scene path where this chat takes place.
-"""
+## Returns the scene path where this chat takes place.
 func chat_scene_path() -> String:
 	return LOCATION_SCENE_PATHS_BY_ID.get(location_id, Global.SCENE_OVERWORLD)
 
 
-"""
-Returns the scene path which should be loaded after this cutscene.
-
-If no destination scene path is defined, this returns the chat scene path.
-"""
+## Returns the scene path which should be loaded after this cutscene.
+##
+## If no destination scene path is defined, this returns the chat scene path.
 func destination_scene_path() -> String:
 	var result: String
 	if destination_id:
@@ -176,9 +158,7 @@ func reset() -> void:
 	_position.reset()
 
 
-"""
-Jump to any chat sequences whose 'start_if' conditions are met.
-"""
+## Jump to any chat sequences whose 'start_if' conditions are met.
 func _apply_start_if_conditions() -> void:
 	# look for 'start_if' conditions...
 	var start_keys := []
@@ -203,9 +183,7 @@ func _apply_start_if_conditions() -> void:
 		push_warning("Multiple start_if conditions were met: %s" % [[start_keys]])
 
 
-"""
-Skip any dialog lines whose 'say_if' conditions are unmet.
-"""
+## Skip any dialog lines whose 'say_if' conditions are unmet.
 func _apply_say_if_conditions() -> void:
 	var did_increment := true
 	while did_increment:

--- a/project/src/main/ui/chat/chat-ui.gd
+++ b/project/src/main/ui/chat/chat-ui.gd
@@ -1,25 +1,23 @@
 extends Control
-"""
-Displays UI elements for a chat sequence.
-"""
+## Displays UI elements for a chat sequence.
 
 signal popped_in
 signal chat_event_played(chat_event)
 
-# emitted when we present the player with a chat choice
+## emitted when we present the player with a chat choice
 signal showed_choices
 signal chat_choice_chosen(choice_index)
 
-# emitted when the chat window pops out after a finished chat
+## emitted when the chat window pops out after a finished chat
 signal chat_finished
 
-# how long the player needs to hold the button to skip all chat lines
+## how long the player needs to hold the button to skip all chat lines
 const HOLD_TO_SKIP_DURATION := 0.6
 
-# how long the player has been holding the 'interact' button
+## how long the player has been holding the 'interact' button
 var _accept_action_duration := 0.0
 
-# how long the player has been holding the 'rewind' button
+## how long the player has been holding the 'rewind' button
 var _rewind_action_duration := 0.0
 
 onready var _chat_advancer: ChatAdvancer = $ChatAdvancer
@@ -27,7 +25,7 @@ onready var _chat_choices: ChatChoices = $ChatChoices
 onready var _chat_frame: ChatFrame = $ChatFrame
 onready var _narration_frame: NarrationFrame = $NarrationFrame
 
-# true if the player has advanced past the last line in the chat tree
+## true if the player has advanced past the last line in the chat tree
 var _chat_finished := false
 
 func _process(delta: float) -> void:
@@ -54,11 +52,9 @@ func play_chat_tree(chat_tree: ChatTree) -> void:
 	emit_signal("popped_in")
 
 
-"""
-Process the result of the player pressing the 'rewind' button.
-
-The player can tap the rewind button to view the previous line, or hold the button to rewind continuously.
-"""
+## Process the result of the player pressing the 'rewind' button.
+##
+## The player can tap the rewind button to view the previous line, or hold the button to rewind continuously.
 func _handle_rewind_action(event: InputEvent) -> void:
 	var rewind_action := false
 	if event.is_action_pressed("rewind_text"):
@@ -73,12 +69,10 @@ func _handle_rewind_action(event: InputEvent) -> void:
 		_chat_advancer.rewind()
 
 
-"""
-Process the result of the player pressing the 'advance' button.
-
-The player can tap the advance button to make chat lines appear faster or advance to the next line. They can hold the
-advance button to continuously advance the text.
-"""
+## Process the result of the player pressing the 'advance' button.
+##
+## The player can tap the advance button to make chat lines appear faster or advance to the next line. They can hold
+## the advance button to continuously advance the text.
 func _handle_advance_action(event: InputEvent) -> void:
 	var advance_action := false
 	if event.is_action_pressed("ui_accept"):
@@ -100,9 +94,7 @@ func _handle_advance_action(event: InputEvent) -> void:
 			_chat_advancer.advance()
 
 
-"""
-Displays the current chat event to the player.
-"""
+## Displays the current chat event to the player.
 func _on_ChatAdvancer_chat_event_shown(chat_event: ChatEvent) -> void:
 	if _chat_advancer.rewinding_text or _chat_choices.is_showing_choices():
 		# if we're asked to rewind or play more chat lines without picking a choice, hide the choices
@@ -147,14 +139,12 @@ func _on_ChatAdvancer_chat_event_shown(chat_event: ChatEvent) -> void:
 			_chat_advancer.advance()
 
 
-"""
-Extracts the moods for each available choice of a chat event.
-
-The resulting array excludes any choices whose link_if conditions are unmet.
-
-Returns:
-	An array of ChatEvent.Mood instances for each chat branch
-"""
+## Extracts the moods for each available choice of a chat event.
+##
+## The resulting array excludes any choices whose link_if conditions are unmet.
+##
+## Returns:
+## 	An array of ChatEvent.Mood instances for each chat branch
 func _enabled_link_moods(var chat_event: ChatEvent) -> Array:
 	var moods := []
 	for i in chat_event.enabled_link_indexes():
@@ -175,14 +165,12 @@ func _enabled_link_moods(var chat_event: ChatEvent) -> Array:
 	return moods
 
 
-"""
-Extracts the strings to show the player for each available choice of a chat event.
-
-The resulting array excludes any choices whose link_if conditions are unmet.
-
-Returns:
-	An array of string choices for each chat branch
-"""
+## Extracts the strings to show the player for each available choice of a chat event.
+##
+## The resulting array excludes any choices whose link_if conditions are unmet.
+##
+## Returns:
+## 	An array of string choices for each chat branch
 func _enabled_link_texts(var chat_event: ChatEvent) -> Array:
 	var texts := []
 	for i in chat_event.enabled_link_indexes():

--- a/project/src/main/ui/chat/chatscript-parser.gd
+++ b/project/src/main/ui/chat/chatscript-parser.gd
@@ -1,17 +1,13 @@
 class_name ChatscriptParser
-"""
-Parses a chatscript (.chat) file containing a cutscene or lines of chat.
+## Parses a chatscript (.chat) file containing a cutscene or lines of chat.
+##
+## This class is stateful and intended to be used once and thrown away. If it is reused, the previously parsed
+## chat tree will be erased.
 
-This class is stateful and intended to be used once and thrown away. If it is reused, the previously parsed chat_tree
-will be erased.
-"""
-
-"""
-Tracks the state for the parser.
-
-The ChatscriptParser has different states based on whether it's parsing chat, characters, locations, or something
-else.
-"""
+## Tracks the state for the parser.
+##
+## The ChatscriptParser has different states based on whether it's parsing chat, characters, locations, or something
+## else.
 class AbstractState:
 	
 	var chat_tree: ChatTree
@@ -25,11 +21,9 @@ class AbstractState:
 
 # -----------------------------------------------------------------------------
 
-"""
-Default parser state for parsing headers and metadata.
-
-Mostly contains logic for transitioning into other states.
-"""
+## Default parser state for parsing headers and metadata.
+##
+## Mostly contains logic for transitioning into other states.
 class DefaultState extends AbstractState:
 	
 	var chat_state: AbstractState
@@ -62,20 +56,16 @@ class DefaultState extends AbstractState:
 
 # -----------------------------------------------------------------------------
 
-"""
-Parser state for parsing location data (where a conversation takes place).
-"""
+## Parser state for parsing location data (where a conversation takes place).
 class LocationState extends AbstractState:
 	
 	func _init(init_chat_tree: ChatTree).(init_chat_tree) -> void:
 			pass
 	
 	
-	"""
-	Syntax:
-		[location]
-		indoors
-	"""
+	## Syntax:
+	## 	[location]
+	## 	indoors
 	func line(line: String) -> String:
 		var result := ""
 		if line:
@@ -86,20 +76,16 @@ class LocationState extends AbstractState:
 
 # -----------------------------------------------------------------------------
 
-"""
-Parser state for parsing destination data (where the player goes after a conversation).
-"""
+## Parser state for parsing destination data (where the player goes after a conversation).
 class DestinationState extends AbstractState:
 	
 	func _init(init_chat_tree: ChatTree).(init_chat_tree) -> void:
 			pass
 	
 	
-	"""
-	Syntax:
-		[destination]
-		indoors
-	"""
+	## Syntax:
+	## 	[destination]
+	## 	indoors
 	func line(line: String) -> String:
 		var result := ""
 		if line:
@@ -110,15 +96,13 @@ class DestinationState extends AbstractState:
 
 # -----------------------------------------------------------------------------
 
-"""
-Parser state for parsing character data (participants in a conversation).
-"""
+## Parser state for parsing character data (participants in a conversation).
 class CharactersState extends AbstractState:
 	
-	# Creature aliases used in chatscript chat lines. ChatState references this dictionary when parsing chat lines.
-	#
-	# key: creature id
-	# value: alias used in chatscript chat lines
+	## Creature aliases used in chatscript chat lines. ChatState references this dictionary when parsing chat lines.
+	##
+	## key: creature id
+	## value: alias used in chatscript chat lines
 	var _character_aliases: Dictionary
 	
 	func _init(init_chat_tree: ChatTree, init_chat_aliases: Dictionary).(init_chat_tree) -> void:
@@ -134,13 +118,11 @@ class CharactersState extends AbstractState:
 		return result
 	
 	
-	"""
-	Syntax:
-		skins, s, kitchen_9        - a character named 'skins' with an alias 's' spawns at kitchen_9
-		skins, s, !kitchen_9        - a character named 'skins' with an alias 's' spawns invisible at kitchen_9
-		skins, s                   - a character named 'skins' with an alias 's'
-		skins                      - a character named 'skins'
-	"""
+	## Syntax:
+	## 	skins, s, kitchen_9        - a character named 'skins' with an alias 's' spawns at kitchen_9
+	## 	skins, s, !kitchen_9        - a character named 'skins' with an alias 's' spawns invisible at kitchen_9
+	## 	skins, s                   - a character named 'skins' with an alias 's'
+	## 	skins                      - a character named 'skins'
 	func _parse_character_name(line: String) -> void:
 		var line_parts := line.split(",")
 		var character_name := "" if line_parts.size() < 1 else line_parts[0].strip_edges()
@@ -156,42 +138,38 @@ class CharactersState extends AbstractState:
 
 # -----------------------------------------------------------------------------
 
-"""
-Parser state for parsing chat lines (chat events and branches)
-"""
+## Parser state for parsing chat lines (chat events and branches)
 class ChatState extends AbstractState:
 	
-	# Creature aliases used in chatscript chat lines. CharactersState populates this dictionary when parsing
-	# characters.
-	#
-	# key: creature id
-	# value: alias used in chatscript chat lines
+	## Creature aliases used in chatscript chat lines. CharactersState populates this dictionary when parsing
+	## characters.
+	##
+	## key: creature id
+	## value: alias used in chatscript chat lines
 	var _character_aliases: Dictionary
 	
-	# The current chat event being parsed. Any parsed metadata and links will be attached to this event.
+	## The current chat event being parsed. Any parsed metadata and links will be attached to this event.
 	var _event: ChatEvent
 	
-	# The current branch key being parsed. Any additional chat events will be attached to this branch.
+	## The current branch key being parsed. Any additional chat events will be attached to this branch.
 	var _branch_key := ""
 	
 	func _init(init_chat_tree: ChatTree, init_chat_aliases: Dictionary).(init_chat_tree) -> void:
 		_character_aliases = init_chat_aliases
 	
 	
-	"""
-	Syntax:
-		s: /._. Are you sure?
-		[yes] Okay, fine.
-		[no]
-		
-		[yes]
-		p1: ^_^ Okay fine, I could use some exercise.
-		s: ^__^ Great!
-		
-		[no]
-		p1: Never mind, I don't want to.
-		s: u_u Oh...
-	"""
+	## Syntax:
+	## 	s: /._. Are you sure?
+	## 	[yes] Okay, fine.
+	## 	[no]
+	##
+	## 	[yes]
+	## 	p1: ^_^ Okay fine, I could use some exercise.
+	## 	s: ^__^ Great!
+	##
+	## 	[no]
+	## 	p1: Never mind, I don't want to.
+	## 	s: u_u Oh...
 	func line(line: String) -> String:
 		var result := ""
 		if line:
@@ -211,10 +189,8 @@ class ChatState extends AbstractState:
 		return result
 	
 	
-	"""
-	Syntax:
-		s: ^_^ Oh okay cool!
-	"""
+	## Syntax:
+	## 	s: ^_^ Oh okay cool!
 	func _parse_chat_line(line: String) -> void:
 		if not ": " in line:
 			push_warning("Malformed chat line: %s" % [line])
@@ -241,11 +217,9 @@ class ChatState extends AbstractState:
 		chat_tree.append(_branch_key, _event)
 	
 	
-	"""
-	Syntax:
-		[very-good] I think you killed it!
-		[just-okay] <_< I think it was just okay...
-	"""
+	## Syntax:
+	## 	[very-good] I think you killed it!
+	## 	[just-okay] <_< I think it was just okay...
 	func _parse_chat_link(line: String) -> void:
 		# add branch to _event
 		if not line.begins_with("[") or not "]" in line:
@@ -264,10 +238,8 @@ class ChatState extends AbstractState:
 		_event.add_link(branch_name, branch_text, branch_mood)
 	
 	
-	"""
-	Syntax:
-		[very-good]
-	"""
+	## Syntax:
+	## 	[very-good]
 	func _parse_branch_key(line: String) -> void:
 		if not line.begins_with("[") or not line.ends_with("]"):
 			push_warning("Malformed chat branch: %s" % [line])
@@ -276,10 +248,8 @@ class ChatState extends AbstractState:
 		_branch_key = line.trim_prefix("[").trim_suffix("]")
 	
 	
-	"""
-	Syntax:
-		(I'm not sure if they heard me.)
-	"""
+	## Syntax:
+	## 	(I'm not sure if they heard me.)
 	func _parse_thought(line: String) -> void:
 		if not line.begins_with("(") or not line.ends_with(")"):
 			push_warning("Malformed thought: %s" % [line])
@@ -294,10 +264,8 @@ class ChatState extends AbstractState:
 		chat_tree.append(_branch_key, _event)
 	
 	
-	"""
-	Syntax:
-		' (spira enters)'  <-- with a leading space
-	"""
+	## Syntax:
+	## 	' (spira enters)'  <-- with a leading space
 	func _parse_meta(line: String) -> void:
 		if not line.begins_with(" (") or not line.ends_with(")"):
 			push_warning("Malformed meta: %s" % [line])
@@ -313,9 +281,7 @@ class ChatState extends AbstractState:
 			_event.link_metas.back().append_array(meta)
 	
 	
-	"""
-	Translates human-readable phrases like 'spira enters' into metadata like 'creature_enter spira'
-	"""
+	## Translates human-readable phrases like 'spira enters' into metadata like 'creature_enter spira'
 	func _translate_meta_item(item: String) -> String:
 		var result := item
 		if item.ends_with(" enters"):
@@ -341,9 +307,7 @@ class ChatState extends AbstractState:
 		return result
 	
 	
-	"""
-	Wraps 'player' and 'sensei' in pound signs so their names will be translated.
-	"""
+	## Wraps 'player' and 'sensei' in pound signs so their names will be translated.
 	func _unalias(name: String) -> String:
 		var result := name
 		result = _character_aliases.get(result, result)
@@ -353,13 +317,13 @@ class ChatState extends AbstractState:
 
 # -----------------------------------------------------------------------------
 
-# Current version for saved chatscript data. Should be updated if and only if the chat format breaks backwards
-# compatibility. This version number follows a 'ymdh' hex date format which is documented in issue #234.
+## Current version for saved chatscript data. Should be updated if and only if the chat format breaks backwards
+## compatibility. This version number follows a 'ymdh' hex date format which is documented in issue #234.
 const CHATSCRIPT_VERSION := "2476"
 
-# Emoticons which can appear at the start of a chat line to define its mood
-# key: String emoji representing a chatscript mood
-# value: int corresponding to an entry in ChatEvent.Mood
+## Emoticons which can appear at the start of a chat line to define its mood
+## key: String emoji representing a chatscript mood
+## value: int corresponding to an entry in ChatEvent.Mood
 const MOOD_PREFIXES := {
 	"._.": ChatEvent.Mood.DEFAULT,
 	"<_<": ChatEvent.Mood.AWKWARD0,
@@ -398,9 +362,9 @@ const MOOD_PREFIXES := {
 	"^Y^": ChatEvent.Mood.YES1,
 }
 
-# Different directions a creature can face
-# key: String representing a direction a creature can face
-# value: int corresponding to an entry in Creatures.Orientation
+## Different directions a creature can face
+## key: String representing a direction a creature can face
+## value: int corresponding to an entry in Creatures.Orientation
 const ORIENTATION_STRINGS := {
 	"left": Creatures.SOUTHWEST,
 	"right": Creatures.SOUTHEAST,
@@ -410,23 +374,23 @@ const ORIENTATION_STRINGS := {
 	"ne": Creatures.NORTHEAST,
 }
 
-# parser headers which appear in square braces in the chatscript file
+## parser headers which appear in square braces in the chatscript file
 const DEFAULT := "default"
 const LOCATION := "location"
 const DESTINATION := "destination"
 const CHARACTERS := "characters"
 const CHAT := "chat"
 
-# key: parser state name such as 'default', 'location', 'characters', 'chat'
-# value: AbstractState
+## key: parser state name such as 'default', 'location', 'characters', 'chat'
+## value: AbstractState
 var _states_by_name: Dictionary
 
-# the chat tree being parsed
+## the chat tree being parsed
 var _chat_tree := ChatTree.new()
 var _state: AbstractState
 
-# key: creature id
-# value: alias used in chatscript chat lines
+## key: creature id
+## value: alias used in chatscript chat lines
 var _character_aliases := {}
 
 func _init() -> void:
@@ -441,12 +405,10 @@ func _init() -> void:
 	_state = _states_by_name[DEFAULT]
 
 
-"""
-Parses a ChatTree from the specified chatscript resource.
-
-This class is stateful and intended to be used once and thrown away. If chat_tree_from_file is invoked more than once,
-the previously parsed chat_tree will be erased.
-"""
+## Parses a ChatTree from the specified chatscript resource.
+##
+## This class is stateful and intended to be used once and thrown away. If chat_tree_from_file is invoked more than
+## once, the previously parsed chat_tree will be erased.
 func chat_tree_from_file(path: String) -> ChatTree:
 	_chat_tree.reset()
 	_character_aliases.clear()

--- a/project/src/main/ui/chat/label-typer.gd
+++ b/project/src/main/ui/chat/label-typer.gd
@@ -1,32 +1,30 @@
 class_name LabelTyper
 extends Node
-"""
-Animates a Label to gradually reveal text, mimicking speech.
-"""
+## Animates a Label to gradually reveal text, mimicking speech.
 
 signal all_text_shown
 
-# How many seconds to delay when displaying a character.
+## How many seconds to delay when displaying a character.
 const DEFAULT_PAUSE := 0.05
 
-# How many seconds to delay when displaying whitespace or the special lull character, '/'.
+## How many seconds to delay when displaying whitespace or the special lull character, '/'.
 const PAUSE_CHARACTERS := {
 	" ": 0.00,
 	"/": 0.40,
 	"\n": 0.80,
 }
 
-# Stores the delay in seconds for each visible_characters index.
+## Stores the delay in seconds for each visible_characters index.
 var _visible_character_pauses := {}
 
-# The delay in seconds before displaying the next character.
+## The delay in seconds before displaying the next character.
 var _pause := 0.0
 
-# 1.0 = slow, 2.0 = normal, 3.0 = faster, 5.0 = fastest, 1000000.0 = fastestest
+## 1.0 = slow, 2.0 = normal, 3.0 = faster, 5.0 = fastest, 1000000.0 = fastestest
 var _text_speed := 2.0
 
 onready var _label := get_parent()
-# plays a typewriter sound as text appears
+## plays a typewriter sound as text appears
 onready var _bebebe_sound: AudioStreamPlayer = $BebebeSound
 
 func _process(delta: float) -> void:
@@ -52,12 +50,10 @@ func _process(delta: float) -> void:
 			emit_signal("all_text_shown")
 
 
-"""
-Animates the label to gradually reveal the current text, mimicking speech.
-
-This function also calculates the duration to pause for each character. All visible characters cause a short pause.
-Newlines cause a long pause. Slashes cause a medium pause and are hidden from the player.
-"""
+## Animates the label to gradually reveal the current text, mimicking speech.
+##
+## This function also calculates the duration to pause for each character. All visible characters cause a short pause.
+## Newlines cause a long pause. Slashes cause a medium pause and are hidden from the player.
 func show_message(text_with_lulls: String, initial_pause: float = 0.0) -> void:
 	text_with_lulls = ChattableManager.substitute_variables(text_with_lulls)
 	
@@ -70,16 +66,12 @@ func show_message(text_with_lulls: String, initial_pause: float = 0.0) -> void:
 	_calculate_pauses(text_with_lulls, initial_pause)
 
 
-"""
-Returns 'true' if the label's visible_characters value is large enough to show all characters.
-"""
+## Returns 'true' if the label's visible_characters value is large enough to show all characters.
 func is_all_text_visible() -> bool:
 	return _label.visible_characters >= _label.get_total_character_count()
 
 
-"""
-Hides the message and clears any stored data about its state.
-"""
+## Hides the message and clears any stored data about its state.
 func hide_message() -> void:
 	_visible_character_pauses.clear()
 	_label.visible_characters = 0
@@ -88,9 +80,7 @@ func hide_message() -> void:
 	set_process(false)
 
 
-"""
-Increases the label's visible_characters value to to show all characters.
-"""
+## Increases the label's visible_characters value to to show all characters.
 func make_all_text_visible() -> void:
 	if _label.visible_characters < _label.get_total_character_count():
 		_label.visible_characters = _label.get_total_character_count()

--- a/project/src/main/ui/chat/mood-sprite.gd
+++ b/project/src/main/ui/chat/mood-sprite.gd
@@ -1,9 +1,7 @@
 extends Control
-"""
-Shows a little 'happy face' icon next to each chat choice.
-"""
+## Shows a little 'happy face' icon next to each chat choice.
 
-# the location of the mood icon; the right or left side of the chat window
+## the location of the mood icon; the right or left side of the chat window
 export (bool) var mood_right: bool setget set_mood_right
 
 var textures := {
@@ -37,13 +35,11 @@ var textures := {
 }
 
 
-"""
-Sets which mood should be displayed.
-
-Parameters:
-	'mood': An enum in ChatEvent.Mood corresponding to the mood to show. '-1' is a valid value, and will result in no
-		mood being shown.
-"""
+## Sets which mood should be displayed.
+##
+## Parameters:
+## 	'mood': An enum in ChatEvent.Mood corresponding to the mood to show. '-1' is a valid value, and will result in no
+## 		mood being shown.
 func set_mood(new_mood: int) -> void:
 	if textures.has(new_mood):
 		$Texture.texture = textures[new_mood]
@@ -51,9 +47,7 @@ func set_mood(new_mood: int) -> void:
 		$Texture.texture = null
 
 
-"""
-Sets the location of the mood icon.
-"""
+## Sets the location of the mood icon.
 func set_mood_right(new_mood_right: bool) -> void:
 	mood_right = new_mood_right
 	if mood_right:

--- a/project/src/main/ui/chat/narration-frame.gd
+++ b/project/src/main/ui/chat/narration-frame.gd
@@ -1,20 +1,16 @@
 class_name NarrationFrame
 extends Control
-"""
-Window which displays a narration line.
-"""
+## Window which displays a narration line.
 
 signal pop_out_completed
 
-# emitted after the full chat line is typed out onscreen
+## emitted after the full chat line is typed out onscreen
 signal all_text_shown
 
-# 'true' after pop_in is called, and 'false' after pop_out is called
+## 'true' after pop_in is called, and 'false' after pop_out is called
 var _popped_in := false
 
-"""
-Makes the chat window appear.
-"""
+## Makes the chat window appear.
 func pop_in() -> void:
 	if _popped_in:
 		# chat window is already popped in
@@ -24,9 +20,7 @@ func pop_in() -> void:
 	$PopInSound.play()
 
 
-"""
-Makes the chat window disappear.
-"""
+## Makes the chat window disappear.
 func pop_out() -> void:
 	if not _popped_in:
 		# chat window is already popped out
@@ -36,9 +30,7 @@ func pop_out() -> void:
 	$PopOutSound.play()
 
 
-"""
-Animates the narration UI to gradually reveal the specified text, mimicking speech.
-"""
+## Animates the narration UI to gradually reveal the specified text, mimicking speech.
 func play_chat_event(chat_event: ChatEvent) -> void:
 	if not $NarrationPanel.visible:
 		# Ensure the chat window is showing before we start changing its text and playing sounds

--- a/project/src/main/ui/chat/narration-line-panel.gd
+++ b/project/src/main/ui/chat/narration-line-panel.gd
@@ -1,10 +1,8 @@
 class_name NarrationLinePanel
 extends Panel
-"""
-Displays a panel containing lines of narration for cutscenes.
-"""
+## Displays a panel containing lines of narration for cutscenes.
 
-# emitted after the full chat line is typed out onscreen
+## emitted after the full chat line is typed out onscreen
 signal all_text_shown
 
 onready var _label: Label = $NarrationLabel
@@ -15,12 +13,10 @@ func _ready() -> void:
 	hide_message()
 
 
-"""
-Animates the label to gradually reveal the current text, mimicking speech.
-
-This function also calculates the duration to pause for each character. All visible characters cause a short pause.
-Newlines cause a long pause. Slashes cause a medium pause and are hidden from the player.
-"""
+## Animates the label to gradually reveal the current text, mimicking speech.
+##
+## This function also calculates the duration to pause for each character. All visible characters cause a short pause.
+## Newlines cause a long pause. Slashes cause a medium pause and are hidden from the player.
 func show_message(text_with_lulls: String, initial_pause: float = 0.0) -> void:
 	visible = true
 	_label_typer.show_message(text_with_lulls, initial_pause)
@@ -31,16 +27,12 @@ func hide_message() -> void:
 	_label_typer.hide_message()
 
 
-"""
-Returns 'true' if the label's visible_characters value is large enough to show all characters.
-"""
+## Returns 'true' if the label's visible_characters value is large enough to show all characters.
 func is_all_text_visible() -> bool:
 	return _label.visible_characters >= _label.get_total_character_count()
 
 
-"""
-Increases the label's visible_characters value to to show all characters.
-"""
+## Increases the label's visible_characters value to to show all characters.
 func make_all_text_visible() -> void:
 	_label_typer.make_all_text_visible()
 

--- a/project/src/main/ui/chat/touch-translator.gd
+++ b/project/src/main/ui/chat/touch-translator.gd
@@ -1,16 +1,14 @@
 extends Control
-"""
-Converts touch events into ui_accept events which can be handled by the ChatUi.
-"""
+## Converts touch events into ui_accept events which can be handled by the ChatUi.
 
 export (NodePath) var chat_frame_path: NodePath
 export (NodePath) var narration_frame_path: NodePath
 
-# index of the current touch event, or -1 if there is none
+## index of the current touch event, or -1 if there is none
 var _touch_index := -1
 
-# a scancode which triggers a ui_accept action.
-# echo events cannot be emitted without an InputEventKey instance which requires a scancode
+## a scancode which triggers a ui_accept action.
+## echo events cannot be emitted without an InputEventKey instance which requires a scancode
 var _ui_accept_scancode: int
 
 onready var _chat_frame: ChatFrame = get_node(chat_frame_path)
@@ -52,9 +50,7 @@ func _process(_delta: float) -> void:
 		_emit_ui_accept_event(true, true)
 
 
-"""
-Translates the current touch event into a ui_accept event.
-"""
+## Translates the current touch event into a ui_accept event.
 func _emit_ui_accept_event(pressed: bool, echo: bool) -> void:
 	var ev := InputEventKey.new()
 	ev.scancode = _ui_accept_scancode
@@ -63,11 +59,9 @@ func _emit_ui_accept_event(pressed: bool, echo: bool) -> void:
 	Input.parse_input_event(ev)
 
 
-"""
-Temporarily disables touch translation.
-
-This is done when showing chat choices, or when the chat window is not being shown.
-"""
+## Temporarily disables touch translation.
+##
+## This is done when showing chat choices, or when the chat window is not being shown.
 func _disable_translation() -> void:
 	if _touch_index != -1:
 		_emit_ui_accept_event(false, false)
@@ -75,12 +69,10 @@ func _disable_translation() -> void:
 	set_process(false)
 
 
-"""
-Reenables touch translation.
-
-Touch translation is reenabled during a brief delay to prevent a bug where a touch event is immediately processed,
-causing all text to appear.
-"""
+## Reenables touch translation.
+##
+## Touch translation is reenabled during a brief delay to prevent a bug where a touch event is immediately processed,
+## causing all text to appear.
 func _enable_translation() -> void:
 	call_deferred("set_process", true)
 

--- a/project/src/main/ui/cheat-code-detector.gd
+++ b/project/src/main/ui/cheat-code-detector.gd
@@ -1,24 +1,22 @@
 class_name CheatCodeDetector
 extends Node
-"""
-Detects when the player enters cheat codes.
+## Detects when the player enters cheat codes.
+##
+## When the player types a key, this class checks whether the user finished typing a cheat code. If a cheat code was
+## typed, this class emits a signal which can be used to activate the cheat code. Any gameplay effects and sound
+## effects are the responsibility of the class receiving the signal.
+##
+## It's recommended the class receiving a cheat code signal play an audio cue. The
+## res://assets/main/ui/cheat-disable.wav and res://assets/main/ui/cheat-enable.wav sound files exist for this purpose.
 
-When the player types a key, this class checks whether the user finished typing a cheat code. If a cheat code was
-typed, this class emits a signal which can be used to activate the cheat code. Any gameplay effects and sound effects
-are the responsibility of the class receiving the signal.
-
-It's recommended the class receiving a cheat code signal play an audio cue. The res://assets/main/ui/cheat-disable.wav
-and res://assets/main/ui/cheat-enable.wav sound files exist for this purpose.
-"""
-
-# emitted when a cheat is entered.
+## emitted when a cheat is entered.
 signal cheat_detected(cheat, detector)
 
-# The maximum length of cheat codes. Entered keys are stored in a buffer, and we don't want the buffer to grow to a
-# ridiculous size.
+## The maximum length of cheat codes. Entered keys are stored in a buffer, and we don't want the buffer to grow to a
+## ridiculous size.
 const MAX_LENGTH := 32
 
-# Dictionary of key scancodes used in cheat codes, and their alphanumeric representation.
+## Dictionary of key scancodes used in cheat codes, and their alphanumeric representation.
 const CODE_KEYS := {
 	KEY_SPACE:" ", KEY_APOSTROPHE:"'", KEY_COMMA:",", KEY_MINUS:"-", KEY_PERIOD:".", KEY_SLASH:"/",
 	KEY_0:"0", KEY_1:"1", KEY_2:"2", KEY_3:"3", KEY_4:"4", KEY_5:"5", KEY_6:"6", KEY_7:"7", KEY_8:"8", KEY_9:"9",
@@ -31,26 +29,22 @@ const CODE_KEYS := {
 	KEY_BRACELEFT:"[", KEY_BACKSLASH:"\\", KEY_BRACERIGHT:"]", KEY_QUOTELEFT:"`",
 }
 
-# List of cheat codes. Cheat codes should be lower-case, and should not be contained within one another or the shorter
-# cheat code will take precedence.
+## List of cheat codes. Cheat codes should be lower-case, and should not be contained within one another or the shorter
+## cheat code will take precedence.
 export (Array, String) var codes := []
 
-# Buffer of key strings which were previously pressed.
+## Buffer of key strings which were previously pressed.
 var _previous_keypresses := ""
 
 
-"""
-Plays the sound effect for enabling/disabling a cheat.
-"""
+## Plays the sound effect for enabling/disabling a cheat.
 func play_cheat_sound(enabled: bool) -> void:
 	var cheat_sound := $CheatEnableSound if enabled else $CheatDisableSound
 	cheat_sound.play()
 
 
-"""
-Processes an input event, delegating to the appropriate 'key_pressed', 'key_just_pressed', 'key_released',
-'key_just_released' functions.
-"""
+## Processes an input event, delegating to the appropriate 'key_pressed', 'key_just_pressed', 'key_released',
+## 'key_just_released' functions.
 func _input(event: InputEvent) -> void:
 	if event is InputEventKey and event.scancode in CODE_KEYS:
 		var key_string: String = CODE_KEYS[event.scancode]
@@ -58,12 +52,10 @@ func _input(event: InputEvent) -> void:
 			_key_just_pressed(key_string)
 
 
-"""
-Called for the first frame when a key is pressed.
-
-Parameters:
-	'key_string': An single-character alphanumeric representation of the pressed key
-"""
+## Called for the first frame when a key is pressed.
+##
+## Parameters:
+## 	'key_string': An single-character alphanumeric representation of the pressed key
 func _key_just_pressed(key_string: String) -> void:
 	_previous_keypresses += key_string
 	# remove the oldest keypresses so the buffer doesn't grow infinitely

--- a/project/src/main/ui/creature-stress-test.gd
+++ b/project/src/main/ui/creature-stress-test.gd
@@ -1,15 +1,13 @@
 extends Node
-"""
-Shows the impact of creatures on FPS.
-
-As of February 2021, adding more creatures results in a massive performance performance degradation. This stress test
-lets us objectively measure how far performance degrades with each new creature, to quantify bottlenecks and potential
-performance improvements.
-"""
+## Shows the impact of creatures on FPS.
+##
+## As of February 2021, adding more creatures results in a massive performance performance degradation. This stress
+## test lets us objectively measure how far performance degrades with each new creature, to quantify bottlenecks and
+## potential performance improvements.
 
 const INITIAL_CREATURE_COUNT := 5
 
-# We use a predictable set of creature IDs so that unusual creatures will not impact the results
+## We use a predictable set of creature IDs so that unusual creatures will not impact the results
 const CREATURE_IDS := [
 	"alexander", "beats", "dingold", "goris", "logana", "pipedro",
 	"rhinosaur", "snorz", "squawkapus", "stunker", "terpion", "vile",
@@ -25,14 +23,12 @@ func _ready() -> void:
 	_refresh_creature_count()
 
 
-"""
-Adds creatures to the scene.
-
-The creatures are selected sequentially using a predetermined set of creature IDs.
-
-Parameters:
-	'count': The number of creatures to add.
-"""
+## Adds creatures to the scene.
+##
+## The creatures are selected sequentially using a predetermined set of creature IDs.
+##
+## Parameters:
+## 	'count': The number of creatures to add.
 func _add_creatures(count: int) -> void:
 	for _i in range(count):
 		var creature: Creature = CreatureScene.instance()
@@ -49,14 +45,12 @@ func _add_creatures(count: int) -> void:
 		_refresh_creature_count()
 
 
-"""
-Removes creatures from the scene.
-
-The creatures are removed in FILO order.
-
-Parameters:
-	'count': The number of creatures to add.
-"""
+## Removes creatures from the scene.
+##
+## The creatures are removed in FILO order.
+##
+## Parameters:
+## 	'count': The number of creatures to add.
 func _remove_creatures(count: int) -> void:
 	for _i in range(count):
 		if $Creatures.get_child_count() == 0:
@@ -68,19 +62,15 @@ func _remove_creatures(count: int) -> void:
 		_refresh_creature_count()
 
 
-"""
-Updates the 'creature count' label.
-"""
+## Updates the 'creature count' label.
 func _refresh_creature_count() -> void:
 	$Ui/Control/CreatureCount.text = str($Creatures.get_child_count())
 
 
-"""
-When the player presses a button, we add or remove creatures from the scene.
-
-Parameters:
-	'creature_delta': The number of creatures to add if positive, or to remove if negative.
-"""
+## When the player presses a button, we add or remove creatures from the scene.
+##
+## Parameters:
+## 	'creature_delta': The number of creatures to add if positive, or to remove if negative.
 func _on_CreatureButton_pressed(creature_delta: int) -> void:
 	if creature_delta > 0:
 		_add_creatures(creature_delta)

--- a/project/src/main/ui/cutscene-button.gd
+++ b/project/src/main/ui/cutscene-button.gd
@@ -1,7 +1,5 @@
 extends ImageButton
-"""
-Button which enables/disables cutscenes.
-"""
+## Button which enables/disables cutscenes.
 
 enum CutsceneButtonState {
 	IMPLICIT_PLAY, # this cutscene is implicitly played; the player has no preference
@@ -22,10 +20,10 @@ var _no_pressed_texture: Texture = preload("res://assets/main/ui/level-select/cu
 var _yes_texture: Texture = preload("res://assets/main/ui/level-select/cutscene-yes.png")
 var _yes_pressed_texture: Texture = preload("res://assets/main/ui/level-select/cutscene-yes-pressed.png")
 
-# tracks whether the player wants to play or skip all cutscenes
+## tracks whether the player wants to play or skip all cutscenes
 var _cutscene_force := IMPLICIT_PLAY setget set_cutscene_force
 
-# tracks whether the current level's cutscenes will be implicitly skipped if the player has no preference
+## tracks whether the current level's cutscenes will be implicitly skipped if the player has no preference
 var _cutscene_implicit_force := IMPLICIT_PLAY
 
 onready var _level_buttons: LevelButtons = get_node(level_buttons_path)
@@ -48,9 +46,7 @@ func set_cutscene_force(new_cutscene_force: int) -> void:
 	_refresh_cutscene_force()
 
 
-"""
-Refresh the button's appearance and update the global 'cutscene_force' setting.
-"""
+## Refresh the button's appearance and update the global 'cutscene_force' setting.
 func _refresh_cutscene_force() -> void:
 	# update the button's icon
 	match _cutscene_force:
@@ -78,9 +74,7 @@ func _refresh_cutscene_force() -> void:
 			SystemData.misc_settings.cutscene_force = Levels.CutsceneForce.SKIP
 
 
-"""
-Returns 'true' if the specified level's preroll cutscene should be played.
-"""
+## Returns 'true' if the specified level's preroll cutscene should be played.
 func _will_play_preroll(settings: LevelSettings) -> bool:
 	if not ChatLibrary.has_preroll(settings.id):
 		return false
@@ -88,9 +82,7 @@ func _will_play_preroll(settings: LevelSettings) -> bool:
 	return CurrentLevel.should_play_cutscene(ChatLibrary.chat_tree_for_preroll(settings.id), true)
 
 
-"""
-Returns 'true' if the specified level's postroll cutscene should be played.
-"""
+## Returns 'true' if the specified level's postroll cutscene should be played.
 func _will_play_postroll(settings: LevelSettings) -> bool:
 	if not ChatLibrary.has_postroll(settings.id):
 		return false
@@ -105,9 +97,7 @@ func _on_pressed() -> void:
 		FORCE_SKIP: set_cutscene_force(FORCE_PLAY)
 
 
-"""
-When the player selects a new level, we sometimes update the cutscene button's appearance.
-"""
+## When the player selects a new level, we sometimes update the cutscene button's appearance.
 func _on_LevelButtons_unlocked_level_selected(_level_lock: LevelLock, settings: LevelSettings) -> void:
 	# update the implicit state based on the selected level
 	_cutscene_implicit_force = IMPLICIT_SKIP

--- a/project/src/main/ui/font-fit-label.gd
+++ b/project/src/main/ui/font-fit-label.gd
@@ -1,14 +1,12 @@
 class_name FontFitLabel
 extends Label
-"""
-This label changes its font dynamically based on the amount of text it needs to display. It chooses the largest font
-which will not overrun its boundaries.
-"""
+## This label changes its font dynamically based on the amount of text it needs to display. It chooses the largest font
+## which will not overrun its boundaries.
 
-# When calculating how much text we can accommodate, there is a 3 pixel gap between each row.
+## When calculating how much text we can accommodate, there is a 3 pixel gap between each row.
 const FONT_GAP := 3
 
-# Different fonts to try. Should be ordered from largest to smallest.
+## Different fonts to try. Should be ordered from largest to smallest.
 export(Array, Font) var fonts := [] setget set_fonts
 
 var chosen_font_index := -1 setget set_chosen_font_index
@@ -22,12 +20,10 @@ func _ready() -> void:
 	max_lines_visible = max(1, max_lines_visible)
 
 
-"""
-Sets the label's font to the largest font which will accommodate its text.
-
-If the label's text is modified this should be called manually. This class cannot respond to text changes or override
-set_text because of Godot #29390 (https://github.com/godotengine/godot/issues/29390)
-"""
+## Sets the label's font to the largest font which will accommodate its text.
+##
+## If the label's text is modified this should be called manually. This class cannot respond to text changes or
+## override set_text because of Godot #29390 (https://github.com/godotengine/godot/issues/29390)
 func pick_largest_font() -> void:
 	for i in range(fonts.size()):
 		# start with the largest font, and try smaller and smaller fonts

--- a/project/src/main/ui/fps-label.gd
+++ b/project/src/main/ui/fps-label.gd
@@ -1,7 +1,5 @@
 extends Label
-"""
-Renders the current frames-per-second to the screen, '60.00 fps'
-"""
+## Renders the current frames-per-second to the screen, '60.00 fps'
 
 func _process(_delta: float) -> void:
 	text = "%d fps" % Engine.get_frames_per_second()

--- a/project/src/main/ui/high-score-table.gd
+++ b/project/src/main/ui/high-score-table.gd
@@ -1,15 +1,13 @@
 class_name HighScoreTable
 extends VBoxContainer
-"""
-A table which displays the player's high scores in practice mode.
+## A table which displays the player's high scores in practice mode.
+##
+## Scores are separated by mode and difficulty. We also keep daily scores separate.
 
-Scores are separated by mode and difficulty. We also keep daily scores separate.
-"""
-
-# level to display high scores for
+## level to display high scores for
 var _level: LevelSettings setget set_level
 
-# if true, only performances with today's date are included
+## if true, only performances with today's date are included
 export (bool) var daily := false setget set_daily
 
 onready var _label: Label = $Label
@@ -19,25 +17,19 @@ func _ready() -> void:
 	_refresh_contents()
 
 
-"""
-Toggles this high score table between 'Today's Best' and 'All-time Best'
-"""
+## Toggles this high score table between 'Today's Best' and 'All-time Best'
 func set_daily(new_daily: bool) -> void:
 	daily = new_daily
 	_refresh_contents()
 
 
-"""
-Sets the level to display high scores for.
-"""
+## Sets the level to display high scores for.
 func set_level(new_level: LevelSettings) -> void:
 	_level = new_level
 	_refresh_contents()
 
 
-"""
-Clears all rows in the grid container.
-"""
+## Clears all rows in the grid container.
 func _clear_rows() -> void:
 	_label.text = tr("Today's Best") if daily else tr("All-time Best")
 	for child_obj in _grid_container.get_children():
@@ -45,9 +37,7 @@ func _clear_rows() -> void:
 		child.queue_free()
 
 
-"""
-Adds new rows to the grid container.
-"""
+## Adds new rows to the grid container.
 func _add_rows() -> void:
 	if not _level:
 		return
@@ -56,18 +46,14 @@ func _add_rows() -> void:
 		_add_row(rank_result_row(best_result, daily))
 
 
-"""
-Clears and regenerates the cells in the grid container.
-"""
+## Clears and regenerates the cells in the grid container.
 func _refresh_contents() -> void:
 	if is_inside_tree():
 		_clear_rows()
 		_add_rows()
 
 
-"""
-Adds a new row to the grid container.
-"""
+## Adds a new row to the grid container.
 func _add_row(items: Array) -> void:
 	for item_obj in items:
 		var item: String = item_obj
@@ -77,11 +63,9 @@ func _add_row(items: Array) -> void:
 		$GridContainer.add_child(item_label)
 
 
-"""
-Returns a table row for the specified rank result.
-
-This table row includes a timestamp, number of line clears, score/time, and grade.
-"""
+## Returns a table row for the specified rank result.
+##
+## This table row includes a timestamp, number of line clears, score/time, and grade.
 static func rank_result_row(result: RankResult, daily_result: bool = false) -> Array:
 	var row := []
 

--- a/project/src/main/ui/image-button.gd
+++ b/project/src/main/ui/image-button.gd
@@ -1,11 +1,9 @@
 class_name ImageButton
 extends Button
-"""
-A button represented by a pair of icons.
-
-Pressing the button toggles between the normal and pressed icon. The button's size changes based on the player's touch
-settings.
-"""
+## A button represented by a pair of icons.
+##
+## Pressing the button toggles between the normal and pressed icon. The button's size changes based on the player's
+## touch settings.
 
 export (Texture) var normal_icon: Texture setget set_normal_icon
 export (Texture) var pressed_icon: Texture setget set_pressed_icon

--- a/project/src/main/ui/level-select/grade-labels.gd
+++ b/project/src/main/ui/level-select/grade-labels.gd
@@ -1,19 +1,15 @@
 extends Control
-"""
-Manages grade labels which overlay level select buttons.
-
-These grade labels appear in the corner and show the player's performance.
-"""
+## Manages grade labels which overlay level select buttons.
+##
+## These grade labels appear in the corner and show the player's performance.
 
 export (PackedScene) var GradeLabelScene: PackedScene
 
-# key: LevelSelectButton instance
-# value: HookableGradeLabel for the specified button
+## key: LevelSelectButton instance
+## value: HookableGradeLabel for the specified button
 var _labels_by_button: Dictionary
 
-"""
-Add a grade label for the specified button.
-"""
+## Add a grade label for the specified button.
 func _add_label(button: LevelSelectButton) -> void:
 	if _labels_by_button.has(button):
 		# avoid adding two labels for the same button

--- a/project/src/main/ui/level-select/hookable-grade-label.gd
+++ b/project/src/main/ui/level-select/hookable-grade-label.gd
@@ -1,13 +1,11 @@
 class_name HookableGradeLabel
 extends Node2D
-"""
-Shows a grade label for a specific level.
+## Shows a grade label for a specific level.
+##
+## This can be something like 'S' or 'B+' if a level has been cleared, or something like a lock/key icon for levels
+## which haven't yet been cleared.
 
-This can be something like 'S' or 'B+' if a level has been cleared, or something like a lock/key icon for levels
-which haven't yet been cleared.
-"""
-
-# the level button this grade label applies to
+## the level button this grade label applies to
 var button: LevelSelectButton setget set_button
 
 var _cleared_texture: Texture = preload("res://assets/main/ui/level-select/cleared.png")
@@ -15,9 +13,7 @@ var _crown_texture: Texture = preload("res://assets/main/ui/level-select/crown.p
 var _key_texture: Texture = preload("res://assets/main/ui/level-select/key.png")
 var _locked_texture: Texture = preload("res://assets/main/ui/level-select/locked.png")
 
-"""
-Assigns this label's button, and updates the label's appearance.
-"""
+## Assigns this label's button, and updates the label's appearance.
 func set_button(new_button: LevelSelectButton) -> void:
 	if button == new_button:
 		# skip the unnecessary overhead in hooking/unhooking signals and refreshing our appearance
@@ -37,12 +33,10 @@ func set_button(new_button: LevelSelectButton) -> void:
 	_refresh_appearance()
 
 
-"""
-Updates the text/icon based on the level's status.
-
-If the level has been cleared, we display text corresponding to the player's grade. If the level hasn't been cleared,
-we show a lock/key/crown icon corresponding to the level's lock status.
-"""
+## Updates the text/icon based on the level's status.
+##
+## If the level has been cleared, we display text corresponding to the player's grade. If the level hasn't been
+## cleared, we show a lock/key/crown icon corresponding to the level's lock status.
 func _refresh_appearance() -> void:
 	if button.is_class("WorldSelectButton"):
 		var world_button: WorldSelectButton = button
@@ -70,11 +64,9 @@ func _refresh_appearance() -> void:
 	visible = false if button.lowlight else true
 
 
-"""
-Updates the icon based on the level's status.
-
-We show a lock/key/crown icon corresponding to the level's lock status.
-"""
+## Updates the icon based on the level's status.
+##
+## We show a lock/key/crown icon corresponding to the level's lock status.
 func _refresh_status_icon(lock_status: int) -> void:
 	$GradeLabel.visible = false
 	$StatusIcon.visible = true
@@ -102,9 +94,7 @@ func _refresh_status_icon(lock_status: int) -> void:
 	$StatusIcon.material.set("shader_param/black", outline_color)
 
 
-"""
-Updates the text based on the player's grade on a level.
-"""
+## Updates the text based on the player's grade on a level.
 func _refresh_grade_text(rank: float) -> void:
 	$GradeLabel.visible = true
 	$StatusIcon.visible = false

--- a/project/src/main/ui/level-select/level-buttons.gd
+++ b/project/src/main/ui/level-select/level-buttons.gd
@@ -1,52 +1,50 @@
 class_name LevelButtons
 extends Control
-"""
-Creates and arranges level buttons for the level select screen.
-"""
+## Creates and arranges level buttons for the level select screen.
 
 enum LevelsToInclude {
 	ALL_LEVELS, # show both tutorial levels and regular levels
 	TUTORIALS_ONLY, # only show tutorials; hide regular levels
 }
 
-# Emitted when the player highlights an unlocked level to show more information.
+## Emitted when the player highlights an unlocked level to show more information.
 signal unlocked_level_selected(level_lock, settings)
 
-# Emitted when the player highlights a locked level to show more information.
+## Emitted when the player highlights a locked level to show more information.
 signal locked_level_selected(level_lock, settings)
 
-# Emitted when the player highlights the 'overall' button.
+## Emitted when the player highlights the 'overall' button.
 signal overall_selected(world_id, ranks)
 
-# Emitted when a new level select button or world select button is added.
+## Emitted when a new level select button or world select button is added.
 signal button_added(button)
 
 const ALL_LEVELS := LevelsToInclude.ALL_LEVELS
 const TUTORIALS_ONLY := LevelsToInclude.TUTORIALS_ONLY
 
-# Levels are arranged into a big rectangle. This is the ratio of the rectangle's width to height.
+## Levels are arranged into a big rectangle. This is the ratio of the rectangle's width to height.
 const BUTTON_ARRANGEMENT_WIDTH_FACTOR := 1.77778
 
-# The width of level buttons when they're small (about 10-20 visible)
+## The width of level buttons when they're small (about 10-20 visible)
 const COLUMN_WIDTH_SMALL := 120
 
-# The width of level buttons when they're big (about 30-40 visible)
+## The width of level buttons when they're big (about 30-40 visible)
 const COLUMN_WIDTH_LARGE := 180
 
-# The amount of space between level buttons
+## The amount of space between level buttons
 const VERTICAL_SPACING := LevelSelectButton.VERTICAL_SPACING
 
 export (PackedScene) var LevelSelectButtonScene: PackedScene
 export (PackedScene) var WorldSelectButtonScene: PackedScene
 
-# Allows for hiding/showing certain levels
+## Allows for hiding/showing certain levels
 export (LevelsToInclude) var levels_to_include := ALL_LEVELS setget set_levels_to_include
 
-# VBoxContainer instances containing columns of level buttons
+## VBoxContainer instances containing columns of level buttons
 var _max_row_count
 var _columns := []
 
-# current column width; shrinks when zoomed out
+## current column width; shrinks when zoomed out
 var _column_width := COLUMN_WIDTH_SMALL
 
 var _duration_calculator := DurationCalculator.new()
@@ -65,18 +63,14 @@ func set_levels_to_include(new_levels_to_include: int) -> void:
 	_add_buttons()
 
 
-"""
-Removes all buttons/placeholders in preparation for loading a new set of levels.
-"""
+## Removes all buttons/placeholders in preparation for loading a new set of levels.
 func _clear_contents() -> void:
 	for child in get_children():
 		remove_child(child)
 		child.queue_free()
 
 
-"""
-Adds buttons representing levels the player can choose.
-"""
+## Adds buttons representing levels the player can choose.
 func _add_buttons() -> void:
 	# calculate which worlds should be shown
 	var included_world_ids: Array
@@ -122,9 +116,7 @@ func _add_buttons() -> void:
 		last_world_button.grab_focus()
 
 
-"""
-Adds a node to the rightmost column, or creates a new column if the column is full
-"""
+## Adds a node to the rightmost column, or creates a new column if the column is full
 func _add_button_to_column(button: LevelSelectButton) -> void:
 	if not _columns or _columns[_columns.size() - 1].get_child_count() >= _max_row_count:
 		# create a new column
@@ -140,9 +132,7 @@ func _add_button_to_column(button: LevelSelectButton) -> void:
 	emit_signal("button_added", button)
 
 
-"""
-Adds the world button which show the player's progress for a world.
-"""
+## Adds the world button which show the player's progress for a world.
 func _world_button(world_id: String) -> WorldSelectButton:
 	var world_select_button: WorldSelectButton = WorldSelectButtonScene.instance()
 	world_select_button.world_id = world_id
@@ -167,9 +157,7 @@ func _world_button(world_id: String) -> WorldSelectButton:
 	return world_select_button
 
 
-"""
-Creates a level select button for the specified level.
-"""
+## Creates a level select button for the specified level.
 func _level_select_button(world_id: String, level_id: String) -> LevelSelectButton:
 	var level_settings: LevelSettings = LevelLibrary.level_settings(level_id)
 	var level_select_button: LevelSelectButton = LevelSelectButtonScene.instance()
@@ -203,9 +191,7 @@ func _lowlight_unrelated_buttons(world_id: String) -> void:
 		else:
 			level_select_button.lowlight = true
 
-"""
-When the player clicks a level button twice, we launch the selected level
-"""
+## When the player clicks a level button twice, we launch the selected level
 func _on_LevelSelectButton_level_started(settings: LevelSettings) -> void:
 	CurrentLevel.set_launched_level(settings.id)
 	CurrentLevel.cutscene_force = SystemData.misc_settings.cutscene_force
@@ -222,9 +208,7 @@ func _on_LevelSelectButton_level_started(settings: LevelSettings) -> void:
 		CurrentLevel.push_level_trail()
 
 
-"""
-When the player clicks a level button once, we emit a signal to show more information.
-"""
+## When the player clicks a level button once, we emit a signal to show more information.
 func _on_LevelSelectButton_focus_entered(settings: LevelSettings) -> void:
 	var world_lock: WorldLock = LevelLibrary.world_lock_for_level(settings.id)
 	_lowlight_unrelated_buttons(world_lock.world_id)
@@ -234,9 +218,7 @@ func _on_LevelSelectButton_focus_entered(settings: LevelSettings) -> void:
 		emit_signal("unlocked_level_selected", LevelLibrary.level_lock(settings.id), settings)
 
 
-"""
-When the player clicks the 'overall' button once, we emit a signal to show more information.
-"""
+## When the player clicks the 'overall' button once, we emit a signal to show more information.
 func _on_WorldButton_focus_entered(world_select_button: WorldSelectButton) -> void:
 	_lowlight_unrelated_buttons(world_select_button.world_id)
 	emit_signal("overall_selected", world_select_button.world_id, world_select_button.ranks)

--- a/project/src/main/ui/level-select/level-description-panel.gd
+++ b/project/src/main/ui/level-select/level-description-panel.gd
@@ -1,7 +1,5 @@
 extends Panel
-"""
-A panel on the level select screen which shows level descriptions.
-"""
+## A panel on the level select screen which shows level descriptions.
 
 func _update_tutorial_world_text(ranks: Array) -> void:
 	var text := ""
@@ -39,16 +37,12 @@ func _update_world_text(ranks: Array) -> void:
 	$MarginContainer/Label.text = text
 
 
-"""
-When an unlocked level is selected, we display the level's description.
-"""
+## When an unlocked level is selected, we display the level's description.
 func _on_LevelButtons_unlocked_level_selected(_level_lock: LevelLock, settings: LevelSettings) -> void:
 	$MarginContainer/Label.text = settings.description
 
 
-"""
-When a locked level is selected, we tell the player how to unlock it.
-"""
+## When a locked level is selected, we tell the player how to unlock it.
 func _on_LevelButtons_locked_level_selected(level_lock: LevelLock, settings: LevelSettings) -> void:
 	var text := ""
 	match level_lock.status:
@@ -67,9 +61,7 @@ func _on_LevelButtons_locked_level_selected(level_lock: LevelLock, settings: Lev
 	$MarginContainer/Label.text = text
 
 
-"""
-When the 'overall' button is selected, we summarize the player's progress.
-"""
+## When the 'overall' button is selected, we summarize the player's progress.
 func _on_LevelButtons_overall_selected(world_id: String, ranks: Array) -> void:
 	if world_id == LevelLibrary.TUTORIAL_WORLD_ID:
 		_update_tutorial_world_text(ranks)

--- a/project/src/main/ui/level-select/level-info-panel.gd
+++ b/project/src/main/ui/level-select/level-info-panel.gd
@@ -1,11 +1,9 @@
 extends Panel
-"""
-A panel on the level select screen which summarizes level details.
+## A panel on the level select screen which summarizes level details.
+##
+## This includes details such as the level's duration, difficulty, and the player's high score.
 
-This includes details such as the level's duration, difficulty, and the player's high score.
-"""
-
-# All calculated durations are rounded to one of these aesthetically pleasing values.
+## All calculated durations are rounded to one of these aesthetically pleasing values.
 const DURATIONS := [
 	10, 15, 20, 30, 45, 60,
 	90, 120, 150, 180, 270, 360, 480, 600
@@ -114,9 +112,7 @@ func _update_world_text(ranks: Array) -> void:
 	$MarginContainer/Label.text = text
 
 
-"""
-When an unlocked level is selected, we display some statistics for that level.
-"""
+## When an unlocked level is selected, we display some statistics for that level.
 func _on_LevelButtons_unlocked_level_selected(_level_lock: LevelLock, settings: LevelSettings) -> void:
 	if settings.other.tutorial:
 		_update_tutorial_level_text(settings)
@@ -124,16 +120,12 @@ func _on_LevelButtons_unlocked_level_selected(_level_lock: LevelLock, settings: 
 		_update_level_text(settings)
 
 
-"""
-When a locked level is selected, we clear out the info panel.
-"""
+## When a locked level is selected, we clear out the info panel.
 func _on_LevelButtons_locked_level_selected(_level_lock: LevelLock, _settings: LevelSettings) -> void:
 	$MarginContainer/Label.text = ""
 
 
-"""
-When the 'overall' button is selected, we display statistics for all of the levels.
-"""
+## When the 'overall' button is selected, we display statistics for all of the levels.
 func _on_LevelButtons_overall_selected(world_id: String, ranks: Array) -> void:
 	if world_id == LevelLibrary.TUTORIAL_WORLD_ID:
 		_update_tutorial_world_text(ranks)

--- a/project/src/main/ui/level-select/level-library.gd
+++ b/project/src/main/ui/level-select/level-library.gd
@@ -1,57 +1,51 @@
 extends Node
-"""
-Manages data for all levels in the game. This includes their rules, unlock criteria, and whether the player's unlocked
-them yet.
+## Manages data for all levels in the game. This includes their rules, unlock criteria, and whether the player's
+## unlocked them yet.
+##
+## Levels are stored as json resources. This class parses those json resources into LevelSettings so they can be used
+## by the puzzle code.
 
-Levels are stored as json resources. This class parses those json resources into LevelSettings so they can be used by
-the puzzle code.
-"""
-
-# The mandatory tutorial the player must complete before playing the game
+## The mandatory tutorial the player must complete before playing the game
 const BEGINNER_TUTORIAL := "tutorial/basics_0"
 const TUTORIAL_WORLD_ID := "tutorial"
 
-# Path to the json file with the list of levels. Can be changed for tests.
+## Path to the json file with the list of levels. Can be changed for tests.
 const DEFAULT_WORLDS_PATH := "res://assets/main/puzzle/worlds.json"
 
-# Path to the json file with the list of levels. Can be changed for tests.
+## Path to the json file with the list of levels. Can be changed for tests.
 var worlds_path := DEFAULT_WORLDS_PATH setget set_worlds_path
 
-# Ordered list of all world IDs
+## Ordered list of all world IDs
 var world_ids: Array
 
-# key: group id
-# value: level IDs belonging to the group
+## key: group id
+## value: level IDs belonging to the group
 var _level_groups: Dictionary
 
-# key: level id
-# value: LevelLock with the specified id
+## key: level id
+## value: LevelLock with the specified id
 var _level_locks: Dictionary
 
-# ley: level id
-# value: LevelSettings for the specified level
+## ley: level id
+## value: LevelSettings for the specified level
 var _level_settings_by_id: Dictionary
 
-# key: world id
-# value: WorldLock with the specified id
+## key: world id
+## value: WorldLock with the specified id
 var _world_locks: Dictionary
 
-# key: level id
-# value: WorldLock containing the specified level
+## key: level id
+## value: WorldLock containing the specified level
 var _world_locks_by_level_id: Dictionary
 
-"""
-Loads the list of levels from JSON, processing it to determine which levels are locked.
-"""
+## Loads the list of levels from JSON, processing it to determine which levels are locked.
 func _ready() -> void:
 	_load_raw_json_data()
 	refresh_cleared_levels()
 	PlayerData.connect("level_history_changed", self, "_on_PlayerData_level_history_changed")
 
 
-"""
-Recalculates which worlds and levels are available to the player and how to unlock them.
-"""
+## Recalculates which worlds and levels are available to the player and how to unlock them.
 func refresh_cleared_levels() -> void:
 	_reset_cleared_worlds_and_levels()
 	_update_locked_worlds()
@@ -80,12 +74,10 @@ func level_settings(level_id: String) -> LevelSettings:
 	return _level_settings_by_id.get(level_id)
 
 
-"""
-Returns the first unfinished, unlocked level id for a creature.
-
-This is the level which will be played if the player talks to them on the overworld. Finished levels can be played
-through the cell phone. Locked levels cannot be played; they must be unlocked first.
-"""
+## Returns the first unfinished, unlocked level id for a creature.
+##
+## This is the level which will be played if the player talks to them on the overworld. Finished levels can be played
+## through the cell phone. Locked levels cannot be played; they must be unlocked first.
 func next_creature_level(creature_id: String) -> String:
 	var priority_result := ""
 	var result := ""
@@ -121,11 +113,9 @@ func next_creature_level(creature_id: String) -> String:
 	return priority_result if priority_result else result
 
 
-"""
-Returns a list of IDs for levels shown to the player.
-
-Many levels are hidden from the player at the beginning of the game. They become visible as the player progresses.
-"""
+## Returns a list of IDs for levels shown to the player.
+##
+## Many levels are hidden from the player at the beginning of the game. They become visible as the player progresses.
 func shown_level_ids(world_id: String) -> Array:
 	var shown_level_ids := []
 	for level_id in world_lock(world_id).level_ids:
@@ -154,9 +144,7 @@ func is_world_finished(world_id: String) -> bool:
 	return world_lock and world_lock.last_level and PlayerData.level_history.is_level_finished(world_lock.last_level)
 
 
-"""
-Loads the list of levels from JSON.
-"""
+## Loads the list of levels from JSON.
 func _load_raw_json_data() -> void:
 	var worlds_text := FileUtils.get_file_as_text(worlds_path)
 	var worlds_json: Dictionary = parse_json(worlds_text)
@@ -199,12 +187,10 @@ func _load_raw_json_data() -> void:
 			_level_settings_by_id[level_lock.level_id] = level_settings
 
 
-"""
-Reset the world/level status to a default state so that it can be recalculated.
-
-When worlds and levels are first loaded from JSON, they're in a clean state. We restore them to this clean state later
-before recalculating the player's current status.
-"""
+## Reset the world/level status to a default state so that it can be recalculated.
+##
+## When worlds and levels are first loaded from JSON, they're in a clean state. We restore them to this clean state
+## later before recalculating the player's current status.
 func _reset_cleared_worlds_and_levels() -> void:
 	# reset unlocked worlds
 	for world_lock_obj in _world_locks.values():
@@ -219,9 +205,7 @@ func _reset_cleared_worlds_and_levels() -> void:
 		level_lock.status = LevelLock.STATUS_NONE
 		level_lock.keys_needed = -1
 
-"""
-Update the world lock status to 'lock' for locked worlds.
-"""
+## Update the world lock status to 'lock' for locked worlds.
 func _update_locked_worlds() -> void:
 	for world_lock_obj in _world_locks.values():
 		var world_lock: WorldLock = world_lock_obj
@@ -235,9 +219,7 @@ func _update_locked_worlds() -> void:
 				world_lock.status = WorldLock.STATUS_LOCK
 
 
-"""
-Update the level lock status to 'hard lock' for locked levels.
-"""
+## Update the level lock status to 'hard lock' for locked levels.
 func _update_locked_levels() -> void:
 	for level_lock_obj in _level_locks.values():
 		var level_lock: LevelLock = level_lock_obj
@@ -264,9 +246,7 @@ func _update_locked_levels() -> void:
 			level_lock.keys_needed = skip_count - allowed_skips
 
 
-"""
-Returns the list of level IDs which contribute to unlocking this level.
-"""
+## Returns the list of level IDs which contribute to unlocking this level.
 func _unlock_level_ids(level_lock: LevelLock) -> Array:
 	var unlock_level_ids := []
 	if level_lock.unlocked_if_type == LevelLock.IF_LEVEL_FINISHED:
@@ -277,12 +257,10 @@ func _unlock_level_ids(level_lock: LevelLock) -> Array:
 	return unlock_level_ids
 
 
-"""
-Returns the number of skips which are allowed when unlocking this level.
-
-A level may have fifteen levels which unlock it, but the player only needs to clear ten of them. This would be
-represented as allowing 'five skips'.
-"""
+## Returns the number of skips which are allowed when unlocking this level.
+##
+## A level may have fifteen levels which unlock it, but the player only needs to clear ten of them. This would be
+## represented as allowing 'five skips'.
 func _allowed_skips(level_lock: LevelLock) -> int:
 	var allowed_skips := 0
 	if level_lock.unlocked_if_type == LevelLock.IF_GROUP_FINISHED:
@@ -291,9 +269,7 @@ func _allowed_skips(level_lock: LevelLock) -> int:
 	return allowed_skips
 
 
-"""
-Update the lock status to 'soft lock' for unlockable levels
-"""
+## Update the lock status to 'soft lock' for unlockable levels
 func _update_unlockable_levels() -> void:
 	# update levels with locks/keys
 	for level_lock_obj in _level_locks.values():

--- a/project/src/main/ui/level-select/level-lock.gd
+++ b/project/src/main/ui/level-select/level-lock.gd
@@ -1,16 +1,14 @@
 class_name LevelLock
-"""
-Keeps track of whether a level is unlocked, and the requirements to unlock it.
-"""
+## Keeps track of whether a level is unlocked, and the requirements to unlock it.
 
-# the requirements to unlock a level
+## the requirements to unlock a level
 enum UnlockedIf {
 	ALWAYS_UNLOCKED, # never locked
 	IF_LEVEL_FINISHED, # unlocked if the player finishes a specific level(s)
 	IF_GROUP_FINISHED, # unlocked if the player finishes some levels in a group
 }
 
-# the status whether or not a level is locked/unlocked
+## the status whether or not a level is locked/unlocked
 enum LockStatus {
 	NONE, # not locked
 	CLEARED, # cleared without any rank; used for tutorials
@@ -33,34 +31,32 @@ const STATUS_HARD_LOCK := LockStatus.HARD_LOCK
 
 var level_id: String
 
-# Some levels activate chat sequences. This field specifies which character's chat should activate.
+## Some levels activate chat sequences. This field specifies which character's chat should activate.
 var creature_id: String
 
-# Some levels involve specific customers or a specific chef.
+## Some levels involve specific customers or a specific chef.
 var customer_ids: Array
 var chef_id: String
 
-# the requirements to unlock this level
+## the requirements to unlock this level
 var unlocked_if_type := ALWAYS_UNLOCKED
 
-"""
-An array of strings representing unlock criteria.
-
-For IF_LEVEL_FINISHED locks, this is an array of level IDs.
-For IF_GROUP_FINISHED locks, this is a group ID and (optionally) a number of levels which can be skipped.
-"""
+## An array of strings representing unlock criteria.
+##
+## For IF_LEVEL_FINISHED locks, this is an array of level IDs.
+## For IF_GROUP_FINISHED locks, this is a group ID and (optionally) a number of levels which can be skipped.
 var unlocked_if_values := []
 
-# the condition required to make this level high priority
+## the condition required to make this level high priority
 var prioritized_if: String
 
-# the status whether or not this level is locked/unlocked
+## the status whether or not this level is locked/unlocked
 var status := STATUS_NONE
 
-# the number of remaining levels the player needs to play to unlock this level
+## the number of remaining levels the player needs to play to unlock this level
 var keys_needed := -1
 
-# array of string group IDs for groups this level belongs to
+## array of string group IDs for groups this level belongs to
 var groups := []
 
 func from_json_dict(json: Dictionary) -> void:

--- a/project/src/main/ui/level-select/level-select-button.gd
+++ b/project/src/main/ui/level-select/level-select-button.gd
@@ -1,15 +1,13 @@
 class_name LevelSelectButton
 extends Button
-"""
-A button on the level select screen which launches a level.
-"""
+## A button on the level select screen which launches a level.
 
-# emitted when a level is launched.
+## emitted when a level is launched.
 signal level_started
 
 signal lowlight_changed
 
-# short levels have smaller buttons; long levels have larger buttons
+## short levels have smaller buttons; long levels have larger buttons
 enum LevelSize {
 	SHORT,
 	MEDIUM,
@@ -25,28 +23,28 @@ const VERTICAL_SPACING := 6
 var world_id: String
 var level_id: String
 
-# the duration of the level; this affects the button size
+## the duration of the level; this affects the button size
 var level_duration: int = LevelSize.MEDIUM setget set_level_duration
 
-# the width of the column this button is in
+## the width of the column this button is in
 var level_column_width: int = 120
 
-# the status whether or not this level is locked/unlocked
+## the status whether or not this level is locked/unlocked
 var lock_status: int = LevelLock.STATUS_NONE setget set_lock_status
 
-# the number of remaining levels the player needs to play to unlock this level
+## the number of remaining levels the player needs to play to unlock this level
 var keys_needed := -1 setget set_keys_needed
 
 var level_title: String setget set_level_title
 
-# 'true' if this button should be darkened so that it doesn't draw the player's attention.
+## 'true' if this button should be darkened so that it doesn't draw the player's attention.
 var lowlight: bool setget set_lowlight
 
-# 'true' if this button just received focus this frame. a mouse click which grants focus doesn't emit a 'level
-# started' event
+## 'true' if this button just received focus this frame. a mouse click which grants focus doesn't emit a 'level
+## started' event
 var _focus_just_entered := false
 
-# 'true' if the 'level started' signal should be emitted in response to a button click.
+## 'true' if the 'level started' signal should be emitted in response to a button click.
 var _emit_level_started := false
 
 onready var _label := $Label
@@ -91,9 +89,7 @@ func set_lowlight(new_lowlight: bool) -> void:
 	emit_signal("lowlight_changed")
 
 
-"""
-Updates the button's text, colors, size and icon based on the level and its status.
-"""
+## Updates the button's text, colors, size and icon based on the level and its status.
 func _refresh_appearance() -> void:
 	if not is_inside_tree():
 		return

--- a/project/src/main/ui/level-select/level-select-panel-top.gd
+++ b/project/src/main/ui/level-select/level-select-panel-top.gd
@@ -1,7 +1,5 @@
 extends Control
-"""
-Shows the top portion of the level select panel, including the level buttons and cutscene button.
-"""
+## Shows the top portion of the level select panel, including the level buttons and cutscene button.
 
 func _ready() -> void:
 	$CutsceneButton.connect("resized", self, "_on_CutsceneButton_resized")

--- a/project/src/main/ui/level-select/level-select.gd
+++ b/project/src/main/ui/level-select/level-select.gd
@@ -1,11 +1,9 @@
 extends Control
-"""
-The level select screen which shows buttons and level info.
-"""
+## The level select screen which shows buttons and level info.
 
 export (NodePath) var level_buttons_path: NodePath
 
-# Allows for hiding/showing certain levels
+## Allows for hiding/showing certain levels
 export (LevelButtons.LevelsToInclude) var levels_to_include: int setget set_levels_to_include
 
 onready var _level_buttons: LevelButtons = get_node(level_buttons_path)
@@ -13,11 +11,9 @@ onready var _level_buttons: LevelButtons = get_node(level_buttons_path)
 func _ready() -> void:
 	_level_buttons.levels_to_include = levels_to_include
 
-"""
-Parameters:
-	'new_levels_to_include': An enum in LevelButtons.LevelsToInclude which specifies which allows for hiding or
-			showing certain levels.
-"""
+## Parameters:
+## 	'new_levels_to_include': An enum in LevelButtons.LevelsToInclude which specifies which allows for hiding or
+## 			showing certain levels.
 func set_levels_to_include(new_levels_to_include: int) -> void:
 	levels_to_include = new_levels_to_include
 	_refresh_levels_to_include()

--- a/project/src/main/ui/level-select/world-lock.gd
+++ b/project/src/main/ui/level-select/world-lock.gd
@@ -1,15 +1,13 @@
 class_name WorldLock
-"""
-Keeps track of whether a world is unlocked, and the requirements to unlock it.
-"""
+## Keeps track of whether a world is unlocked, and the requirements to unlock it.
 
-# the requirements to unlock a world
+## the requirements to unlock a world
 enum UnlockedIf {
 	ALWAYS_UNLOCKED, # never locked
 	IF_WORLD_FINISHED, # unlocked if the player finishes a specific world(s)
 }
 
-# the status whether or not a world is locked/unlocked
+## the status whether or not a world is locked/unlocked
 enum LockStatus {
 	NONE, # not locked
 	LOCK, # locked
@@ -26,22 +24,20 @@ var world_name: String
 var prologue_chat_key: String
 var epilogue_chat_key: String
 
-# the requirements to unlock this level
+## the requirements to unlock this level
 var unlocked_if_type := ALWAYS_UNLOCKED
 
-# The final level in the world. Finishing this level counts as finishing the entire world.
+## The final level in the world. Finishing this level counts as finishing the entire world.
 var last_level: String
 
-"""
-An array of strings representing unlock criteria.
-
-For IF_WORLD_FINISHED locks, this is an array of world IDs.
-"""
+## An array of strings representing unlock criteria.
+##
+## For IF_WORLD_FINISHED locks, this is an array of world IDs.
 var unlocked_if_values := []
 
 var level_ids: Array
 
-# the status whether or not this level is locked/unlocked
+## the status whether or not this level is locked/unlocked
 var status := STATUS_NONE
 
 func from_json_dict(json: Dictionary) -> void:

--- a/project/src/main/ui/level-select/world-select-button.gd
+++ b/project/src/main/ui/level-select/world-select-button.gd
@@ -1,21 +1,15 @@
 class_name WorldSelectButton
 extends LevelSelectButton
-"""
-A button on the level select screen which displays world information.
-"""
+## A button on the level select screen which displays world information.
 
-# an array of level ranks. incomplete levels are treated as rank 999
+## an array of level ranks. incomplete levels are treated as rank 999
 var ranks: Array
 
-"""
-Workaround for Godot #21789 to make get_class return class_name
-"""
+## Workaround for Godot #21789 to make get_class return class_name
 func get_class() -> String:
 	return "WorldSelectButton"
 
 
-"""
-Workaround for Godot #21789 to make is_class match class_name
-"""
+## Workaround for Godot #21789 to make is_class match class_name
 func is_class(name: String) -> bool:
 	return name == "WorldSelectButton" or .is_class(name)

--- a/project/src/main/ui/menu/bad-save-data-control.gd
+++ b/project/src/main/ui/menu/bad-save-data-control.gd
@@ -1,17 +1,13 @@
 extends ColorRect
-"""
-A popup window which is shown if there is a problem loading the save data.
-"""
+## A popup window which is shown if there is a problem loading the save data.
 
 func _ready() -> void:
 	hide()
 
 
-"""
-Displays a popup window describing the problem loading the save data.
-
-The popup window is populated based on PlayerSave's current state.
-"""
+## Displays a popup window describing the problem loading the save data.
+##
+## The popup window is populated based on PlayerSave's current state.
 func popup() -> void:
 	show()
 	$Popup.popup()

--- a/project/src/main/ui/menu/loading-screen.gd
+++ b/project/src/main/ui/menu/loading-screen.gd
@@ -1,7 +1,5 @@
 extends Control
-"""
-Shows a progress bar while resources are loading.
-"""
+## Shows a progress bar while resources are loading.
 
 onready var _progress_bar: ProgressBar = $ProgressBar
 

--- a/project/src/main/ui/menu/main-menu-create.gd
+++ b/project/src/main/ui/menu/main-menu-create.gd
@@ -1,7 +1,5 @@
 extends VBoxContainer
-"""
-A panel shown on the main menu which contains various editors.
-"""
+## A panel shown on the main menu which contains various editors.
 
 func _on_Levels_pressed() -> void:
 	MusicPlayer.stop()

--- a/project/src/main/ui/menu/main-menu-debug.gd
+++ b/project/src/main/ui/menu/main-menu-debug.gd
@@ -1,9 +1,7 @@
 extends VBoxContainer
-"""
-A panel shown on the main menu containing developer tools.
-
-The panel only appears in debug builds of the game.
-"""
+## A panel shown on the main menu containing developer tools.
+##
+## The panel only appears in debug builds of the game.
 
 func _ready() -> void:
 	# only show debug panel for debug builds

--- a/project/src/main/ui/menu/main-menu-play.gd
+++ b/project/src/main/ui/menu/main-menu-play.gd
@@ -1,7 +1,5 @@
 extends VBoxContainer
-"""
-A panel shown on the main menu which contains game modes to play.
-"""
+## A panel shown on the main menu which contains game modes to play.
 
 const WORLD0_ID := "world0"
 

--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -1,10 +1,8 @@
 class_name MainMenu
 extends Control
-"""
-The menu the user sees after starting the game.
-
-Includes buttons for starting a new game, launching the level editor, and exiting the game.
-"""
+## The menu the user sees after starting the game.
+##
+## Includes buttons for starting a new game, launching the level editor, and exiting the game.
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()

--- a/project/src/main/ui/menu/practice-difficulty-selector.gd
+++ b/project/src/main/ui/menu/practice-difficulty-selector.gd
@@ -1,37 +1,29 @@
 extends VBoxContainer
-"""
-UI control for selecting difficulty in practice mode.
-"""
+## UI control for selecting difficulty in practice mode.
 
 signal difficulty_changed
 
-# difficulties which appear as tick mark labels
+## difficulties which appear as tick mark labels
 var _difficulty_names: Array setget set_difficulty_names
 
 func _on_Slider_value_changed(_value: float) -> void:
 	emit_signal("difficulty_changed")
 
-"""
-Returns the currently selected difficulty string such as 'Normal' or 'Expert'
-"""
+## Returns the currently selected difficulty string such as 'Normal' or 'Expert'
 func get_selected_difficulty() -> String:
 	if not is_inside_tree():
 		return "Normal"
 	return _difficulty_names[$Slider.value]
 
 
-"""
-Sets the currently selected difficulty string such as 'Normal' or 'Expert'
-"""
+## Sets the currently selected difficulty string such as 'Normal' or 'Expert'
 func set_selected_difficulty(new_difficulty: String) -> void:
 	$Slider.value = _difficulty_names.find(new_difficulty)
 
 
-"""
-Lowlights difficulty labels, turning them black.
-
-In rank mode, this lets the player see which ranks haven't yet completed.
-"""
+## Lowlights difficulty labels, turning them black.
+##
+## In rank mode, this lets the player see which ranks haven't yet completed.
 func set_difficulty_lowlights(new_lowlights: Array) -> void:
 	for i in range($Labels.get_child_count()):
 		var label: Label = $Labels.get_child(i)
@@ -39,9 +31,7 @@ func set_difficulty_lowlights(new_lowlights: Array) -> void:
 		label.set("custom_colors/font_color", Color.black if lowlighted else Color.white)
 
 
-"""
-Sets the difficulty names which appear as tick mark labels.
-"""
+## Sets the difficulty names which appear as tick mark labels.
 func set_difficulty_names(new_names: Array) -> void:
 	_difficulty_names = new_names
 	

--- a/project/src/main/ui/menu/practice-high-scores.gd
+++ b/project/src/main/ui/menu/practice-high-scores.gd
@@ -1,7 +1,5 @@
 extends Panel
-"""
-UI control which shows daily and all-time high scores.
-"""
+## UI control which shows daily and all-time high scores.
 
 func set_level(new_level: LevelSettings) -> void:
 	$Tables/DailyTable.set_level(new_level)

--- a/project/src/main/ui/menu/practice-menu.gd
+++ b/project/src/main/ui/menu/practice-menu.gd
@@ -1,19 +1,15 @@
 extends Control
-"""
-Scene which lets the player repeatedly play a set of levels.
+## Scene which lets the player repeatedly play a set of levels.
+##
+## Displays their daily and all-time high scores for each mode, encouraging the player to improve.
 
-Displays their daily and all-time high scores for each mode, encouraging the player to improve.
-"""
-
-# Rank required to unlock harder levels. Rank 24 is an S-
+## Rank required to unlock harder levels. Rank 24 is an S-
 const RANK_TO_UNLOCK := 24.0
 
-"""
-Array of level categories used to initialize the scene.
-[0]: Mode name, used to reference the mode selector
-[1]: Difficulty name, used to populate the difficulty selector
-[2]: Level name, used to load the level definitions
-"""
+## Array of level categories used to initialize the scene.
+## [0]: Mode name, used to reference the mode selector
+## [1]: Difficulty name, used to populate the difficulty selector
+## [2]: Level name, used to load the level definitions
 const LEVEL_CATEGORIES := [
 	["Marathon", "Normal", "practice/marathon_normal"],
 	["Marathon", "Hard", "practice/marathon_hard"],
@@ -52,16 +48,12 @@ const LEVEL_CATEGORIES := [
 	["Sandbox", "Master", "practice/sandbox_master"],
 ]
 
-"""
-Key: Mode names, 'Marathon', 'Ultra'
-Value: Difficulty names, 'Normal', 'Hard'
-"""
+## key: Mode names, 'Marathon', 'Ultra'
+## value: Difficulty names, 'Normal', 'Hard'
 var mode_difficulties: Dictionary
 
-"""
-Key: Mode/Difficulty names separated with a space, 'Marathon Normal', 'Ultra Hard'
-Value: Level names, 'marathon_normal', 'ultra_hard'
-"""
+## key: Mode/Difficulty names separated with a space, 'Marathon Normal', 'Ultra Hard'
+## value: Level names, 'marathon_normal', 'ultra_hard'
 var levels: Dictionary
 
 var _rank_lowlights := []
@@ -114,12 +106,10 @@ func _refresh() -> void:
 	$VBoxContainer/HighScores.set_level(_get_level())
 
 
-"""
-Calculates the lowlights for rank difficulties, if they have not yet been calculated.
-
-This calculation is complex and involves iterating over all of the player's performances for all of the rank
-levels, so we cache the result.
-"""
+## Calculates the lowlights for rank difficulties, if they have not yet been calculated.
+##
+## This calculation is complex and involves iterating over all of the player's performances for all of the rank
+## levels, so we cache the result.
 func _calculate_lowlights() -> void:
 	if _rank_lowlights:
 		# already calculated

--- a/project/src/main/ui/menu/practice-mode-selector.gd
+++ b/project/src/main/ui/menu/practice-mode-selector.gd
@@ -1,25 +1,19 @@
 extends VBoxContainer
-"""
-UI control for picking a mode in practice mode.
-
-Also displays a description of the mode, 'Score 200 points as quickly as possible!'
-"""
+## UI control for picking a mode in practice mode.
+##
+## Also displays a description of the mode, 'Score 200 points as quickly as possible!'
 
 signal mode_changed
 
-# group which ensures only one mode button is pressed
+## group which ensures only one mode button is pressed
 onready var button_group: ButtonGroup = $Buttons/Marathon.group
 
-"""
-Returns the currently selected mode string such as 'Normal' or 'Expert'
-"""
+## Returns the currently selected mode string such as 'Normal' or 'Expert'
 func get_selected_mode() -> String:
 	return button_group.get_pressed_button().name
 
 
-"""
-Sets the currently selected mode string such as 'Marathon' or 'Sprint'
-"""
+## Sets the currently selected mode string such as 'Marathon' or 'Sprint'
 func set_selected_mode(new_selected_mode: String) -> void:
 	match new_selected_mode:
 		"Marathon":
@@ -34,9 +28,7 @@ func set_selected_mode(new_selected_mode: String) -> void:
 			$Buttons/Sandbox.pressed = true
 
 
-"""
-Sets the currently selected level, used for generating a description.
-"""
+## Sets the currently selected level, used for generating a description.
 func set_level(new_level: LevelSettings) -> void:
 	var new_description := ""
 	match get_selected_mode():

--- a/project/src/main/ui/menu/splash-screen.gd
+++ b/project/src/main/ui/menu/splash-screen.gd
@@ -1,7 +1,5 @@
 extends Control
-"""
-A splash screen which precedes the main menu.
-"""
+## A splash screen which precedes the main menu.
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()

--- a/project/src/main/ui/menu/system-buttons.gd
+++ b/project/src/main/ui/menu/system-buttons.gd
@@ -1,10 +1,8 @@
 extends VBoxContainer
-"""
-Navigational buttons which occur on most menu screens.
-"""
+## Navigational buttons which occur on most menu screens.
 
-# If true, the `ui_cancel` action will activate the quit button. This should be unset in contexts where the 'quit'
-# button does something destructive such as quitting the game or abandoning an editor.
+## If true, the `ui_cancel` action will activate the quit button. This should be unset in contexts where the 'quit'
+## button does something destructive such as quitting the game or abandoning an editor.
 export (bool) var quit_on_cancel: bool = true setget set_quit_on_cancel
 
 onready var _ui_cancel_shortcut := preload("res://src/main/ui/UiCancelShortcut.tres")

--- a/project/src/main/ui/menu/tutorial-menu.gd
+++ b/project/src/main/ui/menu/tutorial-menu.gd
@@ -1,7 +1,5 @@
 extends Control
-"""
-Scene which lets the player launch tutorials.
-"""
+## Scene which lets the player launch tutorials.
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()

--- a/project/src/main/ui/money-label.gd
+++ b/project/src/main/ui/money-label.gd
@@ -1,15 +1,13 @@
 class_name MoneyLabel
 extends Control
-"""
-Shows the player's money.
+## Shows the player's money.
+##
+## Money can be shown in an compact form like '17.2 b' or an expanded form like '17,213,529,312'.
 
-Money can be shown in an compact form like '17.2 b' or an expanded form like '17,213,529,312'.
-"""
-
-# 'true' if the money should be shown in a compact form like '17.2 b' to save on space.
+## 'true' if the money should be shown in a compact form like '17.2 b' to save on space.
 export (bool) var compact: bool setget set_compact
 
-# The amount of money shown by this label. Might differ from the player's actual money during animations.
+## The amount of money shown by this label. Might differ from the player's actual money during animations.
 var shown_money: int
 
 func _ready() -> void:
@@ -26,11 +24,9 @@ func set_compact(new_compact: bool) -> void:
 	set_shown_money(PlayerData.money)
 
 
-"""
-Updates the label to show the player's current money.
-
-Negative money is displayed as 0 to avoid UI oddities ($-300)
-"""
+## Updates the label to show the player's current money.
+##
+## Negative money is displayed as 0 to avoid UI oddities ($-300)
 func set_shown_money(new_money: int) -> void:
 	shown_money = new_money
 	if compact:

--- a/project/src/main/ui/music-popup-tween.gd
+++ b/project/src/main/ui/music-popup-tween.gd
@@ -1,7 +1,5 @@
 extends Tween
-"""
-Makes the music popup appear and disappear.
-"""
+## Makes the music popup appear and disappear.
 
 enum PopupState {
 	POPPED_OUT, # off the top of the screen
@@ -10,17 +8,17 @@ enum PopupState {
 	POPPING_OUT # moving offscreen
 }
 
-# the how long it takes the popup to slide in or out of view
+## the how long it takes the popup to slide in or out of view
 const TWEEN_DURATION := 0.2
 
-# the duration that the popup remains visible
+## the duration that the popup remains visible
 const POPUP_DURATION := 4.0
 
-# the music panel's y coordinate when popped in and when popped out
+## the music panel's y coordinate when popped in and when popped out
 const POP_IN_Y := 32
 const POP_OUT_Y := 0
 
-# tracks whether the popup is currently popping in or out
+## tracks whether the popup is currently popping in or out
 var _popup_state: int = PopupState.POPPED_OUT
 
 onready var _music_panel := get_node("../Panel")
@@ -36,12 +34,10 @@ func _enter_tree() -> void:
 	get_tree().connect("idle_frame", self, "_restore_tween_and_timer_state")
 
 
-"""
-Makes the music popup appear, and then hides it after a few seconds.
-
-Parameters:
-	'pop_in_delay': The number of seconds to wait before showing the popup.
-"""
+## Makes the music popup appear, and then hides it after a few seconds.
+##
+## Parameters:
+## 	'pop_in_delay': The number of seconds to wait before showing the popup.
 func pop_in_and_out(pop_in_delay: float) -> void:
 	if pop_in_delay:
 		# we use a one-shot listener method instead of a yield statement to avoid 'class instance is gone' errors.
@@ -81,13 +77,11 @@ func _pop_out() -> void:
 		_popup_state = PopupState.POPPED_OUT
 
 
-"""
-Restores the MusicPopupTween and Timer to the state before they exited the tree.
-
-The MusicPopup is a singleton so that it maintains its position as the player navigates menus. However, timers and
-tweens stop running when they exit the scene tree. This method restores the timers and tweens so that they're running
-again.
-"""
+## Restores the MusicPopupTween and Timer to the state before they exited the tree.
+##
+## The MusicPopup is a singleton so that it maintains its position as the player navigates menus. However, timers and
+## tweens stop running when they exit the scene tree. This method restores the timers and tweens so that they're
+## running again.
 func _restore_tween_and_timer_state() -> void:
 	# disconnect our one-shot method
 	get_tree().disconnect("idle_frame", self, "_restore_tween_and_timer_state")

--- a/project/src/main/ui/music-popup.gd
+++ b/project/src/main/ui/music-popup.gd
@@ -1,9 +1,7 @@
 extends Control
-"""
-A toaster popup which shows the current song title.
-"""
+## A toaster popup which shows the current song title.
 
-# the bgm which was last shown in this popup
+## the bgm which was last shown in this popup
 var _shown_bgm: CheckpointSong
 
 onready var _music_label := $Panel/HBoxContainer/Label
@@ -16,14 +14,12 @@ func _ready() -> void:
 	_music_label.connect("item_rect_changed", self, "_on_Label_item_rect_changed")
 
 
-"""
-Update the popup's appearance based on the current song, and maybe show it.
-
-The popup is only shown if the song changes, and if the song is audible.
-
-Parameters:
-	'value': The song to show in the popup
-"""
+## Update the popup's appearance based on the current song, and maybe show it.
+##
+## The popup is only shown if the song changes, and if the song is audible.
+##
+## Parameters:
+## 	'value': The song to show in the popup
 func _refresh_panel(value: CheckpointSong) -> void:
 	if _shown_bgm == value or not is_inside_tree():
 		return

--- a/project/src/main/ui/nametag-panel.gd
+++ b/project/src/main/ui/nametag-panel.gd
@@ -1,15 +1,13 @@
 class_name NametagPanel
 extends Panel
-"""
-Resizes and shows nametag labels.
-"""
+## Resizes and shows nametag labels.
 
 export (Array, Vector2) var panel_sizes: Array
 
-# size of the nametag needed to display the name text
+## size of the nametag needed to display the name text
 var nametag_size: int
 
-# The name is copied into multiple labels. We display the smallest label which fits.
+## The name is copied into multiple labels. We display the smallest label which fits.
 onready var _labels := {
 	ChatTheme.NAMETAG_SMALL: $Small,
 	ChatTheme.NAMETAG_MEDIUM: $Medium,
@@ -28,9 +26,7 @@ func refresh_chat_theme(chat_theme: ChatTheme) -> void:
 	set_font_color(chat_theme.nametag_font_color)
 
 
-"""
-Assigns the name label's text and updates our nametag_size field to the smallest name label which fit.
-"""
+## Assigns the name label's text and updates our nametag_size field to the smallest name label which fit.
 func set_nametag_text(new_text: String) -> void:
 	new_text = ChattableManager.substitute_variables(new_text, true)
 	
@@ -53,9 +49,7 @@ func set_nametag_text(new_text: String) -> void:
 		rect_size = panel_sizes[nametag_size - 1]
 
 
-"""
-Hides all labels. Labels are eventually shown when show_label() is invoked.
-"""
+## Hides all labels. Labels are eventually shown when show_label() is invoked.
 func hide_labels() -> void:
 	for label in _labels.values():
 		label.visible = false

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -1,45 +1,43 @@
 class_name OverworldUi
 extends CanvasLayer
-"""
-UI elements for the overworld.
-
-This includes chats, buttons and debug messages.
-"""
+## UI elements for the overworld.
+##
+## This includes chats, buttons and debug messages.
 
 signal chat_started
 signal chat_ended
 
-# emitted when we launch a creature's talk animation
+## emitted when we launch a creature's talk animation
 signal chatter_talked(chatter)
 
-# emitted when the player talks to a creature for the first time, caching their chat
+## emitted when the player talks to a creature for the first time, caching their chat
 signal chat_cached(chattable)
 
-# emitted when creatures enter or exit a conversation
+## emitted when creatures enter or exit a conversation
 signal visible_chatters_changed()
 
-# emitted when we present the player with a chat choice
+## emitted when we present the player with a chat choice
 signal showed_chat_choices
 
-# when starting an inplace conversation, all participants must be within this
-# radius. Otherwise a separate cutscene will launch.
+## when starting an inplace conversation, all participants must be within this
+## radius. Otherwise a separate cutscene will launch.
 const MAX_INPLACE_CHAT_DISTANCE := 600
 
-# Characters involved in the current conversation. This includes the player, sensei and any other participants. We
-# try to keep them all in frame and facing each other.
+## Characters involved in the current conversation. This includes the player, sensei and any other participants. We
+## try to keep them all in frame and facing each other.
 var chatters := []
 
-# If 'true' the overworld is being used to play a cutscene. If 'false' the overworld is allowing free roam.
+## If 'true' the overworld is being used to play a cutscene. If 'false' the overworld is allowing free roam.
 var cutscene := false
 
 var _show_version := true setget set_show_version, is_show_version
 
-# These two fields store details for the upcoming level. We store the level details during the chat sequence
-# and launch the level when the chat window closes.
+## These two fields store details for the upcoming level. We store the level details during the chat sequence
+## and launch the level when the chat window closes.
 var _current_chat_tree: ChatTree
 
-# A cache of ChatTree objects representing chat the player's seen since this scene was loaded. This prevents the
-# player from cycling through the chat over and over if you talk to a creature multiple times repetitively.
+## A cache of ChatTree objects representing chat the player's seen since this scene was loaded. This prevents the
+## player from cycling through the chat over and over if you talk to a creature multiple times repetitively.
 var _chat_tree_cache: Dictionary
 
 func _ready() -> void:
@@ -86,9 +84,7 @@ func is_show_version() -> bool:
 	return _show_version
 
 
-"""
-Turn the the active chat participants towards each other, and make them face the camera.
-"""
+## Turn the the active chat participants towards each other, and make them face the camera.
 func make_chatters_face_eachother() -> void:
 	var chatter_bounding_box: Rect2
 	chatter_bounding_box = get_chatter_bounding_box([], [ChattableManager.player, ChattableManager.sensei])
@@ -117,18 +113,16 @@ func make_chatters_face_eachother() -> void:
 			chatter.orient_toward(ChattableManager.player.position)
 
 
-"""
-Calculates the bounding box of the characters involved in the current conversation.
-
-Parameters:
-	'include': (Optional) characters in the current conversation will only be included if they are in this list.
-	
-	'exclude': (Optional) Characters in the current conversation will be excluded if they are in this list.
-
-Returns:
-	The smallest rectangle including all characters in the current conversation. If no characters meet this criteria,
-	this returns an zero-size rectangle at (0, 0).
-"""
+## Calculates the bounding box of the characters involved in the current conversation.
+##
+## Parameters:
+## 	'include': (Optional) characters in the current conversation will only be included if they are in this list.
+##
+## 	'exclude': (Optional) Characters in the current conversation will be excluded if they are in this list.
+##
+## Returns:
+## 	The smallest rectangle including all characters in the current conversation. If no characters meet this criteria,
+## 	this returns an zero-size rectangle at (0, 0).
 func get_chatter_bounding_box(include: Array = [], exclude: Array = []) -> Rect2:
 	var bounding_box: Rect2
 	
@@ -148,12 +142,10 @@ func get_chatter_bounding_box(include: Array = [], exclude: Array = []) -> Rect2
 	return bounding_box
 
 
-"""
-Returns 'true' if the current chat is a quick one-liner chat.
-
-Quick one-line chats don't interrupt the player or zoom the camera in; the player can just talk to someone and keep
-running. That's why we call them 'drive by chats'.
-"""
+## Returns 'true' if the current chat is a quick one-liner chat.
+##
+## Quick one-line chats don't interrupt the player or zoom the camera in; the player can just talk to someone and keep
+## running. That's why we call them 'drive by chats'.
 func is_drive_by_chat() -> bool:
 	return not _current_chat_tree.can_advance()
 
@@ -181,14 +173,12 @@ func _find_creatures_in_chat_tree(chat_tree: ChatTree) -> Array:
 	return creatures
 
 
-"""
-Assign nametag sides for each chat line.
-
-We calculate the midpoint of the chatters. Creatures to the right of the midpoint have their nametags on the right.
-Creatures to the left have their nametags on the left.
-
-This information is stored back into the chat tree so that it can be utilized by the chat ui.
-"""
+## Assign nametag sides for each chat line.
+##
+## We calculate the midpoint of the chatters. Creatures to the right of the midpoint have their nametags on the right.
+## Creatures to the left have their nametags on the left.
+##
+## This information is stored back into the chat tree so that it can be utilized by the chat ui.
 func _assign_nametag_sides(new_chat_tree: ChatTree) -> void:
 	var chatter_bounding_box := get_chatter_bounding_box([], [])
 	var center_of_chatters: Vector2 = chatter_bounding_box.position + chatter_bounding_box.size * 0.5
@@ -208,9 +198,7 @@ func _assign_nametag_sides(new_chat_tree: ChatTree) -> void:
 				chat_event.nametag_side = ChatEvent.NametagSide.LEFT
 
 
-"""
-Updates the different UI components to be visible/invisible based on the UI's current state.
-"""
+## Updates the different UI components to be visible/invisible based on the UI's current state.
 func _update_visible() -> void:
 	$Control/ChatUi.visible = true if chatters else false
 	$Control/Labels/SoutheastLabels/VersionLabel.visible = _show_version and not chatters
@@ -220,11 +208,9 @@ func _refresh_rect_size() -> void:
 	$Control.rect_size = $Control.get_viewport_rect().size
 
 
-"""
-Returns the chat tree corresponding to the curently focused chattable.
-
-This is relevant when the player talks to a creature with a non-food speech bubble.
-"""
+## Returns the chat tree corresponding to the curently focused chattable.
+##
+## This is relevant when the player talks to a creature with a non-food speech bubble.
 func _focused_chattable_chat_tree() -> ChatTree:
 	var focused_chattable: Node2D = ChattableManager.focused_chattable
 	if not focused_chattable:
@@ -242,18 +228,16 @@ func _focused_chattable_chat_tree() -> ChatTree:
 	return _chat_tree_cache[focused_chattable]
 
 
-"""
-Applies the specified ChatEvent metadata to the scene.
-
-ChatEvents can include metadata making creatures appear, disappear, laugh or turn around. This method locates the
-creature referenced by the metadata and performs the appropriate action.
-
-Parameters:
-	'chat_event': (Unused) The chat event whose metadata should be applied. This is unused by OverworldUi but can be
-		utilized by subclasses who extend this method.
-	
-	'meta_item': The metadata item to apply.
-"""
+## Applies the specified ChatEvent metadata to the scene.
+##
+## ChatEvents can include metadata making creatures appear, disappear, laugh or turn around. This method locates the
+## creature referenced by the metadata and performs the appropriate action.
+##
+## Parameters:
+## 	'chat_event': (Unused) The chat event whose metadata should be applied. This is unused by OverworldUi but can be
+## 		utilized by subclasses who extend this method.
+##
+## 	'meta_item': The metadata item to apply.
 func _apply_chat_event_meta(_chat_event: ChatEvent, meta_item: String) -> void:
 	var meta_item_split := meta_item.split(" ")
 	match(meta_item_split[0]):
@@ -410,9 +394,7 @@ func _on_SettingsButton_pressed() -> void:
 	$Control/SettingsMenu.show()
 
 
-"""
-When the player hits the 'talk' button we either launch a level or start a chat.
-"""
+## When the player hits the 'talk' button we either launch a level or start a chat.
 func _on_TalkButton_pressed() -> void:
 	var focused_chattable: Node2D = ChattableManager.focused_chattable
 	if not focused_chattable:

--- a/project/src/main/ui/rect-fit-label.gd
+++ b/project/src/main/ui/rect-fit-label.gd
@@ -1,14 +1,12 @@
 class_name RectFitLabel
 extends Label
-"""
-This label changes its size dynamically based on the amount of text it needs to display. It chooses the smallest size
-where the text does not overrun its boundaries.
-"""
+## This label changes its size dynamically based on the amount of text it needs to display. It chooses the smallest
+## size where the text does not overrun its boundaries.
 
-# When calculating how much text we can accommodate, there is a 3 pixel gap between each row.
+## When calculating how much text we can accommodate, there is a 3 pixel gap between each row.
 const FONT_GAP := 3
 
-# Different label sizes to try, ordered from smallest to largest.
+## Different label sizes to try, ordered from smallest to largest.
 export(Array, Vector2) var sizes := [] setget set_sizes
 
 var chosen_size_index := -1 setget set_chosen_size_index
@@ -21,12 +19,10 @@ func _ready() -> void:
 	max_lines_visible = max(1, max_lines_visible)
 
 
-"""
-Sets the label's size to the smallest size which will accommodate its text.
-
-If the label's text is modified this should be called manually. This class cannot respond to text changes or override
-set_text because of Godot #29390 (https://github.com/godotengine/godot/issues/29390)
-"""
+## Sets the label's size to the smallest size which will accommodate its text.
+##
+## If the label's text is modified this should be called manually. This class cannot respond to text changes or
+## override set_text because of Godot #29390 (https://github.com/godotengine/godot/issues/29390)
 func pick_smallest_size() -> void:
 	for i in range(sizes.size()):
 		# start with the smallest size, and try larger and larger sizes

--- a/project/src/main/ui/scene-transition-cover.gd
+++ b/project/src/main/ui/scene-transition-cover.gd
@@ -1,9 +1,8 @@
 extends CanvasLayer
-"""
-Covers the screen during scene transitions.
-
-This must be a CanvasLayer and not simply a Control because it needs to cover everything, including other CanvasLayers.
-"""
+## Covers the screen during scene transitions.
+##
+## This must be a CanvasLayer and not simply a Control because it needs to cover everything, including other
+## CanvasLayers.
 
 onready var _tween: Tween = $Tween
 onready var _color_rect: ColorRect = $ColorRect
@@ -18,10 +17,8 @@ func _ready() -> void:
 	_initialize_fade()
 
 
-"""
-Makes our alpha component opaque or translucent based on the transition state. Also schedules the 'fade in' event if
-necessary.
-"""
+## Makes our alpha component opaque or translucent based on the transition state. Also schedules the 'fade in' event if
+## necessary.
 func _initialize_fade() -> void:
 	_color_rect.modulate.a = 1.0 if SceneTransition.fading else 0.0
 	if SceneTransition.fading:
@@ -32,9 +29,7 @@ func _initialize_fade() -> void:
 		SceneTransition.fade_in()
 
 
-"""
-Starts a tween which changes this node's opacity.
-"""
+## Starts a tween which changes this node's opacity.
 func _launch_fade_tween(new_alpha: float, duration: float) -> void:
 	_color_rect.color = SceneTransition.fade_color
 	

--- a/project/src/main/ui/scene-transition.gd
+++ b/project/src/main/ui/scene-transition.gd
@@ -1,34 +1,30 @@
 extends Node
-"""
-Emits scene transition signals and keeps track of the currently active scene transition.
-"""
+## Emits scene transition signals and keeps track of the currently active scene transition.
 
 const SCREEN_FADE_OUT_DURATION := 0.3
 const SCREEN_FADE_IN_DURATION := 0.6
 
-# A scene transition emits these four signals in order as the screen fades out and fades back in
+## A scene transition emits these four signals in order as the screen fades out and fades back in
 signal fade_out_started
 signal fade_in_started
 
-# Set to 'true' when the scene transition starts fading out, and 'false' when it finishes fading back in
+## Set to 'true' when the scene transition starts fading out, and 'false' when it finishes fading back in
 var fading: bool
 
-# The color to fade to during scene transitions.
+## The color to fade to during scene transitions.
 var fade_color: Color = ProjectSettings.get_setting("rendering/environment/default_clear_color")
 
-# The method and parameters to call on the Breadcrumb node after fading out.
+## The method and parameters to call on the Breadcrumb node after fading out.
 var breadcrumb_method: FuncRef
 var breadcrumb_arg_array: Array
 
-"""
-Navigates forward one level, appending the new path to the breadcrumb trail after a scene transition.
-
-Parameters:
-	'path': The path to append to the breadcrumb trail. This is usually a scene path such as 'res://MyScene.tscn', but
-		it can also include a '::foo' suffix for navigation paths which do not result in a scene change.
-
-	'skip_transition': If 'true', the scene changes immediately without fading.
-"""
+## Navigates forward one level, appending the new path to the breadcrumb trail after a scene transition.
+##
+## Parameters:
+## 	'path': The path to append to the breadcrumb trail. This is usually a scene path such as 'res://MyScene.tscn', but
+## 		it can also include a '::foo' suffix for navigation paths which do not result in a scene change.
+##
+## 	'skip_transition': If 'true', the scene changes immediately without fading.
 func push_trail(path: String, skip_transition: bool = false) -> void:
 	if skip_transition or not get_tree().get_nodes_in_group("scene_transition_covers"):
 		# explicitly assign fading to false in case the user clicks a button while still fading in
@@ -39,12 +35,10 @@ func push_trail(path: String, skip_transition: bool = false) -> void:
 		_fade_out(funcref(Breadcrumb, "push_trail"), [path])
 
 
-"""
-Navigates back one level in the breadcrumb trail after a scene transition.
-
-Parameters:
-	'skip_transition': If 'true', the scene changes immediately without fading.
-"""
+## Navigates back one level in the breadcrumb trail after a scene transition.
+##
+## Parameters:
+## 	'skip_transition': If 'true', the scene changes immediately without fading.
 func pop_trail(skip_transition: bool = false) -> void:
 	if skip_transition \
 			or not get_tree().get_nodes_in_group("scene_transition_covers") \
@@ -54,15 +48,14 @@ func pop_trail(skip_transition: bool = false) -> void:
 		_fade_out(funcref(Breadcrumb, "pop_trail"))
 
 
-"""
-Stays at the current level in the breadcrumb trail, but replaces the current navigation path after a scene transition.
-
-Parameters:
-	'path': The path to append to the breadcrumb trail. This is usually a scene path such as 'res://MyScene.tscn', but
-		it can also include a '::foo' suffix for navigation paths which do not result in a scene change.
-
-	'skip_transition': If 'true', the scene changes immediately without fading.
-"""
+## Stays at the current level in the breadcrumb trail, but replaces the current navigation path after a scene
+## transition.
+##
+## Parameters:
+## 	'path': The path to append to the breadcrumb trail. This is usually a scene path such as 'res://MyScene.tscn', but
+## 		it can also include a '::foo' suffix for navigation paths which do not result in a scene change.
+##
+## 	'skip_transition': If 'true', the scene changes immediately without fading.
 func replace_trail(path: String, skip_transition: bool = false) -> void:
 	if skip_transition \
 			or not get_tree().get_nodes_in_group("scene_transition_covers") \
@@ -72,31 +65,23 @@ func replace_trail(path: String, skip_transition: bool = false) -> void:
 		_fade_out(funcref(Breadcrumb, "replace_trail"), [path])
 
 
-"""
-Called when the 'fade out' visual transition ends, triggering a scene transition.
-"""
+## Called when the 'fade out' visual transition ends, triggering a scene transition.
 func end_fade_out() -> void:
 	if breadcrumb_method:
 		breadcrumb_method.call_funcv(breadcrumb_arg_array)
 
 
-"""
-Launches the 'fade in' visual transition.
-"""
+## Launches the 'fade in' visual transition.
 func fade_in() -> void:
 	emit_signal("fade_in_started")
 
 
-"""
-Called when the 'fade in' visual transition ends, toggling a state variable.
-"""
+## Called when the 'fade in' visual transition ends, toggling a state variable.
 func end_fade_in() -> void:
 	fading = false
 
 
-"""
-Launches the 'fade out' visual transition.
-"""
+## Launches the 'fade out' visual transition.
 func _fade_out(new_breadcrumb_method: FuncRef, new_breadcrumb_arg_array: Array = []) -> void:
 	breadcrumb_method = new_breadcrumb_method
 	breadcrumb_arg_array = new_breadcrumb_arg_array

--- a/project/src/main/ui/settings/keybind/custom-keybind-button.gd
+++ b/project/src/main/ui/settings/keybind/custom-keybind-button.gd
@@ -1,15 +1,13 @@
 extends Button
-"""
-A button which shows the player's custom keybind, and lets them rebind a key.
-"""
+## A button which shows the player's custom keybind, and lets them rebind a key.
 
-# emitted when the player starts or stops rebinding a key
+## emitted when the player starts or stops rebinding a key
 signal awaiting_changed(awaiting)
 
 export (String) var action_name: String
 export (int) var action_index: int
 
-# 'true' if this button is waiting for the player to press a key
+## 'true' if this button is waiting for the player to press a key
 var awaiting := false
 
 func _ready() -> void:
@@ -27,9 +25,7 @@ func _input(event: InputEvent) -> void:
 			end_awaiting()
 
 
-"""
-Takes the button out of the 'awaiting state', so it no longer waits for the player to press a key.
-"""
+## Takes the button out of the 'awaiting state', so it no longer waits for the player to press a key.
 func end_awaiting() -> void:
 	if not awaiting:
 		return
@@ -40,9 +36,7 @@ func end_awaiting() -> void:
 	emit_signal("awaiting_changed", awaiting)
 
 
-"""
-Takes the button into the 'awaiting state', where it waits for the player to press a key.
-"""
+## Takes the button into the 'awaiting state', where it waits for the player to press a key.
 func _start_awaiting() -> void:
 	var custom_keybind_buttons := get_tree().get_nodes_in_group("custom_keybind_buttons")
 	for keybind_button in custom_keybind_buttons:
@@ -54,9 +48,7 @@ func _start_awaiting() -> void:
 	emit_signal("awaiting_changed", awaiting)
 
 
-"""
-Updates the button's text based on the player's current keybinds.
-"""
+## Updates the button's text based on the player's current keybinds.
 func _refresh_text() -> void:
 	var new_text := ""
 	var json: Dictionary = SystemData.keybind_settings.get_custom_keybind(action_name, action_index)

--- a/project/src/main/ui/settings/keybind/custom-keybind-row.gd
+++ b/project/src/main/ui/settings/keybind/custom-keybind-row.gd
@@ -1,8 +1,6 @@
 tool
 extends HBoxContainer
-"""
-A row which lets the player define keybinds for a specific action, such as 'Move Piece Left'.
-"""
+## A row which lets the player define keybinds for a specific action, such as 'Move Piece Left'.
 
 export (String) var description: String setget set_description
 export (String) var action_name setget set_action_name

--- a/project/src/main/ui/settings/keybind/preset-keybind-row.gd
+++ b/project/src/main/ui/settings/keybind/preset-keybind-row.gd
@@ -1,10 +1,8 @@
 tool
 extends HBoxContainer
-"""
-A row which shows the player the keybinds for a specific action, such as 'Move Piece Left'.
-
-This row is used for presets like 'Guideline' and 'WASD', and is non-interactive.
-"""
+## A row which shows the player the keybinds for a specific action, such as 'Move Piece Left'.
+##
+## This row is used for presets like 'Guideline' and 'WASD', and is non-interactive.
 
 export (String) var description: String setget set_description
 export (String) var keybind_value: String setget set_keybind_value

--- a/project/src/main/ui/settings/keybind/settings-keybinds-control.gd
+++ b/project/src/main/ui/settings/keybind/settings-keybinds-control.gd
@@ -1,7 +1,5 @@
 extends VBoxContainer
-"""
-A UI control which lets the player view and update the game's keybinds.
-"""
+## A UI control which lets the player view and update the game's keybinds.
 
 func _ready() -> void:
 	$Presets/Guideline.connect("pressed", self, "_on_Guideline_pressed")
@@ -17,13 +15,11 @@ func _ready() -> void:
 	_refresh_keybind_labels()
 
 
-"""
-Updates the UI controls to reflect the currently selected preset.
-
-The 'WASD' and 'Guideline' presets reuse the same UI controls and change the label contents.
-
-The 'Custom' preset swaps in different UI controls because it's interactive.
-"""
+## Updates the UI controls to reflect the currently selected preset.
+##
+## The 'WASD' and 'Guideline' presets reuse the same UI controls and change the label contents.
+##
+## The 'Custom' preset swaps in different UI controls because it's interactive.
 func _refresh_keybind_labels() -> void:
 	$PresetScrollContainer.visible = false
 	$CustomScrollContainer.visible = false

--- a/project/src/main/ui/settings/settings-copy-save-data.gd
+++ b/project/src/main/ui/settings/settings-copy-save-data.gd
@@ -1,11 +1,9 @@
 extends HBoxContainer
-"""
-UI component for a copying the selected save data to the clipboard
-"""
+## UI component for a copying the selected save data to the clipboard
 
 export var _save_slot_control_path: NodePath
 
-# UI component for a changing the current save slot or deleting save slots
+## UI component for a changing the current save slot or deleting save slots
 onready var _save_slot_control: SaveSlotControl = get_node(_save_slot_control_path)
 
 onready var _copied_label: Label = $HBoxContainer/Copied

--- a/project/src/main/ui/settings/settings-creature-detail.gd
+++ b/project/src/main/ui/settings/settings-creature-detail.gd
@@ -1,7 +1,5 @@
 extends HBoxContainer
-"""
-UI control for toggling the creature detail level.
-"""
+## UI control for toggling the creature detail level.
 
 onready var _option_button: OptionButton = $OptionButton
 
@@ -17,10 +15,8 @@ func _on_OptionButton_item_selected(_index: int) -> void:
 	SystemData.graphics_settings.creature_detail = _index
 
 
-"""
-When the player changes the detail levels, we add an asterisk.
-
-This asterisk directs them to a warning explaining that the settings won't take effect immediately.
-"""
+## When the player changes the detail levels, we add an asterisk.
+##
+## This asterisk directs them to a warning explaining that the settings won't take effect immediately.
 func _on_GraphicsSettings_creature_detail_changed(_value: int) -> void:
 	$Label.text = $Label.text.trim_suffix("*") + "*"

--- a/project/src/main/ui/settings/settings-dialogs.gd
+++ b/project/src/main/ui/settings/settings-dialogs.gd
@@ -1,32 +1,30 @@
 extends Control
-"""
-Shows popup dialogs for the settings menu.
-"""
+## Shows popup dialogs for the settings menu.
 
-# emitted when the player is prompted to change their save slot and answers 'yes'
+## emitted when the player is prompted to change their save slot and answers 'yes'
 signal change_save_confirmed
 
-# emitted when the player is prompted to change their save slot and answers 'no' or closes the window
+## emitted when the player is prompted to change their save slot and answers 'no' or closes the window
 signal change_save_cancelled
 
-# emitted when the player is prompted to delete a save slot and answers 'yes'
+## emitted when the player is prompted to delete a save slot and answers 'yes'
 signal delete_confirmed
 
-# emitted when the player is prompted to delete a save slot and answers 'no' or closes the window
+## emitted when the player is prompted to delete a save slot and answers 'no' or closes the window
 signal delete_cancelled
 
 export var _save_slot_control_path: NodePath
 
-# 'Are you sure you want to change save slots?' confirmation dialog
+## 'Are you sure you want to change save slots?' confirmation dialog
 onready var _change_save_confirmation := $ChangeSaveConfirmation
 
-# 'Delete save data?' confirmation dialog
+## 'Delete save data?' confirmation dialog
 onready var _delete_confirmation_1 := $DeleteConfirmation1
 
-# 'Are you sure?' confirmation dialog
+## 'Are you sure?' confirmation dialog
 onready var _delete_confirmation_2 := $DeleteConfirmation2
 
-# UI component for a changing the current save slot or deleting save slots
+## UI component for a changing the current save slot or deleting save slots
 onready var _save_slot_control: SaveSlotControl = get_node(_save_slot_control_path)
 
 func _ready() -> void:
@@ -51,22 +49,18 @@ func _ready() -> void:
 	_delete_confirmation_2.get_close_button().connect("pressed", self, "_on_DeleteConfirmation_cancelled")
 
 
-"""
-Displays a dialog prompting the user if they want to change their save slot
-"""
+## Displays a dialog prompting the user if they want to change their save slot
 func confirm_new_save_slot() -> void:
 	_change_save_confirmation.popup_centered()
 
 
-"""
-Expands a simple delete confirmation message into a more detailed message.
-
-Parameters:
-	'message': A simple message like 'Are you sure?'
-
-Returns:
-	A more detailed message like 'Are you sure? B: Gordo (13.5 hours)'
-"""
+## Expands a simple delete confirmation message into a more detailed message.
+##
+## Parameters:
+## 	'message': A simple message like 'Are you sure?'
+##
+## Returns:
+## 	A more detailed message like 'Are you sure? B: Gordo (13.5 hours)'
 func _delete_confirmation_dialog_text(message: String) -> String:
 	var selected_save_slot := _save_slot_control.get_selected_save_slot()
 	var playtime_in_seconds: float = SystemSave.get_save_slot_playtime(selected_save_slot)
@@ -76,18 +70,14 @@ func _delete_confirmation_dialog_text(message: String) -> String:
 	return "%s\n%s (%s)" % [message, save_slot_name, playtime_message]
 
 
-"""
-Displays a dialog prompting the user if they want to delete a save
-"""
+## Displays a dialog prompting the user if they want to delete a save
 func _on_SaveSlot_delete_pressed() -> void:
 	_delete_confirmation_1.dialog_text = _delete_confirmation_dialog_text(tr("Delete save data?"))
 	_delete_confirmation_1.popup_centered()
 	_delete_confirmation_1.get_cancel().grab_focus()
 
 
-"""
-Displays a dialog prompting the user if they're sure want to delete a save
-"""
+## Displays a dialog prompting the user if they're sure want to delete a save
 func _on_DeleteConfirmation1_confirmed() -> void:
 	_delete_confirmation_2.dialog_text = _delete_confirmation_dialog_text(tr("Are you sure?"))
 	_delete_confirmation_2.popup_centered()

--- a/project/src/main/ui/settings/settings-ghost-piece.gd
+++ b/project/src/main/ui/settings/settings-ghost-piece.gd
@@ -1,7 +1,5 @@
 extends Control
-"""
-UI control for toggling the ghost piece.
-"""
+## UI control for toggling the ghost piece.
 
 onready var _check_box := $CheckBox
 

--- a/project/src/main/ui/settings/settings-language.gd
+++ b/project/src/main/ui/settings/settings-language.gd
@@ -1,7 +1,5 @@
 extends HBoxContainer
-"""
-UI control for changing the game's language.
-"""
+## UI control for changing the game's language.
 
 const DEFAULT_LOCALE := "en"
 
@@ -20,17 +18,15 @@ func _ready() -> void:
 		push_warning("Locale '%s' was not in the list of loaded locales" % [current_loaded_locale])
 
 
-"""
-Returns the loaded locale closest to the translation server's locale.
-
-Locale can be of the form 'll_CC', i.e. language code and regional code, e.g. 'en_US', 'en_GB', etc. It might also be
-simply 'll', e.g. 'en'. To find the relevant translation, we look for those with locale starting with the language
-code, and then if any is an exact match for the long form. If not found, we fall back to a near match (another locale
-with same language code).
-
-This logic aligns with the logic in Godot's source code (core/translation.cpp). I could not find anywhere this logic
-or its result was exposed to GDScript.
-"""
+## Returns the loaded locale closest to the translation server's locale.
+##
+## Locale can be of the form 'll_CC', i.e. language code and regional code, e.g. 'en_US', 'en_GB', etc. It might also
+## be simply 'll', e.g. 'en'. To find the relevant translation, we look for those with locale starting with the
+## language code, and then if any is an exact match for the long form. If not found, we fall back to a near match
+## (another locale with same language code).
+##
+## This logic aligns with the logic in Godot's source code (core/translation.cpp). I could not find anywhere this logic
+## or its result was exposed to GDScript.
 func _current_loaded_locale() -> String:
 	var result: String
 	var translation_server_locale := TranslationServer.get_locale()

--- a/project/src/main/ui/settings/settings-menu.gd
+++ b/project/src/main/ui/settings/settings-menu.gd
@@ -1,10 +1,8 @@
 class_name SettingsMenu
 extends CanvasLayer
-"""
-Menu which lets the player adjust settings.
-
-This is meant to be overlaid over over scenes, which is why it is a CanvasLayer.
-"""
+## Menu which lets the player adjust settings.
+##
+## This is meant to be overlaid over over scenes, which is why it is a CanvasLayer.
 
 signal show
 signal hide
@@ -18,13 +16,13 @@ const QUIT := QuitType.QUIT
 const SAVE_AND_QUIT := QuitType.SAVE_AND_QUIT
 const GIVE_UP := QuitType.GIVE_UP
 
-# The text on the menu's quit button
+## The text on the menu's quit button
 export (QuitType) var quit_type: int setget set_quit_type
 
-# the UI control which was focused before this settings menu popped up
+## the UI control which was focused before this settings menu popped up
 var _old_focus_owner: Control
 
-# method name and parameters for a method to call after system data is saved
+## method name and parameters for a method to call after system data is saved
 var _post_save_method: String
 var _post_save_args_array: Array
 
@@ -61,9 +59,7 @@ func set_quit_type(new_quit_type: int) -> void:
 	_refresh_quit_type()
 
 
-"""
-Shows the menu and pauses the scene tree.
-"""
+## Shows the menu and pauses the scene tree.
 func show() -> void:
 	_bg.show()
 	_touch_buttons.visible = true
@@ -75,9 +71,7 @@ func show() -> void:
 	emit_signal("show")
 
 
-"""
-Hides the menu and unpauses the scene tree.
-"""
+## Hides the menu and unpauses the scene tree.
 func hide() -> void:
 	_bg.hide()
 	_touch_buttons.visible = false
@@ -90,20 +84,18 @@ func hide() -> void:
 	emit_signal("hide")
 
 
-"""
-Prompts the user for confirmation, if necessary, and saves their system settings.
-
-Confirmation is only required when changing the current save slot. If the player confirms changing their save slot, we
-drop them back on the title screen.
-
-In all other cases, either if the player is not confirmed or if they decide to not change their save slot, the
-specified 'post_save_method' is invoked to dismiss the settings menu.
-
-Parameters:
-	'new_post_save_method': The method to use to dismiss the settings menu after data is saved.
-	
-	'new_post_save_args_array': The method parameters to use to dismiss the settings menu after data is saved.
-"""
+## Prompts the user for confirmation, if necessary, and saves their system settings.
+##
+## Confirmation is only required when changing the current save slot. If the player confirms changing their save slot,
+## we drop them back on the title screen.
+##
+## In all other cases, either if the player is not confirmed or if they decide to not change their save slot, the
+## specified 'post_save_method' is invoked to dismiss the settings menu.
+##
+## Parameters:
+## 	'new_post_save_method': The method to use to dismiss the settings menu after data is saved.
+##
+## 	'new_post_save_args_array': The method parameters to use to dismiss the settings menu after data is saved.
 func _confirm_and_save(new_post_save_method: String, new_post_save_args_array: Array) -> void:
 	_post_save_method = new_post_save_method
 	_post_save_args_array = new_post_save_args_array
@@ -128,9 +120,7 @@ func _refresh_quit_type() -> void:
 	_quit_button.text = quit_text
 
 
-"""
-Loads the current save slot's data and returns the player to the splash screen.
-"""
+## Loads the current save slot's data and returns the player to the splash screen.
 func _load_player_data() -> void:
 	PlayerSave.load_player_data()
 	Breadcrumb.trail = []

--- a/project/src/main/ui/settings/settings-open-user-folder.gd
+++ b/project/src/main/ui/settings/settings-open-user-folder.gd
@@ -1,10 +1,8 @@
 extends HBoxContainer
-"""
-UI component for opening the user's data folder.
-
-The user's data folder has all their save data. Accessing this folder is useful when backing up their data or changing
-PCs.
-"""
+## UI component for opening the user's data folder.
+##
+## The user's data folder has all their save data. Accessing this folder is useful when backing up their data or
+## changing PCs.
 
 onready var _button := $Button
 

--- a/project/src/main/ui/settings/settings-save-slot.gd
+++ b/project/src/main/ui/settings/settings-save-slot.gd
@@ -1,8 +1,6 @@
 class_name SaveSlotControl
 extends HBoxContainer
-"""
-UI component for a changing the current save slot or deleting save slots
-"""
+## UI component for a changing the current save slot or deleting save slots
 
 signal delete_pressed
 

--- a/project/src/main/ui/settings/settings-tab-container.gd
+++ b/project/src/main/ui/settings/settings-tab-container.gd
@@ -1,14 +1,10 @@
 extends TabContainer
-"""
-Top-level tab container for the settings menu.
-"""
+## Top-level tab container for the settings menu.
 
-"""
-Override the default tab names with localized names.
-
-By default, Godot uses node names for tab titles. Node names don't get extracted with pybabel and can't be translated
-with gettext. Explicitly setting the tab titles addresses both of these problems.
-"""
+## Override the default tab names with localized names.
+##
+## By default, Godot uses node names for tab titles. Node names don't get extracted with pybabel and can't be
+## translated with gettext. Explicitly setting the tab titles addresses both of these problems.
 func _ready() -> void:
 	set_tab_title(0, tr("Sound + Graphics"))
 	set_tab_title(1, tr("Gameplay"))

--- a/project/src/main/ui/settings/settings-touch-fat-finger.gd
+++ b/project/src/main/ui/settings/settings-touch-fat-finger.gd
@@ -1,9 +1,7 @@
 extends Control
-"""
-UI control for adjusting the touchscreen fat finger setting.
-
-The fat finger setting decides how easy it is to mash two buttons with one finger.
-"""
+## UI control for adjusting the touchscreen fat finger setting.
+##
+## The fat finger setting decides how easy it is to mash two buttons with one finger.
 
 const VALUES := [0.00, 0.50, 0.66, 0.83, 1.00]
 

--- a/project/src/main/ui/settings/settings-touch-scheme.gd
+++ b/project/src/main/ui/settings/settings-touch-scheme.gd
@@ -1,9 +1,7 @@
 extends Control
-"""
-UI control for adjusting the touchscreen control scheme.
-
-The control scheme decides which buttons appear where.
-"""
+## UI control for adjusting the touchscreen control scheme.
+##
+## The control scheme decides which buttons appear where.
 
 func _ready() -> void:
 	$OptionButton.add_item(tr("Easy Console"))

--- a/project/src/main/ui/settings/settings-touch-size.gd
+++ b/project/src/main/ui/settings/settings-touch-size.gd
@@ -1,9 +1,7 @@
 extends Control
-"""
-UI control for adjusting the touchscreen button size.
-"""
+## UI control for adjusting the touchscreen button size.
 
-# step values of 1.19
+## step values of 1.19
 const VALUES := [
 	0.25, 0.30, 0.35, 0.42, 0.50, 0.59, 0.71, 0.84, 1.00, 1.19, 1.42, 1.69
 ]

--- a/project/src/main/ui/settings/settings-use-vsync.gd
+++ b/project/src/main/ui/settings/settings-use-vsync.gd
@@ -1,7 +1,5 @@
 extends HBoxContainer
-"""
-UI control for toggling vertical synchronization.
-"""
+## UI control for toggling vertical synchronization.
 
 onready var _check_box: CheckBox = $CheckBox
 

--- a/project/src/main/ui/settings/settings-warning.gd
+++ b/project/src/main/ui/settings/settings-warning.gd
@@ -1,7 +1,5 @@
 extends Label
-"""
-Shows a warning if the player changes settings which can't be changed immediately.
-"""
+## Shows a warning if the player changes settings which can't be changed immediately.
 
 func _ready() -> void:
 	visible = false

--- a/project/src/main/ui/swipe-container.gd
+++ b/project/src/main/ui/swipe-container.gd
@@ -1,10 +1,8 @@
 class_name SwipeContainer
 extends ScrollContainer
-"""
-Allows you to scroll a scroll container by dragging. Includes momentum.
-
-Adapted from https://github.com/godotengine/godot/issues/21137#issuecomment-474598933
-"""
+## Allows you to scroll a scroll container by dragging. Includes momentum.
+##
+## Adapted from https://github.com/godotengine/godot/issues/21137#issuecomment-474598933
 
 const MIN_SWIPE_DISTANCE := 25
 

--- a/project/src/main/ui/touch/action-button.gd
+++ b/project/src/main/ui/touch/action-button.gd
@@ -1,42 +1,40 @@
 class_name ActionButton
 extends TextureRect
-"""
-A touchscreen button used with EightWay.
-
-Note: Intuitively this functionality should be implemented as a TouchscreenButton. However this is challenging
-because of several unique and exciting decisions regarding the design of TouchscreenButton, as well as some
-bugs and limitations in its current implementation.
-
-1. https://github.com/godotengine/godot/issues/18654 The absence of Godot #18654 prevents setters from being
-overridden. This makes it difficult to change the button's icon when its action changes.
-
-2. https://github.com/godotengine/godot/issues/171 Most buttons and UI elements are controls, but TouchscreenButton
-does not behave like a control. There are workarounds for this, but in the end it is easier to embed touchscreen
-functionality within a control node, rather than to force a Node2D to behave like a control.
-
-3. TouchscreenButton does not have a way to set its state as pressed/unpressed. This makes it impossible to have
-business logic pulled out into a controller class such as EightWay.
-
-4. https://github.com/godotengine/godot/issues/39693 Godot #36963 prevents TouchscreenButton from accepting input
-outside of its boundaries. This makes it difficult to arrange TouchscreenButtons with overlapping collision shapes for
-diagonal presses.
-"""
+## A touchscreen button used with EightWay.
+##
+## Note: Intuitively this functionality should be implemented as a TouchscreenButton. However this is challenging
+## because of several unique and exciting decisions regarding the design of TouchscreenButton, as well as some
+## bugs and limitations in its current implementation.
+##
+## 1. https://github.com/godotengine/godot/issues/18654 The absence of Godot #18654 prevents setters from being
+## overridden. This makes it difficult to change the button's icon when its action changes.
+##
+## 2. https://github.com/godotengine/godot/issues/171 Most buttons and UI elements are controls, but TouchscreenButton
+## does not behave like a control. There are workarounds for this, but in the end it is easier to embed touchscreen
+## functionality within a control node, rather than to force a Node2D to behave like a control.
+##
+## 3. TouchscreenButton does not have a way to set its state as pressed/unpressed. This makes it impossible to have
+## business logic pulled out into a controller class such as EightWay.
+##
+## 4. https://github.com/godotengine/godot/issues/39693 Godot #36963 prevents TouchscreenButton from accepting input
+## outside of its boundaries. This makes it difficult to arrange TouchscreenButtons with overlapping collision shapes
+## for diagonal presses.
 
 signal pressed
 
-# the action activated by this button. also affects its appearance
+## the action activated by this button. also affects its appearance
 export (String) var action: String setget set_action
 
-# if false, pressing the button won't emit any actions.
+## if false, pressing the button won't emit any actions.
 export (bool) var emit_actions: bool = true
 
 var pressed := false setget set_pressed
 
-# the current textures this button toggles between when pressed/unpressed
+## the current textures this button toggles between when pressed/unpressed
 var _normal_texture: Texture
 var _pressed_texture: Texture
 
-# the default textures to use when our action has no icon
+## the default textures to use when our action has no icon
 onready var _empty_texture := preload("res://assets/main/ui/touch/empty.png")
 onready var _empty_pressed_texture := preload("res://assets/main/ui/touch/empty-pressed.png")
 
@@ -88,17 +86,13 @@ func _ready() -> void:
 	_refresh()
 
 
-"""
-Sets the action used for this button and updates its appearance.
-"""
+## Sets the action used for this button and updates its appearance.
 func set_action(new_action: String) -> void:
 	action = new_action
 	_refresh()
 
 
-"""
-Emits a pressed/released InputEvent and updates the button's appearance.
-"""
+## Emits a pressed/released InputEvent and updates the button's appearance.
 func set_pressed(new_pressed: bool) -> void:
 	if pressed == new_pressed:
 		return
@@ -115,9 +109,7 @@ func set_pressed(new_pressed: bool) -> void:
 	emit_signal("pressed")
 
 
-"""
-Updates the button's appearance based on its assigned action.
-"""
+## Updates the button's appearance based on its assigned action.
 func _refresh() -> void:
 	_normal_texture = _normal_textures.get(action, _empty_texture)
 	_pressed_texture = _pressed_textures.get(action, _empty_pressed_texture)

--- a/project/src/main/ui/touch/eight-way.gd
+++ b/project/src/main/ui/touch/eight-way.gd
@@ -1,36 +1,34 @@
 extends Control
-"""
-Manages four touchscreen buttons in a plus shape which behave like a directional pad.
-
-The player can press each button individually to emit different actions. If diagonal weights are specified, the player
-can press two diagonally adjacent buttons with a single touch.
-"""
+## Manages four touchscreen buttons in a plus shape which behave like a directional pad.
+##
+## The player can press each button individually to emit different actions. If diagonal weights are specified, the
+## player can press two diagonally adjacent buttons with a single touch.
 
 signal pressed
 
-# radius from the eightway's center where touches should be processed. significantly larger than its visual radius
+## radius from the eightway's center where touches should be processed. significantly larger than its visual radius
 const RADIUS = 180
 
-# actions associated with each cardinal direction. if omitted, the button will not be shown
+## actions associated with each cardinal direction. if omitted, the button will not be shown
 export (String) var up_action: String setget set_up_action
 export (String) var down_action: String setget set_down_action
 export (String) var left_action: String setget set_left_action
 export (String) var right_action: String setget set_right_action
 
-# these values influence how easy it is to press two buttons at once
-# 0.0 = impossible; 1.0 = as easy as pressing a single button
+## these values influence how easy it is to press two buttons at once
+## 0.0 = impossible; 1.0 = as easy as pressing a single button
 export (float, 0, 1) var up_right_weight := 0.0
 export (float, 0, 1) var up_left_weight := 0.0
 export (float, 0, 1) var down_right_weight := 0.0
 export (float, 0, 1) var down_left_weight := 0.0
 
-# if false, pressing the buttons won't emit any actions.
+## if false, pressing the buttons won't emit any actions.
 export (bool) var emit_actions := true setget set_emit_actions
 
-# the position relative to our center of the most recent touch event
+## the position relative to our center of the most recent touch event
 var _touch_dir: Vector2
 
-# the index of the most recent touch event
+## the index of the most recent touch event
 var _touch_index := -1
 
 onready var _up := $HBoxContainer/VBoxContainer/Up
@@ -46,9 +44,7 @@ func _ready() -> void:
 	_refresh_right_action()
 
 
-"""
-Converts drag/touch events into button presses.
-"""
+## Converts drag/touch events into button presses.
 func _input(event: InputEvent) -> void:
 	if not is_visible_in_tree():
 		return
@@ -95,16 +91,12 @@ func set_right_action(new_right_action: String) -> void:
 	_refresh_right_action()
 
 
-"""
-Becomes visible and receives touch input.
-"""
+## Becomes visible and receives touch input.
 func show() -> void:
 	visible = true
 
 
-"""
-Becomes invisible. Releases any held buttons and ignores touch input.
-"""
+## Becomes invisible. Releases any held buttons and ignores touch input.
 func hide() -> void:
 	visible = false
 	_touch_index = -1
@@ -131,21 +123,17 @@ func _refresh_right_action() -> void:
 		_right.action = right_action
 
 
-"""
-Release all buttons currently pressed.
-
-This also emits InputEvents for any action buttons released.
-"""
+## Release all buttons currently pressed.
+##
+## This also emits InputEvents for any action buttons released.
 func _release_buttons() -> void:
 	for button in _buttons:
 		button.pressed = false
 
 
-"""
-Press the buttons associated with the newest touch event.
-
-This also emits InputEvents for any action buttons pressed or released.
-"""
+## Press the buttons associated with the newest touch event.
+##
+## This also emits InputEvents for any action buttons pressed or released.
 func _press_buttons() -> void:
 	# cardinal direction; 0 = right, 1 = down, 2 = left, 3 = right
 	var touch_cardinal_dir := wrapi(round(2 * _touch_dir.angle() / PI), 0, 4)
@@ -161,12 +149,10 @@ func _press_buttons() -> void:
 	_up.pressed = touch_cardinal_dir == 3 or up_left_pressed or up_right_pressed
 
 
-"""
-Returns a number [0.0, 4.0] for how close the touch is to the specified diagonal.
-
-0.0 = very close, 4.0 = very far. A value less than 1.0 indicates the touch is in the same correct quadrant as the
-diagonal.
-"""
+## Returns a number [0.0, 4.0] for how close the touch is to the specified diagonal.
+##
+## 0.0 = very close, 4.0 = very far. A value less than 1.0 indicates the touch is in the same correct quadrant as the
+## diagonal.
 func _diagonalness(diagonal_direction: Vector2) -> float:
 	return abs(8 * _touch_dir.angle_to(diagonal_direction) / PI)
 

--- a/project/src/main/ui/volume-setting-control.gd
+++ b/project/src/main/ui/volume-setting-control.gd
@@ -1,21 +1,19 @@
 extends Control
-"""
-UI control for adjusting volume.
+## UI control for adjusting volume.
+##
+## Updates the player's stored settings, and also updates the audio server.
 
-Updates the player's stored settings, and also updates the audio server.
-"""
-
-# The type of volume which is controlled by this slider: music, sounds or voices
+## The type of volume which is controlled by this slider: music, sounds or voices
 export (VolumeSettings.VolumeType) var volume_type: int setget set_volume_type
 
-# Text description of this volume setting, 'Master Volume'
+## Text description of this volume setting, 'Master Volume'
 onready var _setting_label: Label = $Label
 
-# UI controls for the volume slider
+## UI controls for the volume slider
 onready var _slider: HSlider = $HBoxContainer/HSlider
 onready var _percent_label: Label = $HBoxContainer/Percent
 
-# Timers and sounds to play an sfx sample after the slider is dragged
+## Timers and sounds to play an sfx sample after the slider is dragged
 onready var _sample_timer: Timer = $SampleTimer
 onready var _sample_sound: AudioStreamPlayer = $SampleSound
 onready var _sample_voice: AudioStreamPlayer = $SampleVoice

--- a/project/src/main/ui/wallpaper/sticker-row.gd
+++ b/project/src/main/ui/wallpaper/sticker-row.gd
@@ -1,24 +1,22 @@
 class_name StickerRow
 extends Control
-"""
-A row of wallpaper sprites which slowly scroll by.
-"""
+## A row of wallpaper sprites which slowly scroll by.
 
-# the scroll velocity. only the x component is used
+## the scroll velocity. only the x component is used
 export (PackedScene) var StickerScene: PackedScene
 export (Vector2) var velocity: Vector2 setget set_velocity
 export (Color) var color: Color
 
-# sprite textures. we alternate between these textures and flip them horizontally. the second texture is optional.
+## sprite textures. we alternate between these textures and flip them horizontally. the second texture is optional.
 export (Texture) var texture_0: Texture setget set_texture_0
 export (Texture) var texture_1: Texture setget set_texture_1
 var _textures: Array
 var _texture_index := 0
 
-# counts down to 0, at which point a single sprite is omitted
+## counts down to 0, at which point a single sprite is omitted
 var _blank_texture_countdown := randi() % 7
 
-# the sticker furthest back in the row. when it moves enough a new sticker is created to take its place
+## the sticker furthest back in the row. when it moves enough a new sticker is created to take its place
 var _back_sticker: Sprite
 
 func _physics_process(delta: float) -> void:
@@ -79,11 +77,9 @@ func set_velocity(new_velocity: Vector2) -> void:
 	_back_sticker = null
 
 
-"""
-Adds a sticker to the row.
-
-The new sticker is placed behind the back sticker.
-"""
+## Adds a sticker to the row.
+##
+## The new sticker is placed behind the back sticker.
 func _add_sticker() -> void:
 	var new_sticker: Sticker = StickerScene.instance()
 	
@@ -113,9 +109,7 @@ func _add_sticker() -> void:
 	_back_sticker = new_sticker
 
 
-"""
-Refresh the texture array and texture index based on the assigned textures.
-"""
+## Refresh the texture array and texture index based on the assigned textures.
 func _refresh_textures() -> void:
 	_textures = []
 	if texture_0:

--- a/project/src/main/ui/wallpaper/sticker.gd
+++ b/project/src/main/ui/wallpaper/sticker.gd
@@ -1,26 +1,24 @@
 class_name Sticker
 extends Sprite
-"""
-An image which scrolls by on the wallpaper.
-"""
+## An image which scrolls by on the wallpaper.
 
-# The unmodified scale/rotation before pulsing/spinning
+## The unmodified scale/rotation before pulsing/spinning
 var base_scale := Vector2(1.0, 1.0) setget set_base_scale
 var base_rotation := 0.0 setget set_base_rotation
 
-# Stickers pulse and rotate. This field is used to calculate the pulse/rotation amount
+## Stickers pulse and rotate. This field is used to calculate the pulse/rotation amount
 var _total_time := 0.0
 
-# How much the sticker should grow and shrink; 1.0 = grow from 0% to 200%
+## How much the sticker should grow and shrink; 1.0 = grow from 0% to 200%
 onready var _rescale_amount := 0.04 * rand_range(0.8, 1.2)
 
-# How many seconds the sticker should take to grow and shrink once
+## How many seconds the sticker should take to grow and shrink once
 onready var _rescale_period := 4.50 * rand_range(0.8, 1.2)
 
-# How far the sticker should rotate; 1.0 = one full circle forward and backward
+## How far the sticker should rotate; 1.0 = one full circle forward and backward
 onready var _spin_amount := 0.04 * rand_range(0.8, 1.2)
 
-# How many seconds the sticker should take to rotate back and forth once
+## How many seconds the sticker should take to rotate back and forth once
 onready var _spin_period := 4.50 * rand_range(0.8, 1.2)
 
 func _ready() -> void:

--- a/project/src/main/ui/wallpaper/wallpaper-border.gd
+++ b/project/src/main/ui/wallpaper/wallpaper-border.gd
@@ -1,20 +1,19 @@
 class_name WallpaperBorder
 extends Control
-"""
-A wavy border which separates two solid colored sections of wallpaper.
+## A wavy border which separates two solid colored sections of wallpaper.
+##
+## TextureRects can't scale their textures unless the control itself is scaled. However, scaled controls wreak havoc
+## with Godot's layout manager. To reconcile this, WallpaperBorder is an unscaled control which contains a scaled
+## TextureRect.
 
-TextureRects can't scale their textures unless the control itself is scaled. However, scaled controls wreak havoc with
-Godot's layout manager. To reconcile this, WallpaperBorder is an unscaled control which contains a scaled TextureRect.
-"""
-
-# the size in pixels of the source wallpaper texture. this texture is scaled to the dimensions of the border.
+## the size in pixels of the source wallpaper texture. this texture is scaled to the dimensions of the border.
 const TEXTURE_SIZE := Vector2(512, 512)
 
-# the scroll velocity. only the x component is used
+## the scroll velocity. only the x component is used
 export (Vector2) var velocity: Vector2
 
-# the desired width and height of the border.
-# a value of [200, 50] means that the texture will be 200 pixels wide and 50 pixels high.
+## the desired width and height of the border.
+## a value of [200, 50] means that the texture will be 200 pixels wide and 50 pixels high.
 export (Vector2) var texture_scale: Vector2 = Vector2(512.0, 512.0) setget set_texture_scale
 
 onready var _texture_rect: TextureRect = $TextureRect
@@ -35,9 +34,7 @@ func set_texture_scale(new_texture_scale: Vector2) -> void:
 	_recalculate_texture_rect_size()
 
 
-"""
-Assigns the two colors used for this border.
-"""
+## Assigns the two colors used for this border.
 func set_gradient_colors(color_0: Color, color_1: Color) -> void:
 	var shader_material: ShaderMaterial = _texture_rect.material
 	var gradient_texture: GradientTexture = shader_material.get("shader_param/gradient")
@@ -45,12 +42,10 @@ func set_gradient_colors(color_0: Color, color_1: Color) -> void:
 	gradient_texture.gradient.colors[1] = color_1
 
 
-"""
-Updates the TextureRect's size and scale.
-
-The scale is adjusted so that the texture is tiled with the correct dimensions. The size is adjusted so that the
-TextureRect occupies the full width and height necessary
-"""
+## Updates the TextureRect's size and scale.
+##
+## The scale is adjusted so that the texture is tiled with the correct dimensions. The size is adjusted so that the
+## TextureRect occupies the full width and height necessary
 func _recalculate_texture_rect_size() -> void:
 	if not is_inside_tree():
 		return

--- a/project/src/main/ui/wallpaper/wallpaper.gd
+++ b/project/src/main/ui/wallpaper/wallpaper.gd
@@ -1,16 +1,14 @@
 extends Control
-"""
-A background wallpaper with colored areas, borders and shapes.
-"""
+## A background wallpaper with colored areas, borders and shapes.
 
-# optional float parameters don't have the concept of null. this default value acts as a substitute so we can tell
-# when a float value is unspecified.
+## optional float parameters don't have the concept of null. this default value acts as a substitute so we can tell
+## when a float value is unspecified.
 const UNSPECIFIED_FLOAT := 3025403.0
 
 export (PackedScene) var WallpaperBorderScene: PackedScene
 export (PackedScene) var StickerRowScene: PackedScene
 
-# the two colors used for this wallpaper
+## the two colors used for this wallpaper
 var _color_0: Color
 var _color_1: Color
 
@@ -51,9 +49,7 @@ func _ready() -> void:
 		sticker_row_index += 1
 
 
-"""
-Assigns the background colors based on the day of the week.
-"""
+## Assigns the background colors based on the day of the week.
 func _assign_daily_colors() -> void:
 	match OS.get_datetime().get("weekday"):
 		OS.DAY_MONDAY: # chocolate brown
@@ -105,16 +101,14 @@ func _add_color_rect(rect_y: float, rect_height: float) -> ColorRect:
 	return color_rect
 
 
-"""
-Sets the left/top/right/bottom margins for a node.
-
-When one value is specified, it applies the same margin to all four sides.
-
-When two values are specified, the first margin applies to the left and right, the second to the top and bottom.
-
-When three values are specified, the first margin applies to the left, the second to the top and bottom, and the third
-to the right.
-"""
+## Sets the left/top/right/bottom margins for a node.
+##
+## When one value is specified, it applies the same margin to all four sides.
+##
+## When two values are specified, the first margin applies to the left and right, the second to the top and bottom.
+##
+## When three values are specified, the first margin applies to the left, the second to the top and bottom, and the
+## third to the right.
 static func set_margins(target: Node, left: float, top: float = UNSPECIFIED_FLOAT,
 		right: float = UNSPECIFIED_FLOAT, bottom: float = UNSPECIFIED_FLOAT) -> void:
 	target.margin_left = left
@@ -123,16 +117,14 @@ static func set_margins(target: Node, left: float, top: float = UNSPECIFIED_FLOA
 	target.margin_bottom = bottom if bottom != UNSPECIFIED_FLOAT else top
 
 
-"""
-Sets the left/top/right/bottom anchors for a node.
-
-When one value is specified, it applies the same anchor to all four sides.
-
-When two values are specified, the first anchor applies to the left and right, the second to the top and bottom.
-
-When three values are specified, the first anchor applies to the left, the second to the top and bottom, and the third
-to the right.
-"""
+## Sets the left/top/right/bottom anchors for a node.
+##
+## When one value is specified, it applies the same anchor to all four sides.
+##
+## When two values are specified, the first anchor applies to the left and right, the second to the top and bottom.
+##
+## When three values are specified, the first anchor applies to the left, the second to the top and bottom, and the
+## third to the right.
 static func set_anchors(target: Control, left: float, top: float = UNSPECIFIED_FLOAT,
 		right: float = UNSPECIFIED_FLOAT, bottom: float = UNSPECIFIED_FLOAT) -> void:
 	target.anchor_left = left

--- a/project/src/main/utils.gd
+++ b/project/src/main/utils.gd
@@ -1,8 +1,6 @@
 tool
 class_name Utils
-"""
-Contains global utilities.
-"""
+## Contains global utilities.
 
 const NUM_SCANCODES := {
 	KEY_0: 0, KEY_1: 1, KEY_2: 2, KEY_3: 3, KEY_4: 4,
@@ -13,9 +11,7 @@ static func print_json(value) -> String:
 	return JSON.print(value, "  ")
 
 
-"""
-Returns the scancode for a keypress event, or -1 if the event is not a keypress event.
-"""
+## Returns the scancode for a keypress event, or -1 if the event is not a keypress event.
 static func key_scancode(event: InputEvent) -> int:
 	var scancode := -1
 	if event is InputEventKey and event.is_pressed() and not event.is_echo():
@@ -23,19 +19,15 @@ static func key_scancode(event: InputEvent) -> int:
 	return scancode
 
 
-"""
-Returns [0-9] for a number key event, or -1 if the event is not a number key event.
-"""
+## Returns [0-9] for a number key event, or -1 if the event is not a number key event.
 static func key_num(event: InputEvent) -> int:
 	return NUM_SCANCODES.get(key_scancode(event), -1)
 
 
-"""
-Returns a vector corresponding to the direction the user is pressing.
-
-Parameters:
-	'event': (Optional) The input event to be evaluated. If null, this method will evaluate all current inputs.
-"""
+## Returns a vector corresponding to the direction the user is pressing.
+##
+## Parameters:
+## 	'event': (Optional) The input event to be evaluated. If null, this method will evaluate all current inputs.
 static func walk_pressed_dir(event: InputEvent = null) -> Vector2:
 	var walk_dir := Vector2.ZERO
 	if event:
@@ -59,12 +51,10 @@ static func walk_pressed_dir(event: InputEvent = null) -> Vector2:
 	return walk_dir
 
 
-"""
-Returns 'true' if the player just released a direction key.
-
-Parameters:
-	'event': (Optional) The input event to be evaluated. If null, this method will evaluate all current inputs.
-"""
+## Returns 'true' if the player just released a direction key.
+##
+## Parameters:
+## 	'event': (Optional) The input event to be evaluated. If null, this method will evaluate all current inputs.
 static func walk_released_dir(event: InputEvent = null) -> bool:
 	var walk_dir := Vector2.ZERO
 	if event:
@@ -88,21 +78,17 @@ static func walk_released_dir(event: InputEvent = null) -> bool:
 	return walk_dir.length() > 0
 
 
-"""
-Returns a transparent version of the specified color.
-
-Tweening from forest green to 'Color.transparent' results in some strange in-between frames which are grey or white.
-It's better to tween to a transparent forest green.
-"""
+## Returns a transparent version of the specified color.
+##
+## Tweening from forest green to 'Color.transparent' results in some strange in-between frames which are grey or white.
+## It's better to tween to a transparent forest green.
 static func to_transparent(color: Color, alpha := 0.0) -> Color:
 	return Color(color.r, color.g, color.b, alpha)
 
 
-"""
-Returns the arithmetic mean (average) of the specified array.
-
-Returns a default value of 0.0 if the array is empty.
-"""
+## Returns the arithmetic mean (average) of the specified array.
+##
+## Returns a default value of 0.0 if the array is empty.
 static func mean(values: Array, default := 0.0) -> float:
 	if not values:
 		return default
@@ -113,11 +99,9 @@ static func mean(values: Array, default := 0.0) -> float:
 	return sum / len(values)
 
 
-"""
-Returns the maximum value of the specified array.
-
-Returns a default value of 0.0 if the array is empty.
-"""
+## Returns the maximum value of the specified array.
+##
+## Returns a default value of 0.0 if the array is empty.
 static func max_value(values: Array, default := 0.0) -> float:
 	if not values:
 		return default
@@ -128,18 +112,14 @@ static func max_value(values: Array, default := 0.0) -> float:
 	return max_value
 
 
-"""
-Returns a random value from the specified array.
-"""
+## Returns a random value from the specified array.
 static func rand_value(values: Array):
 	return values[randi() % values.size()]
 
 
-"""
-Returns a random key from the specified dictionary.
-
-The values in the dictionary are numeric weights for each key.
-"""
+## Returns a random key from the specified dictionary.
+##
+## The values in the dictionary are numeric weights for each key.
 static func weighted_rand_value(weights_map: Dictionary):
 	# select a random index in the range [0.0, sum_of_weights)
 	var selected_index := 0.0
@@ -158,13 +138,11 @@ static func weighted_rand_value(weights_map: Dictionary):
 	return selected_value
 
 
-"""
-Returns the array index whose contents are closest to a target number.
-
-Utils.find_closest([1.0, 2.0, 4.0, 8.0], 6.0) = 2
-Utils.find_closest([1.0, 2.0, 4.0, 8.0], 100) = 3
-Utils.find_closest([], 100)                   = -1
-"""
+## Returns the array index whose contents are closest to a target number.
+##
+## Utils.find_closest([1.0, 2.0, 4.0, 8.0], 6.0) = 2
+## Utils.find_closest([1.0, 2.0, 4.0, 8.0], 100) = 3
+## Utils.find_closest([], 100)                   = -1
 static func find_closest(values: Array, target: float) -> int:
 	if not values:
 		return -1
@@ -176,9 +154,7 @@ static func find_closest(values: Array, target: float) -> int:
 	return result
 
 
-"""
-If the specified key does not exist, this method associates it with the given value.
-"""
+## If the specified key does not exist, this method associates it with the given value.
 static func put_if_absent(dict: Dictionary, key: String, value) -> void:
 	dict[key] = dict.get(key, value)
 
@@ -193,11 +169,9 @@ static func remove_all(values: Array, value) -> Array:
 	return values
 
 
-"""
-Returns a new array containing a - b.
-
-The input arrays are not modified. This code is adapted from Apache Common Collections.
-"""
+## Returns a new array containing a - b.
+##
+## The input arrays are not modified. This code is adapted from Apache Common Collections.
 static func subtract(a: Array, b: Array) -> Array:
 	var result := []
 	var bag := {}
@@ -215,16 +189,14 @@ static func subtract(a: Array, b: Array) -> Array:
 	return result
 
 
-"""
-Assigns a default path for a FileDialog.
-
-At runtime, this will default to the user's data directory. During development, this will default to a resource path
-for convenience when authoring Turbo Fat's creature's/levels.
-
-Note: We only want to assign the path the first time, but we can't check 'is the path empty' because an empty path is a
-valid choice -- a user can navigate to the root directory. So instead of checking 'is the path empty' we check 'is the
-path this specific UUID' since that's something the user will never navigate to accidentally.
-"""
+## Assigns a default path for a FileDialog.
+##
+## At runtime, this will default to the user's data directory. During development, this will default to a resource path
+## for convenience when authoring Turbo Fat's creature's/levels.
+##
+## Note: We only want to assign the path the first time, but we can't check 'is the path empty' because an empty path
+## is a valid choice -- a user can navigate to the root directory. So instead of checking 'is the path empty' we check
+## 'is the path this specific UUID' since that's something the user will never navigate to accidentally.
 static func assign_default_dialog_path(dialog: FileDialog, default_resource_path: String) -> void:
 	if dialog.current_path == "/509e7c82-9399-425a-9f15-9370c2b3de8b":
 		var current_path := ProjectSettings.globalize_path(default_resource_path)
@@ -233,23 +205,19 @@ static func assign_default_dialog_path(dialog: FileDialog, default_resource_path
 		dialog.current_path = current_path
 
 
-"""
-Converts an Aseprite json region to a Rect2.
-"""
+## Converts an Aseprite json region to a Rect2.
 static func json_to_rect2(json: Dictionary) -> Rect2:
 	return Rect2(json.x, json.y, json.w, json.h)
 
 
-"""
-Converts an enum value like 'LevelTriggerPhase.ROTATED_CW' to a snake case string like 'rotated_cw'.
-
-Parameters:
-	'enum_dict': An enum type such as 'PuzzleTileMap.TileSetType'
-	
-	'from': The enum value to convert
-	
-	'default': Default value to assume if the specified enum value is invalid
-"""
+## Converts an enum value like 'LevelTriggerPhase.ROTATED_CW' to a snake case string like 'rotated_cw'.
+##
+## Parameters:
+## 	'enum_dict': An enum type such as 'PuzzleTileMap.TileSetType'
+##
+## 	'from': The enum value to convert
+##
+## 	'default': Default value to assume if the specified enum value is invalid
 static func enum_to_snake_case(
 		enum_dict: Dictionary, from: int, default: String = "e3343934-8d10-46f8-b19d-da50eb47d0d8") -> String:
 	var result: String
@@ -268,31 +236,27 @@ static func enum_to_snake_case(
 	return result
 
 
-"""
-Converts a snake case string like 'rotated_cw' to an enum value like 'LevelTriggerPhase.ROTATED_CW'.
-
-Parameters:
-	'enum_dict': An enum type such as 'PuzzleTileMap.TileSetType'
-	
-	'from': The snake case string to convert
-	
-	'default': Default value to assume if the specified snake case string is invalid
-"""
+## Converts a snake case string like 'rotated_cw' to an enum value like 'LevelTriggerPhase.ROTATED_CW'.
+##
+## Parameters:
+## 	'enum_dict': An enum type such as 'PuzzleTileMap.TileSetType'
+##
+## 	'from': The snake case string to convert
+##
+## 	'default': Default value to assume if the specified snake case string is invalid
 static func enum_from_snake_case(enum_dict: Dictionary, from: String, default: int = 0) -> int:
 	return enum_dict.get(from.to_upper(), default)
 
 
-"""
-Converts a string to a bool, treating values like 'False', and 'false' as false values.
-
-This is a workaround for Godot #27529 (https://github.com/godotengine/godot/issues/27529). When converting a bool to a
-String, the String is set to "True" and "False" for the appropriate boolean values. However, when converting a String
-to a bool, the bool is set to true if the string is non-empty, regardless of the contents.
-
-This code is adapted from Andrettin's suggested fix. Per his suggestion, the result is true if the String is "True",
-"TRUE", "true" or "1", and false if the String is "False", "FALSE", "false" or "0". If the string is set to anything
-else, then it is true if non-empty, and false otherwise.
-"""
+## Converts a string to a bool, treating values like 'False', and 'false' as false values.
+##
+## This is a workaround for Godot #27529 (https://github.com/godotengine/godot/issues/27529). When converting a bool to
+## a String, the String is set to "True" and "False" for the appropriate boolean values. However, when converting a
+## String to a bool, the bool is set to true if the string is non-empty, regardless of the contents.
+##
+## This code is adapted from Andrettin's suggested fix. Per his suggestion, the result is true if the String is "True",
+## "TRUE", "true" or "1", and false if the String is "False", "FALSE", "false" or "0". If the string is set to anything
+## else, then it is true if non-empty, and false otherwise.
 static func to_bool(s: String) -> bool:
 	var result: bool
 	match s:
@@ -302,17 +266,15 @@ static func to_bool(s: String) -> bool:
 	return result
 
 
-"""
-Returns the local position of the center of the cell corresponding to the given tilemap (grid-based) coordinates.
-
-One might expect this could be implemented trivially by passing in something like 'map_to_world(2.5, 2.5)' to
-get the center of the cell at (2, 2). But, map_to_world does not work that way.
-
-One might also expect this could be implemented by doing something like "Get the top left corner, and shift it by half
-the cell size." But, this returns incorrect results for isometric tilemaps.
-
-For now, the nuance and complexity required in correctly implementing this trivial functionality warrants a utility
-function.
-"""
+## Returns the local position of the center of the cell corresponding to the given tilemap (grid-based) coordinates.
+##
+## One might expect this could be implemented trivially by passing in something like 'map_to_world(2.5, 2.5)' to
+## get the center of the cell at (2, 2). But, map_to_world does not work that way.
+##
+## One might also expect this could be implemented by doing something like "Get the top left corner, and shift it by
+## half the cell size." But, this returns incorrect results for isometric tilemaps.
+##
+## For now, the nuance and complexity required in correctly implementing this trivial functionality warrants a utility
+## function.
 static func map_to_world_centered(tile_map: TileMap, cell: Vector2) -> Vector2:
 	return (tile_map.map_to_world(cell) + tile_map.map_to_world(cell + Vector2(1, 1))) * 0.5

--- a/project/src/main/world/chat-icon.gd
+++ b/project/src/main/world/chat-icon.gd
@@ -1,10 +1,8 @@
 class_name ChatIcon
 extends Node2D
-"""
-A visual icon which appears next to something the player can interact with.
-"""
+## A visual icon which appears next to something the player can interact with.
 
-# emitted when the icon is finished vanishing after a call to 'vanish()'
+## emitted when the icon is finished vanishing after a call to 'vanish()'
 signal vanish_finished
 
 enum BubbleType {
@@ -21,15 +19,15 @@ const THOUGHT := BubbleType.THOUGHT
 const SPEECH := BubbleType.SPEECH
 const FOOD := BubbleType.FOOD
 
-# The chat icons bounce. These constants control how they bounce.
+## The chat icons bounce. These constants control how they bounce.
 const BOUNCE_DURATION := 0.7
 const BOUNCE_HEIGHT := 12.0
 
-# The chat icons fade in and fade out as the player get close. These constants control how they fade.
+## The chat icons fade in and fade out as the player get close. These constants control how they fade.
 const COLOR_FOCUSED := Color(1.0, 1.0, 1.0, 1.00)
 const COLOR_UNFOCUSED := Color(1.0, 1.0, 1.0, 0.25)
 
-# mapping from chat icons to chat bubble sprite frames
+## mapping from chat icons to chat bubble sprite frames
 const BUBBLE_TYPE_FRAMES := {
 	NONE: [],
 	FILLER: [0, 1, 2],
@@ -63,11 +61,9 @@ func _physics_process(delta: float) -> void:
 	_sprite.position.y = -57 - abs(BOUNCE_HEIGHT * sin(_bounce_phase * BOUNCE_DURATION * PI))
 
 
-"""
-Initializes the icon's appearance and position for the specified chattable.
-
-Chattables must have a 'ChatIconHook' node. ChatIconHook is a RemoteTransform2D which updates the icon's position.
-"""
+## Initializes the icon's appearance and position for the specified chattable.
+##
+## Chattables must have a 'ChatIconHook' node. ChatIconHook is a RemoteTransform2D which updates the icon's position.
 func initialize(chattable: Node) -> void:
 	_chattable = chattable
 	if _chattable.has_meta("chat_bubble_type"):
@@ -85,11 +81,9 @@ func set_bubble_type(new_bubble_type: int) -> void:
 	_refresh()
 
 
-"""
-Make the chat icon focused, so the player knows they can interact with it.
-
-This brightens the icon and makes it bounce faster.
-"""
+## Make the chat icon focused, so the player knows they can interact with it.
+##
+## This brightens the icon and makes it bounce faster.
 func focus() -> void:
 	if _focused == true:
 		return
@@ -98,19 +92,15 @@ func focus() -> void:
 	_focused = true
 
 
-"""
-Make the chat icon unfocused, so the player knows they need to get closer to interact with it.
-
-This dims the icon and makes it bounce slower.
-"""
+## Make the chat icon unfocused, so the player knows they need to get closer to interact with it.
+##
+## This dims the icon and makes it bounce slower.
 func unfocus() -> void:
 	_tween_modulate(COLOR_UNFOCUSED, 1.6)
 	_focused = false
 
 
-"""
-Makes the chat icon invisible, so the player knows they can't interact with it.
-"""
+## Makes the chat icon invisible, so the player knows they can't interact with it.
 func vanish() -> void:
 	_tween_modulate(Color.transparent, 0.4)
 	_focused = false
@@ -132,9 +122,7 @@ func _refresh() -> void:
 			ChattableManager.connect("focus_changed", self, "_on_ChattableManager_focus_changed")
 
 
-"""
-Tweens this objects 'modulate' property to a new value.
-"""
+## Tweens this objects 'modulate' property to a new value.
 func _tween_modulate(new_modulate: Color, duration: float) -> void:
 	if _sprite.modulate == new_modulate:
 		# don't launch tween if our modulate property is already set appropriately

--- a/project/src/main/world/chat-icons.gd
+++ b/project/src/main/world/chat-icons.gd
@@ -1,13 +1,11 @@
 class_name ChatIcons
 extends Node2D
-"""
-Creates and initializes chat icons for all chattables in the scene tree.
-"""
+## Creates and initializes chat icons for all chattables in the scene tree.
 
 export (PackedScene) var ChatIconScene: PackedScene
 
-# key: Node2D in the 'chattable' node group
-# value: ChatIcon instance
+## key: Node2D in the 'chattable' node group
+## value: ChatIcon instance
 var _chat_icon_by_chattable: Dictionary
 
 onready var overworld_ui: OverworldUi = Global.get_overworld_ui()
@@ -37,11 +35,9 @@ func _on_Chattable_tree_exited(chat_icon: ChatIcon) -> void:
 	chat_icon.queue_free()
 
 
-"""
-After the player talks to a creature we change their speech bubble.
-
-A repeat chat is treated as a 'drive by chat' so it's given the drive by speech bubble.
-"""
+## After the player talks to a creature we change their speech bubble.
+##
+## A repeat chat is treated as a 'drive by chat' so it's given the drive by speech bubble.
 func _on_OverworldUi_chat_cached(focused_chattable: Node2D) -> void:
 	var chat_icon: ChatIcon = _chat_icon_by_chattable.get(focused_chattable, null)
 	if chat_icon and chat_icon.bubble_type == ChatIcon.SPEECH:

--- a/project/src/main/world/chat-letters.gd
+++ b/project/src/main/world/chat-letters.gd
@@ -1,9 +1,7 @@
 extends Node
-"""
-Emits letters when creatures talk.
-
-This helps the player tell which creature is currently talking, especially for creatures with unconventional mouths.
-"""
+## Emits letters when creatures talk.
+##
+## This helps the player tell which creature is currently talking, especially for creatures with unconventional mouths.
 
 const VOICE_POSITIONS_BY_ORIENTATION := {
 	Creatures.SOUTHEAST: Vector2(36, -15),
@@ -23,7 +21,7 @@ onready var overworld_ui: OverworldUi = Global.get_overworld_ui()
 
 onready var _letter_shooter: LetterShooter = $LetterShooter
 
-# the creature currently emitting letters
+## the creature currently emitting letters
 var _chatter: Creature
 
 func _ready() -> void:

--- a/project/src/main/world/chattable-manager.gd
+++ b/project/src/main/world/chattable-manager.gd
@@ -1,32 +1,30 @@
 extends Node
-"""
-Tracks the player's location and the location of all chattables. Handles questions like 'which chattable is focused'
-and 'which chattables are nearby'.
-"""
+## Tracks the player's location and the location of all chattables. Handles questions like 'which chattable is focused'
+## and 'which chattables are nearby'.
 
-# emitted when focus changes to a new object, or when all objects are unfocused.
+## emitted when focus changes to a new object, or when all objects are unfocused.
 signal focus_changed
 
-# Maximum range for the player to successfully interact with an object
+## Maximum range for the player to successfully interact with an object
 const MAX_INTERACT_DISTANCE := 240.0
 
-# The player's sprite
+## The player's sprite
 var player: Creature setget set_player
 
-# The sensei's sprite
+## The sensei's sprite
 var sensei: Creature setget set_sensei
 
-# The overworld object which the player will currently interact with if they hit the button
+## The overworld object which the player will currently interact with if they hit the button
 var focused_chattable: Node2D setget set_focused_chattable
 
-# 'false' if the player is temporarily disallowed from interacting with nearby objects, such as while chatting
+## 'false' if the player is temporarily disallowed from interacting with nearby objects, such as while chatting
 var _focus_enabled := true setget set_focus_enabled, is_focus_enabled
 
-# Mapping from creature ids to Creature objects. The player and sensei are omitted from this mapping, as the player
-# can set their own name and it could conflict with overworld creatures.
+## Mapping from creature ids to Creature objects. The player and sensei are omitted from this mapping, as the player
+## can set their own name and it could conflict with overworld creatures.
 #
-# key: creature id as it appears in chat files
-# value: Creature object corresponding to the creature id
+## key: creature id as it appears in chat files
+## value: Creature object corresponding to the creature id
 var _creatures_by_id := {}
 
 func _ready() -> void:
@@ -68,9 +66,7 @@ func _physics_process(_delta: float) -> void:
 		set_focused_chattable(new_focused_chattable)
 
 
-"""
-Refreshes our state based on the creatures in the scene, and reconnects some signals.
-"""
+## Refreshes our state based on the creatures in the scene, and reconnects some signals.
 func refresh_creatures() -> void:
 	_creatures_by_id.clear()
 	for creature_obj in get_tree().get_nodes_in_group("creatures"):
@@ -83,12 +79,10 @@ func refresh_creatures() -> void:
 			register_creature(creature)
 
 
-"""
-Returns the Creature object corresponding to the specified chatter name.
-
-A name of SENSEI_ID or PLAYER_ID will return the sensei or player object. To avoid
-conflicts, the sensei or player cannot be retrieved by their actual name.
-"""
+## Returns the Creature object corresponding to the specified chatter name.
+##
+## A name of SENSEI_ID or PLAYER_ID will return the sensei or player object. To avoid
+## conflicts, the sensei or player cannot be retrieved by their actual name.
 func get_creature_by_id(chat_id: String) -> Creature:
 	var result: Creature
 	match chat_id:
@@ -100,11 +94,9 @@ func get_creature_by_id(chat_id: String) -> Creature:
 	return result
 
 
-"""
-Loads the chat tree for the currently focused chattable.
-
-Returns a chat tree for the chat sequence which the player should see.
-"""
+## Loads the chat tree for the currently focused chattable.
+##
+## Returns a chat tree for the chat sequence which the player should see.
 func load_chat_tree() -> ChatTree:
 	var chat_tree: ChatTree
 	if focused_chattable is Creature:
@@ -136,20 +128,16 @@ func set_focused_chattable(new_focused_chattable: Node2D) -> void:
 	emit_signal("focus_changed")
 
 
-"""
-Returns 'true' if the player will currently interact with the specified object if they hit the button.
-"""
+## Returns 'true' if the player will currently interact with the specified object if they hit the button.
 func is_focused(chattable: Node2D) -> bool:
 	return chattable == focused_chattable
 
 
-"""
-Globally enables/disables focus for nearby objects.
-
-Regardless of whether or not the focused object changed, this notifies all listeners with a 'focus_changed' event.
-This is because some UI elements render themselves differently during chats when the player can't interact with
-anything.
-"""
+## Globally enables/disables focus for nearby objects.
+##
+## Regardless of whether or not the focused object changed, this notifies all listeners with a 'focus_changed' event.
+## This is because some UI elements render themselves differently during chats when the player can't interact with
+## anything.
 func set_focus_enabled(new_focus_enabled: bool) -> void:
 	_focus_enabled = new_focus_enabled
 	
@@ -161,18 +149,13 @@ func set_focus_enabled(new_focus_enabled: bool) -> void:
 		emit_signal("focus_changed")
 
 
-"""
-Returns 'true' if focus is globally enabled/disabled for all objects.
-"""
+## Returns 'true' if focus is globally enabled/disabled for all objects.
 func is_focus_enabled() -> bool:
 	return _focus_enabled
 
-
-"""
-Substitutes variables in player-visible text.
-
-Text variables are pound sign delimited: 'Hello #player#'. This matches the syntax of Tracery.
-"""
+## Substitutes variables in player-visible text.
+##
+## Text variables are pound sign delimited: 'Hello #player#'. This matches the syntax of Tracery.
 func substitute_variables(string: String, full_name: bool = false) -> String:
 	var result := string
 	if full_name:
@@ -184,11 +167,9 @@ func substitute_variables(string: String, full_name: bool = false) -> String:
 	return result
 
 
-"""
-Returns the level id (if any) corresponding to the curently focused chattable.
-
-This is relevant when the player talks to a creature with a food speech bubble.
-"""
+## Returns the level id (if any) corresponding to the curently focused chattable.
+##
+## This is relevant when the player talks to a creature with a food speech bubble.
 func focused_chattable_level_id() -> String:
 	var focused_creature: Creature = ChattableManager.focused_chattable as Creature
 	if not focused_creature:
@@ -205,29 +186,23 @@ func focused_chattable_creature_id() -> String:
 	return focused_creature.creature_id
 
 
-"""
-Adds the specified creature to the '_creatures_by_id' mapping.
-"""
+## Adds the specified creature to the '_creatures_by_id' mapping.
 func register_creature(creature: Creature) -> void:
 	if creature.creature_id:
 		_creatures_by_id[creature.creature_id] = creature
 
 
-"""
-Removes the specified creature from the '_creatures_by_id' mapping.
-"""
+## Removes the specified creature from the '_creatures_by_id' mapping.
 func unregister_creature(creature: Creature) -> void:
 	for key in _creatures_by_id:
 		if _creatures_by_id[key] == creature:
 			_creatures_by_id.erase(key)
 
 
-"""
-Purges all node instances from the manager.
-
-Because ChattableManager is a singleton, node instances must be purged before changing scenes. Otherwise it's
-possible for an invisible object from a previous scene to receive focus.
-"""
+## Purges all node instances from the manager.
+##
+## Because ChattableManager is a singleton, node instances must be purged before changing scenes. Otherwise it's
+## possible for an invisible object from a previous scene to receive focus.
 func _on_Breadcrumb_before_scene_changed() -> void:
 	player = null
 	sensei = null
@@ -236,8 +211,6 @@ func _on_Breadcrumb_before_scene_changed() -> void:
 	_creatures_by_id.clear()
 
 
-"""
-We prevent the player from interacting with objects during scene transitions.
-"""
+## We prevent the player from interacting with objects during scene transitions.
 func _on_SceneTransition_fade_out_started() -> void:
 	set_focus_enabled(false)

--- a/project/src/main/world/creature-spawner.gd
+++ b/project/src/main/world/creature-spawner.gd
@@ -1,37 +1,35 @@
 extends Node2D
-"""
-Conditionally spawns a creature on the overworld.
-
-The decision to spawn the creature is controlled by the 'spawn_if' property.
-
-The creature's creature_id, properties and groups (the 'chattables' group in particular) can be managed by the
-target_properties and target_groups fields.
-"""
+## Conditionally spawns a creature on the overworld.
+##
+## The decision to spawn the creature is controlled by the 'spawn_if' property.
+##
+## The creature's creature_id, properties and groups (the 'chattables' group in particular) can be managed by the
+## target_properties and target_groups fields.
 
 export (NodePath) var overworld_world_path: NodePath = NodePath("../..")
 
-# (optional) path to a stool the spawned creature sits on
+## (optional) path to a stool the spawned creature sits on
 export (NodePath) var stool_path: NodePath
 
-# the properties of the spawned creature
+## the properties of the spawned creature
 export (Dictionary) var target_properties: Dictionary
 
-# the groups of the spawned creature
+## the groups of the spawned creature
 export (Array) var target_groups: Array
 
-# a boolean expression which, if evaluated to 'true', will result in the creature being spawned
+## a boolean expression which, if evaluated to 'true', will result in the creature being spawned
 export (String) var spawn_if: String
 
-# Maximum fatness for a spawned creature.
-# If a fatter creature spawns here, they will spontaneously and permanently slim down.
+## Maximum fatness for a spawned creature.
+## If a fatter creature spawns here, they will spontaneously and permanently slim down.
 export (float) var max_fatness := 10.0
 
 export (PackedScene) var CreatureScene: PackedScene
 
-# a Stool or ObstacleSpawner instance for the stool the spawned creature sits on, if any
+## a Stool or ObstacleSpawner instance for the stool the spawned creature sits on, if any
 var _stool: Node2D
 
-# the spawned creature, or 'null' if the creature has not yet spawned
+## the spawned creature, or 'null' if the creature has not yet spawned
 var _target_creature: Creature
 
 onready var _overworld_world: OverworldWorld = get_node(overworld_world_path)
@@ -50,9 +48,7 @@ func _ready() -> void:
 		queue_free()
 
 
-"""
-Updates the spawned creature's stool to be occupied or unoccupied.
-"""
+## Updates the spawned creature's stool to be occupied or unoccupied.
 func _update_stool_occupied() -> void:
 	var occupied := _target_creature != null
 	if _stool is ObstacleSpawner:
@@ -61,9 +57,7 @@ func _update_stool_occupied() -> void:
 		_stool.occupied = occupied
 
 
-"""
-Spawns the creature and removes the spawner from the scene tree.
-"""
+## Spawns the creature and removes the spawner from the scene tree.
 func _spawn_target() -> void:
 	if not is_inside_tree():
 		# If the spawner was already removed from the scene tree, don't spawn the creature.

--- a/project/src/main/world/creature/arm-shadow.gd
+++ b/project/src/main/world/creature/arm-shadow.gd
@@ -1,36 +1,28 @@
 #tool #uncomment to view creature in editor
 extends CreatureCurve
-"""
-The shadow drawn below the creature's arm.
-"""
+## The shadow drawn below the creature's arm.
 
-# cached NearArm sprite used for calculating shadows
+## cached NearArm sprite used for calculating shadows
 var _near_arm: CreaturePackedSprite
 
-"""
-Disconnects creature visuals listeners specific to arm shadows.
-
-Overrides the superclass's implementation to disconnect additional listeners.
-"""
+## Disconnects creature visuals listeners specific to arm shadows.
+##
+## Overrides the superclass's implementation to disconnect additional listeners.
 func disconnect_creature_visuals_listeners() -> void:
 	.disconnect_creature_visuals_listeners()
 	_near_arm.disconnect("frame_changed", self, "_on_NearArm_frame_changed")
 
 
-"""
-Connects creature visuals listeners specific to arm shadows.
-
-Overrides the superclass's implementation to connect additional listeners.
-"""
+## Connects creature visuals listeners specific to arm shadows.
+##
+## Overrides the superclass's implementation to connect additional listeners.
 func connect_creature_visuals_listeners() -> void:
 	.connect_creature_visuals_listeners()
 	_near_arm = creature_visuals.get_node("NearArm")
 	_near_arm.connect("frame_changed", self, "_on_NearArm_frame_changed")
 
 
-"""
-Updates the 'drawn' property based on the arm's current frame.
-"""
+## Updates the 'drawn' property based on the arm's current frame.
 func refresh_drawn() -> void:
 	.refresh_drawn()
 	if _near_arm.frame == 0:

--- a/project/src/main/world/creature/body-sweat.gd
+++ b/project/src/main/world/creature/body-sweat.gd
@@ -1,7 +1,5 @@
 extends Particles2D
-"""
-Manages the sweat drops which slide down the creature's body.
-"""
+## Manages the sweat drops which slide down the creature's body.
 
 export var creature_visuals_path: NodePath
 

--- a/project/src/main/world/creature/body.gd
+++ b/project/src/main/world/creature/body.gd
@@ -1,43 +1,41 @@
 class_name Body
 #tool #uncomment to view creature in editor
 extends Node2D
-"""
-Draws the creature's torso. This includes the body shape, a belly, shadows and an outline.
-
-Because the creature can grow, the torso is drawn dynamically and is not represented by a sprite. The shape of the
-torso and its various parts are stored in CreatureCurve instances which are substituted at runtime. These CreatureCurve
-instances are invisible by default, but can be made visible by toggling the 'editing' flag. This is useful when editing
-curves in the Godot editor.
-"""
+## Draws the creature's torso. This includes the body shape, a belly, shadows and an outline.
+##
+## Because the creature can grow, the torso is drawn dynamically and is not represented by a sprite. The shape of the
+## torso and its various parts are stored in CreatureCurve instances which are substituted at runtime. These
+## CreatureCurve instances are invisible by default, but can be made visible by toggling the 'editing' flag. This is
+## useful when editing curves in the Godot editor.
 
 export (NodePath) var creature_visuals_path: NodePath setget set_creature_visuals_path
 
-# The color for the body outline
+## The color for the body outline
 export (Color) var line_color := Color.black
 
-# The main color for most of the creature's body
+## The main color for most of the creature's body
 export (Color) var body_color := Color.green
 
-# The secondary color for the creature's belly
+## The secondary color for the creature's belly
 export (Color) var belly_color := Color.red
 
-# The color to use for shadows, including an alpha component
+## The color to use for shadows, including an alpha component
 export (Color) var shadow_color := Color.blue
 
-# If 'true', the CreatureCurve instances will be made visible. This is useful
-# when editing curves in the Godot editor.
+## If 'true', the CreatureCurve instances will be made visible. This is useful
+## when editing curves in the Godot editor.
 export (bool) var editing := false setget set_editing
 
-# The CreatureCurve defining the rounded shape of the torso.
+## The CreatureCurve defining the rounded shape of the torso.
 var body_shape: CreatureCurve
 
-# An optional CreatureCurve defining the shape of the belly markings.
+## An optional CreatureCurve defining the shape of the belly markings.
 var belly: CreatureCurve
 
-# An optional CreatureCurve defining an body-colored line which blends the neck with the back of the head
+## An optional CreatureCurve defining an body-colored line which blends the neck with the back of the head
 var neck_blend: CreatureCurve
 
-# A node containing CreatureCurves which define the shapes of shadows for the arms, body and head.
+## A node containing CreatureCurves which define the shapes of shadows for the arms, body and head.
 var shadows: Node
 
 var _creature_visuals: CreatureVisuals
@@ -69,9 +67,7 @@ func set_editing(new_editing: bool) -> void:
 	_refresh_editing()
 
 
-"""
-Reassigns the CreatureCurve fields based on the current child nodes.
-"""
+## Reassigns the CreatureCurve fields based on the current child nodes.
 func refresh_children() -> void:
 	_disconnect_curve_signals([body_shape, belly, neck_blend])
 	if shadows:
@@ -89,18 +85,14 @@ func refresh_children() -> void:
 	update()
 
 
-"""
-Connects signals to receive updates from the specified CreatureCurves.
-"""
+## Connects signals to receive updates from the specified CreatureCurves.
 func _connect_curve_signals(creature_curves: Array) -> void:
 	for creature_curve in creature_curves:
 		if creature_curve:
 			creature_curve.connect("appearance_changed", self, "_on_CreatureCurve_appearance_changed")
 
 
-"""
-Disconnects signals to no longer receive updates from the specified CreatureCurves.
-"""
+## Disconnects signals to no longer receive updates from the specified CreatureCurves.
 func _disconnect_curve_signals(creature_curves: Array) -> void:
 	for creature_curve in creature_curves:
 		if creature_curve:
@@ -159,12 +151,10 @@ func _curve_drawn(creature_curve: CreatureCurve) -> bool:
 	return creature_curve and creature_curve.drawn
 
 
-"""
-Fills the shadows for the arms, body and head.
-
-The shadow shapes overrun the body shape and overlap each other. We perform some processing to avoid drawing
-overlapping shadows and to avoid drawing outside the body shape.
-"""
+## Fills the shadows for the arms, body and head.
+##
+## The shadow shapes overrun the body shape and overlap each other. We perform some processing to avoid drawing
+## overlapping shadows and to avoid drawing outside the body shape.
 func _fill_shadows() -> void:
 	if not shadows:
 		return
@@ -203,11 +193,9 @@ func _fill_shadows() -> void:
 			_draw_body_polygon(intersecting_points_obj, shadow_color)
 
 
-"""
-Fills the creature's belly markings.
-
-The belly markings overrun the body shape. We perform some processing to avoid drawing outside the body shape.
-"""
+## Fills the creature's belly markings.
+##
+## The belly markings overrun the body shape. We perform some processing to avoid drawing outside the body shape.
 func _fill_belly() -> void:
 	if not _curve_drawn(belly):
 		return
@@ -221,9 +209,7 @@ func _fill_belly() -> void:
 		_draw_body_polygon(intersecting_points_obj, belly_color)
 
 
-"""
-Draw a filled polygon.
-"""
+## Draw a filled polygon.
 func _draw_body_polygon(points: PoolVector2Array, color: Color) -> void:
 	if points.size() < 3 or color.a == 0:
 		# don't waste cycles filling invisible polygons
@@ -233,9 +219,7 @@ func _draw_body_polygon(points: PoolVector2Array, color: Color) -> void:
 	draw_polygon(points, _poly_colors, PoolVector2Array())
 
 
-"""
-Draw a polyline.
-"""
+## Draw a polyline.
 func _draw_body_polyline(points: PoolVector2Array, color: Color, line_width: float, closed: bool) -> void:
 	if points.size() < 3 or color.a == 0:
 		# don't waste cycles outlining invisible polygons

--- a/project/src/main/world/creature/creature-animations.gd
+++ b/project/src/main/world/creature/creature-animations.gd
@@ -1,15 +1,13 @@
 #tool #uncomment to view creature in editor
 class_name CreatureAnimations
 extends Node
-"""
-Animates the creature's limbs, facial expressions and movement.
-
-Contains AnimationPlayers to handle things like idle emotes, movement and idle animations.
-
-Exposes properties which manipulate multiple sprites simultaneously. Toggling things like arm and eye emotes involves
-animating four sprites. It's tedious having four near-identical animation tracks, so this class consolidates those four
-frame properties into one.
-"""
+## Animates the creature's limbs, facial expressions and movement.
+##
+## Contains AnimationPlayers to handle things like idle emotes, movement and idle animations.
+##
+## Exposes properties which manipulate multiple sprites simultaneously. Toggling things like arm and eye emotes
+## involves animating four sprites. It's tedious having four near-identical animation tracks, so this class
+## consolidates those four frame properties into one.
 
 export (int) var emote_eye_frame: int setget set_emote_eye_frame
 export (int) var eye_frame: int setget set_eye_frame
@@ -31,16 +29,16 @@ var _near_arm: PackedSprite
 var _tail_z0: PackedSprite
 var _tail_z1: PackedSprite
 
-# IdleTimer which launches idle animations periodically
+## IdleTimer which launches idle animations periodically
 onready var _idle_timer: Timer = $IdleTimer
 
-# recoils the creature's head
+## recoils the creature's head
 onready var _tween: Tween = $Tween
 
-# EmotePlayer which animates moods: blinking, smiling, sweating, etc.
+## EmotePlayer which animates moods: blinking, smiling, sweating, etc.
 onready var _emote_player: AnimationPlayer = $EmotePlayer
 
-# AnimationPlayer which animates movement: running, walking, etc.
+## AnimationPlayer which animates movement: running, walking, etc.
 onready var _movement_player: AnimationPlayer = $MovementPlayer
 
 func _ready() -> void:
@@ -55,20 +53,16 @@ func set_creature_visuals_path(new_creature_visuals_path: NodePath) -> void:
 	_refresh_creature_visuals_path()
 
 
-"""
-Sets the frame for the emote eye sprites, resetting the non-emote sprites to a default frame.
-"""
+## Sets the frame for the emote eye sprites, resetting the non-emote sprites to a default frame.
 func set_emote_eye_frame(new_emote_eye_frame: int) -> void:
 	emote_eye_frame = new_emote_eye_frame
 	_refresh_emote_eye_frame()
 
 
-"""
-Resets the eye/arm frames to default values.
-
-This is used during development to ensure the .tscn file doesn't include unnecessary changes when we play animations
-in the Godot editor. It is not used during the game.
-"""
+## Resets the eye/arm frames to default values.
+##
+## This is used during development to ensure the .tscn file doesn't include unnecessary changes when we play animations
+## in the Godot editor. It is not used during the game.
 func reset() -> void:
 	set_emote_eye_frame(0)
 	set_eye_frame(0)
@@ -87,12 +81,10 @@ func eat() -> void:
 	_emote_player.eat()
 
 
-"""
-Animates the creature's appearance according to the specified mood: happy, angry, etc...
-
-Parameters:
-	'mood': The creature's new mood from ChatEvent.Mood
-"""
+## Animates the creature's appearance according to the specified mood: happy, angry, etc...
+##
+## Parameters:
+## 	'mood': The creature's new mood from ChatEvent.Mood
 func play_mood(mood: int) -> void:
 	_idle_timer.stop_idle_animation()
 	
@@ -104,10 +96,8 @@ func play_mood(mood: int) -> void:
 		_emote_player.emote(mood)
 
 
-"""
-The 'feed' animation causes a few side-effects. The creature's head recoils and some sounds play. This method controls
-all of those secondary visual effects of the creature being fed.
-"""
+## The 'feed' animation causes a few side-effects. The creature's head recoils and some sounds play. This method
+## controls all of those secondary visual effects of the creature being fed.
 func show_food_effects() -> void:
 	_tween.interpolate_property(_head_bobber, "position:x",
 			clamp(_head_bobber.position.x - 6, -20, 0), 0, 0.5,
@@ -143,9 +133,7 @@ func _refresh_emote_eye_frame() -> void:
 	_emote_eye_z1.frame = emote_eye_frame
 
 
-"""
-Sets the frame for the eye sprites, resetting the emote sprites to a default frame.
-"""
+## Sets the frame for the eye sprites, resetting the emote sprites to a default frame.
 func set_eye_frame(new_eye_frame: int) -> void:
 	eye_frame = new_eye_frame
 	_refresh_eye_frame()
@@ -161,9 +149,7 @@ func _refresh_eye_frame() -> void:
 	_emote_eye_z1.frame = 0
 
 
-"""
-Sets the frame for the emote arm sprites, resetting the non-emote sprites to a default frame.
-"""
+## Sets the frame for the emote arm sprites, resetting the non-emote sprites to a default frame.
 func set_emote_arm_frame(new_emote_arm_frame: int) -> void:
 	emote_arm_frame = new_emote_arm_frame
 	_refresh_emote_arm_frame()

--- a/project/src/main/world/creature/creature-chat-icon-hook.gd
+++ b/project/src/main/world/creature/creature-chat-icon-hook.gd
@@ -1,7 +1,5 @@
 extends RemoteTransform2D
-"""
-Defines the position so that chat icons appear next to the creature's head.
-"""
+## Defines the position so that chat icons appear next to the creature's head.
 
 var creature_visuals: CreatureVisuals setget set_creature_visuals
 
@@ -31,11 +29,9 @@ func _connect_creature_visuals_listeners() -> void:
 	creature_visuals.connect("head_moved", self, "_on_CreatureVisuals_head_moved")
 
 
-"""
-Reposition the icon next to the creature's head.
-
-If we don't reposition the icon, it gets lost behind creatures that are fat.
-"""
+## Reposition the icon next to the creature's head.
+##
+## If we don't reposition the icon, it gets lost behind creatures that are fat.
 func _refresh_target_position() -> void:
 	if not creature_visuals:
 		return

--- a/project/src/main/world/creature/creature-collision-shape.gd
+++ b/project/src/main/world/creature/creature-collision-shape.gd
@@ -1,13 +1,9 @@
 extends CollisionShape2D
-"""
-Collision shape for creatures on the overworld.
-"""
+## Collision shape for creatures on the overworld.
 
 var creature_visuals: CreatureVisuals
 
-"""
-Increases the collision shape size for fatter creatures.
-"""
+## Increases the collision shape size for fatter creatures.
 func refresh_extents() -> void:
 	if not creature_visuals:
 		return

--- a/project/src/main/world/creature/creature-curve.gd
+++ b/project/src/main/world/creature/creature-curve.gd
@@ -1,39 +1,35 @@
 #tool #uncomment to view creature in editor
 class_name CreatureCurve
 extends SmoothPath
-"""
-Draws a big blobby shape defining a part of the creature's shadow.
+## Draws a big blobby shape defining a part of the creature's shadow.
+##
+## Godot has no out-of-the-box method for tweening curves, so this class exposes a 'fatness' property which can be from
+## 0.0 to 10.0 to tween between a few different torso curves. It also provides some utility methods for developers to
+## maintain these curve definitions, as they can't be edited with the usual animation editor.
 
-Godot has no out-of-the-box method for tweening curves, so this class exposes a 'fatness' property which can be from
-0.0 to 10.0 to tween between a few different torso curves. It also provides some utility methods for developers to
-maintain these curve definitions, as they can't be edited with the usual animation editor.
-"""
-
-# Emitted when the curve becomes drawn, becomes non-drawn, or changes its shape
+## Emitted when the curve becomes drawn, becomes non-drawn, or changes its shape
 signal appearance_changed
 
-"""
-Setting this to 'true' will prevent the body's current curve from being overwritten by the fatness property.
-"""
+## Setting this to 'true' will prevent the body's current curve from being overwritten by the fatness property.
 export (bool) var editing := true
 
-# toggle to save the currently edited curve in this node's 'curve_defs'
+## toggle to save the currently edited curve in this node's 'curve_defs'
 export (bool) var _save_curve: bool setget save_curve
 
-# defines the shadow curve coordinates for each of the creature's levels of fatness.
+## defines the shadow curve coordinates for each of the creature's levels of fatness.
 export (Array) var curve_defs: Array setget set_curve_defs
 
-# if false, the body will not render this curve when the creature faces away from the camera.
+## if false, the body will not render this curve when the creature faces away from the camera.
 export (bool) var drawn_when_facing_north: bool = true
 
-# if false, the body will not render this curve when the creature faces toward the camera.
+## if false, the body will not render this curve when the creature faces toward the camera.
 export (bool) var drawn_when_facing_south: bool = true
 
 export (NodePath) var creature_visuals_path: NodePath setget set_creature_visuals_path
 
-# If true, the curve is drawn on the creature's body.
-# This is independent of the 'visible' property. When the game is running, these curves will be invisible but still
-# must be drawn. When developers are editing the curve data, these curves must be visible for Godot's Path2D tools.
+## If true, the curve is drawn on the creature's body.
+## This is independent of the 'visible' property. When the game is running, these curves will be invisible but still
+## must be drawn. When developers are editing the curve data, these curves must be visible for Godot's Path2D tools.
 var drawn := true setget set_drawn
 
 var creature_visuals: CreatureVisuals
@@ -48,9 +44,7 @@ func set_creature_visuals_path(new_creature_visuals_path: NodePath) -> void:
 	_refresh_creature_visuals_path()
 
 
-"""
-Saves the currently edited curve in this node's 'curve_defs'.
-"""
+## Saves the currently edited curve in this node's 'curve_defs'.
 func save_curve(value: bool) -> void:
 	if not value:
 		return
@@ -80,9 +74,7 @@ func save_curve(value: bool) -> void:
 		curve_defs.insert(fatness_index, new_entry)
 
 
-"""
-Updates the 'drawn' property based on the creature's orientation.
-"""
+## Updates the 'drawn' property based on the creature's orientation.
 func refresh_drawn() -> void:
 	var new_drawn := true
 	if creature_visuals:
@@ -105,22 +97,18 @@ func set_curve_defs(new_curve_defs: Array) -> void:
 	_refresh_curve()
 
 
-"""
-Disconnects creature visuals listeners specific to arm shadows.
-
-Can be overridden to disconnect additional listeners.
-"""
+## Disconnects creature visuals listeners specific to arm shadows.
+##
+## Can be overridden to disconnect additional listeners.
 func disconnect_creature_visuals_listeners() -> void:
 	creature_visuals.disconnect("visual_fatness_changed", self, "_on_CreatureVisuals_visual_fatness_changed")
 	creature_visuals.disconnect("orientation_changed", self, "_on_CreatureVisuals_orientation_changed")
 	creature_visuals.disconnect("dna_loaded", self, "_on_CreatureVisuals_dna_loaded")
 
 
-"""
-Connects creature visuals listeners specific to arm shadows.
-
-Can be overridden to connect additional listeners.
-"""
+## Connects creature visuals listeners specific to arm shadows.
+##
+## Can be overridden to connect additional listeners.
 func connect_creature_visuals_listeners() -> void:
 	creature_visuals.connect("visual_fatness_changed", self, "_on_CreatureVisuals_visual_fatness_changed")
 	creature_visuals.connect("orientation_changed", self, "_on_CreatureVisuals_orientation_changed")
@@ -173,12 +161,10 @@ func _refresh_curve() -> void:
 	emit_signal("appearance_changed")
 
 
-"""
-Recalculates the curve coordinates based on how fat the creature is.
-
-Parameters:
-	'fatness': How fat the creature's body is; 5.0 = 5x normal size
-"""
+## Recalculates the curve coordinates based on how fat the creature is.
+##
+## Parameters:
+## 	'fatness': How fat the creature's body is; 5.0 = 5x normal size
 func _on_CreatureVisuals_visual_fatness_changed() -> void:
 	_refresh_curve()
 

--- a/project/src/main/world/creature/creature-def.gd
+++ b/project/src/main/world/creature/creature-def.gd
@@ -1,11 +1,9 @@
 class_name CreatureDef
-"""
-Stores information about a creature such as their name, appearance, and chat lines.
-"""
+## Stores information about a creature such as their name, appearance, and chat lines.
 
 const CREATURE_DATA_VERSION := "19dd"
 
-# default chat theme when starting a new game
+## default chat theme when starting a new game
 const DEFAULT_CHAT_THEME_DEF := {
 	"accent_scale": 1.33,
 	"accent_swapped": true,
@@ -13,7 +11,7 @@ const DEFAULT_CHAT_THEME_DEF := {
 	"color": "b23823"
 }
 
-# default creature appearance when starting a new game
+## default creature appearance when starting a new game
 const DEFAULT_DNA := {
 	"accessory": "0",
 	"belly": "1",
@@ -40,34 +38,34 @@ const DEFAULT_DNA := {
 	"tail": "0",
 }
 
-# default name when starting a new game
+## default name when starting a new game
 const DEFAULT_NAME := "Spira"
 
-# creature's id, e.g 'boatricia'
+## creature's id, e.g 'boatricia'
 var creature_id: String
 
-# creature's name, e.g 'Boatricia'
+## creature's name, e.g 'Boatricia'
 var creature_name: String
 
-# a shortened version of the creature's name, for use in conversation
+## a shortened version of the creature's name, for use in conversation
 var creature_short_name: String
 
-# defines the creature's appearance such as eye color and mouth shape
+## defines the creature's appearance such as eye color and mouth shape
 var dna: Dictionary
 
-# defines the chat window's appearance, such as 'blue', 'soccer balls' and 'giant'.
+## defines the chat window's appearance, such as 'blue', 'soccer balls' and 'giant'.
 var chat_theme_def: Dictionary
 
-# dictionaries containing metadata for which chat sequences should be launched in which order
+## dictionaries containing metadata for which chat sequences should be launched in which order
 var chat_selectors: Array
 
-# how fat the creature's body is; 5.0 = 5x normal size
+## how fat the creature's body is; 5.0 = 5x normal size
 var min_fatness := 1.0
 
-# how fast the creature should gain weight during a puzzle. 4.0x = four times faster than normal.
+## how fast the creature should gain weight during a puzzle. 4.0x = four times faster than normal.
 var weight_gain_scale := 1.0
 
-# how fast the creature should lose weight between puzzles. 0.25x = four times slower than normal.
+## how fast the creature should lose weight between puzzles. 0.25x = four times slower than normal.
 var metabolism_scale := 1.0
 
 func from_json_dict(json: Dictionary) -> void:
@@ -121,15 +119,13 @@ func to_json_dict() -> Dictionary:
 	return result
 
 
-"""
-Loads creature data from a json path. Substitutes any missing data.
-
-Note: This method signature should specify a return type of 'CreatureDef', but that causes console errors due to Godot
-#30668 (https://github.com/godotengine/godot/issues/30668).
-
-Returns:
-	The newly loaded creature data, or 'null' if there was a problem loading the json data.
-"""
+## Loads creature data from a json path. Substitutes any missing data.
+##
+## Note: This method signature should specify a return type of 'CreatureDef', but that causes console errors due to
+## Godot #30668 (https://github.com/godotengine/godot/issues/30668).
+##
+## Returns:
+## 	The newly loaded creature data, or 'null' if there was a problem loading the json data.
 func from_json_path(path: String) -> Object:
 	var result := self
 	var creature_def_text: String = FileUtils.get_file_as_text(path)
@@ -152,12 +148,10 @@ func from_json_path(path: String) -> Object:
 	return result
 
 
-"""
-Changes the creature's name, and derives a new short name and creature id from their new name.
-
-A creature's name shouldn't change during regular gameplay. This is only for the creature editor and for other randomly
-generated creatures.
-"""
+## Changes the creature's name, and derives a new short name and creature id from their new name.
+##
+## A creature's name shouldn't change during regular gameplay. This is only for the creature editor and for other
+## randomly generated creatures.
 func rename(new_creature_name: String) -> void:
 	creature_name = new_creature_name
 	creature_short_name = NameUtils.sanitize_short_name(creature_name)

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -1,19 +1,17 @@
 #tool #uncomment to view creature in editor
 extends Node
 
-"""
-Loads creature resources based on creature definitions. For example, a creature definition might describe high-level
-information about the creature's appearance, such as 'she has red eyes' or 'she has a star on her forehead'. This
-class converts that information into granular information such as 'her Eye/Sprint/TxMap/RGB value is ff3030', and also
-loads resource files specific to each creature.
-"""
+## Loads creature resources based on creature definitions. For example, a creature definition might describe high-level
+## information about the creature's appearance, such as 'she has red eyes' or 'she has a star on her forehead'. This
+## class converts that information into granular information such as 'her Eye/Sprint/TxMap/RGB value is ff3030', and
+## also loads resource files specific to each creature.
 
-# The color inside a creature's mouth
+## The color inside a creature's mouth
 const PINK_INSIDE_COLOR := Color("f39274")
 
 const SHADOW_ALPHA := 0.25
 
-# AnimationPlayer scenes with animations for each type of mouth
+## AnimationPlayer scenes with animations for each type of mouth
 var _mouth_player_scenes := {
 	"1": preload("res://src/main/world/creature/Mouth1Player.tscn"),
 	"2": preload("res://src/main/world/creature/Mouth2Player.tscn"),
@@ -24,7 +22,7 @@ var _mouth_player_scenes := {
 	"7": preload("res://src/main/world/creature/Mouth7Player.tscn"),
 }
 
-# AnimationPlayer scenes with animations for each type of ear
+## AnimationPlayer scenes with animations for each type of ear
 var _ear_player_scenes := {
 	"1": preload("res://src/main/world/creature/Ear1Player.tscn"),
 	"2": preload("res://src/main/world/creature/Ear2Player.tscn"),
@@ -43,13 +41,13 @@ var _ear_player_scenes := {
 	"15": preload("res://src/main/world/creature/Ear15Player.tscn"),
 }
 
-# Scenes which draw different bodies
+## Scenes which draw different bodies
 var _body_shape_scenes := {
 	"1": preload("res://src/main/world/creature/Body1Shape.tscn"),
 	"2": preload("res://src/main/world/creature/Body2Shape.tscn"),
 }
 
-# Scenes which draw belly colors for different bodies
+## Scenes which draw belly colors for different bodies
 var _belly_scenes := {
 	"1 1": preload("res://src/main/world/creature/Body1Belly1.tscn"),
 	"1 2": preload("res://src/main/world/creature/Body1Belly2.tscn"),
@@ -57,19 +55,19 @@ var _belly_scenes := {
 	"2 2": preload("res://src/main/world/creature/Body2Belly2.tscn"),
 }
 
-# Scenes which draw shadows for different bodies
+## Scenes which draw shadows for different bodies
 var _shadows_scenes := {
 	"1": preload("res://src/main/world/creature/Body1Shadows.tscn"),
 	"2": preload("res://src/main/world/creature/Body2Shadows.tscn"),
 }
 
-# Scenes which draw 'neck blends' which blend the neck with the back of the head
+## Scenes which draw 'neck blends' which blend the neck with the back of the head
 var _neck_blend_scenes_new := {
 	"1": preload("res://src/main/world/creature/Body1NeckBlend.tscn"),
 	"2": preload("res://src/main/world/creature/Body2NeckBlend.tscn"),
 }
 
-# AnimationPlayers which rearrange body parts for different bodies
+## AnimationPlayers which rearrange body parts for different bodies
 var _fat_sprite_mover_scenes := {
 	"1": preload("res://src/main/world/creature/FatSpriteMover1.tscn"),
 	"2": preload("res://src/main/world/creature/FatSpriteMover2.tscn"),
@@ -83,9 +81,7 @@ func _ready() -> void:
 	_name_generator.load_american_animals()
 
 
-"""
-Returns a random creature definition.
-"""
+## Returns a random creature definition.
 func random_def() -> CreatureDef:
 	var result: CreatureDef
 	if PlayerData.creature_queue.has_secondary_creature() and randf() < 0.2:
@@ -101,18 +97,14 @@ func random_def() -> CreatureDef:
 	return result
 
 
-"""
-Returns a chat theme definition for a generated creature.
-"""
+## Returns a chat theme definition for a generated creature.
 func chat_theme_def(dna: Dictionary) -> Dictionary:
 	var new_def: Dictionary = PlayerData.creature_library.player_def.chat_theme_def.duplicate()
 	new_def.color = dna.body_rgb
 	return new_def
 
 
-"""
-Returns an AnimationPlayer for the specified type type of mouth.
-"""
+## Returns an AnimationPlayer for the specified type type of mouth.
 func new_mouth_player(mouth_key: String) -> AnimationPlayer:
 	var result: AnimationPlayer
 	if _mouth_player_scenes.has(mouth_key):
@@ -120,9 +112,7 @@ func new_mouth_player(mouth_key: String) -> AnimationPlayer:
 	return result
 
 
-"""
-Returns an AnimationPlayer for the specified type of ear.
-"""
+## Returns an AnimationPlayer for the specified type of ear.
 func new_ear_player(ear_key: String) -> AnimationPlayer:
 	var result: AnimationPlayer
 	if _ear_player_scenes.has(ear_key):
@@ -130,9 +120,7 @@ func new_ear_player(ear_key: String) -> AnimationPlayer:
 	return result
 
 
-"""
-Returns a CreatureCurve for drawing a type of body.
-"""
+## Returns a CreatureCurve for drawing a type of body.
 func new_body_shape(body_key: String) -> CreatureCurve:
 	var result: CreatureCurve
 	if _body_shape_scenes.has(body_key):
@@ -140,9 +128,7 @@ func new_body_shape(body_key: String) -> CreatureCurve:
 	return result
 
 
-"""
-Returns a CreatureCurve for drawing belly colors for a type of body.
-"""
+## Returns a CreatureCurve for drawing belly colors for a type of body.
 func new_belly(body_key: String, body_colors_key: String) -> CreatureCurve:
 	var result: CreatureCurve
 	var key := "%s %s" % [body_key, body_colors_key]
@@ -151,9 +137,7 @@ func new_belly(body_key: String, body_colors_key: String) -> CreatureCurve:
 	return result
 
 
-"""
-Returns a Node2D containing CreatureCurves for drawing shadows for a type of body.
-"""
+## Returns a Node2D containing CreatureCurves for drawing shadows for a type of body.
 func new_shadows(body_key: String) -> Node2D:
 	var result: Node2D
 	if _shadows_scenes.has(body_key):
@@ -161,9 +145,7 @@ func new_shadows(body_key: String) -> Node2D:
 	return result
 
 
-"""
-Returns a CreatureCurve which blends the neck with the back of the head.
-"""
+## Returns a CreatureCurve which blends the neck with the back of the head.
 func new_neck_blend(body_key: String) -> CreatureCurve:
 	var result: CreatureCurve
 	if _neck_blend_scenes_new.has(body_key):
@@ -171,9 +153,7 @@ func new_neck_blend(body_key: String) -> CreatureCurve:
 	return result
 
 
-"""
-Returns an AnimationPlayer which rearranges body parts for a type of bodyq.
-"""
+## Returns an AnimationPlayer which rearranges body parts for a type of bodyq.
 func new_fat_sprite_mover(body_key: String) -> AnimationPlayer:
 	var result: AnimationPlayer
 	if _fat_sprite_mover_scenes.has(body_key):
@@ -181,39 +161,34 @@ func new_fat_sprite_mover(body_key: String) -> AnimationPlayer:
 	return result
 
 
-"""
-Loads all the appropriate resources and property definitions for a creature. The resulting textures are stored back in
-the 'dna' parameter which is passed in.
-
-This can also be invoked with an empty creature definition, in which case the creature definition will be populated
-with the property definitions needed to unload all of their textures and colors.
-
-Parameters:
-	'dna': Defines high-level information about the creature's appearance, such as 'she has red eyes'. The response
-		includes granular information such as 'her Eye/Sprint/TxMap/RGB value is ff3030'.
-"""
+## Loads all the appropriate resources and property definitions for a creature. The resulting textures are stored back
+## in the 'dna' parameter which is passed in.
+##
+## This can also be invoked with an empty creature definition, in which case the creature definition will be populated
+## with the property definitions needed to unload all of their textures and colors.
+##
+## Parameters:
+## 	'dna': Defines high-level information about the creature's appearance, such as 'she has red eyes'. The response
+## 		includes granular information such as 'her Eye/Sprint/TxMap/RGB value is ff3030'.
 func load_details(dna: Dictionary) -> void:
 	_load_head(dna)
 	_load_body(dna)
 	_load_colors(dna)
 
-
-"""
-Loads a creature texture based on a dna key/value pair.
-
-The input dna contains key/value pairs which we need to map to a texture to load, such as {'ear': '0'}. We map
-this key/value pair to a resource such as res://assets/main/world/creature/0/ear-z1.png. The input parameters include
-the dictionary of key/value pairs, which specific key/value pair we should look up, and the filename to associate with
-the key/value pair.
-
-Parameters:
-	'dna': The dictionary of key/value pairs defining a set of textures to load.
-	
-	'key': The specific key/value pair to be looked up. If the key is empty, the value will be hard-coded to '1'.
-	
-	'filename': The stripped-down filename of the resource to look up. All creature texture files have a path of
-		res://assets/main/world/creature/0/{something}.png, so this parameter only specifies the {something}.
-"""
+## Loads a creature texture based on a dna key/value pair.
+##
+## The input dna contains key/value pairs which we need to map to a texture to load, such as {'ear': '0'}. We map
+## this key/value pair to a resource such as res://assets/main/world/creature/0/ear-z1.png. The input parameters
+## include the dictionary of key/value pairs, which specific key/value pair we should look up, and the filename to
+## associate with the key/value pair.
+##
+## Parameters:
+## 	'dna': The dictionary of key/value pairs defining a set of textures to load.
+##
+## 	'key': The specific key/value pair to be looked up. If the key is empty, the value will be hard-coded to '1'.
+##
+## 	'filename': The stripped-down filename of the resource to look up. All creature texture files have a path of
+## 		res://assets/main/world/creature/0/{something}.png, so this parameter only specifies the {something}.
 func _load_texture(dna: Dictionary, node_path: String, key: String, filename: String) -> void:
 	# load the texture resource
 	var resource_path: String
@@ -253,9 +228,7 @@ func _dna_value(dna: Dictionary, key: String) -> String:
 	return dna_value
 
 
-"""
-Loads the resources for a creature's head based on a creature definition.
-"""
+## Loads the resources for a creature's head based on a creature definition.
 func _load_head(dna: Dictionary) -> void:
 	_load_texture(dna, "Neck0/HeadBobber/Head", "head", "head-packed")
 	
@@ -289,9 +262,7 @@ func _load_head(dna: Dictionary) -> void:
 	_load_texture(dna, "Neck0/HeadBobber/AccessoryZ2", "accessory", "accessory-z2-packed")
 
 
-"""
-Loads the resources for a creature's arms, legs and torso based on a creature definition.
-"""
+## Loads the resources for a creature's arms, legs and torso based on a creature definition.
 func _load_body(dna: Dictionary) -> void:
 	# All creatures have a body, but this class supports passing in an empty creature definition to unload the
 	# textures from creature sprites. So we leave those textures as null if we're not explicitly told to draw the
@@ -309,9 +280,7 @@ func _load_body(dna: Dictionary) -> void:
 	_load_texture(dna, "TailZ1", "tail", "tail-z1-packed")
 
 
-"""
-Assigns the creature's colors based on a creature definition.
-"""
+## Assigns the creature's colors based on a creature definition.
 func _load_colors(dna: Dictionary) -> void:
 	var belly_color: Color
 	if dna.has("belly_rgb"):
@@ -415,9 +384,7 @@ func _load_colors(dna: Dictionary) -> void:
 	_set_krgb(dna, "Neck0/HeadBobber/HornZ1", line_color, body_color, horn_color)
 
 
-"""
-Assigns shader colors for the specified creature node.
-"""
+## Assigns shader colors for the specified creature node.
 func _set_krgb(dna: Dictionary, path: String, black: Color,
 		red: Color = Color.black, green: Color = Color.black, blue: Color = Color.black):
 	dna["shader:%s:black" % path] = black

--- a/project/src/main/world/creature/creature-outline.gd
+++ b/project/src/main/world/creature/creature-outline.gd
@@ -1,12 +1,10 @@
 class_name CreatureOutline
 extends Node2D
-"""
-Augments creature visuals with an elevation and an outline.
-"""
+## Augments creature visuals with an elevation and an outline.
 
 signal elevation_changed(elevation)
 
-# How high the creature should be elevated off the ground, in pixels.
+## How high the creature should be elevated off the ground, in pixels.
 var elevation: float
 
 var creature_visuals: CreatureVisuals

--- a/project/src/main/world/creature/creature-packed-sprite.gd
+++ b/project/src/main/world/creature/creature-packed-sprite.gd
@@ -1,9 +1,7 @@
 #tool #uncomment to view creature in editor
 class_name CreaturePackedSprite
 extends PackedSprite
-"""
-Sprites which toggles between a single 'toward the camera' and 'away from the camera' frame
-"""
+## Sprites which toggles between a single 'toward the camera' and 'away from the camera' frame
 
 export (bool) var invisible_while_sprinting := false
 

--- a/project/src/main/world/creature/creature-sfx.gd
+++ b/project/src/main/world/creature/creature-sfx.gd
@@ -1,10 +1,8 @@
 class_name CreatureSfx
 extends Node2D
-"""
-Plays creature-related sound effects.
-"""
+## Plays creature-related sound effects.
 
-# sounds the creatures make when they enter the restaurant
+## sounds the creatures make when they enter the restaurant
 onready var hello_voices := [
 	preload("res://assets/main/world/creature/hello-voice-0.wav"),
 	preload("res://assets/main/world/creature/hello-voice-1.wav"),
@@ -12,7 +10,7 @@ onready var hello_voices := [
 	preload("res://assets/main/world/creature/hello-voice-3.wav"),
 ]
 
-# sounds which get played when the creature eats
+## sounds which get played when the creature eats
 onready var _munch_sounds := [
 	preload("res://assets/main/world/creature/munch0.wav"),
 	preload("res://assets/main/world/creature/munch1.wav"),
@@ -21,7 +19,7 @@ onready var _munch_sounds := [
 	preload("res://assets/main/world/creature/munch4.wav"),
 ]
 
-# satisfied sounds the creatures make when a player builds a big combo
+## satisfied sounds the creatures make when a player builds a big combo
 onready var _combo_voices := [
 	preload("res://assets/main/world/creature/combo-voice-00.wav"),
 	preload("res://assets/main/world/creature/combo-voice-01.wav"),
@@ -45,7 +43,7 @@ onready var _combo_voices := [
 	preload("res://assets/main/world/creature/combo-voice-19.wav"),
 ]
 
-# sounds the creatures make when they ask for their check
+## sounds the creatures make when they ask for their check
 onready var _goodbye_voices := [
 	preload("res://assets/main/world/creature/goodbye-voice-0.wav"),
 	preload("res://assets/main/world/creature/goodbye-voice-1.wav"),
@@ -53,16 +51,16 @@ onready var _goodbye_voices := [
 	preload("res://assets/main/world/creature/goodbye-voice-3.wav"),
 ]
 
-# index of the most recent combo sound that was played
+## index of the most recent combo sound that was played
 var _combo_voice_index := 0
 
-# 'true' if the creature should not make any sounds when walking/loading. Used for the creature editor.
+## 'true' if the creature should not make any sounds when walking/loading. Used for the creature editor.
 var suppress_sfx := false
 
 var creature_visuals: CreatureVisuals setget set_creature_visuals
 
-# AudioStreamPlayer which plays all of the creature's voices. We reuse the same player so that they can't say two
-# things at once.
+## AudioStreamPlayer which plays all of the creature's voices. We reuse the same player so that they can't say two
+## things at once.
 onready var _voice_player := $VoicePlayer
 
 onready var _munch_sound := $MunchSound
@@ -85,9 +83,7 @@ func set_creature_visuals(new_creature_visuals: CreatureVisuals) -> void:
 	_connect_creature_visuals_listeners()
 
 
-"""
-Plays a 'mmm!' voice sample, for when a player builds a big combo.
-"""
+## Plays a 'mmm!' voice sample, for when a player builds a big combo.
 func play_combo_voice() -> void:
 	if suppress_sfx:
 		return
@@ -97,9 +93,7 @@ func play_combo_voice() -> void:
 	_voice_player.play()
 
 
-"""
-Plays a 'hello!' voice sample, for when a creature enters the restaurant
-"""
+## Plays a 'hello!' voice sample, for when a creature enters the restaurant
 func play_hello_voice(force: bool = false) -> void:
 	if suppress_sfx:
 		return
@@ -109,9 +103,7 @@ func play_hello_voice(force: bool = false) -> void:
 		_voice_player.play()
 
 
-"""
-Plays a 'check please!' voice sample, for when a creature is ready to leave
-"""
+## Plays a 'check please!' voice sample, for when a creature is ready to leave
 func play_goodbye_voice(force: bool = false) -> void:
 	if suppress_sfx:
 		return
@@ -148,12 +140,10 @@ func _connect_creature_visuals_listeners() -> void:
 	creature_visuals.connect("landed", self, "_on_CreatureVisuals_landed")
 
 
-"""
-Use a different AudioStreamPlayer for munch sounds, to avoid interrupting speech.
-
-Of course in real life you can't talk with your mouth full -- but combo sounds are positive feedback, so it's nice to
-avoid interrupting them.
-"""
+## Use a different AudioStreamPlayer for munch sounds, to avoid interrupting speech.
+##
+## Of course in real life you can't talk with your mouth full -- but combo sounds are positive feedback, so it's nice
+## to avoid interrupting them.
 func _on_CreatureVisuals_food_eaten(_food_type: int) -> void:
 	if suppress_sfx:
 		return

--- a/project/src/main/world/creature/creature-shadow.gd
+++ b/project/src/main/world/creature/creature-shadow.gd
@@ -1,22 +1,20 @@
 class_name CreatureShadow
 extends Node2D
-"""
-Script which updates the size and position of a shadow beneath a creature.
-"""
+## Script which updates the size and position of a shadow beneath a creature.
 
-# The direction of this shadow relative to the creature. Used for creatures sitting on restaurant stools.
+## The direction of this shadow relative to the creature. Used for creatures sitting on restaurant stools.
 export (Vector2) var shadow_offset: Vector2
 
 export (NodePath) var creature_path: NodePath setget set_creature_path
 export (Vector2) var shadow_scale := Vector2(1.0, 1.0)
 
-# The Creature this shadow is for
+## The Creature this shadow is for
 var _creature: Creature
 
-# Oval shadow sprite
+## Oval shadow sprite
 onready var _sprite: Sprite = $Sprite
 
-# Scales the shadow based on the creature's fatness
+## Scales the shadow based on the creature's fatness
 onready var _fat_player: AnimationPlayer = $FatPlayer
 
 func _ready() -> void:
@@ -35,9 +33,7 @@ func set_creature_path(new_creature_path: NodePath) -> void:
 	_refresh_creature_path()
 
 
-"""
-Connects the shadow to a new creature and updates its position.
-"""
+## Connects the shadow to a new creature and updates its position.
 func _refresh_creature_path() -> void:
 	if not (is_inside_tree() and creature_path):
 		return
@@ -55,9 +51,7 @@ func _refresh_creature_path() -> void:
 		_refresh_creature_shadow_scale()
 
 
-"""
-Recalculates the CreatureShadow scale property based on the creature's fatness.
-"""
+## Recalculates the CreatureShadow scale property based on the creature's fatness.
 func _refresh_creature_shadow_scale() -> void:
 	_fat_player.play("fat")
 	_fat_player.advance(_creature.get_visual_fatness())

--- a/project/src/main/world/creature/creature-visuals.gd
+++ b/project/src/main/world/creature/creature-visuals.gd
@@ -1,30 +1,28 @@
 #tool #uncomment to view creature in editor
 class_name CreatureVisuals
 extends Node2D
-"""
-Handles animations and audio/visual effects for a creature.
+## Handles animations and audio/visual effects for a creature.
+##
+## To edit creatures in the Godot editor:
+## 	1. Run the 'edit-creature.sh on' shell command to enable the necessary tool scripts
+## 	2. Toggle the CreatureVisuals.random_creature property in the Godot editor
+## 	3. Make your changes
+## 	4. When you're finished, toggle the CreatureVisuals.reset_creature property in the Godot editor
+## 	5. Lastly, run the 'edit-creature.sh off' shell command to disable the necessary tool scripts
+##
+## Do not leave the tool scripts enabled. Doing so causes errors in the Godot console and impacts performance as
+## unnecessary textures are loaded.
 
-To edit creatures in the Godot editor:
-	1. Run the 'edit-creature.sh on' shell command to enable the necessary tool scripts
-	2. Toggle the CreatureVisuals.random_creature property in the Godot editor
-	3. Make your changes
-	4. When you're finished, toggle the CreatureVisuals.reset_creature property in the Godot editor
-	5. Lastly, run the 'edit-creature.sh off' shell command to disable the necessary tool scripts
-
-Do not leave the tool scripts enabled. Doing so causes errors in the Godot console and impacts performance as
-unnecessary textures are loaded.
-"""
-
-# emitted on the frame when creature bites into some food
+## emitted on the frame when creature bites into some food
 signal food_eaten(food_type)
 
-# emitted when a creature's textures and animations are loaded
+## emitted when a creature's textures and animations are loaded
 signal dna_loaded
 
-# emitted when a creature is assigned new set of dna
+## emitted when a creature is assigned new set of dna
 signal dna_changed(dna)
 
-# emitted during the 'run' animation when the creature touches the ground
+## emitted during the 'run' animation when the creature touches the ground
 # warning-ignore:unused_signal
 signal landed
 
@@ -35,53 +33,53 @@ signal visual_fatness_changed
 signal comfort_changed
 signal talking_changed
 
-# emitted by FatSpriteMover when it moves the head by making the creature fatter
+## emitted by FatSpriteMover when it moves the head by making the creature fatter
 # warning-ignore:unused_signal
 signal head_moved
 
 const SOUTHEAST_DIR := Vector2(0.70710678118, 0.70710678118)
 
-# toggle to assign default animation frames based on the creature's orientation
+## toggle to assign default animation frames based on the creature's orientation
 export (bool) var _reset_frames setget reset_frames
 
-# toggle to remove the creature's textures
+## toggle to remove the creature's textures
 export (bool) var _reset_creature setget reset_creature
 
-# toggle to generate a creature with a random appearance
+## toggle to generate a creature with a random appearance
 export (bool) var _random_creature setget random_creature
 
-# the state of whether the creature is walking, running or idle
+## the state of whether the creature is walking, running or idle
 export (Creatures.MovementMode) var movement_mode := Creatures.IDLE setget set_movement_mode
 
-# the direction the creature is facing
+## the direction the creature is facing
 export (Creatures.Orientation) var orientation := Creatures.SOUTHEAST setget set_orientation
 
-# describes the colors and textures used to draw the creature
+## describes the colors and textures used to draw the creature
 export (Dictionary) var dna: Dictionary setget set_dna
 
-# how fat the creature looks right now; gradually approaches the 'fatness' property
+## how fat the creature looks right now; gradually approaches the 'fatness' property
 export (float) var visual_fatness := 1.0 setget set_visual_fatness
 
-# how fat the creature will become eventually; visual_fatness gradually approaches this value
+## how fat the creature will become eventually; visual_fatness gradually approaches this value
 var fatness := 1.0 setget set_fatness, get_fatness
 
-# comfort improves as the creature eats, and degrades as they overeat. comfort is a number from [-1.0, 1.0]. -1.0 is
-# very uncomfortable, 1.0 is very comfortable
+## comfort improves as the creature eats, and degrades as they overeat. comfort is a number from [-1.0, 1.0]. -1.0 is
+## very uncomfortable, 1.0 is very comfortable
 var comfort := 0.0 setget set_comfort
 
-# MouthPlayer instance which animates mouths
+## MouthPlayer instance which animates mouths
 var mouth_player
 
-# used to temporarily suppress sfx signals. used when skipping to the middle of animations which play sfx
+## used to temporarily suppress sfx signals. used when skipping to the middle of animations which play sfx
 var _suppress_sfx_signal_timer := 0.0
 
-# forces listeners to update their animation frame
+## forces listeners to update their animation frame
 var _force_orientation_change := false
 
-# the food type the creature is eating
+## the food type the creature is eating
 var _food_type: int
 
-# CreatureAnimations instance which animates the creature's limbs, facial expressions and movement.
+## CreatureAnimations instance which animates the creature's limbs, facial expressions and movement.
 onready var _animations: Node = $Animations
 
 func _ready() -> void:
@@ -120,36 +118,30 @@ func set_visual_fatness(new_visual_fatness: float) -> void:
 	emit_signal("visual_fatness_changed")
 
 
-"""
-Returns the creature's fatness, a float which determines how fat the creature
-should be; 5.0 = 5x normal size
-
-Parameters:
-	'creature_index': (Optional) The creature to ask about. Defaults to the current creature.
-"""
+## Returns the creature's fatness, a float which determines how fat the creature
+## should be; 5.0 = 5x normal size
+##
+## Parameters:
+## 	'creature_index': (Optional) The creature to ask about. Defaults to the current creature.
 func get_fatness() -> float:
 	return fatness
 
 
-"""
-Increases/decreases the creature's fatness, a float which determines how fat
-the creature should be; 5.0 = 5x normal size
-
-Parameters:
-	'fatness_percent': Controls how fat the creature should be; 5.0 = 5x normal size
-	
-	'creature_index': (Optional) The creature to be altered. Defaults to the current creature.
-"""
+## Increases/decreases the creature's fatness, a float which determines how fat
+## the creature should be; 5.0 = 5x normal size
+##
+## Parameters:
+## 	'fatness_percent': Controls how fat the creature should be; 5.0 = 5x normal size
+##
+## 	'creature_index': (Optional) The creature to be altered. Defaults to the current creature.
 func set_fatness(new_fatness: float) -> void:
 	fatness = new_fatness
 	emit_signal("fatness_changed")
 
 
-"""
-Updates the frame to something appropriate for the creature's orientation.
-
-Usually the frame is controlled by an animation. But when it's not, this ensures it still looks reasonable.
-"""
+## Updates the frame to something appropriate for the creature's orientation.
+##
+## Usually the frame is controlled by an animation. But when it's not, this ensures it still looks reasonable.
 func reset_frames(value: bool = true) -> void:
 	if not value:
 		return
@@ -162,29 +154,23 @@ func reset_frames(value: bool = true) -> void:
 	emit_signal("orientation_changed", -1, orientation)
 
 
-"""
-Resets the eyes to a forward/backward facing frame.
-
-Because the eye frames also become visible/invisible during emotes, they don't react to normal orientation/movement
-changes and are instead reset manually.
-"""
+## Resets the eyes to a forward/backward facing frame.
+##
+## Because the eye frames also become visible/invisible during emotes, they don't react to normal orientation/movement
+## changes and are instead reset manually.
 func reset_eye_frames() -> void:
 	$Neck0/HeadBobber/EyeZ0.frame = 1 if oriented_south() else 2
 	$Neck0/HeadBobber/EyeZ1.frame = 1 if oriented_south() else 2
 
 
-"""
-Remove the creature's textures.
-"""
+## Remove the creature's textures.
 func reset_creature(value: bool = true) -> void:
 	if not value:
 		return
 	set_dna({})
 
 
-"""
-Generates a creature with a random appearance.
-"""
+## Generates a creature with a random appearance.
 func random_creature(value: bool = true) -> void:
 	if not value:
 		return
@@ -192,12 +178,10 @@ func random_creature(value: bool = true) -> void:
 	set_dna(new_dna)
 
 
-"""
-Sets the creature's orientation, and alters their appearance appropriately.
-
-If the creature swaps between facing left or right, certain sprites are flipped horizontally. If the creature swaps
-between facing forward or backward, certain sprites play different animations or toggle between different frames.
-"""
+## Sets the creature's orientation, and alters their appearance appropriately.
+##
+## If the creature swaps between facing left or right, certain sprites are flipped horizontally. If the creature swaps
+## between facing forward or backward, certain sprites play different animations or toggle between different frames.
 func set_orientation(new_orientation: int) -> void:
 	var old_orientation := orientation
 	orientation = new_orientation
@@ -226,15 +210,13 @@ func set_orientation(new_orientation: int) -> void:
 	emit_signal("orientation_changed", old_orientation, new_orientation)
 
 
-"""
-Adjusts the creature's scale, flipping them horizontally based on their orientation.
-
-The sprite resources portray creatures facing southeast/northwest, and need to be horizontally flipped for other
-orientations.
-
-Parameters:
-	'new_scale_x': The new scale.x and scale.y value. Negative values are OK, and will be normalized.
-"""
+## Adjusts the creature's scale, flipping them horizontally based on their orientation.
+##
+## The sprite resources portray creatures facing southeast/northwest, and need to be horizontally flipped for other
+## orientations.
+##
+## Parameters:
+## 	'new_scale_x': The new scale.x and scale.y value. Negative values are OK, and will be normalized.
 func rescale(new_scale_x: float) -> void:
 	scale = Vector2(abs(new_scale_x), abs(new_scale_x))
 	scale.x = abs(scale.x) if orientation in [Creatures.SOUTHEAST, Creatures.NORTHWEST] \
@@ -245,12 +227,10 @@ func rescale(new_scale_x: float) -> void:
 	$Body.scale.x = 1 if oriented_south() else -1
 
 
-"""
-Launches the 'feed' animation. The creature makes a biting motion and plays a munch sound.
-
-Parameters:
-	'food_type': An enum from FoodType corresponding to the food to show
-"""
+## Launches the 'feed' animation. The creature makes a biting motion and plays a munch sound.
+##
+## Parameters:
+## 	'food_type': An enum from FoodType corresponding to the food to show
 func feed(food_type: int) -> void:
 	if not visible:
 		# If no creature is visible, it could mean their resources haven't loaded yet. Don't play any animations or
@@ -266,10 +246,8 @@ func feed(food_type: int) -> void:
 		mouth_player.eat()
 
 
-"""
-Recolors the creature according to the specified creature definition. This involves updating shaders and sprite
-properties.
-"""
+## Recolors the creature according to the specified creature definition. This involves updating shaders and sprite
+## properties.
 func set_dna(new_dna: Dictionary) -> void:
 	dna = new_dna
 	if not is_inside_tree():
@@ -282,10 +260,8 @@ func set_dna(new_dna: Dictionary) -> void:
 	emit_signal("dna_changed", dna)
 
 
-"""
-The 'feed' animation causes a few side-effects. The creature's head recoils and some sounds play. This method controls
-all of those secondary visual effects of the creature being fed.
-"""
+## The 'feed' animation causes a few side-effects. The creature's head recoils and some sounds play. This method
+## controls all of those secondary visual effects of the creature being fed.
 func show_food_effects() -> void:
 	_animations.show_food_effects()
 	emit_signal("food_eaten", _food_type)
@@ -299,15 +275,13 @@ func oriented_north() -> bool:
 	return Creatures.oriented_north(orientation)
 
 
-"""
-Plays a movement animation with the specified prefix and direction, such as a 'run' animation going left.
-
-Parameters:
-	'animation_prefix': A partial name of an animation on $Creature/Animations/MovementPlayer, omitting the directional
-			suffix
-	
-	'movement_direction': A vector in the (X, Y) direction the creature is moving.
-"""
+## Plays a movement animation with the specified prefix and direction, such as a 'run' animation going left.
+##
+## Parameters:
+## 	'animation_prefix': A partial name of an animation on $Creature/Animations/MovementPlayer, omitting the directional
+## 			suffix
+##
+## 	'movement_direction': A vector in the (X, Y) direction the creature is moving.
 func play_movement_animation(animation_prefix: String, movement_direction: Vector2 = Vector2.ZERO) -> void:
 	if movement_direction.length() > 0.1:
 		# tiny movement vectors are often the result of a collision. we ignore these to avoid constantly flipping
@@ -339,12 +313,10 @@ func set_movement_mode(new_mode: int) -> void:
 		emit_signal("movement_mode_changed", old_mode, new_mode)
 
 
-"""
-Animates the creature's appearance according to the specified mood: happy, angry, etc...
-
-Parameters:
-	'mood': The creature's new mood from ChatEvent.Mood
-"""
+## Animates the creature's appearance according to the specified mood: happy, angry, etc...
+##
+## Parameters:
+## 	'mood': The creature's new mood from ChatEvent.Mood
 func play_mood(mood: int) -> void:
 	_animations.play_mood(mood)
 
@@ -353,11 +325,9 @@ func restart_idle_timer() -> void:
 	_animations.restart_idle_timer()
 
 
-"""
-Emits a signal to play a sound effect.
-
-We temporarily suppress sound effect signals when skipping forward in an animation which plays sound effects.
-"""
+## Emits a signal to play a sound effect.
+##
+## We temporarily suppress sound effect signals when skipping forward in an animation which plays sound effects.
 func emit_sfx_signal(signal_name: String) -> void:
 	if _suppress_sfx_signal_timer > 0.0:
 		pass
@@ -365,43 +335,33 @@ func emit_sfx_signal(signal_name: String) -> void:
 		emit_signal(signal_name)
 
 
-"""
-Launches a talking animation, opening and closes the creature's mouth for a few seconds.
-"""
+## Launches a talking animation, opening and closes the creature's mouth for a few seconds.
 func talk() -> void:
 	$TalkTimer.start()
 	emit_signal("talking_changed")
 
 
-"""
-Returns 'true' of the creature's talk animation is playing.
-"""
+## Returns 'true' of the creature's talk animation is playing.
 func is_talking() -> bool:
 	return not $TalkTimer.is_stopped()
 
 
-"""
-Temporarily suppresses sfx signals.
-
-Used when skipping to the middle of animations which play sfx.
-"""
+## Temporarily suppresses sfx signals.
+##
+## Used when skipping to the middle of animations which play sfx.
 func briefly_suppress_sfx_signal() -> void:
 	_suppress_sfx_signal_timer = 0.000000001
 
 
-"""
-Returns the number of seconds between the beginning of the eating animation and the 'chomp' noise.
-"""
+## Returns the number of seconds between the beginning of the eating animation and the 'chomp' noise.
 func get_eating_delay() -> float:
 	return 0.033
 
 
-"""
-Computes the nearest orientation for the specified direction.
-
-For example, a direction of (0.99, -0.13) is mostly pointing towards the x-axis, so it would result in an orientation
-of 'southeast'.
-"""
+## Computes the nearest orientation for the specified direction.
+##
+## For example, a direction of (0.99, -0.13) is mostly pointing towards the x-axis, so it would result in an
+## orientation of 'southeast'.
 func _compute_orientation(direction: Vector2) -> int:
 	if direction.length() == 0:
 		# we default to the current orientation if given a zero-length vector

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -1,9 +1,7 @@
 #tool #uncomment to view creature in editor
 class_name Creature
 extends KinematicBody2D
-"""
-Script for representing a creature in the 2D overworld.
-"""
+## Script for representing a creature in the 2D overworld.
 
 signal fatness_changed
 signal visual_fatness_changed
@@ -12,25 +10,25 @@ signal talking_changed
 
 signal dna_loaded
 
-# emitted on the frame when creature bites into some food
+## emitted on the frame when creature bites into some food
 signal food_eaten
 
-# emitted after a creature finishes fading in/out and their visible/modulate values are finalized
+## emitted after a creature finishes fading in/out and their visible/modulate values are finalized
 signal fade_in_finished
 signal fade_out_finished
 
 const IDLE = Creatures.IDLE
 
-# Number from [0.0, 1.0] which determines how quickly the creature slows down
+## Number from [0.0, 1.0] which determines how quickly the creature slows down
 const FRICTION := 0.15
 
-# How slow can the creature move before she stops
+## How slow can the creature move before she stops
 const MIN_RUN_SPEED := 150
 
-# How fast can the creature move
+## How fast can the creature move
 const MAX_RUN_SPEED := 338
 
-# How fast can the creature accelerate
+## How fast can the creature accelerate
 const MAX_RUN_ACCELERATION := 2250
 
 const CREATURE_FADE_IN_DURATION := 0.6
@@ -40,20 +38,20 @@ export (String) var creature_id: String setget set_creature_id
 export (Dictionary) var dna: Dictionary setget set_dna
 export (bool) var suppress_sfx: bool = false setget set_suppress_sfx
 
-# if 'true' the creature will only use the fatness in the creature definition,
-# ignoring any accrued fatness from puzzles
+## if 'true' the creature will only use the fatness in the creature definition,
+## ignoring any accrued fatness from puzzles
 export (bool) var suppress_fatness: bool = false
 
-# how high the creature's torso is from the floor, such as when they're sitting on a stool or standing up
+## how high the creature's torso is from the floor, such as when they're sitting on a stool or standing up
 export (float) var elevation: float setget set_elevation
 
-# virtual property; value is not kept up-to-date and should only be accessed through getters/setters
+## virtual property; value is not kept up-to-date and should only be accessed through getters/setters
 export (Creatures.Orientation) var orientation: int setget set_orientation, get_orientation
 
-# virtual property; value is only exposed through getters/setters
+## virtual property; value is only exposed through getters/setters
 var creature_def: CreatureDef setget set_creature_def, get_creature_def
 
-# dictionaries containing metadata for which chat sequences should be launched in which order
+## dictionaries containing metadata for which chat sequences should be launched in which order
 var chat_selectors: Array setget set_chat_selectors
 
 var creature_name: String setget set_creature_name
@@ -61,41 +59,41 @@ var creature_short_name: String
 var chat_theme_def: Dictionary setget set_chat_theme_def
 var chat_extents: Vector2 setget ,get_chat_extents
 
-# the direction the creature wants to move, in isometric and non-isometric coordinates
+## the direction the creature wants to move, in isometric and non-isometric coordinates
 var iso_walk_direction := Vector2.ZERO
 var non_iso_walk_direction := Vector2.ZERO setget set_non_iso_walk_direction
 
-# the number of times the creature was fed during this puzzle
+## the number of times the creature was fed during this puzzle
 var feed_count := 0
 var box_feed_count := 0
 
-# the minimum fatness; some creatures never get very thin
+## the minimum fatness; some creatures never get very thin
 var min_fatness := 1.0
 
-# how fast the creature should gain weight during a puzzle. 4.0x = four times faster than normal.
-# 0.0 = creature does not gain weight
+## how fast the creature should gain weight during a puzzle. 4.0x = four times faster than normal.
+## 0.0 = creature does not gain weight
 var weight_gain_scale := 1.0
 
-# how fast the creature should lose weight between puzzles. 0.25x = four times slower than normal.
+## how fast the creature should lose weight between puzzles. 0.25x = four times slower than normal.
 var metabolism_scale := 1.0
 
-# the base fatness when the creature enters the restaurant
-# player score is added to this to determine their new fatness
+## the base fatness when the creature enters the restaurant
+## player score is added to this to determine their new fatness
 var base_fatness := 1.0
 
 var creature_visuals: CreatureVisuals
 
-# 'true' if the creature is being slowed by friction while stopping or turning
+## 'true' if the creature is being slowed by friction while stopping or turning
 var _friction := false
 
-# the velocity the player is moving, in isometric and non-isometric coordinates
+## the velocity the player is moving, in isometric and non-isometric coordinates
 var _iso_velocity := Vector2.ZERO
 var _non_iso_velocity := Vector2.ZERO
 
-# a number from [0.0 - 1.0] based on how fast the creature can move with their current animation
+## a number from [0.0 - 1.0] based on how fast the creature can move with their current animation
 var _run_anim_speed := 1.0
 
-# handles animations and audio/visual effects for a creature
+## handles animations and audio/visual effects for a creature
 var _creature_outline: CreatureOutline
 
 onready var _creature_sfx: CreatureSfx = $CreatureSfx
@@ -146,13 +144,11 @@ func _physics_process(delta: float) -> void:
 	_maybe_play_bonk_sound(old_non_iso_velocity)
 
 
-"""
-Increases the collision shape size for fatter creatures.
-
-This is not done on all creatures, because having fatter creatures collide with chairs/tables differently as they gain
-weight introduces problems. It's easier to leave their collision shapes consistent and just have a few visual bugs here
-and there.
-"""
+## Increases the collision shape size for fatter creatures.
+##
+## This is not done on all creatures, because having fatter creatures collide with chairs/tables differently as they
+## gain weight introduces problems. It's easier to leave their collision shapes consistent and just have a few visual
+## bugs here and there.
 func refresh_collision_extents() -> void:
 	_collision_shape.refresh_extents()
 
@@ -235,31 +231,25 @@ func set_chat_theme_def(new_chat_theme_def: Dictionary) -> void:
 	set_meta("chat_theme_def", chat_theme_def)
 
 
-"""
-Plays a movement animation with the specified prefix and direction, such as a 'run' animation going left.
-
-Parameters:
-	'animation_prefix': A partial name of an animation on Creature/MovementPlayer, omitting the directional suffix
-	
-	'movement_direction': A vector in the (X, Y) direction the creature is moving.
-"""
+## Plays a movement animation with the specified prefix and direction, such as a 'run' animation going left.
+##
+## Parameters:
+## 	'animation_prefix': A partial name of an animation on Creature/MovementPlayer, omitting the directional suffix
+##
+## 	'movement_direction': A vector in the (X, Y) direction the creature is moving.
 func play_movement_animation(animation_prefix: String, movement_direction: Vector2 = Vector2.ZERO) -> void:
 	creature_visuals.play_movement_animation(animation_prefix, movement_direction)
 
 
-"""
-Animates the creature's appearance according to the specified mood: happy, angry, etc...
-
-Parameters:
-	'mood': The creature's new mood from ChatEvent.Mood
-"""
+## Animates the creature's appearance according to the specified mood: happy, angry, etc...
+##
+## Parameters:
+## 	'mood': The creature's new mood from ChatEvent.Mood
 func play_mood(mood: int) -> void:
 	creature_visuals.play_mood(mood)
 
 
-"""
-Orients this creature so they're facing the specified target.
-"""
+## Orients this creature so they're facing the specified target.
 func orient_toward(target_position: Vector2) -> void:
 	# calculate the relative direction of the object this creature should face
 	var direction: Vector2 = Global.from_iso(position.direction_to(target_position))
@@ -284,15 +274,13 @@ func get_orientation() -> int:
 	return creature_visuals.orientation if creature_visuals else orientation
 
 
-"""
-Stores this creature's fatness in the CreatureLibrary.
-
-This allows the creature to maintain their fatness if we see them again. They lose a little weight in between.
-
-Parameters:
-	'stored_fatness': The fatness to save in the creature library. This can be higher than the creature's current
-			fatness if they're still eating.
-"""
+## Stores this creature's fatness in the CreatureLibrary.
+##
+## This allows the creature to maintain their fatness if we see them again. They lose a little weight in between.
+##
+## Parameters:
+## 	'stored_fatness': The fatness to save in the creature library. This can be higher than the creature's current
+## 			fatness if they're still eating.
 func save_fatness(stored_fatness: float) -> void:
 	if not creature_id:
 		# randomly-generated creatures have no creature id; their fatness isn't stored
@@ -307,46 +295,36 @@ func save_fatness(stored_fatness: float) -> void:
 	PlayerData.creature_library.set_fatness(creature_id, stored_fatness)
 
 
-"""
-Plays a 'hello!' voice sample, for when a creature enters the restaurant
-"""
+## Plays a 'hello!' voice sample, for when a creature enters the restaurant
 func play_hello_voice(force: bool = false) -> void:
 	if not suppress_sfx:
 		_creature_sfx.play_hello_voice(force)
 
 
-"""
-Plays a 'mmm!' voice sample, for when a player builds a big combo.
-"""
+## Plays a 'mmm!' voice sample, for when a player builds a big combo.
 func play_combo_voice() -> void:
 	if not suppress_sfx:
 		_creature_sfx.play_combo_voice()
 
 
-"""
-Plays a 'check please!' voice sample, for when a creature is ready to leave
-"""
+## Plays a 'check please!' voice sample, for when a creature is ready to leave
 func play_goodbye_voice(force: bool = false) -> void:
 	if not suppress_sfx:
 		_creature_sfx.play_goodbye_voice(force)
 
 
-"""
-Parameters:
-	'food_type': An enum from FoodType corresponding to the food to show
-"""
+## Parameters:
+## 	'food_type': An enum from FoodType corresponding to the food to show
 func feed(food_type: int) -> void:
 	feed_count += 1
 	box_feed_count += 1
 	creature_visuals.feed(food_type)
 
 
-"""
-Changes the creature's name, and derives a new short name and creature id from their new name.
-
-A creature's name shouldn't change during regular gameplay. This is only for the creature editor and for other randomly
-generated creatures.
-"""
+## Changes the creature's name, and derives a new short name and creature id from their new name.
+##
+## A creature's name shouldn't change during regular gameplay. This is only for the creature editor and for other
+## randomly generated creatures.
 func rename(new_creature_name: String) -> void:
 	set_creature_name(new_creature_name)
 	creature_short_name = NameUtils.sanitize_short_name(creature_name)
@@ -400,16 +378,12 @@ func refresh_dna() -> void:
 	creature_visuals.dna = dna
 
 
-"""
-Workaround for Godot #21789 to make get_class return class_name
-"""
+## Workaround for Godot #21789 to make get_class return class_name
 func get_class() -> String:
 	return "Creature"
 
 
-"""
-Workaround for Godot #21789 to make is_class match class_name
-"""
+## Workaround for Godot #21789 to make is_class match class_name
 func is_class(name: String) -> bool:
 	return name == "Creature" or .is_class(name)
 
@@ -422,16 +396,12 @@ func get_chat_extents() -> Vector2:
 	return $CollisionShape2D.shape.extents
 
 
-"""
-Temporarily suppresses 'hello' sounds.
-"""
+## Temporarily suppresses 'hello' sounds.
 func start_suppress_sfx_timer() -> void:
 	_creature_sfx.start_suppress_sfx_timer()
 
 
-"""
-Make the creature visible and gradually adjust their alpha up to 1.0.
-"""
+## Make the creature visible and gradually adjust their alpha up to 1.0.
 func fade_in() -> void:
 	if not visible:
 		visible = true
@@ -440,37 +410,27 @@ func fade_in() -> void:
 	_launch_fade_tween(1.0, CREATURE_FADE_IN_DURATION)
 
 
-"""
-Launches a talking animation, opening and closes the creature's mouth for a few seconds.
-"""
+## Launches a talking animation, opening and closes the creature's mouth for a few seconds.
 func talk() -> void:
 	creature_visuals.talk()
 
 
-"""
-Returns 'true' of the creature's talk animation is playing.
-"""
+## Returns 'true' of the creature's talk animation is playing.
 func is_talking() -> bool:
 	return creature_visuals.is_talking()
 
 
-"""
-Gradually adjust this creature's alpha down to 0.0 and make them invisible.
-"""
+## Gradually adjust this creature's alpha down to 0.0 and make them invisible.
 func fade_out() -> void:
 	_launch_fade_tween(0.0, CREATURE_FADE_OUT_DURATION)
 
 
-"""
-Returns the number of seconds between the beginning of the eating animation and the 'chomp' noise.
-"""
+## Returns the number of seconds between the beginning of the eating animation and the 'chomp' noise.
 func get_eating_delay() -> float:
 	return creature_visuals.get_eating_delay()
 
 
-"""
-Starts a tween which changes this creature's opacity.
-"""
+## Starts a tween which changes this creature's opacity.
 func _launch_fade_tween(new_alpha: float, duration: float) -> void:
 	_fade_tween.remove_all()
 	_fade_tween.interpolate_property(self, "modulate", modulate, Utils.to_transparent(modulate, new_alpha), duration)
@@ -510,11 +470,9 @@ func _apply_walk(delta: float) -> void:
 		_accelerate_xy(delta, non_iso_walk_direction, MAX_RUN_ACCELERATION, MAX_RUN_SPEED * _run_anim_speed)
 
 
-"""
-Accelerates the creature horizontally.
-
-If the creature would be accelerated beyond the specified maximum speed, the creature's acceleration is reduced.
-"""
+## Accelerates the creature horizontally.
+##
+## If the creature would be accelerated beyond the specified maximum speed, the creature's acceleration is reduced.
 func _accelerate_xy(delta: float, _non_iso_push_direction: Vector2,
 		acceleration: float, max_speed: float) -> void:
 	if _non_iso_push_direction.length() == 0:
@@ -527,20 +485,16 @@ func _accelerate_xy(delta: float, _non_iso_push_direction: Vector2,
 	set_non_iso_velocity(new_velocity)
 
 
-"""
-Plays a bonk sound if a creature bumps into a wall.
-"""
+## Plays a bonk sound if a creature bumps into a wall.
 func _maybe_play_bonk_sound(old_non_iso_velocity: Vector2) -> void:
 	var velocity_diff := _non_iso_velocity - old_non_iso_velocity
 	if velocity_diff.length() > MAX_RUN_SPEED * _run_anim_speed * 0.9:
 		_creature_sfx.play_bonk_sound()
 
 
-"""
-Updates the movement animation and run speed.
-
-The run speed varies based on how fat the creature is.
-"""
+## Updates the movement animation and run speed.
+##
+## The run speed varies based on how fat the creature is.
 func _update_animation() -> void:
 	if non_iso_walk_direction.length() > 0:
 		var animation_prefix: String
@@ -596,9 +550,7 @@ func _on_FadeTween_tween_all_completed() -> void:
 		emit_signal("fade_in_finished")
 
 
-"""
-Converts a score in the range [0.0, 5000.0] to a fatness in the range [1.0, 10.0]
-"""
+## Converts a score in the range [0.0, 5000.0] to a fatness in the range [1.0, 10.0]
 func score_to_fatness(in_score: float) -> float:
 	var result: float
 	if weight_gain_scale == 0.0:
@@ -624,9 +576,7 @@ func score_to_comfort(combo: float, customer_score: float) -> float:
 	return comfort
 
 
-"""
-Converts the creature's fatness in the range [1.0, 10.0] to a score in the range [0.0, 5000.0]
-"""
+## Converts the creature's fatness in the range [1.0, 10.0] to a score in the range [0.0, 5000.0]
 func fatness_to_score(in_fatness: float) -> float:
 	return (50 / max(weight_gain_scale, 0.01)) * (pow(in_fatness, 2) - 1)
 
@@ -635,9 +585,7 @@ func _on_CreatureVisuals_talking_changed() -> void:
 	emit_signal("talking_changed")
 
 
-"""
-When a new scene is loaded, creatures fade in. This conceals visual glitches as their body parts load.
-"""
+## When a new scene is loaded, creatures fade in. This conceals visual glitches as their body parts load.
 func _on_SceneTransition_fade_in_started() -> void:
 	if visible:
 		visible = false

--- a/project/src/main/world/creature/creatures.gd
+++ b/project/src/main/world/creature/creatures.gd
@@ -1,7 +1,5 @@
 class_name Creatures
-"""
-Enums, constants and utilities related to creatures.
-"""
+## Enums, constants and utilities related to creatures.
 
 enum Orientation {
 	SOUTHEAST,
@@ -29,27 +27,23 @@ const RUN := MovementMode.RUN
 const WALK := MovementMode.WALK
 const WIGGLE := MovementMode.WIGGLE
 
-# How large creatures can grow; 5.0 = 5x normal size
+## How large creatures can grow; 5.0 = 5x normal size
 const MAX_FATNESS := 10.0
 
-# the creature definition path for the sensei who leads tutorials
+## the creature definition path for the sensei who leads tutorials
 const SENSEI_PATH := "res://assets/main/creatures/sensei/creature.json"
 
-"""
-Returns true if the specified creature orientation points south (towards the camera)
-
-Parameters:
-	'orientation': an enum from Creatures.Orientation
-"""
+## Returns true if the specified creature orientation points south (towards the camera)
+##
+## Parameters:
+## 	'orientation': an enum from Creatures.Orientation
 static func oriented_south(orientation: int) -> bool:
 	return orientation in [SOUTHWEST, SOUTHEAST]
 
 
-"""
-Returns true if the specified creature orientation points north (away from the camera)
-
-Parameters:
-	'orientation': an enum from Creatures.Orientation
-"""
+## Returns true if the specified creature orientation points north (away from the camera)
+##
+## Parameters:
+## 	'orientation': an enum from Creatures.Orientation
 static func oriented_north(orientation: int) -> bool:
 	return orientation in [NORTHWEST, NORTHEAST]

--- a/project/src/main/world/creature/dna-alternatives.gd
+++ b/project/src/main/world/creature/dna-alternatives.gd
@@ -1,20 +1,16 @@
 #tool #uncomment to view creature in editor
 class_name DnaAlternatives
-"""
-Provides alternatives for alleles which conflict.
+## Provides alternatives for alleles which conflict.
+##
+## Certain glasses might overlap a creature's nose in a weird way. We have a 'ban list' elsewhere for combos which
+## don't work outright, but this class provides alternatives so that we can give the glasses a slightly different
+## design, or remove parts of the eyeglass frames or things like that.
 
-Certain glasses might overlap a creature's nose in a weird way. We have a 'ban list' elsewhere for combos which don't
-work outright, but this class provides alternatives so that we can give the glasses a slightly different design, or
-remove parts of the eyeglass frames or things like that.
-"""
-
-"""
-key: allele value key like 'accessory-2', for an allele which can vary
-value: array of three items
-	value[0]: conflicting allele key, such as 'nose'
-	value[1]: array of conflicting allele values
-	value[2]: alternative allele value to replace the allele with
-"""
+## key: allele value key like 'accessory-2', for an allele which can vary
+## value: array of three items
+## 	value[0]: conflicting allele key, such as 'nose'
+## 	value[1]: array of conflicting allele values
+## 	value[2]: alternative allele value to replace the allele with
 var _alternatives: Dictionary
 
 func _init() -> void:
@@ -31,18 +27,16 @@ func _init() -> void:
 	_add_alternative("ear", ["10"], "hair", "1", "1a")
 
 
-"""
-Returns an alternative for the specified allele value if a conflict is detected.
-
-Returns an empty string if there is no conflict.
-
-Parameters:
-	'dna': The dictionary of key/value pairs defining a set of textures to load.
-	
-	'key': Allele key which can vary, such as 'accessory'
-	
-	'value': Allele value which can vary, such as '2' which might sometimes switch to '2a'
-"""
+## Returns an alternative for the specified allele value if a conflict is detected.
+##
+## Returns an empty string if there is no conflict.
+##
+## Parameters:
+## 	'dna': The dictionary of key/value pairs defining a set of textures to load.
+##
+## 	'key': Allele key which can vary, such as 'accessory'
+##
+## 	'value': Allele value which can vary, such as '2' which might sometimes switch to '2a'
 func alternative(dna: Dictionary, key: String, value: String) -> String:
 	var result := ""
 	var allele_value_key := _allele_value_key(key, value)
@@ -54,20 +48,18 @@ func alternative(dna: Dictionary, key: String, value: String) -> String:
 	return result
 
 
-"""
-Adds an alternative for an allele value which can vary if a conflict is detected.
-
-Parameters:
-	'conflicting_allele': Conflicting allele key, such as 'nose'
-	
-	'conflicting_values': Array of conflicting allele values, such as '2'
-	
-	'allele': Allele key which can vary if s conflict is detected, such as 'accessory'
-	
-	'allele_value': Allele value which can vary if a conflict is detected, such as '3'
-	
-	'alternative_value': The allele value it should switch to if a conflict is detected
-"""
+## Adds an alternative for an allele value which can vary if a conflict is detected.
+##
+## Parameters:
+## 	'conflicting_allele': Conflicting allele key, such as 'nose'
+##
+## 	'conflicting_values': Array of conflicting allele values, such as '2'
+##
+## 	'allele': Allele key which can vary if s conflict is detected, such as 'accessory'
+##
+## 	'allele_value': Allele value which can vary if a conflict is detected, such as '3'
+##
+## 	'alternative_value': The allele value it should switch to if a conflict is detected
 func _add_alternative(conflicting_allele: String, conflicting_values: Array,
 		allele: String, allele_value: String, alternative_value: String) -> void:
 	var allele_value_key := _allele_value_key(allele, allele_value)

--- a/project/src/main/world/creature/dna-loader.gd
+++ b/project/src/main/world/creature/dna-loader.gd
@@ -1,20 +1,19 @@
 #tool #uncomment to view creature in editor
 extends Node
-"""
-Assigns and unassigns textures and animations based on a creature's dna.
+## Assigns and unassigns textures and animations based on a creature's dna.
+##
+## This needs to be separate from the CreatureVisuals node because it must continue running while paused. Otherwise the
+## creature editor will have strange behavior, particularly in its color picker.
 
-This needs to be separate from the CreatureVisuals node because it must continue running while paused. Otherwise the
-creature editor will have strange behavior, particularly in its color picker.
-"""
-
-# emitted when a creature's textures and animations are loaded
+## emitted when a creature's textures and animations are loaded
 signal dna_loaded
 
-# The maximum amount of microseconds to spend setting shader params in each frame. This is capped to avoid frame drops.
+## The maximum amount of microseconds to spend setting shader params in each frame. This is capped to avoid frame
+## drops.
 const MAX_SHADER_USEC_PER_FRAME := 120
 
-# Array of string shader keys from the dna which haven't yet been loaded. Instead of loading these up front, we load
-# these gradually over time. Setting shader params is slow and setting too many at once causes frame drops.
+## Array of string shader keys from the dna which haven't yet been loaded. Instead of loading these up front, we load
+## these gradually over time. Setting shader params is slow and setting too many at once causes frame drops.
 var _pending_shader_keys: Array
 
 onready var _creature_visuals: CreatureVisuals = get_parent()
@@ -36,12 +35,11 @@ func _process(_delta: float) -> void:
 				_creature_visuals.get_node(node_path).material.set_shader_param(shader_param, shader_value)
 
 
-"""
-Unassigns the textures and animations for the creature.
-
-Different body parts have different animations and textures. Before changing the creature's appearance, any old
-textures and animations need to be stopped and removed, and any signals disconnected. This method handles all of that.
-"""
+## Unassigns the textures and animations for the creature.
+##
+## Different body parts have different animations and textures. Before changing the creature's appearance, any old
+## textures and animations need to be stopped and removed, and any signals disconnected. This method handles all of
+## that.
 func unload_dna() -> void:
 	_creature_visuals.get_node("Animations/EmotePlayer").unemote_immediate()
 	for node_path in [
@@ -105,11 +103,9 @@ func unload_dna() -> void:
 	_creature_visuals.get_node("Animations").reset()
 
 
-"""
-Assigns the textures and animations based on the creature's dna.
-
-This method assumes that any existing animations and connections have been disconnected.
-"""
+## Assigns the textures and animations based on the creature's dna.
+##
+## This method assumes that any existing animations and connections have been disconnected.
 func load_dna() -> void:
 	if _creature_visuals.dna.has("mouth"):
 		_add_dna_node(CreatureLoader.new_mouth_player(_creature_visuals.dna.mouth), "mouth",
@@ -159,9 +155,7 @@ func load_dna() -> void:
 	emit_signal("dna_loaded")
 
 
-"""
-Removes a 'dna node', one which swaps out based on the creature's DNA.
-"""
+## Removes a 'dna node', one which swaps out based on the creature's DNA.
 func _remove_dna_node(path: NodePath) -> void:
 	if not _creature_visuals.has_node(path):
 		return
@@ -172,18 +166,16 @@ func _remove_dna_node(path: NodePath) -> void:
 	node.queue_free()
 
 
-"""
-Adds a 'dna node', one which swaps out based on the creature's DNA.
-
-Parameters:
-	'node': The node to add
-	
-	'key_message': The node description to display in error messages
-	
-	'value_message': The node value to display in error messages
-	
-	'parent': The parent of the new node
-"""
+## Adds a 'dna node', one which swaps out based on the creature's DNA.
+##
+## Parameters:
+## 	'node': The node to add
+##
+## 	'key_message': The node description to display in error messages
+##
+## 	'value_message': The node value to display in error messages
+##
+## 	'parent': The parent of the new node
 func _add_dna_node(node: Node, key_message: String, value_message: String, parent: Node = self) -> void:
 	if not node:
 		push_warning("Invalid %s: %s" % [key_message, value_message])

--- a/project/src/main/world/creature/dna-utils.gd
+++ b/project/src/main/world/creature/dna-utils.gd
@@ -1,15 +1,13 @@
 #tool #uncomment to view creature in editor
 extends Node
-"""
-Provides utilities for manipulating DNA definitions.
+## Provides utilities for manipulating DNA definitions.
+##
+## DNA is defined using dictionaries. The keys or 'alleles' include things like eye color or mouth shape.
 
-DNA is defined using dictionaries. The keys or 'alleles' include things like eye color or mouth shape.
-"""
-
-# Colors used for creature's outlines
+## Colors used for creature's outlines
 const LINE_COLORS := ["6c4331", "41281e", "3c3c3d"]
 
-# Palettes used for recoloring creatures
+## Palettes used for recoloring creatures
 const CREATURE_PALETTES := [
 	{"line_rgb": "6c4331", "body_rgb": "b23823", "belly_rgb": "c9442a",
 		"hair_rgb": "af845c", "eye_rgb": "282828 dedede", "horn_rgb": "f1e398",
@@ -140,22 +138,22 @@ const CREATURE_PALETTES := [
 			"cloth_rgb": "f2c12a", "glass_rgb": "fad669", "plastic_rgb": "f28c2a"}, # magma orange
 ]
 
-# alleles corresponding to creature body parts
+## alleles corresponding to creature body parts
 const BODY_PART_ALLELES := [
 	"belly", "bellybutton", "body", "cheek", "collar", "ear", "eye", "hair",
 	"head", "horn", "mouth", "nose", "tail", "accessory"
 ]
 
-# alleles corresponding to creature colors
+## alleles corresponding to creature colors
 const COLOR_ALLELES := [
 	"line_rgb", "body_rgb", "belly_rgb", "cloth_rgb", "glass_rgb", "plastic_rgb",
 	"hair_rgb", "eye_rgb", "horn_rgb",
 ]
 
-# all alleles, including body parts and colors
+## all alleles, including body parts and colors
 const ALLELES := BODY_PART_ALLELES + COLOR_ALLELES
 
-# body part names shown to the player
+## body part names shown to the player
 const ALLELE_NAMES := {
 	"accessory-0": "(none)",
 	"accessory-1": "Shades",
@@ -256,12 +254,12 @@ const ALLELE_NAMES := {
 	"tail-7": "Lizard",
 }
 
-# key: alleles
-# value: positive numeric weights [0.0-100.0]. high values for common alleles
+## key: alleles
+## value: positive numeric weights [0.0-100.0]. high values for common alleles
 var _allele_weights := {}
 
-# key: allele combo key, such as 'mouth-1-nose-2'
-# value: positive/negative adjustments [-100, 100]. positive for good combos, negative for bad combos
+## key: allele combo key, such as 'mouth-1-nose-2'
+## value: positive/negative adjustments [-100, 100]. positive for good combos, negative for bad combos
 var _allele_combo_adjustments := {}
 
 func _ready() -> void:
@@ -327,11 +325,9 @@ func _ready() -> void:
 	_set_allele_weight("tail", "0", 5.0)
 
 
-"""
-Returns unique list of line colors for the specified dna.
-
-This includes some fixed brownish/greyish colors, as well as a darker version of the body color.
-"""
+## Returns unique list of line colors for the specified dna.
+##
+## This includes some fixed brownish/greyish colors, as well as a darker version of the body color.
 func line_colors(dna: Dictionary) -> Array:
 	var result := LINE_COLORS.duplicate()
 	if dna.has("body_rgb"):
@@ -341,12 +337,10 @@ func line_colors(dna: Dictionary) -> Array:
 	return result
 
 
-"""
-Return a minimal copy of the specified dna.
-
-CreatureLoader populates the dna dictionary with redundant properties such as textures and shader properties. This
-returns a version of the dna with that extra stuff stripped out so it doesn't clutter our save files.
-"""
+## Return a minimal copy of the specified dna.
+##
+## CreatureLoader populates the dna dictionary with redundant properties such as textures and shader properties. This
+## returns a version of the dna with that extra stuff stripped out so it doesn't clutter our save files.
 func trim_dna(dna: Dictionary) -> Dictionary:
 	var result := {}
 	for allele in ALLELES:
@@ -355,11 +349,9 @@ func trim_dna(dna: Dictionary) -> Dictionary:
 	return result
 
 
-"""
-Fill in the creature's missing traits with random values.
-
-Otherwise, missing values will be left empty, leading to invisible body parts or strange colors.
-"""
+## Fill in the creature's missing traits with random values.
+##
+## Otherwise, missing values will be left empty, leading to invisible body parts or strange colors.
 func fill_dna(dna: Dictionary) -> Dictionary:
 	# duplicate the dna so that we don't modify the original
 	var result := dna.duplicate()
@@ -380,26 +372,20 @@ func fill_dna(dna: Dictionary) -> Dictionary:
 	return result
 
 
-"""
-Returns a dna dictionary containing sensible random values.
-
-This includes an aesthetically pleasing palette and body parts that look good together.
-"""
+## Returns a dna dictionary containing sensible random values.
+##
+## This includes an aesthetically pleasing palette and body parts that look good together.
 func random_dna() -> Dictionary:
 	return fill_dna({})
 
 
-"""
-Returns a human-readable allele name for use in the editor.
-"""
+## Returns a human-readable allele name for use in the editor.
 func allele_name(key: String, value: String) -> String:
 	var combo_key := "%s-%s" % [key, value]
 	return ALLELE_NAMES.get(combo_key, combo_key)
 
 
-"""
-Returns a unique list of values for the specified allele.
-"""
+## Returns a unique list of values for the specified allele.
 func unique_allele_values(property: String) -> Array:
 	var result := []
 	
@@ -428,9 +414,7 @@ func unique_allele_values(property: String) -> Array:
 	return result
 
 
-"""
-Returns a random palette from a list of preset palettes.
-"""
+## Returns a random palette from a list of preset palettes.
 func random_creature_palette() -> Dictionary:
 	return Utils.rand_value(CREATURE_PALETTES).duplicate()
 
@@ -447,11 +431,9 @@ func invalid_allele_value(dna: Dictionary, property: String, value: String) -> S
 	return invalid_property
 
 
-"""
-Returns a dictionary with weights for the specified allele.
-
-Some values are more common than others, and some combinations are more common as well.
-"""
+## Returns a dictionary with weights for the specified allele.
+##
+## Some values are more common than others, and some combinations are more common as well.
 func allele_weights(dna: Dictionary, property: String) -> Dictionary:
 	var result := {}
 	
@@ -501,12 +483,10 @@ func _get_allele_combo_adjustment(key1: String, value1: String, key2: String, va
 	return _allele_combo_adjustments.get(combo_key, 0)
 
 
-"""
-A key corresponding to an allele combination, such as 'bird beak with tiny eyes'.
-
-A combination such as 'bird beak with tiny eyes' gets turned into a string key such as 'mouth-4-eye-2' which is
-compatible with dictionaries.
-"""
+## A key corresponding to an allele combination, such as 'bird beak with tiny eyes'.
+##
+## A combination such as 'bird beak with tiny eyes' gets turned into a string key such as 'mouth-4-eye-2' which is
+## compatible with dictionaries.
 func _allele_combo_key(key1: String, value1: String, key2: String, value2: String) -> String:
 	var combo_key: String
 	if key1 <= key2:

--- a/project/src/main/world/creature/ear-player.gd
+++ b/project/src/main/world/creature/ear-player.gd
@@ -1,8 +1,6 @@
 #tool #uncomment to view creature in editor
 extends AnimationPlayer
-"""
-An AnimationPlayer which animates ears.
-"""
+## An AnimationPlayer which animates ears.
 
 export (NodePath) var creature_visuals_path: NodePath setget set_creature_visuals_path
 
@@ -27,10 +25,8 @@ func set_creature_visuals_path(new_creature_visuals_path: NodePath) -> void:
 	_refresh_creature_visuals_path()
 
 
-"""
-Randomly advances the current animation up to 1.0 seconds. Used to ensure all creatures don't wiggle their ears
-synchronously.
-"""
+## Randomly advances the current animation up to 1.0 seconds. Used to ensure all creatures don't wiggle their ears
+## synchronously.
 func advance_animation_randomly() -> void:
 	advance(min(randf(), randf()))
 

--- a/project/src/main/world/creature/emote-player.gd
+++ b/project/src/main/world/creature/emote-player.gd
@@ -1,12 +1,10 @@
 #tool #uncomment to view creature in editor
 extends AnimationPlayer
-"""
-Script for AnimationPlayers which animate moods: blinking, smiling, sweating, etc.
-"""
+## Script for AnimationPlayers which animate moods: blinking, smiling, sweating, etc.
 
 signal animation_stopped
 
-# mapping from moods to animation names
+## mapping from moods to animation names
 const EMOTE_ANIMS := {
 	ChatEvent.Mood.AWKWARD0: "awkward0",
 	ChatEvent.Mood.AWKWARD1: "awkward1",
@@ -36,7 +34,7 @@ const EMOTE_ANIMS := {
 	ChatEvent.Mood.YES1: "yes1",
 }
 
-# animation names for eating while smiling; referenced for animation transitions
+## animation names for eating while smiling; referenced for animation transitions
 const EAT_SMILE_ANIMS := {
 	"eat-smile0": "_",
 	"eat-again-smile0": "_",
@@ -44,7 +42,7 @@ const EAT_SMILE_ANIMS := {
 	"eat-again-smile1": "_",
 }
 
-# animation names for eating while sweating; referenced for animation transitions
+## animation names for eating while sweating; referenced for animation transitions
 const EAT_SWEAT_ANIMS := {
 	"eat-sweat0": "_",
 	"eat-again-sweat0": "_",
@@ -54,7 +52,7 @@ const EAT_SWEAT_ANIMS := {
 	"eat-again-sweat2": "_"
 }
 
-# custom transition for cases where the default mood transition looks awkward
+## custom transition for cases where the default mood transition looks awkward
 const TRANSITIONS := {
 	[ChatEvent.Mood.AWKWARD0, ChatEvent.Mood.AWKWARD0]: "_transition_noop",
 	[ChatEvent.Mood.AWKWARD0, ChatEvent.Mood.AWKWARD1]: "_transition_noop",
@@ -108,25 +106,25 @@ const TRANSITIONS := {
 	[ChatEvent.Mood.YES1, ChatEvent.Mood.YES1]: "_transition_noop",
 }
 
-# Time spent resetting to a neutral emotion: fading out speech bubbles, untilting the head, etc...
+## Time spent resetting to a neutral emotion: fading out speech bubbles, untilting the head, etc...
 const UNEMOTE_DURATION := 0.08
 
 export (NodePath) var creature_visuals_path: NodePath setget set_creature_visuals_path
 
-# stores the previous mood so that we can apply mood transitions.
+## stores the previous mood so that we can apply mood transitions.
 var _prev_mood: int
 
-# stores the current mood. used to prevent sync issues when changing moods faster than 80 milliseconds.
+## stores the current mood. used to prevent sync issues when changing moods faster than 80 milliseconds.
 var _mood: int
 
 var _creature_visuals: CreatureVisuals
 
-# specific sprites manipulated frequently when emoting
+## specific sprites manipulated frequently when emoting
 var _emote_eye_z0: PackedSprite
 var _emote_eye_z1: PackedSprite
 var _head_bobber: Sprite
 
-# list of sprites to reset when unemoting
+## list of sprites to reset when unemoting
 var _emote_sprites: Array
 
 func _ready() -> void:
@@ -153,25 +151,19 @@ func set_creature_visuals_path(new_creature_visuals_path: NodePath) -> void:
 	_refresh_creature_visuals_path()
 
 
-"""
-Stops and emits an 'animation_stopped' signal.
-"""
+## Stops and emits an 'animation_stopped' signal.
 func stop(reset: bool = true) -> void:
 	var old_anim := current_animation
 	.stop(reset)
 	emit_signal("animation_stopped", old_anim)
 
 
-"""
-Randomly advances the current animation up to 2.0 seconds. Used to ensure all creatures don't blink synchronously.
-"""
+## Randomly advances the current animation up to 2.0 seconds. Used to ensure all creatures don't blink synchronously.
 func advance_animation_randomly() -> void:
 	advance(randf() * 2.0)
 
 
-"""
-Plays an eating animation appropriate to the creature's comfort level.
-"""
+## Plays an eating animation appropriate to the creature's comfort level.
 func eat() -> void:
 	# default eating animation
 	var emote_anim_name := "eat-again"
@@ -253,12 +245,10 @@ func eat() -> void:
 		advance(0.00001)
 
 
-"""
-Animates the creature's appearance according to the specified mood: happy, angry, etc...
-
-Parameters:
-	'mood': The creature's new mood from ChatEvent.Mood
-"""
+## Animates the creature's appearance according to the specified mood: happy, angry, etc...
+##
+## Parameters:
+## 	'mood': The creature's new mood from ChatEvent.Mood
 func emote(mood: int) -> void:
 	_mood = mood
 	if _prev_mood in EMOTE_ANIMS:
@@ -287,15 +277,13 @@ func emote(mood: int) -> void:
 		_prev_mood = mood
 
 
-"""
-Starts resetting the creature to a default neutral mood.
-
-This does not take place immediately, but fires off a tween. Callers should wait until $ResetTween completes before
-updating the creature's appearance.
-
-Parameters:
-	'anim_name': (Optional) The animation which was previously playing.
-"""
+## Starts resetting the creature to a default neutral mood.
+##
+## This does not take place immediately, but fires off a tween. Callers should wait until $ResetTween completes before
+## updating the creature's appearance.
+##
+## Parameters:
+## 	'anim_name': (Optional) The animation which was previously playing.
 func unemote(anim_name: String = "") -> void:
 	stop()
 	_unemote_non_tweened_properties()
@@ -325,12 +313,10 @@ func unemote(anim_name: String = "") -> void:
 	_prev_mood = ChatEvent.Mood.DEFAULT
 
 
-"""
-Resets the position and rotation of nodes which shift around during emotes.
-
-This only includes 'non-tweened properties'; properties which snap back to their starting value without being tweened
-into place.
-"""
+## Resets the position and rotation of nodes which shift around during emotes.
+##
+## This only includes 'non-tweened properties'; properties which snap back to their starting value without being
+## tweened into place.
 func _unemote_non_tweened_properties() -> void:
 	_creature_visuals.get_node("Neck0/HeadBobber/EmoteArmZ0").frame = 0
 	_creature_visuals.get_node("Neck0/HeadBobber/EmoteArmZ1").frame = 0
@@ -345,11 +331,9 @@ func _unemote_non_tweened_properties() -> void:
 	_emote_eye_z1.position = Vector2(0, 256)
 
 
-"""
-Immediately resets the creature to a default neutral mood.
-
-This takes place immediately, callers do not need to wait for $ResetTween.
-"""
+## Immediately resets the creature to a default neutral mood.
+##
+## This takes place immediately, callers do not need to wait for $ResetTween.
 func unemote_immediate() -> void:
 	stop()
 	_unemote_non_tweened_properties()
@@ -363,18 +347,16 @@ func unemote_immediate() -> void:
 	_post_unemote()
 
 
-"""
-Updates the values for a set of animation keys.
-
-Parameters:
-	'anim_name': The animation to update
-	
-	'track_path': The track to update
-	
-	'key_indexes': The key indexes to update
-	
-	'value': The new value to set the animation keys to
-"""
+## Updates the values for a set of animation keys.
+##
+## Parameters:
+## 	'anim_name': The animation to update
+##
+## 	'track_path': The track to update
+##
+## 	'key_indexes': The key indexes to update
+##
+## 	'value': The new value to set the animation keys to
 func _update_animation_keys(anim_name: String, track_path: String, key_indexes: Array, value) -> void:
 	var track_index := get_animation(anim_name).find_track(NodePath(track_path))
 	if track_index == -1:
@@ -385,13 +367,11 @@ func _update_animation_keys(anim_name: String, track_path: String, key_indexes: 
 		get_animation(anim_name).track_set_key_value(track_index, key_index, value)
 
 
-"""
-Finishes resetting the creature to a default neutral mood.
-
-The tweens reset most of the creature's appearance, but they don't adjust scale or blendmode. This is to avoid a
-jarring effect if a speech bubble gradually grows to a large side, or if a creature's pink blush swaps to a neon
-green.
-"""
+## Finishes resetting the creature to a default neutral mood.
+##
+## The tweens reset most of the creature's appearance, but they don't adjust scale or blendmode. This is to avoid a
+## jarring effect if a speech bubble gradually grows to a large side, or if a creature's pink blush swaps to a neon
+## green.
 func _post_unemote() -> void:
 	for emote_sprite in _emote_sprites:
 		emote_sprite.frame = 0
@@ -416,16 +396,12 @@ func _post_unemote() -> void:
 	_creature_visuals.get_node("Neck0").scale = Vector2(1.0, 1.0)
 
 
-"""
-Transition function for moods which don't need a transition.
-"""
+## Transition function for moods which don't need a transition.
 func _transition_noop() -> void:
 	pass
 
 
-"""
-Transitions from 'awkward1' to 'awkward0', hiding the white sweat circles.
-"""
+## Transitions from 'awkward1' to 'awkward0', hiding the white sweat circles.
 func _transition_awkward1_awkward0() -> void:
 	_creature_visuals.get_node("Neck0").scale = Vector2(1.0, 1.0)
 	$ResetTween.remove_all()
@@ -433,9 +409,7 @@ func _transition_awkward1_awkward0() -> void:
 	$ResetTween.start()
 
 
-"""
-Transitions from 'laugh1' to 'laugh0', hiding the yellow laugh lines.
-"""
+## Transitions from 'laugh1' to 'laugh0', hiding the yellow laugh lines.
 func _transition_laugh1_laugh0() -> void:
 	_head_bobber.reset_head_bob()
 	$ResetTween.remove_all()
@@ -443,9 +417,7 @@ func _transition_laugh1_laugh0() -> void:
 	$ResetTween.start()
 
 
-"""
-Transitions from 'love1' to 'love0', hiding the hearts and blush.
-"""
+## Transitions from 'love1' to 'love0', hiding the hearts and blush.
 func _transition_love1_love0() -> void:
 	_emote_eye_z0.rotation_degrees = 0
 	_emote_eye_z0.position = Vector2(0, 256)
@@ -456,9 +428,7 @@ func _transition_love1_love0() -> void:
 	$ResetTween.start()
 
 
-"""
-Transitions from 'rage1' to 'rage0', hiding the red anger symbols.
-"""
+## Transitions from 'rage1' to 'rage0', hiding the red anger symbols.
 func _transition_rage1_rage0() -> void:
 	_head_bobber.reset_head_bob()
 	$ResetTween.remove_all()
@@ -466,9 +436,7 @@ func _transition_rage1_rage0() -> void:
 	$ResetTween.start()
 
 
-"""
-Transitions from 'sigh1' to 'sigh0', turning the head forward again
-"""
+## Transitions from 'sigh1' to 'sigh0', turning the head forward again
 func _transition_sigh1_sigh0() -> void:
 	_creature_visuals.get_node("Neck0").scale = Vector2(1.0, 1.0)
 	$ResetTween.remove_all()
@@ -477,9 +445,7 @@ func _transition_sigh1_sigh0() -> void:
 	$ResetTween.start()
 
 
-"""
-Transitions from 'smile1' to 'smile0', hiding the pink love bubble and blush.
-"""
+## Transitions from 'smile1' to 'smile0', hiding the pink love bubble and blush.
 func _transition_smile1_smile0() -> void:
 	$ResetTween.remove_all()
 	_tween_nodes_to_transparent(["Neck0/HeadBobber/EmoteBrain", "Neck0/HeadBobber/EmoteGlow"])
@@ -488,9 +454,7 @@ func _transition_smile1_smile0() -> void:
 	$ResetTween.start()
 
 
-"""
-Transitions from 'sweat1' to 'sweat0', hiding the white sweat circles.
-"""
+## Transitions from 'sweat1' to 'sweat0', hiding the white sweat circles.
 func _transition_sweat1_sweat0() -> void:
 	_head_bobber.reset_head_bob()
 	_creature_visuals.get_node("NearArm").frame = 1
@@ -505,14 +469,12 @@ func _tween_nodes_to_transparent(paths: Array) -> void:
 		$ResetTween.interpolate_property(node, "modulate", node.modulate, Color.transparent, UNEMOTE_DURATION)
 
 
-"""
-This function manually assigns fields which Godot would ideally assign automatically by calling _ready. It is a
-workaround for Godot issue #16974 (https://github.com/godotengine/godot/issues/16974)
-
-Tool scripts do not call _ready on reload, which means all onready fields will be null. This breaks this script's
-functionality and throws errors when it is used as a tool. This function manually assigns those fields to avoid those
-problems.
-"""
+## This function manually assigns fields which Godot would ideally assign automatically by calling _ready. It is a
+## workaround for Godot issue #16974 (https://github.com/godotengine/godot/issues/16974)
+##
+## Tool scripts do not call _ready on reload, which means all onready fields will be null. This breaks this script's
+## functionality and throws errors when it is used as a tool. This function manually assigns those fields to avoid
+## those problems.
 func _apply_tool_script_workaround() -> void:
 	if not _creature_visuals:
 		_creature_visuals = get_parent()

--- a/project/src/main/world/creature/fast-creature-outline.gd
+++ b/project/src/main/world/creature/fast-creature-outline.gd
@@ -1,11 +1,9 @@
 tool
 extends CreatureOutline
-"""
-An implementation of CreatureOutline which is optimized for performance, specifically on web and mobile targets.
-
-This implementation avoids using any ViewportTextures. The ViewportTexture utilized by ViewportCreatureOutline offers
-poor performance on mobile and web targets.
-"""
+## An implementation of CreatureOutline which is optimized for performance, specifically on web and mobile targets.
+##
+## This implementation avoids using any ViewportTextures. The ViewportTexture utilized by ViewportCreatureOutline
+## offers poor performance on mobile and web targets.
 
 func _ready() -> void:
 	creature_visuals = $Holder/Visuals

--- a/project/src/main/world/creature/fat-sprite-mover.gd
+++ b/project/src/main/world/creature/fat-sprite-mover.gd
@@ -1,11 +1,9 @@
 #tool #uncomment to view creature in editor
 extends AnimationPlayer
-"""
-Moves the creature's body parts around as they become fatter.
-
-While this is an AnimationPlayer, the animation is only used to rearrange their body parts. It shouldn't ever be
-played as an animation.
-"""
+## Moves the creature's body parts around as they become fatter.
+##
+## While this is an AnimationPlayer, the animation is only used to rearrange their body parts. It shouldn't ever be
+## played as an animation.
 
 export (NodePath) var creature_visuals_path: NodePath setget set_creature_visuals_path
 

--- a/project/src/main/world/creature/head-bobber.gd
+++ b/project/src/main/world/creature/head-bobber.gd
@@ -1,13 +1,11 @@
 #tool #uncomment to view creature in editor
 class_name HeadBobber
 extends Sprite
-"""
-Bobs the character's head up and down.
+## Bobs the character's head up and down.
+##
+## Provides a few different 'bob modes', so that the character can shudder, nod, or laugh in different situations.
 
-Provides a few different 'bob modes', so that the character can shudder, nod, or laugh in different situations.
-"""
-
-# ways the creature's head can move ambiently
+## ways the creature's head can move ambiently
 enum HeadBobMode {
 	OFF, # no movement
 	BOB, # nodding vertically
@@ -20,16 +18,16 @@ const BOB_BOB := HeadBobMode.BOB
 const BOB_BOUNCE := HeadBobMode.BOUNCE
 const BOB_SHUDDER := HeadBobMode.SHUDDER
 
-# these three fields control the creature's head motion: how it's moving, as well as how much/how fast
+## these three fields control the creature's head motion: how it's moving, as well as how much/how fast
 export (HeadBobMode) var head_bob_mode := HeadBobMode.BOB setget set_head_bob_mode
 export (float) var head_motion_pixels := 2.0
 export (float) var head_motion_seconds := 6.5
 
-# the creature's head bobs up and down slowly, these constants control how much it bobs
+## the creature's head bobs up and down slowly, these constants control how much it bobs
 const HEAD_BOB_SECONDS := 6.5
 const HEAD_BOB_PIXELS := 2.0
 
-# the total number of seconds which have elapsed since the object was created
+## the total number of seconds which have elapsed since the object was created
 var _total_seconds := 0.0
 
 func _process(delta: float) -> void:

--- a/project/src/main/world/creature/head-sweat-drops.gd
+++ b/project/src/main/world/creature/head-sweat-drops.gd
@@ -1,7 +1,5 @@
 extends Particles2D
-"""
-Manages the sweat drops which slide down the creature's body.
-"""
+## Manages the sweat drops which slide down the creature's body.
 
 export var creature_visuals_path: NodePath
 

--- a/project/src/main/world/creature/head-sweat-squirts.gd
+++ b/project/src/main/world/creature/head-sweat-squirts.gd
@@ -1,8 +1,6 @@
 #tool #uncomment to view creature in editor
 extends Particles2D
-"""
-Manages the sweat drops which leap from the creature's head.
-"""
+## Manages the sweat drops which leap from the creature's head.
 
 export var creature_visuals_path: NodePath setget set_creature_visuals_path
 

--- a/project/src/main/world/creature/idle-timer.gd
+++ b/project/src/main/world/creature/idle-timer.gd
@@ -1,26 +1,24 @@
 class_name IdleTimer
 extends Timer
-"""
-Launches idle animations periodically.
+## Launches idle animations periodically.
+##
+## Idle animations are launched if the creature remains in the 'ambient' state for awhile.
+##
+## This class does not play any animations itself. It sends signals to tell AnimationPlayers when they should start and
+## stop playing idle animations.
 
-Idle animations are launched if the creature remains in the 'ambient' state for awhile.
-
-This class does not play any animations itself. It sends signals to tell AnimationPlayers when they should start and
-stop playing idle animations.
-"""
-
-# notifies AnimationPlayers that an idle animation should play.
+## notifies AnimationPlayers that an idle animation should play.
 signal idle_animation_started(anim_name)
 
-# notifies AnimationPlayers that any current idle animation should be interrupted. this class has no concept of how
-# long each animation takes or whether they're still playing, so it's possible this signal will be emitted when no
-# idle animation is active.
+## notifies AnimationPlayers that any current idle animation should be interrupted. this class has no concept of how
+## long each animation takes or whether they're still playing, so it's possible this signal will be emitted when no
+## idle animation is active.
 signal idle_animation_stopped()
 
-# the average amount of seconds to wait before launching an idle animation
+## the average amount of seconds to wait before launching an idle animation
 const IDLE_FREQUENCY := 24.0
 
-# list of idle animation names to launch
+## list of idle animation names to launch
 const IDLE_ANIMS := [
 	"idle-look-over-shoulder0",
 	"idle-look-over-shoulder1",
@@ -32,7 +30,7 @@ const IDLE_ANIMS := [
 	"idle-ear-wiggle1",
 ]
 
-# animationplayer which is monitored to see if the creature is in the 'ambient' state
+## animationplayer which is monitored to see if the creature is in the 'ambient' state
 export (NodePath) var emote_player_path: NodePath
 
 export (NodePath) var creature_visuals_path: NodePath
@@ -62,23 +60,19 @@ func restart() -> void:
 	_update_state(true)
 
 
-"""
-Stops the currently playing idle animation.
-
-This class has no concept of how long an animation is or whether it's still playing, but it emits a signal which
-animation players can listen for.
-"""
+## Stops the currently playing idle animation.
+##
+## This class has no concept of how long an animation is or whether it's still playing, but it emits a signal which
+## animation players can listen for.
 func stop_idle_animation() -> void:
 	emit_signal("idle_animation_stopped")
 
 
-"""
-Updates our state based on the current animation.
-
-If the current animation is 'ambient', the timer counts down to launch idle animations.
-
-If the current animation is not 'ambient' state, the timer pauses and does not launch idle animations.
-"""
+## Updates our state based on the current animation.
+##
+## If the current animation is 'ambient', the timer counts down to launch idle animations.
+##
+## If the current animation is not 'ambient' state, the timer pauses and does not launch idle animations.
 func _update_state(start: bool = false) -> void:
 	if start:
 		start(rand_range(IDLE_FREQUENCY * 0.5, IDLE_FREQUENCY * 1.5))
@@ -111,9 +105,7 @@ func _on_EmotePlayer_animation_finished(_anim_name: String) -> void:
 	_update_state()
 
 
-"""
-Launches an idle animation and restarts the timer.
-"""
+## Launches an idle animation and restarts the timer.
 func _on_timeout() -> void:
 	var idle_anim: String = Utils.rand_value(IDLE_ANIMS)
 	if idle_anim:
@@ -121,9 +113,7 @@ func _on_timeout() -> void:
 	_update_state(true)
 
 
-"""
-Restarts the idle timer when a new creature shows up.
-"""
+## Restarts the idle timer when a new creature shows up.
 func _on_CreatureVisuals_dna_loaded() -> void:
 	_update_state(true)
 

--- a/project/src/main/world/creature/mouth-player.gd
+++ b/project/src/main/world/creature/mouth-player.gd
@@ -1,11 +1,9 @@
 #tool #uncomment to view creature in editor
 class_name MouthPlayer
 extends AnimationPlayer
-"""
-An AnimationPlayer which animates mouths.
-"""
+## An AnimationPlayer which animates mouths.
 
-# emote animations which should result in a frown, if the mouth is capable of frowning
+## emote animations which should result in a frown, if the mouth is capable of frowning
 const FROWN_ANIMS = {
 	"ambient-sweat": "",
 	"cry0": "",
@@ -52,9 +50,7 @@ func set_creature_visuals_path(new_creature_visuals_path: NodePath) -> void:
 	_refresh_creature_visuals_path()
 
 
-"""
-Plays an eating animation.
-"""
+## Plays an eating animation.
 func eat() -> void:
 	if current_animation.begins_with("eat"):
 		stop()
@@ -96,9 +92,7 @@ func _refresh_creature_visuals_path() -> void:
 	_emote_glow = _creature_visuals.get_node("Neck0/HeadBobber/EmoteGlow")
 
 
-"""
-Plays an appropriate mouth ambient animation for the creature's orientation and mood.
-"""
+## Plays an appropriate mouth ambient animation for the creature's orientation and mood.
 func _play_mouth_ambient_animation() -> void:
 	var mouth_ambient_animation: String
 	if _creature_visuals.orientation in [Creatures.SOUTHWEST, Creatures.SOUTHEAST]:
@@ -117,14 +111,12 @@ func _play_mouth_ambient_animation() -> void:
 	play(mouth_ambient_animation)
 
 
-"""
-This function manually assigns fields which Godot would ideally assign automatically by calling _ready. It is a
-workaround for Godot issue #16974 (https://github.com/godotengine/godot/issues/16974)
-
-Tool scripts do not call _ready on reload, which means all onready fields will be null. This breaks this script's
-functionality and throws errors when it is used as a tool. This function manually assigns those fields to avoid those
-problems.
-"""
+## This function manually assigns fields which Godot would ideally assign automatically by calling _ready. It is a
+## workaround for Godot issue #16974 (https://github.com/godotengine/godot/issues/16974)
+##
+## Tool scripts do not call _ready on reload, which means all onready fields will be null. This breaks this script's
+## functionality and throws errors when it is used as a tool. This function manually assigns those fields to avoid
+## those problems.
 func _apply_tool_script_workaround() -> void:
 	if not _creature_visuals:
 		_creature_visuals = get_parent()

--- a/project/src/main/world/creature/player.gd
+++ b/project/src/main/world/creature/player.gd
@@ -1,13 +1,11 @@
 class_name Player
 extends Creature
-"""
-Script for manipulating the player-controlled character in the overworld.
-"""
+## Script for manipulating the player-controlled character in the overworld.
 
-# If 'true' the player cannot move. Used during cutscenes.
+## If 'true' the player cannot move. Used during cutscenes.
 var input_disabled := false
 
-# if 'true' the ui has focus, and the player shouldn't move.
+## if 'true' the ui has focus, and the player shouldn't move.
 var ui_has_focus := false setget set_ui_has_focus
 
 func _ready() -> void:
@@ -33,9 +31,7 @@ func set_ui_has_focus(new_ui_has_focus: bool) -> void:
 		set_non_iso_walk_direction(Vector2(0, 0))
 
 
-"""
-Stop moving when a chat choice appears.
-"""
+## Stop moving when a chat choice appears.
 func _on_OverworldUi_showed_chat_choices() -> void:
 	if non_iso_walk_direction:
 		set_non_iso_walk_direction(Vector2.ZERO)

--- a/project/src/main/world/creature/sensei.gd
+++ b/project/src/main/world/creature/sensei.gd
@@ -1,16 +1,14 @@
 class_name Sensei
 extends Creature
-"""
-Script for manipulating the sensei in the overworld.
+## Script for manipulating the sensei in the overworld.
+##
+## The sensei follows the player around.
 
-The sensei follows the player around.
-"""
-
-# the sensei tries to keep a respectable distance from the player
+## the sensei tries to keep a respectable distance from the player
 const TOO_CLOSE_THRESHOLD := 140.0
 const TOO_FAR_THRESHOLD := 280.0
 
-# If 'true' the sensei cannot move. Used during cutscenes.
+## If 'true' the sensei cannot move. Used during cutscenes.
 var movement_disabled := false
 
 func _ready() -> void:

--- a/project/src/main/world/creature/smooth-path.gd
+++ b/project/src/main/world/creature/smooth-path.gd
@@ -1,12 +1,10 @@
 tool
 class_name SmoothPath
 extends Path2D
-"""
-A utility class which allows developers to draw curves in the Godot editor. Use the path tool to define line segments,
-then enable the 'smooth' setting in the inspector.
-
-Adapted from Dlean Jeans' code at https://godotengine.org/qa/32506/how-to-draw-a-curve-in-2d?show=57123#a57123
-"""
+## A utility class which allows developers to draw curves in the Godot editor. Use the path tool to define line
+## segments, then enable the 'smooth' setting in the inspector.
+##
+## Adapted from Dlean Jeans' code at https://godotengine.org/qa/32506/how-to-draw-a-curve-in-2d?show=57123#a57123
 
 export(float) var spline_length := 25.0
 export(bool) var _smooth: bool setget smooth
@@ -17,7 +15,7 @@ export(Color) var line_color := Color.black setget set_line_color
 export(Color) var fill_color := Color.transparent setget set_fill_color
 export(float) var line_width := 8.0
 
-# internal array used for drawing polygons
+## internal array used for drawing polygons
 var _poly_colors := PoolColorArray()
 
 func _ready() -> void:
@@ -53,12 +51,10 @@ func set_fill_color(new_fill_color: Color) -> void:
 	update()
 
 
-"""
-Straightens the Path2D into a series of straight lines, instead of smooth curves.
-
-Parameters:
-	'value': If true, the Path2D will be straightened. If false, the method does nothing.
-"""
+## Straightens the Path2D into a series of straight lines, instead of smooth curves.
+##
+## Parameters:
+## 	'value': If true, the Path2D will be straightened. If false, the method does nothing.
 func straighten(value: bool) -> void:
 	if not value:
 		return
@@ -67,11 +63,9 @@ func straighten(value: bool) -> void:
 		curve.set_point_out(i, Vector2())
 
 
-"""
-Smooths the Path2D into a series of smooth curves, instead of straight lines.
-
-Parameters: If 'value' is true, the Path2D will be smoothed. If false, the method does nothing.
-"""
+## Smooths the Path2D into a series of smooth curves, instead of straight lines.
+##
+## Parameters: If 'value' is true, the Path2D will be smoothed. If false, the method does nothing.
 func smooth(value: bool) -> void:
 	if not value:
 		return

--- a/project/src/main/world/creature/sprint.gd
+++ b/project/src/main/world/creature/sprint.gd
@@ -1,11 +1,7 @@
 #tool #uncomment to view creature in editor
 extends PackedSprite
-"""
-Draws the creature's arms, legs and torso when sprinting.
-"""
+## Draws the creature's arms, legs and torso when sprinting.
 
-"""
-Turn sprite visible when the creature is sprinting.
-"""
+## Turn sprite visible when the creature is sprinting.
 func _on_CreatureVisuals_movement_mode_changed(_old_mode: int, new_mode: int) -> void:
 	visible = new_mode == Creatures.SPRINT

--- a/project/src/main/world/creature/tail-player.gd
+++ b/project/src/main/world/creature/tail-player.gd
@@ -1,9 +1,7 @@
 extends AnimationPlayer
-"""
-An AnimationPlayer which animates a creature's tail.
-
-Specifically, this animationplayer ensures the tail is always moving, if nothing else is animating it.
-"""
+## An AnimationPlayer which animates a creature's tail.
+##
+## Specifically, this animationplayer ensures the tail is always moving, if nothing else is animating it.
 
 export (NodePath) var movement_player_path: NodePath
 export (NodePath) var creature_visuals_path: NodePath
@@ -25,9 +23,7 @@ func _process(_delta: float) -> void:
 		_play_tail_ambient_animation()
 
 
-"""
-Plays an appropriate tail ambient animation for the creature's orientation and movement state.
-"""
+## Plays an appropriate tail ambient animation for the creature's orientation and movement state.
 func _play_tail_ambient_animation() -> void:
 	var tail_ambient_animation: String
 	if _creature_visuals.orientation in [Creatures.SOUTHWEST, Creatures.SOUTHEAST]:

--- a/project/src/main/world/creature/viewport-creature-outline.gd
+++ b/project/src/main/world/creature/viewport-creature-outline.gd
@@ -1,12 +1,10 @@
 tool
 extends CreatureOutline
-"""
-An implementation of CreatureOutline which is optimized for graphics quality.
+## An implementation of CreatureOutline which is optimized for graphics quality.
+##
+## This implementation utilizes a ViewportTexture to render an outline around the creature.
 
-This implementation utilizes a ViewportTexture to render an outline around the creature.
-"""
-
-# rendering of a creature with an outline shader applied
+## rendering of a creature with an outline shader applied
 onready var _texture_rect := $TextureRect
 
 func _ready() -> void:

--- a/project/src/main/world/creature/walking-buddy.gd
+++ b/project/src/main/world/creature/walking-buddy.gd
@@ -1,12 +1,10 @@
 class_name WalkingBuddy
 extends Creature
-"""
-A creature who walks in a straight line alongside another creature.
-
-The creature can be designated a 'leader' or a 'follower' which alters their walking behavior. The leader continues
-walking as long as they're not too far from the follower. The follower continues walking until they get too close to
-the leader.
-"""
+## A creature who walks in a straight line alongside another creature.
+##
+## The creature can be designated a 'leader' or a 'follower' which alters their walking behavior. The leader continues
+## walking as long as they're not too far from the follower. The follower continues walking until they get too close to
+## the leader.
 
 enum LeaderOrFollower {
 	NONE,
@@ -21,49 +19,45 @@ enum WalkState {
 	ABOUT_TO_WALK, # preparing to walk
 }
 
-# creatures try to keep a respectable distance from one another
+## creatures try to keep a respectable distance from one another
 const TOO_CLOSE_THRESHOLD := 200.0
 const TOO_FAR_THRESHOLD := 600.0
 
-# the direction the creatures walk, when they're walking
+## the direction the creatures walk, when they're walking
 const WALK_DIR := Vector2(0.70710678118, 0.70710678118)
 
-# the path to the other creature whom this creature is walking with
+## the path to the other creature whom this creature is walking with
 export (NodePath) var buddy_path: NodePath
 
-# the path to the destination. the leader stops walking if they reach this destination
+## the path to the destination. the leader stops walking if they reach this destination
 export (NodePath) var destination_path: NodePath
 
-# designates this creature as either a leader or follower
+## designates this creature as either a leader or follower
 export (LeaderOrFollower) var leader_or_follower: int
 
-# the creature's walking state. they start out in the WALKING state, but might change to the SITTING state if they
-# reach their destination or if the cutscene specifies to stop.
+## the creature's walking state. they start out in the WALKING state, but might change to the SITTING state if they
+## reach their destination or if the cutscene specifies to stop.
 var _walk_state: int = WalkState.WALKING
 
-# the other creature whom this creature is walking with
+## the other creature whom this creature is walking with
 onready var buddy: Creature = get_node(buddy_path)
 
-# the leader stops walking if they reach this destination
+## the leader stops walking if they reach this destination
 onready var destination: Node2D = get_node(destination_path)
 
-# the creature reevaluates whether they should continue walking when this timer times out
+## the creature reevaluates whether they should continue walking when this timer times out
 onready var _move_timer: Timer = $MoveTimer
 
-"""
-Note: Some superclass method calls are implicit in gdscript for notifications. This is planned to require explicit
-super() calls in Godot 4.0
-"""
+## Note: Some superclass method calls are implicit in gdscript for notifications. This is planned to require explicit
+## super() calls in Godot 4.0
 func _ready() -> void:
 	_move_timer.connect("timeout", self, "_on_MoveTimer_timeout")
 	set_non_iso_walk_direction(WALK_DIR)
 
 
-"""
-Makes the creature stop walking and sit down.
-
-They will only continue walking if the 'start_walking' method is called.
-"""
+## Makes the creature stop walking and sit down.
+##
+## They will only continue walking if the 'start_walking' method is called.
 func stop_walking(delay: float = 0.0) -> void:
 	if delay == 0:
 		# sit immediately so that we can emote with our hands
@@ -74,32 +68,26 @@ func stop_walking(delay: float = 0.0) -> void:
 		_start_move_timer(delay)
 
 
-"""
-Makes the creature resume walking.
-"""
+## Makes the creature resume walking.
 func start_walking(delay: float = 0.0) -> void:
 	_walk_state = WalkState.ABOUT_TO_WALK
 	_start_move_timer(delay)
 
 
-"""
-Starts the move timer, but preserves the default wait time.
-
-This allows the move timer to have a longer one-time delay without changing its permanent behavior.
-"""
+## Starts the move timer, but preserves the default wait time.
+##
+## This allows the move timer to have a longer one-time delay without changing its permanent behavior.
 func _start_move_timer(delay: float) -> void:
 	var old_wait_time := _move_timer.wait_time
 	_move_timer.start(delay)
 	_move_timer.wait_time = old_wait_time
 
 
-"""
-Updates the creature's walk direction. This usually causes them to walk, but they might pause too.
-
-Creatures will pause if they get too far apart or too close together. This is to allow for situations where one
-creature moves faster than the other. As long as they're an appropriate distance apart, this method will make them
-walk towards their destination.
-"""
+## Updates the creature's walk direction. This usually causes them to walk, but they might pause too.
+##
+## Creatures will pause if they get too far apart or too close together. This is to allow for situations where one
+## creature moves faster than the other. As long as they're an appropriate distance apart, this method will make them
+## walk towards their destination.
 func _walk() -> void:
 	var buddy_relative_pos: Vector2 = Global.from_iso(buddy.position - position)
 	
@@ -128,9 +116,7 @@ func _walk() -> void:
 		set_non_iso_walk_direction(new_non_iso_walk_direction)
 
 
-"""
-Makes the creature stop walking, sit, and face towards their friend.
-"""
+## Makes the creature stop walking, sit, and face towards their friend.
 func _sit_and_reorient() -> void:
 	set_non_iso_walk_direction(Vector2.ZERO)
 	# If we don't zero out the creature's velocity, CreatureVisuals overwrites our assigned orientation
@@ -138,9 +124,7 @@ func _sit_and_reorient() -> void:
 	orient_toward(buddy.position)
 
 
-"""
-When the move timer times out, we evaluate our walk state and change the creature's behavior.
-"""
+## When the move timer times out, we evaluate our walk state and change the creature's behavior.
 func _on_MoveTimer_timeout() -> void:
 	match _walk_state:
 		WalkState.ABOUT_TO_SIT:

--- a/project/src/main/world/cutscene-manager.gd
+++ b/project/src/main/world/cutscene-manager.gd
@@ -1,16 +1,14 @@
 extends Node
-"""
-Maintains a queue of pending cutscenes.
+## Maintains a queue of pending cutscenes.
+##
+## When the game plays cutscenes, it plays one or more cutscenes and sometimes plays a level or returns to a different
+## overworld scene. This script maintains a queue of the pending cutscenes and levels.
 
-When the game plays cutscenes, it plays one or more cutscenes and sometimes plays a level or returns to a different
-overworld scene. This script maintains a queue of the pending cutscenes and levels.
-"""
-
-# List of positions the sensei should spawn following a cutscene where the sensei was absent.
+## List of positions the sensei should spawn following a cutscene where the sensei was absent.
 #
-# In most cutscenes, the player and sensei will spawn at their position in the cutscene. For cutscenes where the sensei
-# was absent, we spawn them near the player. This dictionary contains a list of those spawn locations keyed by the
-# player's location in the cutscene, in the format '<location_id>/<spawn_id>'
+## In most cutscenes, the player and sensei will spawn at their position in the cutscene. For cutscenes where the
+## sensei was absent, we spawn them near the player. This dictionary contains a list of those spawn locations keyed by
+## the player's location in the cutscene, in the format '<location_id>/<spawn_id>'
 const SENSEI_SPAWN_IDS_BY_PLAYER_LOCATION := {
 	"outdoors/restaurant_1": "restaurant_11",
 	"outdoors/restaurant_4": "restaurant_11",
@@ -25,65 +23,49 @@ const SENSEI_SPAWN_IDS_BY_PLAYER_LOCATION := {
 	"indoors/kitchen_11": "kitchen_5",
 }
 
-# Queue of ChatTree and String instances. ChatTrees represent cutscenes, and strings represent level IDs.
+## Queue of ChatTree and String instances. ChatTrees represent cutscenes, and strings represent level IDs.
 var _queue := []
 
 func reset() -> void:
 	_queue.clear()
 
 
-"""
-Adds a cutscene to the back of the queue.
-"""
+## Adds a cutscene to the back of the queue.
 func enqueue_chat_tree(chat_tree: ChatTree) -> void:
 	_queue.push_back(chat_tree)
 
 
-"""
-Inserts a cutscene in the given position in the queue.
-"""
+## Inserts a cutscene in the given position in the queue.
 func insert_chat_tree(position: int, chat_tree: ChatTree) -> void:
 	_queue.insert(position, chat_tree)
 
 
-"""
-Adds a level to the back of the queue.
-"""
+## Adds a level to the back of the queue.
 func enqueue_level(level_id: String) -> void:
 	_queue.push_back(level_id)
 
 
-"""
-Returns 'true' if the first item in the queue represents a cutscene.
-"""
+## Returns 'true' if the first item in the queue represents a cutscene.
 func is_front_chat_tree() -> bool:
 	return _queue and _queue.front() is ChatTree
 
 
-"""
-Returns 'true' if the first item in the queue represents a level.
-"""
+## Returns 'true' if the first item in the queue represents a level.
 func is_front_level_id() -> bool:
 	return _queue and _queue.front() is String
 
 
-"""
-Removes and returns the cutscene at the front of the queue.
-"""
+## Removes and returns the cutscene at the front of the queue.
 func pop_chat_tree() -> ChatTree:
 	return _queue.pop_front() as ChatTree
 
 
-"""
-Removes and returns the level at the front of the queue.
-"""
+## Removes and returns the level at the front of the queue.
 func pop_level_id() -> String:
 	return _queue.pop_front() as String
 
 
-"""
-Transitions to the cutscene at the front of the queue, staying at the current level in the breadcrumb trail.
-"""
+## Transitions to the cutscene at the front of the queue, staying at the current level in the breadcrumb trail.
 func replace_cutscene_trail() -> void:
 	if not is_front_chat_tree():
 		push_error("CutsceneManager._queue.front (%s) is not a cutscene" % [_queue.front()])
@@ -93,9 +75,7 @@ func replace_cutscene_trail() -> void:
 	SceneTransition.replace_trail(chat_tree.chat_scene_path())
 
 
-"""
-Transitions to the cutscene at the front of the queue, extending the breadcrumb trail.
-"""
+## Transitions to the cutscene at the front of the queue, extending the breadcrumb trail.
 func push_cutscene_trail() -> void:
 	if not is_front_chat_tree():
 		push_error("CutsceneManager._queue.front (%s) is not a cutscene" % [_queue.front()])
@@ -105,9 +85,7 @@ func push_cutscene_trail() -> void:
 	SceneTransition.push_trail(chat_tree.chat_scene_path())
 
 
-"""
-Transitions to the level at the front of the queue, extending the breadcrumb trail.
-"""
+## Transitions to the level at the front of the queue, extending the breadcrumb trail.
 func push_level_trail() -> void:
 	if not is_front_level_id():
 		push_error("CutsceneManager._queue.front (%s) is not a level id" % [_queue.front()])
@@ -117,11 +95,9 @@ func push_level_trail() -> void:
 	CurrentLevel.push_level_trail()
 
 
-"""
-Assign the player and sensei spawn IDs based on the specified chat tree.
-
-This makes it so they'll spawn in appopriate positions after the cutscene is over.
-"""
+## Assign the player and sensei spawn IDs based on the specified chat tree.
+##
+## This makes it so they'll spawn in appopriate positions after the cutscene is over.
 func assign_player_spawn_ids(chat_tree: ChatTree) -> void:
 	Global.player_spawn_id = ""
 	Global.sensei_spawn_id = ""

--- a/project/src/main/world/environment/buttercup-sign.gd
+++ b/project/src/main/world/environment/buttercup-sign.gd
@@ -1,9 +1,7 @@
 extends OverworldObstacle
-"""
-The 'Buttercup Cafe' sign which appears on the overworld.
-"""
+## The 'Buttercup Cafe' sign which appears on the overworld.
 
-# Defining chat extents makes this sign easier to interact with when obstructed
+## Defining chat extents makes this sign easier to interact with when obstructed
 onready var chat_extents: Vector2 = $CollisionShape2D.shape.extents
 
 func _ready() -> void:

--- a/project/src/main/world/environment/obstacle-map-shadows.gd
+++ b/project/src/main/world/environment/obstacle-map-shadows.gd
@@ -1,18 +1,14 @@
 extends TileMap
-"""
-Draws shadows under tiles from an obstacle tilemap.
-"""
+## Draws shadows under tiles from an obstacle tilemap.
 
 export (NodePath) var obstacle_map_path: NodePath
 
-"""
-Maps tile indexes to their grid size. This allows us to generate larger shadows for tiles which span multiple cells.
-
-This mapping is optional. Tile indexes which are absent will be given a 1x1 cell shadow.
-
-key: tile index corresponding to a tile in the obstacle map
-value: a rectangle which measures tile's grid size, in cells
-"""
+## Maps tile indexes to their grid size. This allows us to generate larger shadows for tiles which span multiple cells.
+##
+## This mapping is optional. Tile indexes which are absent will be given a 1x1 cell shadow.
+##
+## key: tile index corresponding to a tile in the obstacle map
+## value: a rectangle which measures tile's grid size, in cells
 export (Dictionary) var cell_shadow_mapping
 
 onready var _obstacle_map: TileMap = get_node(obstacle_map_path)

--- a/project/src/main/world/environment/oval-shadow.gd
+++ b/project/src/main/world/environment/oval-shadow.gd
@@ -1,12 +1,10 @@
 class_name OvalShadow
 extends Sprite
-"""
-Script which updates the position of a shadow beneath a 'shadow caster'.
-"""
+## Script which updates the position of a shadow beneath a 'shadow caster'.
 
 export (NodePath) var shadow_caster_path: NodePath setget set_shadow_caster_path
 
-# The shadow caster this shadow is for
+## The shadow caster this shadow is for
 var _shadow_caster: Node2D
 
 func _ready() -> void:
@@ -25,9 +23,7 @@ func set_shadow_caster_path(new_shadow_caster_path: NodePath) -> void:
 	_refresh_shadow_caster_path()
 
 
-"""
-Connects the shadow to a new shadow caster and updates its position.
-"""
+## Connects the shadow to a new shadow caster and updates its position.
 func _refresh_shadow_caster_path() -> void:
 	if not (is_inside_tree() and shadow_caster_path):
 		return

--- a/project/src/main/world/environment/overworld-obstacle.gd
+++ b/project/src/main/world/environment/overworld-obstacle.gd
@@ -1,33 +1,27 @@
 class_name OverworldObstacle
 extends KinematicBody2D
-"""
-Something which blocks the player on the overworld, such as a tree or bush.
+## Something which blocks the player on the overworld, such as a tree or bush.
+##
+## These objects can also be inspected (talked to) if the chat_key is set.
 
-These objects can also be inspected (talked to) if the chat_key is set.
-"""
-
-# the size of the shadow cast by this object
+## the size of the shadow cast by this object
 export (float) var shadow_scale: float = 1.0 setget set_shadow_scale
 
-# The key identifying the chat resource for this object. If set, the object will have a thought bubble and the player
-# will be able to inspect it.
+## The key identifying the chat resource for this object. If set, the object will have a thought bubble and the player
+## will be able to inspect it.
 export (String) var chat_key: String setget set_chat_key
 
 func _init() -> void:
 	add_to_group("shadow_casters")
 
 
-"""
-When the shadow scale is set, we update the node's metadata so the shadow will be rendered correctly.
-"""
+## When the shadow scale is set, we update the node's metadata so the shadow will be rendered correctly.
 func set_shadow_scale(new_shadow_scale: float) -> void:
 	shadow_scale = new_shadow_scale
 	set_meta("shadow_scale", shadow_scale)
 
 
-"""
-When the chat path is set, we update the node's groups and metadata to integrate the node into the chat framework.
-"""
+## When the chat path is set, we update the node's groups and metadata to integrate the node into the chat framework.
 func set_chat_key(new_chat_key: String) -> void:
 	chat_key = new_chat_key
 	if new_chat_key:

--- a/project/src/main/world/environment/ripple-sprite.gd
+++ b/project/src/main/world/environment/ripple-sprite.gd
@@ -1,12 +1,10 @@
 class_name RippleSprite
 extends AnimatedSprite
-"""
-Renders an animated goop ripple.
+## Renders an animated goop ripple.
+##
+## Each ripple is only one tile in size. A goop wave is made up of many ripples in a line.
 
-Each ripple is only one tile in size. A goop wave is made up of many ripples in a line.
-"""
-
-# duration for goop ripples to fade in and out when they hit the edge of the map
+## duration for goop ripples to fade in and out when they hit the edge of the map
 const FADE_DURATION := 0.3
 
 export (Ripples.RippleState) var ripple_state := Ripples.RippleState.OFF setget set_ripple_state
@@ -18,9 +16,7 @@ func _ready() -> void:
 	_refresh_ripple_state()
 
 
-"""
-Sets the ripple state and updates the ripple's appearance.
-"""
+## Sets the ripple state and updates the ripple's appearance.
 func set_ripple_state(new_ripple_state: int) -> void:
 	if ripple_state == new_ripple_state:
 		return
@@ -29,13 +25,11 @@ func set_ripple_state(new_ripple_state: int) -> void:
 	_refresh_ripple_state()
 
 
-"""
-Updates the ripple appearance based on the ripple state.
-
-If the ripple state is 'left', 'right', 'both' or 'none', this makes the sprite visible and plays an animation.
-
-If the ripple state is 'off', this makes the sprite invisible.
-"""
+## Updates the ripple appearance based on the ripple state.
+##
+## If the ripple state is 'left', 'right', 'both' or 'none', this makes the sprite visible and plays an animation.
+##
+## If the ripple state is 'off', this makes the sprite invisible.
 func _refresh_ripple_state() -> void:
 	# fade the sprite in or out
 	var new_modulate := Color.transparent if ripple_state == Ripples.RippleState.OFF else Color.white

--- a/project/src/main/world/environment/ripple-wave.gd
+++ b/project/src/main/world/environment/ripple-wave.gd
@@ -1,27 +1,25 @@
 class_name RippleWave
 extends Node2D
-"""
-Renders an animated goop wave.
+## Renders an animated goop wave.
+##
+## A goop wave is made up of many RippleSprite instances in a line.
 
-A goop wave is made up of many RippleSprite instances in a line.
-"""
-
-# controls how frequently waves speed up and slow down, in seconds
+## controls how frequently waves speed up and slow down, in seconds
 const SPEED_PERIOD := 6.0
 
 export (float) var speed: float = 100.0
 export (PackedScene) var RippleSpriteScene: PackedScene
 
-# The tilemap where waves should appear. Ripples appear and disappear based on the occupied cells of this tilemap.
+## The tilemap where waves should appear. Ripples appear and disappear based on the occupied cells of this tilemap.
 var _tile_map: TileMap
 
-# an enum from Ripples.RippleDirection for this wave's movement
+## an enum from Ripples.RippleDirection for this wave's movement
 var _direction: int = Ripples.RippleDirection.SOUTHEAST
 
-# the current position in the speed adjustment curve
+## the current position in the speed adjustment curve
 var _speed_phase := rand_range(0, SPEED_PERIOD)
 
-# controls how frequently this wave speeds up and slows down, in seconds
+## controls how frequently this wave speeds up and slows down, in seconds
 var _speed_period := rand_range(SPEED_PERIOD * 0.5, SPEED_PERIOD * 1.5)
 
 func _ready() -> void:
@@ -52,21 +50,17 @@ func _process(delta: float) -> void:
 		queue_free()
 
 
-"""
-Called after instance() to set the wave's initial values.
-"""
+## Called after instance() to set the wave's initial values.
 func initialize(init_tile_map: TileMap, init_direction: int, init_position: Vector2) -> void:
 	_tile_map = init_tile_map
 	_direction = init_direction
 	position = init_position
 
 
-"""
-Adds all ripple sprites corresponding to this wave.
-
-Ripples are never added after the wave is initially spawned. Instead, they are turned visible/invisible as the
-underlying terrain changes.
-"""
+## Adds all ripple sprites corresponding to this wave.
+##
+## Ripples are never added after the wave is initially spawned. Instead, they are turned visible/invisible as the
+## underlying terrain changes.
 func _add_ripple_sprites() -> void:
 	# calculate which cells are on the edge of the tilemap
 	# all cells get a ripplesprite. unoccupied cells get a ripplesprite which starts invisible
@@ -81,9 +75,7 @@ func _add_ripple_sprites() -> void:
 				_add_ripple_sprite(Vector2(cell_position.x, y))
 
 
-"""
-Adds a ripple sprite overlaying the specified position in the tilemap.
-"""
+## Adds a ripple sprite overlaying the specified position in the tilemap.
 func _add_ripple_sprite(cell_pos: Vector2) -> void:
 	var ripple_sprite: RippleSprite = RippleSpriteScene.instance()
 	
@@ -106,9 +98,7 @@ func _add_ripple_sprite(cell_pos: Vector2) -> void:
 	add_child(ripple_sprite)
 
 
-"""
-Refreshes all ripple's states and appearance based on the tilemap.
-"""
+## Refreshes all ripple's states and appearance based on the tilemap.
 func _refresh_ripple_sprites() -> void:
 	var cell_forward_vector: Vector2 = Ripples.TILEMAP_VECTOR_BY_RIPPLE_DIRECTION[_direction]
 	var cell_right_vector: Vector2 = _round_vector2(cell_forward_vector.rotated(PI / 2))
@@ -147,10 +137,8 @@ func _refresh_ripple_sprites() -> void:
 			ripple_sprite.ripple_state = Ripples.RippleState.CONNECTED_NONE
 
 
-"""
-Rounds floating point vectors to avoid bugs when interacting with the TileMap class.
-
-Workaround for Godot #18324 (https://github.com/godotengine/godot/issues/18324).
-"""
+## Rounds floating point vectors to avoid bugs when interacting with the TileMap class.
+##
+## Workaround for Godot #18324 (https://github.com/godotengine/godot/issues/18324).
 static func _round_vector2(v: Vector2) -> Vector2:
 	return Vector2(round(v.x), round(v.y))

--- a/project/src/main/world/environment/ripple-waves.gd
+++ b/project/src/main/world/environment/ripple-waves.gd
@@ -1,25 +1,23 @@
 extends Node2D
-"""
-Renders animated goop waves.
-"""
+## Renders animated goop waves.
 
 const MAX_WAVE_COUNT := 50
 
-# the path to the underlying tilemap which controls where waves can spawn
+## the path to the underlying tilemap which controls where waves can spawn
 export (NodePath) var tile_map_path: NodePath
 
-# wave movement direction
+## wave movement direction
 export (Ripples.RippleDirection) var direction := Ripples.RippleDirection.NORTHEAST
 
 export (PackedScene) var RippleWaveScene: PackedScene
 
-# wave movement speed
+## wave movement speed
 export (float) var speed: float = 100.0
 
-# duration between waves
+## duration between waves
 export (float) var wait_time: float = 6.0
 
-# the path underlying tilemap which controls where waves can spawn
+## the path underlying tilemap which controls where waves can spawn
 onready var _tile_map: TileMap = get_node(tile_map_path)
 
 onready var _wave_spawn_timer := $WaveSpawnTimer
@@ -40,11 +38,9 @@ func _ready() -> void:
 		_spawn_wave(wave_position)
 
 
-"""
-Calculates the position of the specified wave.
-
-When spawning the initial waves, waves are offset based on the wave frequency and movement speed.
-"""
+## Calculates the position of the specified wave.
+##
+## When spawning the initial waves, waves are offset based on the wave frequency and movement speed.
 func _wave_position(wave_index: int = 0) -> Vector2:
 	# calculate where the first wave should spawn
 	var wave_cell_position := Vector2(0, 0)
@@ -71,9 +67,7 @@ func _wave_position(wave_index: int = 0) -> Vector2:
 	return zero_wave_position + wave_index * offset_per_wave
 
 
-"""
-Spawns a wave at the specified position.
-"""
+## Spawns a wave at the specified position.
 func _spawn_wave(wave_position: Vector2) -> void:
 	var ripple_wave_scene: RippleWave = RippleWaveScene.instance()
 	ripple_wave_scene.initialize(_tile_map, direction, wave_position)

--- a/project/src/main/world/environment/ripples.gd
+++ b/project/src/main/world/environment/ripples.gd
@@ -1,9 +1,7 @@
 class_name Ripples
-"""
-Enums, constants and utilities for overworld goop ripples.
-"""
+## Enums, constants and utilities for overworld goop ripples.
 
-# directions waves can travel
+## directions waves can travel
 enum RippleDirection {
 	NORTHEAST,
 	SOUTHEAST,
@@ -11,7 +9,7 @@ enum RippleDirection {
 	NORTHWEST,
 }
 
-# states controlling a ripple's appearance
+## states controlling a ripple's appearance
 enum RippleState {
 	OFF,
 	CONNECTED_NONE,
@@ -20,8 +18,8 @@ enum RippleState {
 	CONNECTED_BOTH,
 }
 
-# key: enum from RippleDirection
-# value: unit vector for use in tilemaps; northeast points up
+## key: enum from RippleDirection
+## value: unit vector for use in tilemaps; northeast points up
 const TILEMAP_VECTOR_BY_RIPPLE_DIRECTION := {
 	RippleDirection.NORTHEAST: Vector2.UP,
 	RippleDirection.SOUTHEAST: Vector2.RIGHT,
@@ -29,8 +27,8 @@ const TILEMAP_VECTOR_BY_RIPPLE_DIRECTION := {
 	RippleDirection.NORTHWEST: Vector2.LEFT,
 }
 
-# key: enum from RippleDirection
-# value: unit vector where abs(x) = abs(2y); northeast points right and slightly up
+## key: enum from RippleDirection
+## value: unit vector where abs(x) = abs(2y); northeast points right and slightly up
 const ISO_VECTOR_BY_RIPPLE_DIRECTION := {
 	RippleDirection.NORTHEAST: Vector2(0.89443, -0.44721),
 	RippleDirection.SOUTHEAST: Vector2(0.89443, 0.44721),

--- a/project/src/main/world/environment/stool.gd
+++ b/project/src/main/world/environment/stool.gd
@@ -1,19 +1,17 @@
 tool
 class_name Stool
 extends OverworldObstacle
-"""
-A stool which appears on the overworld.
+## A stool which appears on the overworld.
+##
+## The stool can toggle to an 'occupied' state when it's sat upon. This affects its collisions and appearance.
 
-The stool can toggle to an 'occupied' state when it's sat upon. This affects its collisions and appearance.
-"""
-
-# the texture to use when the stool has a creature sitting on it
+## the texture to use when the stool has a creature sitting on it
 export (Texture) var occupied_texture: Texture
 
-# the texture to use when the stool does not have a creature sitting on it
+## the texture to use when the stool does not have a creature sitting on it
 export (Texture) var unoccupied_texture: Texture
 
-# 'true' if the stool has a creature sitting on it
+## 'true' if the stool has a creature sitting on it
 export (bool) var occupied := false setget set_occupied
 
 func _ready() -> void:

--- a/project/src/main/world/ground-map-indoors.gd
+++ b/project/src/main/world/ground-map-indoors.gd
@@ -1,19 +1,17 @@
 tool
 extends TileMap
-"""
-Maintains a tilemap for indoor floors.
+## Maintains a tilemap for indoor floors.
+##
+## The indoor tilemap special tiling logic to render floors with deliberate imperfections.
 
-The indoor tilemap special tiling logic to render floors with deliberate imperfections.
-"""
-
-# the index of specific tiles in the tilemap's tileset
+## the index of specific tiles in the tilemap's tileset
 const CARPET_TILE_INDEX := 82455
 const KITCHEN_TILE_INDEX := 54907
 
-# autotile coordinates for a carpet cell without imperfections
+## autotile coordinates for a carpet cell without imperfections
 const CARPET_FLAWLESS_CELL := Vector2(0, 0)
 
-# autotile coordinates for carpet cells with imperfections
+## autotile coordinates for carpet cells with imperfections
 const CARPET_FLAWED_CELLS := [
 	Vector2(1, 0), Vector2(2, 0),
 	Vector2(0, 1), Vector2(1, 1), Vector2(2, 1),
@@ -21,36 +19,34 @@ const CARPET_FLAWED_CELLS := [
 	Vector2(0, 3), Vector2(1, 3), Vector2(2, 3),
 ]
 
-# percent of carpet cells without imperfections, in the range [0.0, 1.0]
+## percent of carpet cells without imperfections, in the range [0.0, 1.0]
 const CARPET_QUALITY := 0.86
 
-# autotile coordinates for a kitchen cell with a drain
+## autotile coordinates for a kitchen cell with a drain
 const KITCHEN_DRAIN_CELL := Vector2(1, 0)
 
-# autotile coordinates for a kitchen cell without imperfections
+## autotile coordinates for a kitchen cell without imperfections
 const KITCHEN_FLAWLESS_CELL := Vector2(0, 0)
 
-# autotile coordinates for a kitchen cell with imperfections
+## autotile coordinates for a kitchen cell with imperfections
 const KITCHEN_FLAWED_CELLS := [
 	Vector2(2, 0),
 	Vector2(0, 1), Vector2(1, 1), Vector2(2, 1),
 	Vector2(0, 2), Vector2(1, 2), Vector2(2, 2),
 	Vector2(0, 3), Vector2(1, 3), Vector2(2, 3),
 ]
-# percent of kitchen cells without imperfections, in the range [0.0, 1.0]
+## percent of kitchen cells without imperfections, in the range [0.0, 1.0]
 const KITCHEN_QUALITY := 0.93
 
-# An editor toggle which manually applies autotiling.
+## An editor toggle which manually applies autotiling.
 #
-# Godot has no way of automatically reacting to GridMap/TileMap changes. See Godot #11855
-# https://github.com/godotengine/godot/issues/11855
+## Godot has no way of automatically reacting to GridMap/TileMap changes. See Godot #11855
+## https://github.com/godotengine/godot/issues/11855
 export (bool) var _autotile: bool setget autotile
 
-"""
-Autotiles floors, applying imperfections.
-
-The floor autotiling logic applies probabilities and cannot be handled by Godot's built-in autotiling.
-"""
+## Autotiles floors, applying imperfections.
+##
+## The floor autotiling logic applies probabilities and cannot be handled by Godot's built-in autotiling.
 func autotile(_value: bool) -> void:
 	for cell in get_used_cells():
 		match get_cellv(cell):
@@ -58,12 +54,10 @@ func autotile(_value: bool) -> void:
 			KITCHEN_TILE_INDEX: _autotile_kitchen_floor(cell)
 
 
-"""
-Autotiles a tile containing a carpet.
-
-Parameters:
-	'cell': The TileMap coordinates of the cell to be autotiled.
-"""
+## Autotiles a tile containing a carpet.
+##
+## Parameters:
+## 	'cell': The TileMap coordinates of the cell to be autotiled.
 func _autotile_carpet(cell: Vector2) -> void:
 	if randf() < CARPET_QUALITY:
 		# replace the cell with a perfect carpet tile
@@ -73,14 +67,12 @@ func _autotile_carpet(cell: Vector2) -> void:
 		_set_cell_autotile_coord(cell, Utils.rand_value(CARPET_FLAWED_CELLS))
 
 
-"""
-Autotiles a tile containing a tiled kitchen floor.
-
-Tiles containing regular floors are randomly blemished, while tiles containing drains are left alone.
-
-Parameters:
-	'cell': The TileMap coordinates of the cell to be autotiled.
-"""
+## Autotiles a tile containing a tiled kitchen floor.
+##
+## Tiles containing regular floors are randomly blemished, while tiles containing drains are left alone.
+##
+## Parameters:
+## 	'cell': The TileMap coordinates of the cell to be autotiled.
 func _autotile_kitchen_floor(cell: Vector2) -> void:
 	if get_cell_autotile_coord(cell.x, cell.y) == KITCHEN_DRAIN_CELL:
 		# cell contains a drain; leave it alone
@@ -93,14 +85,12 @@ func _autotile_kitchen_floor(cell: Vector2) -> void:
 		_set_cell_autotile_coord(cell, Utils.rand_value(KITCHEN_FLAWED_CELLS))
 
 
-"""
-Updates the autotile coordinate for a TileMap cell.
-
-Parameters:
-	'cell': The TileMap coordinates of the cell to be updated.
-	
-	'autotile_coord': The autotile coordinates to assign.
-"""
+## Updates the autotile coordinate for a TileMap cell.
+##
+## Parameters:
+## 	'cell': The TileMap coordinates of the cell to be updated.
+##
+## 	'autotile_coord': The autotile coordinates to assign.
 func _set_cell_autotile_coord(cell: Vector2, autotile_coord: Vector2) -> void:
 	var tile: int = get_cell(cell.x, cell.y)
 	var flip_x: bool = is_cell_x_flipped(cell.x, cell.y)

--- a/project/src/main/world/letter-projectile.gd
+++ b/project/src/main/world/letter-projectile.gd
@@ -1,37 +1,33 @@
 class_name LetterProjectile
 extends Node2D
-"""
-A letter emitted when a creature talks.
-"""
+## A letter emitted when a creature talks.
 
-# How fast the letter should move
+## How fast the letter should move
 const BASE_SPEED := 92.0
 
-# Letters to cycle through when spawning projectiles.
-# These spell out Turbofat in Katakana, sort of (ta-ru-bo-ha-to)
+## Letters to cycle through when spawning projectiles.
+## These spell out Turbofat in Katakana, sort of (ta-ru-bo-ha-to)
 const LETTERS := ["タ", "ル", "ボ", "フ", "ト"]
 
-# How fast the letter should move relative to the base speed. 1.0 = 100% speed. 0.0 = 0% speed.
+## How fast the letter should move relative to the base speed. 1.0 = 100% speed. 0.0 = 0% speed.
 export (float) var speed_scale := 1.0
 
-# The direction the letter should move, in radians
+## The direction the letter should move, in radians
 var angle := 0.0
 
 var speed := BASE_SPEED
 
-"""
-Initializes the letter's text, position and angle.
-
-A small amount of noise is applied to the position and angle so that the letters don't move in a perfectly uniform
-manner.
-
-Parameters:
-	'init_index': The letter's index. Used to cycle its appearance and behavior.
-	
-	'init_position': The approximate position where the letter should spawn.
-	
-	'init_angle': The approximate direction the letter should move, in radians
-"""
+## Initializes the letter's text, position and angle.
+##
+## A small amount of noise is applied to the position and angle so that the letters don't move in a perfectly uniform
+## manner.
+##
+## Parameters:
+## 	'init_index': The letter's index. Used to cycle its appearance and behavior.
+##
+## 	'init_position': The approximate position where the letter should spawn.
+##
+## 	'init_angle': The approximate direction the letter should move, in radians
 func initialize(init_index: int, init_position: Vector2, init_angle: float) -> void:
 	position = init_position + Vector2(rand_range(-4.0, 4.0), rand_range(-4.0, 4.0))
 	angle = init_angle + rand_range(0.04, 0.10) * (1.0 if init_index % 2 == 0 else -1.0)

--- a/project/src/main/world/letter-shooter.gd
+++ b/project/src/main/world/letter-shooter.gd
@@ -1,51 +1,41 @@
 class_name LetterShooter
 extends Node
-"""
-Emits letters from a particular position and direction.
-"""
+## Emits letters from a particular position and direction.
 
-# the scene describing the letters to emit
+## the scene describing the letters to emit
 export (PackedScene) var LetterProjectileScene: PackedScene
 
-# The approximate direction the letter should move, in radians
+## The approximate direction the letter should move, in radians
 export (float) var letter_angle := 0.0
 
-# The approximate position where the letter should spawn.
+## The approximate position where the letter should spawn.
 export (Vector2) var letter_position: Vector2
 
-# The next letter's index. Used to cycle the letter's appearance and behavior.
+## The next letter's index. Used to cycle the letter's appearance and behavior.
 var _letter_index := 0
 
 func _ready() -> void:
 	$ShootTimer.connect("timeout", self, "_on_ShootTimer_timeout")
 
 
-"""
-Start emitting letters.
-
-Letters will emit continuously until stop() is called.
-"""
+## Start emitting letters.
+##
+## Letters will emit continuously until stop() is called.
 func start() -> void:
 	$ShootTimer.start()
 
 
-"""
-Stop emitting letters.
-"""
+## Stop emitting letters.
 func stop() -> void:
 	$ShootTimer.stop()
 
 
-"""
-Returns 'true' if this LetterShooter is not currently emitting letters.
-"""
+## Returns 'true' if this LetterShooter is not currently emitting letters.
 func is_stopped() -> bool:
 	return $ShootTimer.is_stopped()
 
 
-"""
-Emit a new letter.
-"""
+## Emit a new letter.
 func _on_ShootTimer_timeout() -> void:
 	var letter_projectile: LetterProjectile = LetterProjectileScene.instance()
 	letter_projectile.initialize(_letter_index, letter_position, letter_angle)

--- a/project/src/main/world/obstacle-map-indoors.gd
+++ b/project/src/main/world/obstacle-map-indoors.gd
@@ -1,32 +1,30 @@
 tool
 class_name ObstacleMapIndoors
 extends ObstacleMap
-"""
-Maintains a tilemap for indoor obstacles.
-
-The indoor tilemap is an isometric tilemap which must be drawn from left to right. This tilemap includes functionality
-for sorting tiles by their x coordinate.
-"""
+## Maintains a tilemap for indoor obstacles.
+##
+## The indoor tilemap is an isometric tilemap which must be drawn from left to right. This tilemap includes
+## functionality for sorting tiles by their x coordinate.
 
 const BIND_TOP := TileSet.BIND_TOP
 const BIND_BOTTOM := TileSet.BIND_BOTTOM
 const BIND_LEFT := TileSet.BIND_LEFT
 const BIND_RIGHT := TileSet.BIND_RIGHT
 
-# constants representing the orientation of certain tiles, which direction objects are facing
+## constants representing the orientation of certain tiles, which direction objects are facing
 const UP := 1
 const DOWN := 2
 const LEFT := 4
 const RIGHT := 8
 
-# the index of specific tiles in the tilemap's tileset
+## the index of specific tiles in the tilemap's tileset
 const BARE_COUNTERTOP_TILE_INDEX := 8
 const GRILL_TILE_INDEX := 9
 const SINK_TILE_INDEX := 10
 const COUNTERTOP_PLATES_TILE_INDEX := 11
 
-# key: union of TileSet bindings for adjacent cells containing countertops
-# value: countertop autotile coordinate
+## key: union of TileSet bindings for adjacent cells containing countertops
+## value: countertop autotile coordinate
 var COUNTERTOP_AUTOTILE_COORDS_BY_BINDING := {
 	0: Vector2(0, 0),
 	BIND_TOP: Vector2(1, 0),
@@ -41,8 +39,8 @@ var COUNTERTOP_AUTOTILE_COORDS_BY_BINDING := {
 	BIND_LEFT | BIND_RIGHT: Vector2(2, 2),
 }
 
-# key: union of TileSet bindings for adjacent cells containing countertops
-# value: array of possible countertop-plates autotile coordinates
+## key: union of TileSet bindings for adjacent cells containing countertops
+## value: array of possible countertop-plates autotile coordinates
 var COUNTERTOP_PLATES_AUTOTILE_COORDS_BY_BINDING := {
 	0: [Vector2(0, 0), Vector2(1, 0)],
 	BIND_TOP: [Vector2(2, 0), Vector2(3, 0)],
@@ -58,8 +56,8 @@ var COUNTERTOP_PLATES_AUTOTILE_COORDS_BY_BINDING := {
 	BIND_LEFT | BIND_RIGHT: [Vector2(4, 3), Vector2(5, 3), Vector2(0, 4), Vector2(1, 4)],
 }
 
-# key: countertop autotile coordinate
-# value: direction which the grill is facing on that tile (UP, DOWN, LEFT, RIGHT)
+## key: countertop autotile coordinate
+## value: direction which the grill is facing on that tile (UP, DOWN, LEFT, RIGHT)
 var GRILL_ORIENTATION_BY_CELL := {
 	Vector2(0, 0): UP,
 	Vector2(1, 0): UP,
@@ -95,11 +93,11 @@ var GRILL_ORIENTATION_BY_CELL := {
 	Vector2(3, 7): RIGHT,
 }
 
-# key: array containing 3 elements representing TileSet bindings and metadata:
-#    key[0] = direction which the grill is currently facing (UP, DOWN, LEFT, RIGHT)
-#    key[1] = union of TileSet bindings for adjacent cells containing grills
-#    key[2] = union of TileSet bindings for adjacent cells containing grills and countertops
-# value: grill autotile coordinate
+## key: array containing 3 elements representing TileSet bindings and metadata:
+##    key[0] = direction which the grill is currently facing (UP, DOWN, LEFT, RIGHT)
+##    key[1] = union of TileSet bindings for adjacent cells containing grills
+##    key[2] = union of TileSet bindings for adjacent cells containing grills and countertops
+## value: grill autotile coordinate
 const GRILL_AUTOTILE_COORDS_BY_BINDING := {
 	[UP, 0, 0]: Vector2(0, 0),
 	[UP, 0, BIND_LEFT]: Vector2(1, 0),
@@ -135,8 +133,8 @@ const GRILL_AUTOTILE_COORDS_BY_BINDING := {
 	[RIGHT, BIND_BOTTOM, BIND_TOP | BIND_BOTTOM]: Vector2(3, 7),
 }
 
-# key: sink autotile coordinate
-# value: direction which the sink is facing on that tile (UP, DOWN, LEFT, RIGHT)
+## key: sink autotile coordinate
+## value: direction which the sink is facing on that tile (UP, DOWN, LEFT, RIGHT)
 const SINK_ORIENTATION_BY_CELL := {
 	Vector2(0, 0): UP,
 	Vector2(1, 0): UP,
@@ -152,10 +150,10 @@ const SINK_ORIENTATION_BY_CELL := {
 	Vector2(2, 3): RIGHT,
 }
 
-# key: array containing 3 elements representing TileSet bindings and metadata:
-#    key[0] = direction which the sink is currently facing (UP, DOWN, LEFT, RIGHT)
-#    key[1] = union of TileSet bindings for adjacent cells containing sinks
-# value: sink autotile coordinate
+## key: array containing 3 elements representing TileSet bindings and metadata:
+##    key[0] = direction which the sink is currently facing (UP, DOWN, LEFT, RIGHT)
+##    key[1] = union of TileSet bindings for adjacent cells containing sinks
+## value: sink autotile coordinate
 const SINK_AUTOTILE_COORDS_BY_BINDING := {
 	[UP, 0]: Vector2(0, 0),
 	[UP, BIND_LEFT]: Vector2(1, 0),
@@ -171,20 +169,18 @@ const SINK_AUTOTILE_COORDS_BY_BINDING := {
 	[RIGHT, BIND_BOTTOM]: Vector2(2, 3),
 }
 
-# An editor toggle which manually applies autotiling.
+## An editor toggle which manually applies autotiling.
 #
-# Godot has no way of automatically reacting to GridMap/TileMap changes. See Godot #11855
-# https://github.com/godotengine/godot/issues/11855
+## Godot has no way of automatically reacting to GridMap/TileMap changes. See Godot #11855
+## https://github.com/godotengine/godot/issues/11855
 export (bool) var _autotile: bool setget autotile
 
 
-"""
-Autotiles tiles with kitchen countertops.
-
-The kitchen countertop autotiling involves multiple cell types and cannot be handled by Godot's built-in autotiling.
-Instead of configuring the autotiling behavior with the TileSet's autotile bitmask, it is configured with several
-dictionary constants defined in this script.
-"""
+## Autotiles tiles with kitchen countertops.
+##
+## The kitchen countertop autotiling involves multiple cell types and cannot be handled by Godot's built-in autotiling.
+## Instead of configuring the autotiling behavior with the TileSet's autotile bitmask, it is configured with several
+## dictionary constants defined in this script.
 func autotile(_value: bool) -> void:
 	for cell in get_used_cells():
 		match get_cellv(cell):
@@ -194,12 +190,10 @@ func autotile(_value: bool) -> void:
 			COUNTERTOP_PLATES_TILE_INDEX: _autotile_countertop_plates(cell)
 
 
-"""
-Autotiles a tile containing a bare countertop.
-
-Parameters:
-	'cell': The TileMap coordinates of the cell to be autotiled.
-"""
+## Autotiles a tile containing a bare countertop.
+##
+## Parameters:
+## 	'cell': The TileMap coordinates of the cell to be autotiled.
 func _autotile_bare_countertop(cell: Vector2) -> void:
 	var adjacent_countertops := _adjacencies(cell,
 			[BARE_COUNTERTOP_TILE_INDEX, GRILL_TILE_INDEX, COUNTERTOP_PLATES_TILE_INDEX])
@@ -209,12 +203,10 @@ func _autotile_bare_countertop(cell: Vector2) -> void:
 		_set_cell_autotile_coord(cell, COUNTERTOP_AUTOTILE_COORDS_BY_BINDING[adjacent_countertops])
 
 
-"""
-Autotiles a tile containing a countertop with plates on it.
-
-Parameters:
-	'cell': The TileMap coordinates of the cell to be autotiled.
-"""
+## Autotiles a tile containing a countertop with plates on it.
+##
+## Parameters:
+## 	'cell': The TileMap coordinates of the cell to be autotiled.
 func _autotile_countertop_plates(cell: Vector2) -> void:
 	var adjacent_countertops := _adjacencies(cell,
 			[BARE_COUNTERTOP_TILE_INDEX, GRILL_TILE_INDEX, COUNTERTOP_PLATES_TILE_INDEX])
@@ -225,14 +217,12 @@ func _autotile_countertop_plates(cell: Vector2) -> void:
 		_set_cell_autotile_coord(cell, Utils.rand_value(bindings))
 
 
-"""
-Updates the autotile coordinate for a TileMap cell.
-
-Parameters:
-	'cell': The TileMap coordinates of the cell to be updated.
-	
-	'autotile_coord': The autotile coordinates to assign.
-"""
+## Updates the autotile coordinate for a TileMap cell.
+##
+## Parameters:
+## 	'cell': The TileMap coordinates of the cell to be updated.
+##
+## 	'autotile_coord': The autotile coordinates to assign.
 func _set_cell_autotile_coord(cell: Vector2, autotile_coord: Vector2) -> void:
 	var tile: int = get_cell(cell.x, cell.y)
 	var flip_x: bool = is_cell_x_flipped(cell.x, cell.y)
@@ -241,12 +231,10 @@ func _set_cell_autotile_coord(cell: Vector2, autotile_coord: Vector2) -> void:
 	set_cell(cell.x, cell.y, tile, flip_x, flip_y, transpose, autotile_coord)
 
 
-"""
-Autotiles a tile containing a grill.
-
-Parameters:
-	'cell': The TileMap coordinates of the cell to be autotiled.
-"""
+## Autotiles a tile containing a grill.
+##
+## Parameters:
+## 	'cell': The TileMap coordinates of the cell to be autotiled.
 func _autotile_grill(cell: Vector2) -> void:
 	# calculate the grill's current orientation
 	var grill_orientation: int = GRILL_ORIENTATION_BY_CELL.get(get_cell_autotile_coord(cell.x, cell.y))
@@ -268,12 +256,10 @@ func _autotile_grill(cell: Vector2) -> void:
 		_set_cell_autotile_coord(cell, GRILL_AUTOTILE_COORDS_BY_BINDING.get(grill_key))
 
 
-"""
-Autotiles a cell containing a sink.
-
-Parameters:
-	'cell': The TileMap coordinates of the cell to be autotiled.
-"""
+## Autotiles a cell containing a sink.
+##
+## Parameters:
+## 	'cell': The TileMap coordinates of the cell to be autotiled.
 func _autotile_sink(cell: Vector2) -> void:
 	var orientation: int = SINK_ORIENTATION_BY_CELL.get(get_cell_autotile_coord(cell.x, cell.y))
 	
@@ -291,19 +277,16 @@ func _autotile_sink(cell: Vector2) -> void:
 	if SINK_AUTOTILE_COORDS_BY_BINDING.has(sink_key):
 		_set_cell_autotile_coord(cell, SINK_AUTOTILE_COORDS_BY_BINDING.get(sink_key))
 
-
-"""
-Calculates which adjacent cells match the specified tile indexes.
-
-
-Parameters:
-	'cell': The TileMap coordinates of the cell to be analyzed.
-	
-	'tile_indexes': The tile indexes to check for in adjacent cells
-
-Returns:
-	An int bitmask of matching cell directions (UP, DOWN, LEFT, RIGHT)
-"""
+## Calculates which adjacent cells match the specified tile indexes.
+##
+##
+## Parameters:
+## 	'cell': The TileMap coordinates of the cell to be analyzed.
+##
+## 	'tile_indexes': The tile indexes to check for in adjacent cells
+##
+## Returns:
+## 	An int bitmask of matching cell directions (UP, DOWN, LEFT, RIGHT)
 func _adjacencies(cell: Vector2, tile_indexes: Array) -> int:
 	var binding := 0
 	binding |= BIND_TOP if get_cellv(cell + Vector2.UP) in tile_indexes else 0

--- a/project/src/main/world/obstacle-map.gd
+++ b/project/src/main/world/obstacle-map.gd
@@ -1,31 +1,27 @@
 tool
 class_name ObstacleMap
 extends TileMap
-"""
-Maintains a tilemap for overworld obstacles.
-
-This includes visible obstacles such as walls, as well as invisible obstacles which prevent the player from running off
-the edge of the world.
-"""
+## Maintains a tilemap for overworld obstacles.
+##
+## This includes visible obstacles such as walls, as well as invisible obstacles which prevent the player from running
+## off the edge of the world.
 
 export (NodePath) var ground_map_path: NodePath
 
-# the tile index in this tilemap which should be used to make tiles impassable
+## the tile index in this tilemap which should be used to make tiles impassable
 export (int) var impassable_tile_index := -1
 
-# tilemap containing data on which cells are walkable
+## tilemap containing data on which cells are walkable
 onready var _ground_map: TileMap = get_node(ground_map_path)
 
 func _ready() -> void:
 	_refresh_invisible_obstacles()
 
 
-"""
-Refreshes the position of invisible obstacles which keep the player from stepping off the edge.
-
-These invisible obstacles are placed wherever there's an 'unwalkable cell' like a cliff next to a 'walkable cell' like
-a patch of ground.
-"""
+## Refreshes the position of invisible obstacles which keep the player from stepping off the edge.
+##
+## These invisible obstacles are placed wherever there's an 'unwalkable cell' like a cliff next to a 'walkable cell'
+## like a patch of ground.
 func _refresh_invisible_obstacles() -> void:
 	# remove all invisible obstacles
 	for cell_obj in get_used_cells_by_id(impassable_tile_index):

--- a/project/src/main/world/obstacle-spawner.gd
+++ b/project/src/main/world/obstacle-spawner.gd
@@ -1,29 +1,27 @@
 class_name ObstacleSpawner
 extends Node2D
-"""
-Conditionally spawns an obstacle on the overworld.
-
-The decision to spawn the obstacle is controlled by the 'spawn_if' property.
-
-The obstacle's properties and groups (the 'chattables' group in particular) can be managed by the target_properties and
-target_groups fields.
-"""
+## Conditionally spawns an obstacle on the overworld.
+##
+## The decision to spawn the obstacle is controlled by the 'spawn_if' property.
+##
+## The obstacle's properties and groups (the 'chattables' group in particular) can be managed by the target_properties
+## and target_groups fields.
 
 export (NodePath) var overworld_world_path: NodePath = NodePath("../..")
 
-# the PackedScene of the spawned obstacle
+## the PackedScene of the spawned obstacle
 export (PackedScene) var TargetScene: PackedScene
 
-# the properties of the spawned obstacle
+## the properties of the spawned obstacle
 export (Dictionary) var target_properties: Dictionary
 
-# the groups of the spawned obstacle
+## the groups of the spawned obstacle
 export (Array) var target_groups: Array
 
-# a boolean expression which, if evaluated to 'true', will result in the obstacle being spawned
+## a boolean expression which, if evaluated to 'true', will result in the obstacle being spawned
 export (String) var spawn_if: String
 
-# the spawned object, or 'null' if the object has not yet spawned
+## the spawned object, or 'null' if the object has not yet spawned
 var _spawned_object: Node2D
 
 onready var _overworld_world: OverworldWorld = get_node(overworld_world_path)
@@ -38,12 +36,10 @@ func _ready() -> void:
 		queue_free()
 
 
-"""
-Assigns a new property, updating the spawned object if it has already been spawned.
-
-This method is useful for assigning properties during scene setup, when it's not always clear which order
-ObstacleSpawners resolve in or whether they've spawned an object yet.
-"""
+## Assigns a new property, updating the spawned object if it has already been spawned.
+##
+## This method is useful for assigning properties during scene setup, when it's not always clear which order
+## ObstacleSpawners resolve in or whether they've spawned an object yet.
 func set_target_property(property: String, value) -> void:
 	# if the object has not spawned we need to update our target_properties dictionary
 	target_properties[property] = value
@@ -52,9 +48,7 @@ func set_target_property(property: String, value) -> void:
 		_spawned_object.set(property, value)
 
 
-"""
-Spawns the obstacle and remove the spawner from the scene tree.
-"""
+## Spawns the obstacle and remove the spawner from the scene tree.
 func _spawn_target() -> void:
 	# change the spawner's name to avoid conflicting with the spawned object
 	var old_name := name

--- a/project/src/main/world/overworld-bg.gd
+++ b/project/src/main/world/overworld-bg.gd
@@ -1,7 +1,5 @@
 extends ColorRect
-"""
-Background drawn behind the overworld.
-"""
+## Background drawn behind the overworld.
 
 func _ready() -> void:
 	get_tree().get_root().connect("size_changed", self, "_on_Viewport_size_changed")

--- a/project/src/main/world/overworld-buttons.gd
+++ b/project/src/main/world/overworld-buttons.gd
@@ -1,7 +1,5 @@
 extends Control
-"""
-Manages the buttons for the overworld.
-"""
+## Manages the buttons for the overworld.
 
 onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
 
@@ -15,9 +13,7 @@ func _ready() -> void:
 		_resize_container(container)
 
 
-"""
-Resizes a button container based on the player's touch settings.
-"""
+## Resizes a button container based on the player's touch settings.
 func _resize_container(container: Control) -> void:
 	if container.rect_min_size.y != 96 * SystemData.touch_settings.size:
 		container.rect_min_size.y = 96 * SystemData.touch_settings.size

--- a/project/src/main/world/overworld-camera.gd
+++ b/project/src/main/world/overworld-camera.gd
@@ -1,26 +1,24 @@
 extends Camera2D
-"""
-Overworld camera. Follows the main character and zooms in during conversations.
-"""
+## Overworld camera. Follows the main character and zooms in during conversations.
 
-# how far from the camera center the player needs to be before the camera zooms out
+## how far from the camera center the player needs to be before the camera zooms out
 const AUTO_ZOOM_OUT_DISTANCE := 100.0
 
-# amount of empty space around characters
+## amount of empty space around characters
 const CAMERA_BOUNDARY := 160
 
-# duration of sweeping pan/zoom during cutscenes and conversations
+## duration of sweeping pan/zoom during cutscenes and conversations
 const ZOOM_DURATION := 1.8
 
-# speed of pan/zoom adjustments when zoomed in or out
+## speed of pan/zoom adjustments when zoomed in or out
 const LERP_WEIGHT_NEAR := 0.05
 const LERP_WEIGHT_FAR := 0.10
 
-# zoom amount when zoomed in or out
+## zoom amount when zoomed in or out
 const ZOOM_AMOUNT_NEAR := Vector2(0.5, 0.5)
 const ZOOM_AMOUNT_FAR := Vector2(1.0, 1.0)
 
-# 'true' if the camera should currently be zoomed in for a conversation
+## 'true' if the camera should currently be zoomed in for a conversation
 var close_up: bool setget set_close_up
 
 onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
@@ -60,19 +58,15 @@ func set_close_up(new_close_up: bool) -> void:
 	_tween_camera_to_chatters()
 
 
-"""
-Returns a rectangle representing the area which should be captured by the camera.
-"""
+## Returns a rectangle representing the area which should be captured by the camera.
 func _calculate_camera_bounding_box() -> Rect2:
 	return _overworld_ui.get_chatter_bounding_box().grow(CAMERA_BOUNDARY)
 
 
-"""
-Returns a number in the range [0.0, 1.0] corresponding the fattest creature in the cutscene.
-
-A value of 0.0 means all the characters are thin. A value of 1.0 means at least one character is very fat. This value
-is used in making camera adjustments.
-"""
+## Returns a number in the range [0.0, 1.0] corresponding the fattest creature in the cutscene.
+##
+## A value of 0.0 means all the characters are thin. A value of 1.0 means at least one character is very fat. This
+## value is used in making camera adjustments.
 func _max_fatness_weight() -> float:
 	var max_visual_fatness := 1.0
 	for chatter in _overworld_ui.chatters:
@@ -81,11 +75,9 @@ func _max_fatness_weight() -> float:
 	return inverse_lerp(1.0, 10.0, clamp(max_visual_fatness, 1.0, 10.0))
 
 
-"""
-Calculate the desired camera position based on the chatting creatures.
-
-This method does not update the camera's zoom value. It returns a value which can be used in a lerp or tween.
-"""
+## Calculate the desired camera position based on the chatting creatures.
+##
+## This method does not update the camera's zoom value. It returns a value which can be used in a lerp or tween.
 func _calculate_position() -> Vector2:
 	if not ChattableManager.player:
 		return position
@@ -103,11 +95,9 @@ func _calculate_position() -> Vector2:
 	return new_position
 
 
-"""
-Calculate the desired camera zoom based on the chatting creatures.
-
-This method does not update the camera's zoom value. It returns a value which can be used in a lerp or tween.
-"""
+## Calculate the desired camera zoom based on the chatting creatures.
+##
+## This method does not update the camera's zoom value. It returns a value which can be used in a lerp or tween.
 func _calculate_zoom() -> Vector2:
 	if not close_up:
 		return ZOOM_AMOUNT_FAR
@@ -125,11 +115,9 @@ func _calculate_zoom() -> Vector2:
 	return new_zoom
 
 
-"""
-Launches a new tween, panning and zooming the camera to the current chat participants.
-
-This overwrites any old pan/zoom tween.
-"""
+## Launches a new tween, panning and zooming the camera to the current chat participants.
+##
+## This overwrites any old pan/zoom tween.
 func _tween_camera_to_chatters() -> void:
 	_tween.remove_all()
 	var new_zoom := _calculate_zoom()
@@ -159,10 +147,8 @@ func _on_OverworldUi_chat_ended() -> void:
 	set_close_up(false)
 
 
-"""
-Launches a pan/zoom tween when creatures exit or enter the cutscene.
-
-This method might get called multiple times in rapid succession, or possibly even in the same frame.
-"""
+## Launches a pan/zoom tween when creatures exit or enter the cutscene.
+##
+## This method might get called multiple times in rapid succession, or possibly even in the same frame.
 func _on_OverworldUi_visible_chatters_changed() -> void:
 	_tween_camera_to_chatters()

--- a/project/src/main/world/overworld-corner-map.gd
+++ b/project/src/main/world/overworld-corner-map.gd
@@ -1,16 +1,14 @@
 extends TileMap
-"""
-Tilemap which covers the corners of the overworld tilemap.
+## Tilemap which covers the corners of the overworld tilemap.
+##
+## Without this tilemap, a simple 16-tile autotiling would result in tiny holes at the corners of a filled in area.
+## This tilemap fills in the holes.
 
-Without this tilemap, a simple 16-tile autotiling would result in tiny holes at the corners of a filled in area. This
-tilemap fills in the holes.
-"""
-
-# Defines which tiles should be covered by a corner cover. Corner covers are given the same tile index as the source
-# tile, but their autotile index is defined by this mapping.
+## Defines which tiles should be covered by a corner cover. Corner covers are given the same tile index as the source
+## tile, but their autotile index is defined by this mapping.
 #
-# key: (int) tile index which should be covered with a corner cover
-# value: (Vector2) autotile coordinate of the corner cover
+## key: (int) tile index which should be covered with a corner cover
+## value: (Vector2) autotile coordinate of the corner cover
 export (Dictionary) var cornerable_tiles := {}
 
 onready var _parent_map: TileMap = get_parent()
@@ -34,11 +32,9 @@ func _process(_delta: float) -> void:
 		dirty = false
 
 
-"""
-Returns the parent autotile bitmask (PAB) for the specified cell.
-
-This function has a confusingly short name because it's referenced repetitively in some long lines of code.
-"""
+## Returns the parent autotile bitmask (PAB) for the specified cell.
+##
+## This function has a confusingly short name because it's referenced repetitively in some long lines of code.
 func _pab(cell_index: int, cell_pos: Vector2) -> int:
 	var coord := _parent_map.get_cell_autotile_coord(cell_pos.x, cell_pos.y)
 	return _parent_map.tile_set.autotile_get_bitmask(cell_index, coord)

--- a/project/src/main/world/overworld-exit.gd
+++ b/project/src/main/world/overworld-exit.gd
@@ -1,12 +1,10 @@
 tool
 extends Area2D
-"""
-An exit on the floor which the player can step on to go somewhere else.
+## An exit on the floor which the player can step on to go somewhere else.
+##
+## Stepping on this exit results transitions to a new scene.
 
-Stepping on this exit results transitions to a new scene.
-"""
-
-# The direction the exit is facing. Also the direction the player needs to move to use the exit.
+## The direction the exit is facing. Also the direction the player needs to move to use the exit.
 enum ExitDirection {
 	NORTH,
 	NORTHEAST,
@@ -27,8 +25,8 @@ const SOUTHWEST = ExitDirection.SOUTHWEST
 const WEST = ExitDirection.WEST
 const NORTHWEST = ExitDirection.NORTHWEST
 
-# key: an enum from ExitDirection
-# value: a non-isometric unit vector in the direction the exit is facing
+## key: an enum from ExitDirection
+## value: a non-isometric unit vector in the direction the exit is facing
 const VECTOR_BY_EXIT_DIRECTION := {
 	NORTH: Vector2.UP,
 	NORTHEAST: Vector2(sqrt(2), -sqrt(2)),
@@ -40,35 +38,35 @@ const VECTOR_BY_EXIT_DIRECTION := {
 	NORTHWEST: Vector2(-sqrt(2), -sqrt(2))
 }
 
-# the path of the scene to transition to when the player uses the exit
+## the path of the scene to transition to when the player uses the exit
 export (String) var destination_scene_path
 
-# the direction the exit is facing. Also the direction the player needs to move to use the exit
+## the direction the exit is facing. Also the direction the player needs to move to use the exit
 export (ExitDirection) var exit_direction := ExitDirection.NORTH setget set_exit_direction
 
-# the id of the spawn where the player will appear on the overworld after using the exit
+## the id of the spawn where the player will appear on the overworld after using the exit
 export (String) var player_spawn_id: String
 
-# the id of the spawn where the sensei will appear on the overworld after using the exit
+## the id of the spawn where the sensei will appear on the overworld after using the exit
 export (String) var sensei_spawn_id: String
 
-# sprite sheet for when the exit faces east or west
+## sprite sheet for when the exit faces east or west
 var _exit_e_sheet := preload("res://assets/main/world/environment/exit-e-sheet.png")
 
-# sprite sheet for when the exit faces north or south
+## sprite sheet for when the exit faces north or south
 var _exit_n_sheet := preload("res://assets/main/world/environment/exit-n-sheet.png")
 
-# sprite sheet for when the exit faces northeast, southeast, southwest or northwest
+## sprite sheet for when the exit faces northeast, southeast, southwest or northwest
 var _exit_ne_sheet := preload("res://assets/main/world/environment/exit-ne-sheet.png")
 
-# 'true' if the player is currently overlapping the exit. this might not make them exit if they're sitting still or
-# moving the wrong way
+## 'true' if the player is currently overlapping the exit. this might not make them exit if they're sitting still or
+## moving the wrong way
 var _player_overlapping := false
 
-# 'true' if the player stepped on this exit arrow and is exiting
+## 'true' if the player stepped on this exit arrow and is exiting
 var _player_exiting := false
 
-# We embed the get_overworld_ui() call in a conditional to avoid errors in the editor
+## We embed the get_overworld_ui() call in a conditional to avoid errors in the editor
 onready var _overworld_ui: OverworldUi = null if Engine.editor_hint else Global.get_overworld_ui()
 
 func _ready() -> void:
@@ -108,9 +106,7 @@ func set_exit_direction(new_exit_direction: int) -> void:
 		_refresh_exit_direction()
 
 
-"""
-Updates the appearance and collision shape based on the new exit direction.
-"""
+## Updates the appearance and collision shape based on the new exit direction.
 func _refresh_exit_direction() -> void:
 	$CollisionShape2D.position = VECTOR_BY_EXIT_DIRECTION.get(exit_direction) * 20
 	

--- a/project/src/main/world/overworld-touch-buttons.gd
+++ b/project/src/main/world/overworld-touch-buttons.gd
@@ -1,7 +1,5 @@
 extends Control
-"""
-Touchscreen buttons displayed for the overworld.
-"""
+## Touchscreen buttons displayed for the overworld.
 
 onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
 
@@ -16,29 +14,23 @@ func _ready() -> void:
 		hide()
 
 
-"""
-Shows the touchscreen buttons and captures touch input.
-"""
+## Shows the touchscreen buttons and captures touch input.
 func show() -> void:
 	.show()
 	# stop ignoring touch input
 	$ButtonsSw.show()
 
 
-"""
-Hides the touchscreen buttons and ignores touch input.
-"""
+## Hides the touchscreen buttons and ignores touch input.
 func hide() -> void:
 	.hide()
 	# release any held buttons, and ignore touch input
 	$ButtonsSw.hide()
 
 
-"""
-Updates the buttons based on the player's settings.
-
-This updates their location and size.
-"""
+## Updates the buttons based on the player's settings.
+##
+## This updates their location and size.
 func _refresh_button_positions() -> void:
 	$ButtonsSw.rect_scale = Vector2(1.0, 1.0) * SystemData.touch_settings.size
 	$ButtonsSw.rect_position.y = rect_size.y - 10 - $ButtonsSw.rect_size.y * $ButtonsSw.rect_scale.y

--- a/project/src/main/world/overworld-walk-camera.gd
+++ b/project/src/main/world/overworld-walk-camera.gd
@@ -1,12 +1,10 @@
 extends Camera2D
-"""
-Overworld camera for the walking scene. Follows the two characters.
-"""
+## Overworld camera for the walking scene. Follows the two characters.
 
-# amount of empty space around characters
+## amount of empty space around characters
 const CAMERA_BOUNDARY := 160
 
-# speed of pan adjustments
+## speed of pan adjustments
 const LERP_WEIGHT := 0.10
 
 onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
@@ -16,19 +14,15 @@ func _process(_delta: float) -> void:
 	position = lerp(position, new_position, LERP_WEIGHT)
 
 
-"""
-Returns a rectangle representing the area which should be captured by the camera.
-"""
+## Returns a rectangle representing the area which should be captured by the camera.
 func _calculate_camera_bounding_box() -> Rect2:
 	return _overworld_ui.get_chatter_bounding_box().grow(CAMERA_BOUNDARY)
 
 
-"""
-Returns a number in the range [0.0, 1.0] corresponding the fattest creature in the cutscene.
-
-A value of 0.0 means all the characters are thin. A value of 1.0 means at least one character is very fat. This value
-is used in making camera adjustments.
-"""
+## Returns a number in the range [0.0, 1.0] corresponding the fattest creature in the cutscene.
+##
+## A value of 0.0 means all the characters are thin. A value of 1.0 means at least one character is very fat. This
+## value is used in making camera adjustments.
 func _max_fatness_weight() -> float:
 	var max_visual_fatness := 1.0
 	for creature in get_tree().get_nodes_in_group("creatures"):
@@ -36,11 +30,9 @@ func _max_fatness_weight() -> float:
 	return inverse_lerp(1.0, 10.0, clamp(max_visual_fatness, 1.0, 10.0))
 
 
-"""
-Calculate the desired camera position based on the chatting creatures.
-
-This method does not update the camera's zoom value. It returns a value which can be used in a lerp or tween.
-"""
+## Calculate the desired camera position based on the chatting creatures.
+##
+## This method does not update the camera's zoom value. It returns a value which can be used in a lerp or tween.
 func _calculate_position() -> Vector2:
 	var camera_bounding_box := _calculate_camera_bounding_box()
 	var new_position := camera_bounding_box.position + camera_bounding_box.size * 0.5

--- a/project/src/main/world/overworld-walk-ui.gd
+++ b/project/src/main/world/overworld-walk-ui.gd
@@ -1,16 +1,12 @@
 extends OverworldUi
-"""
-UI elements for the overworld walking scene.
-"""
+## UI elements for the overworld walking scene.
 
-# The delay between the speaker and the listener when they start walking. The speaking creature starts walking first,
-# then the other creature starts walking after a short pause.
+## The delay between the speaker and the listener when they start walking. The speaking creature starts walking first,
+## then the other creature starts walking after a short pause.
 const WALK_REACTION_DELAY := 0.4
 
-"""
-Extends the parent class's _apply_chat_event_meta() method to add support for the 'start_walking' and 'stop_walking'
-metadata items.
-"""
+## Extends the parent class's _apply_chat_event_meta() method to add support for the 'start_walking' and 'stop_walking'
+## metadata items.
 func _apply_chat_event_meta(chat_event: ChatEvent, meta_item: String) -> void:
 	._apply_chat_event_meta(chat_event, meta_item)
 	match(meta_item):

--- a/project/src/main/world/overworld-walk-world.gd
+++ b/project/src/main/world/overworld-walk-world.gd
@@ -1,7 +1,5 @@
 extends Node
-"""
-Prepares the the overworld walking scene.
-"""
+## Prepares the the overworld walking scene.
 
 onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
 

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -1,8 +1,6 @@
 class_name OverworldWorld
 extends Node
-"""
-Populates/unpopulates the creatures and obstacles on the overworld.
-"""
+## Populates/unpopulates the creatures and obstacles on the overworld.
 
 export (NodePath) var shadow_caster_shadows_path: NodePath
 export (NodePath) var creature_shadows_path: NodePath
@@ -82,9 +80,7 @@ func _launch_cutscene() -> void:
 		_overworld_ui.make_chatters_face_eachother()
 
 
-"""
-Relocate a creature to a spawn point.
-"""
+## Relocate a creature to a spawn point.
 func move_creature_to_spawn(creature: Creature, spawn_id: String) -> void:
 	var target_spawn: Spawn
 	for spawn_obj in get_tree().get_nodes_in_group("spawns"):
@@ -102,9 +98,7 @@ func move_creature_to_spawn(creature: Creature, spawn_id: String) -> void:
 		push_warning("Could not locate spawn with id '%s'" % [spawn_id])
 
 
-"""
-Creates a new creature with the specified creature_id and adds it to the scene.
-"""
+## Creates a new creature with the specified creature_id and adds it to the scene.
 func add_creature(creature_id: String, chattable: bool = true) -> Creature:
 	var creature: Creature = CreatureScene.instance()
 	creature.creature_id = creature_id
@@ -130,9 +124,7 @@ func process_new_obstacle(obstacle: Node2D) -> void:
 		_shadow_caster_shadows.create_shadow(obstacle)
 
 
-"""
-Locates the creature with the specified creature_id.
-"""
+## Locates the creature with the specified creature_id.
 func _find_creature(creature_id: String) -> Creature:
 	var creature: Creature
 	

--- a/project/src/main/world/phone-menu.gd
+++ b/project/src/main/world/phone-menu.gd
@@ -1,7 +1,5 @@
 extends CanvasLayer
-"""
-Level select menu which appears when the player clicks the 'phone' button.
-"""
+## Level select menu which appears when the player clicks the 'phone' button.
 
 signal show
 signal hide
@@ -14,9 +12,7 @@ func _ready() -> void:
 	_resize_container($Buttons/Northeast)
 
 
-"""
-Shows the menu and pauses the scene tree.
-"""
+## Shows the menu and pauses the scene tree.
 func show() -> void:
 	$Bg.show()
 	$LevelSelect.show()
@@ -24,9 +20,7 @@ func show() -> void:
 	emit_signal("show")
 
 
-"""
-Hides the menu and unpauses the scene tree.
-"""
+## Hides the menu and unpauses the scene tree.
 func hide() -> void:
 	$Bg.hide()
 	$LevelSelect.hide()
@@ -34,9 +28,7 @@ func hide() -> void:
 	emit_signal("hide")
 
 
-"""
-Resizes a button container based on the player's touch settings.
-"""
+## Resizes a button container based on the player's touch settings.
 func _resize_container(container: Control) -> void:
 	if container.rect_min_size.y != 96 * SystemData.touch_settings.size:
 		container.rect_min_size.y = 96 * SystemData.touch_settings.size

--- a/project/src/main/world/restaurant/chef-camera-mover.gd
+++ b/project/src/main/world/restaurant/chef-camera-mover.gd
@@ -1,10 +1,8 @@
 extends AnimationPlayer
-"""
-Moves the restaurant scene's camera to keep fat chefs in frame.
-
-While this is an AnimationPlayer, the animation is only used to calculate the camera position. It shouldn't ever be
-played as an animation.
-"""
+## Moves the restaurant scene's camera to keep fat chefs in frame.
+##
+## While this is an AnimationPlayer, the animation is only used to calculate the camera position. It shouldn't ever be
+## played as an animation.
 
 export (NodePath) var restaurant_scene_path: NodePath
 

--- a/project/src/main/world/restaurant/customer-camera-mover.gd
+++ b/project/src/main/world/restaurant/customer-camera-mover.gd
@@ -1,18 +1,16 @@
 extends AnimationPlayer
-"""
-Moves the restaurant scene's camera as customers get fatter.
-
-While this is an AnimationPlayer, the animation is only used to calculate the camera position. It shouldn't ever be
-played as an animation.
-"""
+## Moves the restaurant scene's camera as customers get fatter.
+##
+## While this is an AnimationPlayer, the animation is only used to calculate the camera position. It shouldn't ever be
+## played as an animation.
 
 export (NodePath) var restaurant_scene_path: NodePath
 export (NodePath) var customer_camera_path: NodePath
 
-# the position that the restaurant scene's camera lerps to
+## the position that the restaurant scene's camera lerps to
 export (Vector2) var target_camera_position: Vector2
 
-# fields which control the screen shake effect
+## fields which control the screen shake effect
 var _shake_total_seconds := 0.0
 var _shake_remaining_seconds := 0.0
 var _shake_magnitude := 8.0

--- a/project/src/main/world/restaurant/customer-switch-tween.gd
+++ b/project/src/main/world/restaurant/customer-switch-tween.gd
@@ -1,9 +1,7 @@
 extends Tween
-"""
-Pans the camera from one creature to another.
-"""
+## Pans the camera from one creature to another.
 
-# the amount of time spent panning the camera to a new creature
+## the amount of time spent panning the camera to a new creature
 const PAN_DURATION_SECONDS := 0.4
 
 export (NodePath) var customer_camera_path: NodePath

--- a/project/src/main/world/restaurant/door-chime.gd
+++ b/project/src/main/world/restaurant/door-chime.gd
@@ -1,9 +1,7 @@
 extends AudioStreamPlayer2D
-"""
-Door chime which rings when a customer enters the restaurant.
-"""
+## Door chime which rings when a customer enters the restaurant.
 
-# sounds which get played when a creature shows up
+## sounds which get played when a creature shows up
 onready var _chime_sounds := [
 	preload("res://assets/main/world/door-chime0.wav"),
 	preload("res://assets/main/world/door-chime1.wav"),
@@ -17,9 +15,7 @@ func play_door_chime() -> void:
 	play()
 
 
-"""
-Temporarily suppresses door chime sounds.
-"""
+## Temporarily suppresses door chime sounds.
 func start_suppress_sfx_timer() -> void:
 	$SuppressSfxTimer.start(1.0)
 

--- a/project/src/main/world/restaurant/layout-container.gd
+++ b/project/src/main/world/restaurant/layout-container.gd
@@ -1,10 +1,8 @@
 extends Control
-"""
-Keeps children controls positioned correctly.
-
-A more versatile version of Godot's 'CenterContainer' class. CenterContainer keeps children controls centered, but
-this container keeps aligns children controls in several possible layouts.
-"""
+## Keeps children controls positioned correctly.
+##
+## A more versatile version of Godot's 'CenterContainer' class. CenterContainer keeps children controls centered, but
+## this container keeps aligns children controls in several possible layouts.
 
 enum Layout {
 	TOP_LEFT,
@@ -20,7 +18,7 @@ enum Layout {
 	CENTER,
 }
 
-# The position to apply to the children controls
+## The position to apply to the children controls
 export (Layout) var layout := Layout.CENTER_TOP
 
 func _ready() -> void:
@@ -29,9 +27,7 @@ func _ready() -> void:
 		child.connect("resized", self, "_on_Child_Control_resized", [child])
 
 
-"""
-Realigns child controls when they are resized.
-"""
+## Realigns child controls when they are resized.
 func _on_Child_Control_resized(child: Node) -> void:
 	# align child vertically
 	match layout:

--- a/project/src/main/world/restaurant/restaurant-scene.gd
+++ b/project/src/main/world/restaurant/restaurant-scene.gd
@@ -1,17 +1,15 @@
 class_name RestaurantScene
 extends Node2D
-"""
-Handles animations and audio/visual effects for the restaurant and its creatures.
-"""
+## Handles animations and audio/visual effects for the restaurant and its creatures.
 
-# emitted on the frame when creature bites into some food
+## emitted on the frame when creature bites into some food
 signal food_eaten(food_type)
 signal current_creature_index_changed(value)
 
-# the creature which food is currently being served to
+## the creature which food is currently being served to
 var current_creature_index := 0 setget set_current_creature_index
 
-# all of the seats in the scene. each 'seat' includes a table, chairs, a creature, etc...
+## all of the seats in the scene. each 'seat' includes a table, chairs, a creature, etc...
 onready var _seats := [$Seat1, $Seat2, $Seat3]
 onready var _creatures := [$Creature1, $Creature2, $Creature3]
 
@@ -32,13 +30,11 @@ func set_current_creature_index(new_index: int) -> void:
 	emit_signal("current_creature_index_changed", new_index)
 
 
-"""
-Recolors the creature according to the specified creature definition. This involves updating shaders and sprite
-properties.
-
-Parameters:
-	'creature_def': defines the creature's attributes such as name and appearance.
-"""
+## Recolors the creature according to the specified creature definition. This involves updating shaders and sprite
+## properties.
+##
+## Parameters:
+## 	'creature_def': defines the creature's attributes such as name and appearance.
 func summon_creature(creature_def: CreatureDef, creature_index: int = -1) -> void:
 	get_customer(creature_index).set_creature_def(creature_def)
 	get_customer(creature_index).set_comfort(0)
@@ -57,30 +53,22 @@ func get_chef() -> Creature:
 	return $Chef as Creature
 
 
-"""
-Returns an array of Creature objects representing customers in the scene.
-"""
+## Returns an array of Creature objects representing customers in the scene.
 func get_customers() -> Array:
 	return _creatures
 
 
-"""
-Returns the creature with the specified optional index. Defaults to the creature being fed.
-"""
+## Returns the creature with the specified optional index. Defaults to the creature being fed.
 func get_customer(creature_index: int = -1) -> Creature:
 	return _creatures[current_creature_index] if creature_index == -1 else _creatures[creature_index]
 
 
-"""
-Temporarily suppresses 'hello' and 'door chime' sounds.
-"""
+## Temporarily suppresses 'hello' and 'door chime' sounds.
 func start_suppress_sfx_timer() -> void:
 	$DoorChime.start_suppress_sfx_timer()
 
 
-"""
-Returns the seat with the specified optional index. Defaults to the seat of the creature being fed.
-"""
+## Returns the seat with the specified optional index. Defaults to the seat of the creature being fed.
 func _get_seat(seat_index: int = -1) -> Control:
 	return _seats[current_creature_index] if seat_index == -1 else _seats[seat_index]
 

--- a/project/src/main/world/restaurant/seat.gd
+++ b/project/src/main/world/restaurant/seat.gd
@@ -1,10 +1,8 @@
 extends Node2D
-"""
-The 'seat' scene includes a creature and some furniture, all of which cast shadows. But the 'seat' scene does not
-contain the shadows itself, since they need to appear behind other objects outside of this scene.
-
-This script contains logic for scaling an injected 'creature shadow' object as the creature grows in size.
-"""
+## The 'seat' scene includes a creature and some furniture, all of which cast shadows. But the 'seat' scene does not
+## contain the shadows itself, since they need to appear behind other objects outside of this scene.
+##
+## This script contains logic for scaling an injected 'creature shadow' object as the creature grows in size.
 
 var _creature: Creature setget set_creature
 
@@ -13,9 +11,7 @@ func set_creature(new_creature: Creature) -> void:
 	refresh()
 
 
-"""
-Updates the properties of the seat and the creature sitting in it.
-"""
+## Updates the properties of the seat and the creature sitting in it.
 func refresh() -> void:
 	if _creature and _creature.is_visible_in_tree():
 		# draw a shadow on the creature's stool

--- a/project/src/main/world/screwport-texrect.gd
+++ b/project/src/main/world/screwport-texrect.gd
@@ -1,18 +1,16 @@
 extends TextureRect
-"""
-A TextureRect with a ViewportTexture which moves with the camera.
+## A TextureRect with a ViewportTexture which moves with the camera.
+##
+## Updates its own position to stay centered on the screen. Updates the Viewport's canvas_transform to keep its
+## contents aligned with the world.
+##
+## 'screwport-texrect' is a portmanteau of ScreenViewportTextureRect. The class name seemed too long for something
+## so simple.
 
-Updates its own position to stay centered on the screen. Updates the Viewport's canvas_transform to keep its contents
-aligned with the world.
-
-'screwport-texrect' is a portmanteau of ScreenViewportTextureRect. The class name seemed too long for something
-so simple.
-"""
-
-# the viewport in our viewport texture
+## the viewport in our viewport texture
 var _viewport: Viewport
 
-# the root node of the viewport which we can rescale
+## the root node of the viewport which we can rescale
 var _viewport_root: Node2D
 
 func _ready() -> void:
@@ -36,14 +34,12 @@ func _process(_delta: float) -> void:
 	call_deferred("_reposition_viewport")
 
 
-"""
-Rescales our target viewport based on our parent viewport.
-
-Our parent viewport changes its size and scale based on the window size. When the window is resized, our parent
-viewport often adopts nonsensical sizes like (70,400, 123) which cause problems if we try and reuse them for our target
-viewport. So we rescale the target viewport's boundaries based on our parent's viewport transform to prevent throwing
-errors or causing memory issues.
-"""
+## Rescales our target viewport based on our parent viewport.
+##
+## Our parent viewport changes its size and scale based on the window size. When the window is resized, our parent
+## viewport often adopts nonsensical sizes like (70,400, 123) which cause problems if we try and reuse them for our
+## target viewport. So we rescale the target viewport's boundaries based on our parent's viewport transform to prevent
+## throwing errors or causing memory issues.
 func _rescale_and_reposition_viewport() -> void:
 	# Adjust the viewport and texture size to match the scaled viewport size.
 	# This should match OS.get_window_size() if we're being rendered in the main viewport.
@@ -59,9 +55,7 @@ func _rescale_and_reposition_viewport() -> void:
 	_reposition_viewport()
 
 
-"""
-Updates the texture position and viewport origin to remain centered on the screen.
-"""
+## Updates the texture position and viewport origin to remain centered on the screen.
 func _reposition_viewport() -> void:
 	# align ourselves with the upper-left corner of the screen
 	rect_position -= get_global_transform_with_canvas().origin

--- a/project/src/main/world/shadow-caster-shadows.gd
+++ b/project/src/main/world/shadow-caster-shadows.gd
@@ -1,11 +1,9 @@
 class_name ShadowCasterShadows
 extends Node2D
-"""
-Manages shadows for all 'shadow casters' in a scene.
-
-Shadow casters are objects which cast shadows. This doesn't include environment tiles and creatures, which have special
-shadow casting logic.
-"""
+## Manages shadows for all 'shadow casters' in a scene.
+##
+## Shadow casters are objects which cast shadows. This doesn't include environment tiles and creatures, which have
+## special shadow casting logic.
 
 export (PackedScene) var OvalShadowScene: PackedScene
 

--- a/project/src/main/world/spawn.gd
+++ b/project/src/main/world/spawn.gd
@@ -1,21 +1,19 @@
 class_name Spawn
 extends Node2D
-"""
-A point where a creature can appear on the overworld.
-"""
+## A point where a creature can appear on the overworld.
 
-# the direction the creature will face
+## the direction the creature will face
 export (Creatures.Orientation) var orientation := Creatures.SOUTHEAST
 
-# (optional) path to a stool the spawned creature sits on
+## (optional) path to a stool the spawned creature sits on
 export (NodePath) var stool_path: NodePath
 
-# a unique id for this spawn point
+## a unique id for this spawn point
 export (String) var id: String
 
 export (float) var elevation: float
 
-# stool the creature sits on, if any
+## stool the creature sits on, if any
 var _stool: Stool
 
 func _ready() -> void:
@@ -23,9 +21,7 @@ func _ready() -> void:
 		_stool = get_node(stool_path)
 
 
-"""
-Relocates the specified creature to this spawn point.
-"""
+## Relocates the specified creature to this spawn point.
 func move_creature(creature: Creature) -> void:
 	creature.position = position
 	creature.orientation = orientation

--- a/project/src/test/puzzle/piece/test-piece-kicks-jl.gd
+++ b/project/src/test/puzzle/piece/test-piece-kicks-jl.gd
@@ -1,7 +1,5 @@
 extends "res://src/test/puzzle/piece/test-piece-kicks.gd"
-"""
-Tests the j/l piece's kick behavior.
-"""
+## Tests the j/l piece's kick behavior.
 
 func test_j_lwallkick_cw() -> void:
 	from_grid = [
@@ -212,9 +210,7 @@ func test_l_floorkick_ccw() -> void:
 	assert_kick()
 
 
-"""
-A 'vee kick' is when a J/L piece pivots like a V piece to hook its long end into a gap
-"""
+## A 'vee kick' is when a J/L piece pivots like a V piece to hook its long end into a gap
 func test_j_vee_kick0() -> void:
 	from_grid = [
 		"   ::",
@@ -231,9 +227,7 @@ func test_j_vee_kick0() -> void:
 	assert_kick()
 
 
-"""
-It would be nice if this kick worked, but it conflicts with the wall kicks and snack kicks.
-"""
+## It would be nice if this kick worked, but it conflicts with the wall kicks and snack kicks.
 func test_j_vee_kick0_failed() -> void:
 	from_grid = [
 		"   ::",
@@ -316,9 +310,7 @@ func test_l_vee_kick_cw0() -> void:
 	assert_kick()
 
 
-"""
-It would be nice if this kick worked, but it conflicts with the wall kicks and snack kicks.
-"""
+## It would be nice if this kick worked, but it conflicts with the wall kicks and snack kicks.
 func test_l_vee_kick_cw0_failed() -> void:
 	from_grid = [
 		"::   ",
@@ -385,9 +377,7 @@ func test_l_vee_kick3() -> void:
 	assert_kick()
 
 
-"""
-A 'gold kick' is when a J/L piece hooks its short end into a small gap
-"""
+## A 'gold kick' is when a J/L piece hooks its short end into a small gap
 func test_j_gold_kick0() -> void:
 	from_grid = [
 		"  :  ",
@@ -532,9 +522,7 @@ func test_l_gold_kick3() -> void:
 	assert_kick()
 
 
-"""
-A 'golder kick' is when a J/L piece hooks its short end into a small gap from far away.
-"""
+## A 'golder kick' is when a J/L piece hooks its short end into a small gap from far away.
 func test_j_golder_kick() -> void:
 	from_grid = [
 		"     ",
@@ -611,9 +599,7 @@ func test_j_climb_r2_1() -> void:
 	assert_kick()
 
 
-"""
-It's important a j piece can climb onto an l piece against a wall, to start a jlo box
-"""
+## It's important a j piece can climb onto an l piece against a wall, to start a jlo box
 func test_j_climb_r2_jlo() -> void:
 	from_grid = [
 		"     ",
@@ -804,9 +790,7 @@ func test_l_climb_l2_1() -> void:
 	assert_kick()
 
 
-"""
-It's important an l piece can climb onto an j piece against a wall, to start a jlo box
-"""
+## It's important an l piece can climb onto an j piece against a wall, to start a jlo box
 func test_l_climb_l2_jlo() -> void:
 	from_grid = [
 		"     ",
@@ -825,9 +809,7 @@ func test_l_climb_l2_jlo() -> void:
 	assert_kick()
 
 
-"""
-A 'hammer kick' is where the J piece pivots around its tip, like swinging a hammer.
-"""
+## A 'hammer kick' is where the J piece pivots around its tip, like swinging a hammer.
 func test_j_hammer_kick0() -> void:
 	from_grid = [
 		"    ",
@@ -864,9 +846,7 @@ func test_l_hammer_kick() -> void:
 	assert_kick()
 
 
-"""
-A plant kick is when the j/l piece pivots around its hinge like a t block.
-"""
+## A plant kick is when the j/l piece pivots around its hinge like a t block.
 func test_j_plant_kick0() -> void:
 	from_grid = [
 		":: ::",
@@ -939,9 +919,7 @@ func test_l_plant_kick1() -> void:
 	assert_kick()
 
 
-"""
-A 'snack kick' is when a j piece wraps around a p piece to make a snack block.
-"""
+## A 'snack kick' is when a j piece wraps around a p piece to make a snack block.
 func test_j_snack_kick0() -> void:
 	from_grid = [
 		"  :::",

--- a/project/src/test/puzzle/piece/test-piece-kicks-qp.gd
+++ b/project/src/test/puzzle/piece/test-piece-kicks-qp.gd
@@ -1,7 +1,5 @@
 extends "res://src/test/puzzle/piece/test-piece-kicks.gd"
-"""
-Tests the p/q piece's kick behavior.
-"""
+## Tests the p/q piece's kick behavior.
 
 func test_p_floorkick_cw() -> void:
 	from_grid = [
@@ -167,9 +165,7 @@ func test_q_lwallkick_r0() -> void:
 	assert_kick()
 
 
-"""
-A 'pump kick' is when the nub of a p/q piece swings into a gap, while the other 4 blocks remain in place
-"""
+## A 'pump kick' is when the nub of a p/q piece swings into a gap, while the other 4 blocks remain in place
 func test_p_pump_kick0() -> void:
 	from_grid = [
 		"    ",
@@ -296,9 +292,7 @@ func test_q_pump_kick3() -> void:
 	assert_kick()
 
 
-"""
-A 'murky kick' is when the nub of a p/q piece swings into a faraway gap, pulling the piece with it
-"""
+## A 'murky kick' is when the nub of a p/q piece swings into a faraway gap, pulling the piece with it
 func test_p_murky_kick0() -> void:
 	# there's enough space above the piece to do a (0, -2) kick, which would be bad
 	from_grid = [
@@ -465,9 +459,7 @@ func test_q_climb_l0() -> void:
 	assert_kick()
 
 
-"""
-A 'bump kick' is when the bulky part of a p/q piece bumps into a block and gets nudged out of the way
-"""
+## A 'bump kick' is when the bulky part of a p/q piece bumps into a block and gets nudged out of the way
 func test_p_bump_kick_0r() -> void:
 	from_grid = [
 		"  :::",

--- a/project/src/test/puzzle/piece/test-piece-kicks-t.gd
+++ b/project/src/test/puzzle/piece/test-piece-kicks-t.gd
@@ -1,14 +1,10 @@
 extends "res://src/test/puzzle/piece/test-piece-kicks.gd"
-"""
-Tests the t piece's kick behavior.
-"""
+## Tests the t piece's kick behavior.
 
-"""
-A rose kick is when the t piece pivots around the middle of its three extrusions.
-
- T  <--- it rotates around this part. doesn't it look like a rose?
-ttt
-"""
+## A rose kick is when the t piece pivots around the middle of its three extrusions.
+##
+##  T  <--- it rotates around this part. doesn't it look like a rose?
+## ttt
 func test_rose_kick_left() -> void:
 	from_grid = [
 		":: ",
@@ -73,11 +69,9 @@ func test_rose_kick_right() -> void:
 	assert_kick()
 
 
-"""
-A duck kick is when the T-piece tries to rotate an extrusion towards its flat side, and gets shoved away.
-
-This does not replace the usual floor kick, but acts as a replacement if the floor kick fails.
-"""
+## A duck kick is when the T-piece tries to rotate an extrusion towards its flat side, and gets shoved away.
+##
+## This does not replace the usual floor kick, but acts as a replacement if the floor kick fails.
 func test_duck_kick_down0() -> void:
 	from_grid = [
 		"::  ",

--- a/project/src/test/puzzle/piece/test-piece-kicks-u.gd
+++ b/project/src/test/puzzle/piece/test-piece-kicks-u.gd
@@ -1,7 +1,5 @@
 extends "res://src/test/puzzle/piece/test-piece-kicks.gd"
-"""
-Tests the u piece's kick behavior.
-"""
+## Tests the u piece's kick behavior.
 
 func test_floorkick_2l() -> void:
 	from_grid = [
@@ -179,9 +177,7 @@ func test_lwallkick_l2() -> void:
 	assert_kick()
 
 
-"""
-A spire kick is when a u piece rotates while a block is in its gap.
-"""
+## A spire kick is when a u piece rotates while a block is in its gap.
 func test_spire_kick_0r() -> void:
 	from_grid = [
 		"     ",
@@ -286,9 +282,7 @@ func test_spire_kick_r0() -> void:
 	assert_kick()
 
 
-"""
-a 'diagonalnw kick' is when the u piece is boxed in by the nw/se corners
-"""
+## a 'diagonalnw kick' is when the u piece is boxed in by the nw/se corners
 func test_diagonalnw_kick_2l() -> void:
 	from_grid = [
 		"::   ",
@@ -357,9 +351,7 @@ func test_diagonalnw_kick_r2() -> void:
 	assert_kick()
 
 
-"""
-a 'diagonalne kick' is when the u piece is boxed in by the ne/sw corners
-"""
+## a 'diagonalne kick' is when the u piece is boxed in by the ne/sw corners
 func test_diagonalne_kick_2l() -> void:
 	from_grid = [
 		"   ::",
@@ -428,9 +420,7 @@ func test_diagonalne_kick_r2() -> void:
 	assert_kick()
 
 
-"""
-a 'shaft kick' is when the u piece rotates after being dropped down a narrow shaft
-"""
+## a 'shaft kick' is when the u piece rotates after being dropped down a narrow shaft
 func test_shaft_kick_r2_0() -> void:
 	from_grid = [
 		"  ::",
@@ -590,9 +580,7 @@ func test_climb_kick_r0() -> void:
 	assert_kick()
 
 
-"""
-A 'ledge kick' is when the piece is teetering on a ledge and shouldn't drop off.
-"""
+## A 'ledge kick' is when the piece is teetering on a ledge and shouldn't drop off.
 func test_ledge_kick_right_0r() -> void:
 	from_grid = [
 		"    ",

--- a/project/src/test/puzzle/piece/test-piece-kicks-v.gd
+++ b/project/src/test/puzzle/piece/test-piece-kicks-v.gd
@@ -1,7 +1,5 @@
 extends "res://src/test/puzzle/piece/test-piece-kicks.gd"
-"""
-Tests the v piece's kick behavior.
-"""
+## Tests the v piece's kick behavior.
 
 func test_climb_r0_0() -> void:
 	from_grid = [
@@ -212,9 +210,7 @@ func test_climb_2l_1() -> void:
 	assert_kick()
 
 
-"""
-A 'snack kick' is when a v piece rotates around an o piece to make a snack block.
-"""
+## A 'snack kick' is when a v piece rotates around an o piece to make a snack block.
 func test_snack_kick_cw() -> void:
 	from_grid = [
 		"     ",
@@ -291,9 +287,7 @@ func test_snack_kick_down_cw() -> void:
 	assert_kick()
 
 
-"""
-The v piece can't technically wall kick, but it can kick against other blocks similar to a wall kick
-"""
+## The v piece can't technically wall kick, but it can kick against other blocks similar to a wall kick
 func test_rwallkick_cw0() -> void:
 	from_grid = [
 		"     ",
@@ -475,9 +469,7 @@ func test_rwallkick_ccw4() -> void:
 	assert_kick()
 
 
-"""
-A ritzy kick is when the hinge of the v piece pivots one square diagonally.
-"""
+## A ritzy kick is when the hinge of the v piece pivots one square diagonally.
 func test_ritzy_kick_cw0() -> void:
 	from_grid = [
 		"    ",
@@ -606,10 +598,8 @@ func test_ritzy_kick_ccw3() -> void:
 	assert_kick()
 
 
-"""
-A plant kick is when the v piece pivots around its hinge like a t block. This is disorienting and should be a last
-resort.
-"""
+## A plant kick is when the v piece pivots around its hinge like a t block. This is disorienting and should be a last
+## resort.
 func test_plant_kick_cw0() -> void:
 	from_grid = [
 		"::   ",

--- a/project/src/test/puzzle/piece/test-piece-kicks.gd
+++ b/project/src/test/puzzle/piece/test-piece-kicks.gd
@@ -1,10 +1,8 @@
 extends "res://addons/gut/test.gd"
-"""
-Framework for testing piece kicks.
-"""
+## Framework for testing piece kicks.
 
-# Unit tests need to distinguish between a piece rotating in place and failing to rotate.
-# This should only be used in tests; a piece kicking to -99, -99 could cause a softlock the game.
+## Unit tests need to distinguish between a piece rotating in place and failing to rotate.
+## This should only be used in tests; a piece kicking to -99, -99 could cause a softlock the game.
 const FAILED_KICK := Vector2(-99, -99)
 
 var from_grid := []
@@ -13,9 +11,7 @@ var to_grid := []
 var _from_piece: ActivePiece
 var _to_piece: ActivePiece
 
-"""
-A test which demonstrates the test framework itself is functioning properly.
-"""
+## A test which demonstrates the test framework itself is functioning properly.
 func test_framework() -> void:
 	from_grid = [
 		"  :::",
@@ -44,12 +40,10 @@ func test_framework() -> void:
 	assert_eq(_to_piece.orientation, 1)
 
 
-"""
-Verifies that the piece kicks appropriately when rotated.
-
-Verifies the piece shown in 'from_grid' can rotate to the orientation shown in 'to_grid'. Also verifies the piece is
-moved to the correct position.
-"""
+## Verifies that the piece kicks appropriately when rotated.
+##
+## Verifies the piece shown in 'from_grid' can rotate to the orientation shown in 'to_grid'. Also verifies the piece is
+## moved to the correct position.
 func assert_kick() -> void:
 	var result := _kick_piece()
 	var text := "Rotating '%s' block from %s -> %s should kick %s" \
@@ -62,14 +56,12 @@ func assert_kick() -> void:
 		assert_eq(result, _to_piece.pos - _from_piece.pos, text)
 
 
-"""
-Attempts to rotate the piece to a new orientation, kicking if necessary
-
-Returns one of the following:
-	1. FAILED_KICK if the piece could not rotate.
-	2. A zero vector if the piece could rotate without kicking.
-	3. A non-zero vector if the piece could rotate, but needed to be kicked.
-"""
+## Attempts to rotate the piece to a new orientation, kicking if necessary
+##
+## Returns one of the following:
+## 	1. FAILED_KICK if the piece could not rotate.
+## 	2. A zero vector if the piece could rotate without kicking.
+## 	3. A non-zero vector if the piece could rotate, but needed to be kicked.
 func _kick_piece() -> Vector2:
 	var result: Vector2
 	_from_piece = _create_active_piece(from_grid)
@@ -90,9 +82,7 @@ func _kick_piece() -> Vector2:
 	return result
 
 
-"""
-Returns 'true' if the specified cell has a block in it or if it's outside the ascii drawing's boundaries.
-"""
+## Returns 'true' if the specified cell has a block in it or if it's outside the ascii drawing's boundaries.
 func _is_cell_blocked(pos: Vector2) -> bool:
 	var blocked := false
 	if pos.y < 0 or pos.y >= from_grid.size(): blocked = true
@@ -101,11 +91,9 @@ func _is_cell_blocked(pos: Vector2) -> bool:
 	return blocked
 
 
-"""
-Create an active piece from an ascii drawing.
-
-Calculates the piece's type, position and orientation.
-"""
+## Create an active piece from an ascii drawing.
+##
+## Calculates the piece's type, position and orientation.
 func _create_active_piece(ascii_grid: Array) -> ActivePiece:
 	var piece_type := _determine_piece_type(ascii_grid)
 	if not piece_type:

--- a/project/src/test/puzzle/piece/test-piece-queue.gd
+++ b/project/src/test/puzzle/piece/test-piece-queue.gd
@@ -21,16 +21,14 @@ func test_no_possibilities() -> void:
 	assert_eq([], non_adjacent_indexes(["o", "l", "o"], "o"))
 
 
-"""
-Convenience function which converts strings into appropriate piece parameters.
-
-Parameters:
-	'piece_strings': An array of strings like 't' and 'o' corresponding to piece shapes.
-	
-	'piece_type_string': A string like 't' or 'o' corresponding to a piece type.
-	
-	'from_index': The lowest position to check in the piece queue.
-"""
+## Convenience function which converts strings into appropriate piece parameters.
+##
+## Parameters:
+## 	'piece_strings': An array of strings like 't' and 'o' corresponding to piece shapes.
+##
+## 	'piece_type_string': A string like 't' or 'o' corresponding to a piece type.
+##
+## 	'from_index': The lowest position to check in the piece queue.
 func non_adjacent_indexes(piece_strings: Array, piece_type_string: String, from_index: int = 0) -> Array:
 	var pieces := []
 	for piece_string in piece_strings:

--- a/project/src/test/puzzle/test-rank-calculator.gd
+++ b/project/src/test/puzzle/test-rank-calculator.gd
@@ -171,9 +171,8 @@ func test_calculate_rank_ultra_200_lost() -> void:
 	assert_eq(RankCalculator.grade(rank.combo_score_per_line_rank), "S")
 
 
-"""
-This is an edge case where, if the player gets too many points for ultra, they can sort of be robbed of a master rank.
-"""
+## This is an edge case where, if the player gets too many points for ultra, they can sort of be robbed of a master
+## rank.
 func test_calculate_rank_ultra_200_overshot() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 200)
 	PuzzleState.level_performance.seconds = 19
@@ -188,9 +187,7 @@ func test_calculate_rank_ultra_200_overshot() -> void:
 	assert_eq(RankCalculator.grade(rank.seconds_rank), "SSS")
 
 
-"""
-A level requiring only one line clear used to trigger divide by zero errors.
-"""
+## A level requiring only one line clear used to trigger divide by zero errors.
 func test_calculate_rank_ultra_1() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 1)
 	PuzzleState.level_performance.seconds = 7.233
@@ -227,9 +224,7 @@ func test_calculate_rank_five_creatures() -> void:
 	assert_eq(RankCalculator.grade(rank2.score_rank), "A+")
 
 
-"""
-This edge case used to result in a combo_score_per_line of 22.5
-"""
+## This edge case used to result in a combo_score_per_line of 22.5
 func test_combo_score_per_line_ultra_overshot() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 200)
 	PuzzleState.level_performance.combo_score = 45
@@ -238,9 +233,7 @@ func test_combo_score_per_line_ultra_overshot() -> void:
 	assert_eq(rank.combo_score_per_line, 20.0)
 
 
-"""
-This edge case used to result in a combo_score_per_line of 0.305
-"""
+## This edge case used to result in a combo_score_per_line of 0.305
 func test_combo_score_per_line_death() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.LINES, 200, 150)
 	PuzzleState.level_performance.combo_score = 195
@@ -250,9 +243,7 @@ func test_combo_score_per_line_death() -> void:
 	assert_almost_eq(rank.combo_score_per_line, 6.09, 0.1)
 
 
-"""
-A player reaching a success condition should be given a rank boost.
-"""
+## A player reaching a success condition should be given a rank boost.
 func test_success_bonus_score() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.LINES, 300, 200)
 	PuzzleState.level_performance.seconds = 240

--- a/project/src/test/test-rolling-backups.gd
+++ b/project/src/test/test-rolling-backups.gd
@@ -57,9 +57,7 @@ func test_rotate_backups_none_exist() -> void:
 	assert_false(file.file_exists(_backups.rolling_filename(RollingBackups.PREV_WEEK)), "RollingBackups.PREV_WEEK")
 
 
-"""
-Don't overwrite the 'this_xxx' backups if they already exist
-"""
+## Don't overwrite the 'this_xxx' backups if they already exist
 func test_rotate_backups_dont_overwrite_thisxxx() -> void:
 	FileUtils.write_file(_backups.data_filename, "new-920")
 	FileUtils.write_file(_backups.rolling_filename(RollingBackups.THIS_HOUR), "old-920")
@@ -68,9 +66,7 @@ func test_rotate_backups_dont_overwrite_thisxxx() -> void:
 	assert_eq(FileUtils.get_file_as_text(_backups.rolling_filename(RollingBackups.THIS_HOUR)), "old-920")
 
 
-"""
-Move the 'this_xxx' backups out of the way if they're old
-"""
+## Move the 'this_xxx' backups out of the way if they're old
 func test_move_backups() -> void:
 	FileUtils.write_file(_backups.rolling_filename(RollingBackups.THIS_HOUR), "")
 	var file: File = File.new()

--- a/project/src/test/world/autotile-fixer.gd
+++ b/project/src/test/world/autotile-fixer.gd
@@ -1,21 +1,17 @@
 extends Node
 tool
-"""
-Applies autotiling rules to all cells in a TileMap.
+## Applies autotiling rules to all cells in a TileMap.
+##
+## After editing a TileSet, there's no easy way to reapply its autotile rules across an entire TileMap. This
+## AutotileFixer node makes it easier.
+##
+## Instructions: Attach this node to a TileMap and toggle this node's 'autotile' property. This will apply autotiling
+## rules to all tiles in the TileMap.
 
-After editing a TileSet, there's no easy way to reapply its autotile rules across an entire TileMap. This
-AutotileFixer node makes it easier.
-
-Instructions: Attach this node to a TileMap and toggle this node's 'autotile' property. This will apply autotiling
-rules to all tiles in the TileMap.
-"""
-
-# An editor toggle which manually applies autotiling.
+## An editor toggle which manually applies autotiling.
 export (bool) var _autotile: bool setget autotile
 
-"""
-Applies autotiling rules to all cells in a TileMap.
-"""
+## Applies autotiling rules to all cells in a TileMap.
 func autotile(_value: bool) -> void:
 	if not _value:
 		return


### PR DESCRIPTION
Future versions of GDScript will support docstrings; comments starting
with a double hash symbol "##". I've switched our class/field/method
comments over to the double hash symbol syntax.

Previously, our block comments were implemented with triple quotes '"""'
which are not intended to be used as comments. Instead they just create
unused string literals which, while harmless, still seem like a
questionable practice.