### PR TITLE
Added 'preplaced pieces' rank logic

### DIFF
--- a/project/assets/main/puzzle/levels/boatricia1.json
+++ b/project/assets/main/puzzle/levels/boatricia1.json
@@ -10,6 +10,9 @@
   "piece_types": [
     "start_piece_u"
   ],
+  "rank": [
+    "preplaced_pieces 4"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/boatricia2.json
+++ b/project/assets/main/puzzle/levels/boatricia2.json
@@ -10,6 +10,9 @@
   "piece_types": [
     "start_piece_j"
   ],
+  "rank": [
+    "preplaced_pieces 5"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/marsh/goodbye-bones.json
+++ b/project/assets/main/puzzle/levels/marsh/goodbye-bones.json
@@ -10,7 +10,8 @@
   },
   "rank": [
     "customer_combo 9",
-    "leftover_lines 3"
+    "leftover_lines 3",
+    "preplaced_pieces 10"
   ],
   "piece_types": [
     "piece_j",

--- a/project/assets/main/puzzle/levels/marsh/goodbye-everyone.json
+++ b/project/assets/main/puzzle/levels/marsh/goodbye-everyone.json
@@ -14,6 +14,9 @@
     "piece_o",
     "piece_v"
   ],
+  "rank": [
+    "preplaced_pieces 8"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/marsh/goodbye-skins.json
+++ b/project/assets/main/puzzle/levels/marsh/goodbye-skins.json
@@ -8,7 +8,8 @@
     "value": "120"
   },
   "rank": [
-    "box_factor 0.8"
+    "box_factor 0.8",
+    "preplaced_pieces 6"
   ],
   "lose_condition": [
     "top_out 9"

--- a/project/assets/main/puzzle/levels/marsh/hello-bones.json
+++ b/project/assets/main/puzzle/levels/marsh/hello-bones.json
@@ -10,6 +10,9 @@
   "piece_types": [
     "start_piece_j"
   ],
+  "rank": [
+    "preplaced_pieces 6"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/marsh/hello-everyone.json
+++ b/project/assets/main/puzzle/levels/marsh/hello-everyone.json
@@ -20,7 +20,8 @@
     "extra_seconds_per_piece 0.25",
     "box_factor 1.10",
     "combo_factor 1.21",
-    "hide_combos_rank"
+    "hide_combos_rank",
+    "preplaced_pieces 4"
   ],
   "triggers": [
     {

--- a/project/assets/main/puzzle/levels/marsh/hello-shirts.json
+++ b/project/assets/main/puzzle/levels/marsh/hello-shirts.json
@@ -14,6 +14,9 @@
     "piece_o",
     "piece_v"
   ],
+  "rank": [
+    "preplaced_pieces 3"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/marsh/hello-skins.json
+++ b/project/assets/main/puzzle/levels/marsh/hello-skins.json
@@ -11,7 +11,8 @@
     "top_out 9"
   ],
   "rank": [
-    "extra_seconds_per_piece 0.4"
+    "extra_seconds_per_piece 0.4",
+    "preplaced_pieces 3"
   ],
   "triggers": [
     {

--- a/project/assets/main/puzzle/levels/marsh/lets-all-get-merry.json
+++ b/project/assets/main/puzzle/levels/marsh/lets-all-get-merry.json
@@ -7,6 +7,9 @@
     "type": "lines",
     "value": "50"
   },
+  "rank": [
+    "preplaced_pieces 14"
+  ],
   "speed_ups": [
     {
       "type": "lines",

--- a/project/assets/main/puzzle/levels/marsh/pulling-for-bones.json
+++ b/project/assets/main/puzzle/levels/marsh/pulling-for-bones.json
@@ -17,6 +17,9 @@
     "piece_t",
     "piece_u"
   ],
+  "rank": [
+    "preplaced_pieces 3"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/marsh/pulling-for-everyone.json
+++ b/project/assets/main/puzzle/levels/marsh/pulling-for-everyone.json
@@ -11,6 +11,9 @@
     "start_piece_q",
     "start_piece_p"
   ],
+  "rank": [
+    "preplaced_pieces 4"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/marsh/pulling-for-shirts.json
+++ b/project/assets/main/puzzle/levels/marsh/pulling-for-shirts.json
@@ -19,6 +19,9 @@
     "piece_v",
     "piece_v"
   ],
+  "rank": [
+    "preplaced_pieces 4"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/marsh/pulling-for-skins.json
+++ b/project/assets/main/puzzle/levels/marsh/pulling-for-skins.json
@@ -9,7 +9,8 @@
   },
   "rank": [
     "extra_seconds_per_piece 0.6",
-    "box_factor 0.8"
+    "box_factor 0.8",
+    "preplaced_pieces 1"
   ],
   "piece_types": [
     "start_piece_v"

--- a/project/assets/main/puzzle/levels/placeholder01.json
+++ b/project/assets/main/puzzle/levels/placeholder01.json
@@ -10,6 +10,9 @@
   "piece_types": [
     "start_piece_j"
   ],
+  "rank": [
+    "preplaced_pieces 4"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/placeholder02.json
+++ b/project/assets/main/puzzle/levels/placeholder02.json
@@ -10,6 +10,9 @@
   "piece_types": [
     "start_piece_j"
   ],
+  "rank": [
+    "preplaced_pieces 6"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/placeholder03.json
+++ b/project/assets/main/puzzle/levels/placeholder03.json
@@ -14,6 +14,9 @@
     "piece_o",
     "piece_v"
   ],
+  "rank": [
+    "preplaced_pieces 3"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/placeholder04.json
+++ b/project/assets/main/puzzle/levels/placeholder04.json
@@ -10,6 +10,9 @@
   "piece_types": [
     "start_piece_p"
   ],
+  "rank": [
+    "preplaced_pieces 6"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/placeholder05.json
+++ b/project/assets/main/puzzle/levels/placeholder05.json
@@ -11,6 +11,9 @@
     "start_piece_q",
     "start_piece_p"
   ],
+  "rank": [
+    "preplaced_pieces 4"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/placeholder06.json
+++ b/project/assets/main/puzzle/levels/placeholder06.json
@@ -17,6 +17,9 @@
     "piece_t",
     "piece_u"
   ],
+  "rank": [
+    "preplaced_pieces 3"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/placeholder07.json
+++ b/project/assets/main/puzzle/levels/placeholder07.json
@@ -19,6 +19,9 @@
     "piece_v",
     "piece_v"
   ],
+  "rank": [
+    "preplaced_pieces 4"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/placeholder09.json
+++ b/project/assets/main/puzzle/levels/placeholder09.json
@@ -7,6 +7,9 @@
     "type": "lines",
     "value": "50"
   },
+  "rank": [
+    "preplaced_pieces 14"
+  ],
   "speed_ups": [
     {
       "type": "lines",

--- a/project/assets/main/puzzle/levels/placeholder10.json
+++ b/project/assets/main/puzzle/levels/placeholder10.json
@@ -10,7 +10,8 @@
   },
   "rank": [
     "customer_combo 9",
-    "leftover_lines 3"
+    "leftover_lines 3",
+    "preplaced_pieces 10"
   ],
   "piece_types": [
     "piece_j",

--- a/project/assets/main/puzzle/levels/placeholder12.json
+++ b/project/assets/main/puzzle/levels/placeholder12.json
@@ -13,6 +13,9 @@
   "piece_types": [
     "start_piece_j"
   ],
+  "rank": [
+    "preplaced_pieces 7"
+  ],
   "speed_ups": [
     {
       "type": "time_over",

--- a/project/assets/main/puzzle/levels/placeholder13.json
+++ b/project/assets/main/puzzle/levels/placeholder13.json
@@ -14,6 +14,9 @@
     "piece_o",
     "piece_v"
   ],
+  "rank": [
+    "preplaced_pieces 8"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/assets/main/puzzle/levels/placeholder14.json
+++ b/project/assets/main/puzzle/levels/placeholder14.json
@@ -17,6 +17,9 @@
     "piece_v",
     "piece_v"
   ],
+  "rank": [
+    "preplaced_pieces 8"
+  ],
   "tiles": {
     "start": [
       {

--- a/project/src/main/puzzle/level/rank-rules.gd
+++ b/project/src/main/puzzle/level/rank-rules.gd
@@ -50,6 +50,9 @@ var customer_combo := 0
 ## extra time it takes an expert to move the piece where it belongs
 var extra_seconds_per_piece := 0.0
 
+## helpful pieces which are already placed for the player
+var preplaced_pieces := 0
+
 ## expected leftover lines
 var leftover_lines := 0
 
@@ -91,6 +94,7 @@ func _init() -> void:
 	_rule_parser.add_int("leftover_lines")
 	_rule_parser.add_float("master_pickup_score")
 	_rule_parser.add_float("master_pickup_score_per_line")
+	_rule_parser.add_int("preplaced_pieces")
 	_rule_parser.add(ShowRankPropertyParser.new(self, "show_boxes_rank"))
 	_rule_parser.add(ShowRankPropertyParser.new(self, "show_combos_rank"))
 	_rule_parser.add(ShowRankPropertyParser.new(self, "show_lines_rank"))

--- a/project/src/test/puzzle/test-rank-calculator.gd
+++ b/project/src/test/puzzle/test-rank-calculator.gd
@@ -397,7 +397,50 @@ func test_very_short_level() -> void:
 	assert_eq(RankCalculator.grade(rank2.score_rank), "SSS")
 
 
-func test_leftover_score_low_combo_factor() -> void:
+func test_preplaced_pieces_ultra() -> void:
+	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 200)
+	
+	# 17 seconds is very fast for scoring 200 points.
+	PuzzleState.level_performance.seconds = 17
+	var rank1 := _rank_calculator.calculate_rank()
+	assert_eq(RankCalculator.grade(rank1.seconds_rank), "M")
+	
+	# 17 seconds isn't as impressive if the playfield starts with pieces on it.
+	CurrentLevel.settings.rank.preplaced_pieces = 5
+	PuzzleState.level_performance.seconds = 17
+	var rank2 := _rank_calculator.calculate_rank()
+	assert_eq(RankCalculator.grade(rank2.seconds_rank), "SS")
+	
+	# 12 seconds is required, because some pieces are preplaced
+	CurrentLevel.settings.rank.preplaced_pieces = 5
+	PuzzleState.level_performance.seconds = 12
+	var rank3 := _rank_calculator.calculate_rank()
+	assert_eq(RankCalculator.grade(rank3.seconds_rank), "M")
+
+
+func test_preplaced_pieces_sprint() -> void:
+	CurrentLevel.settings.set_finish_condition(Milestone.TIME_OVER, 17)
+	
+	# 650 points is a lot in 17 seconds.
+	PuzzleState.level_performance.score = 650
+	var rank1 := _rank_calculator.calculate_rank()
+	assert_eq(RankCalculator.grade(rank1.score_rank), "M")
+	
+	# 650 points isn't as impressive if the playfield starts with pieces on it.
+	CurrentLevel.settings.rank.preplaced_pieces = 5
+	PuzzleState.level_performance.score = 650
+	var rank2 := _rank_calculator.calculate_rank()
+	assert_eq(RankCalculator.grade(rank2.score_rank), "SSS")
+	
+	# 700 points are required, because some pieces are preplaced
+	CurrentLevel.settings.rank.preplaced_pieces = 5
+	PuzzleState.level_performance.score = 700
+	var rank3 := _rank_calculator.calculate_rank()
+	assert_eq(RankCalculator.grade(rank3.score_rank), "M")
+
+
+
+func test_target_leftover_score_low_combo_factor() -> void:
 	assert_almost_eq(_rank_calculator.target_leftover_score(12), 426.0, 10.0)
 	
 	# with a combo factor of 0, the leftover score should be 100 less


### PR DESCRIPTION
Some levels such as 'Teensy Taste' had boxes or pieces already on the
playfield. This meant the game would award an M rank for a time of 0:16 seconds
because it thought the player needed 30 pieces to finish the level. However it
should require a time of 0:12 seconds for an M rank, because the player only
needs 25 pieces.

The 'preplaced pieces' value for each level factors in how helpful the
pieces are. On Teensy Taste for example, there are five pieces on the
playfield, but preplaced_pieces is deliberately set to four, because the
boxes are arranged in a way that requires slow play.