### PR TITLE
Refactorings: Career mode advancement logic improvements.

### DIFF
--- a/project/src/main/puzzle/level/level-history.gd
+++ b/project/src/main/puzzle/level/level-history.gd
@@ -14,7 +14,7 @@ var rank_results := {}
 var successful_levels := {}
 
 ## key: level name
-## value: date when the player first finished the level
+## value: Date when the player first finished the level. Losing or quitting does not count as finishing.
 var finished_levels := {}
 
 func level_names() -> Array:
@@ -121,6 +121,7 @@ func prune(level_id: String) -> void:
 	rank_results[level_id] = [rank_results[level_id][0]] + best.keys()
 
 
+## Returns 'true' if the level has been finished. Losing or quitting does not count as finishing.
 func is_level_finished(level_id: String) -> bool:
 	return finished_levels.has(level_id)
 

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -165,10 +165,8 @@ func _quit_puzzle() -> void:
 		var chat_tree := ChatLibrary.chat_tree_for_key(world_lock.epilogue_chat_key)
 		CutsceneManager.enqueue_cutscene(chat_tree)
 	
-	if PlayerData.career.is_career_mode() and not PuzzleState.game_ended:
-		# apply penalties for skipping in career mode
-		PlayerData.career.advance_clock(0, false)
-		PlayerData.career.skipped_previous_level = true
+	if PlayerData.career.is_career_mode():
+		PlayerData.career.process_puzzle_result()
 	
 	CurrentLevel.clear_launched_level()
 	PlayerData.creature_queue.clear()

--- a/project/src/main/ui/career/career-distance-label.gd
+++ b/project/src/main/ui/career/career-distance-label.gd
@@ -24,13 +24,15 @@ func _refresh_label() -> void:
 	# Display the distance travelled with the distance penalty applied
 	_label.text = StringUtils.comma_sep(PlayerData.career.distance_travelled - distance_penalty)
 	
-	# Append the distance_option with the distance penalty applied
-	if PlayerData.career.distance_earned > 0:
+	# Append the distance_option with the distance penalty
+	var distance_earned_value := PlayerData.career.distance_earned - distance_penalty
+	
+	if distance_earned_value > 0:
 		# distance_earned is positive; prefix distance_option with a '+'
-		_label.text += " (+%s)" % [StringUtils.comma_sep(PlayerData.career.distance_earned - distance_penalty)]
-	elif PlayerData.career.distance_earned < 0:
+		_label.text += " (+%s)" % [StringUtils.comma_sep(distance_earned_value)]
+	elif distance_earned_value < 0:
 		# distance_earned is negative; no prefix is necessary, distance_option already includes a '-'
-		_label.text += " (%s)" % [StringUtils.comma_sep(PlayerData.career.distance_earned - distance_penalty)]
+		_label.text += " (%s)" % [StringUtils.comma_sep(distance_earned_value)]
 	else:
 		# distance_earned is zero; don't show it
 		pass


### PR DESCRIPTION
Fixed bug where CareerData referenced 'PlayerData.career' instead of referencing
itself.

Broke up CareerData.advance_clock() function which was growing large.

Extracted new CareerData.process_puzzle_result() function from Puzzle to keep the
career-specific logic separate from the puzzle logic.

Extracted new level_choice_count() method. Currently this only toggles
based on whether the player is playing a boss level, but in the future
there are other reasons why the player will have only one level to
choose.