### PR TITLE
Fixed RippleWaves nodes with correct tile ids

### DIFF
--- a/project/src/demo/world/environment/RippleWavesDemo.tscn
+++ b/project/src/demo/world/environment/RippleWavesDemo.tscn
@@ -17,5 +17,3 @@ direction = 2
 speed = 50.0
 wait_time = 4.0
 rippleable_tile_ids = [ 0 ]
-
-[editable path="GroundMap"]

--- a/project/src/main/world/environment/LemonWinEnvironment.tscn
+++ b/project/src/main/world/environment/LemonWinEnvironment.tscn
@@ -76,6 +76,7 @@ tile_map_path = NodePath("../GroundMap")
 direction = 2
 speed = 30.0
 wait_time = 12.0
+rippleable_tile_ids = [ 0 ]
 
 [node name="Terrain" type="TileMap" parent="Ground"]
 position = Vector2( -2, 1 )

--- a/project/src/main/world/environment/MarshEnvironment.tscn
+++ b/project/src/main/world/environment/MarshEnvironment.tscn
@@ -101,6 +101,7 @@ tile_map_path = NodePath("../GroundMap")
 direction = 2
 speed = 30.0
 wait_time = 12.0
+rippleable_tile_ids = [ 0 ]
 
 [node name="Terrain" type="TileMap" parent="Ground"]
 position = Vector2( -2, 1 )

--- a/project/src/main/world/environment/MarshWinEnvironment.tscn
+++ b/project/src/main/world/environment/MarshWinEnvironment.tscn
@@ -79,6 +79,7 @@ tile_map_path = NodePath("../GroundMap")
 direction = 2
 speed = 30.0
 wait_time = 12.0
+rippleable_tile_ids = [ 0 ]
 
 [node name="Terrain" type="TileMap" parent="Ground"]
 position = Vector2( -2, 1 )

--- a/project/src/main/world/environment/OverworldEnvironment.tscn
+++ b/project/src/main/world/environment/OverworldEnvironment.tscn
@@ -100,6 +100,7 @@ tile_map_path = NodePath("../GroundMap")
 direction = 2
 speed = 30.0
 wait_time = 12.0
+rippleable_tile_ids = [ 0 ]
 
 [node name="Terrain" type="TileMap" parent="Ground"]
 position = Vector2( -2, 1 )

--- a/project/src/main/world/environment/OverworldWalkEnvironment.tscn
+++ b/project/src/main/world/environment/OverworldWalkEnvironment.tscn
@@ -80,6 +80,7 @@ tile_map_path = NodePath("../GroundMap")
 direction = 3
 speed = 30.0
 wait_time = 12.0
+rippleable_tile_ids = [ 0 ]
 
 [node name="Terrain" type="TileMap" parent="Ground"]
 position = Vector2( -2, 1 )


### PR DESCRIPTION
Without these tile IDs, ripple waves would be inappropriately generated
on bare terrain