### PR TITLE
Career level tweaks: dark, ultra/sprint, name switch

### DIFF
--- a/project/assets/main/puzzle/career-worlds.json
+++ b/project/assets/main/puzzle/career-worlds.json
@@ -6,10 +6,10 @@
       "piece_speed": "0",
       "levels": [
         {
-          "id": "career/secret_brownies"
+          "id": "career/90_second_sprint"
         },
         {
-          "id": "career/fruit_salad"
+          "id": "career/cocoa_canyon"
         },
         {
           "id": "career/unfresh_fruits"
@@ -43,101 +43,83 @@
       "piece_speed": "0-3",
       "levels": [
         {
-          "id": "career/just_cream"
+          "id": "career/1000_race"
         },
         {
           "id": "career/boxing_day"
         },
         {
-          "id": "career/real_meal"
+          "id": "career/fruit_salad"
         },
         {
-          "id": "career/pineapple_on_its_side_cake"
-        },
-        {
-          "id": "career/muffin_impossible_2"
-        },
-        {
-          "id": "career/its_square_to_be_square"
-        },
-        {
-          "id": "career/cocoa_canyon"
-        },
-        {
-          "id": "career/its_tee_time"
-        },
-        {
-          "id": "career/veggie_patty"
-        },
-        {
-          "id": "career/lets_all_get_merry"
-        },
-        {
-          "id": "career/a_little_garbage"
-        },
-        {
-          "id": "career/teensy_taste"
+          "id": "career/just_cream"
         },
         {
           "id": "career/muffin_impossible"
         },
         {
+          "id": "career/secret_brownies"
+        },
+        {
           "id": "career/snack_box_blitz"
         },
         {
+          "id": "career/lets_all_get_merry"
+        },
+        {
+          "id": "career/strawberry_shortcut"
+        },
+        {
           "id": "career/unfresh_fruits"
+        },
+        {
+          "id": "career/cleaning_duty"
         }
       ]
     },
     {
-      "name": "The Great Frungle Kingdom",
+      "name": "Cannoli Sandbar",
       "distance": 25,
       "piece_speed": "1-5",
       "levels": [
         {
-          "id": "career/just_cream"
-        },
-        {
-          "id": "career/boxing_day"
-        },
-        {
-          "id": "career/real_meal"
-        },
-        {
-          "id": "career/pineapple_on_its_side_cake"
-        },
-        {
-          "id": "career/muffin_impossible_2"
-        },
-        {
-          "id": "career/its_square_to_be_square"
+          "id": "career/1000_race"
         },
         {
           "id": "career/cocoa_canyon"
         },
         {
-          "id": "career/its_tee_time"
+          "id": "career/strawberry_shortcut"
         },
         {
-          "id": "career/veggie_patty"
+          "id": "career/veggie_haters"
         },
         {
-          "id": "career/lets_all_get_merry"
+          "id": "career/pineapple_on_its_side_cake"
         },
         {
-          "id": "career/a_little_garbage"
+          "id": "career/unfresh_fruits_2"
         },
         {
-          "id": "career/teensy_taste"
+          "id": "career/real_meal"
         },
         {
-          "id": "career/muffin_impossible"
+          "id": "career/secret_brownies"
         },
         {
-          "id": "career/snack_box_blitz"
+          "id": "career/a_little_extra"
         },
         {
-          "id": "career/unfresh_fruits"
+          "id": "career/its_square_to_be_square"
+        },
+        {
+          "id": "career/curly_queue"
+        },
+        {
+          "id": "career/one_step_ahead"
+        },
+        {
+          "id": "career/wedding_cake_for_one"
         }
       ]
     },
@@ -147,49 +129,43 @@
       "piece_speed": "3-7",
       "levels": [
         {
-          "id": "career/just_cream"
+          "id": "career/90_second_sprint"
         },
         {
-          "id": "career/boxing_day"
+          "id": "career/fruit_salad"
         },
         {
-          "id": "career/real_meal"
+          "id": "career/a_little_extra"
         },
         {
-          "id": "career/pineapple_on_its_side_cake"
-        },
-        {
-          "id": "career/muffin_impossible_2"
-        },
-        {
-          "id": "career/its_square_to_be_square"
+          "id": "career/unfresh_fruits_2"
         },
         {
           "id": "career/cocoa_canyon"
         },
         {
-          "id": "career/its_tee_time"
+          "id": "career/strawberry_shortcut"
         },
         {
-          "id": "career/veggie_patty"
+          "id": "career/just_cream"
         },
         {
-          "id": "career/lets_all_get_merry"
+          "id": "career/muffin_impossible_2"
         },
         {
           "id": "career/a_little_garbage"
         },
         {
-          "id": "career/teensy_taste"
+          "id": "career/real_meal"
         },
         {
-          "id": "career/muffin_impossible"
+          "id": "career/curly_queue_2"
         },
         {
-          "id": "career/snack_box_blitz"
+          "id": "career/leftovers"
         },
         {
-          "id": "career/unfresh_fruits"
+          "id": "career/tempting_jellies"
         }
       ]
     },
@@ -199,49 +175,37 @@
       "piece_speed": "5-8",
       "levels": [
         {
-          "id": "career/just_cream"
-        },
-        {
-          "id": "career/boxing_day"
-        },
-        {
-          "id": "career/real_meal"
-        },
-        {
-          "id": "career/pineapple_on_its_side_cake"
-        },
-        {
-          "id": "career/muffin_impossible_2"
-        },
-        {
-          "id": "career/its_square_to_be_square"
-        },
-        {
-          "id": "career/cocoa_canyon"
-        },
-        {
-          "id": "career/its_tee_time"
-        },
-        {
-          "id": "career/veggie_patty"
+          "id": "career/90_second_sprint"
         },
         {
           "id": "career/lets_all_get_merry"
         },
         {
-          "id": "career/a_little_garbage"
+          "id": "career/cocoa_canyon"
         },
         {
-          "id": "career/teensy_taste"
+          "id": "career/secret_brownies"
         },
         {
-          "id": "career/muffin_impossible"
+          "id": "career/veggie_patty"
         },
         {
           "id": "career/snack_box_blitz"
         },
         {
-          "id": "career/unfresh_fruits"
+          "id": "career/its_tee_time"
+        },
+        {
+          "id": "career/a_little_garbage_2"
+        },
+        {
+          "id": "career/muffin_impossible_2"
+        },
+        {
+          "id": "career/strawberry_shortcut"
+        },
+        {
+          "id": "career/low_gravity"
         }
       ]
     },
@@ -251,101 +215,83 @@
       "piece_speed": "6-9",
       "levels": [
         {
-          "id": "career/just_cream"
+          "id": "career/90_second_sprint"
         },
         {
-          "id": "career/boxing_day"
+          "id": "career/fruit_salad"
         },
         {
-          "id": "career/real_meal"
-        },
-        {
-          "id": "career/pineapple_on_its_side_cake"
-        },
-        {
-          "id": "career/muffin_impossible_2"
+          "id": "career/unfresh_fruits_2"
         },
         {
           "id": "career/its_square_to_be_square"
         },
         {
-          "id": "career/cocoa_canyon"
-        },
-        {
-          "id": "career/its_tee_time"
-        },
-        {
           "id": "career/veggie_patty"
         },
         {
-          "id": "career/lets_all_get_merry"
+          "id": "career/muffin_impossible_3"
         },
         {
-          "id": "career/a_little_garbage"
+          "id": "career/just_cream"
         },
         {
-          "id": "career/teensy_taste"
+          "id": "career/accelerator"
         },
         {
-          "id": "career/muffin_impossible"
+          "id": "career/a_little_garbage_2"
         },
         {
-          "id": "career/snack_box_blitz"
+          "id": "career/nowhere_to_turn"
         },
         {
-          "id": "career/unfresh_fruits"
+          "id": "career/zero_gravity"
+        },
+        {
+          "id": "career/too_fast_to_fast"
+        },
+        {
+          "id": "career/wedding_cake_for_one"
         }
       ]
     },
     {
       "name": "Starberry Mountain",
       "distance": 100,
-      "piece_speed": "A0-AD",
+      "piece_speed": "A1-AD",
       "levels": [
         {
-          "id": "career/just_cream"
+          "id": "career/dark/three_minute_sprint"
         },
         {
-          "id": "career/boxing_day"
+          "id": "career/dark/3000_race"
         },
         {
-          "id": "career/real_meal"
+          "id": "career/dark/muffin_impossible_2"
         },
         {
-          "id": "career/pineapple_on_its_side_cake"
+          "id": "career/dark/a_little_garbage_2"
         },
         {
-          "id": "career/muffin_impossible_2"
+          "id": "career/dark/boxing_day"
         },
         {
-          "id": "career/its_square_to_be_square"
+          "id": "career/dark/fruit_salad"
         },
         {
-          "id": "career/cocoa_canyon"
+          "id": "career/dark/secret_brownies"
         },
         {
-          "id": "career/its_tee_time"
+          "id": "career/dark/strawberry_shortcut"
         },
         {
-          "id": "career/veggie_patty"
+          "id": "career/dark/a_little_extra"
         },
         {
-          "id": "career/lets_all_get_merry"
+          "id": "career/dark/its_square_to_be_square"
         },
         {
-          "id": "career/a_little_garbage"
-        },
-        {
-          "id": "career/teensy_taste"
-        },
-        {
-          "id": "career/muffin_impossible"
-        },
-        {
-          "id": "career/snack_box_blitz"
-        },
-        {
-          "id": "career/unfresh_fruits"
+          "id": "career/dark/too_fast_to_fast"
         }
       ]
     }

--- a/project/assets/main/puzzle/levels/career/1000-race.json
+++ b/project/assets/main/puzzle/levels/career/1000-race.json
@@ -1,6 +1,6 @@
 {
   "version": "297a",
-  "start_speed": "A0",
+  "start_speed": "0",
   "title": "1,000¥ Race",
   "description": "Earn 1,000¥ as fast as possible. No tricks!",
   "finish_condition": {

--- a/project/assets/main/puzzle/levels/career/90-second-sprint.json
+++ b/project/assets/main/puzzle/levels/career/90-second-sprint.json
@@ -1,6 +1,6 @@
 {
   "version": "297a",
-  "start_speed": "A0",
+  "start_speed": "0",
   "title": "90 Second Sprint",
   "description": "Nothing fancy, let's just cook!",
   "finish_condition": {

--- a/project/assets/main/puzzle/levels/career/a-little-garbage.json
+++ b/project/assets/main/puzzle/levels/career/a-little-garbage.json
@@ -9,7 +9,7 @@
   },
   "timers": [
     {
-      "interval": 5
+      "interval": 6
     }
   ],
   "triggers": [

--- a/project/assets/main/puzzle/levels/career/dark/3000-race.json
+++ b/project/assets/main/puzzle/levels/career/dark/3000-race.json
@@ -1,6 +1,6 @@
 {
   "version": "297a",
-  "start_speed": "F0",
+  "start_speed": "A1",
   "title": "3,000¥ Race",
   "description": "Earn 3,000¥ as fast as possible. No tricks!",
   "finish_condition": {

--- a/project/assets/main/puzzle/levels/career/dark/muffin-impossible-2.json
+++ b/project/assets/main/puzzle/levels/career/dark/muffin-impossible-2.json
@@ -5,7 +5,7 @@
   "description": "More awkward mismatched pieces!? When will the pain stop?",
   "finish_condition": {
     "type": "score",
-    "value": "1800"
+    "value": "1200"
   },
   "piece_types": [
     "piece_j",

--- a/project/assets/main/puzzle/levels/career/dark/three-minute-sprint.json
+++ b/project/assets/main/puzzle/levels/career/dark/three-minute-sprint.json
@@ -1,6 +1,6 @@
 {
   "version": "297a",
-  "start_speed": "F0",
+  "start_speed": "A1",
   "title": "Three Minute Sprint",
   "description": "Nothing fancy, let's just cook!",
   "finish_condition": {

--- a/project/assets/main/puzzle/levels/career/lets-all-get-merry.json
+++ b/project/assets/main/puzzle/levels/career/lets-all-get-merry.json
@@ -1,8 +1,8 @@
 {
   "version": "297a",
   "start_speed": "3",
-  "title": "It's Really Time To Leave",
-  "description": "Can't we stay forever?",
+  "title": "Let's All Get Merry",
+  "description": "It's a dessert party and everybody's invited!",
   "finish_condition": {
     "type": "lines",
     "value": "50"

--- a/project/assets/main/puzzle/levels/career/muffin-impossible-2.json
+++ b/project/assets/main/puzzle/levels/career/muffin-impossible-2.json
@@ -5,7 +5,7 @@
   "description": "More awkward mismatched pieces!? When will the pain stop?",
   "finish_condition": {
     "type": "score",
-    "value": "1200"
+    "value": "800"
   },
   "piece_types": [
     "piece_j",

--- a/project/assets/test/ui/level-select/career-worlds.json
+++ b/project/assets/test/ui/level-select/career-worlds.json
@@ -78,7 +78,7 @@
       ]
     },
     {
-      "name": "Cannoli Sandbar",
+      "name": "Merrymellow Marsh",
       "distance": 25,
       "piece_speed": "1-5",
       "levels": [
@@ -124,7 +124,7 @@
       ]
     },
     {
-      "name": "Merrymellow Marsh",
+      "name": "Cannoli Sandbar",
       "distance": 40,
       "piece_speed": "3-7",
       "levels": [
@@ -261,37 +261,37 @@
       "piece_speed": "A1-AD",
       "levels": [
         {
-          "id": "dark/three_minute_sprint"
+          "id": "career/dark/three_minute_sprint"
         },
         {
-          "id": "dark/3000_race"
+          "id": "career/dark/3000_race"
         },
         {
-          "id": "dark/muffin_impossible_2"
+          "id": "career/dark/muffin_impossible_2"
         },
         {
-          "id": "dark/a_little_garbage_2"
+          "id": "career/dark/a_little_garbage_2"
         },
         {
-          "id": "dark/boxing_day"
+          "id": "career/dark/boxing_day"
         },
         {
-          "id": "dark/fruit_salad"
+          "id": "career/dark/fruit_salad"
         },
         {
-          "id": "dark/secret_brownies"
+          "id": "career/dark/secret_brownies"
         },
         {
-          "id": "dark/strawberry_shortcut"
+          "id": "career/dark/strawberry_shortcut"
         },
         {
-          "id": "dark/a_little_extra"
+          "id": "career/dark/a_little_extra"
         },
         {
-          "id": "dark/its_square_to_be_square"
+          "id": "career/dark/its_square_to_be_square"
         },
         {
-          "id": "dark/too_fast_to_fast"
+          "id": "career/dark/too_fast_to_fast"
         }
       ]
     }


### PR DESCRIPTION
Added dark, ultra, sprint levels to career mode. I accidentally added
these to the test resource before instead of the one used by the game.
I've also fixed the path to the dark levels, as they were referencing
invalid resources before.

Renamed career regions. Cannoli Sandbar thematically fits for being
the region with only four customers.

Sprint/ultra career mode levels now have an appropriate piece speed.
This allows them to scale in difficulty.

Made 'muffin impossible' and 'a little garbage' levels easier. They were
disproportionately difficult.