### PR TITLE
Worlds can replace environments in the editor

### DIFF
--- a/project/src/main/global.gd
+++ b/project/src/main/global.gd
@@ -100,3 +100,11 @@ func should_chat() -> bool:
 func get_overworld_ui() -> OverworldUi:
 	var nodes := get_tree().get_nodes_in_group("overworld_ui")
 	return nodes[0]
+
+
+## Locates the node responsible for creating and initializing chat icons, if one exists.
+##
+## The free-roam sections in story mode have chat icons. Career mode and cutscenes do not.
+func get_chat_icon_container() -> ChatIcons:
+	var nodes := get_tree().get_nodes_in_group("chat_icon_containers")
+	return nodes[0] if nodes else null

--- a/project/src/main/ui/career/CareerWin.tscn
+++ b/project/src/main/ui/career/CareerWin.tscn
@@ -589,6 +589,7 @@ bus = "Sound Bus"
 
 [node name="World" type="Node" parent="."]
 script = ExtResource( 4 )
+EnvironmentScene = ExtResource( 2 )
 
 [node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 2 )]
 script = ExtResource( 9 )

--- a/project/src/main/ui/career/career-win-world.gd
+++ b/project/src/main/ui/career/career-win-world.gd
@@ -1,3 +1,53 @@
+tool
 class_name CareerWinWorld
 extends Node
 ## Populates/unpopulates the creatures and obstacles in the career mode's victory screen.
+
+## Scene resource defining the obstacles and creatures to show
+export (Resource) var EnvironmentScene: Resource setget set_environment_scene
+
+var _overworld_ui: OverworldUi
+
+onready var _overworld_environment: OverworldEnvironment = $Environment
+
+func _ready() -> void:
+	if Engine.is_editor_hint():
+		return
+	
+	_refresh_environment_scene()
+
+
+func set_environment_scene(new_environment_scene: Resource) -> void:
+	EnvironmentScene = new_environment_scene
+	_refresh_environment_scene()
+
+
+## Loads a new overworld environment, replacing the current one in the scene tree.
+func _refresh_environment_scene() -> void:
+	if not is_inside_tree():
+		return
+	
+	# delete old environment nodes
+	for old_overworld_environment in get_tree().get_nodes_in_group("overworld_environments"):
+		if old_overworld_environment.get_parent() != self:
+			# only remove our direct children
+			continue
+		old_overworld_environment.queue_free()
+		remove_child(old_overworld_environment)
+	_overworld_environment = null
+	
+	# insert new environment node
+	if EnvironmentScene:
+		_overworld_environment = EnvironmentScene.instance()
+	else:
+		var empty_environment_scene := load(OverworldEnvironment.SCENE_EMPTY_ENVIRONMENT)
+		_overworld_environment = empty_environment_scene.instance()
+	add_child(_overworld_environment)
+	move_child(_overworld_environment, 0)
+	_overworld_environment.owner = get_tree().get_edited_scene_root()
+	
+	# create chat icons for all chattables
+	if not Engine.editor_hint:
+		var chat_icons := Global.get_chat_icon_container()
+		if chat_icons:
+			chat_icons.recreate_all_icons()

--- a/project/src/main/world/CareerMap.tscn
+++ b/project/src/main/world/CareerMap.tscn
@@ -67,6 +67,7 @@ __meta__ = {
 [node name="World" type="Node" parent="."]
 script = ExtResource( 25 )
 player_path2d_path = NodePath("Environment/PlayerPath")
+EnvironmentScene = ExtResource( 4 )
 MileMarkerScene = ExtResource( 48 )
 
 [node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 4 )]

--- a/project/src/main/world/ChatIcons.tscn
+++ b/project/src/main/world/ChatIcons.tscn
@@ -3,6 +3,6 @@
 [ext_resource path="res://src/main/world/ChatIcon.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/chat-icons.gd" type="Script" id=2]
 
-[node name="ChatIcons" type="Node2D"]
+[node name="ChatIcons" type="Node2D" groups=["chat_icon_containers"]]
 script = ExtResource( 2 )
 ChatIconScene = ExtResource( 1 )

--- a/project/src/main/world/Overworld.tscn
+++ b/project/src/main/world/Overworld.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://src/main/world/ChatIcons.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/OverworldUi.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/world/ChatLetters.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/world/environment/OverworldEnvironment.tscn" type="PackedScene" id=4]
+[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=5]
+[ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=6]
 [ext_resource path="res://src/main/world/overworld-camera.gd" type="Script" id=21]
 [ext_resource path="res://src/main/world/overworld-world.gd" type="Script" id=51]
 
@@ -22,8 +24,14 @@ __meta__ = {
 
 [node name="World" type="Node" parent="."]
 script = ExtResource( 51 )
+EnvironmentScene = ExtResource( 4 )
 
-[node name="Environment" parent="World" instance=ExtResource( 4 )]
+[node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 4 )]
+script = ExtResource( 6 )
+creature_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/CreatureShadows")
+shadow_caster_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/ShadowCasterShadows")
+obstacles_path = NodePath("Obstacles")
+CreatureScene = ExtResource( 5 )
 
 [node name="ChatLetters" parent="World" instance=ExtResource( 3 )]
 

--- a/project/src/main/world/OverworldIndoors.tscn
+++ b/project/src/main/world/OverworldIndoors.tscn
@@ -22,6 +22,7 @@ __meta__ = {
 
 [node name="World" type="Node" parent="."]
 script = ExtResource( 4 )
+EnvironmentScene = ExtResource( 1 )
 
 [node name="Environment" parent="World" instance=ExtResource( 1 )]
 

--- a/project/src/main/world/OverworldWalk.tscn
+++ b/project/src/main/world/OverworldWalk.tscn
@@ -24,6 +24,7 @@ __meta__ = {
 
 [node name="World" type="Node" parent="."]
 script = ExtResource( 3 )
+EnvironmentScene = ExtResource( 1 )
 
 [node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 1 )]
 script = ExtResource( 5 )

--- a/project/src/main/world/career-world.gd
+++ b/project/src/main/world/career-world.gd
@@ -1,3 +1,4 @@
+tool
 extends Node
 ## Populates/unpopulates the creatures and obstacles in the career mode's world.
 
@@ -17,6 +18,9 @@ const MOODS_RARE := [Creatures.Mood.AWKWARD1, Creatures.Mood.SIGH0, Creatures.Mo
 
 export (NodePath) var player_path2d_path: NodePath
 
+## Scene resource defining the obstacles and creatures to show
+export (Resource) var EnvironmentScene: Resource setget set_environment_scene
+
 export (PackedScene) var MileMarkerScene: PackedScene
 
 ## List of moods each customer has when their level is chosen. Index 0 corresponds to the leftmost customer. Each
@@ -33,6 +37,10 @@ onready var _overworld_environment: OverworldEnvironment = $Environment
 onready var _camera: Camera2D = $Camera
 
 func _ready() -> void:
+	if Engine.is_editor_hint():
+		return
+	
+	_refresh_environment_scene()
 	var percent := _distance_percent()
 	_move_player_to_path(percent)
 	_move_sensei_to_path(percent)
@@ -40,6 +48,42 @@ func _ready() -> void:
 		_add_customer(percent)
 	_add_mile_markers_to_path()
 	_move_camera()
+
+
+func set_environment_scene(new_environment_scene: Resource) -> void:
+	EnvironmentScene = new_environment_scene
+	_refresh_environment_scene()
+
+
+## Loads a new overworld environment, replacing the current one in the scene tree.
+func _refresh_environment_scene() -> void:
+	if not is_inside_tree():
+		return
+	
+	# delete old environment nodes
+	for old_overworld_environment in get_tree().get_nodes_in_group("overworld_environments"):
+		if old_overworld_environment.get_parent() != self:
+			# only remove our direct children
+			continue
+		old_overworld_environment.queue_free()
+		remove_child(old_overworld_environment)
+	_overworld_environment = null
+	
+	# insert new environment node
+	if EnvironmentScene:
+		_overworld_environment = EnvironmentScene.instance()
+	else:
+		var empty_environment_scene := load(OverworldEnvironment.SCENE_EMPTY_ENVIRONMENT)
+		_overworld_environment = empty_environment_scene.instance()
+	add_child(_overworld_environment)
+	move_child(_overworld_environment, 0)
+	_overworld_environment.owner = get_tree().get_edited_scene_root()
+	
+	# create chat icons for all chattables
+	if not Engine.editor_hint:
+		var chat_icons := Global.get_chat_icon_container()
+		if chat_icons:
+			chat_icons.recreate_all_icons()
 
 
 ## Calculates how far to the right the player should be positioned.

--- a/project/src/main/world/chat-icons.gd
+++ b/project/src/main/world/chat-icons.gd
@@ -19,7 +19,7 @@ func _ready() -> void:
 func recreate_all_icons() -> void:
 	# assign chat_bubble_type for all creatures based on ChatLibrary
 	for creature in get_tree().get_nodes_in_group("creatures"):
-		var chat_bubble_type := ChatLibrary.chat_icon_for_creature(creature)
+		var chat_bubble_type: int = ChatLibrary.chat_icon_for_creature(creature)
 		creature.set_meta("chat_bubble_type", chat_bubble_type)
 	
 	# remove existing chat icons

--- a/project/src/main/world/environment/EmptyEnvironment.tscn
+++ b/project/src/main/world/environment/EmptyEnvironment.tscn
@@ -1,0 +1,111 @@
+[gd_scene load_steps=15 format=2]
+
+[ext_resource path="res://src/main/world/ground-map-indoors.gd" type="Script" id=1]
+[ext_resource path="res://src/main/world/obstacle-map-indoors.gd" type="Script" id=2]
+[ext_resource path="res://assets/main/world/restaurant/interior-shadow.png" type="Texture" id=8]
+[ext_resource path="res://src/main/world/environment/obstacle-map-shadows.gd" type="Script" id=9]
+[ext_resource path="res://src/main/world/shadow-caster-shadows.gd" type="Script" id=14]
+[ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=15]
+[ext_resource path="res://src/main/world/ScrewportTexrect.tscn" type="PackedScene" id=17]
+[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=19]
+[ext_resource path="res://src/main/world/creature/CreatureShadows.tscn" type="PackedScene" id=23]
+[ext_resource path="res://src/main/world/environment/OvalShadow.tscn" type="PackedScene" id=24]
+[ext_resource path="res://src/main/world/restaurant/indoor-obstacle-library.tres" type="TileSet" id=40]
+[ext_resource path="res://src/main/world/restaurant/floor-library.tres" type="TileSet" id=41]
+
+[sub_resource type="TileSet" id=1]
+0/name = "interior-shadow.png 0"
+0/texture = ExtResource( 8 )
+0/tex_offset = Vector2( 39, 0 )
+0/modulate = Color( 1, 1, 1, 1 )
+0/region = Rect2( 0, 1, 286, 144 )
+0/tile_mode = 0
+0/occluder_offset = Vector2( 0, 0 )
+0/navigation_offset = Vector2( 0, 0 )
+0/shape_offset = Vector2( 0, 0 )
+0/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+0/shape_one_way = false
+0/shape_one_way_margin = 0.0
+0/shapes = [  ]
+0/z_index = 0
+
+[sub_resource type="ViewportTexture" id=2]
+viewport_path = NodePath("Ground/Shadows/Viewport")
+
+[node name="Environment" type="Node2D" groups=["overworld_environments"]]
+script = ExtResource( 15 )
+creature_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/CreatureShadows")
+shadow_caster_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/ShadowCasterShadows")
+obstacles_path = NodePath("Obstacles")
+CreatureScene = ExtResource( 19 )
+
+[node name="Ground" type="Node2D" parent="."]
+z_index = -1
+
+[node name="GroundMap" type="TileMap" parent="Ground"]
+scale = Vector2( 0.5, 0.5 )
+mode = 2
+tile_set = ExtResource( 41 )
+cell_size = Vector2( 128, 104 )
+cell_custom_transform = Transform2D( 128, 0.007, -78, 104, 0, 0 )
+cell_tile_origin = 1
+centered_textures = true
+format = 1
+script = ExtResource( 1 )
+
+[node name="Shadows" type="Node2D" parent="Ground"]
+
+[node name="Viewport" type="Viewport" parent="Ground/Shadows"]
+size = Vector2( 1024, 600 )
+transparent_bg = true
+usage = 0
+
+[node name="ViewportRoot" type="Node2D" parent="Ground/Shadows/Viewport"]
+
+[node name="ObstacleMapShadows" type="TileMap" parent="Ground/Shadows/Viewport/ViewportRoot"]
+scale = Vector2( 0.5, 0.5 )
+mode = 2
+tile_set = SubResource( 1 )
+cell_size = Vector2( 128, 104 )
+cell_custom_transform = Transform2D( 128, 0.007, -78, 104, 0, 0 )
+cell_tile_origin = 1
+centered_textures = true
+format = 1
+script = ExtResource( 9 )
+obstacle_map_path = NodePath("../../../../../Obstacles/ObstacleMap")
+cell_shadow_mapping = {
+1: Rect2( 0, 0, 0, 0 ),
+3: Rect2( -1, 0, 3, 1 ),
+4: Rect2( -1, 0, 3, 1 ),
+5: Rect2( -1, 0, 3, 1 ),
+6: Rect2( -1, 0, 3, 1 ),
+7: Rect2( -1, 0, 3, 1 )
+}
+
+[node name="CreatureShadows" parent="Ground/Shadows/Viewport/ViewportRoot" instance=ExtResource( 23 )]
+
+[node name="ShadowCasterShadows" type="Node2D" parent="Ground/Shadows/Viewport/ViewportRoot"]
+script = ExtResource( 14 )
+OvalShadowScene = ExtResource( 24 )
+
+[node name="ScrewportTexrect" parent="Ground/Shadows" instance=ExtResource( 17 )]
+texture = SubResource( 2 )
+
+[node name="Obstacles" type="YSort" parent="."]
+
+[node name="ObstacleMap" type="TileMap" parent="Obstacles"]
+scale = Vector2( 0.5, 0.5 )
+mode = 2
+tile_set = ExtResource( 40 )
+cell_size = Vector2( 128, 104 )
+cell_custom_transform = Transform2D( 128, 0.007, -78, 104, 0, 0 )
+cell_tile_origin = 1
+cell_y_sort = true
+show_collision = true
+centered_textures = true
+format = 1
+script = ExtResource( 2 )
+ground_map_path = NodePath("../../Ground/GroundMap")
+impassable_tile_index = 1
+
+[node name="Spawns" type="Node2D" parent="."]

--- a/project/src/main/world/environment/overworld-environment.gd
+++ b/project/src/main/world/environment/overworld-environment.gd
@@ -21,10 +21,12 @@ func _ready() -> void:
 ## Adds a new obstacle. The obstacle is placed below the given node in the list of children.
 func add_obstacle_below_node(node: Node2D, child_node: Node2D) -> void:
 	_obstacles.add_child_below_node(node, child_node)
+	process_new_obstacle(child_node)
 
 
 func add_obstacle(node: Node2D) -> void:
 	_obstacles.add_child(node)
+	process_new_obstacle(node)
 
 
 ## Relocate a creature to a spawn point.
@@ -67,6 +69,9 @@ func add_creature(creature_id: String = "", chattable: bool = true) -> Creature:
 
 ## Creates shadows and chat icons when an obstacle is added to the world.
 func process_new_obstacle(obstacle: Node2D) -> void:
+	if not is_inside_tree():
+		return
+	
 	# create chat icon
 	if _chat_icons and obstacle.is_in_group("chattables"):
 		_chat_icons.create_icon(obstacle)

--- a/project/src/main/world/overworld-walk-world.gd
+++ b/project/src/main/world/overworld-walk-world.gd
@@ -1,15 +1,62 @@
+tool
 extends Node
 ## Populates/unpopulates the creatures and obstacles on the overworld walking scene.
 
-onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
+## Scene resource defining the obstacles and creatures to show
+export (Resource) var EnvironmentScene: Resource setget set_environment_scene
+
+var _overworld_ui: OverworldUi
+
+onready var _overworld_environment: OverworldEnvironment = $Environment
 
 func _ready() -> void:
+	if Engine.is_editor_hint():
+		return
+	
+	_overworld_ui = Global.get_overworld_ui()
+	
 	MusicPlayer.play_tutorial_bgm()
 	
 	ChattableManager.refresh_creatures()
 	$Camera.position = ChattableManager.player.position
 	if CurrentCutscene.chat_tree:
 		_launch_cutscene()
+
+
+func set_environment_scene(new_environment_scene: Resource) -> void:
+	EnvironmentScene = new_environment_scene
+	_refresh_environment_scene()
+
+
+## Loads a new overworld environment, replacing the current one in the scene tree.
+func _refresh_environment_scene() -> void:
+	if not is_inside_tree():
+		return
+	
+	# delete old environment nodes
+	for old_overworld_environment in get_tree().get_nodes_in_group("overworld_environments"):
+		if old_overworld_environment.get_parent() != self:
+			# only remove our direct children
+			continue
+		old_overworld_environment.queue_free()
+		remove_child(old_overworld_environment)
+	_overworld_environment = null
+	
+	# insert new environment node
+	if EnvironmentScene:
+		_overworld_environment = EnvironmentScene.instance()
+	else:
+		var empty_environment_scene := load(OverworldEnvironment.SCENE_EMPTY_ENVIRONMENT)
+		_overworld_environment = empty_environment_scene.instance()
+	add_child(_overworld_environment)
+	move_child(_overworld_environment, 0)
+	_overworld_environment.owner = get_tree().get_edited_scene_root()
+	
+	# create chat icons for all chattables
+	if not Engine.editor_hint:
+		var chat_icons := Global.get_chat_icon_container()
+		if chat_icons:
+			chat_icons.recreate_all_icons()
 
 
 func _launch_cutscene() -> void:

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -1,11 +1,22 @@
+tool
 class_name OverworldWorld
 extends Node
 ## Populates/unpopulates the creatures and obstacles on the overworld.
+
+## Scene resource defining the obstacles and creatures to show
+export (Resource) var EnvironmentScene: Resource setget set_environment_scene
 
 onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
 onready var _overworld_environment: OverworldEnvironment = $Environment
 
 func _ready() -> void:
+	if Engine.is_editor_hint():
+		return
+	
+	_refresh_environment_scene()
+	
+	_overworld_ui = Global.get_overworld_ui()
+	
 	if not Breadcrumb.trail:
 		# For developers accessing the Overworld scene directly, we initialize a default Breadcrumb trail.
 		# For regular players the Breadcrumb trail will already be initialized by the menus.
@@ -24,6 +35,42 @@ func _ready() -> void:
 			_overworld_environment.move_creature_to_spawn(ChattableManager.sensei, Global.sensei_spawn_id)
 	
 	$Camera.position = ChattableManager.player.position
+
+
+func set_environment_scene(new_environment_scene: Resource) -> void:
+	EnvironmentScene = new_environment_scene
+	_refresh_environment_scene()
+
+
+## Loads a new overworld environment, replacing the current one in the scene tree.
+func _refresh_environment_scene() -> void:
+	if not is_inside_tree():
+		return
+	
+	# delete old environment nodes
+	for old_overworld_environment in get_tree().get_nodes_in_group("overworld_environments"):
+		if old_overworld_environment.get_parent() != self:
+			# only remove our direct children
+			continue
+		old_overworld_environment.queue_free()
+		remove_child(old_overworld_environment)
+	_overworld_environment = null
+	
+	# insert new environment node
+	if EnvironmentScene:
+		_overworld_environment = EnvironmentScene.instance()
+	else:
+		var empty_environment_scene := load(OverworldEnvironment.SCENE_EMPTY_ENVIRONMENT)
+		_overworld_environment = empty_environment_scene.instance()
+	add_child(_overworld_environment)
+	move_child(_overworld_environment, 0)
+	_overworld_environment.owner = get_tree().get_edited_scene_root()
+	
+	# create chat icons for all chattables
+	if not Engine.editor_hint:
+		var chat_icons := Global.get_chat_icon_container()
+		if chat_icons:
+			chat_icons.recreate_all_icons()
 
 
 func _launch_cutscene() -> void:


### PR DESCRIPTION
Overworld environments can now be substituted in the editor by changing
the EnvironmentScene property.

Fixed missing shadows for spawned items.