### PR TITLE
Fixed career distance label, breadcrumb trail

### DIFF
--- a/project/src/main/ui/career/career-distance-label.gd
+++ b/project/src/main/ui/career/career-distance-label.gd
@@ -21,9 +21,9 @@ func _refresh_label() -> void:
 	var focused_level_button_index := _level_select.focused_level_button_index()
 	var distance_penalty: int = PlayerData.career.distance_penalties()[focused_level_button_index]
 	
-	# Display the distance travelled with the distance penalty applied
+	# Display the distance travelled and distance earned with the distance penalty applied
+	_label.text = StringUtils.comma_sep(PlayerData.career.distance_travelled - distance_penalty)
 	var distance_earned_value := PlayerData.career.distance_earned - distance_penalty
-	_label.text = StringUtils.comma_sep(distance_earned_value)
 	
 	if distance_earned_value > 0:
 		# distance_earned is positive; prefix distance_option with a '+'

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -21,6 +21,12 @@ onready var _level_select_control := $LevelSelect
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
+	
+	if not Breadcrumb.trail:
+		# For developers accessing the Overworld scene directly, we initialize a default Breadcrumb trail.
+		# For regular players the Breadcrumb trail will already be initialized by the menus.
+		Breadcrumb.initialize_trail()
+	
 	MusicPlayer.play_chill_bgm()
 	PlayerData.career.connect("distance_travelled_changed", self, "_on_CareerData_distance_travelled_changed")
 	


### PR DESCRIPTION
Distance label was incorrectly displaying values like '4 (+4) instead of
'53 (+4)'. This was broken in 8c356a5d when adding the 'banked steps'
logic.

Career map now initializes a breadcrumb trail, if one is not already
initialized. This avoids bugs when launnching CareerMap directly from
the editor.