### PR TITLE
Refactor: Benchmarks, greetiness

### DIFF
--- a/project/src/demo/puzzle/PuzzleDemo.tscn
+++ b/project/src/demo/puzzle/PuzzleDemo.tscn
@@ -5,6 +5,6 @@
 
 [node name="PuzzleDemo" type="Node"]
 script = ExtResource( 2 )
-level_path = "res://assets/main/puzzle/levels/tutorial/cakes-0.json"
+level_path = "res://assets/main/puzzle/levels/practice/sprint-normal.json"
 
 [node name="Puzzle" parent="." instance=ExtResource( 1 )]

--- a/project/src/demo/world/restaurant/restaurant-view-demo.gd
+++ b/project/src/demo/world/restaurant/restaurant-view-demo.gd
@@ -45,7 +45,6 @@ func _input(event: InputEvent) -> void:
 			_customer().creature_name = NAMES[_current_name_index]
 			_player().creature_name = NAMES[_current_name_index]
 		KEY_V:
-			Global.greetiness = 2
 			_customer().get_node("CreatureSfx").play_goodbye_voice()
 		KEY_0, KEY_1, KEY_2, KEY_3, KEY_4, KEY_5, KEY_6, KEY_7, KEY_8, KEY_9:
 			if Input.is_key_pressed(KEY_SHIFT):

--- a/project/src/main/global.gd
+++ b/project/src/main/global.gd
@@ -35,23 +35,12 @@ const FATNESSES := [
 ## The factor to multiply by to convert non-isometric coordinates into isometric coordinates
 const ISO_FACTOR := Vector2(1.0, 0.5)
 
-## Target number of creature greetings (hello, goodbye) per minute
-const GREETINGS_PER_MINUTE := 3.0
-
 ## Stores all of the benchmarks which have been started
 var _benchmark_start_times := Dictionary()
-
-## A number in the range [-1, 1] which corresponds to how many greetings we've given recently. If it's close to 1,
-## we're very unlikely to receive a greeting. If it's close to -1, we're very likely to receive a greeting.
-var greetiness := 0.0
 
 func _init() -> void:
 	# ensure music, pieces are random
 	randomize()
-
-
-func _process(delta: float) -> void:
-	greetiness = clamp(greetiness + delta * GREETINGS_PER_MINUTE / 60, -1.0, 1.0)
 
 
 ## Convert a coordinate from global coordinates to isometric (squashed) coordinates
@@ -67,7 +56,7 @@ static func from_iso(vector: Vector2) -> Vector2:
 ## Sets the start time for a benchmark. Calling 'benchmark_start(foo)' and 'benchmark_finish(foo)' will display a
 ## message like 'foo took 123 milliseconds'.
 func benchmark_start(key: String = "") -> void:
-	_benchmark_start_times[key] = OS.get_ticks_msec()
+	_benchmark_start_times[key] = OS.get_ticks_usec()
 
 
 ## Prints the amount of time which has passed since a benchmark was started. Calling 'benchmark_start(foo)' and
@@ -76,22 +65,7 @@ func benchmark_end(key: String = "") -> void:
 	if not _benchmark_start_times.has(key):
 		print("Invalid benchmark: %s" % key)
 		return
-	print("benchmark %s: %.3f msec" % [key, (OS.get_ticks_msec() - _benchmark_start_times[key])])
-
-
-## Returns 'true' if the creature should greet us. We calculate this based on how many times we've been greeted
-## recently.
-##
-## Novice players or fast players won't mind receiving a lot of sounds related to combos because those sounds are
-## associated with positive reinforcement (big combos), but they could get annoyed if creatures say hello/goodbye too
-## frequently because those sounds are associated with negative reinforcement (broken combos).
-func should_chat() -> bool:
-	var should_chat := true
-	if greetiness + randf() > 1.0:
-		greetiness -= 1.0 / GREETINGS_PER_MINUTE
-	else:
-		should_chat = false
-	return should_chat
+	print("benchmark %s: %.3f msec" % [key, (OS.get_ticks_usec() - _benchmark_start_times[key]) / 1000.0])
 
 
 func get_overworld_ui() -> OverworldUi:

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -27,7 +27,7 @@ func _ready() -> void:
 	for i in range(3):
 		_restaurant_view.summon_creature(i)
 	
-	get_customer().play_hello_voice(true)
+	get_customer().play_hello_voice()
 	
 	if CurrentLevel.settings.other.skip_intro:
 		$PuzzleMusicManager.start_puzzle_music()

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -25,6 +25,7 @@ onready var _customer_view_viewport := $CustomerView/Viewport
 onready var _customer_view := $CustomerView
 onready var _restaurant_nametag_panel := $RestaurantNametag/Panel
 onready var _restaurant_viewport_scene := $RestaurantViewport/Scene
+onready var _hello_timer := $HelloTimer
 
 func _ready() -> void:
 	# Godot doesn't like when ViewportContainers have a different size from their Viewport, so we can't set
@@ -40,6 +41,7 @@ func _ready() -> void:
 	get_chef().connect("creature_name_changed", self, "_on_Chef_creature_name_changed")
 	for customer in get_customers():
 		customer.connect("creature_name_changed", self, "_on_Customer_creature_name_changed")
+		customer.connect("dna_loaded", self, "_on_Customer_dna_loaded", [customer])
 	_refresh_chef_name()
 	_refresh_customer_name()
 
@@ -162,7 +164,7 @@ func _on_PuzzleState_combo_changed(value: int) -> void:
 	if PuzzleState.no_more_customers:
 		pass
 	elif PuzzleState.game_active:
-		get_customer().play_goodbye_voice()
+		_hello_timer.maybe_play_goodbye_voice(get_customer())
 		scroll_to_new_creature()
 	
 	# losing your combo doesn't erase the 'recent bonus' value, but decreases it a lot
@@ -215,3 +217,7 @@ func _on_Customer_creature_name_changed() -> void:
 
 func _on_RestaurantScene_current_creature_index_changed(_value: int) -> void:
 	_refresh_customer_name()
+
+
+func _on_Customer_dna_loaded(customer: Creature) -> void:
+	_hello_timer.maybe_play_hello_voice(customer)

--- a/project/src/main/world/creature/Creature.tscn
+++ b/project/src/main/world/creature/Creature.tscn
@@ -369,12 +369,8 @@ stream = ExtResource( 5 )
 volume_db = -4.0
 bus = "Sound Bus"
 
-[node name="HelloTimer" type="Timer" parent="CreatureSfx"]
-one_shot = true
-
 [node name="SuppressSfxTimer" type="Timer" parent="CreatureSfx"]
 one_shot = true
-autostart = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource( 1 )
@@ -382,8 +378,6 @@ script = ExtResource( 8 )
 
 [node name="FadeTween" type="Tween" parent="."]
 
-[connection signal="dna_loaded" from="." to="CreatureSfx" method="_on_Creature_dna_loaded"]
 [connection signal="food_eaten" from="." to="CreatureSfx" method="_on_Creature_food_eaten"]
 [connection signal="landed" from="." to="CreatureSfx" method="_on_Creature_landed"]
-[connection signal="timeout" from="CreatureSfx/HelloTimer" to="CreatureSfx" method="_on_HelloTimer_timeout"]
 [connection signal="timeout" from="CreatureSfx/SuppressSfxTimer" to="CreatureSfx" method="_on_SuppressSfxTimer_timeout"]

--- a/project/src/main/world/creature/creature-sfx.gd
+++ b/project/src/main/world/creature/creature-sfx.gd
@@ -69,14 +69,13 @@ onready var _munch_sound := $MunchSound
 onready var _hop_sound := $HopSound
 onready var _bonk_sound := $BonkSound
 
-onready var _hello_timer := $HelloTimer
 onready var _suppress_sfx_timer := $SuppressSfxTimer
 
 func _ready() -> void:
 	_refresh_should_play_sfx()
 
 
-## Plays a 'mmm!' voice sample, for when a player builds a big combo.
+## Plays a 'mmm!' voice sample for when a player builds a big combo.
 func play_combo_voice() -> void:
 	if not should_play_sfx:
 		return
@@ -86,24 +85,22 @@ func play_combo_voice() -> void:
 	_voice_player.play()
 
 
-## Plays a 'hello!' voice sample, for when a creature enters the restaurant
-func play_hello_voice(force: bool = false) -> void:
+## Plays a 'hello!' voice sample for when a creature enters the restaurant.
+func play_hello_voice() -> void:
 	if not should_play_sfx:
 		return
 	
-	if Global.should_chat() or force:
-		_voice_player.stream = Utils.rand_value(hello_voices)
-		_voice_player.play()
+	_voice_player.stream = Utils.rand_value(hello_voices)
+	_voice_player.play()
 
 
-## Plays a 'check please!' voice sample, for when a creature is ready to leave
-func play_goodbye_voice(force: bool = false) -> void:
+## Plays a 'check please!' voice sample for when a creature is ready to leave.
+func play_goodbye_voice() -> void:
 	if not should_play_sfx:
 		return
 	
-	if Global.should_chat() or force:
-		_voice_player.stream = Utils.rand_value(_goodbye_voices)
-		_voice_player.play()
+	_voice_player.stream = Utils.rand_value(_goodbye_voices)
+	_voice_player.play()
 
 
 func play_bonk_sound() -> void:
@@ -175,19 +172,8 @@ func _on_Creature_food_eaten(_food_type: int) -> void:
 	_munch_sound.play()
 
 
-func _on_Creature_dna_loaded() -> void:
-	if not should_play_sfx:
-		return
-	
-	_hello_timer.start()
-
-
 func _on_Creature_landed() -> void:
 	play_hop_sound()
-
-
-func _on_HelloTimer_timeout() -> void:
-	play_hello_voice()
 
 
 func _on_SuppressSfxTimer_timeout() -> void:

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -302,22 +302,19 @@ func save_fatness(stored_fatness: float) -> void:
 	PlayerData.creature_library.set_fatness(creature_id, stored_fatness)
 
 
-## Plays a 'hello!' voice sample, for when a creature enters the restaurant
-func play_hello_voice(force: bool = false) -> void:
-	if not suppress_sfx:
-		_creature_sfx.play_hello_voice(force)
+## Plays a 'hello!' voice sample for when a creature enters the restaurant.
+func play_hello_voice() -> void:
+	_creature_sfx.play_hello_voice()
 
 
-## Plays a 'mmm!' voice sample, for when a player builds a big combo.
+## Plays a 'mmm!' voice sample for when a player builds a big combo.
 func play_combo_voice() -> void:
-	if not suppress_sfx:
-		_creature_sfx.play_combo_voice()
+	_creature_sfx.play_combo_voice()
 
 
-## Plays a 'check please!' voice sample, for when a creature is ready to leave
-func play_goodbye_voice(force: bool = false) -> void:
-	if not suppress_sfx:
-		_creature_sfx.play_goodbye_voice(force)
+## Plays a 'check please!' voice sample for when a creature is ready to leave.
+func play_goodbye_voice() -> void:
+	_creature_sfx.play_goodbye_voice()
 
 
 ## Parameters:

--- a/project/src/main/world/restaurant/RestaurantView.tscn
+++ b/project/src/main/world/restaurant/RestaurantView.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=17 format=2]
 
 [ext_resource path="res://src/main/world/restaurant/chef-camera-mover.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/restaurant/RestaurantScene.tscn" type="PackedScene" id=2]
@@ -11,6 +11,7 @@
 [ext_resource path="res://src/main/world/restaurant/customer-camera-mover.gd" type="Script" id=9]
 [ext_resource path="res://src/main/world/restaurant/RestaurantNametagPanel.tscn" type="PackedScene" id=10]
 [ext_resource path="res://src/main/world/restaurant/LayoutContainer.tscn" type="PackedScene" id=11]
+[ext_resource path="res://src/main/world/restaurant/hello-timer.gd" type="Script" id=12]
 
 [sub_resource type="Animation" id=1]
 resource_name = "fat-se"
@@ -217,6 +218,11 @@ margin_left = -60.0
 margin_right = 60.0
 custom_styles/panel = SubResource( 4 )
 
+[node name="HelloTimer" type="Timer" parent="."]
+one_shot = true
+script = ExtResource( 12 )
+
+[connection signal="timeout" from="HelloTimer" to="HelloTimer" method="_on_timeout"]
 [connection signal="current_creature_index_changed" from="RestaurantViewport/Scene" to="." method="_on_RestaurantScene_current_creature_index_changed"]
 [connection signal="current_creature_index_changed" from="RestaurantViewport/Scene" to="CustomerCameraMover" method="_on_RestaurantScene_current_creature_index_changed"]
 [connection signal="food_eaten" from="RestaurantViewport/Scene" to="CustomerCameraMover" method="_on_RestaurantScene_food_eaten"]

--- a/project/src/main/world/restaurant/hello-timer.gd
+++ b/project/src/main/world/restaurant/hello-timer.gd
@@ -1,0 +1,59 @@
+extends Timer
+## Manages creature greetings (hello, goodbye) and ensures they don't happen too frequently.
+
+## Target number of creature greetings (hello, goodbye) per minute
+const GREETINGS_PER_MINUTE := 3.0
+
+## The creature who is about to say hello. We use a weak reference to avoid playing sound effects for creatures who
+## leave the scene tree.
+##
+## Ref: (Creature) The creature who is about to say hello.
+var _hello_customer_ref: WeakRef
+
+## A number in the range [-1, 1] which corresponds to how many greetings we've given recently. If it's close to 1,
+## we're very unlikely to receive a greeting. If it's close to -1, we're very likely to receive a greeting.
+var greetiness := 0.0
+
+func _process(delta: float) -> void:
+	greetiness = clamp(greetiness + delta * GREETINGS_PER_MINUTE / 60, -1.0, 1.0)
+
+
+## Returns 'true' if the creature should greet us. We calculate this based on how many times we've been greeted
+## recently.
+##
+## Novice players or fast players won't mind receiving a lot of sounds related to combos because those sounds are
+## associated with positive reinforcement (big combos), but they could get annoyed if creatures say hello/goodbye too
+## frequently because those sounds are associated with negative reinforcement (broken combos).
+func _should_chat() -> bool:
+	var _should_chat := true
+	if greetiness + randf() > 1.0:
+		greetiness -= 1.0 / GREETINGS_PER_MINUTE
+	else:
+		_should_chat = false
+	return _should_chat
+
+
+## Conditionally schedules a 'hello!' voice sample for when a creature enters the restaurant.
+##
+## If there have been too many greetings recently, the 'hello!' voice sample is not scheduled.
+func maybe_play_hello_voice(customer: Creature) -> void:
+	if _should_chat():
+		_hello_customer_ref = weakref(customer)
+		start()
+
+
+## Conditionally plays a 'check please!' voice sample for when a creature is ready to leave.
+##
+## If there have been too many greetings recently, the 'goodbye' voice sample is not played.
+func maybe_play_goodbye_voice(customer: Creature) -> void:
+	if _should_chat():
+		customer.play_goodbye_voice()
+
+
+func _on_timeout() -> void:
+	var customer: Creature
+	if _hello_customer_ref:
+		customer = _hello_customer_ref.get_ref()
+	if customer:
+		customer.play_hello_voice()
+		_hello_customer_ref = null


### PR DESCRIPTION
Improved benchmark accuracy -- it was weirdly printing '3.000 msec',
giving the impression that it had microsecond accuracy while still
relying on milliseconds. It now relies on microseconds.

Moved greetiness logic from Global into RestaurantView. Moved HelloTimer from
Creature into RestaurantView.