### PR TITLE
Fixed unlock behavior for 'anonymous customer' levels.

### DIFF
--- a/project/src/main/ui/level-select/career-level-library.gd
+++ b/project/src/main/ui/level-select/career-level-library.gd
@@ -176,10 +176,15 @@ func trim_levels_by_characters(levels: Array, chef_ids: Array, customer_ids: Arr
 		trimmed_levels.append_array(levels)
 	else:
 		for level in levels:
-			if level.chef_id in chef_ids:
-				trimmed_levels.append(level)
-			elif level.customer_ids and level.customer_ids[0] in customer_ids:
-				# If a level includes multiple customers, we ignore everything but the first customer. The first
-				# customer is the only creature who appears on the map.
-				trimmed_levels.append(level)
+			if level.chef_id:
+				if level.chef_id in chef_ids:
+					trimmed_levels.append(level)
+			elif level.customer_ids:
+				if level.customer_ids[0] in customer_ids:
+					# If a level includes multiple customers, we ignore everything but the first customer. The first
+					# customer is the only creature who appears on the map.
+					trimmed_levels.append(level)
+			else:
+				if CareerLevel.ANONYMOUS_CUSTOMER in customer_ids:
+					trimmed_levels.append(level)
 	return trimmed_levels

--- a/project/src/test/ui/level-select/test-career-level-library.gd
+++ b/project/src/test/ui/level-select/test-career-level-library.gd
@@ -82,6 +82,10 @@ func test_trim_levels_by_characters_customer() -> void:
 	all_levels.back().from_json_dict({
 		"id": "level_212",
 	})
+	all_levels.append(CareerLevel.new())
+	all_levels.back().from_json_dict({
+		"id": "level_213",
+	})
 	
 	var trimmed_levels := CareerLevelLibrary.trim_levels_by_characters(all_levels, [], ["customer_211"])
 	assert_eq(trimmed_levels.size(), 1)
@@ -99,10 +103,37 @@ func test_trim_levels_by_characters_chef() -> void:
 	all_levels.back().from_json_dict({
 		"id": "level_212",
 	})
+	all_levels.append(CareerLevel.new())
+	all_levels.back().from_json_dict({
+		"id": "level_213",
+	})
 	
 	var trimmed_levels := CareerLevelLibrary.trim_levels_by_characters(all_levels, ["chef_211"], [])
 	assert_eq(trimmed_levels.size(), 1)
 	assert_eq(trimmed_levels[0].level_id, "level_211")
+
+
+func test_trim_levels_by_characters_anonymous_customer() -> void:
+	var all_levels := []
+	all_levels.append(CareerLevel.new())
+	all_levels.back().from_json_dict({
+		"id": "level_211",
+		"chef_id": "chef_211",
+	})
+	all_levels.append(CareerLevel.new())
+	all_levels.back().from_json_dict({
+		"id": "level_212",
+		"customer_ids": ["customer_212"],
+	})
+	all_levels.append(CareerLevel.new())
+	all_levels.back().from_json_dict({
+		"id": "level_213",
+	})
+	
+	var trimmed_levels := CareerLevelLibrary.trim_levels_by_characters(
+			all_levels, [], [CareerLevel.ANONYMOUS_CUSTOMER])
+	assert_eq(trimmed_levels.size(), 1)
+	assert_eq(trimmed_levels[0].level_id, "level_213")
 
 
 func test_trim_levels_by_characters_all() -> void:
@@ -117,6 +148,10 @@ func test_trim_levels_by_characters_all() -> void:
 		"id": "level_212",
 		"customer_ids": ["customer_212"],
 	})
+	all_levels.append(CareerLevel.new())
+	all_levels.back().from_json_dict({
+		"id": "level_213",
+	})
 	
-	var trimmed_levels := CareerLevelLibrary.trim_levels_by_characters(all_levels, ["chef_211"], ["customer_212"])
-	assert_eq(trimmed_levels.size(), 2)
+	var trimmed_levels := CareerLevelLibrary.trim_levels_by_characters(all_levels, [], [])
+	assert_eq(trimmed_levels.size(), 3)


### PR DESCRIPTION
'Anonymous customer' unlock behavior was not working properly, resulting
in no levels appearing once the player got to Diota's story arc