### PR TITLE
Prevent save scumming of career mode boss levels.

### DIFF
--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -314,7 +314,7 @@ func _update_career_data(rank_result: RankResult) -> void:
 	else:
 		distance_to_advance = 25
 	
-	PlayerData.career.advance_distance(distance_to_advance, rank_result.success)
+	PlayerData.career.advance_clock(distance_to_advance, rank_result.success)
 
 
 ## Wait until after the game ends to save the player's data.

--- a/project/src/test/world/test-career-data.gd
+++ b/project/src/test/world/test-career-data.gd
@@ -21,37 +21,37 @@ func test_prev_daily_earnings() -> void:
 	assert_eq(60, _data.prev_daily_earnings[CareerData.MAX_DAILY_HISTORY - 1])
 
 
-func test_advance_distance_stops_at_boss_level_0() -> void:
-	_data.advance_distance(50, false)
+func test_advance_clock_stops_at_boss_level_0() -> void:
+	_data.advance_clock(50, false)
 	assert_eq(_data.distance_earned, 50)
 	assert_eq(_data.distance_travelled, 9)
 
 
-func test_advance_distance_stops_at_boss_level_1() -> void:
+func test_advance_clock_stops_at_boss_level_1() -> void:
 	_data.distance_travelled = 8 # just before a boss level
-	_data.advance_distance(3, true)
+	_data.advance_clock(3, true)
 	assert_eq(_data.distance_earned, 3)
 	assert_eq(_data.distance_travelled, 9)
 
 
 ## The player skips one boss level, but gets stopped by the next boss level
-func test_advance_distance_skips_boss_level() -> void:
+func test_advance_clock_skips_boss_level() -> void:
 	PlayerData.career.max_distance_travelled = 10
-	_data.advance_distance(50, false)
+	_data.advance_clock(50, false)
 	assert_eq(_data.distance_earned, 50)
 	assert_eq(_data.distance_travelled, 24)
 
 
-func test_advance_distance_clears_boss_level() -> void:
+func test_advance_clock_clears_boss_level() -> void:
 	_data.distance_travelled = 9 # boss level
-	_data.advance_distance(4, true)
+	_data.advance_clock(4, true)
 	assert_eq(_data.distance_earned, 4)
 	assert_eq(_data.distance_travelled, 13)
 
 
-func test_advance_distance_fails_boss_level() -> void:
+func test_advance_clock_fails_boss_level() -> void:
 	_data.distance_travelled = 9 # boss level
-	_data.advance_distance(4, false)
+	_data.advance_clock(4, false)
 	assert_true(_data.distance_earned < 0,
 			"distance_earned should be less than 0 but was %s" % [_data.distance_earned])
 	assert_true(_data.distance_travelled < 9,
@@ -103,5 +103,5 @@ func test_distance_penalties_negative() -> void:
 
 
 func test_distance_penalties_boss_level() -> void:
-	_data.advance_distance(50, false)
+	_data.advance_clock(50, false)
 	assert_eq(_data.distance_penalties(), [0, 0, 0])


### PR DESCRIPTION
Career mode advanced the clock and set distance earned to '0' to
discourage savescumming -- but for boss levels this isn't enough,
because they actually apply a penalty on failure. Career mode now
applies this penalty before the level starts.

Renamed 'advance_distance' to 'advance_clock' and changed its behavior
slightly. This allows us to reuse it for the savescumming logic.