### PR TITLE
Career levels define chefs, customers

### DIFF
--- a/project/assets/main/puzzle/career-worlds.json
+++ b/project/assets/main/puzzle/career-worlds.json
@@ -125,10 +125,10 @@
           "id": "career/its_square_to_be_square"
         },
         {
-          "id": "career/curly_queue"
+          "id": "career/fruit_salad"
         },
         {
-          "id": "career/one_step_ahead"
+          "id": "career/muffin_impossible_2"
         },
         {
           "id": "career/wedding_cake_for_one"
@@ -153,43 +153,58 @@
       },
       "levels": [
         {
-          "id": "career/90_second_sprint"
-        },
-        {
-          "id": "career/fruit_salad"
-        },
-        {
           "id": "career/a_little_extra"
         },
         {
-          "id": "career/unfresh_fruits_2"
+          "id": "career/unfresh_fruits_2",
+          "chef_id": "bones"
         },
         {
-          "id": "career/cocoa_canyon"
+          "id": "career/cocoa_canyon",
+          "chef_id": "bones"
         },
         {
-          "id": "career/strawberry_shortcut"
+          "id": "career/just_cream",
+          "chef_id": "bones"
         },
         {
-          "id": "career/just_cream"
+          "id": "career/tempting_jellies",
+          "chef_id": "bones"
         },
         {
-          "id": "career/muffin_impossible_2"
+          "id": "career/90_second_sprint",
+          "chef_id": "shirts"
         },
         {
-          "id": "career/a_little_garbage"
+          "id": "career/strawberry_shortcut",
+          "chef_id": "shirts"
         },
         {
-          "id": "career/real_meal"
+          "id": "career/a_little_garbage",
+          "chef_id": "shirts"
         },
         {
-          "id": "career/curly_queue_2"
+          "id": "career/real_meal",
+          "chef_id": "shirts"
         },
         {
-          "id": "career/leftovers"
+          "id": "career/curly_queue",
+          "chef_id": "skins",
+          "customer_ids": [
+            "rhonk"
+          ]
         },
         {
-          "id": "career/tempting_jellies"
+          "id": "career/curly_queue_2",
+          "chef_id": "skins"
+        },
+        {
+          "id": "career/nowhere_to_turn",
+          "chef_id": "skins"
+        },
+        {
+          "id": "career/one_step_ahead",
+          "chef_id": "skins"
         }
       ]
     },
@@ -276,7 +291,7 @@
           "id": "career/a_little_garbage_2"
         },
         {
-          "id": "career/nowhere_to_turn"
+          "id": "career/leftovers"
         },
         {
           "id": "career/zero_gravity"

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -72,7 +72,7 @@ func set_launched_level(new_level_id: String) -> void:
 	
 	if level_lock:
 		creature_id = level_lock.creature_id
-		customers = level_lock.customer_ids
+		customers = level_lock.customer_ids.duplicate()
 		chef_id = level_lock.chef_id
 	else:
 		creature_id = ""

--- a/project/src/main/ui/career/career-map-ui.gd
+++ b/project/src/main/ui/career/career-map-ui.gd
@@ -1,6 +1,52 @@
 extends CanvasLayer
 ## UI elements for the career map's settings menu.
 
+## Alter the player's career mode data to force a cutscene.
+##
+## This is triggered by a cheat code.
+func _force_cutscene() -> void:
+	PlayerData.career.hours_passed = CareerData.CAREER_INTERLUDE_HOURS[0]
+	PlayerData.career.skipped_previous_level = false
+	
+	var region := CareerLevelLibrary.region_for_distance(PlayerData.career.distance_travelled)
+	var chat_key_pair := {}
+	if region.cutscene_path:
+		# find a region-specific cutscene
+		chat_key_pair = CareerCutsceneLibrary.next_chat_key_pair([region.cutscene_path])
+	if not chat_key_pair:
+		# no region-specific cutscene available; find a general cutscene
+		chat_key_pair = CareerCutsceneLibrary.next_chat_key_pair([CareerData.GENERAL_CHAT_KEY_ROOT])
+	if not chat_key_pair:
+		var chat_keys := CareerCutsceneLibrary.chat_keys([CareerData.GENERAL_CHAT_KEY_ROOT])
+		var min_chat_age := ChatHistory.CHAT_AGE_NEVER
+		var newest_chat_key := ""
+		for chat_key in chat_keys:
+			var chat_age := PlayerData.chat_history.get_chat_age(chat_key)
+			if chat_age < min_chat_age:
+				min_chat_age = chat_age
+				newest_chat_key = chat_key
+		PlayerData.chat_history.delete_history_item(newest_chat_key)
+
+
+## Alter the player's career mode data to force a boss level.
+##
+## This is triggered by a cheat code.
+func _force_boss_level() -> void:
+	var region := CareerLevelLibrary.region_for_distance(PlayerData.career.distance_travelled)
+	if region.length == CareerData.MAX_DISTANCE_TRAVELLED:
+		# if they're in the last region, move them to the end of the previous region
+		PlayerData.career.distance_travelled = region.distance - 1
+	else:
+		# move them to the end of the current region
+		PlayerData.career.distance_travelled = region.length + region.distance - 1
+	
+	# set their max_distance_travelled so that the boss level isn't skipped
+	PlayerData.career.max_distance_travelled = PlayerData.career.distance_travelled
+	
+	# reload the CareerMap scene
+	SceneTransition.change_scene()
+
+
 func _on_SettingsButton_pressed() -> void:
 	$SettingsMenu.show()
 
@@ -24,27 +70,8 @@ func _on_SettingsMenu_other_quit_pressed() -> void:
 
 func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDetector) -> void:
 	if cheat == "cutsio":
-		# alter the player's career mode data to force a cutscene
-		PlayerData.career.hours_passed = CareerData.CAREER_INTERLUDE_HOURS[0]
-		PlayerData.career.skipped_previous_level = false
-		
-		var region := CareerLevelLibrary.region_for_distance(PlayerData.career.distance_travelled)
-		var chat_key_pair := {}
-		if region.cutscene_path:
-			# find a region-specific cutscene
-			chat_key_pair = CareerCutsceneLibrary.next_chat_key_pair([region.cutscene_path])
-		if not chat_key_pair:
-			# no region-specific cutscene available; find a general cutscene
-			chat_key_pair = CareerCutsceneLibrary.next_chat_key_pair([CareerData.GENERAL_CHAT_KEY_ROOT])
-		if not chat_key_pair:
-			var chat_keys := CareerCutsceneLibrary.chat_keys([CareerData.GENERAL_CHAT_KEY_ROOT])
-			var min_chat_age := ChatHistory.CHAT_AGE_NEVER
-			var newest_chat_key := ""
-			for chat_key in chat_keys:
-				var chat_age := PlayerData.chat_history.get_chat_age(chat_key)
-				if chat_age < min_chat_age:
-					min_chat_age = chat_age
-					newest_chat_key = chat_key
-			PlayerData.chat_history.delete_history_item(newest_chat_key)
-		
+		_force_cutscene()
+		detector.play_cheat_sound(true)
+	elif cheat == "bossio":
+		_force_boss_level()
 		detector.play_cheat_sound(true)

--- a/project/src/main/ui/level-select/career-region.gd
+++ b/project/src/main/ui/level-select/career-region.gd
@@ -17,6 +17,8 @@ var distance := 0
 var icon_name: String
 
 ## The smallest distance the player must travel to exit this region.
+##
+## If the length is CareerData.MAX_DISTANCE_TRAVELLED, this region cannot be exited.
 var length := 0
 
 ## List of CareerLevel instances which store career-mode-specific information about this region's levels.

--- a/project/src/main/world/CareerMap.tscn
+++ b/project/src/main/world/CareerMap.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=36 format=2]
+[gd_scene load_steps=38 format=2]
 
 [ext_resource path="res://src/main/ui/level-select/grade-labels.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/career-map.gd" type="Script" id=2]
@@ -6,6 +6,8 @@
 [ext_resource path="res://src/main/world/environment/MarshEnvironment.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=5]
 [ext_resource path="res://src/main/ui/level-select/LevelSelectButton.tscn" type="PackedScene" id=6]
+[ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=7]
+[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=8]
 [ext_resource path="res://src/main/ui/menu/theme/h1.theme" type="Theme" id=9]
 [ext_resource path="res://assets/main/ui/touch/menu.png" type="Texture" id=10]
 [ext_resource path="res://assets/main/ui/touch/menu-pressed.png" type="Texture" id=11]
@@ -69,7 +71,12 @@ player_path2d_path = NodePath("Environment/PlayerPath")
 EnvironmentScene = ExtResource( 4 )
 MileMarkerScene = ExtResource( 48 )
 
-[node name="Environment" parent="World" instance=ExtResource( 4 )]
+[node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 4 )]
+script = ExtResource( 7 )
+creature_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/CreatureShadows")
+shadow_caster_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/ShadowCasterShadows")
+obstacles_path = NodePath("Obstacles")
+CreatureScene = ExtResource( 8 )
 
 [node name="Camera" type="Camera2D" parent="World"]
 current = true
@@ -288,7 +295,7 @@ quit_type = 3
 layer = 10
 
 [node name="CheatCodeDetector" parent="Ui" instance=ExtResource( 5 )]
-codes = [ "cutsio" ]
+codes = [ "cutsio", "bossio" ]
 
 [connection signal="level_button_focused" from="LevelSelect" to="Ui/Control/StatusBar/Distance" method="_on_LevelSelect_level_button_focused"]
 [connection signal="level_button_focused" from="LevelSelect" to="World" method="_on_LevelSelect_level_button_focused"]

--- a/project/src/main/world/cutscene-manager.gd
+++ b/project/src/main/world/cutscene-manager.gd
@@ -105,6 +105,8 @@ func _pop_level() -> void:
 	CurrentLevel.set_launched_level(level_properties["level_id"])
 	if level_properties.has("piece_speed"):
 		CurrentLevel.piece_speed = level_properties["piece_speed"]
+	if level_properties.has("chef_id"):
+		CurrentLevel.chef_id = level_properties["chef_id"]
 	if level_properties.has("customers"):
 		CurrentLevel.customers = level_properties["customers"]
 	if level_properties.has("cutscene_force"):


### PR DESCRIPTION
Fixed CustomerDef entries polluting LevelLocks and CareerLevels.
CurrentLevel.customers was receiving a reference to the original array
instead of making a copy, which meant new customers showing up would
affect the source data as well.