### PR TITLE
Fixed bug where prologue camera did not follow characters.

### DIFF
--- a/project/src/main/world/OverworldWalk.tscn
+++ b/project/src/main/world/OverworldWalk.tscn
@@ -240,6 +240,7 @@ script = ExtResource( 2 )
 ChatIconScene = ExtResource( 42 )
 
 [node name="Camera" type="Camera2D" parent="World"]
+current = true
 smoothing_enabled = true
 smoothing_speed = 12.5
 script = ExtResource( 4 )


### PR DESCRIPTION
The Camera2D.current flag was accidentally unassigned in a1c71244.