### PR TITLE
Fixed potential overworld related NPEs. body_pos_from_head_pos

### DIFF
--- a/project/src/main/global.gd
+++ b/project/src/main/global.gd
@@ -70,7 +70,7 @@ func benchmark_end(key: String = "") -> void:
 
 func get_overworld_ui() -> OverworldUi:
 	var nodes := get_tree().get_nodes_in_group("overworld_ui")
-	return nodes[0]
+	return nodes[0] if nodes else null
 
 
 ## Locates the node responsible for creating and initializing chat icons, if one exists.

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -74,8 +74,7 @@ func get_customer_mouth_position(customer: Creature) -> Vector2:
 	var target_pos: Vector2
 	# calculate the position within the restaurant scene
 	var mouth_position: Vector2 = MOUTH_POSITIONS_BY_ORIENTATION[customer.get_orientation()]
-	target_pos = customer.get_node("ChatIconHook").get_global_transform_with_canvas() \
-			.xform(mouth_position * customer.creature_visuals.scale.y)
+	target_pos = customer.body_pos_from_head_pos(mouth_position)
 	# calculate the position within the customer viewport
 	target_pos = _customer_view_viewport.canvas_transform.xform(target_pos)
 	# calculate the position within the customer viewport texture
@@ -121,7 +120,7 @@ func scroll_to_new_creature(new_creature_index: int = -1) -> void:
 
 ## Returns a random creature index different from the current creature index.
 func next_creature_index() -> int:
-	return (get_current_creature_index() + randi() % 2 + 1) % 3
+	return (get_current_creature_index() + randi() % 2 + 1) % get_customers().size()
 
 
 ## Temporarily suppresses 'hello' and 'door chime' sounds.
@@ -215,7 +214,7 @@ func _on_Customer_creature_name_changed() -> void:
 	_refresh_customer_name()
 
 
-func _on_RestaurantScene_current_creature_index_changed(_value: int) -> void:
+func _on_RestaurantPuzzleScene_current_creature_index_changed(_value: int) -> void:
 	_refresh_customer_name()
 
 

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -592,6 +592,17 @@ func fatness_to_score(in_fatness: float) -> float:
 	return (50 / max(weight_gain_scale, 0.01)) * (pow(in_fatness, 2) - 1)
 
 
+## Converts a coordinate relative to the creature's head into a coordinate relative to the creature's body.
+##
+## Parameters:
+## 	'v': A coordinate relative to the creature's head.
+##
+## Returns:
+## 	A coordinate relative to the creature's body.
+func body_pos_from_head_pos(v: Vector2) -> Vector2:
+	return _chat_icon_hook.get_global_transform_with_canvas().xform(v * creature_visuals.scale.y)
+
+
 func _on_CreatureVisuals_talking_changed() -> void:
 	emit_signal("talking_changed")
 

--- a/project/src/main/world/creature/player.gd
+++ b/project/src/main/world/creature/player.gd
@@ -15,7 +15,7 @@ func _ready() -> void:
 
 
 func _unhandled_input(_event: InputEvent) -> void:
-	if _overworld_ui.cutscene or ui_has_focus:
+	if (_overworld_ui and _overworld_ui.cutscene) or ui_has_focus:
 		# disable movement input during cutscenes, or when navigating menus
 		return
 	

--- a/project/src/main/world/creature/sensei.gd
+++ b/project/src/main/world/creature/sensei.gd
@@ -17,8 +17,12 @@ func _ready() -> void:
 
 
 func _on_MoveTimer_timeout() -> void:
-	if _overworld_ui.cutscene:
+	if _overworld_ui and _overworld_ui.cutscene:
 		# disable movement during cutscenes
+		return
+	
+	if not ChattableManager.player:
+		# disable movement outside free roam mode
 		return
 	
 	var player_relative_pos: Vector2 = Global.from_iso(ChattableManager.player.position - position)

--- a/project/src/main/world/free-roam-exit.gd
+++ b/project/src/main/world/free-roam-exit.gd
@@ -80,7 +80,7 @@ func _physics_process(_delta: float) -> void:
 	if Engine.is_editor_hint() or not ChattableManager.player:
 		# don't try to change scenes in the editor
 		return
-	if _overworld_ui.is_chatting():
+	if _overworld_ui and _overworld_ui.is_chatting():
 		# don't change scenes while chatting
 		return
 	

--- a/project/src/main/world/restaurant/RestaurantView.tscn
+++ b/project/src/main/world/restaurant/RestaurantView.tscn
@@ -223,6 +223,6 @@ one_shot = true
 script = ExtResource( 12 )
 
 [connection signal="timeout" from="HelloTimer" to="HelloTimer" method="_on_timeout"]
-[connection signal="current_creature_index_changed" from="RestaurantViewport/Scene" to="." method="_on_RestaurantScene_current_creature_index_changed"]
-[connection signal="current_creature_index_changed" from="RestaurantViewport/Scene" to="CustomerCameraMover" method="_on_RestaurantScene_current_creature_index_changed"]
-[connection signal="food_eaten" from="RestaurantViewport/Scene" to="CustomerCameraMover" method="_on_RestaurantScene_food_eaten"]
+[connection signal="current_creature_index_changed" from="RestaurantViewport/Scene" to="." method="_on_RestaurantPuzzleScene_current_creature_index_changed"]
+[connection signal="current_creature_index_changed" from="RestaurantViewport/Scene" to="CustomerCameraMover" method="_on_RestaurantPuzzleScene_current_creature_index_changed"]
+[connection signal="food_eaten" from="RestaurantViewport/Scene" to="CustomerCameraMover" method="_on_RestaurantPuzzleScene_food_eaten"]

--- a/project/src/main/world/restaurant/customer-camera-mover.gd
+++ b/project/src/main/world/restaurant/customer-camera-mover.gd
@@ -58,10 +58,10 @@ func _on_Creature_visual_fatness_changed(index: int) -> void:
 		_refresh_target_camera_position()
 
 
-func _on_RestaurantScene_current_creature_index_changed(_value: int) -> void:
+func _on_RestaurantPuzzleScene_current_creature_index_changed(_value: int) -> void:
 	_refresh_target_camera_position()
 
 
-func _on_RestaurantScene_food_eaten(_food_type: int) -> void:
+func _on_RestaurantPuzzleScene_food_eaten(_food_type: int) -> void:
 	_shake_total_seconds = 0.20
 	_shake_remaining_seconds = 0.20

--- a/project/src/main/world/restaurant/customer-switch-tween.gd
+++ b/project/src/main/world/restaurant/customer-switch-tween.gd
@@ -8,7 +8,7 @@ export (NodePath) var customer_camera_path: NodePath
 
 onready var _customer_camera: Camera2D = get_node(customer_camera_path)
 
-func _on_RestaurantScene_current_creature_index_changed(value: int) -> void:
+func _on_RestaurantPuzzleScene_current_creature_index_changed(value: int) -> void:
 	interpolate_property(
 			_customer_camera, "position:x",
 			_customer_camera.position.x, 2000 * value, PAN_DURATION_SECONDS,


### PR DESCRIPTION
Fixed a few potential NPEs in classes like FreeRoamExit, Sensei and
Player. These scripts were written assuming they'd only be used in
freeroam/career mode where there is a chat ui, player and sensei -- but with
upcoming code changes they are also used in puzzle mode where many of these
assumptions are violated.

Extracted Creature.body_pos_from_head_pos function.