### PR TITLE
Zoomed out career mode camera.

### DIFF
--- a/project/src/main/world/career-camera.gd
+++ b/project/src/main/world/career-camera.gd
@@ -2,7 +2,7 @@ extends Camera2D
 ## Career mode camera. Focuses on the area around the player, drifting slightly.
 
 ## amount of empty space around characters
-const CAMERA_BOUNDARY := 120
+const CAMERA_BOUNDARY := 240
 
 ## how fast the camera moves when being moved manually with a cheat code
 const MANUAL_CAMERA_SPEED := 3000

--- a/project/src/main/world/career-world.gd
+++ b/project/src/main/world/career-world.gd
@@ -3,10 +3,10 @@ extends OverworldWorld
 ## Populates/unpopulates the creatures and obstacles in the career mode's world.
 
 ## horizontal distance to maintain when placing the player and the sensei
-const X_DIST_BETWEEN_PLAYER_AND_SENSEI := 180
+const X_DIST_BETWEEN_PLAYER_AND_SENSEI := 240
 
 ## horizontal distance to maintain when placing customers
-const X_DIST_BETWEEN_CUSTOMERS := 200
+const X_DIST_BETWEEN_CUSTOMERS := 300
 
 ## vertical distance separating the customers from the player's path
 const Y_DIST_BETWEEN_CUSTOMERS_AND_PATH := 80


### PR DESCRIPTION
With the camera as zoomed in as it was, you couldn't see certain details
like the signs on buildings. It's now zoomed out more so more of the
environment is visible.