### PR TITLE
Fixed career mode music bug: no music on HTML5

### DIFF
--- a/project/src/main/ui/career/CareerWin.tscn
+++ b/project/src/main/ui/career/CareerWin.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=44 format=2]
+[gd_scene load_steps=45 format=2]
 
 [ext_resource path="res://src/main/ui/career/career-win.gd" type="Script" id=1]
 [ext_resource path="res://assets/main/world/environment/marsh-path-sheet.png" type="Texture" id=2]
@@ -34,6 +34,7 @@
 [ext_resource path="res://src/main/world/environment/MarshBush.tscn" type="PackedScene" id=32]
 [ext_resource path="res://assets/main/ui/applause.wav" type="AudioStream" id=33]
 [ext_resource path="res://src/main/world/obstacle-manager.gd" type="Script" id=34]
+[ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=37]
 
 [sub_resource type="DynamicFont" id=1]
 size = 32
@@ -760,5 +761,11 @@ CreatureScene = ExtResource( 19 )
 [node name="ApplauseSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 33 )
 bus = "Sound Bus"
+
+[node name="Ui" type="CanvasLayer" parent="."]
+
+[node name="MusicPopup" parent="Ui" instance=ExtResource( 37 )]
+
+[node name="SceneTransitionCover" parent="Ui" instance=ExtResource( 3 )]
 
 [connection signal="pressed" from="Chalkboard/VBoxContainer/ButtonRow/Button" to="." method="_on_Button_pressed"]

--- a/project/src/main/ui/career/career-win.gd
+++ b/project/src/main/ui/career/career-win.gd
@@ -85,6 +85,9 @@ onready var _applause_sound := $ApplauseSound
 onready var _obstacle_manager: ObstacleManager = get_node(obstacle_manager_path)
 
 func _ready() -> void:
+	ResourceCache.substitute_singletons()
+	MusicPlayer.play_chill_bgm()
+	
 	_refresh_title_text()
 	_refresh_icons()
 	_refresh_labels()

--- a/project/src/main/world/CareerMap.tscn
+++ b/project/src/main/world/CareerMap.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=73 format=2]
+[gd_scene load_steps=74 format=2]
 
 [ext_resource path="res://src/main/ui/level-select/grade-labels.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/career-map.gd" type="Script" id=2]
@@ -49,6 +49,7 @@
 [ext_resource path="res://assets/main/ui/icon-time-of-day-sheet.png" type="Texture" id=47]
 [ext_resource path="res://src/main/world/environment/MileMarker.tscn" type="PackedScene" id=48]
 [ext_resource path="res://src/main/world/career-camera.gd" type="Script" id=49]
+[ext_resource path="res://src/main/ui/SceneTransitionCover.tscn" type="PackedScene" id=50]
 [ext_resource path="res://assets/main/world/environment/marsh-path-sheet.png" type="Texture" id=51]
 [ext_resource path="res://assets/main/world/environment/block-shadow.png" type="Texture" id=53]
 [ext_resource path="res://src/main/world/environment/obstacle-library.tres" type="TileSet" id=54]
@@ -197,11 +198,11 @@ draw_center = false
 
 [sub_resource type="StyleBoxEmpty" id=13]
 
-[sub_resource type="InputEventAction" id=8]
+[sub_resource type="InputEventAction" id=22]
 action = "ui_cancel"
 
 [sub_resource type="ShortCut" id=14]
-shortcut = SubResource( 8 )
+shortcut = SubResource( 22 )
 
 [node name="Node" type="Node"]
 script = ExtResource( 2 )
@@ -766,10 +767,12 @@ expand_icon = true
 normal_icon = ExtResource( 10 )
 pressed_icon = ExtResource( 11 )
 
-[node name="MusicPopup" parent="Ui/Control" instance=ExtResource( 24 )]
-
 [node name="SettingsMenu" parent="Ui" instance=ExtResource( 14 )]
 quit_type = 3
+
+[node name="MusicPopup" parent="Ui" instance=ExtResource( 24 )]
+
+[node name="SceneTransitionCover" parent="Ui" instance=ExtResource( 50 )]
 
 [connection signal="level_button_focused" from="LevelSelect" to="Ui/Control/StatusBar/Distance" method="_on_LevelSelect_level_button_focused"]
 [connection signal="level_button_focused" from="LevelSelect" to="World" method="_on_LevelSelect_level_button_focused"]

--- a/project/src/main/world/OverworldUi.tscn
+++ b/project/src/main/world/OverworldUi.tscn
@@ -328,7 +328,6 @@ custom_styles/normal = SubResource( 5 )
 disabled = true
 
 [node name="MusicPopup" parent="Control" instance=ExtResource( 16 )]
-mouse_filter = 2
 
 [node name="SceneTransitionCover" parent="Control" instance=ExtResource( 4 )]
 

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -22,6 +22,7 @@ onready var _level_select_buttons := $LevelSelect/Control/LevelButtons.get_child
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
+	MusicPlayer.play_chill_bgm()
 	PlayerData.career.connect("distance_travelled_changed", self, "_on_CareerData_distance_travelled_changed")
 	if PlayerData.career.is_day_over():
 		PlayerData.career.push_career_trail()


### PR DESCRIPTION
Career mode's map screen and win screen were missing the 'play_chill_bgm' so
music wouldn't play in HTML5. It was also missing the
SceneTransitionCover so it would play the wrong music.