### PR TITLE
Refactor: Extracted CareerCalendar, CareerFlow

### DIFF
--- a/project/src/main/career-calendar.gd
+++ b/project/src/main/career-calendar.gd
@@ -1,0 +1,113 @@
+## Advances the calendar and clock in career mode.
+
+var career_data: CareerData
+
+func _init(init_career_data: CareerData) -> void:
+	career_data = init_career_data
+
+
+## Advances the clock and advances the player the specified distance.
+##
+## Even if new_distance_earned is a large number, the player's travel distance can be limited in two scenarios:
+##
+## 1. If they just played a non-boss level, they cannot advance past a boss level they haven't cleared.
+##
+## 2. If they just played a boss level, they cannot advance without meeting its success criteria.
+##
+## Parameters:
+## 	'new_distance_earned': The maximum distance the player will travel.
+##
+## 	'success': 'True' if the player met the success criteria for the current level.
+func advance_clock(new_distance_earned: int, success: bool) -> void:
+	career_data.distance_earned = new_distance_earned
+	career_data.skipped_previous_level = false
+	
+	career_data.hours_passed += 1
+	
+	if career_data.is_boss_level():
+		var boss_region: CareerRegion = CareerLevelLibrary.region_for_distance(career_data.distance_travelled)
+		if success:
+			# if they pass a boss level, update max_distance_travelled to mark the region as cleared
+			career_data.max_distance_travelled = boss_region.distance + boss_region.length
+		else:
+			# if they fail a boss level, they lose 1-2 days worth of progress
+			career_data.distance_earned = -int(max(boss_region.length * rand_range(0.125, 0.25), 2))
+	
+	if career_data.distance_earned > 0:
+		# if they make forward progress, they also spend their banked steps
+		career_data.distance_earned += career_data.banked_steps
+		career_data.banked_steps = 0
+	
+	var unapplied_distance_earned := career_data.distance_earned
+	while unapplied_distance_earned != 0:
+		unapplied_distance_earned = _apply_distance_earned(unapplied_distance_earned)
+
+
+## Apply some of the player's distance earned, either advancing the player or banking the steps for later.
+##
+## This only applies a small chunk of the player's distance earned, stopping at region boundaries. It should be called
+## iteratively until it returns zero.
+##
+## Parameters:
+## 	'unapplied_distance_earned': The amount of distance_earned which hasn't been applied to advance the player, or
+## 		banked for later.
+##
+## Returns:
+## 	The remaining amount of the player's distance earned, after applying some of it toward advancing the player or
+## 		banking the steps for later.
+func _apply_distance_earned(unapplied_distance_earned: int) -> int:
+	var region: CareerRegion = CareerLevelLibrary.region_for_distance(career_data.distance_travelled)
+	var newly_banked_steps := 0
+	var newly_travelled_distance := unapplied_distance_earned
+	
+	if not career_data.is_region_cleared(region) and region.intro_level \
+			and not career_data.is_intro_level_finished(region):
+		# The player can't advance further into this region, they haven't cleared its intro level. Move them to
+		# the start of the region and forbid movement.
+		newly_banked_steps = unapplied_distance_earned
+	elif career_data.distance_travelled + unapplied_distance_earned >= region.distance + region.length:
+		# The player is trying to cross into the next region
+		var distance_to_next_region := region.distance + region.length - career_data.distance_travelled
+		if career_data.is_region_cleared(region):
+			# The player can cross into the next region. Move them to the start of the next region and allow
+			# movement.
+			newly_travelled_distance = distance_to_next_region
+		else:
+			# The player can't cross into the next region, they haven't cleared the boss level. Move them to the end
+			# of this region and forbid movement.
+			newly_banked_steps = unapplied_distance_earned - distance_to_next_region + 1
+	
+	# if the player hit a wall, we bank their steps and don't move them as far this time
+	career_data.banked_steps += newly_banked_steps
+	newly_travelled_distance -= newly_banked_steps
+	unapplied_distance_earned -= newly_banked_steps
+	
+	career_data.distance_travelled += newly_travelled_distance
+	unapplied_distance_earned -= newly_travelled_distance
+	
+	return unapplied_distance_earned
+
+
+## Advances the calendar day and resets all daily variables.
+func advance_calendar() -> void:
+	career_data.prev_daily_earnings.push_front(career_data.daily_earnings)
+	if career_data.prev_daily_earnings.size() > CareerData.MAX_DAILY_HISTORY:
+		career_data.prev_daily_earnings = career_data.prev_daily_earnings.slice(0, CareerData.MAX_DAILY_HISTORY - 1)
+	
+	career_data.max_distance_travelled = max(career_data.max_distance_travelled, career_data.distance_travelled)
+	career_data.prev_distance_travelled.push_front(career_data.distance_travelled)
+	if career_data.prev_distance_travelled.size() > CareerData.MAX_DAILY_HISTORY:
+		career_data.prev_distance_travelled = career_data.prev_distance_travelled.slice(0, CareerData.MAX_DAILY_HISTORY - 1)
+	
+	career_data.banked_steps = 0
+	career_data.distance_earned = 0
+	career_data.hours_passed = 0
+	career_data.daily_customers = 0
+	career_data.daily_earnings = 0
+	career_data.daily_level_ids.clear()
+	career_data.daily_seconds_played = 0.0
+	career_data.daily_steps = 0
+	career_data.day = min(career_data.day + 1, CareerData.MAX_DAY)
+	
+	# Put the player at the start of their current region and trigger the 'distance_travelled_changed' signal
+	career_data.distance_travelled = CareerLevelLibrary.region_for_distance(career_data.distance_travelled).distance

--- a/project/src/main/career-flow.gd
+++ b/project/src/main/career-flow.gd
@@ -1,0 +1,81 @@
+## Maintains the flow of scenes in career mode. Redirects the player to cutscenes, victory screens and interludes.
+
+var career_data: CareerData
+
+func _init(init_career_data: CareerData) -> void:
+	career_data = init_career_data
+
+
+## Launches the next scene in career mode. Either a new level, or a cutscene/ending scene.
+func push_career_trail() -> void:
+	# Purge any puzzle or cutscene scenes from trail before changing the scene.
+	while Breadcrumb.trail.front() != Global.SCENE_CAREER_MAP:
+		Breadcrumb.trail.pop_front()
+	
+	var redirected := false
+	if not redirected and not CutsceneQueue.is_queue_empty():
+		# If there are pending puzzles/cutscenes, show them.
+		
+		# If the player is playing a puzzle, we immediately apply failure penalties to the player's save data so they
+		# can't quit and retry.
+		if CutsceneQueue.is_front_level():
+			_preapply_failure_penalties()
+		
+		CutsceneQueue.push_trail()
+		redirected = true
+	
+	if not redirected and career_data.should_play_prologue():
+		# If they haven't seen the region's prologue cutscene, we show it.
+		var region: CareerRegion = CareerLevelLibrary.region_for_distance(career_data.distance_travelled)
+		var prologue_chat_key: String = region.get_prologue_chat_key()
+		CurrentCutscene.set_launched_cutscene(prologue_chat_key)
+		CurrentCutscene.push_cutscene_trail()
+		redirected = true
+	
+	if not redirected and career_data.is_day_over():
+		# After the final level, we show a 'you win' screen.
+		SceneTransition.replace_trail("res://src/main/ui/career/CareerWin.tscn")
+		redirected = true
+	
+	if not redirected:
+		# After a puzzle (or any other scene), we go back to the career map.
+		SceneTransition.change_scene()
+
+
+## Updates the state of career mode based on the player's puzzle performance.
+##
+## If the player skips or fails a level, this has consequences including skipping cutscenes and advancing the clock.
+func process_puzzle_result() -> void:
+	var skip_remaining_cutscenes := false
+	if not PuzzleState.game_ended:
+		# player skipped a level
+		skip_remaining_cutscenes = true
+		career_data.advance_clock(0, false)
+		career_data.skipped_previous_level = true
+	
+	if CutsceneQueue.has_cutscene_flag("intro_level") \
+			and not CurrentLevel.best_result in [Levels.Result.FINISHED, Levels.Result.WON]:
+		# player lost an intro level
+		skip_remaining_cutscenes = true
+	
+	if CutsceneQueue.has_cutscene_flag("boss_level") \
+			and not CurrentLevel.best_result == Levels.Result.WON:
+		# player didn't meet the win criteria for a boss level
+		skip_remaining_cutscenes = true
+	
+	if skip_remaining_cutscenes:
+		# skip career cutscenes if they skip a level, or if they fail a boss level
+		CutsceneQueue.reset()
+
+
+## Applies penalties for skipping a level to the player's save data, so they can't quit and retry.
+func _preapply_failure_penalties() -> void:
+	var temp_distance_earned := career_data.distance_earned
+	var temp_distance_travelled := career_data.distance_travelled
+	var temp_hours_passed := career_data.hours_passed
+	career_data.advance_clock(0, false)
+	career_data.skipped_previous_level = true
+	PlayerSave.save_player_data()
+	career_data.distance_earned = temp_distance_earned
+	career_data.distance_travelled = temp_distance_travelled
+	career_data.hours_passed = temp_hours_passed


### PR DESCRIPTION
CareerData was getting quite large and had logic for advancing the
calendar, deciding which cutscenes should play, deciding when to skip
cutscenes. Some of this logic has been split off into new 'CareerData'
and 'CareerFlow' scripts.