### PR TITLE
Refactoring: int_series return, AfterLineCleared, puzzle-messages onr…

### DIFF
--- a/project/src/main/puzzle/level/phase-conditions.gd
+++ b/project/src/main/puzzle/level/phase-conditions.gd
@@ -91,44 +91,41 @@ class AfterPieceWrittenPhaseCondition extends PhaseCondition:
 	## 	A dictionary of int values meeting the specified condition. The values are set to 'true'.
 	func _parse_int_series(int_series_string: String, max_int: int) -> Dictionary:
 		var result := {}
-		if not int_series_string:
-			return result
 		
-		if int_series_string.ends_with("..."):
-			# append all raw values
-			var ints_split := int_series_string.trim_suffix("...").split(",")
-			for index_obj in ints_split:
-				result[int(index_obj)] = true
-			
+		# append all raw values
+		var ints_split := int_series_string.trim_suffix("...").split(",")
+		for index_obj in ints_split:
+			result[int(index_obj)] = true
+		
+		# This unusual for loop checks for ellipses, and allows us to 'break' for errors to avoid 'return' statements
+		# in the middle of a method
+		for _i in range(1 if int_series_string.ends_with("...") else 0):
 			# determine difference of last two values
 			if ints_split.size() < 2:
 				push_warning("index string doesn't have enough values to extrapolate: '%s'" % [int_series_string])
-				return result
+				break
+			
 			var low := int(ints_split[ints_split.size() - 2])
 			var high := int(ints_split[ints_split.size() - 1])
 			if high <= low:
 				push_warning("nonsensical index string extrapolation: '%s'" % [int_series_string])
-				return result
-			var i := 2 * high - low
+				break
 			
+			var i := 2 * high - low
 			# extrapolate until we hit max_int
 			while i < max_int:
 				result[i] = true
 				i += high - low
-		else:
-			# append all raw values
-			for index_obj in int_series_string.split(","):
-				result[int(index_obj)] = true
 		
 		return result
 
 
-class AfterLinesClearedPhaseCondition extends PhaseCondition:
+class AfterLineClearedPhaseCondition extends PhaseCondition:
 	## key: (int) a line which causes the trigger to fire when cleared. 0 is the highest line in the playfield.
 	## value: true
 	var which_lines := {}
 	
-	## Creates a new AfterLinesClearedPhaseCondition instance with the specified configuration.
+	## Creates a new AfterLineClearedPhaseCondition instance with the specified configuration.
 	##
 	## The phase_config parameter accepts an optional 'y' expression defining which line clears will fire this trigger.
 	## Commas and hyphens are accepted, 0 is the lowest line in the playfield.
@@ -199,7 +196,7 @@ class AfterLinesClearedPhaseCondition extends PhaseCondition:
 		return {"y": y_expression}
 
 var phase_conditions_by_string := {
-	"after_line_cleared": AfterLinesClearedPhaseCondition,
+	"after_line_cleared": AfterLineClearedPhaseCondition,
 	"after_piece_written": AfterPieceWrittenPhaseCondition,
 }
 

--- a/project/src/main/puzzle/puzzle-messages.gd
+++ b/project/src/main/puzzle/puzzle-messages.gd
@@ -7,6 +7,11 @@ signal start_button_pressed
 signal settings_button_pressed
 signal back_button_pressed
 
+onready var _message_label := $MessageLabel
+onready var _back_button := $Buttons/Back
+onready var _start_button := $Buttons/Start
+onready var _settings_button := $Buttons/Settings
+
 func _ready() -> void:
 	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
 	PuzzleState.connect("game_started", self, "_on_PuzzleState_game_started")
@@ -15,41 +20,41 @@ func _ready() -> void:
 	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")
 	PuzzleState.connect("after_game_ended", self, "_on_PuzzleState_after_game_ended")
 	CurrentLevel.connect("best_result_changed", self, "_on_Level_best_result_changed")
-	$MessageLabel.hide()
+	_message_label.hide()
 	
 	if PlayerData.career.is_career_mode():
 		# they can't go back in career mode
-		$Buttons/Back.text = tr("Skip")
+		_back_button.text = tr("Skip")
 	
 	# grab focus so the player can start a new game or navigate with the keyboard
-	$Buttons/Start.grab_focus()
+	_start_button.grab_focus()
 
 
 func is_settings_button_visible() -> bool:
-	return $Buttons/Settings.is_visible_in_tree()
+	return _settings_button.is_visible_in_tree()
 
 
 ## Shows a succinct single-line message, like 'Game Over'
 func show_message(text: String) -> void:
-	$MessageLabel.show()
-	$MessageLabel.text = text
+	_message_label.show()
+	_message_label.text = text
 
 
 func hide_message() -> void:
-	$MessageLabel.hide()
+	_message_label.hide()
 
 
 func hide_buttons() -> void:
-	$Buttons/Start.hide()
-	$Buttons/Settings.hide()
-	$Buttons/Back.hide()
+	_start_button.hide()
+	_settings_button.hide()
+	_back_button.hide()
 
 
 func show_buttons() -> void:
-	$Buttons/Start.show()
-	$Buttons/Start.grab_focus()
-	$Buttons/Settings.show()
-	$Buttons/Back.show()
+	_start_button.show()
+	_start_button.grab_focus()
+	_settings_button.show()
+	_back_button.show()
 
 
 func _on_Start_pressed() -> void:
@@ -106,14 +111,14 @@ func _on_PuzzleState_game_ended() -> void:
 
 ## Restores the HUD elements after the player wins or loses.
 func _on_PuzzleState_after_game_ended() -> void:
-	$MessageLabel.hide()
-	$Buttons/Settings.show()
-	$Buttons/Back.show()
-	$Buttons/Start.show()
+	_message_label.hide()
+	_settings_button.show()
+	_back_button.show()
+	_start_button.show()
 	if CurrentLevel.settings.other.tutorial or CurrentLevel.settings.other.after_tutorial:
 		if not PuzzleState.level_performance.lost:
 			# if they won, make them exit; hide the start button
-			$Buttons/Start.hide()
+			_start_button.hide()
 			
 			# don't redirect them back to the splash screen, send them to the main menu
 			if Breadcrumb.trail.size() >= 2 and Breadcrumb.trail[1] == Global.SCENE_SPLASH:
@@ -121,15 +126,15 @@ func _on_PuzzleState_after_game_ended() -> void:
 	
 	if PlayerData.career.is_career_mode():
 		# they only have only one chance in career mode, they can't retry
-		$Buttons/Start.hide()
-		$Buttons/Back.text = tr("Continue")
+		_start_button.hide()
+		_back_button.text = tr("Continue")
 	
 	# determine the default button to focus
-	var buttons_to_focus := [$Buttons/Back, $Buttons/Start]
+	var buttons_to_focus := [_back_button, _start_button]
 	if CurrentLevel.keep_retrying:
-		buttons_to_focus.push_front($Buttons/Start)
+		buttons_to_focus.push_front(_start_button)
 	elif not CurrentLevel.best_result in [Levels.Result.FINISHED, Levels.Result.WON]:
-		buttons_to_focus.push_front($Buttons/Start)
+		buttons_to_focus.push_front(_start_button)
 	
 	# the start button changes its label after the player finishes the level
 	match PuzzleState.end_result():
@@ -137,7 +142,7 @@ func _on_PuzzleState_after_game_ended() -> void:
 			# if they abort the level without playing it, the button doesn't change
 			pass
 		_:
-			$Buttons/Start.text = tr("Retry")
+			_start_button.text = tr("Retry")
 	
 	# grab focus so the player can retry or navigate with the keyboard
 	for button_to_focus_obj in buttons_to_focus:
@@ -151,6 +156,6 @@ func _on_PuzzleState_after_game_ended() -> void:
 func _on_Level_best_result_changed() -> void:
 	match CurrentLevel.best_result:
 		Levels.Result.FINISHED, Levels.Result.WON:
-			$Buttons/Back.text = tr("Back") if CurrentLevel.keep_retrying else tr("Continue")
+			_back_button.text = tr("Back") if CurrentLevel.keep_retrying else tr("Continue")
 		_:
-			$Buttons/Back.text = tr("Back")
+			_back_button.text = tr("Back")

--- a/project/src/test/puzzle/level/test-level-triggers.gd
+++ b/project/src/test/puzzle/level/test-level-triggers.gd
@@ -27,7 +27,7 @@ func test_convert_to_json_and_back_complex() -> void:
 	var trigger: LevelTrigger = triggers.triggers[LevelTrigger.AFTER_LINE_CLEARED][0]
 	assert_eq(trigger.phases.size(), 1)
 	assert_eq(trigger.phases[LevelTrigger.AFTER_LINE_CLEARED].size(), 1)
-	assert_is(trigger.phases[LevelTrigger.AFTER_LINE_CLEARED][0], PhaseConditions.AfterLinesClearedPhaseCondition)
+	assert_is(trigger.phases[LevelTrigger.AFTER_LINE_CLEARED][0], PhaseConditions.AfterLineClearedPhaseCondition)
 	assert_eq(trigger.phases[LevelTrigger.AFTER_LINE_CLEARED][0].which_lines.keys(), [19, 18, 17, 16, 15, 14])
 	assert_is(trigger.effect, LevelTriggerEffects.InsertLineEffect)
 	assert_eq(trigger.effect.tiles_key, "0")

--- a/project/src/test/puzzle/level/test-phase-conditions.gd
+++ b/project/src/test/puzzle/level/test-phase-conditions.gd
@@ -5,17 +5,17 @@ func before_each() -> void:
 
 
 func test_after_lines_cleared_phase_config() -> void:
-	var condition: PhaseConditions.AfterLinesClearedPhaseCondition
-	condition = PhaseConditions.AfterLinesClearedPhaseCondition.new({"y": "2"})
+	var condition: PhaseConditions.AfterLineClearedPhaseCondition
+	condition = PhaseConditions.AfterLineClearedPhaseCondition.new({"y": "2"})
 	assert_eq_shallow(condition.get_phase_config(), {"y": "2"})
 	
-	condition = PhaseConditions.AfterLinesClearedPhaseCondition.new({"y": "1,3,5"})
+	condition = PhaseConditions.AfterLineClearedPhaseCondition.new({"y": "1,3,5"})
 	assert_eq_shallow(condition.get_phase_config(), {"y": "1,3,5"})
 	
-	condition = PhaseConditions.AfterLinesClearedPhaseCondition.new({"y": "0-3"})
+	condition = PhaseConditions.AfterLineClearedPhaseCondition.new({"y": "0-3"})
 	assert_eq_shallow(condition.get_phase_config(), {"y": "0-3"})
 	
-	condition = PhaseConditions.AfterLinesClearedPhaseCondition.new({"y": "0,4-6"})
+	condition = PhaseConditions.AfterLineClearedPhaseCondition.new({"y": "0,4-6"})
 	assert_eq_shallow(condition.get_phase_config(), {"y": "0,4-6"})
 
 


### PR DESCRIPTION
…eady

phase-conditions.gd no longer returns in the middle of its
_parse_int_series method.

Renamed AfterLinesCleared to AfterLineCleared. The old name was inconsistent
with the json after_line_cleared config string.

puzzle-messages.gd stores nodes in onready fields.