### PR TITLE
Career mode decreases distance if you pick certain levels.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -64,6 +64,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/ui/level-select/career-level.gd"
 }, {
+"base": "CanvasLayer",
+"class": "CareerLevelSelect",
+"language": "GDScript",
+"path": "res://src/main/ui/career/career-map-level-select.gd"
+}, {
 "base": "Reference",
 "class": "CareerRegion",
 "language": "GDScript",
@@ -966,6 +971,7 @@ _global_script_class_icons={
 "BoxBuilder": "",
 "CareerData": "",
 "CareerLevel": "",
+"CareerLevelSelect": "",
 "CareerRegion": "",
 "ChatAdvancer": "",
 "ChatChoiceButton": "",

--- a/project/src/main/career-data.gd
+++ b/project/src/main/career-data.gd
@@ -132,6 +132,37 @@ func is_boss_level() -> bool:
 	return result
 
 
+## Returns the player's distance penalties for picking different levels.
+##
+## Upon beating a level, the player is advanced by distance_earned. If they select one of the two leftmost levels,
+## a penalty is applied and they don't travel as far.
+##
+## Returns:
+## 	An array of positive ints corresponding to the penalty for selecting each level. Index 0 corresponds to the
+## 	earliest level.
+func distance_penalties() -> Array:
+	var result := [0, 0, 0]
+	
+	if is_boss_level():
+		# boss levels only have one choice, there is no penalty
+		return result
+	
+	# adjust result[0]
+	if distance_earned < 0: result [0] = 1 # small penalty for level selection after failing a boss stage
+	elif distance_earned <= 1: result[0] = 0 # no penalty after skipping, or for the first level of a set
+	elif distance_earned <= 2: result[0] = 1
+	elif distance_earned <= 5: result[0] = 2
+	elif distance_earned <= 6: result[0] = 3
+	else: result[0] = 4
+	
+	# adjust result[1]
+	if distance_earned <= 1: result[1] = 0 # no penalty after skipping, or for the first level of a set
+	elif distance_earned <= 5: result[1] = 1
+	else: result[1] = 2
+	
+	return result
+
+
 ## Advances the player the specified distance.
 ##
 ## Even if distance_to_advance is a large number, the player's travel distance can be limited in two scenarios.

--- a/project/src/main/ui/career/career-distance-label.gd
+++ b/project/src/main/ui/career/career-distance-label.gd
@@ -3,7 +3,12 @@ extends Control
 ##
 ## This includes a text label like '16 (+3)' and a static icon.
 
+export (NodePath) var level_select_path: NodePath
+
 onready var _label := $Label
+
+## UI components for career mode's level select buttons
+onready var _level_select: CareerLevelSelect = get_node(level_select_path)
 
 func _ready() -> void:
 	PlayerData.career.connect("distance_travelled_changed", self, "_on_CareerData_distance_travelled_changed")
@@ -12,19 +17,28 @@ func _ready() -> void:
 
 ## Refreshes the label based on the player's current distance.
 func _refresh_label() -> void:
-	_label.text = StringUtils.comma_sep(PlayerData.career.distance_travelled)
+	# Determine the currently selected distance penalty
+	var focused_level_button_index := _level_select.focused_level_button_index()
+	var distance_penalty: int = PlayerData.career.distance_penalties()[focused_level_button_index]
 	
-	# append the distance_earned
+	# Display the distance travelled with the distance penalty applied
+	_label.text = StringUtils.comma_sep(PlayerData.career.distance_travelled - distance_penalty)
+	
+	# Append the distance_option with the distance penalty applied
 	if PlayerData.career.distance_earned > 0:
-		# distance_earned is positive; prefix it with a '+'
-		_label.text += " (+%s)" % [StringUtils.comma_sep(PlayerData.career.distance_earned)]
+		# distance_earned is positive; prefix distance_option with a '+'
+		_label.text += " (+%s)" % [StringUtils.comma_sep(PlayerData.career.distance_earned - distance_penalty)]
 	elif PlayerData.career.distance_earned < 0:
-		# distance_earned is negative; no prefix is necessary, it already includes a '-'
-		_label.text += " (%s)" % [StringUtils.comma_sep(PlayerData.career.distance_earned)]
+		# distance_earned is negative; no prefix is necessary, distance_option already includes a '-'
+		_label.text += " (%s)" % [StringUtils.comma_sep(PlayerData.career.distance_earned - distance_penalty)]
 	else:
-		# distance earned is zero; don't show it
+		# distance_earned is zero; don't show it
 		pass
 
 
 func _on_CareerData_distance_travelled_changed() -> void:
+	_refresh_label()
+
+
+func _on_LevelSelect_level_button_focused(_button_index: int) -> void:
 	_refresh_label()

--- a/project/src/main/ui/career/career-map-level-select.gd
+++ b/project/src/main/ui/career/career-map-level-select.gd
@@ -1,3 +1,4 @@
+class_name CareerLevelSelect
 extends CanvasLayer
 ## UI components for career mode's level select buttons.
 
@@ -10,6 +11,13 @@ func _ready() -> void:
 	for i in range(_level_select_buttons.size()):
 		var button: Button = _level_select_buttons[i]
 		button.connect("focus_entered", self, "_on_LevelSelectButton_focus_entered", [i])
+
+
+## Returns the index of the currently focused level button, or -1 if none is selected.
+##
+## For a boss level where only one level is available, this will return '0' if the level button is selected.
+func focused_level_button_index() -> int:
+	return _level_select_buttons.find(_control.get_focus_owner())
 
 
 func _on_LevelSelectButton_focus_entered(button_index: int) -> void:

--- a/project/src/main/world/CareerMap.tscn
+++ b/project/src/main/world/CareerMap.tscn
@@ -671,6 +671,7 @@ script = ExtResource( 13 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+level_select_path = NodePath("../../../../LevelSelect")
 
 [node name="TextureRect" type="Control" parent="Ui/Control/StatusBar/Distance"]
 margin_right = 32.0
@@ -767,6 +768,7 @@ pressed_icon = ExtResource( 11 )
 [node name="SettingsMenu" parent="Ui" instance=ExtResource( 14 )]
 quit_type = 1
 
+[connection signal="level_button_focused" from="LevelSelect" to="Ui/Control/StatusBar/Distance" method="_on_LevelSelect_level_button_focused"]
 [connection signal="level_button_focused" from="LevelSelect" to="World" method="_on_LevelSelect_level_button_focused"]
 [connection signal="pressed" from="LevelSelect/Control/Distance/Down" to="LevelSelect/Control/Distance" method="_on_Down_pressed"]
 [connection signal="pressed" from="LevelSelect/Control/Distance/Up" to="LevelSelect/Control/Distance" method="_on_Up_pressed"]

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -45,8 +45,8 @@ func _refresh_ui() -> void:
 	# turn the level buttons invisible)
 	yield(get_tree(), "idle_frame")
 	if _level_select_buttons and not _level_select_buttons[0].get_focus_owner():
-		var middle_button_index: int = min(_level_select_buttons.size(), _level_settings_for_levels.size()) / 2
-		_level_select_buttons[middle_button_index].grab_focus()
+		var right_button_index: int = min(_level_select_buttons.size(), _level_settings_for_levels.size()) - 1
+		_level_select_buttons[right_button_index].grab_focus()
 
 
 ## Loads level settings for three randomly selected levels from the current CareerRegion.
@@ -142,6 +142,10 @@ func _random_levels() -> Array:
 
 ## When the player clicks a level button twice, we launch the selected level
 func _on_LevelSelectButton_level_started(level_index: int) -> void:
+	# apply a distance penalty if they select an earlier level
+	var distance_penalty: int = PlayerData.career.distance_penalties()[level_index]
+	PlayerData.career.distance_travelled -= distance_penalty
+	
 	var level_settings: LevelSettings = _level_settings_for_levels[level_index]
 	PlayerData.career.daily_level_ids.append(level_settings.id)
 	CurrentLevel.set_launched_level(level_settings.id)

--- a/project/src/test/world/test-career-data.gd
+++ b/project/src/test/world/test-career-data.gd
@@ -56,3 +56,52 @@ func test_advance_distance_fails_boss_level() -> void:
 			"distance_earned should be less than 0 but was %s" % [_data.distance_earned])
 	assert_true(_data.distance_travelled < 9,
 			"distance_travelled should be less than 9 but was %s" % [_data.distance_travelled])
+
+
+func test_distance_penalties_short() -> void:
+	_data.distance_earned = 0
+	assert_eq(_data.distance_penalties(), [0, 0, 0])
+	
+	_data.distance_earned = 1
+	assert_eq(_data.distance_penalties(), [0, 0, 0])
+	
+	_data.distance_earned = 2
+	assert_eq(_data.distance_penalties(), [1, 1, 0])
+
+
+func test_distance_penalties_medium() -> void:
+	_data.distance_earned = 3
+	assert_eq(_data.distance_penalties(), [2, 1, 0])
+	
+	_data.distance_earned = 5
+	assert_eq(_data.distance_penalties(), [2, 1, 0])
+	
+	_data.distance_earned = 6
+	assert_eq(_data.distance_penalties(), [3, 2, 0])
+	
+	_data.distance_earned = 7
+	assert_eq(_data.distance_penalties(), [4, 2, 0])
+
+
+func test_distance_penalties_long() -> void:
+	_data.distance_earned = 10
+	assert_eq(_data.distance_penalties(), [4, 2, 0])
+	
+	_data.distance_earned = 15
+	assert_eq(_data.distance_penalties(), [4, 2, 0])
+	
+	_data.distance_earned = 25
+	assert_eq(_data.distance_penalties(), [4, 2, 0])
+
+
+func test_distance_penalties_negative() -> void:
+	_data.distance_earned = -1
+	assert_eq(_data.distance_penalties(), [1, 0, 0])
+
+	_data.distance_earned = -10
+	assert_eq(_data.distance_penalties(), [1, 0, 0])
+
+
+func test_distance_penalties_boss_level() -> void:
+	_data.advance_distance(50, false)
+	assert_eq(_data.distance_penalties(), [0, 0, 0])


### PR DESCRIPTION
The rightmost level is selected by default. Selecting an earlier level
reduces the player's distance travelled by up to 4 steps.

Closes #1140.