### PR TITLE
Refactor: Renamed CurrentCutscene 'chat_tree' methods to 'cutscene'

### DIFF
--- a/project/src/demo/world/cutscene-demo.gd
+++ b/project/src/demo/world/cutscene-demo.gd
@@ -51,7 +51,7 @@ func _on_StartButton_pressed() -> void:
 		# bugs can result if we play a mismatched scene/cutscene combo
 		CutsceneManager.reset()
 		
-		CutsceneManager.enqueue_chat_tree(chat_tree)
+		CutsceneManager.enqueue_cutscene(chat_tree)
 		SceneTransition.push_trail(chat_tree.chat_scene_path())
 	else:
 		push_warning("Invalid cutscene path: %s" % [_open_input.value])

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -38,7 +38,7 @@ var chef_id: String
 ## Tracks when the player finishes a level.
 var best_result: int = Levels.Result.NONE setget set_best_result
 
-## Tracks whether or not the player wants to play/skip this level's cutscene.
+## Tracks whether or not the player wants to play or skip this level's cutscene.
 var cutscene_force: int = Levels.CutsceneForce.NONE
 
 func _ready() -> void:
@@ -52,7 +52,7 @@ func clear_launched_level() -> void:
 	set_launched_level("")
 
 
-## Sets the launched level data.
+## Stores the launched level data, so the level can be played later.
 ##
 ## Some tutorial levels transition into other levels, so this keeps track of the original. These properties also
 ## used on the overworld to track whether or not it should play a cutscene or allow free roam.

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -224,7 +224,7 @@ func _enqueue_cutscene(chat_tree: ChatTree) -> void:
 	if not CutsceneManager.is_front_chat_tree():
 		# Insert the cutscene into the breadcrumb trail, so it shows up when the puzzle scene is popped
 		Breadcrumb.trail.insert(1, chat_tree.chat_scene_path())
-	CutsceneManager.enqueue_chat_tree(chat_tree)
+	CutsceneManager.enqueue_cutscene(chat_tree)
 
 
 func _on_Hud_start_button_pressed() -> void:

--- a/project/src/main/ui/level-select/level-buttons.gd
+++ b/project/src/main/ui/level-select/level-buttons.gd
@@ -200,7 +200,7 @@ func _on_LevelSelectButton_level_started(settings: LevelSettings) -> void:
 	if CurrentLevel.should_play_cutscene(chat_tree):
 		# [menu > overworld] -> [menu > overworld > cutscene]
 		
-		CutsceneManager.enqueue_chat_tree(chat_tree)
+		CutsceneManager.enqueue_cutscene(chat_tree)
 		CutsceneManager.enqueue_level(settings.id)
 		CutsceneManager.push_cutscene_trail()
 	else:

--- a/project/src/main/ui/menu/main-menu-play.gd
+++ b/project/src/main/ui/menu/main-menu-play.gd
@@ -17,7 +17,7 @@ func _on_Story_pressed() -> void:
 	if world_lock.prologue_chat_key and not PlayerData.chat_history.is_chat_finished(world_lock.prologue_chat_key):
 		# load the prologue scene
 		var chat_tree := ChatLibrary.chat_tree_for_key(world_lock.prologue_chat_key)
-		CutsceneManager.enqueue_chat_tree(chat_tree)
+		CutsceneManager.enqueue_cutscene(chat_tree)
 		SceneTransition.push_trail(chat_tree.chat_scene_path())
 	else:
 		SceneTransition.push_trail(Global.SCENE_OVERWORLD)

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -240,7 +240,7 @@ func _apply_chat_event_meta(_chat_event: ChatEvent, meta_item: String) -> void:
 			var next_scene_key := meta_item_split[1]
 			var next_scene_chat_tree: ChatTree = ChatLibrary.chat_tree_for_key(next_scene_key)
 			# insert the chat tree to ensure it happens before any enqueued levels
-			CutsceneManager.insert_chat_tree(0, next_scene_chat_tree)
+			CutsceneManager.insert_cutscene(0, next_scene_chat_tree)
 		"creature_enter":
 			var creature_id := meta_item_split[1]
 			var creature: Creature = ChattableManager.get_creature_by_id(creature_id)
@@ -264,7 +264,7 @@ func _apply_chat_event_meta(_chat_event: ChatEvent, meta_item: String) -> void:
 
 
 func _start_cutscene(chat_tree: ChatTree) -> void:
-	CutsceneManager.enqueue_chat_tree(chat_tree)
+	CutsceneManager.enqueue_cutscene(chat_tree)
 	
 	if cutscene:
 		# if we're already in a cutscene, we replace the current scene
@@ -406,7 +406,7 @@ func _on_TalkButton_pressed() -> void:
 			start_chat(chat_tree, ChattableManager.focused_chattable)
 		else:
 			# if a location change is necessary, launch a cutscene
-			CutsceneManager.enqueue_chat_tree(chat_tree)
+			CutsceneManager.enqueue_cutscene(chat_tree)
 			CutsceneManager.enqueue_level(level_id)
 			
 			if cutscene:

--- a/project/src/main/world/cutscene-manager.gd
+++ b/project/src/main/world/cutscene-manager.gd
@@ -31,12 +31,12 @@ func reset() -> void:
 
 
 ## Adds a cutscene to the back of the queue.
-func enqueue_chat_tree(chat_tree: ChatTree) -> void:
+func enqueue_cutscene(chat_tree: ChatTree) -> void:
 	_queue.push_back(chat_tree)
 
 
 ## Inserts a cutscene in the given position in the queue.
-func insert_chat_tree(position: int, chat_tree: ChatTree) -> void:
+func insert_cutscene(position: int, chat_tree: ChatTree) -> void:
 	_queue.insert(position, chat_tree)
 
 


### PR DESCRIPTION
The name 'cutscene' has more semantic meaning, as it's not clear that enqueuing
a chat tree has anything to do with cutscenes. The data type is a chat
tree, so I don't feel information is lost.