### PR TITLE
SceneTransition handles 'don't fade out while fading in' scenario

### DIFF
--- a/project/src/main/career-data.gd
+++ b/project/src/main/career-data.gd
@@ -150,10 +150,7 @@ func push_career_trail() -> void:
 		CutsceneManager.push_trail()
 	elif is_day_over():
 		# After the final level, we show a 'you win' screen.
-		#
-		# We do not apply a SceneTransition -- this scene change occurs immediately when the scene is loaded, and
-		# applying a fade in and fade out scene transition simultaneously results in unpredictable behavior.
-		Breadcrumb.replace_trail("res://src/main/ui/career/CareerWin.tscn")
+		SceneTransition.replace_trail("res://src/main/ui/career/CareerWin.tscn")
 	else:
 		# After a puzzle (or any other scene), we go back to the career map.
 		SceneTransition.change_scene()

--- a/project/src/main/ui/career/career-map-ui.gd
+++ b/project/src/main/ui/career/career-map-ui.gd
@@ -14,7 +14,7 @@ func _on_SettingsMenu_hide() -> void:
 
 
 func _on_SettingsMenu_quit_pressed() -> void:
-	Breadcrumb.pop_trail()
+	SceneTransition.pop_trail()
 
 
 func _on_SettingsMenu_other_quit_pressed() -> void:

--- a/project/src/main/ui/level-select/career-region.gd
+++ b/project/src/main/ui/level-select/career-region.gd
@@ -4,7 +4,7 @@ class_name CareerRegion
 ## A human-readable region name, such as 'Lemony Thickets'
 var name: String
 
-## A resource path containing cutscenes for this region, such as 'chat/career/marsh'
+## A resource chat key prefix for cutscenes for this region, such as 'chat/career/marsh'
 var cutscene_path: String
 
 ## The smallest distance the player must travel to enter this region.

--- a/project/src/main/ui/scene-transition.gd
+++ b/project/src/main/ui/scene-transition.gd
@@ -4,7 +4,7 @@ extends Node
 const SCREEN_FADE_OUT_DURATION := 0.3
 const SCREEN_FADE_IN_DURATION := 0.6
 
-## A scene transition emits these four signals in order as the screen fades out and fades back in
+## A scene transition emits these two signals in order as the screen fades out and fades back in
 signal fade_out_started
 signal fade_in_started
 
@@ -26,8 +26,10 @@ var breadcrumb_arg_array: Array
 ##
 ## 	'skip_transition': If 'true', the scene changes immediately without fading.
 func push_trail(path: String, skip_transition: bool = false) -> void:
-	if skip_transition or not get_tree().get_nodes_in_group("scene_transition_covers"):
-		# explicitly assign fading to false in case the user clicks a button while still fading in
+	if skip_transition \
+			or not get_tree().get_nodes_in_group("scene_transition_covers") \
+			or "::" in path:
+		# explicitly assign fading to false in case the scene changes while still fading in
 		fading = false
 		
 		Breadcrumb.push_trail(path)
@@ -43,6 +45,9 @@ func pop_trail(skip_transition: bool = false) -> void:
 	if skip_transition \
 			or not get_tree().get_nodes_in_group("scene_transition_covers") \
 			or (Breadcrumb.trail and "::" in Breadcrumb.trail.front()):
+		# explicitly assign fading to false in case the scene changes while still fading in
+		fading = false
+		
 		Breadcrumb.pop_trail()
 	else:
 		_fade_out(funcref(Breadcrumb, "pop_trail"))
@@ -60,6 +65,9 @@ func replace_trail(path: String, skip_transition: bool = false) -> void:
 	if skip_transition \
 			or not get_tree().get_nodes_in_group("scene_transition_covers") \
 			or "::" in path:
+		# explicitly assign fading to false in case the scene changes while still fading in
+		fading = false
+		
 		Breadcrumb.replace_trail(path)
 	else:
 		_fade_out(funcref(Breadcrumb, "replace_trail"), [path])


### PR DESCRIPTION
Instead of CareerData and other places calling Breadcrumb directly to
avoid the 'don't fade out while fading in' scenario, they all delegate
to SceneTransition which handles it internally.

Consistency changes for SceneTransition. It now assigns 'fading = false'
for all of its transitions instead of just one, and handles the '::'
paths for all of its transitions instead of just one or two.

Minor fixes to comments