### PR TITLE
Added epilogue cutscene to career mode. Added 'epilio' cheat.

### DIFF
--- a/project/assets/main/chat/career/marsh/epilogue.chat
+++ b/project/assets/main/chat/career/marsh/epilogue.chat
@@ -1,0 +1,63 @@
+{"version": "2476", "fixed_zoom": 1.0}
+
+[location]
+marsh/walk
+
+[destination]
+outdoors
+
+[characters]
+player, p1
+sensei, s1
+narrator, n
+
+n: Instead of spending a week in Merrymellow Marsh like they originally planned, #sensei# and #player# ended up staying for an entire month.\n\n...But for some, even an entire month wasn't enough.
+p1: u_u I still wish we could have stayed and helped longer. I was finally starting to feel like I belonged there.
+s1: Well, a wise poet once wrote, "Two sofas diverged in a furniture store."
+s1: "I chose the sofa less comfortable, and that has made all the difference."
+[i_understand] I see
+[thats_stupid] That's stupid
+[you_made_that_up] You made that up
+
+[i_understand]
+p1: /._. I see... And Merrymellow Marsh is like one of those big squishy beanbag chairs,
+p1: The kind where you almost pass out in them, and then you have trouble standing up afterwards.
+s1: Yes, something like that.
+[besides_that]
+
+[you_made_that_up]
+p1: -_- Really? A wise poet wrote that?
+ (stop_walking)
+p1: ...It sounds more like an excuse you made up after buying a crappy sofa.
+s1: Hmph.
+ (start_walking)
+[besides_that]
+
+[thats_stupid]
+p1: ^o^ Well that's stupid. Here's a better poem,
+p1: ^O^ "Buy some proper furniture and your butt will hurt less, you big wing wong."
+ (stop_walking)
+s1: Hmph.
+ (start_walking)
+[besides_that]
+
+[besides_that]
+p1: /._. Well, besides that. Did we even do anything while we were there?
+p1: We only finished with a handful of extra customers, and we still don't know why they came.
+p1: <_< They could stop showing up next week, and we'd be back to square one.
+ (stop_walking)
+s1: ^Y^ Well. ...For now it's just a handful of customers, but that will change in time.
+s1: There's an old saying, 'even the greatest avalanche starts with a single snowflake.'
+ (start_walking)
+p1: @_@ ...the GREATEST avalanche?
+s1: ^_^ Three or four customers now will become thirty or forty.
+s1: And the snowflake becomes a snowball, and the snowball gets bigger...
+p1: ._.; Just to be clear, you're using 'GREATEST' in the pejorative sense right? We're not... we're not pro-avalanche!
+s1: ^o^ ...until two or three years later, when our glorious restaurant will have the destructive force to level an entire city!
+s1: ^O^ Ahha ha ha ha!
+p1: .__.; Okay, come on, seriously! ...Use a nicer metaphor! You're being all weird about this.
+ (stop_walking)
+s1: /._. Even the greatest... PESTILENCE begins with a single cough!
+p1: >_< What!? No, we have a NICE restaurant! It's not a pestilence!
+s1: ^O^ Even the greatest MASSACRE begins with...
+p1: @_@ STOP! Augh!

--- a/project/src/main/player-data.gd
+++ b/project/src/main/player-data.gd
@@ -39,6 +39,8 @@ func _ready() -> void:
 	seconds_played_timer.connect("timeout", self, "_on_SecondsPlayedTimer_timeout")
 	add_child(seconds_played_timer)
 	seconds_played_timer.start()
+	
+	CurrentCutscene.connect("cutscene_played", self, "_on_CurrentCutscene_cutscene_played")
 
 
 ## Resets the player's in-memory data to a default state.
@@ -64,3 +66,15 @@ func _on_SecondsPlayedTimer_timeout() -> void:
 	
 	if career.is_career_mode():
 		career.daily_seconds_played += SECONDS_PLAYED_INCREMENT
+
+
+## When an epilogue cutscene is played in career mode, we advance the player to the next region
+func _on_CurrentCutscene_cutscene_played(chat_key: String) -> void:
+	var region := CareerLevelLibrary.region_for_distance(career.distance_travelled)
+	if chat_key == region.get_epilogue_chat_key():
+		# advance the player to the next region
+		var old_distance_travelled := career.distance_travelled
+		career.distance_travelled = max(career.distance_travelled, region.distance + region.length)
+		career.max_distance_travelled = max(career.max_distance_travelled, career.distance_travelled)
+		if career.distance_travelled > old_distance_travelled:
+			career.distance_earned += (career.distance_travelled - old_distance_travelled)

--- a/project/src/main/ui/level-select/career-region.gd
+++ b/project/src/main/ui/level-select/career-region.gd
@@ -10,6 +10,9 @@ const INTRO_LEVEL_CHAT_KEY_NAME := "intro_level"
 ## Chat key containing each region's boss level cutscene, which plays before/after the boss level
 const BOSS_LEVEL_CHAT_KEY_NAME := "boss_level"
 
+## Chat key containing each region's epilogue cutscene, which plays after all other cutscenes/levels
+const EPILOGUE_CHAT_KEY_NAME := "epilogue"
+
 ## A human-readable region name, such as 'Lemony Thickets'
 var name: String
 
@@ -82,3 +85,7 @@ func get_boss_level_preroll_chat_key() -> String:
 
 func get_boss_level_postroll_chat_key() -> String:
 	return "%s/%s_end" % [cutscene_path, BOSS_LEVEL_CHAT_KEY_NAME] if cutscene_path else ""
+
+
+func get_epilogue_chat_key() -> String:
+	return "%s/%s" % [cutscene_path, EPILOGUE_CHAT_KEY_NAME] if cutscene_path else ""

--- a/project/src/main/world/CareerMap.tscn
+++ b/project/src/main/world/CareerMap.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=38 format=2]
+[gd_scene load_steps=36 format=2]
 
 [ext_resource path="res://src/main/ui/level-select/grade-labels.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/career-map.gd" type="Script" id=2]
@@ -6,8 +6,6 @@
 [ext_resource path="res://src/main/world/environment/MarshEnvironment.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=5]
 [ext_resource path="res://src/main/ui/level-select/LevelSelectButton.tscn" type="PackedScene" id=6]
-[ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=7]
-[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=8]
 [ext_resource path="res://src/main/ui/menu/theme/h1.theme" type="Theme" id=9]
 [ext_resource path="res://assets/main/ui/touch/menu.png" type="Texture" id=10]
 [ext_resource path="res://assets/main/ui/touch/menu-pressed.png" type="Texture" id=11]
@@ -71,12 +69,7 @@ player_path2d_path = NodePath("Environment/PlayerPath")
 EnvironmentScene = ExtResource( 4 )
 MileMarkerScene = ExtResource( 48 )
 
-[node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 4 )]
-script = ExtResource( 7 )
-creature_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/CreatureShadows")
-shadow_caster_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/ShadowCasterShadows")
-obstacles_path = NodePath("Obstacles")
-CreatureScene = ExtResource( 8 )
+[node name="Environment" parent="World" instance=ExtResource( 4 )]
 
 [node name="Camera" type="Camera2D" parent="World"]
 current = true
@@ -295,7 +288,7 @@ quit_type = 3
 layer = 10
 
 [node name="CheatCodeDetector" parent="Ui" instance=ExtResource( 5 )]
-codes = [ "cutsio", "bossio" ]
+codes = [ "cutsio", "bossio", "epilio" ]
 
 [connection signal="level_button_focused" from="LevelSelect" to="Ui/Control/StatusBar/Distance" method="_on_LevelSelect_level_button_focused"]
 [connection signal="level_button_focused" from="LevelSelect" to="World" method="_on_LevelSelect_level_button_focused"]

--- a/project/src/main/world/Overworld.tscn
+++ b/project/src/main/world/Overworld.tscn
@@ -1,11 +1,9 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://src/main/world/ChatIcons.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/OverworldUi.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/world/ChatLetters.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/world/environment/OverworldEnvironment.tscn" type="PackedScene" id=4]
-[ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=5]
-[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=6]
 [ext_resource path="res://src/main/world/overworld-camera.gd" type="Script" id=21]
 [ext_resource path="res://src/main/world/overworld-world.gd" type="Script" id=51]
 
@@ -26,12 +24,7 @@ __meta__ = {
 script = ExtResource( 51 )
 EnvironmentScene = ExtResource( 4 )
 
-[node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 4 )]
-script = ExtResource( 5 )
-creature_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/CreatureShadows")
-shadow_caster_shadows_path = NodePath("Ground/Shadows/Viewport/ViewportRoot/ShadowCasterShadows")
-obstacles_path = NodePath("Obstacles")
-CreatureScene = ExtResource( 6 )
+[node name="Environment" parent="World" instance=ExtResource( 4 )]
 
 [node name="ChatLetters" parent="World" instance=ExtResource( 3 )]
 

--- a/project/src/main/world/current-cutscene.gd
+++ b/project/src/main/world/current-cutscene.gd
@@ -1,6 +1,12 @@
 extends Node
 ## Stores information about the current cutscene.
 
+## Emitted after a scene is launched to play a cutscene.
+##
+## Parameters:
+## 	'chat_key': A chat key such as 'chat/marsh_prologue'
+signal cutscene_played(chat_key)
+
 ## The chat key for the cutscene currently being launched or played
 var chat_key: String
 
@@ -25,6 +31,7 @@ func set_launched_cutscene(new_chat_key: String) -> void:
 ## The new scene is appended to the end of the breadcrumb trail.
 func push_cutscene_trail() -> void:
 	SceneTransition.push_trail(Global.SCENE_CUTSCENE)
+	emit_signal("cutscene_played", chat_key)
 
 
 ## Launches an overworld scene with the previously specified 'launched cutscene' settings.
@@ -32,6 +39,7 @@ func push_cutscene_trail() -> void:
 ## The new scene replaces the current scene in the the breadcrumb trail.
 func replace_cutscene_trail() -> void:
 	SceneTransition.replace_trail(Global.SCENE_CUTSCENE)
+	emit_signal("cutscene_played", chat_key)
 
 
 ## Unsets all of the 'launched cutscene' data.

--- a/project/src/test/ui/chat/test-career-cutscene-library.gd
+++ b/project/src/test/ui/chat/test-career-cutscene-library.gd
@@ -24,6 +24,22 @@ func test_load_all_chat_keys() -> void:
 	])
 
 
+func test_find_chat_key_pairs() -> void:
+	CareerCutsceneLibrary.career_cutscene_root_path = "res://assets/test/ui/chat/fake-career"
+	
+	var chat_key_pairs := CareerCutsceneLibrary.find_chat_key_pairs(["ui/chat/fake_career/marsh"],
+			{CareerCutsceneLibrary.INCLUDE_ALL_NUMERIC_CHILDREN: true})
+	assert_eq_deep(chat_key_pairs, [
+		{"preroll": "ui/chat/fake_career/marsh/00", "postroll": "ui/chat/fake_career/marsh/00_end"},
+		{"preroll": "ui/chat/fake_career/marsh/10_a"},
+		{"preroll": "ui/chat/fake_career/marsh/10_b"},
+		{"postroll": "ui/chat/fake_career/marsh/10_c_end"},
+		{"preroll": "ui/chat/fake_career/marsh/20"},
+		{"preroll": "ui/chat/fake_career/marsh/30_a"},
+		{"preroll": "ui/chat/fake_career/marsh/30_b"},
+	])
+
+
 func test_potential_chat_keys_letter() -> void:
 	CareerCutsceneLibrary.all_chat_key_pairs = [
 		{"preroll": "ui/chat/fake_career/general/00_a"},


### PR DESCRIPTION
Merrymellow Marsh defines an epilogue cutscene. This epilogue plays after
the last normal cutscene of the region. When activated, the player is
automatically advanced past the area.

Added new 'epilio' cheat to force an epilogue to play.