### PR TITLE
Refactor: Combine suppress_sfx mechanisms.

### DIFF
--- a/project/src/main/world/creature/Creature.tscn
+++ b/project/src/main/world/creature/Creature.tscn
@@ -382,4 +382,8 @@ script = ExtResource( 8 )
 
 [node name="FadeTween" type="Tween" parent="."]
 
+[connection signal="dna_loaded" from="." to="CreatureSfx" method="_on_Creature_dna_loaded"]
+[connection signal="food_eaten" from="." to="CreatureSfx" method="_on_Creature_food_eaten"]
+[connection signal="landed" from="." to="CreatureSfx" method="_on_Creature_landed"]
 [connection signal="timeout" from="CreatureSfx/HelloTimer" to="CreatureSfx" method="_on_HelloTimer_timeout"]
+[connection signal="timeout" from="CreatureSfx/SuppressSfxTimer" to="CreatureSfx" method="_on_SuppressSfxTimer_timeout"]

--- a/project/src/main/world/creature/creature-animations.gd
+++ b/project/src/main/world/creature/creature-animations.gd
@@ -29,6 +29,8 @@ var _near_arm: PackedSprite
 var _tail_z0: PackedSprite
 var _tail_z1: PackedSprite
 
+var creature_sfx: CreatureSfx
+
 ## IdleTimer which launches idle animations periodically
 onready var _idle_timer: Timer = $IdleTimer
 
@@ -113,7 +115,9 @@ func play_movement_animation(animation_prefix: String, animation_name: String) -
 			_emote_player.unemote_immediate()
 		if _movement_player.current_animation.begins_with(animation_prefix):
 			var old_position: float = _movement_player.current_animation_position
-			_creature_visuals.briefly_suppress_sfx_signal()
+			if creature_sfx:
+				creature_sfx.briefly_suppress_sfx(0.000000001)
+			
 			_movement_player.play(animation_name)
 			_movement_player.advance(old_position)
 		else:

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -13,6 +13,9 @@ signal dna_loaded
 ## emitted on the frame when creature bites into some food
 signal food_eaten(food_type)
 
+## emitted during the 'run' animation when the creature touches the ground
+signal landed
+
 ## emitted after a creature finishes fading in/out and their visible/modulate values are finalized
 signal fade_in_finished
 signal fade_out_finished
@@ -112,13 +115,15 @@ func _ready() -> void:
 	_creature_outline = creature_outline_scene.instance()
 	add_child(_creature_outline)
 	
-	creature_visuals = $CreatureOutline.creature_visuals
+	creature_visuals = _creature_outline.creature_visuals
 	if not Engine.is_editor_hint():
 		_chat_icon_hook.creature_visuals = creature_visuals
 		_collision_shape.creature_visuals = creature_visuals
-		_creature_sfx.creature_visuals = creature_visuals
+	creature_visuals.creature_sfx = _creature_sfx
+	
 	creature_visuals.connect("dna_loaded", self, "_on_CreatureVisuals_dna_loaded")
 	creature_visuals.connect("food_eaten", self, "_on_CreatureVisuals_food_eaten")
+	creature_visuals.connect("landed", self, "_on_CreatureVisuals_landed")
 	creature_visuals.connect("movement_mode_changed", self, "_on_CreatureVisuals_movement_mode_changed")
 	creature_visuals.connect("talking_changed", self, "_on_CreatureVisuals_talking_changed")
 	creature_visuals.connect("visual_fatness_changed", self, "_on_CreatureVisuals_visual_fatness_changed")
@@ -398,7 +403,9 @@ func get_chat_extents() -> Vector2:
 	return $CollisionShape2D.shape.extents
 
 
-## Temporarily suppresses 'hello' sounds.
+## Temporarily suppresses creature-related sound effects.
+##
+## This includes voices, eating sounds, and movement sound effects.
 func briefly_suppress_sfx(duration: float = 1.0) -> void:
 	_creature_sfx.briefly_suppress_sfx(duration)
 
@@ -530,6 +537,10 @@ func _on_CreatureVisuals_dna_loaded() -> void:
 
 func _on_CreatureVisuals_food_eaten(food_type: int) -> void:
 	emit_signal("food_eaten", food_type)
+
+
+func _on_CreatureVisuals_landed() -> void:
+	emit_signal("landed")
 
 
 func _on_CreatureVisuals_visual_fatness_changed() -> void:

--- a/project/src/main/world/restaurant/RestaurantScene.tscn
+++ b/project/src/main/world/restaurant/RestaurantScene.tscn
@@ -1009,7 +1009,6 @@ one_shot = true
 
 [node name="SuppressSfxTimer" type="Timer" parent="DoorChime"]
 one_shot = true
-autostart = true
 
 [connection signal="dna_loaded" from="Chef" to="DoorChime" method="_on_CreatureVisuals_dna_loaded"]
 [connection signal="food_eaten" from="Chef" to="." method="_on_CreatureVisuals_food_eaten"]


### PR DESCRIPTION
Merged CreatureVisuals' suppress_sfx_timer with CreatureSfx's
suppress_sfx_timer. CreatureSfx emits signals and exposes its
'should_play_sfx' property so that other nodes such as CreatureVisuals
can use it.

Removed redundant SuppressSfxTimer.autostart configuration in
RestaurantScene. This timer is started in the ready function.