### PR TITLE
U pieces can flip in narrow columns.

### DIFF
--- a/project/src/main/puzzle/piece/active-piece.gd
+++ b/project/src/main/puzzle/piece/active-piece.gd
@@ -141,6 +141,8 @@ func kick_piece(kicks: Array = []) -> void:
 			kicks = type.cw_kicks[orientation]
 		elif target_orientation == get_ccw_orientation():
 			kicks = type.ccw_kicks[target_orientation]
+		elif target_orientation == get_flip_orientation():
+			kicks = [type.flips[orientation]]
 		else:
 			kicks = []
 	else:

--- a/project/src/main/puzzle/piece/piece-rotator.gd
+++ b/project/src/main/puzzle/piece/piece-rotator.gd
@@ -85,7 +85,7 @@ func apply_rotate_input(piece: ActivePiece) -> void:
 			rotation_signal = "rotated_180"
 			piece.target_orientation = piece.get_flip_orientation()
 			if not piece.can_move_to_target():
-				piece.target_pos = piece.get_flip_position()
+				piece.kick_piece()
 		
 		if piece.target_pos.y < piece.pos.y and not piece.can_floor_kick():
 			# tried to flip but we don't have any floor kicks for it

--- a/project/src/main/puzzle/piece/piece-types.gd
+++ b/project/src/main/puzzle/piece/piece-types.gd
@@ -11,14 +11,12 @@ const KICKS_JL := [
 		[Vector2( 1,  0), Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1), Vector2(-1, -1)],
 	]
 
-
 const KICKS_T := [
 		[Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1), Vector2( 0, -1)],
 		[Vector2( 1,  0), Vector2( 1, -1), Vector2( 0, -1), Vector2(-1,  0)],
 		[Vector2( 1,  0), Vector2( 1,  1), Vector2( 0,  1), Vector2(-1,  0)],
 		[Vector2(-1,  0), Vector2(-1,  1), Vector2( 0, -1), Vector2( 0,  1)],
 	]
-
 
 const KICKS_U := [
 		[Vector2( 0, -1), Vector2(-1, -1), Vector2(-1,  0), Vector2(-1,  1), Vector2( 0, -2)],
@@ -183,7 +181,7 @@ var piece_u := PieceType.new("u",
 		[Vector2(2, 2), Vector2(2, 2), Vector2(9, 2), Vector2(12, 2), Vector2(5, 2)],
 		[Vector2(10, 2), Vector2(4, 2), Vector2(3, 2), Vector2(9, 2), Vector2(4, 2)]],
 		KICKS_U,
-		[Vector2(0, 0), Vector2(-1, 0), Vector2(0, 0), Vector2(1, 0)],
+		[Vector2(0, 0), Vector2(1, 0), Vector2(0, 0), Vector2(-1, 0)],
 		5 # u-piece allows additional floor kicks because it kicks the floor twice if you rotate it four times
 	)
 

--- a/project/src/test/puzzle/piece/test-piece-kicks-u.gd
+++ b/project/src/test/puzzle/piece/test-piece-kicks-u.gd
@@ -675,3 +675,39 @@ func test_ledge_kick_left_r0() -> void:
 		":   ",
 	]
 	assert_kick()
+
+
+func test_flip_kick_rl_narrow() -> void:
+	from_grid = [
+		"  ",
+		"uu",
+		" u",
+		"uu",
+		"  ",
+	]
+	to_grid = [
+		"  ",
+		"uu",
+		"u ",
+		"uu",
+		"  ",
+	]
+	assert_kick()
+
+
+func test_flip_kick_rl_wide() -> void:
+	from_grid = [
+		"   ",
+		" uu",
+		"  u",
+		" uu",
+		"   ",
+	]
+	to_grid = [
+		"   ",
+		"uu ",
+		"u  ",
+		"uu ",
+		"   ",
+	]
+	assert_kick()


### PR DESCRIPTION
Added piece kick test for U pieces. Moved piece flip kick logic from
PieceRotator.apply_rotate_input() into ActivePiece.kick_piece()