### PR TITLE
Added career meter to puzzles. Tightened step calculation.

### DIFF
--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=92 format=2]
+[gd_scene load_steps=98 format=2]
 
 [ext_resource path="res://src/main/ui/menu/theme/h3.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/tutorial/TutorialHud.tscn" type="PackedScene" id=2]
@@ -32,6 +32,8 @@
 [ext_resource path="res://src/main/puzzle/topout-tracker.gd" type="Script" id=30]
 [ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=31]
 [ext_resource path="res://src/main/puzzle/combo-counters.gd" type="Script" id=32]
+[ext_resource path="res://src/main/puzzle/step-meter.gd" type="Script" id=33]
+[ext_resource path="res://src/main/ui/menu/theme/h2.theme" type="Theme" id=34]
 [ext_resource path="res://src/main/puzzle/FrostingGlob.tscn" type="PackedScene" id=35]
 [ext_resource path="res://src/main/ui/font-fit-label.gd" type="Script" id=36]
 [ext_resource path="res://src/main/puzzle/FoodItem.tscn" type="PackedScene" id=37]
@@ -70,6 +72,7 @@
 [ext_resource path="res://src/main/puzzle/level-timer-manager.gd" type="Script" id=70]
 [ext_resource path="res://src/main/puzzle/piece/piece-queue.gd" type="Script" id=71]
 [ext_resource path="res://src/main/puzzle/StarSeed.tscn" type="PackedScene" id=72]
+[ext_resource path="res://src/main/ui/menu/theme/h2-font-outline.tres" type="DynamicFont" id=73]
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 1, 1, 1, 0.333333 )
@@ -162,6 +165,23 @@ shader_param/frosting_alpha = 0.6
 shader_param/noise = SubResource( 11 )
 shader_param/frosting_texture = SubResource( 9 )
 shader_param/rainbow_texture = SubResource( 12 )
+
+[sub_resource type="StyleBoxFlat" id=22]
+bg_color = Color( 0.254902, 0.156863, 0.117647, 1 )
+corner_radius_top_left = 16
+corner_radius_top_right = 16
+corner_radius_bottom_right = 16
+corner_radius_bottom_left = 16
+
+[sub_resource type="Theme" id=23]
+Panel/styles/panel = SubResource( 22 )
+
+[sub_resource type="StyleBoxFlat" id=24]
+bg_color = Color( 0.282353, 0.72549, 0.407843, 1 )
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+corner_radius_bottom_right = 12
+corner_radius_bottom_left = 12
 
 [sub_resource type="ShaderMaterial" id=14]
 shader = ExtResource( 4 )
@@ -403,6 +423,52 @@ expand = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
+[node name="StepMeter" type="Control" parent="."]
+margin_left = 786.626
+margin_top = 134.094
+margin_right = 846.626
+margin_bottom = 214.094
+script = ExtResource( 33 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Bg" type="Panel" parent="StepMeter"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+theme = SubResource( 23 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Fill" type="Panel" parent="StepMeter"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 5.0
+margin_top = 5.0
+margin_right = -5.0
+margin_bottom = -5.0
+theme = SubResource( 23 )
+custom_styles/panel = SubResource( 24 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Label" type="Label" parent="StepMeter"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+theme = ExtResource( 34 )
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_fonts/font = ExtResource( 73 )
+text = "1"
+align = 1
+valign = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="RecalculateTimer" type="Timer" parent="StepMeter"]
 
 [node name="RestaurantView" parent="." instance=ExtResource( 25 )]
 
@@ -723,3 +789,4 @@ script = ExtResource( 19 )
 [connection signal="quit_pressed" from="SettingsMenu" to="." method="_on_SettingsMenu_quit_pressed"]
 [connection signal="show" from="SettingsMenu" to="Hud/TouchButtons" method="_on_Menu_show"]
 [connection signal="food_spawned" from="StarSeeds" to="FoodItems" method="_on_StarSeeds_food_spawned"]
+[connection signal="timeout" from="StepMeter/RecalculateTimer" to="StepMeter" method="_on_RecalculateTimer_timeout"]

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -296,9 +296,11 @@ func _update_career_data(rank_result: RankResult) -> void:
 	# Update the player's distance to travel based on their overall rank
 	var overall_rank := _overall_rank(rank_result)
 	PlayerData.career.distance_earned = 1
-	if overall_rank > 48.0:
-		PlayerData.career.distance_earned = 2
+	if overall_rank > 36.0:
+		PlayerData.career.distance_earned = 1
 	elif overall_rank > 24.0:
+		PlayerData.career.distance_earned = 2
+	elif overall_rank > 20.0:
 		PlayerData.career.distance_earned = 3
 	elif overall_rank > 16.0:
 		PlayerData.career.distance_earned = 4

--- a/project/src/main/puzzle/step-meter.gd
+++ b/project/src/main/puzzle/step-meter.gd
@@ -1,0 +1,123 @@
+extends Control
+## Displays a distance meter for career mode.
+##
+## This meter increases (and sometimes decreases) as the player progresses through a puzzle.
+
+## Array of dictionaries containing milestone metadata, including the necessary rank, the distance the player will
+## travel, and the UI color.
+const RANK_MILESTONES := [
+	{"rank": 64.0, "distance": 1, "color": Color("48b968")},
+	{"rank": 36.0, "distance": 2, "color": Color("48b968")},
+	{"rank": 24.0, "distance": 3, "color": Color("48b968")},
+	{"rank": 20.0, "distance": 4, "color": Color("78b948")},
+	{"rank": 16.0, "distance": 5, "color": Color("b9b948")},
+	{"rank": 10.0, "distance": 10, "color": Color("b95c48")},
+	{"rank": 4.0, "distance": 15, "color": Color("b94878")},
+	{"rank": 0.0, "distance": 25, "color": Color("b948b9")},
+]
+
+var _rank_calculator: RankCalculator = RankCalculator.new()
+
+## Timer which periodically triggers rank recalculation
+onready var _recalculate_timer: Timer = $RecalculateTimer
+
+func _ready() -> void:
+	# only display the meter in career mode
+	if PlayerData.career.is_career_mode():
+		visible = true
+		_recalculate_timer.start()
+		PuzzleState.connect("after_game_prepared", self, "_on_PuzzleState_after_game_prepared")
+		PuzzleState.connect("score_changed", self, "_on_PuzzleState_score_changed")
+		PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")
+	else:
+		visible = false
+	
+	# initialize the meter as empty
+	_recalculate()
+
+
+## Recalculates the player's projected rank and update the UI
+func _recalculate() -> void:
+	var overall_rank := _overall_rank()
+	var rank_milestone_index := _rank_milestone_index(overall_rank)
+	
+	var next_milestone_progress := inverse_lerp(RANK_MILESTONES[rank_milestone_index - 1].rank,
+			RANK_MILESTONES[rank_milestone_index].rank, overall_rank)
+	next_milestone_progress = clamp(next_milestone_progress, 0.0, 1.0)
+	
+	_update_ui(RANK_MILESTONES[rank_milestone_index], next_milestone_progress)
+
+
+## Update the UI with the specified projected rank data.
+##
+## Parameters:
+## 	'rank_milestone': Metadata about the milestone including the distance travelled and color.
+##
+## 	'next_milestone_progress': A number in the range [0.0, 1.0] describing how close the player is to reaching the
+## 		next milestone. A high value means they've almost reached the next milestone.
+func _update_ui(rank_milestone: Dictionary, next_milestone_progress: float) -> void:
+	$Fill.get("custom_styles/panel").set_bg_color(rank_milestone.color)
+	$Fill.margin_top = lerp(75, 5, next_milestone_progress)
+	$Label.text = str(rank_milestone.distance)
+
+
+## Calculates the highest rank milestone the player's reached.
+func _rank_milestone_index(overall_rank: float) -> int:
+	var rank_milestone_index := 0
+	for i in range(1, RANK_MILESTONES.size()):
+		var rank_milestone: Dictionary = RANK_MILESTONES[i]
+		if overall_rank > rank_milestone.rank:
+			break
+		rank_milestone_index = i
+	return rank_milestone_index
+
+
+## Calculates the player's projected rank.
+##
+## For modes graded on score, we simply rank them based on their current score. For modes graded on time, we predict
+## their final time based on their current score and percent complete.
+func _overall_rank() -> float:
+	var overall_rank: float = RankCalculator.WORST_RANK
+	
+	if CurrentLevel.settings.finish_condition.type == Milestone.SCORE:
+		# for modes graded on time, we predict their final time based on their current performance
+		var rank_result := _rank_calculator.unranked_result()
+		var percent_complete := float(rank_result.score) / CurrentLevel.settings.finish_condition.value
+		percent_complete = clamp(percent_complete, 0.0, 1.0)
+		
+		# This line deliberately inflates our seconds prediction, particularly at the start of a puzzle. We do this
+		# for two reasons. We want the meter to increase, and we don't want the prediction to max out after the first
+		# cleared line
+		percent_complete = pow(percent_complete, 1.5)
+		
+		if percent_complete == 0:
+			# avoid dividing by zero
+			rank_result.seconds = 9999
+		else:
+			rank_result.seconds = clamp(PuzzleState.level_performance.seconds / percent_complete, 0, 9999)
+		
+		rank_result = _rank_calculator.calculate_rank(rank_result)
+		overall_rank = rank_result.seconds_rank
+	else:
+		# for modes graded on score, we feed their current score into the rank calculator
+		var rank_result := _rank_calculator.calculate_rank()
+		overall_rank = rank_result.score_rank
+	
+	return overall_rank
+
+
+func _on_RecalculateTimer_timeout() -> void:
+	if PuzzleState.game_active:
+		_recalculate()
+
+
+func _on_PuzzleState_after_game_prepared() -> void:
+	_recalculate()
+
+
+func _on_PuzzleState_game_ended() -> void:
+	_recalculate()
+
+
+func _on_PuzzleState_score_changed() -> void:
+	_recalculate()


### PR DESCRIPTION
The puzzle now shows a meter next to the player which indicates how far
they'll travel. This meter increases (and sometimes decreases) as they
progress through a puzzle.

The step calculation now makes it harder to travel 2, 3 or 4 steps.
Before, it was incredibly trivial to travel 2 or 3 steps -- it could
often be done in 2-3 line clears.