### PR TITLE
Career mode's level buttons are added one-by-one.

### DIFF
--- a/project/src/main/ui/career/career-map-level-select.gd
+++ b/project/src/main/ui/career/career-map-level-select.gd
@@ -4,20 +4,52 @@ extends CanvasLayer
 
 signal level_button_focused(button_index)
 
-onready var _level_select_buttons := $Control/LevelButtons.get_children()
+export (PackedScene) var LevelSelectButtonScene: PackedScene
+
+var _duration_calculator := DurationCalculator.new()
+
 onready var _control := $Control
-
-func _ready() -> void:
-	for i in range(_level_select_buttons.size()):
-		var button: Button = _level_select_buttons[i]
-		button.connect("focus_entered", self, "_on_LevelSelectButton_focus_entered", [i])
-
+onready var _grade_labels := $Control/GradeLabels
+onready var _level_buttons_container := $Control/LevelButtons
 
 ## Returns the index of the currently focused level button, or -1 if none is selected.
 ##
 ## For a boss level where only one level is available, this will return '0' if the level button is selected.
 func focused_level_button_index() -> int:
-	return _level_select_buttons.find(_control.get_focus_owner())
+	return _level_buttons_container.get_children().find(_control.get_focus_owner())
+
+
+## Removes all level select button nodes from the scene tree.
+func clear_level_select_buttons() -> void:
+	for child in _level_buttons_container.get_children():
+		child.queue_free()
+
+
+## Adds a new level select button to the scene tree.
+##
+## Parameters:
+## 	'settings': The level settings which control the button's appearance.
+func add_level_select_button(settings: LevelSettings) -> LevelSelectButton:
+	var button: LevelSelectButton = LevelSelectButtonScene.instance()
+	button.rect_min_size = Vector2(200, 120)
+	button.size_flags_horizontal = 6
+	button.size_flags_vertical = 4
+	button.level_title = settings.title
+	button.level_id = settings.id
+	var duration := _duration_calculator.duration(settings)
+	if duration < 100:
+		button.level_duration = LevelSelectButton.SHORT
+	elif duration < 200:
+		button.level_duration = LevelSelectButton.MEDIUM
+	else:
+		button.level_duration = LevelSelectButton.LONG
+	
+	button.connect("focus_entered", self, "_on_LevelSelectButton_focus_entered", \
+			[_level_buttons_container.get_child_count()])
+	_level_buttons_container.add_child(button)
+	
+	_grade_labels.add_label(button)
+	return button
 
 
 func _on_LevelSelectButton_focus_entered(button_index: int) -> void:

--- a/project/src/main/ui/level-select/hookable-grade-label.gd
+++ b/project/src/main/ui/level-select/hookable-grade-label.gd
@@ -23,14 +23,12 @@ func set_button(new_button: LevelSelectButton) -> void:
 		button.get_node("GradeHook").remote_path = null
 		button.disconnect("lowlight_changed", self, "_on_LevelSelectButton_lowlight_changed")
 		button.disconnect("tree_exited", self, "_on_LevelSelectButton_tree_exited")
-		button.disconnect("level_info_changed", self, "_on_LevelSelectButton_level_info_changed")
 	
 	button = new_button
 	
 	button.get_node("GradeHook").remote_path = button.get_node("GradeHook").get_path_to(self)
 	button.connect("lowlight_changed", self, "_on_LevelSelectButton_lowlight_changed")
 	button.connect("tree_exited", self, "_on_LevelSelectButton_tree_exited")
-	button.connect("level_info_changed", self, "_on_LevelSelectButton_level_info_changed")
 	
 	_refresh_appearance()
 
@@ -132,7 +130,3 @@ func _on_LevelSelectButton_lowlight_changed() -> void:
 
 func _on_LevelSelectButton_tree_exited() -> void:
 	queue_free()
-
-
-func _on_LevelSelectButton_level_info_changed() -> void:
-	_refresh_appearance()

--- a/project/src/main/ui/level-select/level-select-button.gd
+++ b/project/src/main/ui/level-select/level-select-button.gd
@@ -7,13 +7,6 @@ signal level_started
 
 signal lowlight_changed
 
-## Emitted when the button's level information changes, such as its title, duration or lock status.
-##
-## Because many of these properties are modified sequentially, this script does not emit this signal itself. Otherwise
-## it would end up emitting the signal 7 or 8 times in a row.
-# warning-ignore:unused_signal
-signal level_info_changed
-
 ## short levels have smaller buttons; long levels have larger buttons
 enum LevelSize {
 	SHORT,

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -80,6 +80,7 @@ visible = false
 emit_actions = false
 
 [node name="Window" type="Panel" parent="."]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5

--- a/project/src/main/world/CareerMap.tscn
+++ b/project/src/main/world/CareerMap.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=74 format=2]
+[gd_scene load_steps=68 format=2]
 
 [ext_resource path="res://src/main/ui/level-select/grade-labels.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/career-map.gd" type="Script" id=2]
@@ -103,84 +103,6 @@ viewport_path = NodePath("World/Ground/Shadows/Viewport")
 _data = {
 "points": PoolVector2Array( 0, 0, 0, 0, -371.625, 243.731, 0, 0, 0, 0, 111.709, 374.478, 0, 0, 0, 0, 471.926, 546.111, 0, 0, 0, 0, 684.81, 553.451, 0, 0, 0, 0, 932.105, 487.379, 0, 0, 0, 0, 1098.23, 391.104, 0, 0, 0, 0, 1222.82, 368.451, 0, 0, 0, 0, 1400.27, 398.655, 0, 0, 0, 0, 1600.37, 347.686, 0, 0, 0, 0, 1817.29, 227.125, 0, 0, 0, 0, 2101.23, 203.817, 0, 0, 0, 0, 2285.58, 284.336, 0, 0, 0, 0, 2467.81, 208.055, 0, 0, 0, 0, 2656.54, 103.255, 0, 0, 0, 0, 2847.09, 136.011, 0, 0, 0, 0, 3083.72, 306.148, 0, 0, 0, 0, 3283.85, 358.284, 0, 0, 0, 0, 3465.48, 316.239, 0, 0, 0, 0, 3653.85, 321.284, 0, 0, 0, 0, 3887.61, 375.102, 0, 0, 0, 0, 4122.69, 347.904, 0, 0, 0, 0, 4247.7, 299.169 )
 }
-
-[sub_resource type="StyleBoxFlat" id=2]
-resource_local_to_scene = true
-bg_color = Color( 0.321569, 0.686275, 0.890196, 1 )
-border_width_left = 4
-border_width_top = 4
-border_width_right = 4
-border_width_bottom = 4
-border_color = Color( 0.423529, 0.262745, 0.192157, 1 )
-corner_radius_top_left = 8
-corner_radius_top_right = 8
-corner_radius_bottom_right = 8
-corner_radius_bottom_left = 8
-
-[sub_resource type="StyleBoxFlat" id=3]
-resource_local_to_scene = true
-bg_color = Color( 0.321569, 0.686275, 0.890196, 1 )
-border_width_left = 4
-border_width_top = 4
-border_width_right = 4
-border_width_bottom = 4
-border_color = Color( 0.423529, 0.262745, 0.192157, 1 )
-corner_radius_top_left = 8
-corner_radius_top_right = 8
-corner_radius_bottom_right = 8
-corner_radius_bottom_left = 8
-
-[sub_resource type="StyleBoxFlat" id=4]
-resource_local_to_scene = true
-bg_color = Color( 0.321569, 0.686275, 0.890196, 1 )
-border_width_left = 4
-border_width_top = 4
-border_width_right = 4
-border_width_bottom = 4
-border_color = Color( 0.423529, 0.262745, 0.192157, 1 )
-corner_radius_top_left = 8
-corner_radius_top_right = 8
-corner_radius_bottom_right = 8
-corner_radius_bottom_left = 8
-
-[sub_resource type="StyleBoxFlat" id=5]
-resource_local_to_scene = true
-bg_color = Color( 0.321569, 0.686275, 0.890196, 1 )
-border_width_left = 4
-border_width_top = 4
-border_width_right = 4
-border_width_bottom = 4
-border_color = Color( 0.423529, 0.262745, 0.192157, 1 )
-corner_radius_top_left = 8
-corner_radius_top_right = 8
-corner_radius_bottom_right = 8
-corner_radius_bottom_left = 8
-
-[sub_resource type="StyleBoxFlat" id=6]
-resource_local_to_scene = true
-bg_color = Color( 0.321569, 0.686275, 0.890196, 1 )
-border_width_left = 4
-border_width_top = 4
-border_width_right = 4
-border_width_bottom = 4
-border_color = Color( 0.423529, 0.262745, 0.192157, 1 )
-corner_radius_top_left = 8
-corner_radius_top_right = 8
-corner_radius_bottom_right = 8
-corner_radius_bottom_left = 8
-
-[sub_resource type="StyleBoxFlat" id=7]
-resource_local_to_scene = true
-bg_color = Color( 0.321569, 0.686275, 0.890196, 1 )
-border_width_left = 4
-border_width_top = 4
-border_width_right = 4
-border_width_bottom = 4
-border_color = Color( 0.423529, 0.262745, 0.192157, 1 )
-corner_radius_top_left = 8
-corner_radius_top_right = 8
-corner_radius_bottom_right = 8
-corner_radius_bottom_left = 8
 
 [sub_resource type="StyleBoxFlat" id=20]
 bg_color = Color( 0.423529, 0.262745, 0.192157, 1 )
@@ -528,6 +450,7 @@ script = ExtResource( 49 )
 
 [node name="LevelSelect" type="CanvasLayer" parent="."]
 script = ExtResource( 28 )
+LevelSelectButtonScene = ExtResource( 6 )
 
 [node name="Control" type="Control" parent="LevelSelect"]
 anchor_right = 1.0
@@ -547,39 +470,6 @@ size_flags_vertical = 3
 __meta__ = {
 "_edit_use_anchors_": false
 }
-
-[node name="Button1" parent="LevelSelect/Control/LevelButtons" instance=ExtResource( 6 )]
-margin_left = 58.0
-margin_top = 28.0
-margin_right = 258.0
-margin_bottom = 148.0
-rect_min_size = Vector2( 200, 120 )
-size_flags_horizontal = 6
-size_flags_vertical = 4
-custom_styles/hover = SubResource( 2 )
-custom_styles/normal = SubResource( 3 )
-
-[node name="Button2" parent="LevelSelect/Control/LevelButtons" instance=ExtResource( 6 )]
-margin_left = 379.0
-margin_top = 28.0
-margin_right = 579.0
-margin_bottom = 148.0
-rect_min_size = Vector2( 200, 120 )
-size_flags_horizontal = 6
-size_flags_vertical = 4
-custom_styles/hover = SubResource( 4 )
-custom_styles/normal = SubResource( 5 )
-
-[node name="Button3" parent="LevelSelect/Control/LevelButtons" instance=ExtResource( 6 )]
-margin_left = 701.0
-margin_top = 28.0
-margin_right = 901.0
-margin_bottom = 148.0
-rect_min_size = Vector2( 200, 120 )
-size_flags_horizontal = 6
-size_flags_vertical = 4
-custom_styles/hover = SubResource( 6 )
-custom_styles/normal = SubResource( 7 )
 
 [node name="GradeLabels" type="Control" parent="LevelSelect/Control"]
 anchor_right = 1.0


### PR DESCRIPTION
Career mode's level select buttons are added one-by-one, like
LevelSelectPanel's buttons. This is less weird than its current
implementation, where it always has three buttons but turns them
visible/invisible.

Removed unused 'level info changed' signal. LevelSelectButtons are now
removed and re-added each time, their properties don't change.