### PR TITLE
MilestoneManager renames: progress_value, is_met

### DIFF
--- a/project/src/main/puzzle/Playfield.tscn
+++ b/project/src/main/puzzle/Playfield.tscn
@@ -261,8 +261,8 @@ margin_left = -119.0
 margin_top = 86.0
 margin_right = 119.0
 margin_bottom = 176.0
-custom_styles/normal = ExtResource( 21 )
 custom_fonts/normal_font = ExtResource( 22 )
+custom_styles/normal = ExtResource( 21 )
 text = "Arrows: Move
 Down: Soft drop
 Space: Hard drop

--- a/project/src/main/puzzle/milestone-hud.gd
+++ b/project/src/main/puzzle/milestone-hud.gd
@@ -52,13 +52,13 @@ func update_milebar_values() -> void:
 		_progress_bar.max_value = _progress_bar.min_value + 1.0
 	else:
 		_progress_bar.max_value = next_milestone.value
-	_progress_bar.value = MilestoneManager.milestone_progress(next_milestone)
+	_progress_bar.value = MilestoneManager.progress_value(next_milestone)
 
 
 ## Updates the milestone progress bar text.
 func update_milebar_text() -> void:
 	var milestone := CurrentLevel.settings.finish_condition
-	var remaining: int = max(0, ceil(milestone.value - MilestoneManager.milestone_progress(milestone)))
+	var remaining: int = max(0, ceil(milestone.value - MilestoneManager.progress_value(milestone)))
 	match milestone.type:
 		Milestone.NONE:
 			_value.text = "-"

--- a/project/src/main/puzzle/milestone-manager.gd
+++ b/project/src/main/puzzle/milestone-manager.gd
@@ -19,9 +19,9 @@ func _physics_process(_delta: float) -> void:
 		_check_for_finish()
 
 
-func milestone_met(milestone: Milestone) -> bool:
+func is_met(milestone: Milestone) -> bool:
 	var result := false
-	var progress := milestone_progress(milestone)
+	var progress := progress_value(milestone)
 	match milestone.type:
 		Milestone.NONE:
 			result = false
@@ -32,11 +32,11 @@ func milestone_met(milestone: Milestone) -> bool:
 	return result
 
 
-## Returns the player's current progress toward the specified milestone.
+## Returns the player's current progress toward the specified milestone as a number ranged [0, inf].
 ##
 ## Depending on the milestone type, the returned progress value could be the current score, number of lines cleared or
 ## something else.
-func milestone_progress(milestone: Milestone) -> float:
+func progress_value(milestone: Milestone) -> float:
 	var progress: float
 	match milestone.type:
 		Milestone.CUSTOMERS:
@@ -81,7 +81,7 @@ func _check_for_speed_up() -> void:
 	var new_speed_index: int = PuzzleState.speed_index
 	
 	while new_speed_index + 1 < CurrentLevel.settings.speed.speed_ups.size() \
-			and milestone_met(CurrentLevel.settings.speed.speed_ups[new_speed_index + 1]):
+			and is_met(CurrentLevel.settings.speed.speed_ups[new_speed_index + 1]):
 		new_speed_index += 1
 	
 	if PuzzleState.speed_index != new_speed_index:
@@ -90,7 +90,7 @@ func _check_for_speed_up() -> void:
 
 ## If the player reached the finish milestone, we end the level.
 func _check_for_finish() -> void:
-	if PuzzleState.game_active and milestone_met(CurrentLevel.settings.finish_condition):
+	if PuzzleState.game_active and is_met(CurrentLevel.settings.finish_condition):
 		PuzzleState.trigger_finish()
 
 

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -149,7 +149,7 @@ func end_game() -> void:
 	
 	end_combo()
 	if not level_performance.lost:
-		level_performance.success = MilestoneManager.milestone_met(CurrentLevel.settings.success_condition)
+		level_performance.success = MilestoneManager.is_met(CurrentLevel.settings.success_condition)
 	emit_signal("game_ended")
 	var yield_duration: float
 	match end_result():
@@ -311,7 +311,7 @@ func end_result() -> int:
 		return Levels.Result.NONE
 	elif level_performance.lost:
 		return Levels.Result.LOST
-	elif MilestoneManager.milestone_met(CurrentLevel.settings.success_condition):
+	elif MilestoneManager.is_met(CurrentLevel.settings.success_condition):
 		return Levels.Result.WON
 	else:
 		return Levels.Result.FINISHED

--- a/project/src/main/puzzle/rank-calculator.gd
+++ b/project/src/main/puzzle/rank-calculator.gd
@@ -379,7 +379,7 @@ func _populate_rank_fields(rank_result: RankResult, lenient: bool) -> void:
 	else:
 		rank_result.score_rank = stepify((overall_rank_max + overall_rank_min) / 2.0, 0.01)
 	
-	if MilestoneManager.milestone_met(CurrentLevel.settings.success_condition):
+	if MilestoneManager.is_met(CurrentLevel.settings.success_condition):
 		if rank_result.compare == "-seconds":
 			rank_result.seconds_rank -= CurrentLevel.settings.rank.success_bonus
 		else:

--- a/project/src/main/puzzle/step-meter.gd
+++ b/project/src/main/puzzle/step-meter.gd
@@ -41,11 +41,11 @@ func _recalculate() -> void:
 	var overall_rank := _overall_rank()
 	var rank_milestone_index := _rank_milestone_index(overall_rank)
 	
-	var next_milestone_progress := inverse_lerp(RANK_MILESTONES[rank_milestone_index - 1].rank,
+	var next_progress_value := inverse_lerp(RANK_MILESTONES[rank_milestone_index - 1].rank,
 			RANK_MILESTONES[rank_milestone_index].rank, overall_rank)
-	next_milestone_progress = clamp(next_milestone_progress, 0.0, 1.0)
+	next_progress_value = clamp(next_progress_value, 0.0, 1.0)
 	
-	_update_ui(RANK_MILESTONES[rank_milestone_index], next_milestone_progress)
+	_update_ui(RANK_MILESTONES[rank_milestone_index], next_progress_value)
 
 
 ## Update the UI with the specified projected rank data.
@@ -53,11 +53,11 @@ func _recalculate() -> void:
 ## Parameters:
 ## 	'rank_milestone': Metadata about the milestone including the distance travelled and color.
 ##
-## 	'next_milestone_progress': A number in the range [0.0, 1.0] describing how close the player is to reaching the
+## 	'next_progress_value': A number in the range [0.0, 1.0] describing how close the player is to reaching the
 ## 		next milestone. A high value means they've almost reached the next milestone.
-func _update_ui(rank_milestone: Dictionary, next_milestone_progress: float) -> void:
+func _update_ui(rank_milestone: Dictionary, next_progress_value: float) -> void:
 	$Fill.get("custom_styles/panel").set_bg_color(rank_milestone.color)
-	$Fill.margin_top = lerp(75, 5, next_milestone_progress)
+	$Fill.margin_top = lerp(75, 5, next_progress_value)
 	$Label.text = str(rank_milestone.distance)
 
 


### PR DESCRIPTION
'milestone_progress' was a confusing name, as it was unclear whether it
returned a progress percent like 0.78 or an integer like 580. Its new
name 'progress_value' disambiguates that it returns a value and not a
percent.