### PR TITLE
Fixed many tutorial bugs.

### DIFF
--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -594,6 +594,7 @@ visible = false
 puzzle_path = NodePath("../../..")
 
 [node name="PuzzleMessages" parent="Hud/HudUi" instance=ExtResource( 62 )]
+mouse_filter = 2
 
 [node name="PuzzleTrace" type="Label" parent="Hud/HudUi"]
 visible = false

--- a/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
@@ -49,13 +49,8 @@ func prepare_tutorial_level() -> void:
 			hud.skill_tally_item("SnackStack").visible = true
 			hud.set_message(tr("One last lesson! Try holding soft drop to squish and complete these boxes."))
 		"tutorial/basics_4":
-			# reset timer, scores
-			PuzzleState.reset()
-			puzzle.scroll_to_new_creature()
-			
-			hud.set_message(tr("You're a remarkably quick learner." \
-					+ " I think I hear some customers!\n\nSee if you can earn ¥100."))
-			hud.enqueue_pop_out()
+			dismiss_sensei([tr("You're a remarkably quick learner." \
+					+ " I think I hear some customers!\n\nSee if you can earn ¥100.")])
 
 
 ## Advance to the next level in the tutorial.

--- a/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
@@ -92,13 +92,8 @@ func prepare_tutorial_level() -> void:
 			else:
 				hud.set_message(tr("Okay, final two recipes!\n\n...Can you make two cakes at once?"))
 		"tutorial/cakes_9":
-			# reset timer, scores
-			PuzzleState.reset()
-			puzzle.scroll_to_new_creature()
-			
-			hud.set_message(tr("I'm getting a tummy ache!"
-					+ "\n\nTry your new cake recipes on these customers, while I go lie down..."))
-			hud.enqueue_pop_out()
+			dismiss_sensei([tr("I'm getting a tummy ache!"
+						+ "\n\nTry your new cake recipes on these customers, while I go lie down...")])
 
 
 func _prepare_cake_tally_item(max_value: int) -> void:
@@ -168,6 +163,7 @@ func _advance_level() -> void:
 		"tutorial/cakes_8":
 			if _cakes_built >= 2:
 				_schedule_finish_line_clears()
+				start_customer_countdown()
 				hud.set_message(tr("Wow! That's all eight recipes."))
 			elif _cakes_built == 1:
 				hud.set_message(tr("Oh, you're half way there! ...Now try for the other one."))

--- a/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
@@ -86,13 +86,8 @@ func prepare_tutorial_level() -> void:
 				hud.set_message(tr("Now see if you can do it."
 						+ "\n\nMake two cake boxes, but don't let your combo break."))
 		"tutorial/combo_6":
-			# reset timer, scores
-			PuzzleState.reset()
-			puzzle.scroll_to_new_creature()
-			
-			hud.set_message(tr("...Oh! Customers!\n\nTry to get ¥120 in one big combo."
-					+ "\n\nIt might help to make some boxes first."))
-			hud.enqueue_pop_out()
+			dismiss_sensei([tr("...Oh! Customers!\n\nTry to get ¥120 in one big combo."
+					+ "\n\nIt might help to make some boxes first.")])
 	
 	_prepared_levels[CurrentLevel.settings.id] = true
 

--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -33,6 +33,18 @@ func start_customer_countdown() -> void:
 	puzzle.start_level_countdown()
 
 
+## Resets the timer and scores and dismisses the sensei, so the player can serve some real customers.
+##
+## Parameters:
+## 	'messages': Array of string messages to be shown when the sensei is dismissed.
+func dismiss_sensei(messages: Array) -> void:
+	PuzzleState.reset()
+	PuzzleState.game_active = true
+	puzzle.scroll_to_new_creature()
+	hud.set_messages(messages)
+	hud.enqueue_pop_out()
+
+
 ## Prepares the next section of the tutorial.
 ##
 ## This includes resetting the combo and hiding all completed skill tally items. Subclasses can override this method to

--- a/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
@@ -79,14 +79,8 @@ func prepare_tutorial_level() -> void:
 			else:
 				hud.set_message(tr("Hmmm... What are you up to this time?"))
 		"tutorial/squish_7":
-			# reset timer, scores
-			PuzzleState.reset()
-			puzzle.scroll_to_new_creature()
-
-			# the sixth tutorial section ends with a long message, so we enqueue these messages
-			hud.enqueue_message(tr("Your training is complete!\n\nBut don't let it go to your head,"
-					+ " we still have some customers to take care of."))
-			hud.enqueue_pop_out()
+			dismiss_sensei([tr("Your training is complete!\n\nBut don't let it go to your head,"
+					+ " we still have some customers to take care of.")])
 	
 	_prepared_levels[CurrentLevel.settings.id] = true
 
@@ -129,7 +123,7 @@ func _advance_level() -> void:
 		new_level_id = CurrentLevel.settings.id
 	else:
 		new_level_id = level_ids[level_ids.find(CurrentLevel.settings.id) + 1]
-	PuzzleState.change_level(new_level_id, delay_between_levels)
+	change_level(new_level_id, delay_between_levels)
 
 
 func _handle_squish_move_message() -> void:

--- a/project/src/main/ui/chat/ChatChoiceButton.tscn
+++ b/project/src/main/ui/chat/ChatChoiceButton.tscn
@@ -202,6 +202,7 @@ margin_right = 17.0
 margin_bottom = 41.0
 rect_scale = Vector2( 1.5, 1.5 )
 rect_pivot_offset = Vector2( 15, 15 )
+mouse_filter = 2
 script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false

--- a/project/src/main/ui/menu/TutorialMenu.tscn
+++ b/project/src/main/ui/menu/TutorialMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/ui/ImageButton.tscn" type="PackedScene" id=2]
@@ -8,6 +8,7 @@
 [ext_resource path="res://src/main/ui/menu/tutorial-menu.gd" type="Script" id=6]
 [ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=7]
 [ext_resource path="res://src/main/ui/menu/drop-panel.tres" type="StyleBox" id=8]
+[ext_resource path="res://src/main/ui/SceneTransitionCover.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=16]
 
 [sub_resource type="InputEventAction" id=1]
@@ -41,8 +42,6 @@ __meta__ = {
 
 [node name="LevelSelect" parent="." instance=ExtResource( 3 )]
 levels_to_include = 1
-
-[node name="MusicPopup" parent="." instance=ExtResource( 7 )]
 
 [node name="Buttons" type="Control" parent="."]
 modulate = Color( 1, 1, 1, 0.627451 )
@@ -92,5 +91,9 @@ margin_right = 502.0
 margin_bottom = 100.0
 mouse_filter = 2
 disabled = true
+
+[node name="MusicPopup" parent="." instance=ExtResource( 7 )]
+
+[node name="SceneTransitionCover" parent="." instance=ExtResource( 9 )]
 
 [connection signal="pressed" from="Buttons/Northeast/BackButton" to="." method="_on_BackButton_pressed"]


### PR DESCRIPTION
Fixed bug where basics tutorial (and other tutorials) couldn't be
finished. This bug was introduced in 6a1f692e by making
PuzzleState.reset() disable the game_active flag. Having this flag
disabled in tutorials meant that they wouldn't end the level, because
they didn't think the player was playing.

Fixed bug where mouse/keyboard input was ignored after quitting to the
tutorial menu. This is because the TutorialMenu scene was missing its
scene transition cover, which is responsible for restoring input.

Fixed bug where tutorial buttons like "Ok, I get it!" weren't responding
to mouse input. This occurred because the PuzzleMessages control was
blocking the mouse signals. I've disabled mouse input for the
PuzzleMessages control (not for its children.)

Fixed bug where squish tutorial would change levels before messages were
shown completely. This is because it was calling the global
'change_scene' method instead of the method specific to tutorials.

Cake tutorial launches upbeat music at end, like the other tutorials.