### PR TITLE
ChatTree only accepts one customer, chef.

### DIFF
--- a/project/src/main/ui/chat/career-cutscene-library.gd
+++ b/project/src/main/ui/chat/career-cutscene-library.gd
@@ -91,14 +91,13 @@ func set_career_cutscene_root_path(new_career_cutscene_root_path: String) -> voi
 ##
 ## 	'chef_id': (Optional) The id of a creature who must appear as a chef in the returned cutscenes.
 ##
-## 	'customer_ids': (Optional) A list of string creature ids, where the first id represents a creature who must
-## 		appear as a customer in the returned cutscenes.
+## 	'customer_id': (Optional) The id of a creature who must appear as a customer in the returned cutscenes.
 ##
 ## Returns:
 ## 	A ChatKeyPair defining preroll and postroll cutscenes.
-func next_interlude_chat_key_pair(chat_key_roots: Array, chef_id: String = "", customer_ids: Array = []) \
+func next_interlude_chat_key_pair(chat_key_roots: Array, chef_id: String = "", customer_id: String = "") \
 		-> ChatKeyPair:
-	var potential_chat_key_pairs := potential_chat_key_pairs(chat_key_roots, chef_id, customer_ids)
+	var potential_chat_key_pairs := potential_chat_key_pairs(chat_key_roots, chef_id, customer_id)
 	return Utils.rand_value(potential_chat_key_pairs) if potential_chat_key_pairs else ChatKeyPair.new()
 
 
@@ -113,12 +112,11 @@ func next_interlude_chat_key_pair(chat_key_roots: Array, chef_id: String = "", c
 ##
 ## 	'chef_id': (Optional) The id of a creature who must appear as a chef in the returned cutscenes.
 ##
-## 	'customer_ids': (Optional) A list of string creature ids, where the first id represents a creature who must
-## 		appear as a customer in the returned cutscenes.
+## 	'customer_id': (Optional) The id of a creature who must appear as a customer in the returned cutscenes.
 ##
 ## Returns:
 ## 	A list of ChatKeyPair instances defining preroll and postroll cutscenes.
-func potential_chat_key_pairs(chat_key_roots: Array, chef_id: String = "", customer_ids: Array = []) -> Array:
+func potential_chat_key_pairs(chat_key_roots: Array, chef_id: String = "", customer_id: String = "") -> Array:
 	var exhausted_chat_keys := exhausted_chat_keys(chat_key_roots)
 	var search_flags := CutsceneSearchFlags.new()
 	search_flags.excluded_chat_keys = exhausted_chat_keys
@@ -126,15 +124,15 @@ func potential_chat_key_pairs(chat_key_roots: Array, chef_id: String = "", custo
 	var trimmed_chat_key_pairs := []
 	for potential_chat_key_pair in potential_chat_key_pairs:
 		var accept_chat_key_pair: bool
-		if not chef_id and not customer_ids:
+		if not chef_id and not customer_id:
 			# no criteria specified; accept all chat key pairs
 			accept_chat_key_pair = true
-		elif customer_ids and customer_ids[0] == CareerLevel.ANONYMOUS_CUSTOMER:
+		elif customer_id == CareerLevel.ANONYMOUS_CUSTOMER:
 			# anonymous customer; only accept chat key pairs with no named chefs/customers
 			accept_chat_key_pair = true
 			for chat_key in potential_chat_key_pair.chat_keys():
 				var chat_tree: ChatTree = ChatLibrary.chat_tree_for_key(chat_key)
-				if chat_tree.chef_id or chat_tree.customer_ids:
+				if chat_tree.chef_id or chat_tree.customer_id:
 					accept_chat_key_pair = false
 		else:
 			# only accept chat key pairs with matching chef/customer
@@ -144,8 +142,8 @@ func potential_chat_key_pairs(chat_key_roots: Array, chef_id: String = "", custo
 				if chef_id:
 					if chat_tree.chef_id == chef_id:
 						accept_chat_key_pair = true
-				elif customer_ids:
-					if customer_ids[0] in chat_tree.customer_ids:
+				elif customer_id:
+					if customer_id == chat_tree.customer_id:
 						accept_chat_key_pair = true
 		
 		if accept_chat_key_pair:

--- a/project/src/main/ui/chat/chat-tree.gd
+++ b/project/src/main/ui/chat/chat-tree.gd
@@ -66,9 +66,9 @@ var spawn_locations := {}
 ## cutscenes.
 var chef_id: String
 
-## The creature(s) who acts as the customer(s) for the cutscene, if any. This ensures levels are paired up with
-## appropriate cutscenes.
-var customer_ids := []
+## The creature who acts as the customer for the cutscene, if any. This ensures levels are paired up with appropriate
+## cutscenes.
+var customer_id: String
 
 ## current position in this chat tree
 var _position := Position.new()

--- a/project/src/main/ui/chat/chatscript-parser.gd
+++ b/project/src/main/ui/chat/chatscript-parser.gd
@@ -132,12 +132,16 @@ class CharactersState extends AbstractState:
 		# parse (chef) prefix
 		if character_name.begins_with("(chef)"):
 			character_name = StringUtils.substring_after(character_name, "(chef)").strip_edges()
+			if chat_tree.chef_id:
+				push_warning("Too many chefs: %s" % [character_name])
 			chat_tree.chef_id = character_name
 		
 		# parse (customer) prefix
 		if character_name.begins_with("(customer)"):
 			character_name = StringUtils.substring_after(character_name, "(customer)").strip_edges()
-			chat_tree.customer_ids.append(character_name)
+			if chat_tree.customer_id:
+				push_warning("Too many customers: %s" % [character_name])
+			chat_tree.customer_id = character_name
 		
 		# parse character name
 		if character_name in ["player", "sensei", "narrator"]:

--- a/project/src/main/ui/level-select/career-level-library.gd
+++ b/project/src/main/ui/level-select/career-level-library.gd
@@ -139,11 +139,11 @@ func required_cutscene_characters() -> Dictionary:
 			if chat_tree.chef_id:
 				if not chat_tree.chef_id in chef_ids:
 					chef_ids.append(chat_tree.chef_id)
-			elif chat_tree.customer_ids:
+			elif chat_tree.customer_id:
 				# If a cutscene specifies both a chef AND customer, we ignore the customer. The chef is the only
 				# creature who appears on the map.
-				if not chat_tree.customer_ids[0] in customer_ids:
-					customer_ids.append(chat_tree.customer_ids[0])
+				if not chat_tree.customer_id in customer_ids:
+					customer_ids.append(chat_tree.customer_id)
 			else:
 				if not CareerLevel.ANONYMOUS_CUSTOMER in customer_ids:
 					customer_ids.append(CareerLevel.ANONYMOUS_CUSTOMER)

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -200,22 +200,22 @@ func _interlude_chat_key_pair(career_level: CareerLevel) -> ChatKeyPair:
 	
 	# calculate the chef id/customer ids
 	var chef_id: String
-	var customer_ids: Array
+	var customer_id: String
 	if career_level:
-		if career_level.chef_id or career_level.customer_ids:
+		if career_level.chef_id or career_level.customer_id:
 			chef_id = career_level.chef_id
-			customer_ids = career_level.customer_ids
+			customer_id = career_level.customer_id
 		else:
-			customer_ids = [CareerLevel.ANONYMOUS_CUSTOMER]
+			customer_id = CareerLevel.ANONYMOUS_CUSTOMER
 	
 	if region.cutscene_path:
 		# find a region-specific cutscene
 		result = CareerCutsceneLibrary.next_interlude_chat_key_pair(
-				[region.cutscene_path], chef_id, customer_ids)
+				[region.cutscene_path], chef_id, customer_id)
 	if result.empty():
 		# no region-specific cutscene available; find a general cutscene
 		result = CareerCutsceneLibrary.next_interlude_chat_key_pair(
-				[CareerData.GENERAL_CHAT_KEY_ROOT], chef_id, customer_ids)
+				[CareerData.GENERAL_CHAT_KEY_ROOT], chef_id, customer_id)
 	if not result.empty():
 		result.type = ChatKeyPair.INTERLUDE
 	

--- a/project/src/test/ui/chat/test-career-cutscene-library.gd
+++ b/project/src/test/ui/chat/test-career-cutscene-library.gd
@@ -182,7 +182,7 @@ func test_potential_chat_keys_includes_chef() -> void:
 	]
 	_assert_eq_ckp(CareerCutsceneLibrary.potential_chat_key_pairs([
 		"ui/chat/fake_career_2"
-	], "skins", []), [
+	], "skins"), [
 		# only return scenes with skins as a chef
 		_interlude("ui/chat/fake_career_2/a", ""),
 	])
@@ -197,7 +197,7 @@ func test_potential_chat_keys_includes_customer() -> void:
 	]
 	_assert_eq_ckp(CareerCutsceneLibrary.potential_chat_key_pairs([
 		"ui/chat/fake_career_2"
-	], "", ["rhonk"]), [
+	], "", "rhonk"), [
 		# only return scenes with rhonk as a customer
 		_interlude("ui/chat/fake_career_2/b", ""),
 	])
@@ -212,7 +212,7 @@ func test_potential_chat_keys_includes_unnamed_customers() -> void:
 	]
 	_assert_eq_ckp(CareerCutsceneLibrary.potential_chat_key_pairs([
 		"ui/chat/fake_career_2"
-	], "", [CareerLevel.ANONYMOUS_CUSTOMER]), [
+	], "", CareerLevel.ANONYMOUS_CUSTOMER), [
 		# only return scenes with no named chefs/customers
 		_interlude("ui/chat/fake_career_2/c", ""),
 	])

--- a/project/src/test/ui/chat/test-chatscript-parser.gd
+++ b/project/src/test/ui/chat/test-chatscript-parser.gd
@@ -55,7 +55,7 @@ func test_cutscene_spawn_locations() -> void:
 func test_cutscene_roles() -> void:
 	var chat_tree := _chat_tree_from_file(CUTSCENE_FULL)
 	assert_eq(chat_tree.chef_id, "skins")
-	assert_eq(chat_tree.customer_ids, ["rhonk"])
+	assert_eq(chat_tree.customer_id, "rhonk")
 
 
 func test_cutscene_chat() -> void:


### PR DESCRIPTION
ChatTree accepted one chef id, but multiple customer ids before -- but,
only one customer id was actually used. It now only stores one customer
id.

Chatscript parser now warns if a chatscript file declares more than one
chef or customer.