### PR TITLE
TutorialHud refactoring: SkillTallyPanel, onready fields

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -879,6 +879,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/puzzle/tutorial/skill-tally-item.gd"
 }, {
+"base": "Panel",
+"class": "SkillTallyPanel",
+"language": "GDScript",
+"path": "res://src/main/puzzle/tutorial/skill-tally-panel.gd"
+}, {
 "base": "Path2D",
 "class": "SmoothPath",
 "language": "GDScript",
@@ -1184,6 +1189,7 @@ _global_script_class_icons={
 "SettingsMenu": "",
 "ShadowCasterShadows": "",
 "SkillTallyItem": "",
+"SkillTallyPanel": "",
 "SmoothPath": "",
 "Spawn": "",
 "SpeedRules": "",

--- a/project/src/demo/puzzle/tutorial/tutorial-hud-demo.gd
+++ b/project/src/demo/puzzle/tutorial/tutorial-hud-demo.gd
@@ -27,7 +27,6 @@ const TEXTS := [
 export (String) var level_id: String = LevelLibrary.BEGINNER_TUTORIAL
 
 onready var _tutorial_hud: TutorialHud = $Level/Hud/HudUi/TutorialHud
-onready var _tutorial_messages: TutorialMessages = $Level/Hud/HudUi/TutorialHud/Messages
 
 func _ready() -> void:
 	var level_settings := LevelSettings.new()
@@ -41,12 +40,12 @@ func _input(event: InputEvent) -> void:
 	match Utils.key_scancode(event):
 		KEY_0, KEY_1, KEY_2, KEY_3, KEY_4, KEY_5, KEY_6, KEY_7, KEY_8, KEY_9:
 			if Input.is_key_pressed(KEY_SHIFT):
-				_tutorial_messages.enqueue_message(TEXTS[Utils.key_num(event)])
+				_tutorial_hud.enqueue_message(TEXTS[Utils.key_num(event)])
 			else:
-				_tutorial_messages.set_message(TEXTS[Utils.key_num(event)])
+				_tutorial_hud.set_message(TEXTS[Utils.key_num(event)])
 		KEY_O:
-			_tutorial_messages.set_big_message("O/H/,/// M/Y/!/!/!")
+			_tutorial_hud.set_big_message("O/H/,/// M/Y/!/!/!")
 		KEY_F:
 			_tutorial_hud.flash_for_level_change()
 		KEY_H:
-			_tutorial_messages.enqueue_pop_out()
+			_tutorial_hud.enqueue_pop_out()

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -13,6 +13,7 @@ func _ready() -> void:
 	PuzzleState.connect("game_started", self, "_on_PuzzleState_game_started")
 	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")
 	PuzzleState.connect("after_game_ended", self, "_on_PuzzleState_after_game_ended")
+	PuzzleState.connect("after_level_changed", self, "_on_PuzzleState_after_level_changed")
 	$Fg/Playfield/TileMapClip/TileMap/Viewport/ShadowMap.piece_tile_map = $Fg/PieceManager/TileMap
 	$Fg/PieceManager.connect(
 			"piece_disturbed", $Fg/Playfield.pickups, "_on_PieceManager_piece_disturbed")
@@ -321,6 +322,11 @@ func _update_career_data(rank_result: RankResult) -> void:
 ## This makes the stutter from writing to disk less noticable.
 func _on_PuzzleState_after_game_ended() -> void:
 	PlayerSave.save_player_data()
+
+
+## Briefly pause during level transitions.
+func _on_PuzzleState_after_level_changed() -> void:
+	$Fg/Playfield.add_misc_delay_frames(30)
 
 
 func _on_SettingsMenu_quit_pressed() -> void:

--- a/project/src/main/puzzle/tutorial/TutorialHud.tscn
+++ b/project/src/main/puzzle/tutorial/TutorialHud.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://src/main/ui/chat/ChatChoices.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/ui/chat/ChatLineLabel.tscn" type="PackedScene" id=2]
@@ -8,6 +8,7 @@
 [ext_resource path="res://src/main/ui/chat/ChatPopTween.tscn" type="PackedScene" id=6]
 [ext_resource path="res://src/main/ui/chat/ChatLinePanel.tscn" type="PackedScene" id=7]
 [ext_resource path="res://src/main/puzzle/tutorial/tutorial-diagram.gd" type="Script" id=8]
+[ext_resource path="res://src/main/puzzle/tutorial/skill-tally-panel.gd" type="Script" id=9]
 [ext_resource path="res://assets/main/ui/chat/frame-pop-in.wav" type="AudioStream" id=12]
 [ext_resource path="res://assets/main/ui/chat/frame-pop-out.wav" type="AudioStream" id=13]
 
@@ -116,17 +117,15 @@ margin_right = 405.0
 margin_bottom = 600.0
 rect_min_size = Vector2( 0, 150 )
 
-[node name="SkillTallyItems" type="Panel" parent="."]
+[node name="SkillTallyPanel" type="Panel" parent="."]
 margin_left = 774.0
 margin_top = 10.0
 margin_right = 1014.0
 margin_bottom = 590.0
 custom_styles/panel = ExtResource( 3 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource( 9 )
 
-[node name="GridContainer" type="GridContainer" parent="SkillTallyItems"]
+[node name="GridContainer" type="GridContainer" parent="SkillTallyPanel"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5

--- a/project/src/main/puzzle/tutorial/skill-tally-item.gd
+++ b/project/src/main/puzzle/tutorial/skill-tally-item.gd
@@ -1,8 +1,6 @@
 class_name SkillTallyItem
 extends ProgressBar
-## Provides feedback to the player when they perform an action, such as rotating a piece or clearing a line.
-##
-## This is used during tutorials so the player can see what to do.
+## Provides feedback during tutorials when the player performs an action, such as rotating a piece or clearing a line.
 
 ## if 'true' the skill tally will be shown as '58%' instead of '52/90'
 export (bool) var show_as_percent: bool

--- a/project/src/main/puzzle/tutorial/skill-tally-panel.gd
+++ b/project/src/main/puzzle/tutorial/skill-tally-panel.gd
@@ -1,0 +1,37 @@
+class_name SkillTallyPanel
+extends Panel
+## UI elements for 'skill tally items' which provides feedback during tutorials when the player performs an action,
+## such as rotating a piece or clearing a line.
+
+onready var _grid_container := $GridContainer
+
+func _ready() -> void:
+	visible = false
+	PuzzleState.connect("after_level_changed", self, "_on_PuzzleState_after_level_changed")
+
+
+## Returns a specific SkillTallyItem instance in the panel.
+func skill_tally_item(name: String) -> SkillTallyItem:
+	return _grid_container.get_node(name) as SkillTallyItem
+
+
+## Returns all SkillTallyItem instances in the panel.
+func skill_tally_items() -> Array:
+	return _grid_container.get_children()
+
+
+## Adds a new SkillTallyItem instance to the panel.
+func add_skill_tally_item(item: SkillTallyItem) -> void:
+	_grid_container.add_child(item)
+
+
+## Shows the panel containing skill tally items.
+func show_skill_tally_items() -> void:
+	show()
+	for skill_tally_item in skill_tally_items():
+		skill_tally_item.visible = true
+
+
+## Pauses and plays a camera flash effect for transitions.
+func _on_PuzzleState_after_level_changed() -> void:
+	visible = CurrentLevel.settings.other.tutorial

--- a/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
@@ -38,7 +38,7 @@ func prepare_tutorial_level() -> void:
 			hud.skill_tally_item("SnackBox").visible = true
 			hud.set_message(tr("Try making some snack boxes by arranging pairs of pieces into squares."))
 		"tutorial/cakes_1":
-			hud.get_tutorial_diagram().show_diagram(_cakes_diagram_0)
+			hud.diagram.show_diagram(_cakes_diagram_0)
 			hud.set_message(tr("Arranging pieces into a square makes a snack box worth ¥15."
 					+ "\n\nBut rectangles make cake boxes worth ¥40!"))
 			hud.enqueue_message(tr("A cake box needs exactly three pieces in a rectangle.\n\nNo more, no less."))
@@ -66,7 +66,7 @@ func prepare_tutorial_level() -> void:
 			else:
 				hud.set_message(tr("Here's something more difficult. Can you make two cake boxes at once?"))
 		"tutorial/cakes_5":
-			hud.get_tutorial_diagram().show_diagram(_cakes_diagram_1)
+			hud.diagram.show_diagram(_cakes_diagram_1)
 			hud.set_message(tr("You can make cake boxes with the bigger pieces."
 					+ "\n\nAnd they're worth three times as much sideways!"))
 			hud.enqueue_message(tr("See all those stars? Each star becomes a tasty treat for our customers."

--- a/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
@@ -31,8 +31,8 @@ func _ready() -> void:
 	playfield.connect("line_cleared", self, "_on_Playfield_line_cleared")
 	playfield.connect("box_built", self, "_on_Playfield_box_built")
 	piece_manager.connect("piece_spawned", self, "_on_PieceManager_piece_spawned")
-	hud.get_tutorial_diagram().connect("ok_chosen", self, "_on_TutorialDiagram_ok_chosen")
-	hud.get_tutorial_diagram().connect("help_chosen", self, "_on_TutorialDiagram_help_chosen")
+	hud.diagram.connect("ok_chosen", self, "_on_TutorialDiagram_ok_chosen")
+	hud.diagram.connect("help_chosen", self, "_on_TutorialDiagram_help_chosen")
 	
 	hud.set_message(tr("Today we'll go over combos."
 			+ "\n\nCombos are easy, you might have already done them on accident!"))
@@ -167,7 +167,7 @@ func _show_next_diagram() -> void:
 					+ "\n\nSo, you're allowed to make one mistake! Or, to use one piece to plan ahead."))
 	hud.set_messages(hud_messages)
 	
-	hud.get_tutorial_diagram().show_diagram(_combo_diagram, true)
+	hud.diagram.show_diagram(_combo_diagram, true)
 	_show_diagram_count += 1
 
 
@@ -187,8 +187,8 @@ func _on_PuzzleState_after_piece_written() -> void:
 				_advance_level()
 		"tutorial/combo_3":
 			if PuzzleState.level_performance.pieces == 2:
-				if not hud.get_tutorial_messages().is_all_messages_visible():
-					yield(hud.get_tutorial_messages(), "all_messages_shown")
+				if not hud.messages.is_all_messages_visible():
+					yield(hud.messages, "all_messages_shown")
 				yield(get_tree().create_timer(3.0), "timeout")
 				hud.set_message(tr("Oops! I can still make the cake box, but my combo already broke."))
 			if PuzzleState.level_performance.pieces >= 3:
@@ -197,8 +197,8 @@ func _on_PuzzleState_after_piece_written() -> void:
 		"tutorial/combo_4":
 			if PuzzleState.level_performance.pieces >= 4:
 				hud.set_message(tr("There, I did it!\n\nThat was tricky."))
-				if not hud.get_tutorial_messages().is_all_messages_visible():
-					yield(hud.get_tutorial_messages(), "all_messages_shown")
+				if not hud.messages.is_all_messages_visible():
+					yield(hud.messages, "all_messages_shown")
 				yield(get_tree().create_timer(3.0), "timeout")
 				_advance_level()
 		"tutorial/combo_5":

--- a/project/src/main/puzzle/tutorial/tutorial-diagram.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-diagram.gd
@@ -35,8 +35,8 @@ func show_diagram(texture: Texture, show_choices: bool = false) -> void:
 		$VBoxContainer/ChatChoices.visible = false
 	
 	if show_choices:
-		if not _hud.get_tutorial_messages().is_all_messages_visible():
-			yield(_hud.get_tutorial_messages(), "all_messages_shown")
+		if not _hud.messages.is_all_messages_visible():
+			yield(_hud.messages, "all_messages_shown")
 		var choices: Array
 		match _show_diagram_count % 3:
 			0: choices = [tr("Okay, I get it!"), tr("...Can you go into more detail?")]

--- a/project/src/main/puzzle/tutorial/tutorial-hud.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-hud.gd
@@ -9,8 +9,11 @@ export (NodePath) var puzzle_path: NodePath
 
 export (NodePath) var hud_flash_path: NodePath
 
-onready var puzzle: Puzzle = get_node(puzzle_path)
+onready var messages: TutorialMessages = $Messages
+onready var diagram: TutorialDiagram = $Diagram
+onready var skill_tally_panel: SkillTallyPanel = $SkillTallyPanel
 
+onready var puzzle: Puzzle = get_node(puzzle_path)
 onready var _hud_flash: HudFlash = get_node(hud_flash_path)
 
 func _ready() -> void:
@@ -19,14 +22,6 @@ func _ready() -> void:
 	PuzzleState.connect("after_level_changed", self, "_on_PuzzleState_after_level_changed")
 	CurrentLevel.connect("settings_changed", self, "_on_Level_settings_changed")
 	replace_tutorial_module()
-
-
-func get_tutorial_diagram() -> TutorialDiagram:
-	return $Diagram as TutorialDiagram
-
-
-func get_tutorial_messages() -> TutorialMessages:
-	return $Messages as TutorialMessages
 
 
 ## Loads a new tutorial module corresponding to the current level.
@@ -64,69 +59,65 @@ func replace_tutorial_module() -> void:
 func refresh() -> void:
 	# only visible for tutorial levels
 	visible = CurrentLevel.settings.other.tutorial or CurrentLevel.settings.other.after_tutorial
-	$Diagram.hide()
+	diagram.hide()
 	emit_signal("refreshed")
 
 
 ## Returns a specific SkillTallyItem instance in the panel.
 func skill_tally_item(name: String) -> SkillTallyItem:
-	return get_node("SkillTallyItems/GridContainer/%s" % name) as SkillTallyItem
+	return skill_tally_panel.skill_tally_item(name)
 
 
 ## Returns all SkillTallyItem instances in the panel.
 func skill_tally_items() -> Array:
-	return $SkillTallyItems/GridContainer.get_children()
+	return skill_tally_panel.skill_tally_items()
 
 
 ## Adds a new SkillTallyItem instance to the panel.
 func add_skill_tally_item(item: SkillTallyItem) -> void:
-	$SkillTallyItems/GridContainer.add_child(item)
+	skill_tally_panel.add_skill_tally_item(item)
+
+
+## Shows the panel containing skill tally items.
+func show_skill_tally_items() -> void:
+	skill_tally_panel.show_skill_tally_items()
 
 
 ## Displays a sequence of messages from the sensei.
-func set_messages(messages: Array) -> void:
-	$Messages.set_messages(messages)
+func set_messages(new_messages: Array) -> void:
+	messages.set_messages(new_messages)
 
 
 ## Displays a message from the sensei.
-func set_message(message: String) -> void:
-	$Messages.set_message(message)
+func set_message(new_message: String) -> void:
+	messages.set_message(new_message)
 
 
 ## Displays a BIG message from the sensei, for use in easter eggs.
-func set_big_message(message: String) -> void:
-	$Messages.set_big_message(message)
+func set_big_message(new_message: String) -> void:
+	messages.set_big_message(new_message)
 
 
 ## Displays a message after a short delay.
 ##
 ## If other messages are already in the queue, this message will be appended to the queue.
 func enqueue_message(message: String) -> void:
-	$Messages.enqueue_message(message)
+	messages.enqueue_message(message)
 
 
 ## Hides the currently shown message after a short delay.
 ##
 ## If other messages are already in the queue, this operation will be appended to the queue.
 func enqueue_pop_out() -> void:
-	$Messages.enqueue_pop_out()
+	messages.enqueue_pop_out()
 
 
-## Shows the panel containing skill tally items.
-func show_skill_tally_items() -> void:
-	$SkillTallyItems.show()
-	for skill_tally_item in skill_tally_items():
-		skill_tally_item.visible = true
-
-
+## Plays a camera flash effect for transitions.
 func flash_for_level_change() -> void:
-	puzzle.get_playfield().add_misc_delay_frames(30)
 	_hud_flash.flash()
 
 
-## Pauses and plays a camera flash effect for transitions.
 func _on_PuzzleState_after_level_changed() -> void:
-	$SkillTallyItems.visible = CurrentLevel.settings.other.tutorial
 	flash_for_level_change()
 
 

--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -67,8 +67,8 @@ func prepare_tutorial_level() -> void:
 func change_level(level_id: String, delay_between_levels: float = PuzzleState.DELAY_SHORT) -> void:
 	PuzzleState.emit_signal("before_level_changed", level_id)
 	
-	if not hud.get_tutorial_messages().is_all_messages_visible():
-		yield(hud.get_tutorial_messages(), "all_messages_shown")
+	if not hud.messages.is_all_messages_visible():
+		yield(hud.messages, "all_messages_shown")
 	if delay_between_levels:
 		yield(get_tree().create_timer(delay_between_levels), "timeout")
 	

--- a/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
@@ -29,8 +29,8 @@ func _ready() -> void:
 	playfield.connect("box_built", self, "_on_Playfield_box_built")
 	piece_manager.connect("squish_moved", self, "_on_PieceManager_squish_moved")
 	piece_manager.connect("piece_spawned", self, "_on_PieceManager_piece_spawned")
-	hud.get_tutorial_diagram().connect("ok_chosen", self, "_on_TutorialDiagram_ok_chosen")
-	hud.get_tutorial_diagram().connect("help_chosen", self, "_on_TutorialDiagram_help_chosen")
+	hud.diagram.connect("ok_chosen", self, "_on_TutorialDiagram_ok_chosen")
+	hud.diagram.connect("help_chosen", self, "_on_TutorialDiagram_help_chosen")
 	
 	# display a welcome message before the game starts
 	hud.set_message(tr("Today we'll cover some advanced squish move techniques!"
@@ -154,7 +154,7 @@ func _show_next_diagram() -> void:
 	match _show_diagram_count % 2:
 		0: hud_diagram = _squish_diagram_0
 		1: hud_diagram = _squish_diagram_1
-	hud.get_tutorial_diagram().show_diagram(hud_diagram, true)
+	hud.diagram.show_diagram(hud_diagram, true)
 	_show_diagram_count += 1
 
 
@@ -194,8 +194,8 @@ func _on_PuzzleState_after_piece_written() -> void:
 		"tutorial/squish_5":
 			if PuzzleState.level_performance.pieces == 1:
 				CurrentLevel.settings.input_replay.clear()
-				if not hud.get_tutorial_messages().is_all_messages_visible():
-					yield(hud.get_tutorial_messages(), "all_messages_shown")
+				if not hud.messages.is_all_messages_visible():
+					yield(hud.messages, "all_messages_shown")
 				yield(get_tree().create_timer(1.5), "timeout")
 				if _level_attempt_count.get(CurrentLevel.settings.id, 0) >= 2:
 					hud.set_message(tr("Not again! ...Can you clean this up using squish moves?"
@@ -211,8 +211,8 @@ func _on_PuzzleState_after_piece_written() -> void:
 		"tutorial/squish_6":
 			if PuzzleState.level_performance.pieces == 1:
 				CurrentLevel.settings.input_replay.clear()
-				if not hud.get_tutorial_messages().is_all_messages_visible():
-					yield(hud.get_tutorial_messages(), "all_messages_shown")
+				if not hud.messages.is_all_messages_visible():
+					yield(hud.messages, "all_messages_shown")
 				yield(get_tree().create_timer(1.5), "timeout")
 				if _level_attempt_count.get(CurrentLevel.settings.id, 0) >= 2:
 					hud.set_message(tr("Oh no, it keeps happening! Well, try to clear three lines."


### PR DESCRIPTION
Extracted SkillTallyPanel script from TutorialHud. TutorialHud provides
facade methods for both SkillTallyPanel and TutorialMessages.

Added onready variables for TutorialHud's diagram and messages. This
reduces the amount of get_node calls amde at runtime.

Pushed some of TutorialHud's listeners out into Puzzle and
SkillTallyPanel.