### PR TITLE
Refactor: Extracted CareerData.current_region() methods.

### DIFF
--- a/project/src/main/career-calendar.gd
+++ b/project/src/main/career-calendar.gd
@@ -25,7 +25,7 @@ func advance_clock(new_distance_earned: int, success: bool) -> void:
 	career_data.hours_passed += 1
 	
 	if career_data.is_boss_level():
-		var boss_region: CareerRegion = CareerLevelLibrary.region_for_distance(career_data.distance_travelled)
+		var boss_region: CareerRegion = career_data.current_region()
 		if success:
 			# if they pass a boss level, update max_distance_travelled to mark the region as cleared
 			career_data.max_distance_travelled = boss_region.distance + boss_region.length
@@ -56,7 +56,7 @@ func advance_clock(new_distance_earned: int, success: bool) -> void:
 ## 	The remaining amount of the player's distance earned, after applying some of it toward advancing the player or
 ## 		banking the steps for later.
 func _apply_distance_earned(unapplied_distance_earned: int) -> int:
-	var region: CareerRegion = CareerLevelLibrary.region_for_distance(career_data.distance_travelled)
+	var region: CareerRegion = career_data.current_region()
 	var newly_banked_steps := 0
 	var newly_travelled_distance := unapplied_distance_earned
 	
@@ -110,4 +110,4 @@ func advance_calendar() -> void:
 	career_data.day = min(career_data.day + 1, CareerData.MAX_DAY)
 	
 	# Put the player at the start of their current region and trigger the 'distance_travelled_changed' signal
-	career_data.distance_travelled = CareerLevelLibrary.region_for_distance(career_data.distance_travelled).distance
+	career_data.distance_travelled = career_data.current_region().distance

--- a/project/src/main/career-data.gd
+++ b/project/src/main/career-data.gd
@@ -175,8 +175,28 @@ func push_career_trail() -> void:
 	_career_flow.push_career_trail()
 
 
+## Returns the career region the player is currently in.
+func current_region() -> CareerRegion:
+	return CareerLevelLibrary.region_for_distance(distance_travelled)
+
+
+## Returns the career region before the region the player is currently in, or the first region if the player is still
+## in the first region.
+func prev_region() -> CareerRegion:
+	var current_region := current_region()
+	return CareerLevelLibrary.region_for_distance(current_region.distance - 1)
+
+
+## Returns the career region after the region the player is currently in, or the last region if the player is in the
+## last region.
+func next_region() -> CareerRegion:
+	var current_region := current_region()
+	return CareerLevelLibrary.region_for_distance(current_region.distance + current_region.length)
+
+
+## Returns 'true' if the current career region has a prologue the player hasn't seen.
 func should_play_prologue() -> bool:
-	var region: CareerRegion = CareerLevelLibrary.region_for_distance(distance_travelled)
+	var region: CareerRegion = current_region()
 	var prologue_chat_key: String = region.get_prologue_chat_key()
 	return ChatLibrary.chat_exists(prologue_chat_key) \
 			and not PlayerData.chat_history.is_chat_finished(prologue_chat_key)
@@ -200,7 +220,7 @@ func is_region_cleared(region: CareerRegion) -> bool:
 ## Returns 'true' if the current career mode distance corresponds to an uncleared boss level
 func is_boss_level() -> bool:
 	var result := true
-	var region: CareerRegion = CareerLevelLibrary.region_for_distance(distance_travelled)
+	var region: CareerRegion = current_region()
 	if distance_travelled != region.distance + region.length - 1:
 		# the player is not at the end of the region
 		result = false
@@ -216,7 +236,7 @@ func is_boss_level() -> bool:
 ## Returns 'true' if the current career mode distance corresponds to an uncleared intro level
 func is_intro_level() -> bool:
 	var result := true
-	var region: CareerRegion = CareerLevelLibrary.region_for_distance(distance_travelled)
+	var region: CareerRegion = current_region()
 	if not region.intro_level:
 		result = false
 	elif is_intro_level_finished(region):
@@ -262,7 +282,7 @@ func distance_penalties() -> Array:
 	else: result[1] = 2
 	
 	# penalties can never take you into a previous region
-	var max_penalty: int = distance_travelled - CareerLevelLibrary.region_for_distance(distance_travelled).distance
+	var max_penalty: int = distance_travelled - current_region().distance
 	for i in range(result.size()):
 		result[i] = min(result[i], max_penalty)
 	
@@ -309,7 +329,7 @@ func set_hours_passed(new_hours_passed: int) -> void:
 
 ## When an epilogue cutscene is played, we advance the player to the next region
 func _on_CurrentCutscene_cutscene_played(chat_key: String) -> void:
-	var region: CareerRegion = CareerLevelLibrary.region_for_distance(distance_travelled)
+	var region: CareerRegion = current_region()
 	if chat_key == region.get_epilogue_chat_key():
 		# advance the player to the next region
 		var old_distance_travelled := distance_travelled

--- a/project/src/main/career-flow.gd
+++ b/project/src/main/career-flow.gd
@@ -26,7 +26,7 @@ func push_career_trail() -> void:
 	
 	if not redirected and career_data.should_play_prologue():
 		# If they haven't seen the region's prologue cutscene, we show it.
-		var region: CareerRegion = CareerLevelLibrary.region_for_distance(career_data.distance_travelled)
+		var region: CareerRegion = career_data.current_region()
 		var prologue_chat_key: String = region.get_prologue_chat_key()
 		CurrentCutscene.set_launched_cutscene(prologue_chat_key)
 		CurrentCutscene.push_cutscene_trail()

--- a/project/src/main/ui/career/career-distance.gd
+++ b/project/src/main/ui/career/career-distance.gd
@@ -23,9 +23,9 @@ func _refresh_buttons() -> void:
 		_down_button.disabled = true
 		_up_button.disabled = true
 	
-	var curr_region: CareerRegion = CareerLevelLibrary.region_for_distance(PlayerData.career.distance_travelled)
-	var next_region: CareerRegion = CareerLevelLibrary.region_for_distance(curr_region.distance + curr_region.length)
-	var prev_region: CareerRegion = CareerLevelLibrary.region_for_distance(curr_region.distance - 1)
+	var curr_region: CareerRegion = PlayerData.career.current_region()
+	var next_region: CareerRegion = PlayerData.career.next_region()
+	var prev_region: CareerRegion = PlayerData.career.prev_region()
 	
 	if next_region == curr_region or next_region.distance > PlayerData.career.max_distance_travelled:
 		# disable the up button; the player is at their maximum distance
@@ -41,15 +41,15 @@ func _refresh_buttons() -> void:
 
 func _on_Down_pressed() -> void:
 	# set our distance to the start of the previous region
-	var curr_region: CareerRegion = CareerLevelLibrary.region_for_distance(PlayerData.career.distance_travelled)
-	var prev_region: CareerRegion = CareerLevelLibrary.region_for_distance(curr_region.distance - 1)
+	var curr_region: CareerRegion = PlayerData.career.current_region()
+	var prev_region: CareerRegion = PlayerData.career.prev_region()
 	PlayerData.career.distance_travelled = prev_region.distance
 
 
 func _on_Up_pressed() -> void:
 	# set our distance to the start of the next region
-	var curr_region: CareerRegion = CareerLevelLibrary.region_for_distance(PlayerData.career.distance_travelled)
-	var next_region: CareerRegion = CareerLevelLibrary.region_for_distance(curr_region.distance + curr_region.length)
+	var curr_region: CareerRegion = PlayerData.career.current_region()
+	var next_region: CareerRegion = PlayerData.career.next_region()
 	PlayerData.career.distance_travelled = next_region.distance
 
 

--- a/project/src/main/ui/career/career-map-ui.gd
+++ b/project/src/main/ui/career/career-map-ui.gd
@@ -11,7 +11,7 @@ func _force_cutscene() -> bool:
 	PlayerData.career.hours_passed = CareerData.CAREER_INTERLUDE_HOURS[0]
 	PlayerData.career.skipped_previous_level = false
 	
-	var region := CareerLevelLibrary.region_for_distance(PlayerData.career.distance_travelled)
+	var region := PlayerData.career.current_region()
 	var chat_key_pair := ChatKeyPair.new()
 	if region.cutscene_path:
 		# find a region-specific cutscene

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -61,7 +61,7 @@ func _load_level_settings() -> void:
 	_pickable_level_settings.clear()
 	_pickable_career_levels.clear()
 	
-	var region: CareerRegion = CareerLevelLibrary.region_for_distance(PlayerData.career.distance_travelled)
+	var region: CareerRegion = PlayerData.career.current_region()
 	# decide available career levels
 	if PlayerData.career.is_boss_level():
 		_pickable_career_levels = [region.boss_level]
@@ -121,7 +121,8 @@ func _random_levels() -> Array:
 	
 	if _chat_key_pair(null).type == ChatKeyPair.INTERLUDE:
 		# filter the levels based on the required chefs/customers for the possible upcoming interludes
-		var required_cutscene_characters := CareerLevelLibrary.required_cutscene_characters()
+		var region := PlayerData.career.current_region()
+		var required_cutscene_characters := CareerLevelLibrary.required_cutscene_characters(region)
 		levels = CareerLevelLibrary.trim_levels_by_characters( \
 				levels, required_cutscene_characters.chef_ids, required_cutscene_characters.customer_ids)
 		if not levels:
@@ -154,7 +155,7 @@ func _random_levels() -> Array:
 func _intro_chat_key_pair() -> ChatKeyPair:
 	var result: ChatKeyPair = ChatKeyPair.new()
 	
-	var region := CareerLevelLibrary.region_for_distance(PlayerData.career.distance_travelled)
+	var region := PlayerData.career.current_region()
 	var preroll_key := region.get_intro_level_preroll_chat_key()
 	var postroll_key := region.get_intro_level_postroll_chat_key()
 	if ChatLibrary.chat_exists(preroll_key) and not PlayerData.chat_history.is_chat_finished(preroll_key):
@@ -174,7 +175,7 @@ func _intro_chat_key_pair() -> ChatKeyPair:
 func _boss_chat_key_pair() -> ChatKeyPair:
 	var result: ChatKeyPair = ChatKeyPair.new()
 	
-	var region := CareerLevelLibrary.region_for_distance(PlayerData.career.distance_travelled)
+	var region := PlayerData.career.current_region()
 	var preroll_key := region.get_boss_level_preroll_chat_key()
 	var postroll_key := region.get_boss_level_postroll_chat_key()
 	if ChatLibrary.chat_exists(preroll_key) and not PlayerData.chat_history.is_chat_finished(preroll_key):
@@ -196,7 +197,7 @@ func _boss_chat_key_pair() -> ChatKeyPair:
 func _interlude_chat_key_pair(career_level: CareerLevel) -> ChatKeyPair:
 	var result: ChatKeyPair = ChatKeyPair.new()
 	
-	var region := CareerLevelLibrary.region_for_distance(PlayerData.career.distance_travelled)
+	var region := PlayerData.career.current_region()
 	
 	# calculate the chef id/customer ids
 	var chef_id: String
@@ -303,7 +304,7 @@ func _on_LevelSelectButton_level_started(level_index: int) -> void:
 				CutsceneQueue.set_cutscene_flag("boss_level")
 	
 	if _should_play_epilogue(chat_key_pair):
-		var region := CareerLevelLibrary.region_for_distance(PlayerData.career.distance_travelled)
+		var region := PlayerData.career.current_region()
 		CutsceneQueue.enqueue_cutscene(ChatLibrary.chat_tree_for_key(region.get_epilogue_chat_key()))
 	
 	PlayerData.career.push_career_trail()
@@ -311,7 +312,7 @@ func _on_LevelSelectButton_level_started(level_index: int) -> void:
 
 func _should_play_epilogue(chat_key_pair: ChatKeyPair) -> bool:
 	var result := true
-	var region := CareerLevelLibrary.region_for_distance(PlayerData.career.distance_travelled)
+	var region := PlayerData.career.current_region()
 	
 	if not region.cutscene_path:
 		# no cutscenes for region; do not play epilogue

--- a/project/src/main/world/career-world.gd
+++ b/project/src/main/world/career-world.gd
@@ -128,7 +128,7 @@ func _hide_duplicate_creatures() -> void:
 ## 	A number in the range [0.0, 1.0] describing how far to the right the customer should be positioned.
 func _distance_percent() -> float:
 	var percent: float
-	var region := CareerLevelLibrary.region_for_distance(PlayerData.career.distance_travelled)
+	var region := PlayerData.career.current_region()
 	if region.length == CareerData.MAX_DISTANCE_TRAVELLED:
 		# for 'endless regions' just put them somewhere arbitrary
 		percent = randf()
@@ -228,7 +228,7 @@ func _add_mile_markers_to_path() -> void:
 	# Calculate the values of the left and right mile marker
 	var left_num: int
 	var right_num: int
-	var curr_region: CareerRegion = CareerLevelLibrary.region_for_distance(PlayerData.career.distance_travelled)
+	var curr_region: CareerRegion = PlayerData.career.current_region()
 	if curr_region.length == CareerData.MAX_DISTANCE_TRAVELLED:
 		# In the final (endless) region, numbers count up from 0-99, and then reset back to 0
 		right_num = PlayerData.career.distance_travelled - curr_region.distance


### PR DESCRIPTION
Extracted utility methods for CareerData.current_region(),
previous_region() and next_region().

Reordered CareerLevelLibrary methods. _ready() should be at the top,
private methods should be at the bottom.

CareerLevelLibrary.required_cutscene_characters() no longer refers to
PlayerData. It only referred to it in one place, and I prefer it to be
stateless.