### PR TITLE
Refactor: briefly_suppress_sfx, onready variables, food_eaten signal

### DIFF
--- a/project/src/main/puzzle/puzzle-messages.gd
+++ b/project/src/main/puzzle/puzzle-messages.gd
@@ -30,10 +30,7 @@ func _ready() -> void:
 	_start_button.grab_focus()
 
 
-## Initialize onready variables to avoid null references.
-##
-## Our hide_buttons() method is potentially called in the _ready functions of other nodes, so our onready variables
-## need to be initialized before that.
+## Preemptively initialize onready variables to avoid null references.
 func _enter_tree() -> void:
 	_message_label = $MessageLabel
 	_back_button = $Buttons/Back

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -113,7 +113,7 @@ func _start_puzzle() -> void:
 		PlayerData.creature_library.restore_fatness_state()
 	
 	PlayerData.creature_queue.primary_index = 0
-	_restaurant_view.start_suppress_sfx_timer()
+	_restaurant_view.briefly_suppress_sfx()
 	
 	if PlayerData.creature_queue.primary_queue:
 		var starting_creature_id: String = PlayerData.creature_queue.primary_queue[0].creature_id

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -123,10 +123,10 @@ func next_creature_index() -> int:
 
 
 ## Temporarily suppresses 'hello' and 'door chime' sounds.
-func start_suppress_sfx_timer() -> void:
+func briefly_suppress_sfx(duration: float = 1.0) -> void:
 	for customer in get_customers():
-		customer.start_suppress_sfx_timer()
-	_restaurant_viewport_scene.start_suppress_sfx_timer()
+		customer.briefly_suppress_sfx(duration)
+	_restaurant_viewport_scene.briefly_suppress_sfx(duration)
 
 
 func _refresh_customer_name() -> void:

--- a/project/src/main/world/creature/creature-sfx.gd
+++ b/project/src/main/world/creature/creature-sfx.gd
@@ -127,8 +127,8 @@ func play_hop_sound() -> void:
 	_hop_sound.play()
 
 
-func start_suppress_sfx_timer() -> void:
-	_suppress_sfx_timer.start(1.0)
+func briefly_suppress_sfx(duration: float = 1.0) -> void:
+	_suppress_sfx_timer.start(duration)
 
 
 func _connect_creature_visuals_listeners() -> void:

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -11,7 +11,7 @@ signal talking_changed
 signal dna_loaded
 
 ## emitted on the frame when creature bites into some food
-signal food_eaten
+signal food_eaten(food_type)
 
 ## emitted after a creature finishes fading in/out and their visible/modulate values are finalized
 signal fade_in_finished
@@ -399,8 +399,8 @@ func get_chat_extents() -> Vector2:
 
 
 ## Temporarily suppresses 'hello' sounds.
-func start_suppress_sfx_timer() -> void:
-	_creature_sfx.start_suppress_sfx_timer()
+func briefly_suppress_sfx(duration: float = 1.0) -> void:
+	_creature_sfx.briefly_suppress_sfx(duration)
 
 
 ## Make the creature visible and gradually adjust their alpha up to 1.0.

--- a/project/src/main/world/creature/emote-player.gd
+++ b/project/src/main/world/creature/emote-player.gd
@@ -127,6 +127,8 @@ var _head_bobber: Sprite
 ## list of sprites to reset when unemoting
 var _emote_sprites: Array
 
+onready var _reset_tween := $ResetTween
+
 func _ready() -> void:
 	_refresh_creature_visuals_path()
 
@@ -259,7 +261,7 @@ func emote(mood: int) -> void:
 		else:
 			# reset to the default mood, and wait for the tween to complete
 			unemote()
-			yield($ResetTween, "tween_all_completed")
+			yield(_reset_tween, "tween_all_completed")
 			_post_unemote()
 	else:
 		# initialize eye frames in case the eyes were previously invisible, such as for north-facing creatures
@@ -300,16 +302,16 @@ func unemote(anim_name: String = "") -> void:
 		_emote_eye_z1.frame = 2
 		play("ambient-sweat")
 	
-	$ResetTween.remove_all()
-	$ResetTween.interpolate_property(_head_bobber, "rotation_degrees",
+	_reset_tween.remove_all()
+	_reset_tween.interpolate_property(_head_bobber, "rotation_degrees",
 			_head_bobber.rotation_degrees, 0, UNEMOTE_DURATION)
 	for emote_sprite in _emote_sprites:
-		$ResetTween.interpolate_property(emote_sprite, "rotation_degrees", emote_sprite.rotation_degrees, 0,
+		_reset_tween.interpolate_property(emote_sprite, "rotation_degrees", emote_sprite.rotation_degrees, 0,
 				UNEMOTE_DURATION)
-		$ResetTween.interpolate_property(emote_sprite, "modulate", emote_sprite.modulate,
+		_reset_tween.interpolate_property(emote_sprite, "modulate", emote_sprite.modulate,
 				Utils.to_transparent(emote_sprite.modulate), UNEMOTE_DURATION)
 	_head_bobber.reset_head_bob()
-	$ResetTween.start()
+	_reset_tween.start()
 	_prev_mood = Creatures.Mood.DEFAULT
 
 
@@ -404,17 +406,17 @@ func _transition_noop() -> void:
 ## Transitions from 'awkward1' to 'awkward0', hiding the white sweat circles.
 func _transition_awkward1_awkward0() -> void:
 	_creature_visuals.get_node("Neck0").scale = Vector2(1.0, 1.0)
-	$ResetTween.remove_all()
+	_reset_tween.remove_all()
 	_tween_nodes_to_transparent(["Neck0/HeadBobber/EmoteHead"])
-	$ResetTween.start()
+	_reset_tween.start()
 
 
 ## Transitions from 'laugh1' to 'laugh0', hiding the yellow laugh lines.
 func _transition_laugh1_laugh0() -> void:
 	_head_bobber.reset_head_bob()
-	$ResetTween.remove_all()
+	_reset_tween.remove_all()
 	_tween_nodes_to_transparent(["Neck0/HeadBobber/EmoteBrain"])
-	$ResetTween.start()
+	_reset_tween.start()
 
 
 ## Transitions from 'love1' to 'love0', hiding the hearts and blush.
@@ -423,50 +425,50 @@ func _transition_love1_love0() -> void:
 	_emote_eye_z0.position = Vector2(0, 256)
 	_emote_eye_z1.rotation_degrees = 0
 	_emote_eye_z1.position = Vector2(0, 256)
-	$ResetTween.remove_all()
+	_reset_tween.remove_all()
 	_tween_nodes_to_transparent(["Neck0/HeadBobber/EmoteBrain", "Neck0/HeadBobber/EmoteGlow"])
-	$ResetTween.start()
+	_reset_tween.start()
 
 
 ## Transitions from 'rage1' to 'rage0', hiding the red anger symbols.
 func _transition_rage1_rage0() -> void:
 	_head_bobber.reset_head_bob()
-	$ResetTween.remove_all()
+	_reset_tween.remove_all()
 	_tween_nodes_to_transparent(["Neck0/HeadBobber/EmoteBrain", "Neck0/HeadBobber/EmoteGlow"])
-	$ResetTween.start()
+	_reset_tween.start()
 
 
 ## Transitions from 'sigh1' to 'sigh0', turning the head forward again
 func _transition_sigh1_sigh0() -> void:
 	_creature_visuals.get_node("Neck0").scale = Vector2(1.0, 1.0)
-	$ResetTween.remove_all()
-	$ResetTween.interpolate_property(_head_bobber, "rotation_degrees",
+	_reset_tween.remove_all()
+	_reset_tween.interpolate_property(_head_bobber, "rotation_degrees",
 			_head_bobber.rotation_degrees, 0.0, UNEMOTE_DURATION)
-	$ResetTween.start()
+	_reset_tween.start()
 
 
 ## Transitions from 'smile1' to 'smile0', hiding the pink love bubble and blush.
 func _transition_smile1_smile0() -> void:
-	$ResetTween.remove_all()
+	_reset_tween.remove_all()
 	_tween_nodes_to_transparent(["Neck0/HeadBobber/EmoteBrain", "Neck0/HeadBobber/EmoteGlow"])
-	$ResetTween.interpolate_property(_head_bobber, "rotation_degrees",
+	_reset_tween.interpolate_property(_head_bobber, "rotation_degrees",
 			_head_bobber.rotation_degrees, 0.0, UNEMOTE_DURATION)
-	$ResetTween.start()
+	_reset_tween.start()
 
 
 ## Transitions from 'sweat1' to 'sweat0', hiding the white sweat circles.
 func _transition_sweat1_sweat0() -> void:
 	_head_bobber.reset_head_bob()
 	_creature_visuals.get_node("NearArm").frame = 1
-	$ResetTween.remove_all()
+	_reset_tween.remove_all()
 	_tween_nodes_to_transparent(["Neck0/HeadBobber/EmoteHead"])
-	$ResetTween.start()
+	_reset_tween.start()
 
 
 func _tween_nodes_to_transparent(paths: Array) -> void:
 	for path in paths:
 		var node: Node2D = _creature_visuals.get_node(path)
-		$ResetTween.interpolate_property(node, "modulate", node.modulate, Color.transparent, UNEMOTE_DURATION)
+		_reset_tween.interpolate_property(node, "modulate", node.modulate, Color.transparent, UNEMOTE_DURATION)
 
 
 ## This function manually assigns fields which Godot would ideally assign automatically by calling _ready. It is a
@@ -507,7 +509,7 @@ func _on_animation_finished(anim_name: String) -> void:
 		play("...%s..." % [anim_name.trim_suffix("...")])
 	elif _prev_mood in EMOTE_ANIMS or anim_name in EAT_SMILE_ANIMS or anim_name in EAT_SWEAT_ANIMS:
 		unemote(anim_name)
-		yield($ResetTween, "tween_all_completed")
+		yield(_reset_tween, "tween_all_completed")
 		_post_unemote()
 
 

--- a/project/src/main/world/restaurant/door-chime.gd
+++ b/project/src/main/world/restaurant/door-chime.gd
@@ -10,22 +10,38 @@ onready var _chime_sounds := [
 	preload("res://assets/main/world/door-chime4.wav"),
 ]
 
+onready var _suppress_sfx_timer := $SuppressSfxTimer
+onready var _chime_timer := $ChimeTimer
+
+func _ready() -> void:
+	# suppress door chime at the start of a level
+	briefly_suppress_sfx()
+
+
+## Preemptively initialize onready variables to avoid null references.
+func _enter_tree() -> void:
+	_suppress_sfx_timer = $SuppressSfxTimer
+	_chime_timer = $ChimeTimer
+
+
 func play_door_chime() -> void:
 	stream = Utils.rand_value(_chime_sounds)
 	play()
 
 
 ## Temporarily suppresses door chime sounds.
-func start_suppress_sfx_timer() -> void:
-	$SuppressSfxTimer.start(1.0)
+func briefly_suppress_sfx(duration: float = 1.0) -> void:
+	_suppress_sfx_timer.start(duration)
+	if not _chime_timer.is_stopped():
+		# cancel any queued chimes
+		_chime_timer.stop()
 
 
 func _on_CreatureVisuals_dna_loaded() -> void:
-	if not $SuppressSfxTimer.is_stopped():
-		# suppress door chime at the start of a level
+	if not _suppress_sfx_timer.is_stopped():
 		return
 	
-	$ChimeTimer.start()
+	_chime_timer.start()
 
 
 func _on_ChimeTimer_timeout() -> void:

--- a/project/src/main/world/restaurant/restaurant-scene.gd
+++ b/project/src/main/world/restaurant/restaurant-scene.gd
@@ -64,8 +64,8 @@ func get_customer(creature_index: int = -1) -> Creature:
 
 
 ## Temporarily suppresses 'hello' and 'door chime' sounds.
-func start_suppress_sfx_timer() -> void:
-	$DoorChime.start_suppress_sfx_timer()
+func briefly_suppress_sfx(duration: float = 1.0) -> void:
+	$DoorChime.briefly_suppress_sfx(duration)
 
 
 ## Returns the seat with the specified optional index. Defaults to the seat of the creature being fed.


### PR DESCRIPTION
Globally changed 'start_suppress_sfx_timer' to 'briefly_suppress_sfx'
with an optional parameter. This mirrors the
'briefly_suppress_sfx_signal' method. It is more semantic and less technical.

EmotePlayer and DoorChime use onready variables instead of repeated
get_node calls.

Added missing food_type parameter to Creature's food_eaten signal
declaration.

Simplified 'preemptively initialize onready variables' comment. This is
likely to become a projectwide pattern, and any more detailed
descriptions as to why it's necessary will become unnecessary and likely
inaccurate.