### PR TITLE
Rank tweaks: target lines for score, empty step meter

### DIFF
--- a/project/src/main/puzzle/step-meter.gd
+++ b/project/src/main/puzzle/step-meter.gd
@@ -118,13 +118,11 @@ func _overall_rank() -> float:
 		percent_complete = pow(percent_complete, 1.5)
 		
 		if percent_complete == 0:
-			# avoid dividing by zero
-			rank_result.seconds = 9999
+			overall_rank = RankCalculator.WORST_RANK
 		else:
 			rank_result.seconds = clamp(PuzzleState.level_performance.seconds / percent_complete, 0, 9999)
-		
-		rank_result = _rank_calculator.calculate_rank(rank_result)
-		overall_rank = rank_result.seconds_rank
+			rank_result = _rank_calculator.calculate_rank(rank_result)
+			overall_rank = rank_result.seconds_rank
 	else:
 		# for modes graded on score, we feed their current score into the rank calculator
 		var rank_result := _rank_calculator.calculate_rank()


### PR DESCRIPTION
Improved rank algorithm to calculate how many seconds it takes to get a
fixed number of lines, instead of basing it on points per second. The
points per second approach is flawed because you cannot score points at
a constant rate. If it takes you 10 seconds to get 150 points, you
still cannot get 15 points in 1 second. You only earn points at
intervals, when clearing lines.

Fixed empty step meter at the start of certain timed levels. For levels
with a high scoring requirement, the cap of 9999 seconds was still
enough to affect the meter.