### PR TITLE
Simplified cutscene-world script.

### DIFF
--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -28,7 +28,7 @@ const MAX_INPLACE_CHAT_DISTANCE := 600
 var chatters := []
 
 ## If 'true' the overworld is being used to play a cutscene. If 'false' the overworld is allowing free roam.
-var cutscene := false
+export (bool) var cutscene := false
 
 var _show_version := true setget set_show_version, is_show_version
 

--- a/project/src/main/world/Cutscene.tscn
+++ b/project/src/main/world/Cutscene.tscn
@@ -42,3 +42,4 @@ script = ExtResource( 3 )
 
 [node name="Ui" parent="." instance=ExtResource( 5 )]
 script = ExtResource( 4 )
+cutscene = true

--- a/project/src/main/world/creature/player.gd
+++ b/project/src/main/world/creature/player.gd
@@ -2,11 +2,11 @@ class_name Player
 extends Creature
 ## Script for manipulating the player-controlled character in the overworld.
 
-## If 'true' the player cannot move. Used during cutscenes.
-var input_disabled := false
-
 ## if 'true' the ui has focus, and the player shouldn't move.
 var ui_has_focus := false setget set_ui_has_focus
+
+## Cannot statically type as 'OverworldUi' because of circular reference
+onready var _overworld_ui: Node = Global.get_overworld_ui()
 
 func _ready() -> void:
 	SceneTransition.connect("fade_out_started", self, "_on_SceneTransition_fade_out_started")
@@ -15,7 +15,8 @@ func _ready() -> void:
 
 
 func _unhandled_input(_event: InputEvent) -> void:
-	if input_disabled or ui_has_focus:
+	if _overworld_ui.cutscene or ui_has_focus:
+		# disable movement input during cutscenes, or when navigating menus
 		return
 	
 	if Utils.walk_pressed_dir(_event) or Utils.walk_released_dir(_event):

--- a/project/src/main/world/creature/sensei.gd
+++ b/project/src/main/world/creature/sensei.gd
@@ -8,8 +8,8 @@ extends Creature
 const TOO_CLOSE_THRESHOLD := 140.0
 const TOO_FAR_THRESHOLD := 280.0
 
-## If 'true' the sensei cannot move. Used during cutscenes.
-var movement_disabled := false
+## Cannot statically type as 'OverworldUi' because of circular reference
+onready var _overworld_ui: Node = Global.get_overworld_ui()
 
 func _ready() -> void:
 	set_creature_id(CreatureLibrary.SENSEI_ID)
@@ -17,7 +17,8 @@ func _ready() -> void:
 
 
 func _on_MoveTimer_timeout() -> void:
-	if movement_disabled:
+	if _overworld_ui.cutscene:
+		# disable movement during cutscenes
 		return
 	
 	var player_relative_pos: Vector2 = Global.from_iso(ChattableManager.player.position - position)

--- a/project/src/main/world/cutscene-world.gd
+++ b/project/src/main/world/cutscene-world.gd
@@ -27,13 +27,6 @@ func prepare_environment_resource() -> void:
 ##
 ## Replaces the environment's creatures with those necessary for the cutscene and plays the cutscene's chat tree.
 func _launch_cutscene() -> void:
-	var overworld_ui := Global.get_overworld_ui()
-	overworld_ui.cutscene = true
-	if ChattableManager.player is Player:
-		ChattableManager.player.input_disabled = true
-	if ChattableManager.sensei is Sensei:
-		ChattableManager.sensei.movement_disabled = true
-	
 	_remove_all_creatures()
 	_add_level_creature()
 	_add_cutscene_creatures()


### PR DESCRIPTION
OverworldUi's cutscene flag is now togglable in the editor, eliminating a line
of code from the cutscene-world script.

player.gd and sensei.gd scripts now disable their logic by polling
the OverworldUi.cutscene flag directly, eliminating a few lines of code
from the cutscene-world script.