### PR TITLE
Refactoring: SettingsMenuBottom, CareerWin subcomponents

### DIFF
--- a/project/src/main/ui/career/career-win.gd
+++ b/project/src/main/ui/career/career-win.gd
@@ -4,82 +4,13 @@ extends Control
 ## This summary screen includes things like how much money the player earned and how many customers they served, as
 ## well as a visual map showing their progress through the world.
 
+# Daily step thresholds to trigger positive feedback.
+const DAILY_STEPS_GOOD := 25
+const DAILY_STEPS_OK := 8
+
 export (NodePath) var obstacle_manager_path: NodePath
 
-## Negative titles shown when the player fails, travelling zero steps during a career session.
-var _bad_titles := [
-	tr("OH DEAR WHAT HAPPENED"),
-	tr("OH! NO! GO ON TRYING"),
-	tr("GOSH THAT'S NOT GOOD"),
-]
-
-## Neutral titles shown when the player does poorly, travelling only a few steps during a career session.
-var _good_titles := [
-	tr("OH! WHAT A DAY"),
-	tr("THAT'S FINE"),
-	tr("LET'S GO HOME"),
-]
-
-## Affirming titles shown when the player does well, travelling many steps during a career session.
-##
-## These messages are shown very frequently, so they should have a sense of understatement to them.
-var _great_titles := [
-	tr("CONGRATULATIONS"),
-	tr("WE DID IT"),
-	tr("HOORAY"),
-	tr("FANTASTIC"),
-	tr("YAHOO FOR US"),
-	tr("LOOK WHAT WE DID"),
-	tr("GOSH! WE'RE SO COOL"),
-	tr("WELL HOORAY"),
-	tr("AMAZING"),
-]
-
-## Icons shown alongside the title at the top. One of these is selected randomly each time.
-##
-## Each item in this array is a subarray containing two nested items: a left icon and a right icon.
-var _title_icon_resources := [
-	[
-		preload("res://assets/main/ui/career/chalkboard-title-0a.png"),
-		preload("res://assets/main/ui/career/chalkboard-title-0b.png")
-	],
-	[
-		preload("res://assets/main/ui/career/chalkboard-title-1a.png"),
-		preload("res://assets/main/ui/career/chalkboard-title-1b.png")
-	],
-	[
-		preload("res://assets/main/ui/career/chalkboard-title-2a.png"),
-		preload("res://assets/main/ui/career/chalkboard-title-2b.png")
-	],
-	[
-		preload("res://assets/main/ui/career/chalkboard-title-3a.png"),
-		preload("res://assets/main/ui/career/chalkboard-title-3b.png")
-	],
-]
-
-## Icons shown alongside the 'Served' value. One of these is selected randomly each time.
-var _customer_icon_resources := [
-	preload("res://assets/main/ui/career/chalkboard-customer-0.png"),
-	preload("res://assets/main/ui/career/chalkboard-customer-1.png"),
-	preload("res://assets/main/ui/career/chalkboard-customer-2.png"),
-	preload("res://assets/main/ui/career/chalkboard-customer-3.png"),
-]
-
 onready var _button := $Chalkboard/VBoxContainer/ButtonRow/Button
-
-## Labels which show the current day's information
-onready var _title := $Chalkboard/VBoxContainer/TitleRow/HBoxContainer/Label
-onready var _earned := $Chalkboard/VBoxContainer/EarnedTimeRow/HBoxContainer/Earned/HBoxContainer/Label3
-onready var _served := $Chalkboard/VBoxContainer/ServedStepsRow/HBoxContainer/Served/HBoxContainer/Label3
-onready var _steps := $Chalkboard/VBoxContainer/ServedStepsRow/HBoxContainer/Steps/HBoxContainer/Label3
-onready var _time := $Chalkboard/VBoxContainer/EarnedTimeRow/HBoxContainer/Time/HBoxContainer/Label3
-
-## Icons which change randomly each time
-onready var _left_title_icon := $Chalkboard/VBoxContainer/TitleRow/HBoxContainer/Control1/TextureRect
-onready var _right_title_icon := $Chalkboard/VBoxContainer/TitleRow/HBoxContainer/Control2/TextureRect
-onready var _customer_icon := $Chalkboard/VBoxContainer/ServedStepsRow/HBoxContainer/ \
-		Served/HBoxContainer/Control/TextureRect
-
 onready var _map := $Chalkboard/VBoxContainer/MapRow
 onready var _applause_sound := $ApplauseSound
 onready var _obstacle_manager: ObstacleManager = get_node(obstacle_manager_path)
@@ -88,9 +19,7 @@ func _ready() -> void:
 	ResourceCache.substitute_singletons()
 	MusicPlayer.play_chill_bgm()
 	
-	_refresh_title_text()
-	_refresh_icons()
-	_refresh_labels()
+	_refresh_mood()
 	_refresh_map()
 	
 	PlayerData.career.advance_calendar()
@@ -103,55 +32,22 @@ func _exit_tree() -> void:
 	ResourceCache.remove_singletons()
 
 
-## Updates the title text with a random value.
-##
-## Different titles are shown based on the player's performance. A typical player will always see the same affirming
-## titles, although special titles are selected if they do especially poorly.
-func _refresh_title_text() -> void:
+## Updates the creature moods, and plays an applause sound if the player did well.
+func _refresh_mood() -> void:
 	var player := _obstacle_manager.find_creature(CreatureLibrary.PLAYER_ID)
 	var sensei := _obstacle_manager.find_creature(CreatureLibrary.SENSEI_ID)
-	
-	if PlayerData.career.daily_steps >= 25:
-		# if you travelled 25 steps, you did great
-		_title.text = Utils.rand_value(_great_titles)
-		_applause_sound.play()
+	if PlayerData.career.daily_steps >= DAILY_STEPS_GOOD:
 		player.play_mood(ChatEvent.Mood.LAUGH0)
 		sensei.play_mood(ChatEvent.Mood.LAUGH0)
-	elif PlayerData.career.daily_steps >= 8:
-		# if you travelled 8, you at least did ok
-		_title.text = Utils.rand_value(_good_titles)
+	elif PlayerData.career.daily_steps >= DAILY_STEPS_OK:
 		player.play_mood(ChatEvent.Mood.SMILE0)
 		sensei.play_mood(ChatEvent.Mood.SMILE0)
 	else:
-		# you did not do well
-		_title.text = Utils.rand_value(_bad_titles)
 		player.play_mood(ChatEvent.Mood.RAGE0)
 		sensei.play_mood(ChatEvent.Mood.RAGE0)
-
-
-## Updates the icons in the report.
-##
-## This includes the icons shown alongside the title at the top, and the customer icon shown alongside the 'Served'
-## value. These icons are randomized each time.
-func _refresh_icons() -> void:
-	# Select a random set of icons to show alongside the title at the top
-	var title_icon_resources: Array = Utils.rand_value(_title_icon_resources)
-	_left_title_icon.texture = title_icon_resources[0]
-	_right_title_icon.texture = title_icon_resources[1]
 	
-	# Select a random customer icon to show alongside the 'Served' value
-	var customer_icon_resource: Texture = Utils.rand_value(_customer_icon_resources)
-	_customer_icon.texture = customer_icon_resource
-
-
-## Updates the numeric values in the report.
-##
-## This populates the labels showing things like how much money the player earned and how many customers they served.
-func _refresh_labels() -> void:
-	_earned.text = StringUtils.format_money(min(PlayerData.career.daily_earnings, 999999))
-	_served.text = StringUtils.comma_sep(min(PlayerData.career.daily_customers, 99999))
-	_steps.text = StringUtils.comma_sep(min(PlayerData.career.daily_steps, 99999))
-	_time.text = StringUtils.format_duration(min(PlayerData.career.daily_seconds_played, 5999)) # 99:59
+	if PlayerData.career.daily_steps >= DAILY_STEPS_GOOD:
+		_applause_sound.play()
 
 
 ## Updates the map based on how far the player has travelled.

--- a/project/src/main/ui/career/chalkboard-earned.gd
+++ b/project/src/main/ui/career/chalkboard-earned.gd
@@ -1,0 +1,7 @@
+extends MarginContainer
+## A label which shows the player's daily earnings when the player finishes career mode.
+
+onready var _value_label := $HBoxContainer/Label3
+
+func _ready() -> void:
+	_value_label.text = StringUtils.format_money(min(PlayerData.career.daily_earnings, 999999))

--- a/project/src/main/ui/career/chalkboard-served.gd
+++ b/project/src/main/ui/career/chalkboard-served.gd
@@ -1,0 +1,19 @@
+extends MarginContainer
+
+## Icons shown alongside the 'Served' value. One of these is selected randomly each time.
+var _customer_icon_resources := [
+	preload("res://assets/main/ui/career/chalkboard-customer-0.png"),
+	preload("res://assets/main/ui/career/chalkboard-customer-1.png"),
+	preload("res://assets/main/ui/career/chalkboard-customer-2.png"),
+	preload("res://assets/main/ui/career/chalkboard-customer-3.png"),
+]
+
+onready var _customer_icon := $HBoxContainer/Control/TextureRect
+onready var _value_label := $HBoxContainer/Label3
+
+func _ready() -> void:
+	# Select a random customer icon to show alongside the 'Served' value
+	var customer_icon_resource: Texture = Utils.rand_value(_customer_icon_resources)
+	_customer_icon.texture = customer_icon_resource
+	
+	_value_label.text = StringUtils.comma_sep(min(PlayerData.career.daily_customers, 99999))

--- a/project/src/main/ui/career/chalkboard-steps.gd
+++ b/project/src/main/ui/career/chalkboard-steps.gd
@@ -1,0 +1,7 @@
+extends MarginContainer
+## A label which shows the player's daily steps when the player finishes career mode.
+
+onready var _value_label := $HBoxContainer/Label3
+
+func _ready() -> void:
+	_value_label.text = StringUtils.comma_sep(min(PlayerData.career.daily_steps, 99999))

--- a/project/src/main/ui/career/chalkboard-time.gd
+++ b/project/src/main/ui/career/chalkboard-time.gd
@@ -1,0 +1,7 @@
+extends MarginContainer
+## A label which shows the player's daily seconds played when the player finishes career mode.
+
+onready var _value_label := $HBoxContainer/Label3
+
+func _ready() -> void:
+	_value_label.text = StringUtils.format_duration(min(PlayerData.career.daily_seconds_played, 5999)) # 99:59

--- a/project/src/main/ui/career/chalkboard-title.gd
+++ b/project/src/main/ui/career/chalkboard-title.gd
@@ -1,0 +1,73 @@
+extends HBoxContainer
+## The chalkboard title shown when the player finishes career mode.
+
+## Affirming titles shown when the player does well, travelling many steps during a career session.
+##
+## These messages are shown very frequently, so they should have a sense of understatement to them.
+var _great_titles := [
+	tr("CONGRATULATIONS"),
+	tr("WE DID IT"),
+	tr("HOORAY"),
+	tr("FANTASTIC"),
+	tr("YAHOO FOR US"),
+	tr("LOOK WHAT WE DID"),
+	tr("GOSH! WE'RE SO COOL"),
+	tr("WELL HOORAY"),
+	tr("AMAZING"),
+]
+
+## Neutral titles shown when the player does poorly, travelling only a few steps during a career session.
+var _good_titles := [
+	tr("OH! WHAT A DAY"),
+	tr("THAT'S FINE"),
+	tr("LET'S GO HOME"),
+]
+
+## Negative titles shown when the player fails, travelling zero steps during a career session.
+var _bad_titles := [
+	tr("OH DEAR WHAT HAPPENED"),
+	tr("OH! NO! GO ON TRYING"),
+	tr("GOSH THAT'S NOT GOOD"),
+]
+
+## Icons shown alongside the title at the top. One of these is selected randomly each time.
+##
+## Each item in this array is a subarray containing two nested items: a left icon and a right icon.
+var _title_icon_resources := [
+	[
+		preload("res://assets/main/ui/career/chalkboard-title-0a.png"),
+		preload("res://assets/main/ui/career/chalkboard-title-0b.png")
+	],
+	[
+		preload("res://assets/main/ui/career/chalkboard-title-1a.png"),
+		preload("res://assets/main/ui/career/chalkboard-title-1b.png")
+	],
+	[
+		preload("res://assets/main/ui/career/chalkboard-title-2a.png"),
+		preload("res://assets/main/ui/career/chalkboard-title-2b.png")
+	],
+	[
+		preload("res://assets/main/ui/career/chalkboard-title-3a.png"),
+		preload("res://assets/main/ui/career/chalkboard-title-3b.png")
+	],
+]
+
+## Labels which show the current day's information
+onready var _title := $Label
+
+## Icons which change randomly each time
+onready var _left_title_icon := $Control1/TextureRect
+onready var _right_title_icon := $Control2/TextureRect
+
+func _ready() -> void:
+	if PlayerData.career.daily_steps >= 25:
+		_title.text = Utils.rand_value(_great_titles)
+	elif PlayerData.career.daily_steps >= 8:
+		_title.text = Utils.rand_value(_good_titles)
+	else:
+		_title.text = Utils.rand_value(_bad_titles)
+	
+	# Select a random set of icons to show alongside the title at the top
+	var title_icon_resources: Array = Utils.rand_value(_title_icon_resources)
+	_left_title_icon.texture = title_icon_resources[0]
+	_right_title_icon.texture = title_icon_resources[1]

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=32 format=2]
+[gd_scene load_steps=33 format=2]
 
 [ext_resource path="res://src/main/ui/menu/theme/h4.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=2]
@@ -28,6 +28,7 @@
 [ext_resource path="res://src/main/ui/settings/settings-open-user-folder.gd" type="Script" id=26]
 [ext_resource path="res://src/main/ui/settings/settings-copy-save-data.gd" type="Script" id=27]
 [ext_resource path="res://src/main/ui/settings/settings-lock-cancel.gd" type="Script" id=28]
+[ext_resource path="res://src/main/ui/settings/settings-menu-bottom.gd" type="Script" id=29]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 5.0
@@ -79,7 +80,6 @@ visible = false
 emit_actions = false
 
 [node name="Window" type="Panel" parent="."]
-visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -986,6 +986,7 @@ margin_top = 254.0
 margin_right = 570.0
 margin_bottom = 354.0
 rect_min_size = Vector2( 0, 100 )
+script = ExtResource( 29 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -1202,6 +1203,8 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[connection signal="hide" from="." to="Window/UiArea/Bottom" method="_on_SettingsMenu_hide"]
+[connection signal="show" from="." to="Window/UiArea/Bottom" method="_on_SettingsMenu_show"]
 [connection signal="change_save_cancelled" from="Dialogs" to="." method="_on_Dialogs_change_save_cancelled"]
 [connection signal="change_save_confirmed" from="Dialogs" to="." method="_on_Dialogs_change_save_confirmed"]
 [connection signal="delete_confirmed" from="Dialogs" to="." method="_on_Dialogs_delete_confirmed"]
@@ -1211,9 +1214,12 @@ __meta__ = {
 [connection signal="popup_hide" from="Dialogs/DeleteConfirmation1" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
 [connection signal="about_to_show" from="Dialogs/DeleteConfirmation2" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
 [connection signal="popup_hide" from="Dialogs/DeleteConfirmation2" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
-[connection signal="pressed" from="Window/UiArea/Bottom/HBoxContainer/VBoxContainer1/Holder1/Quit1" to="." method="_on_OtherQuit_pressed"]
-[connection signal="pressed" from="Window/UiArea/Bottom/HBoxContainer/VBoxContainer1/Holder2/Quit2" to="." method="_on_Quit_pressed"]
-[connection signal="pressed" from="Window/UiArea/Bottom/HBoxContainer/VBoxContainer2/Holder/Ok" to="." method="_on_Ok_pressed"]
+[connection signal="ok_pressed" from="Window/UiArea/Bottom" to="." method="_on_Bottom_ok_pressed"]
+[connection signal="other_quit_pressed" from="Window/UiArea/Bottom" to="." method="_on_Bottom_other_quit_pressed"]
+[connection signal="quit_pressed" from="Window/UiArea/Bottom" to="." method="_on_Bottom_quit_pressed"]
+[connection signal="pressed" from="Window/UiArea/Bottom/HBoxContainer/VBoxContainer1/Holder1/Quit1" to="Window/UiArea/Bottom" method="_on_OtherQuit_pressed"]
+[connection signal="pressed" from="Window/UiArea/Bottom/HBoxContainer/VBoxContainer1/Holder2/Quit2" to="Window/UiArea/Bottom" method="_on_Quit_pressed"]
+[connection signal="pressed" from="Window/UiArea/Bottom/HBoxContainer/VBoxContainer2/Holder/Ok" to="Window/UiArea/Bottom" method="_on_Ok_pressed"]
 [connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/GhostPiece/CheckBox" to="Window/UiArea/TabContainer/Gameplay/GhostPiece" method="_on_OptionButton_toggled"]
 [connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/LockCancel/CheckBox" to="Window/UiArea/TabContainer/Gameplay/LockCancel" method="_on_OptionButton_toggled"]
 [connection signal="pressed" from="Window/UiArea/TabContainer/Misc/CopySaveData/HBoxContainer/Button" to="Window/UiArea/TabContainer/Misc/CopySaveData" method="_on_Button_pressed"]

--- a/project/src/main/ui/settings/settings-menu-bottom.gd
+++ b/project/src/main/ui/settings/settings-menu-bottom.gd
@@ -1,0 +1,86 @@
+extends Control
+## The bottom area of the settings menu with the OK and Quit buttons
+
+signal ok_pressed
+signal quit_pressed
+signal other_quit_pressed
+
+## The text on the menu's quit button
+var quit_type: int setget set_quit_type
+
+## the UI control which was focused before this settings menu popped up
+var _old_focus_owner: Control
+
+onready var _ok_button := $HBoxContainer/VBoxContainer2/Holder/Ok
+onready var _ok_shortcut_helper := $HBoxContainer/VBoxContainer2/Holder/Ok/ShortcutHelper
+onready var _quit_button := $HBoxContainer/VBoxContainer1/Holder2/Quit2
+onready var _other_quit_button := $HBoxContainer/VBoxContainer1/Holder1/Quit1
+
+func _ready() -> void:
+	var custom_keybind_buttons := get_tree().get_nodes_in_group("custom_keybind_buttons")
+	for keybind_button in custom_keybind_buttons:
+		keybind_button.connect("awaiting_changed", self, "_on_CustomKeybindButton_awaiting_changed")
+	
+	_refresh_quit_type()
+
+
+func set_quit_type(new_quit_type: int) -> void:
+	quit_type = new_quit_type
+	_refresh_quit_type()
+
+
+func _refresh_quit_type() -> void:
+	var quit_text := ""
+	var other_quit_text := ""
+	match quit_type:
+		SettingsMenu.QuitType.QUIT: quit_text = tr("Quit")
+		SettingsMenu.QuitType.SAVE_AND_QUIT: quit_text = tr("Save + Quit")
+		SettingsMenu.QuitType.GIVE_UP: quit_text = tr("Give Up")
+		SettingsMenu.QuitType.SAVE_AND_QUIT_OR_GIVE_UP:
+			quit_text = tr("Save + Quit")
+			other_quit_text = tr("Give Up")
+	
+	_quit_button.text = quit_text
+	_other_quit_button.text = other_quit_text
+	
+	if other_quit_text:
+		rect_min_size.y = 100
+		rect_size.y = 100
+		$HBoxContainer/VBoxContainer1/Holder1.visible = true
+		$HBoxContainer/VBoxContainer2/Spacer.visible = true
+		$HBoxContainer/VBoxContainer3/Spacer.visible = true
+	else:
+		rect_min_size.y = 50
+		rect_size.y = 50
+		$HBoxContainer/VBoxContainer1/Holder1.visible = false
+		$HBoxContainer/VBoxContainer2/Spacer.visible = false
+		$HBoxContainer/VBoxContainer3/Spacer.visible = false
+
+
+func _on_CustomKeybindButton_awaiting_changed(awaiting: bool) -> void:
+	# When the user is rebinding their keys, we disable the shortcut helper. Otherwise trying to rebind something like
+	# 'escape' will close the settings menu
+	_ok_shortcut_helper.set_process_input(not awaiting)
+
+
+func _on_SettingsMenu_show() -> void:
+	_old_focus_owner = _ok_button.get_focus_owner()
+	_ok_button.grab_focus()
+
+
+func _on_SettingsMenu_hide() -> void:
+	if _old_focus_owner:
+		_old_focus_owner.grab_focus()
+		_old_focus_owner = null
+
+
+func _on_Quit_pressed() -> void:
+	emit_signal("quit_pressed")
+
+
+func _on_OtherQuit_pressed() -> void:
+	emit_signal("other_quit_pressed")
+
+
+func _on_Ok_pressed() -> void:
+	emit_signal("ok_pressed")


### PR DESCRIPTION
Extracted child nodes within SettingsMenu, CareerWin. Both these scripts had
some very long node paths for logic which could be handled by the bottom node.
I've moved the node paths and logic.