### PR TITLE
Refactor: LevelHistory.delete, comments

### DIFF
--- a/project/src/demo/world/cutscene-demo-flags.gd
+++ b/project/src/demo/world/cutscene-demo-flags.gd
@@ -30,7 +30,7 @@ func apply_flags() -> void:
 			PlayerData.level_history.finished_levels[level_key] = OS.get_datetime()
 		elif line.begins_with("not level_finished "):
 			var level_key := StringUtils.substring_after(line, "level_finished ")
-			PlayerData.level_history.finished_levels.erase(level_key)
+			PlayerData.level_history.delete(level_key)
 		else:
 			push_warning("Unrecognized flag: %s" % [line])
 

--- a/project/src/main/puzzle/level/level-history.gd
+++ b/project/src/main/puzzle/level/level-history.gd
@@ -104,6 +104,17 @@ func add(level_id: String, rank_result: RankResult) -> void:
 		finished_levels[level_id] = OS.get_datetime()
 
 
+## Deletes all records of the specified level from the player's history.
+##
+## Returns:
+## 	'true' if the key was present in the player's history, false otherwise.
+func delete(level_id: String) -> bool:
+	var success := rank_results.erase(level_id)
+	successful_levels.erase(level_id)
+	finished_levels.erase(level_id)
+	return success
+
+
 func has(level_id: String) -> bool:
 	return rank_results.has(level_id) and rank_results.get(level_id).size() >= 1
 

--- a/project/src/main/ui/chat/chat-history.gd
+++ b/project/src/main/ui/chat/chat-history.gd
@@ -58,8 +58,12 @@ func add_history_item(chat_key: String) -> void:
 	chat_history[chat_key] = chat_count
 
 
-func delete_history_item(chat_key: String) -> void:
-	chat_history.erase(chat_key)
+## Deletes an item from the chat history.
+##
+## Returns:
+## 	'true' if the key was present in the chat history, 'false' otherwise.
+func delete_history_item(chat_key: String) -> bool:
+	return chat_history.erase(chat_key)
 
 
 ## Returns how long ago the player had the specified chat.

--- a/project/src/main/ui/level-select/career-level-library.gd
+++ b/project/src/main/ui/level-select/career-level-library.gd
@@ -11,7 +11,7 @@ const DEFAULT_WORLDS_PATH := "res://assets/main/puzzle/career-worlds.json"
 ## Path to the json file with the list of levels. Can be changed for tests.
 var worlds_path := DEFAULT_WORLDS_PATH setget set_worlds_path
 
-## List of CareerRegions containing region and level data.
+## List of CareerRegions containing region and level data, sorted by distance
 var regions: Array = []
 
 func all_level_ids() -> Array:

--- a/project/src/main/ui/level-select/career-region.gd
+++ b/project/src/main/ui/level-select/career-region.gd
@@ -1,13 +1,13 @@
 class_name CareerRegion
 ## Stores information about a block of levels for career mode.
 
-## Chat key containing each region's prologue cutscene
+## Chat key containing each region's prologue cutscene, which plays before any other cutscenes/levels
 const PROLOGUE_CHAT_KEY_NAME := "prologue"
 
-## Chat key containing each region's intro level cutscene
+## Chat key containing each region's intro level cutscene, which plays before/after the intro level
 const INTRO_LEVEL_CHAT_KEY_NAME := "intro_level"
 
-## Chat key containing each region's boss level cutscene
+## Chat key containing each region's boss level cutscene, which plays before/after the boss level
 const BOSS_LEVEL_CHAT_KEY_NAME := "boss_level"
 
 ## A human-readable region name, such as 'Lemony Thickets'

--- a/project/src/test/world/test-career-data.gd
+++ b/project/src/test/world/test-career-data.gd
@@ -75,7 +75,7 @@ func test_advance_clock_fails_boss_level() -> void:
 
 func test_advance_clock_stops_at_intro_level() -> void:
 	_data.max_distance_travelled = 10
-	PlayerData.level_history.finished_levels.erase("intro_311")
+	PlayerData.level_history.delete("intro_311")
 	_data.advance_clock(50, false)
 	assert_eq(_data.distance_earned, 50)
 	assert_eq(_data.distance_travelled, 10)


### PR DESCRIPTION
Added new LevelHistory.delete() function. Changed ChatHistory.delete_history_item()
to return true/false based on the result of the deletion. This return
value isn't used, but it implicitly documents that it's OK to erase
non-existent items from the history.

Expanded some comments.