### PR TITLE
Pushed ChalkboardMapRow logic into child nodes

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -359,6 +359,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/ui/career/landmark.gd"
 }, {
+"base": "Control",
+"class": "LandmarkLines",
+"language": "GDScript",
+"path": "res://src/main/ui/career/landmark-lines.gd"
+}, {
 "base": "Sprite",
 "class": "LeafPoof",
 "language": "GDScript",
@@ -1045,6 +1050,7 @@ _global_script_class_icons={
 "KeybindSettings": "",
 "LabelTyper": "",
 "Landmark": "",
+"LandmarkLines": "",
 "LeafPoof": "",
 "LetterProjectile": "",
 "LetterShooter": "",

--- a/project/src/demo/ui/career/chalkboard-map-row-demo.gd
+++ b/project/src/demo/ui/career/chalkboard-map-row-demo.gd
@@ -8,6 +8,21 @@ extends Node
 ## 	[-, =]: Move the player left/right
 ## 	[Shift + -, Shift + =]: Move the player left right faster
 
+# Array of landmark types chosen when the user switches between different landmarks
+const INCREMENTABLE_LANDMARKS := [
+	Landmark.NONE,
+	
+	Landmark.CACTUS,
+	Landmark.FOREST,
+	Landmark.GEAR,
+	Landmark.ISLAND,
+	Landmark.RAINBOW,
+	Landmark.SKULL,
+	Landmark.VOLCANO,
+	
+	Landmark.MYSTERY,
+]
+
 onready var _map_row := $MapRow
 
 func _ready() -> void:
@@ -58,5 +73,6 @@ func _input(event: InputEvent) -> void:
 ## Changes the icon for the specified landmark.
 func _increment_landmark_type(landmark_index: int) -> void:
 	var old_landmark_type: int = _map_row.get_landmark_type(landmark_index)
-	var new_landmark_type: int = (old_landmark_type + 1) % Landmark.LandmarkType.size()
+	var new_index := (INCREMENTABLE_LANDMARKS.find(old_landmark_type, 0) + 1) % INCREMENTABLE_LANDMARKS.size()
+	var new_landmark_type: int = INCREMENTABLE_LANDMARKS[new_index]
 	_map_row.set_landmark_type(landmark_index, new_landmark_type)

--- a/project/src/main/ui/career/ChalkboardMapRow.tscn
+++ b/project/src/main/ui/career/ChalkboardMapRow.tscn
@@ -1,13 +1,15 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://src/main/ui/career/LandmarkLine.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/ui/chalkboard-36.theme" type="Theme" id=2]
 [ext_resource path="res://assets/main/ui/career/map/player-dot.png" type="Texture" id=3]
 [ext_resource path="res://assets/main/ui/career/map/player-sheet.png" type="Texture" id=4]
+[ext_resource path="res://src/main/ui/career/landmark-container.gd" type="Script" id=5]
 [ext_resource path="res://src/main/ui/career/chalkboard-map-row.gd" type="Script" id=7]
 [ext_resource path="res://src/main/ui/career/Landmark.tscn" type="PackedScene" id=8]
 [ext_resource path="res://src/main/ui/career/LandmarkSpacer.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/ui/career/player-landmark.gd" type="Script" id=10]
+[ext_resource path="res://src/main/ui/career/landmark-lines.gd" type="Script" id=11]
 
 [sub_resource type="Animation" id=17]
 length = 0.001
@@ -55,9 +57,6 @@ script = ExtResource( 7 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
-LandmarkScene = ExtResource( 8 )
-LandmarkSpacerScene = ExtResource( 9 )
-LandmarkLineScene = ExtResource( 1 )
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 anchor_right = 1.0
@@ -75,9 +74,11 @@ margin_left = 50.0
 margin_top = 5.0
 margin_right = 880.0
 margin_bottom = 155.0
+script = ExtResource( 11 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+LandmarkLineScene = ExtResource( 1 )
 
 [node name="Line2D1" parent="MarginContainer/Lines" instance=ExtResource( 1 )]
 points = PoolVector2Array( 86.2677, 94.1346, 136.271, 73.4984 )
@@ -100,9 +101,13 @@ margin_top = 5.0
 margin_right = 880.0
 margin_bottom = 155.0
 custom_constants/separation = 0
+script = ExtResource( 5 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+LandmarkScene = ExtResource( 8 )
+LandmarkSpacerScene = ExtResource( 9 )
+map_row_path = NodePath("../..")
 
 [node name="Circles" parent="MarginContainer/Landmarks" instance=ExtResource( 8 )]
 margin_right = 75.0
@@ -157,6 +162,7 @@ script = ExtResource( 10 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+map_row_path = NodePath("../..")
 
 [node name="Label" type="Label" parent="MarginContainer/Player"]
 anchor_left = 0.5
@@ -202,4 +208,5 @@ begin_cap_mode = 2
 end_cap_mode = 2
 antialiased = true
 
-[connection signal="sort_children" from="MarginContainer/Landmarks" to="." method="_on_Landmarks_sort_children"]
+[connection signal="sort_children" from="MarginContainer/Landmarks" to="MarginContainer/Lines" method="_on_Landmarks_sort_children"]
+[connection signal="sort_children" from="MarginContainer/Landmarks" to="MarginContainer/Player" method="_on_Landmarks_sort_children"]

--- a/project/src/main/ui/career/chalkboard-map-row.gd
+++ b/project/src/main/ui/career/chalkboard-map-row.gd
@@ -5,171 +5,91 @@ extends Control
 ## The chalk map is divided into a cluster of circles on the left representing past landmarks, and icons on the right
 ## representing current landmarks.
 
+## Emitted when the player distance changes. Triggers child components to redraw/refresh their values
+signal player_distance_changed
+
+## Emitted when a landmark distance changes. Triggers child components to redraw/refresh their values
+signal landmark_distance_changed
+
+## Emitted when the landmark count changes. Triggers child components to redraw/refresh their values
+signal landmark_count_changed
+
 ## Maximum number of landmarks to show at once
 const MAX_LANDMARK_COUNT := 6
 
-export (Resource) var LandmarkScene: Resource
-export (Resource) var LandmarkSpacerScene: Resource
-export (Resource) var LandmarkLineScene: Resource
-
+## Number of landmarks to show. The circles on the left side of the map count as one landmark.
 var landmark_count: int = 2 setget set_landmark_count
+
+## Distance the player has travelled in the current career session.
 var player_distance: int = 0 setget set_player_distance
 
-## List of Control nodes which separate landmarks.
-var _landmark_spacers := []
-
-## List of Landmark instances which show icons along the map.
-var _landmarks := []
-
-## Draws the landmark icons and distance labels along the map
-onready var _landmarks_container := $MarginContainer/Landmarks
-
-## Draws the lines connecting the landmarks. (Does not draw the line connecting the player.)
-onready var _lines_container := $MarginContainer/Lines
-
-## Draws the dot and label representing the player, as well as the line connecting them to the path.
-onready var _player_landmark := $MarginContainer/Player
-
-func _ready() -> void:
-	_landmarks = get_tree().get_nodes_in_group("landmarks")
-	_landmark_spacers = get_tree().get_nodes_in_group("landmark_spacers")
-	_player_landmark.distance = player_distance
-	
-	_refresh_landmarks()
-	_refresh_player_distance()
-
-
 ## Assigns a new LandmarkType for the specified landmark.
+##
+## Parameters:
+## 	'index': The landmark index. '0' corresponds to the circles on the left side of the map, which are also a
+## 		landmark.
+##
+## 	'landmark_type': An enum from Landmark.LandmarkType for the specified landmark.
 func set_landmark_type(index: int, landmark_type: int) -> void:
-	if index >= _landmarks.size():
+	var landmarks: Array = get_tree().get_nodes_in_group("landmarks")
+	
+	if index >= landmarks.size():
 		push_warning("Invalid landmark index: %s" % [index])
 		return
 	
-	_landmarks[index].type = landmark_type
+	landmarks[index].type = landmark_type
 
 
 ## Returns the LandmarkType for the specified landmark.
+##
+## Parameters:
+## 	'index': The landmark index. '0' corresponds to the circles on the left side of the map, which are also a
+## 		landmark.
+##
+## Returns:
+## 	An enum from Landmark.LandmarkType for the specified landmark.
 func get_landmark_type(index: int) -> int:
-	if index >= _landmarks.size():
+	var landmarks: Array = get_tree().get_nodes_in_group("landmarks")
+	
+	if index >= landmarks.size():
 		push_warning("Invalid landmark index: %s" % [index])
 		return Landmark.LandmarkType.NONE
 	
-	return _landmarks[index].type
+	return landmarks[index].type
 
 
 ## Assigns the distance for the specified landmark.
 ##
 ## This distance is displayed on a label, and also used when calculating the player's distance along the path.
 func set_landmark_distance(index: int, landmark_distance: int) -> void:
-	if index >= _landmarks.size():
+	var landmarks: Array = get_tree().get_nodes_in_group("landmarks")
+	
+	if index >= landmarks.size():
 		push_warning("Invalid landmark index: %s" % [index])
 		return
 	
-	_landmarks[index].distance = landmark_distance
-	_refresh_player_distance()
+	landmarks[index].distance = landmark_distance
+	emit_signal("landmark_distance_changed")
 
 
 ## Returns the distance for the specified landmark.
 ##
 ## This distance is displayed on a label, and also used when calculating the player's distance along the path.
 func get_landmark_distance(index: int) -> int:
-	if index >= _landmarks.size():
+	var landmarks: Array = get_tree().get_nodes_in_group("landmarks")
+	
+	if index >= landmarks.size():
 		push_warning("Invalid landmark index: %s" % [index])
 		return 0
 	
-	return _landmarks[index].distance
+	return landmarks[index].distance
 
 
 func set_landmark_count(new_landmark_count: int) -> void:
 	landmark_count = clamp(new_landmark_count, 1, MAX_LANDMARK_COUNT)
-	_refresh_landmarks()
+	emit_signal("landmark_count_changed")
 
 
 func set_player_distance(new_player_distance: int) -> void:
 	player_distance = new_player_distance
-	_refresh_player_distance()
-
-
-## Adds or remove Landmark nodes based on the requested landmark count.
-##
-## Also adds and removes the corresponding landmark spacers.
-func _refresh_landmarks() -> void:
-	if not is_inside_tree():
-		return
-	
-	while _landmarks.size() < landmark_count:
-		# add spacer
-		var new_spacer: Control = LandmarkSpacerScene.instance()
-		_landmarks_container.add_child(new_spacer)
-		_landmark_spacers.push_back(new_spacer)
-		
-		# add landmark
-		var new_landmark: Landmark = LandmarkScene.instance()
-		_landmarks_container.add_child(new_landmark)
-		_landmarks.push_back(new_landmark)
-	while _landmarks.size() > landmark_count:
-		# remove landmark
-		var removed_landmark: Landmark = _landmarks.pop_back()
-		removed_landmark.queue_free()
-		
-		# remove spacer
-		var removed_spacer: Control = _landmark_spacers.pop_back()
-		removed_spacer.queue_free()
-
-
-## Updates the player's location on the map and the numeric distance label value.
-func _refresh_player_distance() -> void:
-	if not is_inside_tree():
-		return
-	
-	# calculate number
-	_player_landmark.distance = player_distance
-	
-	# figure out which landmarks the player is between
-	var right_landmark_index := 0
-	for i in range(_landmarks.size()):
-		var landmark: Landmark = _landmarks[i]
-		right_landmark_index = i
-		if _player_landmark.distance < landmark.distance:
-			break
-	
-	_player_landmark.landmark_endpoints = _landmark_line_points(right_landmark_index)
-	
-	var from: float = _landmarks[right_landmark_index - 1].distance
-	
-	if _landmarks[right_landmark_index].distance == CareerData.MAX_DISTANCE_TRAVELLED:
-		_player_landmark.progress_percent = clamp(
-			inverse_lerp(from, from + 100, _player_landmark.distance), 0, 0.5)
-	else:
-		_player_landmark.progress_percent = clamp(
-			inverse_lerp(from, _landmarks[right_landmark_index].distance, _player_landmark.distance), 0, 1)
-
-
-## Returns the position of the line connecting two neighboring landmarks.
-func _landmark_line_points(right_landmark_index: int) -> Array:
-	var result := [Vector2.ZERO, Vector2.ZERO]
-	result[0] = _landmarks[right_landmark_index - 1].right_connection_point()
-	result[1] = _landmarks[right_landmark_index].left_connection_point()
-	return result
-
-
-## Removes and regenerates the lines connecting the landmarks.
-func _refresh_lines() -> void:
-	for child in _lines_container.get_children():
-		child.queue_free()
-	
-	for i in range(1, _landmarks.size()):
-		# draw a line connecting the previous landmark to this landmark
-		var landmark_line: Line2D = LandmarkLineScene.instance()
-		landmark_line.points = _landmark_line_points(i)
-		
-		_lines_container.add_child(landmark_line)
-
-
-## When the Landmarks container arranges its children, we regenerate the lines connecting the landmarks.
-##
-## Lines can only be properly positioned after the Landmarks container arranges its children. The lines are arranged
-## based on the position of the landmarks.
-func _on_Landmarks_sort_children() -> void:
-	_refresh_lines()
-	_refresh_player_distance()
+	emit_signal("player_distance_changed")

--- a/project/src/main/ui/career/landmark-container.gd
+++ b/project/src/main/ui/career/landmark-container.gd
@@ -1,0 +1,55 @@
+extends HBoxContainer
+## Draws landmark icons for career mode's chalkboard map.
+
+export (Resource) var LandmarkScene: Resource
+export (Resource) var LandmarkSpacerScene: Resource
+
+export (NodePath) var map_row_path: NodePath
+
+onready var _map_row: ChalkboardMapRow = get_node(map_row_path)
+
+## List of Control nodes which separate landmarks.
+var _landmark_spacers := []
+
+## List of Landmark instances which show icons along the map.
+var _landmarks := []
+
+func _ready() -> void:
+	_map_row.connect("landmark_count_changed", self, "_on_MapRow_landmark_count_changed")
+	_landmarks = get_tree().get_nodes_in_group("landmarks")
+	_landmark_spacers = get_tree().get_nodes_in_group("landmark_spacers")
+	_refresh_landmarks()
+
+
+## Adds or remove Landmark nodes based on the requested landmark count.
+##
+## Also adds and removes the corresponding landmark spacers.
+func _refresh_landmarks() -> void:
+	if not is_inside_tree():
+		return
+	
+	while _landmarks.size() < _map_row.landmark_count:
+		# add spacer
+		var new_spacer: Control = LandmarkSpacerScene.instance()
+		add_child(new_spacer)
+		_landmark_spacers.push_back(new_spacer)
+		
+		# add landmark
+		var new_landmark: Landmark = LandmarkScene.instance()
+		add_child(new_landmark)
+		_landmarks.push_back(new_landmark)
+	
+	while _landmarks.size() > _map_row.landmark_count:
+		# remove landmark from scene tree
+		var removed_landmark: Landmark = _landmarks.pop_back()
+		removed_landmark.queue_free()
+		remove_child(removed_landmark)
+		
+		# remove spacer from scene tree
+		var removed_spacer: Control = _landmark_spacers.pop_back()
+		removed_spacer.queue_free()
+		remove_child(removed_spacer)
+
+
+func _on_MapRow_landmark_count_changed() -> void:
+	_refresh_landmarks()

--- a/project/src/main/ui/career/landmark-lines.gd
+++ b/project/src/main/ui/career/landmark-lines.gd
@@ -1,0 +1,47 @@
+class_name LandmarkLines
+extends Control
+## Draws lines connecting landmark icons for career mode's chalkboard map.
+
+export (Resource) var LandmarkLineScene: Resource
+
+func _ready() -> void:
+	_refresh_lines()
+
+
+## Removes and regenerates the lines connecting the landmarks.
+func _refresh_lines() -> void:
+	var landmarks := get_tree().get_nodes_in_group("landmarks")
+	
+	for child in get_children():
+		child.queue_free()
+	
+	for i in range(1, landmarks.size()):
+		# draw a line connecting the previous landmark to this landmark
+		var landmark_line: Line2D = LandmarkLineScene.instance()
+		landmark_line.points = landmark_line_points(landmarks, i)
+		add_child(landmark_line)
+
+
+## When the Landmarks container arranges its children, we regenerate the lines connecting the landmarks.
+##
+## Lines can only be properly positioned after the Landmarks container arranges its children. The lines are arranged
+## based on the position of the landmarks.
+func _on_Landmarks_sort_children() -> void:
+	_refresh_lines()
+
+
+## Returns the position of the line connecting two neighboring landmarks.
+##
+## Parameters:
+## 	'landmarks': An array of Landmark instances
+##
+## 	'right_landmark_index': The index of the right of the two neighboring landmarks.
+##
+## Returns:
+## 	An array of two Vector2 instances representing the coordinates of a line connecting the specified neighboring
+## 	landmarks.
+static func landmark_line_points(landmarks: Array, right_landmark_index: int) -> Array:
+	var result := [Vector2.ZERO, Vector2.ZERO]
+	result[0] = landmarks[right_landmark_index - 1].right_connection_point()
+	result[1] = landmarks[right_landmark_index].left_connection_point()
+	return result

--- a/project/src/main/ui/career/landmark.gd
+++ b/project/src/main/ui/career/landmark.gd
@@ -79,6 +79,12 @@ func _ready() -> void:
 	_label.rect_position += random_offset
 
 
+## Preemptively initialize onready variables to avoid null references.
+func _enter_tree() -> void:
+	_texture_rect = $TextureRect
+	_label = $Label
+
+
 ## The position on the left side of the landmark where a chalk line can connect.
 ##
 ## This position is relative to the entire map, not relative to this landmark.


### PR DESCRIPTION
Rather than ChalkboardMapRow creating and adding lines, adding landmarks and
calculating the player position, this is now handled by child scripts such as
landmark-lines.gd and player-landmark.gd.

This is honestly more complex than the old implementation, but being
more granular should allow these pieces to change independently and
prevent the parent node from ballooning in size if we add more features
to ChalkboardMapRow.