### PR TITLE
CareerWin fixes: SceneTransitionCover, Control.

### DIFF
--- a/project/src/main/ui/career/CareerWin.tscn
+++ b/project/src/main/ui/career/CareerWin.tscn
@@ -131,8 +131,13 @@ corner_radius_bottom_left = 16
 [sub_resource type="ViewportTexture" id=16]
 viewport_path = NodePath("CanvasLayer/WorldMover/Ground/Shadows/Viewport")
 
-[node name="Node" type="Node"]
+[node name="Node" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 obstacle_manager_path = NodePath("CanvasLayer/WorldMover/ObstacleManager")
 
 [node name="Wallpaper" parent="." instance=ExtResource( 5 )]
@@ -756,16 +761,12 @@ shadow_caster_shadows_path = NodePath("../Ground/Shadows/Viewport/ViewportRoot/S
 obstacles_path = NodePath("../Obstacles")
 CreatureScene = ExtResource( 19 )
 
-[node name="SceneTransitionCover" parent="." instance=ExtResource( 3 )]
-
 [node name="ApplauseSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 33 )
 bus = "Sound Bus"
 
-[node name="Ui" type="CanvasLayer" parent="."]
+[node name="MusicPopup" parent="." instance=ExtResource( 37 )]
 
-[node name="MusicPopup" parent="Ui" instance=ExtResource( 37 )]
-
-[node name="SceneTransitionCover" parent="Ui" instance=ExtResource( 3 )]
+[node name="SceneTransitionCover" parent="." instance=ExtResource( 3 )]
 
 [connection signal="pressed" from="Chalkboard/VBoxContainer/ButtonRow/Button" to="." method="_on_Button_pressed"]

--- a/project/src/main/ui/career/career-win.gd
+++ b/project/src/main/ui/career/career-win.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Control
 ## Shows a summary when the player finishes career mode.
 ##
 ## This summary screen includes things like how much money the player earned and how many customers they served, as


### PR DESCRIPTION
CareerWin had a redundant SceneTransitionCover. This caused redundant
calls to BreadCrumb and bugs in ResourceCache. However, these bugs only
seemed to occur when CareerWin was launched standalone, and don't appear to
affect the released game.

Changed CareerWin from a Node to a Control.

When CareerWin was a Node, a baffling side effect occurred. When
launched as a standalone scene, if you clicked 'OK' and navigated to the
main menu, the main menu's wallpaper would overlay its buttons. Changing it from
a Node to a Control fixes this somehow.