### PR TITLE
Fixed career mode win transition bugs

### DIFF
--- a/project/src/main/career-data.gd
+++ b/project/src/main/career-data.gd
@@ -114,8 +114,11 @@ func to_json_dict() -> Dictionary:
 ## Launches the next scene in career mode. Either a new level, or a cutscene/ending scene.
 func push_career_trail() -> void:
 	if is_day_over():
-		# after the final level, we show a 'you win' screen
-		SceneTransition.replace_trail("res://src/main/ui/career/CareerWin.tscn")
+		# After the final level, we show a 'you win' screen.
+		#
+		# We do not apply a SceneTransition -- this scene change occurs immediately when the scene is loaded, and
+		# applying a fade in and fade out scene transition simultaneously results in unpredictable behavior.
+		Breadcrumb.replace_trail("res://src/main/ui/career/CareerWin.tscn")
 	else:
 		# after the 'overworld map' scene, we launch a level
 		

--- a/project/src/main/ui/career/career-win.gd
+++ b/project/src/main/ui/career/career-win.gd
@@ -99,6 +99,10 @@ func _ready() -> void:
 	_button.grab_focus()
 
 
+func _exit_tree() -> void:
+	ResourceCache.remove_singletons()
+
+
 ## Updates the title text with a random value.
 ##
 ## Different titles are shown based on the player's performance. A typical player will always see the same affirming

--- a/project/src/main/ui/scene-transition-cover.gd
+++ b/project/src/main/ui/scene-transition-cover.gd
@@ -22,10 +22,19 @@ func _initialize_fade() -> void:
 	_color_rect.modulate.a = 1.0 if SceneTransition.fading else 0.0
 	if SceneTransition.fading:
 		_color_rect.color = SceneTransition.fade_color
+		
 		# Schedule the 'fade in' event for later. It would be problematic to start fading in before other nodes have
-		# had a chance to initialize.
-		yield(get_tree(), "idle_frame")
-		SceneTransition.fade_in()
+		# had a chance to initialize. We use a one-shot listener method instead of a yield statement to avoid 'class
+		# instance is gone' errors.
+		if not get_tree().is_connected("idle_frame", self, "_finish_initializing_fade"):
+			get_tree().connect("idle_frame", self, "_finish_initializing_fade")
+
+
+func _finish_initializing_fade() -> void:
+	if get_tree().is_connected("idle_frame", self, "_finish_initializing_fade"):
+		get_tree().disconnect("idle_frame", self, "_finish_initializing_fade")
+	
+	SceneTransition.fade_in()
 
 
 ## Starts a tween which changes this node's opacity.


### PR DESCRIPTION
The transition to Career Mode's win screen was broken when introducing
the fade in effect. This is because the CareerMap scene would apply a
fade in and fade out scene transition simultaneously, resulting in an
empty CareerMap screen loading.

Fixed bug where CareerWin did not remove singletons, resulting in errors
when the singleton MusicPopup was freed.

Fixed 'Class Instance Is Gone' errors in SceneTransitionCover if the
scene changes while fading in.