### PR TITLE
Rudimentary career logic. Player can play a random series of levels

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -54,6 +54,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/puzzle/box-builder.gd"
 }, {
+"base": "Reference",
+"class": "CareerData",
+"language": "GDScript",
+"path": "res://src/main/world/career-data.gd"
+}, {
 "base": "Node",
 "class": "ChatAdvancer",
 "language": "GDScript",
@@ -939,6 +944,7 @@ _global_script_class_icons={
 "BoolExpressionEvaluator": "",
 "BoolExpressionParser": "",
 "BoxBuilder": "",
+"CareerData": "",
 "ChatAdvancer": "",
 "ChatChoiceButton": "",
 "ChatChoices": "",

--- a/project/src/main/global.gd
+++ b/project/src/main/global.gd
@@ -10,6 +10,9 @@ const SCENE_MAIN_MENU := "res://src/main/ui/menu/MainMenu.tscn"
 ## overworld which the player character can run around on and talk to other creatures.
 const SCENE_OVERWORLD := "res://src/main/world/Overworld.tscn"
 
+## scene for career mode which shows the player's progress between levels
+const SCENE_CAREER_MAP := "res://src/main/world/CareerMap.tscn"
+
 ## puzzle where a player drops pieces into a playfield of blocks.
 const SCENE_PUZZLE := "res://src/main/puzzle/Puzzle.tscn"
 

--- a/project/src/main/player-data.gd
+++ b/project/src/main/player-data.gd
@@ -22,6 +22,8 @@ var chat_history := ChatHistory.new()
 var creature_library := CreatureLibrary.new()
 var creature_queue := CreatureQueue.new()
 
+var career := CareerData.new()
+
 var money := 0 setget set_money
 
 ## the player's playtime in seconds
@@ -43,6 +45,7 @@ func reset() -> void:
 	level_history.reset()
 	chat_history.reset()
 	creature_library.reset()
+	career.reset()
 	money = 0
 	seconds_played = 0.0
 	

--- a/project/src/main/player-save.gd
+++ b/project/src/main/player-save.gd
@@ -64,6 +64,7 @@ func save_player_data() -> void:
 		save_json.append(_save_item("level_history", rank_results_json, level_name).to_json_dict())
 	save_json.append(_save_item("chat_history", PlayerData.chat_history.to_json_dict()).to_json_dict())
 	save_json.append(_save_item("creature_library", PlayerData.creature_library.to_json_dict()).to_json_dict())
+	save_json.append(_save_item("career", PlayerData.career.to_json_dict()).to_json_dict())
 	save_json.append(_save_item("successful_levels",
 			PlayerData.level_history.successful_levels).to_json_dict())
 	save_json.append(_save_item("finished_levels",
@@ -206,5 +207,8 @@ func _load_line(type: String, key: String, json_value) -> void:
 		"successful_levels":
 			var value: Dictionary = json_value
 			PlayerData.level_history.successful_levels = value
+		"career":
+			var value: Dictionary = json_value
+			PlayerData.career.from_json_dict(value)
 		_:
 			push_warning("Unrecognized save data type: '%s'" % type)

--- a/project/src/main/puzzle/puzzle-messages.gd
+++ b/project/src/main/puzzle/puzzle-messages.gd
@@ -111,6 +111,10 @@ func _on_PuzzleState_after_game_ended() -> void:
 			if Breadcrumb.trail.size() >= 2 and Breadcrumb.trail[1] == Global.SCENE_SPLASH:
 				Breadcrumb.trail.insert(1, Global.SCENE_MAIN_MENU)
 	
+	if PlayerData.career.is_career_mode():
+		# they only have only one chance in career mode, they can't retry
+		$Buttons/Start.hide()
+	
 	# determine the default button to focus
 	var buttons_to_focus := [$Buttons/Back, $Buttons/Start]
 	if CurrentLevel.keep_retrying:

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -270,6 +270,12 @@ func _on_PuzzleState_game_ended() -> void:
 	PlayerData.emit_signal("level_history_changed")
 	PlayerData.money = int(clamp(PlayerData.money + rank_result.score, 0, PlayerData.MAX_MONEY))
 	
+	if PlayerData.career.is_career_mode():
+		PlayerData.career.daily_earnings = int(clamp(PlayerData.career.daily_earnings + rank_result.score, 0,
+				PlayerData.MAX_MONEY))
+		
+		PlayerData.career.distance_travelled += 3
+	
 	match CurrentLevel.settings.finish_condition.type:
 		Milestone.SCORE:
 			if not PuzzleState.level_performance.lost and rank_result.seconds_rank < 24: $ApplauseSound.play()

--- a/project/src/main/ui/menu/MainMenu.tscn
+++ b/project/src/main/ui/menu/MainMenu.tscn
@@ -76,7 +76,7 @@ custom_fonts/font = ExtResource( 9 )
 text = "Play"
 align = 1
 
-[node name="Story" type="Button" parent="DropPanel/Play"]
+[node name="CareerContainer" type="HBoxContainer" parent="DropPanel/Play"]
 margin_left = 134.0
 margin_top = 72.0
 margin_right = 327.0
@@ -84,8 +84,26 @@ margin_bottom = 119.0
 rect_min_size = Vector2( 193, 47 )
 size_flags_horizontal = 4
 size_flags_vertical = 4
+custom_constants/separation = 10
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Career" type="Button" parent="DropPanel/Play/CareerContainer"]
+margin_right = 136.0
+margin_bottom = 47.0
+rect_min_size = Vector2( 0, 47 )
+size_flags_horizontal = 3
 theme = ExtResource( 2 )
-text = "Continue"
+text = "Career"
+
+[node name="Story" type="Button" parent="DropPanel/Play/CareerContainer"]
+margin_left = 146.0
+margin_right = 193.0
+margin_bottom = 47.0
+rect_min_size = Vector2( 47, 47 )
+theme = ExtResource( 2 )
+text = "?"
 
 [node name="Practice" type="Button" parent="DropPanel/Play"]
 margin_left = 134.0
@@ -192,8 +210,9 @@ __meta__ = {
 [connection signal="pressed" from="DropPanel/Create/Creatures" to="DropPanel/Create" method="_on_Creatures_pressed"]
 [connection signal="pressed" from="DropPanel/Create/Levels" to="DropPanel/Create" method="_on_Levels_pressed"]
 [connection signal="pressed" from="DropPanel/Debug/StressTest" to="DropPanel/Debug" method="_on_StressTest_pressed"]
+[connection signal="pressed" from="DropPanel/Play/CareerContainer/Career" to="DropPanel/Play" method="_on_Career_pressed"]
+[connection signal="pressed" from="DropPanel/Play/CareerContainer/Story" to="DropPanel/Play" method="_on_Story_pressed"]
 [connection signal="pressed" from="DropPanel/Play/Practice" to="DropPanel/Play" method="_on_Practice_pressed"]
-[connection signal="pressed" from="DropPanel/Play/Story" to="DropPanel/Play" method="_on_Story_pressed"]
 [connection signal="pressed" from="DropPanel/Play/Tutorials" to="DropPanel/Play" method="_on_Tutorials_pressed"]
 [connection signal="quit_pressed" from="DropPanel/System" to="." method="_on_System_quit_pressed"]
 [connection signal="settings_pressed" from="DropPanel/System" to="SettingsMenu" method="_on_Settings_pressed"]

--- a/project/src/main/ui/menu/main-menu-play.gd
+++ b/project/src/main/ui/menu/main-menu-play.gd
@@ -3,6 +3,12 @@ extends VBoxContainer
 
 const WORLD0_ID := "world0"
 
+func _on_Career_pressed() -> void:
+	PlayerData.creature_queue.clear()
+	CurrentLevel.clear_launched_level()
+	SceneTransition.push_trail(Global.SCENE_CAREER_MAP)
+
+
 func _on_Story_pressed() -> void:
 	PlayerData.creature_queue.clear()
 	CurrentLevel.clear_launched_level()

--- a/project/src/main/world/CareerMap.tscn
+++ b/project/src/main/world/CareerMap.tscn
@@ -1,0 +1,70 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://src/main/ui/menu/theme/h1.theme" type="Theme" id=1]
+[ext_resource path="res://src/main/world/career-map.gd" type="Script" id=2]
+[ext_resource path="res://src/main/ui/menu/theme/h3.theme" type="Theme" id=3]
+[ext_resource path="res://src/main/ui/SceneTransitionCover.tscn" type="PackedScene" id=4]
+
+[node name="Node" type="Node"]
+script = ExtResource( 2 )
+
+[node name="Button" type="Button" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -92.5
+margin_top = -32.5
+margin_right = 92.5
+margin_bottom = 32.5
+theme = ExtResource( 1 )
+text = "Ok"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Label" type="Label" parent="."]
+anchor_right = 1.0
+margin_top = 54.0326
+margin_bottom = 216.033
+theme = ExtResource( 3 )
+text = "Distance: 3
+
+Earnings: 5
+
+Time: 9:00 am"
+align = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="History" type="RichTextLabel" parent="."]
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+margin_left = -462.0
+margin_top = -214.973
+margin_right = 462.0
+margin_bottom = -52.9732
+theme = ExtResource( 3 )
+bbcode_enabled = true
+bbcode_text = "[center]abc
+def
+ghi
+jkl
+mno
+pqr[/center]"
+text = "abc
+def
+ghi
+jkl
+mno
+pqr"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="SceneTransitionCover" parent="." instance=ExtResource( 4 )]
+
+[connection signal="pressed" from="Button" to="." method="_on_Button_pressed"]

--- a/project/src/main/world/CareerWin.tscn
+++ b/project/src/main/world/CareerWin.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://src/main/world/career-win.gd" type="Script" id=1]
+[ext_resource path="res://src/main/ui/menu/theme/h1.theme" type="Theme" id=2]
+[ext_resource path="res://src/main/ui/SceneTransitionCover.tscn" type="PackedScene" id=3]
+
+[node name="Node" type="Node"]
+script = ExtResource( 1 )
+
+[node name="Button" type="Button" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -108.5
+margin_top = -32.5
+margin_right = 108.5
+margin_bottom = 32.5
+theme = ExtResource( 2 )
+text = "You Win!"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="SceneTransitionCover" parent="." instance=ExtResource( 3 )]
+
+[connection signal="pressed" from="Button" to="." method="_on_Button_pressed"]

--- a/project/src/main/world/career-data.gd
+++ b/project/src/main/world/career-data.gd
@@ -1,0 +1,83 @@
+class_name CareerData
+## Stores current and historical data for Career mode
+##
+## This includes the current day's data like "how much money has the player earned today" and "how far have they
+## travelled today", as well as historical information like "how many days have they played" and "how much money did
+## they earn three days ago"
+
+## how many days worth of records do we keep
+const MAX_DAILY_HISTORY := 40
+
+## how many consecutive levels does the player play in one career session
+const HOURS_PER_CAREER_DAY := 8
+
+## how far has the player travelled in the current career session
+var distance_travelled := 0
+
+## how many consecutive levels has the player played in the current career session
+var hours_passed := 0
+
+## how much money has the player earned in the current career session
+var daily_earnings := 0
+
+## how many days has the player completed
+var day := 0
+
+## Array of ints for previous daily earnings. Index 0 holds the most recent data.
+var prev_daily_earnings := []
+
+func reset() -> void:
+	distance_travelled = 0
+	hours_passed = 0
+	daily_earnings = 0
+	day = 0
+	prev_daily_earnings.clear()
+
+
+func from_json_dict(dict: Dictionary) -> void:
+	distance_travelled = dict.get("distance_travelled", 0)
+	hours_passed = dict.get("hours_passed", 0)
+	daily_earnings = dict.get("daily_earnings", 0)
+	day = dict.get("day", 0)
+	prev_daily_earnings = dict.get("prev_daily_earnings", [])
+
+
+func to_json_dict() -> Dictionary:
+	var results := {}
+	results["distance_travelled"] = distance_travelled
+	results["hours_passed"] = hours_passed
+	results["daily_earnings"] = daily_earnings
+	results["day"] = day
+	results["prev_daily_earnings"] = prev_daily_earnings
+	return results
+
+
+## Launches the next scene in career mode. Either a new level, or a cutscene/ending scene.
+func push_career_trail() -> void:
+	if hours_passed < HOURS_PER_CAREER_DAY:
+		# after the 'overworld map' scene, we launch a level
+		hours_passed += 1
+		PlayerSave.save_player_data()
+		CurrentLevel.push_level_trail()
+	else:
+		# after the final level, we show a 'you win' screen
+		advance_calendar()
+		PlayerSave.save_player_data()
+		SceneTransition.replace_trail("res://src/main/world/CareerWin.tscn")
+
+
+## Returns 'true' if the player is current playing career mode
+func is_career_mode() -> bool:
+	return Global.SCENE_CAREER_MAP in Breadcrumb.trail
+
+
+## Advances the calendar day and resets all daily variables
+func advance_calendar() -> void:
+	prev_daily_earnings.push_front(daily_earnings)
+	if prev_daily_earnings.size() > MAX_DAILY_HISTORY:
+		prev_daily_earnings = prev_daily_earnings.slice(0, MAX_DAILY_HISTORY - 1)
+	
+	distance_travelled = 0
+	hours_passed = 0
+	daily_earnings = 0
+	day = min(day + 1, 999999)

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -1,0 +1,56 @@
+extends Node
+## Shows the player's current progress through career mode.
+##
+## This includes how many levels they've played, how much money they've earned, and how far they've travelled.
+
+## key: (int) corresonding to the number of levels the player has played
+## value: (String) human-readable time of day
+var TEXT_BY_HOURS := {
+	0: "8:00 am",
+	1: "9:10 am",
+	2: "10:15 am",
+	3: "11:20 am",
+	4: "12:30 pm",
+	5: "1:40 pm",
+	6: "2:45 pm",
+	7: "3:50 pm",
+	8: "5:00 pm",
+}
+
+onready var _button := $Button
+onready var _label := $Label
+onready var _history := $History
+
+func _ready() -> void:
+	# prepare the label text
+	_label.text = ""
+	_label.text += "Distance: %s\n\n" % [PlayerData.career.distance_travelled]
+	_label.text += "Earnings: %s\n\n" % [StringUtils.format_money(PlayerData.career.daily_earnings)]
+	_label.text += "Current Time: %s" % [TEXT_BY_HOURS.get(PlayerData.career.hours_passed, "?:?? zm")]
+	if not TEXT_BY_HOURS.has(PlayerData.career.hours_passed):
+		push_warning("TEXT_BY_HOURS has no entry for %s" % [PlayerData.career.hours_passed])
+	
+	# prepare the history text
+	_history.bbcode_text = "[center]"
+	for daily_earnings in PlayerData.career.prev_daily_earnings:
+		if _history.bbcode_text:
+			_history.bbcode_text += "\n"
+		_history.bbcode_text += StringUtils.format_money(daily_earnings)
+	_history.bbcode_text += "[/center]"
+	
+	_button.grab_focus()
+
+
+func _on_Button_pressed() -> void:
+	# select a level id to play
+	var level_ids := []
+	var all_level_ids := LevelLibrary.all_level_ids()
+	for level_id_obj in all_level_ids:
+		var level_id: String = level_id_obj
+		if level_id.begins_with("tutorial/"):
+			continue
+		level_ids.append(level_id)
+	
+	# launch the selected level
+	CurrentLevel.set_launched_level(Utils.rand_value(level_ids))
+	PlayerData.career.push_career_trail()

--- a/project/src/main/world/career-win.gd
+++ b/project/src/main/world/career-win.gd
@@ -1,0 +1,8 @@
+extends Node
+## Shows a 'You win!' screen when the player finishes career mode
+
+onready var _button := $Button
+
+func _on_Button_pressed() -> void:
+	SceneTransition.pop_trail()
+	_button.grab_focus()

--- a/project/src/test/world/test-career-data.gd
+++ b/project/src/test/world/test-career-data.gd
@@ -1,0 +1,16 @@
+extends "res://addons/gut/test.gd"
+
+var _data: CareerData
+
+func before_each() -> void:
+	_data = CareerData.new()
+
+
+func test_it() -> void:
+	for i in range(10, 100):
+		_data.daily_earnings = i
+		_data.advance_calendar()
+	
+	assert_eq(_data.prev_daily_earnings.size(), CareerData.MAX_DAILY_HISTORY)
+	assert_eq(99, _data.prev_daily_earnings[0])
+	assert_eq(60, _data.prev_daily_earnings[CareerData.MAX_DAILY_HISTORY - 1])


### PR DESCRIPTION
A 'Career' button has been added to the main menu. This gives the player
a random series of levels, keeping track of their earnings as they play.
This career data is saved, so they can stop in the middle of a session
or view statistics for their previous sessions.