### PR TITLE
Fixed Tutorial's flash effect to fill the entire screen.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -359,6 +359,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/ui/level-select/hookable-grade-label.gd"
 }, {
+"base": "ColorRect",
+"class": "HudFlash",
+"language": "GDScript",
+"path": "res://src/main/puzzle/hud-flash.gd"
+}, {
 "base": "Timer",
 "class": "IdleTimer",
 "language": "GDScript",
@@ -1075,6 +1080,7 @@ _global_script_class_icons={
 "HeadBobber": "",
 "HighScoreTable": "",
 "HookableGradeLabel": "",
+"HudFlash": "",
 "IdleTimer": "",
 "ImageButton": "",
 "InputReplay": "",

--- a/project/src/demo/puzzle/tutorial/tutorial-hud-demo.gd
+++ b/project/src/demo/puzzle/tutorial/tutorial-hud-demo.gd
@@ -6,6 +6,7 @@ extends Node
 ## 	[shift+0-9]: Enqueues a message; 1 = short, 0 = long
 ## 	[O]: Prints a message in a big font
 ## 	[H]: Hides the message after a short delay
+## 	[F]: Flashes the screen
 
 const TEXTS := [
 	"Oh my,/ you're not supposed to know how to do that!\n\n" \
@@ -45,5 +46,7 @@ func _input(event: InputEvent) -> void:
 				_tutorial_messages.set_message(TEXTS[Utils.key_num(event)])
 		KEY_O:
 			_tutorial_messages.set_big_message("O/H/,/// M/Y/!/!/!")
+		KEY_F:
+			_tutorial_hud.flash_for_level_change()
 		KEY_H:
 			_tutorial_messages.enqueue_pop_out()

--- a/project/src/main/puzzle/HudFlash.tscn
+++ b/project/src/main/puzzle/HudFlash.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/main/puzzle/hud-flash.gd" type="Script" id=1]
+
+[node name="HudFlash" type="ColorRect"]
+modulate = Color( 1, 1, 1, 0 )
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+script = ExtResource( 1 )
+
+[node name="Tween" type="Tween" parent="."]

--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=99 format=2]
+[gd_scene load_steps=100 format=2]
 
 [ext_resource path="res://src/main/ui/menu/theme/h3.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/tutorial/TutorialHud.tscn" type="PackedScene" id=2]
@@ -74,6 +74,7 @@
 [ext_resource path="res://src/main/puzzle/StarSeed.tscn" type="PackedScene" id=72]
 [ext_resource path="res://src/main/ui/menu/theme/h2-font-outline.tres" type="DynamicFont" id=73]
 [ext_resource path="res://src/main/puzzle/puzzle-bg-loader.gd" type="Script" id=74]
+[ext_resource path="res://src/main/puzzle/HudFlash.tscn" type="PackedScene" id=75]
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 1, 1, 1, 0.333333 )
@@ -581,6 +582,7 @@ rect_min_size = Vector2( 1024, 600 )
 [node name="TutorialHud" parent="Hud/HudUi" instance=ExtResource( 2 )]
 visible = false
 puzzle_path = NodePath("../../..")
+hud_flash_path = NodePath("../../HudFlash")
 
 [node name="PuzzleMessages" parent="Hud/HudUi" instance=ExtResource( 62 )]
 mouse_filter = 2
@@ -644,6 +646,8 @@ margin_left = 0.0
 margin_top = 250.0
 margin_right = 482.0
 margin_bottom = 270.0
+
+[node name="HudFlash" parent="Hud" instance=ExtResource( 75 )]
 
 [node name="SettingsMenu" parent="." instance=ExtResource( 26 )]
 

--- a/project/src/main/puzzle/hud-flash.gd
+++ b/project/src/main/puzzle/hud-flash.gd
@@ -1,0 +1,10 @@
+class_name HudFlash
+extends ColorRect
+## Flashes the screen briefly. Used to transition between tutorial sections.
+
+## Flashes the screen briefly. Used to transition between tutorial sections.
+func flash() -> void:
+	modulate.a = 0.25
+	$Tween.remove_all()
+	$Tween.interpolate_property(self, "modulate:a", modulate.a, 0.0, 1.0)
+	$Tween.start()

--- a/project/src/main/puzzle/tutorial/tutorial-hud.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-hud.gd
@@ -7,7 +7,11 @@ signal refreshed
 
 export (NodePath) var puzzle_path: NodePath
 
+export (NodePath) var hud_flash_path: NodePath
+
 onready var puzzle: Puzzle = get_node(puzzle_path)
+
+onready var _hud_flash: HudFlash = get_node(hud_flash_path)
 
 func _ready() -> void:
 	visible = false
@@ -35,12 +39,14 @@ func replace_tutorial_module() -> void:
 	var module_path: String
 	if CurrentLevel.settings.id.begins_with("tutorial/basics_"):
 		module_path = "res://src/main/puzzle/tutorial/TutorialBasicsModule.tscn"
-	elif CurrentLevel.settings.id.begins_with("tutorial/squish_"):
-		module_path = "res://src/main/puzzle/tutorial/TutorialSquishModule.tscn"
-	elif CurrentLevel.settings.id.begins_with("tutorial/combo_"):
-		module_path = "res://src/main/puzzle/tutorial/TutorialComboModule.tscn"
 	elif CurrentLevel.settings.id.begins_with("tutorial/cakes_"):
 		module_path = "res://src/main/puzzle/tutorial/TutorialCakesModule.tscn"
+	elif CurrentLevel.settings.id.begins_with("tutorial/combo_"):
+		module_path = "res://src/main/puzzle/tutorial/TutorialComboModule.tscn"
+	elif CurrentLevel.settings.id.begins_with("tutorial/squish_"):
+		module_path = "res://src/main/puzzle/tutorial/TutorialSquishModule.tscn"
+	elif CurrentLevel.settings.id.begins_with("tutorial/spins_"):
+		module_path = "res://src/main/puzzle/tutorial/TutorialSpinsModule.tscn"
 	
 	if module_path:
 		var tutorial_module_scene: PackedScene = ResourceCache.get_resource(module_path)
@@ -113,18 +119,15 @@ func show_skill_tally_items() -> void:
 		skill_tally_item.visible = true
 
 
-## Pauses and plays a camera _flash effect for transitions.
-func _flash() -> void:
+func flash_for_level_change() -> void:
 	puzzle.get_playfield().add_misc_delay_frames(30)
-	$ZIndex/ColorRect.modulate.a = 0.25
-	$Tween.remove_all()
-	$Tween.interpolate_property($ZIndex/ColorRect, "modulate:a", $ZIndex/ColorRect.modulate.a, 0.0, 1.0)
-	$Tween.start()
+	_hud_flash.flash()
 
 
+## Pauses and plays a camera flash effect for transitions.
 func _on_PuzzleState_after_level_changed() -> void:
 	$SkillTallyItems.visible = CurrentLevel.settings.other.tutorial
-	_flash()
+	flash_for_level_change()
 
 
 func _on_PuzzleState_game_prepared() -> void:


### PR DESCRIPTION
This involved pulling the TutorialHud's flash effect into Puzzle's Canvas
node where it could fill the entire canvas. Instead of TutorialHud
having a HudFlash node, it now has a reference to one.