### PR TITLE
Refactor: OverworldUi, chat_key fixes

### DIFF
--- a/project/src/main/ui/chat/career-cutscene-library.gd
+++ b/project/src/main/ui/chat/career-cutscene-library.gd
@@ -140,8 +140,7 @@ func _exhausted_chat_keys(chat_key_roots: Array) -> Dictionary:
 	var excluded_chat_keys := {}
 	
 	# branches are only exhausted when their leaves are exhausted, so leaves must be traversed first (postorder)
-	var postorder_chat_keys := chat_keys(chat_key_roots)
-	var chat_key_queue := postorder_chat_keys.duplicate()
+	var chat_key_queue := chat_keys(chat_key_roots)
 	while chat_key_queue:
 		var chat_key: String = chat_key_queue.pop_front()
 		var chat_key_pair: Dictionary = _chat_key_pairs_by_preroll.get(chat_key, {})
@@ -179,7 +178,7 @@ func _exhausted_chat_keys(chat_key_roots: Array) -> Dictionary:
 ## Returns:
 ## 	An array of String chat keys in postorder (leaves first)
 func chat_keys(chat_key_roots: Array) -> Array:
-	var postorder_chat_keys := []
+	var chat_keys := []
 	var chat_key_queue := chat_key_roots.duplicate()
 	while chat_key_queue:
 		var chat_key: String = chat_key_queue.pop_front()
@@ -189,8 +188,8 @@ func chat_keys(chat_key_roots: Array) -> Array:
 			var child_key := _child_key(chat_key_roots, chat_key, child)
 			chat_key_queue.push_front(child_key)
 		
-		postorder_chat_keys.push_front(chat_key)
-	return postorder_chat_keys
+		chat_keys.push_front(chat_key)
+	return chat_keys
 
 
 ## Filters the list of potential chat key pairs, excluding the specified chat keys.

--- a/project/src/main/world/CareerMap.tscn
+++ b/project/src/main/world/CareerMap.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=36 format=2]
+[gd_scene load_steps=38 format=2]
 
 [ext_resource path="res://src/main/ui/level-select/grade-labels.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/career-map.gd" type="Script" id=2]
@@ -6,6 +6,8 @@
 [ext_resource path="res://src/main/world/environment/MarshEnvironment.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=5]
 [ext_resource path="res://src/main/ui/level-select/LevelSelectButton.tscn" type="PackedScene" id=6]
+[ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=7]
+[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=8]
 [ext_resource path="res://src/main/ui/menu/theme/h1.theme" type="Theme" id=9]
 [ext_resource path="res://assets/main/ui/touch/menu.png" type="Texture" id=10]
 [ext_resource path="res://assets/main/ui/touch/menu-pressed.png" type="Texture" id=11]
@@ -69,7 +71,12 @@ player_path2d_path = NodePath("Environment/PlayerPath")
 EnvironmentScene = ExtResource( 4 )
 MileMarkerScene = ExtResource( 48 )
 
-[node name="Environment" parent="World" instance=ExtResource( 4 )]
+[node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 4 )]
+script = ExtResource( 7 )
+creature_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/CreatureShadows")
+shadow_caster_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/ShadowCasterShadows")
+obstacles_path = NodePath("Obstacles")
+CreatureScene = ExtResource( 8 )
 
 [node name="Camera" type="Camera2D" parent="World"]
 current = true

--- a/project/src/main/world/Overworld.tscn
+++ b/project/src/main/world/Overworld.tscn
@@ -4,8 +4,8 @@
 [ext_resource path="res://src/main/world/OverworldUi.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/world/ChatLetters.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/world/environment/OverworldEnvironment.tscn" type="PackedScene" id=4]
-[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=5]
-[ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=6]
+[ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=5]
+[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=6]
 [ext_resource path="res://src/main/world/overworld-camera.gd" type="Script" id=21]
 [ext_resource path="res://src/main/world/overworld-world.gd" type="Script" id=51]
 
@@ -27,11 +27,11 @@ script = ExtResource( 51 )
 EnvironmentScene = ExtResource( 4 )
 
 [node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 4 )]
-script = ExtResource( 6 )
+script = ExtResource( 5 )
 creature_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/CreatureShadows")
 shadow_caster_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/ShadowCasterShadows")
 obstacles_path = NodePath("Obstacles")
-CreatureScene = ExtResource( 5 )
+CreatureScene = ExtResource( 6 )
 
 [node name="ChatLetters" parent="World" instance=ExtResource( 3 )]
 

--- a/project/src/main/world/OverworldIndoors.tscn
+++ b/project/src/main/world/OverworldIndoors.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://src/main/world/environment/OverworldIndoorsEnvironment.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/ChatIcons.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/world/OverworldUi.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/world/overworld-world.gd" type="Script" id=4]
+[ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=5]
+[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=6]
 [ext_resource path="res://src/main/world/ChatLetters.tscn" type="PackedScene" id=12]
 [ext_resource path="res://src/main/world/overworld-camera.gd" type="Script" id=39]
 
@@ -24,7 +26,12 @@ __meta__ = {
 script = ExtResource( 4 )
 EnvironmentScene = ExtResource( 1 )
 
-[node name="Environment" parent="World" instance=ExtResource( 1 )]
+[node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 1 )]
+script = ExtResource( 5 )
+creature_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/CreatureShadows")
+shadow_caster_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/ShadowCasterShadows")
+obstacles_path = NodePath("Obstacles")
+CreatureScene = ExtResource( 6 )
 
 [node name="ChatLetters" parent="World" instance=ExtResource( 12 )]
 

--- a/project/src/main/world/cutscene-manager.gd
+++ b/project/src/main/world/cutscene-manager.gd
@@ -133,4 +133,5 @@ func assign_player_spawn_ids(chat_tree: ChatTree) -> void:
 		var player_location_key := "%s/%s" % [chat_tree.location_id, PlayerData.story.player_spawn_id]
 		PlayerData.story.sensei_spawn_id = SENSEI_SPAWN_IDS_BY_PLAYER_LOCATION.get(player_location_key)
 		if not PlayerData.story.sensei_spawn_id:
-			push_warning("SENSEI_SPAWN_IDS_BY_PLAYER_SPAWN_ID did not have an entry for '%s'" % [PlayerData.story.player_spawn_id])
+			push_warning("SENSEI_SPAWN_IDS_BY_PLAYER_SPAWN_ID did not have an entry for '%s'"
+					% [PlayerData.story.player_spawn_id])

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -6,16 +6,17 @@ extends Node
 ## Scene resource defining the obstacles and creatures to show
 export (Resource) var EnvironmentScene: Resource setget set_environment_scene
 
-onready var _overworld_ui: OverworldUi = Global.get_overworld_ui()
+var _overworld_ui: OverworldUi
+
 onready var _overworld_environment: OverworldEnvironment = $Environment
 
 func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 	
-	_refresh_environment_scene()
-	
 	_overworld_ui = Global.get_overworld_ui()
+	
+	_refresh_environment_scene()
 	
 	if not Breadcrumb.trail:
 		# For developers accessing the Overworld scene directly, we initialize a default Breadcrumb trail.


### PR DESCRIPTION
Fixed 'overworld_ui node not found' errors in editor. These errors were
caused because OverworldWorld is now a tool script, but it still had
onready variables.

Renamed 'postorder_chat_keys' variables to 'chat_keys'. Removed
unnecessary code copying these keys to a new array.

Fixed long line in CutsceneManager script.

Reloaded environments in overworld scenes. This results in a more
verbose .tscn file, but it seems like the automatic behavior when
substituting new environments so it's better to have it this way to
minimize changes for future commits.