### PR TITLE
Refactor: Extracted StoryData from Global.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -905,6 +905,11 @@ _global_script_classes=[ {
 "path": "res://src/main/world/environment/stool.gd"
 }, {
 "base": "Reference",
+"class": "StoryData",
+"language": "GDScript",
+"path": "res://src/main/story-data.gd"
+}, {
+"base": "Reference",
 "class": "StringTransformer",
 "language": "GDScript",
 "path": "res://src/main/string-transformer.gd"
@@ -1164,6 +1169,7 @@ _global_script_class_icons={
 "Sticker": "",
 "StickerRow": "",
 "Stool": "",
+"StoryData": "",
 "StringTransformer": "",
 "StringUtils": "",
 "SwipeContainer": "",

--- a/project/src/main/global.gd
+++ b/project/src/main/global.gd
@@ -42,12 +42,6 @@ var _benchmark_start_times := Dictionary()
 ## we're very unlikely to receive a greeting. If it's close to -1, we're very likely to receive a greeting.
 var greetiness := 0.0
 
-## the id of the spawn where the player appears on the overworld
-var player_spawn_id: String
-
-## the id of the spawn where the sensei appears on the overworld
-var sensei_spawn_id: String
-
 func _init() -> void:
 	# ensure music, pieces are random
 	randomize()

--- a/project/src/main/player-data.gd
+++ b/project/src/main/player-data.gd
@@ -22,6 +22,7 @@ var chat_history := ChatHistory.new()
 var creature_library := CreatureLibrary.new()
 var creature_queue := CreatureQueue.new()
 
+var story := StoryData.new()
 var career := CareerData.new()
 
 var money := 0 setget set_money
@@ -45,6 +46,7 @@ func reset() -> void:
 	level_history.reset()
 	chat_history.reset()
 	creature_library.reset()
+	story.reset()
 	career.reset()
 	money = 0
 	seconds_played = 0.0

--- a/project/src/main/story-data.gd
+++ b/project/src/main/story-data.gd
@@ -1,0 +1,14 @@
+class_name StoryData
+## Stores transient data for story mode.
+##
+## This includes the location of the player and sensei.
+
+## the id of the spawn where the player appears on the overworld
+var player_spawn_id: String
+
+## the id of the spawn where the sensei appears on the overworld
+var sensei_spawn_id: String
+
+func reset() -> void:
+	player_spawn_id = ""
+	sensei_spawn_id = ""

--- a/project/src/main/ui/menu/main-menu-play.gd
+++ b/project/src/main/ui/menu/main-menu-play.gd
@@ -11,6 +11,7 @@ func _on_Career_pressed() -> void:
 
 func _on_Story_pressed() -> void:
 	PlayerData.creature_queue.clear()
+	PlayerData.story.reset()
 	CurrentLevel.clear_launched_level()
 	
 	var world_lock := LevelLibrary.world_lock(WORLD0_ID)

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -307,8 +307,8 @@ func _on_ChatUi_chat_finished() -> void:
 			else:
 				# erase spawn IDs to avoid 'could not locate spawn' warnings when playing multiple cutscenes
 				# consecutively
-				Global.player_spawn_id = ""
-				Global.sensei_spawn_id = ""
+				PlayerData.story.player_spawn_id = ""
+				PlayerData.story.sensei_spawn_id = ""
 		
 		if CutsceneManager.is_front_level():
 			# continue to a level (preroll cutscene finished playing)

--- a/project/src/main/world/cutscene-manager.gd
+++ b/project/src/main/world/cutscene-manager.gd
@@ -115,22 +115,22 @@ func _pop_level() -> void:
 ##
 ## This makes it so they'll spawn in appopriate positions after the cutscene is over.
 func assign_player_spawn_ids(chat_tree: ChatTree) -> void:
-	Global.player_spawn_id = ""
-	Global.sensei_spawn_id = ""
+	PlayerData.story.player_spawn_id = ""
+	PlayerData.story.sensei_spawn_id = ""
 	
 	for creature_id in chat_tree.spawn_locations:
 		if creature_id == CreatureLibrary.PLAYER_ID:
-			Global.player_spawn_id = chat_tree.spawn_locations[creature_id]
+			PlayerData.story.player_spawn_id = chat_tree.spawn_locations[creature_id]
 		elif creature_id == CreatureLibrary.SENSEI_ID:
-			Global.sensei_spawn_id = chat_tree.spawn_locations[creature_id]
+			PlayerData.story.sensei_spawn_id = chat_tree.spawn_locations[creature_id]
 	
 	# if the player wasn't in the cutscene (?!) unset the spawn ids
-	if Global.sensei_spawn_id and not Global.player_spawn_id:
-		Global.sensei_spawn_id = ""
+	if PlayerData.story.sensei_spawn_id and not PlayerData.story.player_spawn_id:
+		PlayerData.story.sensei_spawn_id = ""
 	
 	# if the sensei wasn't in the cutscene, move them near the player
-	if Global.player_spawn_id and not Global.sensei_spawn_id:
-		var player_location_key := "%s/%s" % [chat_tree.location_id, Global.player_spawn_id]
-		Global.sensei_spawn_id = SENSEI_SPAWN_IDS_BY_PLAYER_LOCATION.get(player_location_key)
-		if not Global.sensei_spawn_id:
-			push_warning("SENSEI_SPAWN_IDS_BY_PLAYER_SPAWN_ID did not have an entry for '%s'" % [Global.player_spawn_id])
+	if PlayerData.story.player_spawn_id and not PlayerData.story.sensei_spawn_id:
+		var player_location_key := "%s/%s" % [chat_tree.location_id, PlayerData.story.player_spawn_id]
+		PlayerData.story.sensei_spawn_id = SENSEI_SPAWN_IDS_BY_PLAYER_LOCATION.get(player_location_key)
+		if not PlayerData.story.sensei_spawn_id:
+			push_warning("SENSEI_SPAWN_IDS_BY_PLAYER_SPAWN_ID did not have an entry for '%s'" % [PlayerData.story.player_spawn_id])

--- a/project/src/main/world/overworld-exit.gd
+++ b/project/src/main/world/overworld-exit.gd
@@ -94,8 +94,8 @@ func _physics_process(_delta: float) -> void:
 				and player.non_iso_walk_direction.dot(target_direction) >= 0.49:
 			_player_exiting = true
 			
-			Global.player_spawn_id = player_spawn_id
-			Global.sensei_spawn_id = sensei_spawn_id
+			PlayerData.story.player_spawn_id = player_spawn_id
+			PlayerData.story.sensei_spawn_id = sensei_spawn_id
 			player.fade_out()
 			SceneTransition.replace_trail(destination_scene_path)
 

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -28,11 +28,11 @@ func _ready() -> void:
 	if CurrentCutscene.chat_tree:
 		_launch_cutscene()
 	else:
-		if Global.player_spawn_id:
-			_overworld_environment.move_creature_to_spawn(ChattableManager.player, Global.player_spawn_id)
+		if PlayerData.story.player_spawn_id:
+			_overworld_environment.move_creature_to_spawn(ChattableManager.player, PlayerData.story.player_spawn_id)
 		
-		if Global.sensei_spawn_id:
-			_overworld_environment.move_creature_to_spawn(ChattableManager.sensei, Global.sensei_spawn_id)
+		if PlayerData.story.sensei_spawn_id:
+			_overworld_environment.move_creature_to_spawn(ChattableManager.sensei, PlayerData.story.sensei_spawn_id)
 	
 	$Camera.position = ChattableManager.player.position
 


### PR DESCRIPTION
The player_spawn_id and sensei_spawn_id are specific to story mode and
don't need to be in Global. I've moved them into a new StoryData script under
PlayerData. They're currently not persisted, but they could be some day
if we want the player to continue from their previous location.