### PR TITLE
Fixed GradeLabel NPE.

### DIFF
--- a/project/src/main/ui/level-select/hookable-grade-label.gd
+++ b/project/src/main/ui/level-select/hookable-grade-label.gd
@@ -16,6 +16,12 @@ var _locked_texture: Texture = preload("res://assets/main/ui/level-select/locked
 onready var _grade_label := $GradeLabel
 onready var _status_icon := $StatusIcon
 
+## Preemptively initialize onready variables to avoid null references.
+func _enter_tree() -> void:
+	_grade_label = $GradeLabel
+	_status_icon = $StatusIcon
+
+
 ## Assigns this label's button, and updates the label's appearance.
 func set_button(new_button: LevelSelectButton) -> void:
 	if button == new_button:


### PR DESCRIPTION
In Godot 3.4.4, GradeLabel's buttons are assigned before they enter the
tree causing NPEs.