### PR TITLE
Fixed bug where interludes were skipped after failed boss level

### DIFF
--- a/project/src/main/career-data.gd
+++ b/project/src/main/career-data.gd
@@ -363,11 +363,13 @@ func process_puzzle_result() -> void:
 		PlayerData.career.advance_clock(0, false)
 		PlayerData.career.skipped_previous_level = true
 	
-	if PlayerData.career.is_intro_level() and not CurrentLevel.best_result in [Levels.Result.FINISHED, Levels.Result.WON]:
+	if CutsceneManager.has_cutscene_flag("intro_level") \
+			and not CurrentLevel.best_result in [Levels.Result.FINISHED, Levels.Result.WON]:
 		# player lost an intro level
 		skip_remaining_cutscenes = true
 	
-	if PlayerData.career.is_boss_level() and not CurrentLevel.best_result == Levels.Result.WON:
+	if CutsceneManager.has_cutscene_flag("boss_level") \
+			and not CurrentLevel.best_result == Levels.Result.WON:
 		# player didn't meet the win criteria for a boss level
 		skip_remaining_cutscenes = true
 	

--- a/project/src/main/ui/chat/career-cutscene-library.gd
+++ b/project/src/main/ui/chat/career-cutscene-library.gd
@@ -343,6 +343,7 @@ func _refresh_chat_key_pairs() -> void:
 		
 		if not chat_key_pairs_by_preroll_tmp.has(preroll_key):
 			var new_chat_key_pair := ChatKeyPair.new()
+			new_chat_key_pair.type = ChatKeyPair.INTERLUDE
 			new_all_chat_key_pairs.append(new_chat_key_pair)
 			chat_key_pairs_by_preroll_tmp[preroll_key] = new_chat_key_pair
 		

--- a/project/src/main/ui/level-select/level-buttons.gd
+++ b/project/src/main/ui/level-select/level-buttons.gd
@@ -193,6 +193,7 @@ func _lowlight_unrelated_buttons(world_id: String) -> void:
 
 ## When the player clicks a level button twice, we launch the selected level
 func _on_LevelSelectButton_level_started(settings: LevelSettings) -> void:
+	CutsceneManager.reset()
 	var chat_tree := ChatLibrary.chat_tree_for_preroll(settings.id)
 	if ChatLibrary.should_play_cutscene(chat_tree, SystemData.misc_settings.cutscene_force):
 		# [menu > overworld] -> [menu > overworld > cutscene]

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -370,6 +370,7 @@ func _on_TalkButton_pressed() -> void:
 			start_chat(chat_tree, ChattableManager.focused_chattable)
 		else:
 			# if a location change is necessary, launch a cutscene
+			CutsceneManager.reset()
 			CutsceneManager.enqueue_cutscene(chat_tree)
 			CutsceneManager.enqueue_level({
 				"level_id": level_id

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -148,7 +148,9 @@ func _intro_chat_key_pair() -> ChatKeyPair:
 		result.preroll = preroll_key
 	if ChatLibrary.chat_exists(postroll_key) and not PlayerData.chat_history.is_chat_finished(postroll_key):
 		result.postroll = postroll_key
-	
+	if not result.empty():
+		result.type = ChatKeyPair.INTRO_LEVEL
+		
 	return result
 
 
@@ -166,6 +168,8 @@ func _boss_chat_key_pair() -> ChatKeyPair:
 		result.preroll = preroll_key
 	if ChatLibrary.chat_exists(postroll_key) and not PlayerData.chat_history.is_chat_finished(postroll_key):
 		result.postroll = postroll_key
+	if not result.empty():
+		result.type = ChatKeyPair.BOSS_LEVEL
 	
 	return result
 
@@ -181,6 +185,8 @@ func _interlude_chat_key_pair() -> ChatKeyPair:
 	if result.empty():
 		# no region-specific cutscene available; find a general cutscene
 		result = CareerCutsceneLibrary.next_interlude_chat_key_pair([CareerData.GENERAL_CHAT_KEY_ROOT])
+	if not result.empty():
+		result.type = ChatKeyPair.INTERLUDE
 	
 	return result
 
@@ -239,6 +245,8 @@ func _on_LevelSelectButton_level_started(level_index: int) -> void:
 	var preroll_key: String = chat_key_pair.preroll
 	var postroll_key: String = chat_key_pair.postroll
 	
+	CutsceneManager.reset()
+	
 	if preroll_key:
 		CutsceneManager.enqueue_cutscene(ChatLibrary.chat_tree_for_key(preroll_key))
 	
@@ -251,6 +259,13 @@ func _on_LevelSelectButton_level_started(level_index: int) -> void:
 	
 	if postroll_key:
 		CutsceneManager.enqueue_cutscene(ChatLibrary.chat_tree_for_key(postroll_key))
+	
+	if preroll_key or postroll_key:
+		match chat_key_pair.type:
+			ChatKeyPair.INTRO_LEVEL:
+				CutsceneManager.set_cutscene_flag("intro_level")
+			ChatKeyPair.BOSS_LEVEL:
+				CutsceneManager.set_cutscene_flag("boss_level")
 	
 	if _should_play_epilogue(chat_key_pair):
 		CutsceneManager.enqueue_cutscene(ChatLibrary.chat_tree_for_key(region.get_epilogue_chat_key()))

--- a/project/src/main/world/chat-key-pair.gd
+++ b/project/src/main/world/chat-key-pair.gd
@@ -1,11 +1,26 @@
 class_name ChatKeyPair
 ## Defines chat keys for cutscenes which play before or after a level.
 
+enum ChatKeyPairType {
+	NONE,
+	INTRO_LEVEL,
+	INTERLUDE,
+	BOSS_LEVEL,
+}
+
+const NONE := ChatKeyPairType.NONE
+const INTRO_LEVEL := ChatKeyPairType.INTRO_LEVEL
+const INTERLUDE := ChatKeyPairType.INTERLUDE
+const BOSS_LEVEL := ChatKeyPairType.BOSS_LEVEL
+
 ## chat key for cutscene which plays before a level
 var preroll: String
 
 ## chat key for cutscene which plays after a level
 var postroll: String
+
+## Defines a cutscene type, such as intro, boss level or interlude
+var type: int = NONE
 
 ## Returns 'true' if this ChatKeyPair does not define any cutscenes.
 func empty() -> bool:
@@ -23,10 +38,12 @@ func chat_keys() -> Array:
 func from_json_dict(json: Dictionary) -> void:
 	preroll = json.get("preroll", "")
 	postroll = json.get("postroll", "")
+	type = Utils.enum_from_snake_case(ChatKeyPairType, json.get("type"))
 
 
 func to_json_dict() -> Dictionary:
 	return {
 		"preroll": preroll,
 		"postroll": postroll,
+		"type": Utils.enum_to_snake_case(ChatKeyPairType, type)
 	}

--- a/project/src/main/world/cutscene-manager.gd
+++ b/project/src/main/world/cutscene-manager.gd
@@ -26,8 +26,24 @@ const SENSEI_SPAWN_IDS_BY_PLAYER_LOCATION := {
 ## Queue of ChatTree and String instances. ChatTrees represent cutscenes, and strings represent level IDs.
 var _queue := []
 
+## Flags for the current set of cutscenes, indicating things like whether they're for a boss level.
+var _cutscene_flags := {}
+
 func reset() -> void:
 	_queue.clear()
+	_cutscene_flags.clear()
+
+
+## Sets a flag for the current set of cutscenes, indicating something like whether they're for a boss level.
+func set_cutscene_flag(flag: String) -> void:
+	_cutscene_flags[flag] = true
+
+
+## Returns 'true' if the specified flag has been enabled for the current set of cutscenes.
+##
+## These flags can indicate things like whether the cutscenes are for a boss level.
+func has_cutscene_flag(flag: String) -> bool:
+	return _cutscene_flags.has(flag)
 
 
 ## Adds a cutscene to the back of the queue.

--- a/project/src/test/ui/chat/test-career-cutscene-library.gd
+++ b/project/src/test/ui/chat/test-career-cutscene-library.gd
@@ -13,6 +13,7 @@ func after_each() -> void:
 func _interlude(preroll: String, postroll: String) -> ChatKeyPair:
 	var result := ChatKeyPair.new()
 	result.from_json_dict({
+		"type": "interlude",
 		"preroll": preroll,
 		"postroll": postroll,
 	})


### PR DESCRIPTION
Failing a boss level should skip boss cutscenes, but should not skip
interlude cutscenes. To facilitate this, ChatKeyPair has a new 'type'
property, and CutsceneManager has a new 'cutscene_flag' property. These
tools allow the puzzle script to tell whether a boss level cutscene is
playing.