### PR TITLE
ChattableManager refactoring. Cutscene refactorings, bug fixes.

### DIFF
--- a/project/assets/main/puzzle/career-worlds.json
+++ b/project/assets/main/puzzle/career-worlds.json
@@ -7,8 +7,7 @@
       "overworld_environment": "lemon",
       "puzzle_environment": "lemon",
       "piece_speed": "0",
-      "boss_level":
-      {
+      "boss_level": {
         "id": "career/boss_7k"
       },
       "levels": [
@@ -46,8 +45,7 @@
       "distance": 10,
       "icon": "cactus",
       "piece_speed": "0-3",
-      "boss_level":
-      {
+      "boss_level": {
         "id": "career/boss_5k"
       },
       "levels": [
@@ -91,8 +89,7 @@
       "distance": 25,
       "icon": "island",
       "piece_speed": "1-5",
-      "boss_level":
-      {
+      "boss_level": {
         "id": "career/boss_4k"
       },
       "levels": [
@@ -150,16 +147,14 @@
       "overworld_environment": "marsh",
       "piece_speed": "3-7",
       "cutscene_path": "chat/career/marsh",
-      "intro_level":
-      {
+      "intro_level": {
         "id": "career/curly_queue",
         "chef_id": "skins",
         "customer_ids": [
           "rhonk"
         ]
       },
-      "boss_level":
-      {
+      "boss_level": {
         "id": "career/boss_3k"
       },
       "levels": [
@@ -232,8 +227,7 @@
       "distance": 60,
       "icon": "gear",
       "piece_speed": "5-8",
-      "boss_level":
-      {
+      "boss_level": {
         "id": "career/boss_2k"
       },
       "levels": [
@@ -277,8 +271,7 @@
       "distance": 80,
       "icon": "volcano",
       "piece_speed": "6-9",
-      "boss_level":
-      {
+      "boss_level": {
         "id": "career/boss_1k"
       },
       "levels": [

--- a/project/src/main/string-utils.gd
+++ b/project/src/main/string-utils.gd
@@ -119,13 +119,23 @@ static func format_money(money: int) -> String:
 	return result
 
 
-## Returns true if the specified string contains at least one letter (a-z, A-Z)
-static func has_letter(string: String) -> bool:
+## Returns true if the specified string contains at least one letter (a-z, A-Z) outside parentheses.
+static func has_non_parentheses_letter(string: String) -> bool:
+	var ignored_letter := true
 	var result := false
+	var within_parentheses := false
 	for c in string:
-		if is_letter(c):
+		if c == "(":
+			within_parentheses = true
+		elif c == ")" and within_parentheses:
+			within_parentheses = false
+		elif is_letter(c) and not within_parentheses:
+			ignored_letter = true
 			result = true
 			break
+	if ignored_letter and within_parentheses:
+		# close parentheses was missing, such as '(abc'
+		result = true
 	return result
 
 

--- a/project/src/main/ui/chat/chat-frame.gd
+++ b/project/src/main/ui/chat/chat-frame.gd
@@ -69,6 +69,8 @@ func play_chat_event(chat_event: ChatEvent, squished: bool) -> void:
 	var creature_name := ""
 	if chat_event.who:
 		var creature_def := PlayerData.creature_library.get_creature_def(chat_event.who)
+		if not creature_def:
+			push_error("creature_def not found with id '%s'" % [chat_event.who])
 		creature_name = creature_def.creature_name
 	$ChatLinePanel/NametagPanel.set_nametag_text(creature_name)
 	

--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -325,7 +325,7 @@ func _on_ChatUi_chat_event_played(chat_event: ChatEvent) -> void:
 	var chatter: Creature = ChattableManager.get_creature_by_id(chat_event.who)
 	if chatter and chatter.has_method("play_mood"):
 		chatter.call("play_mood", chat_event.mood)
-	if chatter and StringUtils.has_letter(chat_event.text):
+	if chatter and StringUtils.has_non_parentheses_letter(chat_event.text):
 		chatter.talk()
 		emit_signal("chatter_talked", chatter)
 

--- a/project/src/main/world/chattable-manager.gd
+++ b/project/src/main/world/chattable-manager.gd
@@ -73,10 +73,9 @@ func refresh_creatures() -> void:
 		var creature: Creature = creature_obj
 		if creature.creature_id == CreatureLibrary.PLAYER_ID:
 			set_player(creature)
-		elif creature.creature_id == CreatureLibrary.SENSEI_ID:
+		if creature.creature_id == CreatureLibrary.SENSEI_ID:
 			set_sensei(creature)
-		else:
-			register_creature(creature)
+		register_creature(creature)
 
 
 ## Returns the Creature object corresponding to the specified chatter name.
@@ -84,14 +83,7 @@ func refresh_creatures() -> void:
 ## A name of SENSEI_ID or PLAYER_ID will return the sensei or player object. To avoid
 ## conflicts, the sensei or player cannot be retrieved by their actual name.
 func get_creature_by_id(chat_id: String) -> Creature:
-	var result: Creature
-	match chat_id:
-		CreatureLibrary.SENSEI_ID: result = ChattableManager.sensei
-		CreatureLibrary.PLAYER_ID: result = ChattableManager.player
-		_:
-			if _creatures_by_id.has(chat_id):
-				result = _creatures_by_id[chat_id]
-	return result
+	return _creatures_by_id.get(chat_id)
 
 
 ## Loads the chat tree for the currently focused chattable.

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -210,6 +210,8 @@ func _load_texture(dna: Dictionary, node_path: String, key: String, filename: St
 			# Avoid loading non-existent resources. Loading a non-existent resource returns null which is what we want,
 			# but also throws an error.
 			pass
+		elif Engine.is_editor_hint():
+			resource = load(resource_path)
 		else:
 			resource = ResourceCache.get_resource(resource_path)
 	

--- a/project/src/test/test-string-utils.gd
+++ b/project/src/test/test-string-utils.gd
@@ -156,11 +156,23 @@ func test_format_money() -> void:
 	assert_eq(StringUtils.format_money(1234567), "¥1,234,567")
 
 
-func test_has_letter() -> void:
-	assert_eq(StringUtils.has_letter("roof action"), true)
-	assert_eq(StringUtils.has_letter("ROOF ACTION"), true)
-	assert_eq(StringUtils.has_letter("123"), false)
-	assert_eq(StringUtils.has_letter(""), false)
+func test_has_non_parentheses_letter() -> void:
+	assert_eq(StringUtils.has_non_parentheses_letter("roof action"), true)
+	assert_eq(StringUtils.has_non_parentheses_letter("ROOF ACTION"), true)
+	assert_eq(StringUtils.has_non_parentheses_letter("123"), false)
+	assert_eq(StringUtils.has_non_parentheses_letter(""), false)
+
+
+func test_has_non_parentheses_letter_parentheses() -> void:
+	assert_eq(StringUtils.has_non_parentheses_letter("(spell"), true)
+	assert_eq(StringUtils.has_non_parentheses_letter("(spell)"), false)
+	assert_eq(StringUtils.has_non_parentheses_letter("spell)"), true)
+	
+	assert_eq(StringUtils.has_non_parentheses_letter("(spell) fry"), true)
+	assert_eq(StringUtils.has_non_parentheses_letter("(spell) (fry)"), false)
+	assert_eq(StringUtils.has_non_parentheses_letter("spell (fry)"), true)
+	
+	assert_eq(StringUtils.has_non_parentheses_letter("(spell) fry (tap)"), true)
 
 
 func test_hyphens_to_underscores() -> void:


### PR DESCRIPTION
ChattableManager stores/retrieves player/sensei from the same dictionary
as other creatures. We originally avoided this because of name
conflicts, but they're given unique strings like '#sensei#' which can't
conflict.

Reformatted career-worlds.json.

Creatures no longer move their mouths when saying non-verbal lines like
'(sigh)' or '(knock, knock, knock)'

Fixed bug where creatures could no longer be viewed in the editor.
CreatureLoader no longer relies on ResourceCache in the editor.

OverworldWalk scenes should now work in any of the four directions.