### PR TITLE
Replaced KEY_BRACELEFT/RIGHT with KEY_BRACKETLEFT/RIGHT

### DIFF
--- a/project/src/demo/music/music-player-demo.gd
+++ b/project/src/demo/music/music-player-demo.gd
@@ -23,7 +23,7 @@ func _input(event: InputEvent) -> void:
 		KEY_U: MusicPlayer.play_upbeat_bgm(false)
 		KEY_T: MusicPlayer.play_tutorial_bgm(false)
 		KEY_MINUS: MusicPlayer.stop()
-		KEY_BRACERIGHT: next_checkpoint()
+		KEY_BRACKETRIGHT: next_checkpoint()
 
 
 func next_checkpoint() -> void:

--- a/project/src/demo/ui/career/chalkboard-map-row-demo.gd
+++ b/project/src/demo/ui/career/chalkboard-map-row-demo.gd
@@ -54,9 +54,9 @@ func _input(event: InputEvent) -> void:
 		KEY_T: _map_row.set_landmark_type(0, Landmark.CIRCLES_4)
 		KEY_Y: _map_row.set_landmark_type(0, Landmark.CIRCLES_5)
 		KEY_U: _map_row.set_landmark_type(0, Landmark.CIRCLES_6)
-		KEY_BRACELEFT:
+		KEY_BRACKETLEFT:
 			_map_row.landmark_count -= 1
-		KEY_BRACERIGHT:
+		KEY_BRACKETRIGHT:
 			_map_row.landmark_count += 1
 			_map_row.set_landmark_distance(_map_row.landmark_count - 1, _map_row.landmark_count * 20)
 			_map_row.set_landmark_type(_map_row.landmark_count - 1, _random_landmark_type())

--- a/project/src/demo/ui/chat/chat-frame-demo.gd
+++ b/project/src/demo/ui/chat/chat-frame-demo.gd
@@ -107,10 +107,10 @@ func _input(event: InputEvent) -> void:
 		KEY_S:
 			_accent_swapped = not _accent_swapped
 			_play_chat_event()
-		KEY_BRACERIGHT:
+		KEY_BRACKETRIGHT:
 			_texture_index = wrapi(_texture_index + 1, 0, ChatLinePanel.CHAT_TEXTURE_COUNT)
 			_play_chat_event()
-		KEY_BRACELEFT:
+		KEY_BRACKETLEFT:
 			_texture_index = wrapi(_texture_index - 1, 0, ChatLinePanel.CHAT_TEXTURE_COUNT)
 			_play_chat_event()
 		KEY_RIGHT:

--- a/project/src/demo/ui/chat/mood-demo.gd
+++ b/project/src/demo/ui/chat/mood-demo.gd
@@ -42,7 +42,7 @@ func _input(event: InputEvent) -> void:
 			KEY_SLASH: print(to_json($Creature.dna))
 	else:
 		match Utils.key_scancode(event):
-			KEY_BRACELEFT, KEY_BRACERIGHT: $Creature.dna = DnaUtils.random_dna()
+			KEY_BRACKETLEFT, KEY_BRACKETRIGHT: $Creature.dna = DnaUtils.random_dna()
 			
 			KEY_1: $Creature.play_mood(Creatures.Mood.DEFAULT)
 			KEY_Q: $Creature.play_mood(Creatures.Mood.AWKWARD0)

--- a/project/src/demo/world/letter-shooter-demo.gd
+++ b/project/src/demo/world/letter-shooter-demo.gd
@@ -7,5 +7,5 @@ extends Node
 
 func _input(event: InputEvent) -> void:
 	match Utils.key_scancode(event):
-		KEY_BRACERIGHT: $LetterShooter.start()
-		KEY_BRACELEFT: $LetterShooter.stop()
+		KEY_BRACKETRIGHT: $LetterShooter.start()
+		KEY_BRACKETLEFT: $LetterShooter.stop()

--- a/project/src/demo/world/restaurant/restaurant-scene-demo.gd
+++ b/project/src/demo/world/restaurant/restaurant-scene-demo.gd
@@ -14,7 +14,7 @@ func _input(event: InputEvent) -> void:
 		KEY_F: $RestaurantScene.get_customer().feed(Foods.FoodType.BROWN_0)
 		KEY_0, KEY_1, KEY_2, KEY_3, KEY_4, KEY_5, KEY_6, KEY_7, KEY_8, KEY_9:
 			$RestaurantScene.get_customer().set_fatness(FATNESS_KEYS[Utils.key_num(event)])
-		KEY_BRACELEFT, KEY_BRACERIGHT:
+		KEY_BRACKETLEFT, KEY_BRACKETRIGHT:
 			$RestaurantScene.summon_creature(CreatureLoader.random_def())
 		KEY_Q: $RestaurantScene.current_creature_index = 0
 		KEY_W: $RestaurantScene.current_creature_index = 1

--- a/project/src/demo/world/restaurant/restaurant-view-demo.gd
+++ b/project/src/demo/world/restaurant/restaurant-view-demo.gd
@@ -66,7 +66,7 @@ func _input(event: InputEvent) -> void:
 		KEY_Q: $RestaurantView.set_current_creature_index(0)
 		KEY_W: $RestaurantView.set_current_creature_index(1)
 		KEY_E: $RestaurantView.set_current_creature_index(2)
-		KEY_BRACELEFT, KEY_BRACERIGHT:
+		KEY_BRACKETLEFT, KEY_BRACKETRIGHT:
 			$RestaurantView.summon_creature()
 		KEY_RIGHT:
 			$RestaurantView.get_customer().set_orientation(Creatures.SOUTHEAST)

--- a/project/src/main/ui/cheat-code-detector.gd
+++ b/project/src/main/ui/cheat-code-detector.gd
@@ -26,7 +26,7 @@ const CODE_KEYS := {
 	KEY_J:"j", KEY_K:"k", KEY_L:"l", KEY_M:"m", KEY_N:"n", KEY_O:"o", KEY_P:"p", KEY_Q:"q", KEY_R:"r",
 	KEY_S:"s", KEY_T:"t", KEY_U:"u", KEY_V:"v", KEY_W:"w", KEY_X:"x", KEY_Y:"y", KEY_Z:"z",
 	
-	KEY_BRACELEFT:"[", KEY_BACKSLASH:"\\", KEY_BRACERIGHT:"]", KEY_QUOTELEFT:"`",
+	KEY_BRACKETLEFT:"[", KEY_BACKSLASH:"\\", KEY_BRACKETRIGHT:"]", KEY_QUOTELEFT:"`",
 }
 
 ## List of cheat codes. Cheat codes should be lower-case, and should not be contained within one another or the shorter


### PR DESCRIPTION
At some point in a recent Godot release, KEY_BRACELEFT stopped working,
and now KEY_BRACKETLEFT works instead.