### PR TITLE
Added 'banked steps' logic for career mode.

### DIFF
--- a/project/src/main/ui/career/career-distance-label.gd
+++ b/project/src/main/ui/career/career-distance-label.gd
@@ -22,10 +22,8 @@ func _refresh_label() -> void:
 	var distance_penalty: int = PlayerData.career.distance_penalties()[focused_level_button_index]
 	
 	# Display the distance travelled with the distance penalty applied
-	_label.text = StringUtils.comma_sep(PlayerData.career.distance_travelled - distance_penalty)
-	
-	# Append the distance_option with the distance penalty
 	var distance_earned_value := PlayerData.career.distance_earned - distance_penalty
+	_label.text = StringUtils.comma_sep(distance_earned_value)
 	
 	if distance_earned_value > 0:
 		# distance_earned is positive; prefix distance_option with a '+'

--- a/project/src/test/world/test-career-data.gd
+++ b/project/src/test/world/test-career-data.gd
@@ -22,40 +22,75 @@ func test_prev_daily_earnings() -> void:
 
 
 func test_advance_clock_stops_at_boss_level_0() -> void:
+	_data.max_distance_travelled = 0
 	_data.advance_clock(50, false)
 	assert_eq(_data.distance_earned, 50)
 	assert_eq(_data.distance_travelled, 9)
+	assert_eq(_data.banked_steps, 41)
 
 
 func test_advance_clock_stops_at_boss_level_1() -> void:
+	_data.max_distance_travelled = 0
 	_data.distance_travelled = 8 # just before a boss level
 	_data.advance_clock(3, true)
 	assert_eq(_data.distance_earned, 3)
 	assert_eq(_data.distance_travelled, 9)
+	assert_eq(_data.banked_steps, 2)
 
 
 ## The player skips one boss level, but gets stopped by the next boss level
 func test_advance_clock_skips_boss_level() -> void:
-	PlayerData.career.max_distance_travelled = 10 # they've only cleared the first boss level
+	_data.max_distance_travelled = 10 # they've only cleared the first boss level
 	_data.advance_clock(50, false)
 	assert_eq(_data.distance_earned, 50)
 	assert_eq(_data.distance_travelled, 19)
+	assert_eq(_data.banked_steps, 31)
 
 
 func test_advance_clock_clears_boss_level() -> void:
+	_data.max_distance_travelled = 0
 	_data.distance_travelled = 9 # boss level
 	_data.advance_clock(4, true)
 	assert_eq(_data.distance_earned, 4)
 	assert_eq(_data.distance_travelled, 13)
+	assert_eq(_data.banked_steps, 0)
 
 
 func test_advance_clock_fails_boss_level() -> void:
+	_data.max_distance_travelled = 0
 	_data.distance_travelled = 9 # boss level
 	_data.advance_clock(4, false)
 	assert_true(_data.distance_earned < 0,
 			"distance_earned should be less than 0 but was %s" % [_data.distance_earned])
 	assert_true(_data.distance_travelled < 9,
 			"distance_travelled should be less than 9 but was %s" % [_data.distance_travelled])
+	assert_eq(_data.banked_steps, 0)
+
+
+func test_advance_clock_banked_steps_for_failed_boss_level() -> void:
+	_data.max_distance_travelled = 0
+	_data.banked_steps = 5
+	_data.distance_travelled = 9 # boss level
+	_data.advance_clock(4, false)
+	assert_true(_data.distance_earned < 0,
+			"distance_earned should be less than 0 but was %s" % [_data.distance_earned])
+	assert_eq(_data.banked_steps, 5)
+
+
+func test_advance_clock_banked_steps_for_failed_level() -> void:
+	_data.banked_steps = 5
+	_data.advance_clock(0, false)
+	assert_eq(_data.distance_earned, 0)
+	assert_eq(_data.distance_travelled, 0)
+	assert_eq(_data.banked_steps, 5)
+
+
+func test_advance_clock_banked_steps_for_finished_level() -> void:
+	_data.banked_steps = 5
+	_data.advance_clock(1, false)
+	assert_eq(_data.distance_earned, 6)
+	assert_eq(_data.distance_travelled, 6)
+	assert_eq(_data.banked_steps, 0)
 
 
 func test_distance_penalties_short() -> void:
@@ -103,5 +138,6 @@ func test_distance_penalties_negative() -> void:
 
 
 func test_distance_penalties_boss_level() -> void:
+	_data.max_distance_travelled = 0
 	_data.advance_clock(50, false)
 	assert_eq(_data.distance_penalties(), [0, 0, 0])


### PR DESCRIPTION
If the player hits a boss level they haven't cleared, instead of the
steps being thrown away, they're 'banked' and applied the next time the
player advances forward.