### PR TITLE
Fixed piece distribution in 'Just Cream'

### DIFF
--- a/project/assets/main/puzzle/levels/career/just-cream.json
+++ b/project/assets/main/puzzle/levels/career/just-cream.json
@@ -8,6 +8,7 @@
     "value": "35"
   },
   "piece_types": [
+    "no_suppress_o_piece",
     "piece_o",
     "piece_v"
   ],

--- a/project/src/main/puzzle/level/piece-type-rules.gd
+++ b/project/src/main/puzzle/level/piece-type-rules.gd
@@ -48,11 +48,15 @@ var start_types := []
 ## list of PieceTypes to choose from. if empty, defaults to the basic 8 types (jlopqtuv)
 var types := []
 
+## if 'true', O pieces are rerolled once if they come up as the extra piece in the shuffling algorithm
+var suppress_o_piece: bool = true
+
 var _rule_parser: RuleParser
 
 func _init() -> void:
 	_rule_parser = RuleParser.new(self)
 	_rule_parser.add_bool("ordered_start")
+	_rule_parser.add_bool("suppress_o_piece", "no_suppress_o_piece")
 	_rule_parser.add(PieceTypesPropertyParser.new(self))
 
 

--- a/project/src/main/puzzle/piece/piece-queue.gd
+++ b/project/src/main/puzzle/piece/piece-queue.gd
@@ -221,7 +221,7 @@ func _insert_annoying_piece(max_pieces_to_right: int) -> void:
 			Utils.remove_all(extra_piece_types, pieces[new_piece_index].type)
 	
 	if extra_piece_types:
-		if extra_piece_types[0] == PieceTypes.piece_o:
+		if CurrentLevel.settings.piece_types.suppress_o_piece and extra_piece_types[0] == PieceTypes.piece_o:
 			# the o piece is awful, so it comes 10% less often
 			extra_piece_types.shuffle()
 		pieces.insert(new_piece_index, _new_next_piece(extra_piece_types[0]))


### PR DESCRIPTION
New 'no_suppress_o_pieces' flag disables the 'suppress o piece' logic
just for that level. Most levels suppress O pieces because they're hard
to work with, but this specific level is incredibly difficult if there
is not a 50/50 ratio of pieces.