### PR TITLE
Career bugfixes: layers, buttons changing

### DIFF
--- a/project/src/main/world/CareerMap.tscn
+++ b/project/src/main/world/CareerMap.tscn
@@ -768,11 +768,13 @@ normal_icon = ExtResource( 10 )
 pressed_icon = ExtResource( 11 )
 
 [node name="SettingsMenu" parent="Ui" instance=ExtResource( 14 )]
+layer = 5
 quit_type = 3
 
 [node name="MusicPopup" parent="Ui" instance=ExtResource( 24 )]
 
 [node name="SceneTransitionCover" parent="Ui" instance=ExtResource( 50 )]
+layer = 10
 
 [connection signal="level_button_focused" from="LevelSelect" to="Ui/Control/StatusBar/Distance" method="_on_LevelSelect_level_button_focused"]
 [connection signal="level_button_focused" from="LevelSelect" to="World" method="_on_LevelSelect_level_button_focused"]

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -153,6 +153,10 @@ func _random_levels() -> Array:
 
 ## When the player clicks a level button twice, we launch the selected level
 func _on_LevelSelectButton_level_started(level_index: int) -> void:
+	if PlayerData.career.is_connected("distance_travelled_changed", self, "_on_CareerData_distance_travelled_changed"):
+		# avoid changing the level button titles when you pick an earlier level
+		PlayerData.career.disconnect("distance_travelled_changed", self, "_on_CareerData_distance_travelled_changed")
+	
 	# apply a distance penalty if they select an earlier level
 	var distance_penalty: int = PlayerData.career.distance_penalties()[level_index]
 	PlayerData.career.distance_travelled -= distance_penalty


### PR DESCRIPTION
Fixed visual bug where career map's status bar didn't fade out. Fixed
visual bug where career map's status bar stayed in the foreground when the
settings menu was up.

Fixed bug where selecting an earlier level in Career mode made all the
buttons change.