### PR TITLE
Career map hides level buttons when showing settings menu.

### DIFF
--- a/project/src/main/world/CareerMap.tscn
+++ b/project/src/main/world/CareerMap.tscn
@@ -488,6 +488,8 @@ quit_type = 1
 [connection signal="pressed" from="LevelSelect/Control/Distance/Down" to="LevelSelect/Control/Distance" method="_on_Down_pressed"]
 [connection signal="pressed" from="LevelSelect/Control/Distance/Up" to="LevelSelect/Control/Distance" method="_on_Up_pressed"]
 [connection signal="pressed" from="Ui/Control/SettingsButton" to="Ui" method="_on_SettingsButton_pressed"]
+[connection signal="hide" from="Ui/SettingsMenu" to="LevelSelect" method="_on_SettingsMenu_hide"]
 [connection signal="hide" from="Ui/SettingsMenu" to="Ui" method="_on_SettingsMenu_hide"]
 [connection signal="quit_pressed" from="Ui/SettingsMenu" to="Ui" method="_on_SettingsMenu_quit_pressed"]
+[connection signal="show" from="Ui/SettingsMenu" to="LevelSelect" method="_on_SettingsMenu_show"]
 [connection signal="show" from="Ui/SettingsMenu" to="Ui" method="_on_SettingsMenu_show"]

--- a/project/src/main/world/career-map-level-select.gd
+++ b/project/src/main/world/career-map-level-select.gd
@@ -4,6 +4,7 @@ extends CanvasLayer
 signal level_button_focused(button_index)
 
 onready var _level_select_buttons := $Control/Top/LevelButtons.get_children()
+onready var _control := $Control
 
 func _ready() -> void:
 	for i in range(_level_select_buttons.size()):
@@ -13,3 +14,11 @@ func _ready() -> void:
 
 func _on_LevelSelectButton_focus_entered(button_index: int) -> void:
 	emit_signal("level_button_focused", button_index)
+
+
+func _on_SettingsMenu_show() -> void:
+	_control.hide()
+
+
+func _on_SettingsMenu_hide() -> void:
+	_control.show()


### PR DESCRIPTION
The buttons were overlapping the settings menu in an ugly way before.