### PR TITLE
Ignore input when fading out.

### DIFF
--- a/project/src/main/ui/music-popup-tween.gd
+++ b/project/src/main/ui/music-popup-tween.gd
@@ -29,9 +29,12 @@ func _ready() -> void:
 
 
 func _enter_tree() -> void:
-	# wait a frame for the Timer to be added to the scene tree before restoring its state.
-	# we use a one-shot listener method instead of a yield statement to avoid 'class instance is gone' errors.
-	get_tree().connect("idle_frame", self, "_restore_tween_and_timer_state", [get_tree()])
+	# Wait a frame for the Timer to be added to the scene tree before restoring its state. We use a one-shot listener
+	# method instead of a yield statement to avoid 'class instance is gone' errors. We also wrap it in an if statement
+	# because this music popup can be reused as a singleton, so it's possible for it to be launched multiple times
+	# with no idle_frame.
+	if not get_tree().is_connected("idle_frame", self, "_restore_tween_and_timer_state"):
+		get_tree().connect("idle_frame", self, "_restore_tween_and_timer_state", [get_tree()])
 
 
 ## Makes the music popup appear, and then hides it after a few seconds.

--- a/project/src/main/ui/scene-transition.gd
+++ b/project/src/main/ui/scene-transition.gd
@@ -73,6 +73,9 @@ func end_fade_out() -> void:
 
 ## Launches the 'fade in' visual transition.
 func fade_in() -> void:
+	# unignore input immediately; don't wait for fade in to finish
+	get_tree().get_root().set_disable_input(false)
+	
 	emit_signal("fade_in_started")
 
 
@@ -83,6 +86,9 @@ func end_fade_in() -> void:
 
 ## Launches the 'fade out' visual transition.
 func _fade_out(new_breadcrumb_method: FuncRef, new_breadcrumb_arg_array: Array = []) -> void:
+	# ignore input to prevent edge-cases where player does weird things during scene transitions
+	get_tree().get_root().set_disable_input(true)
+	
 	breadcrumb_method = new_breadcrumb_method
 	breadcrumb_arg_array = new_breadcrumb_arg_array
 	fading = true


### PR DESCRIPTION
During career mode, the player could mash the level button repeatedly to
cause unpredictable behavior. Transitioning to a new scene should really
be treated as an atomic operation; the player shouldn't be able to
interrupt it.

We now block the player's input when fading out to prevent them from
mashing buttons or triggering other scene transitions. We restore the
player's input immediately when a new scene is loaded; we don't wait for
the 'fade in' to complete.

Fixed 'signal already connected' error in MusicPopupTween.