### PR TITLE
Avoid hardcoding customer count. Restaurant demo refactorings.

### DIFF
--- a/project/src/demo/world/restaurant/RestaurantPuzzleSceneDemo.tscn
+++ b/project/src/demo/world/restaurant/RestaurantPuzzleSceneDemo.tscn
@@ -3,8 +3,8 @@
 [ext_resource path="res://src/demo/world/restaurant/restaurant-puzzle-scene-demo.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/restaurant/RestaurantPuzzleScene.tscn" type="PackedScene" id=2]
 
-[node name="Demo" type="Node2D"]
-scale = Vector2( 0.3, 0.3 )
+[node name="Demo" type="Node"]
 script = ExtResource( 1 )
 
 [node name="RestaurantPuzzleScene" parent="." instance=ExtResource( 2 )]
+scale = Vector2( 0.3, 0.3 )

--- a/project/src/demo/world/restaurant/RestaurantViewDemo.tscn
+++ b/project/src/demo/world/restaurant/RestaurantViewDemo.tscn
@@ -3,9 +3,7 @@
 [ext_resource path="res://src/main/world/restaurant/RestaurantView.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/demo/world/restaurant/restaurant-view-demo.gd" type="Script" id=2]
 
-[node name="Demo" type="Control"]
-anchor_right = 1.0
-anchor_bottom = 1.0
+[node name="Demo" type="Node"]
 script = ExtResource( 2 )
 
 [node name="RestaurantView" parent="." instance=ExtResource( 1 )]

--- a/project/src/demo/world/restaurant/restaurant-puzzle-scene-demo.gd
+++ b/project/src/demo/world/restaurant/restaurant-puzzle-scene-demo.gd
@@ -1,4 +1,4 @@
-extends Node2D
+extends Node
 ## A demo which shows off the restaurant scene.
 ##
 ## Keys:
@@ -9,13 +9,20 @@ extends Node2D
 
 const FATNESS_KEYS = [10.0, 1.0, 1.5, 2.0, 3.0, 5.0, 6.0, 7.0, 8.0, 9.0]
 
+onready var _scene: RestaurantPuzzleScene = $RestaurantPuzzleScene
+
+func _ready() -> void:
+	for i in range(_scene.get_customers().size()):
+		_scene.summon_customer(CreatureLoader.random_def(), i)
+
+
 func _input(event: InputEvent) -> void:
 	match Utils.key_scancode(event):
-		KEY_F: $RestaurantPuzzleScene.get_customer().feed(Foods.FoodType.BROWN_0)
+		KEY_F: _scene.get_customer().feed(Foods.FoodType.BROWN_0)
 		KEY_0, KEY_1, KEY_2, KEY_3, KEY_4, KEY_5, KEY_6, KEY_7, KEY_8, KEY_9:
-			$RestaurantPuzzleScene.get_customer().set_fatness(FATNESS_KEYS[Utils.key_num(event)])
+			_scene.get_customer().set_fatness(FATNESS_KEYS[Utils.key_num(event)])
 		KEY_BRACKETLEFT, KEY_BRACKETRIGHT:
-			$RestaurantPuzzleScene.summon_customer(CreatureLoader.random_def())
-		KEY_Q: $RestaurantPuzzleScene.current_creature_index = 0
-		KEY_W: $RestaurantPuzzleScene.current_creature_index = 1
-		KEY_E: $RestaurantPuzzleScene.current_creature_index = 2
+			_scene.summon_customer(CreatureLoader.random_def())
+		KEY_Q: _scene.current_creature_index = 0
+		KEY_W: _scene.current_creature_index = 1
+		KEY_E: _scene.current_creature_index = 2

--- a/project/src/demo/world/restaurant/restaurant-view-demo.gd
+++ b/project/src/demo/world/restaurant/restaurant-view-demo.gd
@@ -1,4 +1,4 @@
-extends Control
+extends Node
 ## A demo which shows off the restaurant view.
 ##
 ## Keys:
@@ -31,56 +31,60 @@ const NAMES = [
 
 var _current_name_index := 4
 
+onready var _view := $RestaurantView
+onready var _restaurant_scene := $RestaurantView/RestaurantViewport/Scene
+
 func _ready() -> void:
-	$RestaurantView.summon_customer()
+	for i in range(_view.get_customers().size()):
+		_view.summon_customer(i)
 
 
 func _input(event: InputEvent) -> void:
 	match Utils.key_scancode(event):
-		KEY_D: $RestaurantView/RestaurantViewport/Scene.get_node("DoorChime").play_door_chime()
+		KEY_D: _restaurant_scene.get_node("DoorChime").play_door_chime()
 		KEY_F: _customer().feed(Foods.FoodType.BROWN_0)
 		KEY_I: _customer().creature_visuals.get_node("Animations/IdleTimer").start(0.01)
 		KEY_N:
 			_current_name_index = (_current_name_index + 1) % NAMES.size()
 			_customer().creature_name = NAMES[_current_name_index]
-			_player().creature_name = NAMES[_current_name_index]
+			_chef().creature_name = NAMES[_current_name_index]
 		KEY_V:
 			_customer().get_node("CreatureSfx").play_goodbye_voice()
 		KEY_0, KEY_1, KEY_2, KEY_3, KEY_4, KEY_5, KEY_6, KEY_7, KEY_8, KEY_9:
 			if Input.is_key_pressed(KEY_SHIFT):
 				# shift pressed; change creature's comfort
 				match Utils.key_scancode(event):
-					KEY_1: $RestaurantView.get_customer().set_comfort(0.00) # hasn't eaten
-					KEY_2: $RestaurantView.get_customer().set_comfort(0.30)
-					KEY_3: $RestaurantView.get_customer().set_comfort(0.60)
-					KEY_4: $RestaurantView.get_customer().set_comfort(1.00) # ate enough
-					KEY_5: $RestaurantView.get_customer().set_comfort(-0.10) # starting to overeat
-					KEY_6: $RestaurantView.get_customer().set_comfort(-0.30)
-					KEY_7: $RestaurantView.get_customer().set_comfort(-0.50) # ate too much
-					KEY_8: $RestaurantView.get_customer().set_comfort(-0.70)
-					KEY_9: $RestaurantView.get_customer().set_comfort(-0.90)
-					KEY_0: $RestaurantView.get_customer().set_comfort(-1.00) # ate way too much
+					KEY_1: _view.get_customer().set_comfort(0.00) # hasn't eaten
+					KEY_2: _view.get_customer().set_comfort(0.30)
+					KEY_3: _view.get_customer().set_comfort(0.60)
+					KEY_4: _view.get_customer().set_comfort(1.00) # ate enough
+					KEY_5: _view.get_customer().set_comfort(-0.10) # starting to overeat
+					KEY_6: _view.get_customer().set_comfort(-0.30)
+					KEY_7: _view.get_customer().set_comfort(-0.50) # ate too much
+					KEY_8: _view.get_customer().set_comfort(-0.70)
+					KEY_9: _view.get_customer().set_comfort(-0.90)
+					KEY_0: _view.get_customer().set_comfort(-1.00) # ate way too much
 			else:
 				# shift not pressed; change creature's fatness
-				$RestaurantView.get_customer().set_fatness(FATNESS_KEYS[Utils.key_num(event)])
-		KEY_Q: $RestaurantView.set_current_creature_index(0)
-		KEY_W: $RestaurantView.set_current_creature_index(1)
-		KEY_E: $RestaurantView.set_current_creature_index(2)
+				_view.get_customer().set_fatness(FATNESS_KEYS[Utils.key_num(event)])
+		KEY_Q: _view.set_current_creature_index(0)
+		KEY_W: _view.set_current_creature_index(1)
+		KEY_E: _view.set_current_creature_index(2)
 		KEY_BRACKETLEFT, KEY_BRACKETRIGHT:
-			$RestaurantView.summon_customer()
+			_view.summon_customer()
 		KEY_RIGHT:
-			$RestaurantView.get_customer().set_orientation(Creatures.SOUTHEAST)
+			_view.get_customer().set_orientation(Creatures.SOUTHEAST)
 		KEY_DOWN:
-			$RestaurantView.get_customer().set_orientation(Creatures.SOUTHWEST)
+			_view.get_customer().set_orientation(Creatures.SOUTHWEST)
 		KEY_LEFT:
-			$RestaurantView.get_customer().set_orientation(Creatures.NORTHWEST)
+			_view.get_customer().set_orientation(Creatures.NORTHWEST)
 		KEY_UP:
-			$RestaurantView.get_customer().set_orientation(Creatures.NORTHEAST)
+			_view.get_customer().set_orientation(Creatures.NORTHEAST)
 
 
 func _customer() -> Creature:
-	return $RestaurantView/RestaurantViewport/Scene.get_customer()
+	return _restaurant_scene.get_customer()
 
 
-func _player() -> Creature:
-	return $RestaurantView/RestaurantViewport/Scene.get_player()
+func _chef() -> Creature:
+	return _restaurant_scene.get_chef()

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -24,7 +24,7 @@ func _ready() -> void:
 	PlayerData.creature_library.save_fatness_state()
 	PlayerData.creature_queue.primary_index = 0
 	PlayerData.creature_queue.reset_secondary_creature_queue()
-	for i in range(3):
+	for i in range(_restaurant_view.get_customers().size()):
 		_restaurant_view.summon_customer(i)
 	
 	get_customer().play_hello_voice()
@@ -132,7 +132,7 @@ func _start_puzzle() -> void:
 				_restaurant_view.get_customer(starting_creature_index).set_fatness(fatness)
 		
 		# summon the other creatures
-		for i in range(3):
+		for i in range(_restaurant_view.get_customers().size()):
 			if i != starting_creature_index:
 				_restaurant_view.summon_customer(i)
 		
@@ -142,7 +142,7 @@ func _start_puzzle() -> void:
 		var current_creature_feed_count: int = _restaurant_view.get_customer().feed_count
 		
 		# fill the seats if the creatures ate
-		for i in range(3):
+		for i in range(_restaurant_view.get_customers().size()):
 			if _restaurant_view.get_customer(i).feed_count:
 				_restaurant_view.summon_customer(i)
 		


### PR DESCRIPTION
Customer count is no longer hardcoded at '3' for puzzle restaurant logic, we
now count the number of customers in the scene.

RestaurantViewDemo, RestaurantPuzzleSceneDemo extend Node instead of
Node2D/Control, for consistency with other demos.

Extracted onready variables.

Fixed outdated RestaurantScene.get_player() reference. This was renamed
to get_chef() when we added levels where the player was not the chef.