### PR TITLE
Tutorial framework bugs: TutorialDemo, tutorial duration, target_lines

### DIFF
--- a/project/src/demo/puzzle/puzzle-demo.gd
+++ b/project/src/demo/puzzle/puzzle-demo.gd
@@ -29,6 +29,8 @@ func _ready() -> void:
 		var json_dict: Dictionary = parse_json(json_text)
 		var level_key := LevelSettings.level_key_from_path(level_path)
 		settings.from_json_dict(level_key, json_dict)
+		# Ignore the start_level property so we can test the middle parts of tutorials
+		settings.other.start_level = ""
 		
 	CurrentLevel.start_level(settings)
 	_tutorial_hud.replace_tutorial_module()

--- a/project/src/main/puzzle/duration-calculator.gd
+++ b/project/src/main/puzzle/duration-calculator.gd
@@ -34,25 +34,29 @@ const RANKS_BY_DIFFICULTY := {
 func duration(settings: LevelSettings) -> float:
 	var result := 600.0
 	
-	match settings.finish_condition.type:
-		Milestone.SCORE:
-			# assume the player collects all the one-time pickups
-			var lines := (settings.finish_condition.value - settings.rank.master_pickup_score) \
-					/ _score_per_line(settings)
-			lines = clamp(lines, 1, 10000)
-			result = _duration_for_lines(settings, lines)
-		Milestone.LINES:
-			result = _duration_for_lines(settings, settings.finish_condition.value)
-		Milestone.PIECES:
-			result = _duration_for_lines(settings, settings.finish_condition.value * 2)
-		Milestone.TIME_OVER:
-			result = settings.finish_condition.value
-		Milestone.CUSTOMERS:
-			var rank: float = RANKS_BY_DIFFICULTY[settings.get_difficulty()]
-			var lines_per_customer := RankCalculator.master_customer_combo(settings)
-			lines_per_customer *= pow(RankCalculator.RDF_ENDURANCE, rank)
-			var lines := lines_per_customer * settings.finish_condition.value
-			result = _duration_for_lines(settings, lines)
+	if settings.other.tutorial:
+		# don't estimate duration for tutorials
+		result = 150.0
+	else:
+		match settings.finish_condition.type:
+			Milestone.SCORE:
+				# assume the player collects all the one-time pickups
+				var lines := (settings.finish_condition.value - settings.rank.master_pickup_score) \
+						/ _score_per_line(settings)
+				lines = clamp(lines, 1, 10000)
+				result = _duration_for_lines(settings, lines)
+			Milestone.LINES:
+				result = _duration_for_lines(settings, settings.finish_condition.value)
+			Milestone.PIECES:
+				result = _duration_for_lines(settings, settings.finish_condition.value * 2)
+			Milestone.TIME_OVER:
+				result = settings.finish_condition.value
+			Milestone.CUSTOMERS:
+				var rank: float = RANKS_BY_DIFFICULTY[settings.get_difficulty()]
+				var lines_per_customer := RankCalculator.master_customer_combo(settings)
+				lines_per_customer *= pow(RankCalculator.RDF_ENDURANCE, rank)
+				var lines := lines_per_customer * settings.finish_condition.value
+				result = _duration_for_lines(settings, lines)
 	
 	return result
 

--- a/project/src/main/puzzle/rank-calculator.gd
+++ b/project/src/main/puzzle/rank-calculator.gd
@@ -267,6 +267,9 @@ func _populate_rank_fields(rank_result: RankResult, lenient: bool) -> void:
 	if finish_condition.type in [Milestone.PIECES, Milestone.TIME_OVER]:
 		target_lines = max(0, ceil(target_lines - leftover_lines / 3.0))
 	
+	# avoid divide-by-zero errors
+	target_lines = max(1, target_lines)
+	
 	var target_leftover_score := target_leftover_score(leftover_lines)
 	
 	rank_result.speed_rank = log(rank_result.speed / target_speed) / log(RDF_SPEED)

--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -30,6 +30,7 @@ func _ready() -> void:
 func start_customer_countdown() -> void:
 	yield(PuzzleState, "after_level_changed")
 	MusicPlayer.play_upbeat_bgm(false)
+	PuzzleState.game_active = true
 	puzzle.start_level_countdown()
 
 
@@ -39,7 +40,6 @@ func start_customer_countdown() -> void:
 ## 	'messages': Array of string messages to be shown when the sensei is dismissed.
 func dismiss_sensei(messages: Array) -> void:
 	PuzzleState.reset()
-	PuzzleState.game_active = true
 	puzzle.scroll_to_new_creature()
 	hud.set_messages(messages)
 	hud.enqueue_pop_out()

--- a/project/src/test/puzzle/test-rank-calculator.gd
+++ b/project/src/test/puzzle/test-rank-calculator.gd
@@ -7,22 +7,22 @@ func before_each() -> void:
 	PuzzleState.level_performance = PuzzlePerformance.new()
 
 
-func test_master_lpm_slow_marathon() -> void:
+func test_rank_lpm_slow_marathon() -> void:
 	CurrentLevel.settings.speed.set_start_speed("0")
 	assert_almost_eq(_rank_calculator.rank_lpm(RankResult.BEST_RANK), 30.77, 0.1)
 
 
-func test_master_lpm_medium_marathon() -> void:
+func test_rank_lpm_medium_marathon() -> void:
 	CurrentLevel.settings.speed.set_start_speed("A0")
 	assert_almost_eq(_rank_calculator.rank_lpm(RankResult.BEST_RANK), 35.64, 0.1)
 
 
-func test_master_lpm_fast_marathon() -> void:
+func test_rank_lpm_fast_marathon() -> void:
 	CurrentLevel.settings.speed.set_start_speed("F0")
 	assert_almost_eq(_rank_calculator.rank_lpm(RankResult.BEST_RANK), 65.00, 0.1)
 
 
-func test_master_lpm_mixed_marathon() -> void:
+func test_rank_lpm_mixed_marathon() -> void:
 	CurrentLevel.settings.speed.set_start_speed("0")
 	CurrentLevel.settings.speed.add_speed_up(Milestone.LINES, 30, "A0")
 	CurrentLevel.settings.speed.add_speed_up(Milestone.LINES, 60, "F0")
@@ -30,7 +30,7 @@ func test_master_lpm_mixed_marathon() -> void:
 	assert_almost_eq(_rank_calculator.rank_lpm(RankResult.BEST_RANK), 45.27, 0.1)
 
 
-func test_master_lpm_mixed_sprint() -> void:
+func test_rank_lpm_mixed_sprint() -> void:
 	CurrentLevel.settings.speed.set_start_speed("0")
 	CurrentLevel.settings.speed.add_speed_up(Milestone.TIME_OVER, 30, "A0")
 	CurrentLevel.settings.speed.add_speed_up(Milestone.TIME_OVER, 60, "F0")
@@ -99,11 +99,19 @@ func test_calculate_rank_marathon_300_fail() -> void:
 	assert_eq(rank.score_rank, 999.0)
 
 
-func test_calculate_pieces_rank() -> void:
+func test_calculate_rank_40_pieces() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.PIECES, 80)
 	PuzzleState.level_performance.pieces = 40
 	var rank := _rank_calculator.calculate_rank()
 	assert_eq(RankCalculator.grade(rank.pieces_rank), "S+")
+
+
+func test_calculate_rank_1_piece() -> void:
+	CurrentLevel.settings.set_finish_condition(Milestone.PIECES, 1)
+	PuzzleState.level_performance.pieces = 0
+	var rank := _rank_calculator.calculate_rank()
+	# most importantly, this should avoid a divide-by-zero error
+	assert_eq(RankCalculator.grade(rank.pieces_rank), "-")
 
 
 func test_calculate_rank_sprint_120_top_out() -> void:


### PR DESCRIPTION
PuzzleDemo now ignores the start_level so we can test the middle part of
tutorials.

DurationCalculator no longer calculates the duration of tutorials.
Tutorials have many parts so it was inaccurate to calculate 'The player only
has to clear two lines, so it is a short tutorial'

Fixed divide by zero in RankCalculator with very short levels, such as
levels with only one piece. Target_lines was zero (you can't clear a
line with only one piece) resulting in errors trying to figure out how
the player's performance compared with the expected zero lines.

Moved tutorial's 'game_active = true' statement. This was causing
problems in PuzzleDemo -- when testing the last section of a tutorial,
it would display 'Ready?' but never proceed to 'Go!' because it thought
the game was already active.