### PR TITLE
Add diota's career scenes. Career button can launch cutscene.

### DIFF
--- a/project/assets/main/chat/career/marsh/10-d.chat
+++ b/project/assets/main/chat/career/marsh/10-d.chat
@@ -1,0 +1,56 @@
+{"version": "2476", "fixed_zoom": 1.0}
+
+[location]
+marsh/buttercup_cafe
+
+[characters]
+player, p1, buttercup_1
+sensei, s1, buttercup_11
+richie, r, buttercup_9
+diota, d, !buttercup_3
+
+s1: Hmm, another restaurant this close!? I wonder if this is a part of the problem.
+r: ^O^ What, this place? All they serve is that weird macrobiotic vegan stuff. You don't gotta worry about them.
+p1: /._. We... don't?
+r: I mean, I'm just thinking long term here.
+r: Bottom line is when people gotta pick between healthy food and garbage food, the garbage food always wins.
+r: <__< Y'know I mean. ...No offense.
+ (sensei mood >__<)
+d: ^_^/ Hello, can I um... Oh! ...Wait I've seen you around. You just opened that new "Turbo Fat" gym a few doors down, right?
+ (diota enters)
+ (player faces right)
+r: /._. Yeah it's, actually it's a restaurant!
+d: /._. Turbo Fat... restaurant? ... ... ...Did you name it that on purpose?
+s1: >_< Well it's a better name than "Butt Up Cafe".
+ (richie mood ^o^)
+d: -__- Augh I KNOW! It's obviously "Buttercup Cafe" but... this crystal weed is out of control.
+d: It springs up everywhere, we're calling a landscaping company to come clear it up.
+s1: ^_^ Ahh, haha. Well. Best of luck.
+d: /._. Yeah! So um, anyways nice meeting you, and just let us know if you ever need any, um...
+p1: /._. ???
+d: <_< Sorry! This is awkward but, I realized mid-sentence that I didn't want to... help you.
+d: Like, that makes sense, right? I'm not being selfish?
+[rude] Wow! Rude
+[umm] ...
+[okay] That makes sense
+[fine] We won't help you either
+
+[umm]
+p1: <_< ...
+d: Sorry. Bye!
+ (diota exits)
+
+[okay]
+p1: ^y^ Yeah, that makes sense.
+d: Sorry. Bye!
+ (diota exits)
+
+[fine]
+p1: >_< So that's how it is? ...Fine, we don't want to help you either.
+d: Sorry. Bye!
+ (diota exits)
+
+[rude]
+p1: ._.; Wow! ...That's a little rude...
+d: Sorry. Bye!
+ (diota exits)

--- a/project/assets/main/chat/career/marsh/30-d.chat
+++ b/project/assets/main/chat/career/marsh/30-d.chat
@@ -1,0 +1,46 @@
+{"version": "2476", "fixed_zoom": 1.0}
+
+[location]
+marsh/buttercup_cafe
+
+[characters]
+player, p1, buttercup_11
+sensei, s1, buttercup_9
+diota, d, buttercup_3
+
+d: -_- Oh hello. Did you need something?
+[butts_up] Butt's up with you
+[you_fixed_your_sign] You fixed your sign?
+[are_you_out_of_business] Are you out of business yet
+
+
+[butts_up]
+p1: ^O^ Hello! Butt's up with you?
+d: /._. Butt's... Butt's up? What?
+p1: <__< Oh! You fixed your 'butt up cafe' sign. Now my joke doesn't work. Anyway, how's business?
+d: Right, we fixed that like a WEEK ago! ...But yeah, things have been weird!
+d: A bunch of our customers just... like... stopped showing up all of a sudden?
+[end]
+
+[you_fixed_your_sign]
+p1: /._. Oh, you fixed your sign!
+d: <_< Right, we fixed that like a WEEK ago! ...But yeah, things have been weird!
+d: A bunch of our customers just... like... stopped showing up all of a sudden?
+[end]
+
+[are_you_out_of_business]
+p1: >_< So are you out of business yet?
+d: <_< Ugh well. We fixed our sign last week, so at least the 'butt cafe' jokes have stopped.
+d: But a bunch of our customers just... like... stopped showing up all of a sudden?
+[end]
+
+[end]
+d: ._.; No idea why! And it's not like we have any of their contact info. So... yeah.
+s1: /._. Ah. That's just the worst. I wonder where they could have gone?
+d: /._. ...Yeah. Well. ...How about you, any new customers?
+s1: ^N^ No, no, don't worry. We're not stealing your customers.
+d: ^O^ Ha ha ha, Stealing our customers! ...No, ha ha!
+d: ^n^ No, um. I wasn't worried about that. I was just being polite.
+s1: <__< Oh! ...Well thank you.
+d: ^o^ Sorry. That probably shouldn't be as funny as it is. Ha ha ha.
+s1: <_< ...Your sign looks nice.

--- a/project/assets/main/chat/career/marsh/50-d.chat
+++ b/project/assets/main/chat/career/marsh/50-d.chat
@@ -1,0 +1,40 @@
+{"version": "2476", "fixed_zoom": 1.0}
+
+[location]
+marsh/buttercup_cafe
+
+[characters]
+player, p1, buttercup_11
+sensei, s1, buttercup_9
+diota, d, buttercup_3
+
+p1: /._. Any news?
+d: u_u So yeah, I mean... We're trying a few promotions to get people back, but I don't know.
+d: I HATE marketing, and I always sort of hoped word of mouth would be enough for a place like this?
+d: @_@ And I mean for a while things were going great! ... ...I don't really get what changed....
+p1: Well, maybe people don't like the new name. ...Have you thought about changing it again?
+d: /._. ....Wait, what?
+[butt_up_cafe] ^o^ Switch it back to Butt Up Cafe!
+[butt_cafe] ^O^ Shorten it to Butt Cafe!
+[nevermind] Oh, nevermind
+
+[butt_up_cafe]
+p1: ^o^ You know, maybe people miss the old Butt Up cafe!
+ (s1 mood ^O^)
+d: ...
+d: <__< S-sorry. What? I can't tell if that's a joke or if you're actually making a dig at me.
+d: I'm not really in the right headspace to parse that right now.
+p1: Ha ha. You'll figure it out.
+
+[butt_cafe]
+p1: ^o^ Maybe just call it The Butt Cafe this time! You know, shorter! Punchier!
+ (s1 mood ^O^)
+d: ...
+d: <__< S-sorry. What? I can't tell if that's a joke or if you're actually making a dig at me.
+d: I'm not really in the right headspace to parse that right now.
+p1: Ha ha. You'll figure it out.
+
+[nevermind]
+p1: <__< Oh... nevermind.
+p1: I had an inappropriate joke, but somehow inappropriate jokes seem inappropriate right now.
+d: u_u Heh, thanks. ...Hey, keep in touch, okay?

--- a/project/src/main/ui/chat/chat-tree.gd
+++ b/project/src/main/ui/chat/chat-tree.gd
@@ -34,7 +34,8 @@ const ENVIRONMENT_SCENE_PATHS_BY_ID := {
 	
 	"marsh/walk": "res://src/main/world/environment/OverworldWalkEnvironment.tscn",
 	"marsh/inside_turbo_fat": "res://src/main/world/environment/OverworldIndoorsEnvironment.tscn",
-	"marsh/outside_turbo_fat": "res://src/main/world/environment/MarshEnvironment.tscn"
+	"marsh/outside_turbo_fat": "res://src/main/world/environment/MarshEnvironment.tscn",
+	"marsh/buttercup_cafe": "res://src/main/world/environment/MarshEnvironment.tscn",
 }
 
 ## unique key to identify this conversation in the chat history

--- a/project/src/main/ui/menu/main-menu-play.gd
+++ b/project/src/main/ui/menu/main-menu-play.gd
@@ -6,7 +6,11 @@ const WORLD0_ID := "world0"
 func _on_Career_pressed() -> void:
 	PlayerData.creature_queue.clear()
 	CurrentLevel.clear_launched_level()
-	SceneTransition.push_trail(Global.SCENE_CAREER_MAP)
+	
+	# Launch the first scene in career mode. This is probably the career map, but in some edge cases it could be a
+	# cutscene or victory screen.
+	Breadcrumb.trail.push_front(Global.SCENE_CAREER_MAP)
+	PlayerData.career.push_career_trail()
 
 
 func _on_Story_pressed() -> void:


### PR DESCRIPTION
Added diota's scenes to career mode.

Added logic for career mode to launch a cutscene immediately when career
mode is selected from main menu. This avoids an edge case where the
player is in an area, and then selects a level for that area, and then
the player is shown a prologue for that area.