### PR TITLE
Career mode ensures cutscenes and levels match.

### DIFF
--- a/project/assets/main/chat/career/marsh/10-a-end.chat
+++ b/project/assets/main/chat/career/marsh/10-a-end.chat
@@ -6,7 +6,7 @@ marsh/outside_turbo_fat
 [characters]
 player, p1, restaurant_1
 sensei, s1, restaurant_4
-bones, b, restaurant_8
+(chef) bones, b, restaurant_8
 
 p1: Well that was... good!
 b: <_< Just good?

--- a/project/assets/main/chat/career/marsh/10-b.chat
+++ b/project/assets/main/chat/career/marsh/10-b.chat
@@ -6,7 +6,7 @@ marsh/inside_turbo_fat
 [characters]
 player, p1, entrance_10
 sensei, s1, entrance_7
-shirts, s, entrance_2
+(chef) shirts, s, entrance_2
 
 s: Oh hey what's up. I heard you guys came the other day when I wasn't here. So did I miss like anything... important?
 s1: Ahh, nothing important. We're still trying to figure out why this location isn't attracting more customers.

--- a/project/assets/main/chat/career/marsh/10-c-end.chat
+++ b/project/assets/main/chat/career/marsh/10-c-end.chat
@@ -6,7 +6,7 @@ marsh/inside_turbo_fat
 [characters]
 player, p1, kitchen_5
 sensei, s1, kitchen_3
-skins, s, kitchen_7
+(chef) skins, s, kitchen_7
 
 s1: /._. Hmm... so, do you remember that thing I said not to do?
 s: ._.; ...

--- a/project/assets/main/chat/career/marsh/20-end.chat
+++ b/project/assets/main/chat/career/marsh/20-end.chat
@@ -8,7 +8,7 @@ player, p1, kitchen_5
 sensei, s1, kitchen_9
 richie, r, kitchen_1
 skins, s, kitchen_3
-bones, b, kitchen_7
+(chef) bones, b, kitchen_7
 
 p1: /._. So one thing I noticed, Skins, is when you switch from one dish to the next-
 b: <_< ...My name is Bones...

--- a/project/assets/main/chat/career/marsh/20.chat
+++ b/project/assets/main/chat/career/marsh/20.chat
@@ -8,7 +8,7 @@ player, p1, kitchen_9
 sensei, s1, kitchen_5
 richie, r, kitchen_1
 skins, s, kitchen_3
-bones, b, kitchen_7
+(chef) bones, b, kitchen_7
 
 p1: Well! I guess this is our last day here.
 r: Yeah! Thanks for all your help. We're putting out better food now, and business is starting to pick up a little.

--- a/project/assets/main/chat/career/marsh/30-a-end.chat
+++ b/project/assets/main/chat/career/marsh/30-a-end.chat
@@ -5,7 +5,7 @@ marsh/outside_turbo_fat
 
 [characters]
 player, p1, restaurant_1
-bones, b, restaurant_11
+(chef) bones, b, restaurant_11
 
 b: ^O^ Hey, remember a few days ago when you said there's more than one way to bone a dog! Ha ha!
 p1: ^_^ Ha ha! Yeah. Wait, what's so funny about that?

--- a/project/assets/main/chat/career/marsh/30-b-end.chat
+++ b/project/assets/main/chat/career/marsh/30-b-end.chat
@@ -5,7 +5,7 @@ marsh/outside_turbo_fat
 
 [characters]
 player, p1, restaurant_1
-shirts, s, restaurant_11
+(chef) shirts, s, restaurant_11
 
 s: /._. So are they driving you crazy yet?
 [bones_drives_me_crazy] Bones is clingy

--- a/project/assets/main/chat/career/marsh/30-c-end.chat
+++ b/project/assets/main/chat/career/marsh/30-c-end.chat
@@ -5,7 +5,7 @@ marsh/outside_turbo_fat
 
 [characters]
 player, p1, restaurant_1
-skins, s, restaurant_11
+(chef) skins, s, restaurant_11
 
 s: ^O^ Remember when you said, like, there's more than one way to bone a dog? Ha ha! That was really funny~
 p1: ^_^ Ha ha! Yeah. Wait, what's so funny about that?

--- a/project/assets/main/chat/career/marsh/50-a-end.chat
+++ b/project/assets/main/chat/career/marsh/50-a-end.chat
@@ -5,7 +5,7 @@ marsh/outside_turbo_fat
 
 [characters]
 player, p1, restaurant_11
-bones, b, restaurant_1
+(chef) bones, b, restaurant_1
 
 p1: <_< Sorry, I should probably tell you - Fat Sensei and I aren't coming back to MerryMellow marsh for awhile.
 b: .__.; You're not coming back!? Wait! ...Today's your last day?

--- a/project/assets/main/chat/career/marsh/50-b-end.chat
+++ b/project/assets/main/chat/career/marsh/50-b-end.chat
@@ -5,7 +5,7 @@ marsh/outside_turbo_fat
 
 [characters]
 player, p1, restaurant_11
-skins, s, restaurant_1
+(chef) skins, s, restaurant_1
 
 p1: <_< Sorry, this is hard to say but we were only supposed to be here for one week. And that was like... several weeks ago.
 p1: Fat Sensei and I need to leave for awhile.

--- a/project/assets/main/chat/career/marsh/50-c-end.chat
+++ b/project/assets/main/chat/career/marsh/50-c-end.chat
@@ -6,7 +6,7 @@ marsh/outside_turbo_fat
 [characters]
 player, p1, restaurant_4
 sensei, s1, restaurant_1
-shirts, s, restaurant_8
+(chef) shirts, s, restaurant_8
 
 p1: <_< So I don't know if you've heard, but -- Fat Sensei and I are leaving MerryMellow Marsh for awhile.
 s: /._. Oh. Yeah, it was only supposed to be a week, right? ...Well, sorry to see you go. This place will suck a little more without you.

--- a/project/assets/main/chat/career/marsh/intro-level-end.chat
+++ b/project/assets/main/chat/career/marsh/intro-level-end.chat
@@ -7,7 +7,7 @@ marsh/inside_turbo_fat
 player, p1, kitchen_3
 sensei, s1, kitchen_5
 richie, r, kitchen_11
-skins, s, kitchen_9
+(chef) skins, s, kitchen_9
 bones, b, kitchen_7
 
 s: So how was that?

--- a/project/assets/main/chat/career/marsh/intro-level.chat
+++ b/project/assets/main/chat/career/marsh/intro-level.chat
@@ -7,8 +7,9 @@ marsh/inside_turbo_fat
 player, p1, kitchen_9
 sensei, s1, kitchen_11
 richie, r, kitchen_1
-skins, s, kitchen_3
+(chef) skins, s, kitchen_3
 bones, b, kitchen_5
+(customer) rhonk
 
 s1: -_- So explain again why my beloved restaurant is very, very empty?
 r: Aw come on now! It's not empty, we got the two line cooks here...

--- a/project/assets/test/ui/chat/cutscene-full.chat
+++ b/project/assets/test/ui/chat/cutscene-full.chat
@@ -10,8 +10,9 @@ outdoors
 player, p1, kitchen_3
 sensei, s1, kitchen_5
 richie, r, kitchen_11
-skins, s, kitchen_9
+(chef) skins, s, kitchen_9
 bones, b, kitchen_7
+(customer) rhonk
 
 s: So how was that?
 [very_good] I think you killed it!

--- a/project/assets/test/ui/chat/fake-career-2/a.chat
+++ b/project/assets/test/ui/chat/fake-career-2/a.chat
@@ -1,0 +1,6 @@
+{"version": "2476"}
+
+[characters]
+(chef) skins
+
+skins: test

--- a/project/assets/test/ui/chat/fake-career-2/b.chat
+++ b/project/assets/test/ui/chat/fake-career-2/b.chat
@@ -1,0 +1,6 @@
+{"version": "2476"}
+
+[characters]
+(customer) rhonk
+
+rhonk: test

--- a/project/assets/test/ui/chat/fake-career-2/c.chat
+++ b/project/assets/test/ui/chat/fake-career-2/c.chat
@@ -1,0 +1,6 @@
+{"version": "2476"}
+
+[characters]
+player
+
+player: test

--- a/project/src/main/ui/chat/chat-tree.gd
+++ b/project/src/main/ui/chat/chat-tree.gd
@@ -62,6 +62,14 @@ var destination_id: String
 ## value: spawn id
 var spawn_locations := {}
 
+## The creature who acts as the chef for the cutscene, if any. This ensures levels are paired up with appropriate
+## cutscenes.
+var chef_id: String
+
+## The creature(s) who acts as the customer(s) for the cutscene, if any. This ensures levels are paired up with
+## appropriate cutscenes.
+var customer_ids := []
+
 ## current position in this chat tree
 var _position := Position.new()
 

--- a/project/src/main/ui/chat/chatscript-parser.gd
+++ b/project/src/main/ui/chat/chatscript-parser.gd
@@ -121,18 +121,35 @@ class CharactersState extends AbstractState:
 	## Syntax:
 	## 	skins, s, kitchen_9        - a character named 'skins' with an alias 's' spawns at kitchen_9
 	## 	skins, s, !kitchen_9       - a character named 'skins' with an alias 's' spawns invisible at kitchen_9
+	## 	(chef) skins, s            - a character named 'skins' with an alias 's' is the chef for this scene
+	## 	(customer) rhonk           - a character named 'rhonk' is a customer for this scene
 	## 	skins, s                   - a character named 'skins' with an alias 's'
 	## 	skins                      - a character named 'skins'
 	func _parse_character_name(line: String) -> void:
 		var line_parts := line.split(",")
 		var character_name := "" if line_parts.size() < 1 else line_parts[0].strip_edges()
+		
+		# parse (chef) prefix
+		if character_name.begins_with("(chef)"):
+			character_name = StringUtils.substring_after(character_name, "(chef)").strip_edges()
+			chat_tree.chef_id = character_name
+		
+		# parse (customer) prefix
+		if character_name.begins_with("(customer)"):
+			character_name = StringUtils.substring_after(character_name, "(customer)").strip_edges()
+			chat_tree.customer_ids.append(character_name)
+		
+		# parse character name
 		if character_name in ["player", "sensei", "narrator"]:
 			character_name = "#%s#" % [character_name]
-		var character_alias := "" if line_parts.size() < 2 else line_parts[1].strip_edges()
-		var character_location := "" if line_parts.size() < 3 else line_parts[2].strip_edges()
 		
+		# parse spawn location
+		var character_location := "" if line_parts.size() < 3 else line_parts[2].strip_edges()
 		if character_name and character_location:
 			chat_tree.spawn_locations[character_name] = character_location
+		
+		# parse alias
+		var character_alias := "" if line_parts.size() < 2 else line_parts[1].strip_edges()
 		if character_name and character_alias:
 			_character_aliases[character_alias] = character_name
 

--- a/project/src/main/ui/level-select/career-level.gd
+++ b/project/src/main/ui/level-select/career-level.gd
@@ -1,6 +1,9 @@
 class_name CareerLevel
 ## Stores career-mode-specific information about a level.
 
+## Unique customer ID assigned to levels with no named chefs or customers.
+const ANONYMOUS_CUSTOMER := "#anonymous_customer#"
+
 var level_id: String
 
 ## Some levels involve specific customers or a specific chef.

--- a/project/src/test/ui/chat/test-career-cutscene-library.gd
+++ b/project/src/test/ui/chat/test-career-cutscene-library.gd
@@ -170,3 +170,48 @@ func test_potential_chat_keys_exclude_played_branch() -> void:
 		# only return scenes in second numeric branch
 		_interlude("ui/chat/fake_career/general/00_1_a", ""),
 	])
+
+
+func test_potential_chat_keys_includes_chef() -> void:
+	CareerCutsceneLibrary.all_chat_key_pairs = [
+		# cutscenes include a numeric branch with no remaining cutscenes
+		_interlude("ui/chat/fake_career_2/a", ""),
+		_interlude("ui/chat/fake_career_2/b", ""),
+		_interlude("ui/chat/fake_career_2/c", ""),
+	]
+	_assert_eq_ckp(CareerCutsceneLibrary.potential_chat_key_pairs([
+		"ui/chat/fake_career_2"
+	], "skins", []), [
+		# only return scenes with skins as a chef
+		_interlude("ui/chat/fake_career_2/a", ""),
+	])
+
+
+func test_potential_chat_keys_includes_customer() -> void:
+	CareerCutsceneLibrary.all_chat_key_pairs = [
+		# cutscenes include a numeric branch with no remaining cutscenes
+		_interlude("ui/chat/fake_career_2/a", ""),
+		_interlude("ui/chat/fake_career_2/b", ""),
+		_interlude("ui/chat/fake_career_2/c", ""),
+	]
+	_assert_eq_ckp(CareerCutsceneLibrary.potential_chat_key_pairs([
+		"ui/chat/fake_career_2"
+	], "", ["rhonk"]), [
+		# only return scenes with rhonk as a customer
+		_interlude("ui/chat/fake_career_2/b", ""),
+	])
+
+
+func test_potential_chat_keys_includes_unnamed_customers() -> void:
+	CareerCutsceneLibrary.all_chat_key_pairs = [
+		# cutscenes include a numeric branch with no remaining cutscenes
+		_interlude("ui/chat/fake_career_2/a", ""),
+		_interlude("ui/chat/fake_career_2/b", ""),
+		_interlude("ui/chat/fake_career_2/c", ""),
+	]
+	_assert_eq_ckp(CareerCutsceneLibrary.potential_chat_key_pairs([
+		"ui/chat/fake_career_2"
+	], "", [CareerLevel.ANONYMOUS_CUSTOMER]), [
+		# only return scenes with no named chefs/customers
+		_interlude("ui/chat/fake_career_2/c", ""),
+	])

--- a/project/src/test/ui/chat/test-chatscript-parser.gd
+++ b/project/src/test/ui/chat/test-chatscript-parser.gd
@@ -52,6 +52,12 @@ func test_cutscene_spawn_locations() -> void:
 	assert_has(chat_tree.spawn_locations, "bones", "kitchen_7")
 
 
+func test_cutscene_roles() -> void:
+	var chat_tree := _chat_tree_from_file(CUTSCENE_FULL)
+	assert_eq(chat_tree.chef_id, "skins")
+	assert_eq(chat_tree.customer_ids, ["rhonk"])
+
+
 func test_cutscene_chat() -> void:
 	var chat_tree := _chat_tree_from_file(CUTSCENE_FULL)
 	var event := chat_tree.get_event()

--- a/project/src/test/ui/level-select/test-career-level-library.gd
+++ b/project/src/test/ui/level-select/test-career-level-library.gd
@@ -69,3 +69,54 @@ func test_region_weight_for_distance() -> void:
 		CareerLevelLibrary.region_for_distance(15), 15), 0.55, 0.01)
 	assert_eq(CareerLevelLibrary.region_weight_for_distance(
 		CareerLevelLibrary.region_for_distance(19), 19), 1.0)
+
+
+func test_trim_levels_by_characters_customer() -> void:
+	var all_levels := []
+	all_levels.append(CareerLevel.new())
+	all_levels.back().from_json_dict({
+		"id": "level_211",
+		"customer_ids": ["customer_211"],
+	})
+	all_levels.append(CareerLevel.new())
+	all_levels.back().from_json_dict({
+		"id": "level_212",
+	})
+	
+	var trimmed_levels := CareerLevelLibrary.trim_levels_by_characters(all_levels, [], ["customer_211"])
+	assert_eq(trimmed_levels.size(), 1)
+	assert_eq(trimmed_levels[0].level_id, "level_211")
+
+
+func test_trim_levels_by_characters_chef() -> void:
+	var all_levels := []
+	all_levels.append(CareerLevel.new())
+	all_levels.back().from_json_dict({
+		"id": "level_211",
+		"chef_id": "chef_211",
+	})
+	all_levels.append(CareerLevel.new())
+	all_levels.back().from_json_dict({
+		"id": "level_212",
+	})
+	
+	var trimmed_levels := CareerLevelLibrary.trim_levels_by_characters(all_levels, ["chef_211"], [])
+	assert_eq(trimmed_levels.size(), 1)
+	assert_eq(trimmed_levels[0].level_id, "level_211")
+
+
+func test_trim_levels_by_characters_all() -> void:
+	var all_levels := []
+	all_levels.append(CareerLevel.new())
+	all_levels.back().from_json_dict({
+		"id": "level_211",
+		"chef_id": "chef_211",
+	})
+	all_levels.append(CareerLevel.new())
+	all_levels.back().from_json_dict({
+		"id": "level_212",
+		"customer_ids": ["customer_212"],
+	})
+	
+	var trimmed_levels := CareerLevelLibrary.trim_levels_by_characters(all_levels, ["chef_211"], ["customer_212"])
+	assert_eq(trimmed_levels.size(), 2)


### PR DESCRIPTION
Chatscript now allows cutscenes to specify chefs/customers so they can
be matched up between cutscenes and levels.

When selecting levels in career mode, we now only allow the player to choose
levels featuring creatures from potential upcoming cutscenes.

When selecting a cutscene in career mode, we now only select cutscenes featuring
creatures from the chosen level.