### PR TITLE
Fixed bugs related to creature weight during puzzles.

### DIFF
--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -714,7 +714,6 @@ script = ExtResource( 19 )
 [connection signal="box_built" from="Playfield" to="StarSeeds" method="_on_Playfield_box_built"]
 [connection signal="food_spawned" from="Playfield" to="FoodItems" method="_on_Playfield_food_spawned"]
 [connection signal="line_cleared" from="Playfield" to="." method="_on_Playfield_line_cleared"]
-[connection signal="line_clears_scheduled" from="Playfield" to="StarSeeds" method="_on_Playfield_line_clears_scheduled"]
 [connection signal="line_deleted" from="Playfield" to="StarSeeds" method="_on_Playfield_line_deleted"]
 [connection signal="line_erased" from="Playfield" to="StarSeeds" method="_on_Playfield_line_erased"]
 [connection signal="line_inserted" from="Playfield" to="PieceManager" method="_on_Playfield_line_inserted"]

--- a/project/src/main/puzzle/food-items.gd
+++ b/project/src/main/puzzle/food-items.gd
@@ -63,7 +63,7 @@ func add_food_item(cell: Vector2, food_type: int, remaining_food: int = 0) -> vo
 	var customer := _puzzle.get_customer()
 	var old_fatness: float = _pending_food_fatness.back() if _pending_food_fatness else customer.get_fatness()
 	var base_score := customer.fatness_to_score(customer.base_fatness)
-	var target_fatness := customer.score_to_fatness(base_score + PuzzleState.get_bonus_score())
+	var target_fatness := customer.score_to_fatness(base_score + PuzzleState.fatness_score)
 	
 	var fatness_pct: float = 1.0 / (remaining_food + 1)
 	_pending_food_fatness.append(lerp(old_fatness, target_fatness, fatness_pct))

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -76,6 +76,10 @@ var combo := 0 setget set_combo
 ## and should be a round number like +55 or +130 for visual aesthetics.
 var bonus_score := 0
 
+## Points which contribute to the current customer's fatness. This is usually the same as
+## bonus_score except for some edge cases at the end of the level.
+var fatness_score := 0
+
 ## 'true' if the player has started a game which is still running.
 var game_active: bool
 
@@ -249,6 +253,12 @@ func end_combo() -> void:
 	
 	_add_score(bonus_score)
 	bonus_score = 0
+	if no_more_customers:
+		# For levels with limited customers, don't reset the fatness score. Otherwise creatures suddenly lose weight
+		# during end-of-level line clears.
+		pass
+	else:
+		fatness_score = 0
 	
 	emit_signal("score_changed")
 	if old_combo != combo:
@@ -261,6 +271,7 @@ func reset() -> void:
 	customer_scores = [0]
 	combo = 0
 	bonus_score = 0
+	fatness_score = 0
 	level_performance = PuzzlePerformance.new()
 	speed_index = 0
 	no_more_customers = CurrentLevel.settings.other.tutorial
@@ -349,6 +360,7 @@ func _add_score(delta: int) -> void:
 
 func _add_bonus_score(delta: int) -> void:
 	bonus_score += delta
+	fatness_score += delta
 
 
 func _add_line() -> void:

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -238,7 +238,7 @@ func _on_Playfield_line_cleared(_y: int, total_lines: int, remaining_lines: int,
 	
 	# Save the appropriate fatness in the CreatureLibrary
 	var base_score := customer.fatness_to_score(customer.base_fatness)
-	var new_fatness := customer.score_to_fatness(base_score + PuzzleState.get_bonus_score())
+	var new_fatness := customer.score_to_fatness(base_score + PuzzleState.fatness_score)
 	customer.save_fatness(new_fatness)
 	
 	# When the player finishes a puzzle, we end the game immediately after the last line clear. We don't wait for the

--- a/project/src/main/puzzle/rank-calculator.gd
+++ b/project/src/main/puzzle/rank-calculator.gd
@@ -152,10 +152,8 @@ func rank_lpm(rank: float) -> float:
 		var min_frames_per_line := min_frames_per_line(piece_speed)
 		var mechanical_spl_limit: float = min_frames_per_line / 60 \
 				+ 2 * CurrentLevel.settings.rank.extra_seconds_per_piece
-		var mechanical_lpm_limit := 60.0 / mechanical_spl_limit
 		
-		# calculate the lpm/spl based on which is slower: the mechanical limit, or the player's limit
-		var lines_per_minute := min(mechanical_lpm_limit, player_lpm_limit)
+		# calculate the spl based on which is slower: the mechanical limit, or the player's limit
 		var seconds_per_line := max(mechanical_spl_limit, player_spl_limit)
 		
 		var finish_condition: Milestone = CurrentLevel.settings.finish_condition
@@ -262,7 +260,7 @@ func _populate_rank_fields(rank_result: RankResult, lenient: bool) -> void:
 	
 	# decrease target_lines based on leftover_lines
 	if finish_condition.type in [Milestone.PIECES, Milestone.TIME_OVER]:
-		target_lines = max(0, ceil(target_lines - leftover_lines / 3))
+		target_lines = max(0, ceil(target_lines - leftover_lines / 3.0))
 	
 	# calculate score for leftover_lines; leftover lines should be a tall stack with half as many box points
 	var target_leftover_score := (target_combo_score_per_line + target_combo_score_per_line * 0.5 + 1) * leftover_lines

--- a/project/src/main/puzzle/star-seeds.gd
+++ b/project/src/main/puzzle/star-seeds.gd
@@ -8,7 +8,7 @@ extends Control
 ## Parameters:
 ## 	'cell': A Vector2 corresponding to the tilemap cell where the food should appear
 ##
-## 	'remaining_food': The number of remaining food items for the current set of line clears
+## 	'remaining_food': The number of remaining food items for the current line clear
 ##
 ## 	'food_type': An enum from Foods.FoodType corresponding to the food to spawn
 signal food_spawned(cell, remaining_food, food_type)
@@ -80,9 +80,6 @@ export (NodePath) var _puzzle_tile_map_path: NodePath
 ## key: Vector2 playfield cell positions
 ## value: StarSeed node contained within that cell
 var _star_seeds_by_cell: Dictionary
-
-## the number of remaining food items to spawn for the current sequence of line clears
-var _remaining_food_for_line_clears := 0
 
 export (PackedScene) var StarSeedScene: PackedScene
 
@@ -326,20 +323,17 @@ func _on_Playfield_blocks_prepared() -> void:
 	_prepare_star_seeds_for_level()
 
 
-func _on_Playfield_line_clears_scheduled(ys: Array) -> void:
-	_remaining_food_for_line_clears = 0
-	for y in ys:
-		for x in range(PuzzleTileMap.COL_COUNT):
-			if _star_seeds_by_cell.has(Vector2(x, y)):
-				_remaining_food_for_line_clears += 1
-
-
 func _on_Playfield_before_line_cleared(y: int, _total_lines: int, _remaining_lines: int, _box_ints: Array) -> void:
+	var remaining_food_for_line_clear := 0
 	for x in range(PuzzleTileMap.COL_COUNT):
 		if _star_seeds_by_cell.has(Vector2(x, y)):
-			_remaining_food_for_line_clears -= 1
+			remaining_food_for_line_clear += 1
+	
+	for x in range(PuzzleTileMap.COL_COUNT):
+		if _star_seeds_by_cell.has(Vector2(x, y)):
+			remaining_food_for_line_clear -= 1
 			
-			emit_signal("food_spawned", Vector2(x, y), _remaining_food_for_line_clears,
+			emit_signal("food_spawned", Vector2(x, y), remaining_food_for_line_clear,
 					_star_seeds_by_cell[Vector2(x, y)].food_type)
 
 


### PR DESCRIPTION
In levels ending after a fixed number of customers, the final customer
would get skinny again during the final sequence of line clears. This is
because their fatness was based on the bonus score, but the bonus score
decreased for those kinds of puzzles. Their fatness is now based on a
separate 'fatness score'.

During sequential line clears, the final foods eaten added a lot more
weight than the earlier foods. Imagine a series of ten simultaneous line clears,
each worth 35 points. The creature's weight for each line could be calculated as
adding 10% of the total score, or 100% of the line score. However the bug
occurred because the calculation was doing both; early line clears were lerping
10% of 35 points, but late line clers were lerping 90% of the way towards 350
points. I've fixed the calculation to work line-by-line, ignoring the
overall score.