### PR TITLE
ChatLibrary now exposes chat_key_root_path for tests.

### DIFF
--- a/project/src/test/ui/chat/test-career-cutscene-library.gd
+++ b/project/src/test/ui/chat/test-career-cutscene-library.gd
@@ -1,10 +1,12 @@
 extends "res://addons/gut/test.gd"
 
 func before_each() -> void:
+	ChatLibrary.chat_key_root_path = "res://assets/test"
 	PlayerData.chat_history.reset()
 
 
 func after_each() -> void:
+	ChatLibrary.chat_key_root_path = ChatLibrary.DEFAULT_CHAT_KEY_ROOT_PATH
 	CareerCutsceneLibrary.career_cutscene_root_path = CareerCutsceneLibrary.DEFAULT_CAREER_CUTSCENE_ROOT_PATH
 
 

--- a/project/src/test/ui/chat/test-chatscript-parser.gd
+++ b/project/src/test/ui/chat/test-chatscript-parser.gd
@@ -8,6 +8,14 @@ const CHAT_LINK_MOOD := "res://assets/test/ui/chat/chat-link-mood.chat"
 const CHAT_NEWLINES := "res://assets/test/ui/chat/chat-newlines.chat"
 const CHAT_THOUGHT := "res://assets/test/ui/chat/chat-thought.chat"
 
+func before_each() -> void:
+	ChatLibrary.chat_key_root_path = "res://assets/test"
+
+
+func after_each() -> void:
+	ChatLibrary.chat_key_root_path = ChatLibrary.DEFAULT_CHAT_KEY_ROOT_PATH
+
+
 func _chat_tree_from_file(path: String) -> ChatTree:
 	var parser := ChatscriptParser.new()
 	var chat_tree := parser.chat_tree_from_file(path)
@@ -20,6 +28,12 @@ func test_cutscene_location() -> void:
 	
 	assert_eq(chat_tree.location_id, "outdoors_walk")
 	assert_eq(chat_tree.destination_id, "outdoors")
+
+
+func test_chat_key() -> void:
+	var chat_tree := _chat_tree_from_file(CUTSCENE_FULL)
+	
+	assert_eq(chat_tree.chat_key, "ui/chat/cutscene_full")
 
 
 func test_overall_meta() -> void:


### PR DESCRIPTION
This is slightly cleaner than having source code in the /main source
branch which references the 'res://assets/test' path. It also allows the
'path_from_chat_key' function to work for tests.

Added test showing that ChatScriptParser populates ChatTree.chat_key