### PR TITLE
fixed_zoom cutscene flag.

### DIFF
--- a/project/assets/main/chat/career/marsh/prologue.chat
+++ b/project/assets/main/chat/career/marsh/prologue.chat
@@ -1,4 +1,4 @@
-{"version": "2476"}
+{"version": "2476", "fixed_zoom": 1.0}
 
 [location]
 outdoors_walk

--- a/project/assets/main/chat/marsh-epilogue.chat
+++ b/project/assets/main/chat/marsh-epilogue.chat
@@ -1,4 +1,4 @@
-{"version": "2476"}
+{"version": "2476", "fixed_zoom": 1.0}
 
 [location]
 outdoors_walk

--- a/project/assets/main/chat/marsh-prologue.chat
+++ b/project/assets/main/chat/marsh-prologue.chat
@@ -1,4 +1,4 @@
-{"version": "2476"}
+{"version": "2476", "fixed_zoom": 1.0}
 
 [location]
 outdoors_walk

--- a/project/assets/test/ui/chat/cutscene-full.chat
+++ b/project/assets/test/ui/chat/cutscene-full.chat
@@ -1,4 +1,4 @@
-{"version": "2476"}
+{"version": "2476", "fixed_zoom": 1.0}
 
 [location]
 outdoors_walk

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -152,16 +152,6 @@ func is_chatting() -> bool:
 	return not chatters.empty()
 
 
-## Returns 'true' if the creatures in this chat are walking and talking at the same time.
-func is_walking_chat() -> bool:
-	var result := false
-	for chatter in chatters:
-		if chatter is WalkingBuddy:
-			result = true
-			break
-	return result
-
-
 func _find_creatures_in_chat_tree(chat_tree: ChatTree) -> Array:
 	var creatures := []
 	# calculate which creature ids are involved in this chat

--- a/project/src/main/world/Cutscene.tscn
+++ b/project/src/main/world/Cutscene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://src/main/world/cutscene-world.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/environment/EmptyEnvironment.tscn" type="PackedScene" id=2]
@@ -6,6 +6,8 @@
 [ext_resource path="res://src/main/world/cutscene-ui.gd" type="Script" id=4]
 [ext_resource path="res://src/main/world/OverworldUi.tscn" type="PackedScene" id=5]
 [ext_resource path="res://src/main/world/ChatLetters.tscn" type="PackedScene" id=6]
+[ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=7]
+[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=8]
 
 [node name="Cutscene" type="Node"]
 
@@ -23,7 +25,12 @@ __meta__ = {
 [node name="World" type="Node" parent="."]
 script = ExtResource( 1 )
 
-[node name="Environment" parent="World" instance=ExtResource( 2 )]
+[node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 2 )]
+script = ExtResource( 7 )
+creature_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/CreatureShadows")
+shadow_caster_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/ShadowCasterShadows")
+obstacles_path = NodePath("Obstacles")
+CreatureScene = ExtResource( 8 )
 
 [node name="ChatLetters" parent="World" instance=ExtResource( 6 )]
 

--- a/project/src/main/world/cutscene-camera.gd
+++ b/project/src/main/world/cutscene-camera.gd
@@ -12,6 +12,9 @@ const LERP_WEIGHT := 0.05
 const ZOOM_AMOUNT_NEAR := Vector2(0.5, 0.5)
 const ZOOM_AMOUNT_FAR := Vector2(1.0, 1.0)
 
+## fixed zoom amount for cutscenes which should not zoom in and out
+var fixed_zoom := 0.0
+
 onready var _project_resolution := Vector2(ProjectSettings.get_setting("display/window/size/width"), \
 		ProjectSettings.get_setting("display/window/size/height"))
 
@@ -68,10 +71,9 @@ func _calculate_position() -> Vector2:
 ##
 ## This method does not update the camera's zoom value. It returns a value which can be used in a lerp or tween.
 func _calculate_zoom() -> Vector2:
-	if _overworld_ui.is_walking_chat():
-		# We only adjust the zoom when the creatures are stationary. If they're walking around, it's distracting to
-		# continuously zoom in and out.
-		return ZOOM_AMOUNT_FAR
+	if fixed_zoom:
+		# This cutscene defines a camera zoom.
+		return Vector2(fixed_zoom, fixed_zoom)
 	
 	var camera_bounding_box := _calculate_camera_bounding_box()
 	var new_zoom := Vector2.ZERO

--- a/project/src/main/world/cutscene-world.gd
+++ b/project/src/main/world/cutscene-world.gd
@@ -22,6 +22,9 @@ func _ready() -> void:
 	EnvironmentScene = load(environment_path)
 	_refresh_environment_scene()
 	
+	if CurrentCutscene.chat_tree.meta.has("fixed_zoom"):
+		_camera.fixed_zoom = CurrentCutscene.chat_tree.meta["fixed_zoom"]
+	
 	MusicPlayer.play_chill_bgm()
 	ChattableManager.refresh_creatures()
 	_launch_cutscene()


### PR DESCRIPTION
Added fixed_zoom cutscene flag. This replaces the walk detection logic.
Some cutscenes need to zoom out so that you can see the environment,
such as those in front of the Buttercup Cafe.