### PR TITLE
Customers emote when selected. Results screen line breaks.

### DIFF
--- a/project/src/main/puzzle/results-hud.gd
+++ b/project/src/main/puzzle/results-hud.gd
@@ -60,7 +60,7 @@ func _append_customer_scores(rank_result: RankResult, customer_scores: Array, \
 		var left := tr("Customer #%s") % StringUtils.comma_sep(i + 1)
 		var right := "%s/\n" % StringUtils.format_money(customer_score)
 		var middle := " "
-		var period_count := 50 - _period_count(left + right)
+		var period_count := 49 - _period_count(left + right)
 		for _p in range(period_count):
 			middle += "."
 		text += left + middle + right

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -36,6 +36,8 @@ const CREATURE_FADE_OUT_DURATION := 0.3
 
 export (String) var creature_id: String setget set_creature_id
 export (Dictionary) var dna: Dictionary setget set_dna
+
+## 'true' if the creature should not make any sounds when walking/loading. Used for the creature editor.
 export (bool) var suppress_sfx: bool = false setget set_suppress_sfx
 
 ## if 'true' the creature will only use the fatness in the creature definition,


### PR DESCRIPTION
Customers in career mode now emote when you choose their level. Usually
they're happy but sometimes they're anxious.

Decreased the number of periods in the end of level results display, to
prevent it from wrapping its lines unnecessarily.

Closes #1061.