### PR TITLE
Fixed type error with 'lenient_value'

### DIFF
--- a/project/src/main/puzzle/level/level-settings.gd
+++ b/project/src/main/puzzle/level/level-settings.gd
@@ -68,7 +68,7 @@ func set_finish_condition(type: int, value: int, lenient_value: int = -1) -> voi
 	finish_condition = Milestone.new()
 	finish_condition.set_milestone(type, value)
 	if lenient_value > -1:
-		finish_condition.set_meta("lenient_value", lenient_value)
+		finish_condition.set_meta("lenient_value", str(lenient_value))
 
 
 ## Sets the criteria for succeeding, such as a time or score goal.

--- a/project/src/main/puzzle/rank-calculator.gd
+++ b/project/src/main/puzzle/rank-calculator.gd
@@ -252,7 +252,7 @@ func _populate_rank_fields(rank_result: RankResult, lenient: bool) -> void:
 			target_lines = master_customer_combo(CurrentLevel.settings) * finish_condition.value
 			leftover_lines = 0 # the level ends when your combo breaks, it's inefficient to stack extra pieces
 		Milestone.LINES:
-			target_lines = finish_condition.get_meta("lenient_value") if lenient else finish_condition.value
+			target_lines = int(finish_condition.get_meta("lenient_value")) if lenient else finish_condition.value
 		Milestone.PIECES:
 			# warning-ignore:integer_division
 			target_lines = (finish_condition.value + CurrentLevel.settings.rank.preplaced_pieces) / 2.0


### PR DESCRIPTION
lenient_value was occasionally assigned as an int (in level-settings.gd)
but occasionally set as a string (when parsed from json). This caused
type cast errors in rank-calculator.gd. (These type errors seem new.
It's possible older versions of Godot cast ints and strings implicitly
in this circumstance.)