### PR TITLE
'cutsio' cheat causes scene change. next_chat_key_pair() rename.

### DIFF
--- a/project/src/main/ui/chat/career-cutscene-library.gd
+++ b/project/src/main/ui/chat/career-cutscene-library.gd
@@ -98,7 +98,7 @@ func set_career_cutscene_root_path(new_career_cutscene_root_path: String) -> voi
 ## Returns:
 ## 	A dictionary with a 'preroll' entry and/or a 'postroll' entry, defining chat keys for cutscenes which play
 ## 	before or after a level.
-func next_chat_key_pair(chat_key_roots: Array) -> Dictionary:
+func next_interlude_chat_key_pair(chat_key_roots: Array) -> Dictionary:
 	var potential_chat_key_pairs := potential_chat_key_pairs(chat_key_roots)
 	return Utils.rand_value(potential_chat_key_pairs) if potential_chat_key_pairs else {}
 

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -188,10 +188,10 @@ func _on_LevelSelectButton_level_started(level_index: int) -> void:
 			and not PlayerData.career.skipped_previous_level:
 		if region.cutscene_path:
 			# find a region-specific cutscene
-			chat_key_pair = CareerCutsceneLibrary.next_chat_key_pair([region.cutscene_path])
+			chat_key_pair = CareerCutsceneLibrary.next_interlude_chat_key_pair([region.cutscene_path])
 		if not chat_key_pair:
 			# no region-specific cutscene available; find a general cutscene
-			chat_key_pair = CareerCutsceneLibrary.next_chat_key_pair([CareerData.GENERAL_CHAT_KEY_ROOT])
+			chat_key_pair = CareerCutsceneLibrary.next_interlude_chat_key_pair([CareerData.GENERAL_CHAT_KEY_ROOT])
 	
 	var preroll_key: String = chat_key_pair.get("preroll", "")
 	var postroll_key: String = chat_key_pair.get("postroll", "")


### PR DESCRIPTION
'cutsio' cheat now causes a scene change. Enabling different cutscenes may force
different levels to play, and this is also consistent with other similar cheat
codes (bossio, epilio)

Renamed next_chat_key_pair() to next_interlude_chat_key_pair(). Without
the word 'interlude' it's unclear why other chat key pairs are being
skipped over.