### PR TITLE
Change 'Regret...' condition for tutorials

### DIFF
--- a/project/src/main/puzzle/puzzle-messages.gd
+++ b/project/src/main/puzzle/puzzle-messages.gd
@@ -89,11 +89,12 @@ func _on_PuzzleState_game_started() -> void:
 	hide_message()
 
 
-func _on_PuzzleState_before_level_changed(new_level_id: String) -> void:
-	if CurrentLevel.settings.other.non_interactive:
+func _on_PuzzleState_before_level_changed(_new_level_id: String) -> void:
+	if CurrentLevel.settings.other.non_interactive or not CurrentLevel.settings.input_replay.empty():
 		# non interactive levels don't show a success/failure message
-		pass
-	elif new_level_id == CurrentLevel.settings.id:
+		return
+	
+	if PuzzleState.level_performance.lost:
 		show_message(tr("Regret..."))
 	else:
 		show_message(tr("Good!"))

--- a/project/src/main/puzzle/start-end-sfx.gd
+++ b/project/src/main/puzzle/start-end-sfx.gd
@@ -36,12 +36,12 @@ func _on_PuzzleState_game_started() -> void:
 	play_go_sound()
 
 
-func _on_PuzzleState_before_level_changed(new_level_id: String) -> void:
+func _on_PuzzleState_before_level_changed(_new_level_id: String) -> void:
 	if CurrentLevel.settings.other.non_interactive or not CurrentLevel.settings.input_replay.empty():
 		# no sound effect or fanfare for non-interactive levels
 		return
 	
-	if new_level_id == CurrentLevel.settings.id:
+	if PuzzleState.level_performance.lost:
 		$SectionFailSound.play()
 	else:
 		$SectionCompleteSound.play()

--- a/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
@@ -58,6 +58,7 @@ func prepare_tutorial_level() -> void:
 ## The level to advance to depends on what the player's accomplished so far. If they perform squish moves or snack
 ## boxes before they're instructed to, they can skip parts of the tutorial.
 func _advance_level() -> void:
+	PuzzleState.level_performance.lost = false
 	if CurrentLevel.settings.id == "tutorial/basics_0" and _did_build_cake and _did_squish_move:
 		# the player did something crazy; skip the tutorial entirely
 		

--- a/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
@@ -104,10 +104,10 @@ func _prepare_cake_tally_item(max_value: int) -> void:
 
 ## Advance to the next level in the tutorial.
 func _advance_level() -> void:
+	PuzzleState.level_performance.lost = false
 	_level_finished = true
 	
 	var delay_between_levels := PuzzleState.DELAY_SHORT
-	var failed_section := false
 	match CurrentLevel.settings.id:
 		"tutorial/cakes_0":
 			if _cakes_built == 0:
@@ -125,24 +125,24 @@ func _advance_level() -> void:
 				hud.set_message(tr("Good job! You can make gelatin with a J, L and O piece."))
 			else:
 				hud.set_message(tr("Oops! ...Let's try that again."))
-				failed_section = true
+				PuzzleState.level_performance.lost = true
 		"tutorial/cakes_3":
 			if _cakes_built >= 1:
 				_schedule_finish_line_clears()
 				hud.set_message(tr("Oh? But I even gave you an extra piece to trick you!\n\nHmm, how about this."))
 			else:
 				hud.set_message(tr("Oops! ...Let's try that again."))
-				failed_section = true
+				PuzzleState.level_performance.lost = true
 		"tutorial/cakes_4":
 			if _cakes_built >= 2:
 				_schedule_finish_line_clears()
 				hud.set_message(tr("Wow, color me impressed!\n\nBut, there's one more thing you should know about cake boxes."))
 			elif _cakes_built == 1:
 				hud.set_message(tr("Oh, you're half way there! ...Now try for the other one."))
-				failed_section = true
+				PuzzleState.level_performance.lost = true
 			else:
 				hud.set_message(tr("Oops! ...Let's try that again."))
-				failed_section = true
+				PuzzleState.level_performance.lost = true
 		"tutorial/cakes_5":
 			# wait for the player to finish reading the diagram
 			delay_between_levels = PuzzleState.DELAY_LONG
@@ -152,14 +152,14 @@ func _advance_level() -> void:
 				hud.set_message(tr("Wow, that looks delicious!"))
 			else:
 				hud.set_message(tr("Oops! ...Let's try that again."))
-				failed_section = true
+				PuzzleState.level_performance.lost = true
 		"tutorial/cakes_7":
 			if _cakes_built >= 1:
 				_schedule_finish_line_clears()
 				hud.set_message(tr("Good job!"))
 			else:
 				hud.set_message(tr("Oops! ...Let's try that again."))
-				failed_section = true
+				PuzzleState.level_performance.lost = true
 		"tutorial/cakes_8":
 			if _cakes_built >= 2:
 				_schedule_finish_line_clears()
@@ -167,10 +167,10 @@ func _advance_level() -> void:
 				hud.set_message(tr("Wow! That's all eight recipes."))
 			elif _cakes_built == 1:
 				hud.set_message(tr("Oh, you're half way there! ...Now try for the other one."))
-				failed_section = true
+				PuzzleState.level_performance.lost = true
 			else:
 				hud.set_message(tr("Oops! ...Let's try that again."))
-				failed_section = true
+				PuzzleState.level_performance.lost = true
 	
 	var level_ids := [
 		"tutorial/cakes_0", "tutorial/cakes_1", "tutorial/cakes_2", "tutorial/cakes_3",
@@ -178,7 +178,7 @@ func _advance_level() -> void:
 		"tutorial/cakes_8", "tutorial/cakes_9",
 	]
 	var new_level_id: String
-	if failed_section:
+	if PuzzleState.level_performance.lost:
 		_failure_count += 1
 		new_level_id = CurrentLevel.settings.id
 	else:

--- a/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
@@ -108,8 +108,8 @@ func _set_combo_state(start: int, goal: int = 0) -> void:
 
 ## Advance to the next level in the tutorial.
 func _advance_level() -> void:
+	PuzzleState.level_performance.lost = false
 	var delay_between_levels := PuzzleState.DELAY_SHORT
-	var failed_section := false
 	match CurrentLevel.settings.id:
 		"tutorial/combo_0", "tutorial/combo_2":
 			if hud.skill_tally_item("Combo").is_complete():
@@ -117,7 +117,7 @@ func _advance_level() -> void:
 			else:
 				hud.set_message(tr("Oops! ...You needed to clear a line with that last piece."))
 				delay_between_levels = PuzzleState.DELAY_LONG
-				failed_section = true
+				PuzzleState.level_performance.lost = true
 		"tutorial/combo_1":
 			# no delay for the non-interactive segment where we show the player a diagram
 			delay_between_levels = PuzzleState.DELAY_NONE
@@ -131,14 +131,14 @@ func _advance_level() -> void:
 			else:
 				hud.set_message(tr("Oh! ...You needed to clear a line that time."))
 				delay_between_levels = PuzzleState.DELAY_LONG
-				failed_section = true
+				PuzzleState.level_performance.lost = true
 	
 	var level_ids := [
 		"tutorial/combo_0", "tutorial/combo_1", "tutorial/combo_2", "tutorial/combo_3",
 		"tutorial/combo_4", "tutorial/combo_5", "tutorial/combo_6",
 	]
 	var new_level_id: String
-	if failed_section:
+	if PuzzleState.level_performance.lost:
 		new_level_id = CurrentLevel.settings.id
 	else:
 		new_level_id = level_ids[level_ids.find(CurrentLevel.settings.id) + 1]


### PR DESCRIPTION
Previously, the 'Regret...' message showed up if we made the player
repeat a scenario. But there are times when we'll advance tutorials even
if they fail. The new 'Regret...' message logic keys off of
PuzzleState.level_performance.lost.