### PR TITLE
Tutorial improvements: timing, demo, promptless diagrams

### DIFF
--- a/project/src/demo/puzzle/tutorial/TutorialHudDemo.tscn
+++ b/project/src/demo/puzzle/tutorial/TutorialHudDemo.tscn
@@ -3,12 +3,8 @@
 [ext_resource path="res://src/main/puzzle/Puzzle.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/demo/puzzle/tutorial/tutorial-hud-demo.gd" type="Script" id=2]
 
-[node name="Demo" type="Control"]
-anchor_right = 1.0
-anchor_bottom = 1.0
+[node name="Demo" type="Node"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+level_id = "tutorial/combo_0"
 
 [node name="Level" parent="." instance=ExtResource( 1 )]

--- a/project/src/demo/puzzle/tutorial/tutorial-hud-demo.gd
+++ b/project/src/demo/puzzle/tutorial/tutorial-hud-demo.gd
@@ -1,4 +1,4 @@
-extends Control
+extends Node
 ## Shows off the tutorial message UI.
 ##
 ## Keys:
@@ -22,14 +22,17 @@ const TEXTS := [
 	"Oh my,/ you're not supposed to know how to do that!\n\n...But yes,/ squish moves can help you out of a jam.",
 ]
 
+## a tutorial level id to demo, like 'tutorial/basic_0'
+export (String) var level_id: String = LevelLibrary.BEGINNER_TUTORIAL
+
 onready var _tutorial_hud: TutorialHud = $Level/Hud/HudUi/TutorialHud
 onready var _tutorial_messages: TutorialMessages = $Level/Hud/HudUi/TutorialHud/Messages
 
 func _ready() -> void:
 	var level_settings := LevelSettings.new()
-	level_settings.load_from_resource(LevelLibrary.BEGINNER_TUTORIAL)
+	level_settings.load_from_resource(level_id)
+	level_settings.other.start_level = ""
 	CurrentLevel.start_level(level_settings)
-	
 	_tutorial_hud.replace_tutorial_module()
 
 

--- a/project/src/main/puzzle/puzzle-messages.gd
+++ b/project/src/main/puzzle/puzzle-messages.gd
@@ -77,7 +77,10 @@ func _on_PuzzleState_game_started() -> void:
 
 
 func _on_PuzzleState_before_level_changed(new_level_id: String) -> void:
-	if new_level_id == CurrentLevel.settings.id:
+	if CurrentLevel.settings.other.non_interactive:
+		# non interactive levels don't show a success/failure message
+		pass
+	elif new_level_id == CurrentLevel.settings.id:
 		show_message(tr("Regret..."))
 	else:
 		show_message(tr("Good!"))

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -54,8 +54,8 @@ signal combo_ended
 signal topped_out
 
 const DELAY_NONE := 0.00
-const DELAY_SHORT := 2.35
-const DELAY_LONG := 4.70
+const DELAY_SHORT := 2.05
+const DELAY_LONG := 3.30
 
 const READY_DURATION := 1.4
 

--- a/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
@@ -10,7 +10,7 @@ var _boxes_built := 0
 var _squish_moves := 0
 var _snack_stacks := 0
 
-## tracks what the player did with the most recent piece
+## tracks what the player did with their newest piece
 var _did_line_clear := false
 var _did_box_clear := false
 var _did_build_box := false
@@ -65,7 +65,7 @@ func prepare_tutorial_level() -> void:
 func _advance_level() -> void:
 	if CurrentLevel.settings.id == "tutorial/basics_0" and _did_build_cake and _did_squish_move:
 		# the player did something crazy; skip the tutorial entirely
-		PuzzleState.change_level("tutorial/oh_my", false)
+		change_level("tutorial/oh_my", false)
 		hud.set_big_message(ChatLibrary.add_mega_lull_characters(tr("OH, MY!!!")))
 		hud.enqueue_pop_out()
 		
@@ -74,16 +74,16 @@ func _advance_level() -> void:
 		PuzzleState.end_game()
 	elif _boxes_built == 0 or _box_clears == 0:
 		hud.set_message(tr("Good job!"))
-		PuzzleState.change_level("tutorial/basics_1")
+		change_level("tutorial/basics_1")
 	elif _squish_moves == 0:
 		hud.set_message(tr("Nicely done!"))
-		PuzzleState.change_level("tutorial/basics_2")
+		change_level("tutorial/basics_2")
 	elif _snack_stacks == 0:
 		hud.set_message(tr("Impressive!"))
-		PuzzleState.change_level("tutorial/basics_3")
+		change_level("tutorial/basics_3")
 	else:
 		hud.set_message(tr("Oh! I thought that would be more difficult..."))
-		PuzzleState.change_level("tutorial/basics_4")
+		change_level("tutorial/basics_4")
 		start_customer_countdown()
 
 

--- a/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
@@ -132,7 +132,6 @@ func _advance_level() -> void:
 		"tutorial/combo_5":
 			if hud.skill_tally_item("CakeBox").is_complete():
 				hud.set_message(tr("Impressive!\n\nHmm... Was there anything else?"))
-				delay_between_levels = PuzzleState.DELAY_LONG
 				start_customer_countdown()
 			else:
 				hud.set_message(tr("Oh! ...You needed to clear a line that time."))
@@ -148,7 +147,7 @@ func _advance_level() -> void:
 		new_level_id = CurrentLevel.settings.id
 	else:
 		new_level_id = level_ids[level_ids.find(CurrentLevel.settings.id) + 1]
-	PuzzleState.change_level(new_level_id, delay_between_levels)
+	change_level(new_level_id, delay_between_levels)
 
 
 ## Shows a diagram explaining how combos moves work, with an accompanying sensei message.
@@ -173,7 +172,7 @@ func _show_next_diagram() -> void:
 					+ "\n\nSo, you're allowed to make one mistake! Or, to use one piece to plan ahead."))
 	hud.set_messages(hud_messages)
 	
-	hud.get_tutorial_diagram().show_diagram(_combo_diagram)
+	hud.get_tutorial_diagram().show_diagram(_combo_diagram, true)
 	_show_diagram_count += 1
 
 

--- a/project/src/main/puzzle/tutorial/tutorial-diagram.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-diagram.gd
@@ -20,20 +20,31 @@ func _ready() -> void:
 	hide()
 
 
-func show_diagram(texture: Texture) -> void:
+func show_diagram(texture: Texture, show_choices: bool = false) -> void:
 	show()
 	$VBoxContainer/TextureMarginContainer/TexturePanel/TextureRect.texture = texture
 	
-	if not _hud.get_tutorial_messages().is_all_messages_visible():
-		yield(_hud.get_tutorial_messages(), "all_messages_shown")
-	var choices: Array
-	match _show_diagram_count % 3:
-		0: choices = [tr("Okay, I get it!"), tr("...Can you go into more detail?")]
-		1: choices = [tr("Yes, I see!"), tr("What do you mean by that?")]
-		2: choices = [tr("Oh! That's easy."), tr("Hmm, maybe one more time?")]
-	_show_diagram_count += 1
-	var moods := [ChatEvent.Mood.SMILE0, ChatEvent.Mood.THINK0]
-	$VBoxContainer/ChatChoices.show_choices(choices, moods, 2)
+	# shift the diagram up to make room for chat choices
+	if show_choices:
+		$VBoxContainer/TextureMarginContainer.set("custom_constants/margin_top", 10)
+		$VBoxContainer/TextureMarginContainer.set("custom_constants/margin_bottom", 10)
+		$VBoxContainer/ChatChoices.visible = true
+	else:
+		$VBoxContainer/TextureMarginContainer.set("custom_constants/margin_top", 85)
+		$VBoxContainer/TextureMarginContainer.set("custom_constants/margin_bottom", 85)
+		$VBoxContainer/ChatChoices.visible = false
+	
+	if show_choices:
+		if not _hud.get_tutorial_messages().is_all_messages_visible():
+			yield(_hud.get_tutorial_messages(), "all_messages_shown")
+		var choices: Array
+		match _show_diagram_count % 3:
+			0: choices = [tr("Okay, I get it!"), tr("...Can you go into more detail?")]
+			1: choices = [tr("Yes, I see!"), tr("What do you mean by that?")]
+			2: choices = [tr("Oh! That's easy."), tr("Hmm, maybe one more time?")]
+		_show_diagram_count += 1
+		var moods := [ChatEvent.Mood.SMILE0, ChatEvent.Mood.THINK0]
+		$VBoxContainer/ChatChoices.show_choices(choices, moods, 2)
 
 
 func _on_ChatChoices_chat_choice_chosen(choice_index: int) -> void:

--- a/project/src/main/puzzle/tutorial/tutorial-hud.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-hud.gd
@@ -33,11 +33,11 @@ func replace_tutorial_module() -> void:
 		remove_child(get_node("TutorialModule"))
 	
 	var module_path: String
-	if CurrentLevel.settings.id.begins_with("tutorial/basics"):
+	if CurrentLevel.settings.id.begins_with("tutorial/basics_"):
 		module_path = "res://src/main/puzzle/tutorial/TutorialBasicsModule.tscn"
-	elif CurrentLevel.settings.id.begins_with("tutorial/squish"):
+	elif CurrentLevel.settings.id.begins_with("tutorial/squish_"):
 		module_path = "res://src/main/puzzle/tutorial/TutorialSquishModule.tscn"
-	elif CurrentLevel.settings.id.begins_with("tutorial/combo"):
+	elif CurrentLevel.settings.id.begins_with("tutorial/combo_"):
 		module_path = "res://src/main/puzzle/tutorial/TutorialComboModule.tscn"
 	
 	if module_path:

--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -49,5 +49,24 @@ func prepare_tutorial_level() -> void:
 			skill_tally_item.visible = false
 
 
+## Changes a level after all tutorial messages are shown.
+##
+## Copy/pasted from PuzzleState.change_level with an extra yield statement added.
+func change_level(level_id: String, delay_between_levels: float = PuzzleState.DELAY_SHORT) -> void:
+	PuzzleState.emit_signal("before_level_changed", level_id)
+	
+	if not hud.get_tutorial_messages().is_all_messages_visible():
+		yield(hud.get_tutorial_messages(), "all_messages_shown")
+	if delay_between_levels:
+		yield(get_tree().create_timer(delay_between_levels), "timeout")
+	
+	var settings := LevelSettings.new()
+	settings.load_from_resource(level_id)
+	CurrentLevel.switch_level(settings)
+	# initialize input_frame to allow for recording/replaying inputs
+	PuzzleState.input_frame = 0
+	PuzzleState.emit_signal("after_level_changed")
+
+
 func _on_PuzzleState_after_level_changed() -> void:
 	prepare_tutorial_level()

--- a/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
@@ -105,7 +105,6 @@ func _advance_level() -> void:
 			hud.set_message(tr("That's right! Hmm, how about something tricky..."))
 		"tutorial/squish_4":
 			hud.set_message(tr("Wow, okay! ...I need to think of some harder puzzles."))
-			delay_between_levels = PuzzleState.DELAY_LONG
 		"tutorial/squish_5":
 			if PuzzleState.level_performance.lines >= 3:
 				hud.set_message(tr("Good job!"))
@@ -115,7 +114,6 @@ func _advance_level() -> void:
 		"tutorial/squish_6":
 			if PuzzleState.level_performance.lines >= 3:
 				hud.set_message(tr("Wow! ...I had a few more of these planned, but it looks like you get the idea."))
-				delay_between_levels = PuzzleState.DELAY_LONG
 				start_customer_countdown()
 			else:
 				_failed_section = true
@@ -163,7 +161,7 @@ func _show_next_diagram() -> void:
 	match _show_diagram_count % 2:
 		0: hud_diagram = _squish_diagram_0
 		1: hud_diagram = _squish_diagram_1
-	hud.get_tutorial_diagram().show_diagram(hud_diagram)
+	hud.get_tutorial_diagram().show_diagram(hud_diagram, true)
 	_show_diagram_count += 1
 
 


### PR DESCRIPTION
Added TutorialHud.change_level() method to change levels after all
tutorial messages are shown. The timer was starting when the first
letter of the message was shown, which meant the player had less time to
read longer messages. I've decreased the delay durations to compensate,
so hopefully the delays are roughly the same length as before.

TutorialHudDemo accepts a level_id property to try out different demos.
It also suppresses the level_settings.other.start_level property so that
later tutorial sections can be tested.

TutorialHud now supports diagrams without prompts.