### PR TITLE
Fixed missing 'ObstacleManager' in OverworldIndoors scene.

### DIFF
--- a/project/src/main/world/OverworldIndoors.tscn
+++ b/project/src/main/world/OverworldIndoors.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=49 format=2]
+[gd_scene load_steps=50 format=2]
 
 [ext_resource path="res://src/main/world/creature/sensei.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/creature/player.gd" type="Script" id=2]
@@ -40,6 +40,7 @@
 [ext_resource path="res://src/main/world/environment/obstacle-map-shadows.gd" type="Script" id=38]
 [ext_resource path="res://src/main/world/overworld-camera.gd" type="Script" id=39]
 [ext_resource path="res://src/main/world/screwport-texrect.gd" type="Script" id=40]
+[ext_resource path="res://src/main/world/obstacle-manager.gd" type="Script" id=41]
 [ext_resource path="res://assets/main/world/creature/5/tail-z1-packed.png" type="Texture" id=42]
 [ext_resource path="res://assets/main/world/creature/1/eye-z1-packed.png" type="Texture" id=43]
 [ext_resource path="res://assets/main/world/creature/10/ear-z0-packed.png" type="Texture" id=44]
@@ -867,5 +868,13 @@ smoothing_enabled = true
 script = ExtResource( 39 )
 
 [node name="Tween" type="Tween" parent="World/Camera"]
+
+[node name="ObstacleManager" type="Node" parent="World"]
+script = ExtResource( 41 )
+chat_icons_path = NodePath("../ChatIcons")
+creature_shadows_path = NodePath("../Ground/Shadows/Viewport/ViewportRoot/CreatureShadows")
+shadow_caster_shadows_path = NodePath("../Ground/Shadows/Viewport/ViewportRoot/ShadowCasterShadows")
+obstacles_path = NodePath("../Obstacles")
+CreatureScene = ExtResource( 19 )
 
 [node name="Ui" parent="." instance=ExtResource( 3 )]

--- a/project/src/main/world/OverworldWalk.tscn
+++ b/project/src/main/world/OverworldWalk.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=27 format=2]
+[gd_scene load_steps=28 format=2]
 
 [ext_resource path="res://src/main/world/obstacle-map.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/chat-icons.gd" type="Script" id=2]
@@ -6,6 +6,7 @@
 [ext_resource path="res://src/main/world/overworld-walk-camera.gd" type="Script" id=4]
 [ext_resource path="res://src/main/world/shadow-caster-shadows.gd" type="Script" id=5]
 [ext_resource path="res://src/main/world/environment/obstacle-map-shadows.gd" type="Script" id=6]
+[ext_resource path="res://src/main/world/obstacle-manager.gd" type="Script" id=7]
 [ext_resource path="res://src/main/world/environment/RippleWaves.tscn" type="PackedScene" id=8]
 [ext_resource path="res://src/main/world/overworld-corner-map.gd" type="Script" id=9]
 [ext_resource path="res://src/main/world/screwport-texrect.gd" type="Script" id=10]
@@ -254,6 +255,14 @@ smoothing_speed = 12.5
 script = ExtResource( 4 )
 
 [node name="Tween" type="Tween" parent="World/Camera"]
+
+[node name="ObstacleManager" type="Node" parent="World"]
+script = ExtResource( 7 )
+chat_icons_path = NodePath("../ChatIcons")
+creature_shadows_path = NodePath("../Ground/Shadows/Viewport/ViewportRoot/CreatureShadows")
+shadow_caster_shadows_path = NodePath("../Ground/Shadows/Viewport/ViewportRoot/ShadowCasterShadows")
+obstacles_path = NodePath("../Obstacles")
+CreatureScene = ExtResource( 41 )
 
 [node name="Ui" parent="." instance=ExtResource( 15 )]
 script = ExtResource( 12 )


### PR DESCRIPTION
This ObstacleManager was introduced in deeabe1c to manage overworld
assets, but was only introduced in the Overworld scene and not other
similar scenes such as OverworldIndoors and OverworldWalk.

Closes #1187.