### PR TITLE
Career cutscene bugfixes, comments

### DIFF
--- a/project/src/main/ui/chat/career-cutscene-library.gd
+++ b/project/src/main/ui/chat/career-cutscene-library.gd
@@ -64,7 +64,7 @@ var all_chat_key_pairs := [] setget set_all_chat_key_pairs
 ## key: (String) A preroll chat key like 'chat/career/general_00_a'. For the case where a level has a postroll cutscene
 ## 	but no preroll cutscene, this chat key may actually correspond to a non-existent preroll cutscene.
 ##
-## value: (Dictionary) A ChatKeyPair defining preroll and postroll cutscenes.
+## value: (ChatKeyPair) A ChatKeyPair defining preroll and postroll cutscenes.
 var _chat_key_pairs_by_preroll := {}
 
 ## Defines a hierarchy of preroll cutscenes.
@@ -226,8 +226,8 @@ func chat_keys(chat_key_roots: Array) -> Array:
 ## 	'search_flags': A dictionary of flags defining search behavior, as documented above.
 ##
 ## Returns:
-## 	A filtered list of dictionary entries. Each dictionary entry has a 'preroll' entry and/or a 'postroll' entry,
-## 	defining chat keys for cutscenes which play before or after a level.
+## 	A filtered list of ChatKeyPair instances which define chat keys for cutscenes which play before or after a
+## 	level.
 func find_chat_key_pairs(chat_key_roots: Array, search_flags: Dictionary) -> Array:
 	var potential_chat_key_pairs := []
 	var include_all_numeric_children: bool = search_flags.get(INCLUDE_ALL_NUMERIC_CHILDREN, false)

--- a/project/src/main/ui/chat/chatscript-parser.gd
+++ b/project/src/main/ui/chat/chatscript-parser.gd
@@ -120,7 +120,7 @@ class CharactersState extends AbstractState:
 	
 	## Syntax:
 	## 	skins, s, kitchen_9        - a character named 'skins' with an alias 's' spawns at kitchen_9
-	## 	skins, s, !kitchen_9        - a character named 'skins' with an alias 's' spawns invisible at kitchen_9
+	## 	skins, s, !kitchen_9       - a character named 'skins' with an alias 's' spawns invisible at kitchen_9
 	## 	skins, s                   - a character named 'skins' with an alias 's'
 	## 	skins                      - a character named 'skins'
 	func _parse_character_name(line: String) -> void:

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -178,7 +178,7 @@ func _interlude_chat_key_pair() -> ChatKeyPair:
 	if region.cutscene_path:
 		# find a region-specific cutscene
 		result = CareerCutsceneLibrary.next_interlude_chat_key_pair([region.cutscene_path])
-	if not result:
+	if result.empty():
 		# no region-specific cutscene available; find a general cutscene
 		result = CareerCutsceneLibrary.next_interlude_chat_key_pair([CareerData.GENERAL_CHAT_KEY_ROOT])
 	
@@ -189,15 +189,15 @@ func _interlude_chat_key_pair() -> ChatKeyPair:
 func _chat_key_pair() -> ChatKeyPair:
 	var result: ChatKeyPair = ChatKeyPair.new()
 
-	# if it's an intro level, enqueue any intro level cutscenes
+	# if it's an intro level, return any intro level cutscenes
 	if result.empty() and PlayerData.career.is_intro_level():
 		result = _intro_chat_key_pair()
 	
-	# if it's a boss level, enqueue any boss level cutscenes
+	# if it's a boss level, return any boss level cutscenes
 	if result.empty() and PlayerData.career.is_boss_level():
 		result = _boss_chat_key_pair()
 	
-	# if it's the 3rd or 6th level, enqueue a cutscene
+	# if it's the 3rd or 6th level, return any interludes
 	if result.empty() and PlayerData.career.hours_passed in CareerData.CAREER_INTERLUDE_HOURS \
 			and not PlayerData.career.skipped_previous_level:
 		result = _interlude_chat_key_pair()


### PR DESCRIPTION
Fixed erroneous check for 'not result' instead of 'result.empty()' when
checking whether a region has cutscenes or not. This logic worked when
we used Dictionaries, but does not work for ChatKeyPairs.

Fixed a few comments which used incorrect types and incorrect language.