### PR TITLE
Fixed chat choice overrun bug

### DIFF
--- a/project/src/main/ui/chat/choice-theme.tres
+++ b/project/src/main/ui/chat/choice-theme.tres
@@ -31,10 +31,10 @@ border_width_top = 4
 border_width_right = 4
 border_width_bottom = 4
 border_color = Color( 0.423529, 0.262745, 0.192157, 1 )
-corner_radius_top_left = 8
-corner_radius_top_right = 8
-corner_radius_bottom_right = 8
-corner_radius_bottom_left = 8
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+corner_radius_bottom_right = 12
+corner_radius_bottom_left = 12
 
 [sub_resource type="StyleBoxFlat" id=4]
 draw_center = false


### PR DESCRIPTION
This bug appears to happen because the 'normal' button definition had a
different corner radius than the other button definitions