### PR TITLE
Fix temporary status bar visual glitch when selecting a level.

### DIFF
--- a/project/src/main/ui/career/career-distance-label.gd
+++ b/project/src/main/ui/career/career-distance-label.gd
@@ -36,6 +36,16 @@ func _refresh_label() -> void:
 		pass
 
 
+## Updates the distance label after the player selects a level.
+##
+## After the player selects a label, the distance penalty is applied to the player's distance travelled. This method
+## updates the label's text with the player's raw distance travelled with no penalty applied. This prevents a bug
+## where we temporarily display the distance with the penalty applied twice.
+func suppress_distance_penalty() -> void:
+	# Display the distance travelled with the distance penalty applied
+	_label.text = StringUtils.comma_sep(PlayerData.career.distance_travelled)
+
+
 func _on_CareerData_distance_travelled_changed() -> void:
 	_refresh_label()
 

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -16,6 +16,7 @@ var _duration_calculator := DurationCalculator.new()
 
 onready var _world := $World
 onready var _grade_labels := $LevelSelect/Control/GradeLabels
+onready var _distance_label := $Ui/Control/StatusBar/Distance
 
 ## LevelSelectButtons for all levels the player can select.
 onready var _level_select_buttons := $LevelSelect/Control/LevelButtons.get_children()
@@ -161,6 +162,7 @@ func _on_LevelSelectButton_level_started(level_index: int) -> void:
 	var distance_penalty: int = PlayerData.career.distance_penalties()[level_index]
 	PlayerData.career.distance_travelled -= distance_penalty
 	PlayerData.career.daily_steps -= distance_penalty
+	_distance_label.suppress_distance_penalty()
 	
 	var level_settings: LevelSettings = _level_settings_for_levels[level_index]
 	PlayerData.career.daily_level_ids.append(level_settings.id)


### PR DESCRIPTION
After selecting a level in Career mode, the status bar would briefly
flash from '53 (+3)' to '52 (+1)' because the distance label would
detect the distance_travelled change signal. However, the
distance_travelled change was applying a penalty which the distance
label display already displays -- so this value was incorrect.

CareerMap now includes an explicit step to overwrite this label with the
correct value, so it flashes from '53 (+3)' to '53'