### PR TITLE
LemonTree, FrameOverworldObstacle QOL improvements

### DIFF
--- a/project/src/main/world/environment/frame-overworld-obstacle.gd
+++ b/project/src/main/world/environment/frame-overworld-obstacle.gd
@@ -5,6 +5,29 @@ extends OverworldObstacle
 ## Current frame to display from the sprite sheet.
 export (int) var frame: int setget set_frame
 
+## If true, the sprite's texture is flipped horizontally.
+export (bool) var flip_h: bool setget set_flip_h
+
+## An editor toggle which randomizes the obstacle's appearance
+export (bool) var shuffle: bool setget set_shuffle
+
 func set_frame(new_frame: int) -> void:
 	frame = new_frame
 	$Sprite.frame = frame
+
+
+func set_flip_h(new_flip_h: bool) -> void:
+	flip_h = new_flip_h
+	$Sprite.flip_h = flip_h
+
+
+## Randomizes the obstacle's appearance.
+func set_shuffle(value: bool) -> void:
+	if not value:
+		return
+	
+	set_frame(randi() % ($Sprite.hframes * $Sprite.vframes))
+	set_flip_h(randf() > 0.5)
+	scale = Vector2(1.0, 1.0)
+	
+	property_list_changed_notify()

--- a/project/src/main/world/environment/lemon/LemonEnvironment.tscn
+++ b/project/src/main/world/environment/lemon/LemonEnvironment.tscn
@@ -144,202 +144,208 @@ position = Vector2( 4591.11, 2331.59 )
 
 [node name="LemonTree1" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 1240.82, 1896.81 )
-leaf_type = 1
-mouth_type = 4
+leaf_type = 3
+mouth_type = 5
 
 [node name="LemonTree2" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 1416.72, 1922.67 )
+leaf_type = 2
+mouth_type = 5
 
 [node name="LemonTree3" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 1898.29, 1737.74 )
-leaf_type = 1
-mouth_type = 2
+leaf_type = 3
+mouth_type = 9
 
 [node name="LemonTree4" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 2413.6, 1173.41 )
-leaf_type = 1
-mouth_type = 3
+mouth_type = 2
 
 [node name="LemonTree5" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 2545.66, 1798.39 )
-leaf_type = 2
+leaf_type = 0
 
 [node name="LemonTree6" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 2966.02, 1913.14 )
-leaf_type = 2
+leaf_type = 1
+mouth_type = 4
 
 [node name="LemonTree7" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 3814.01, 2015.68 )
-mouth_type = 3
+mouth_type = 6
 
 [node name="LemonTree8" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 3989.91, 2041.54 )
-leaf_type = 2
-mouth_type = 2
 
 [node name="LemonTree9" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 496.029, 1772.08 )
-mouth_type = 3
+leaf_type = 4
+mouth_type = 2
 
 [node name="LemonTree10" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 1840.23, 1306.51 )
 leaf_type = 2
+mouth_type = 4
 
 [node name="LemonTree11" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 2750.99, 1202.52 )
-leaf_type = 2
-mouth_type = 3
+mouth_type = 7
 
 [node name="LemonTree12" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 2614.64, 1297.88 )
-leaf_type = 2
-mouth_type = 3
+leaf_type = 3
+mouth_type = 0
 
 [node name="LemonTree13" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 2782.05, 1363.34 )
 leaf_type = 1
-mouth_type = 3
+mouth_type = 6
 
 [node name="LemonTree14" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 1792.04, 1685.38 )
 leaf_type = 2
-mouth_type = 1
+mouth_type = 2
 
 [node name="LemonTree15" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 2274.68, 1257.88 )
-leaf_type = 2
-mouth_type = 4
+leaf_type = 3
+mouth_type = 9
 
 [node name="LemonTree16" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 3332.89, 1608.47 )
-leaf_type = 1
+leaf_type = 0
 mouth_type = 2
 
 [node name="LemonTree17" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 3677.13, 1838.94 )
-leaf_type = 1
-mouth_type = 1
+leaf_type = 0
+mouth_type = 2
 
 [node name="LemonTree18" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 3356.39, 1797.79 )
-leaf_type = 2
+leaf_type = 3
 mouth_type = 4
 
 [node name="LemonTree19" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 2720.61, 1811.2 )
 leaf_type = 2
-mouth_type = 3
+mouth_type = 9
 
 [node name="LemonTree20" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 2987.18, 1479.56 )
 leaf_type = 2
-mouth_type = 2
+mouth_type = 8
 
 [node name="LemonTree21" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 3997.14, 2738.14 )
 leaf_type = 2
+mouth_type = 6
 
 [node name="LemonTree22" parent="Obstacles" instance=ExtResource( 6 )]
 position = Vector2( 2216.86, 1623.96 )
-leaf_type = 2
-mouth_type = 4
+leaf_type = 0
+mouth_type = 5
 
 [node name="LemonCookieSmall1" parent="Obstacles" instance=ExtResource( 9 )]
 position = Vector2( 916.02, 1913.88 )
+flip_h = true
 
 [node name="LemonCookieSmall2" parent="Obstacles" instance=ExtResource( 9 )]
 position = Vector2( 2879.09, 1336.48 )
-frame = 1
+frame = 3
+flip_h = true
 
 [node name="LemonCookieSmall3" parent="Obstacles" instance=ExtResource( 9 )]
 position = Vector2( 4830.89, 2694 )
-frame = 2
+frame = 4
 
 [node name="LemonCookieSmall4" parent="Obstacles" instance=ExtResource( 9 )]
 position = Vector2( 1988.69, 1666.52 )
-frame = 3
 
 [node name="LemonCookieSmall5" parent="Obstacles" instance=ExtResource( 9 )]
 position = Vector2( 2590.42, 1614.2 )
-frame = 4
+frame = 3
 
 [node name="LemonCookieSmall6" parent="Obstacles" instance=ExtResource( 9 )]
 position = Vector2( 3464.18, 1498.21 )
-frame = 5
+frame = 3
 
 [node name="LemonCookieSmall7" parent="Obstacles" instance=ExtResource( 9 )]
 position = Vector2( 2133.77, 1756.9 )
-scale = Vector2( -1, 1 )
+frame = 3
 
 [node name="LemonCookieSmall8" parent="Obstacles" instance=ExtResource( 9 )]
 position = Vector2( 1868.73, 1819 )
-scale = Vector2( -1, 1 )
-frame = 1
+frame = 5
+flip_h = true
 
 [node name="LemonCookieSmall9" parent="Obstacles" instance=ExtResource( 9 )]
 position = Vector2( 3594.11, 2446.64 )
-scale = Vector2( -1, 1 )
-frame = 2
+frame = 1
 
 [node name="LemonCookieSmall10" parent="Obstacles" instance=ExtResource( 9 )]
 position = Vector2( 3740.08, 1983.41 )
-scale = Vector2( -1, 1 )
-frame = 3
+frame = 5
+flip_h = true
 
 [node name="LemonCookieSmall11" parent="Obstacles" instance=ExtResource( 9 )]
 position = Vector2( 2330.01, 1533.38 )
-scale = Vector2( -1, 1 )
 frame = 4
 
 [node name="LemonCookieSmall12" parent="Obstacles" instance=ExtResource( 9 )]
 position = Vector2( 3260.38, 2081.41 )
-scale = Vector2( -1, 1 )
-frame = 5
+frame = 1
+flip_h = true
 
 [node name="LemonCookieLarge1" parent="Obstacles" instance=ExtResource( 7 )]
 position = Vector2( 1597.22, 1677.94 )
+frame = 3
+flip_h = true
 
 [node name="LemonCookieLarge2" parent="Obstacles" instance=ExtResource( 7 )]
 position = Vector2( 3305.59, 2150.28 )
-frame = 1
+frame = 3
+flip_h = true
 
 [node name="LemonCookieLarge3" parent="Obstacles" instance=ExtResource( 7 )]
 position = Vector2( 4253.12, 2783.85 )
-frame = 2
+frame = 1
+flip_h = true
 
 [node name="LemonCookieLarge4" parent="Obstacles" instance=ExtResource( 7 )]
 position = Vector2( 2027.05, 1202.1 )
 frame = 3
+flip_h = true
 
 [node name="LemonCookieLarge5" parent="Obstacles" instance=ExtResource( 7 )]
 position = Vector2( 3118.79, 1432 )
-scale = Vector2( -1, 1 )
+frame = 3
 
 [node name="LemonCookieLarge6" parent="Obstacles" instance=ExtResource( 7 )]
 position = Vector2( 2513.6, 1188.61 )
-scale = Vector2( -1, 1 )
 frame = 1
+flip_h = true
 
 [node name="LemonCookieLarge7" parent="Obstacles" instance=ExtResource( 7 )]
 position = Vector2( 3687.05, 2735.49 )
-scale = Vector2( -1, 1 )
 frame = 2
+flip_h = true
 
 [node name="LemonCookieLarge8" parent="Obstacles" instance=ExtResource( 7 )]
 position = Vector2( 761.041, 1431.09 )
-scale = Vector2( -1, 1 )
-frame = 3
+frame = 2
+flip_h = true
 
 [node name="LemonLemon1" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 2172.29, 1197.71 )
+frame = 3
 
 [node name="LemonLemon2" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 2377.48, 1572.08 )
-frame = 1
 
 [node name="LemonLemon3" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 4155.74, 2270.55 )
-frame = 2
+frame = 1
 
 [node name="LemonLemon4" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 4185.94, 2723.61 )
@@ -347,21 +353,21 @@ frame = 2
 
 [node name="LemonLemon5" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 4398.28, 2966.86 )
-scale = Vector2( -1, 1 )
+frame = 1
+flip_h = true
 
 [node name="LemonLemon6" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 4418.97, 2928.95 )
-scale = Vector2( -1, 1 )
-frame = 1
+frame = 2
+flip_h = true
 
 [node name="LemonLemon7" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 3900.18, 2068.77 )
-scale = Vector2( -1, 1 )
-frame = 2
+frame = 1
+flip_h = true
 
 [node name="LemonLemon8" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 2711.44, 1899.78 )
-scale = Vector2( -1, 1 )
 frame = 2
 
 [node name="LemonLemon9" parent="Obstacles" instance=ExtResource( 10 )]
@@ -369,38 +375,39 @@ position = Vector2( 882.339, 1557.2 )
 
 [node name="LemonLemon10" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 1489.49, 1767.17 )
-frame = 1
+frame = 3
+flip_h = true
 
 [node name="LemonLemon11" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 3059.21, 1917.37 )
-frame = 2
+flip_h = true
 
 [node name="LemonLemon12" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 3531.23, 1786.23 )
-frame = 2
+frame = 3
 
 [node name="LemonLemon13" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 3820.72, 2480.97 )
 rotation = 3.14159
-scale = Vector2( 1, -1 )
+frame = 1
 
 [node name="LemonLemon14" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 3743.25, 2503.48 )
 rotation = 3.14159
-scale = Vector2( 1, -1 )
-frame = 1
+frame = 3
+flip_h = true
 
 [node name="LemonLemon15" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 3744.08, 2464.86 )
 rotation = 3.14159
-scale = Vector2( 1, -1 )
 frame = 2
+flip_h = true
 
 [node name="LemonLemon16" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 3260.33, 1646.82 )
 rotation = 3.14159
-scale = Vector2( 1, -1 )
-frame = 2
+frame = 3
+flip_h = true
 
 [node name="Spawns" type="Node2D" parent="."]
 

--- a/project/src/main/world/environment/lemon/LemonFreeRoamEnvironment.tscn
+++ b/project/src/main/world/environment/lemon/LemonFreeRoamEnvironment.tscn
@@ -170,96 +170,97 @@ position = Vector2( 4591.11, 2331.59 )
 
 [node name="LemonTree1" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 1240.82, 1896.81 )
-leaf_type = 1
-mouth_type = 4
+leaf_type = 3
+mouth_type = 7
 
 [node name="LemonTree2" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 1416.72, 1922.67 )
+leaf_type = 4
 
 [node name="LemonTree3" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 1898.29, 1737.74 )
-leaf_type = 1
-mouth_type = 2
+mouth_type = 8
 
 [node name="LemonTree4" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 2413.6, 1173.41 )
-leaf_type = 1
-mouth_type = 3
+leaf_type = 0
+mouth_type = 6
 
 [node name="LemonTree5" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 2545.66, 1798.39 )
-leaf_type = 2
+mouth_type = 8
 
 [node name="LemonTree6" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 2966.02, 1913.14 )
-leaf_type = 2
+leaf_type = 0
+mouth_type = 8
 
 [node name="LemonTree7" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 3814.01, 2015.68 )
-mouth_type = 3
+mouth_type = 8
 
 [node name="LemonTree8" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 3989.91, 2041.54 )
-leaf_type = 2
-mouth_type = 2
+leaf_type = 1
+mouth_type = 9
 
 [node name="LemonTree9" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 496.029, 1772.08 )
-mouth_type = 3
+leaf_type = 4
+mouth_type = 2
 
 [node name="LemonTree10" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 1840.23, 1306.51 )
-leaf_type = 2
+leaf_type = 3
+mouth_type = 6
 
 [node name="LemonTree11" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 2750.99, 1202.52 )
-leaf_type = 2
-mouth_type = 3
+leaf_type = 4
+mouth_type = 9
 
 [node name="LemonTree12" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 2614.64, 1297.88 )
-leaf_type = 2
-mouth_type = 3
+leaf_type = 0
+mouth_type = 9
 
 [node name="LemonTree13" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 2782.05, 1363.34 )
-leaf_type = 1
-mouth_type = 3
+leaf_type = 4
+mouth_type = 6
 
 [node name="LemonTree14" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 1792.04, 1685.38 )
-leaf_type = 2
-mouth_type = 1
+mouth_type = 9
 
 [node name="LemonTree15" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 2274.68, 1257.88 )
-leaf_type = 2
-mouth_type = 4
+mouth_type = 8
 
 [node name="LemonTree16" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 3332.89, 1608.47 )
-leaf_type = 1
-mouth_type = 2
+leaf_type = 2
+mouth_type = 4
 
 [node name="LemonTree17" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 3677.13, 1838.94 )
-leaf_type = 1
-mouth_type = 1
+leaf_type = 3
+mouth_type = 7
 
 [node name="LemonTree18" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 3356.39, 1797.79 )
-leaf_type = 2
+leaf_type = 1
 mouth_type = 4
 
 [node name="LemonTree19" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 2720.61, 1811.2 )
 leaf_type = 2
-mouth_type = 3
+mouth_type = 6
 
 [node name="LemonTree20" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 2987.18, 1479.56 )
-leaf_type = 2
-mouth_type = 2
+leaf_type = 1
+mouth_type = 4
 
 [node name="LemonTree21" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 3997.14, 2738.14 )
@@ -268,96 +269,99 @@ leaf_type = 2
 [node name="LemonTree22" parent="Obstacles" instance=ExtResource( 16 )]
 position = Vector2( 2216.86, 1623.96 )
 leaf_type = 2
-mouth_type = 4
+mouth_type = 0
 
 [node name="LemonCookieSmall1" parent="Obstacles" instance=ExtResource( 19 )]
 position = Vector2( 916.02, 1913.88 )
+frame = 2
+flip_h = true
 
 [node name="LemonCookieSmall2" parent="Obstacles" instance=ExtResource( 19 )]
 position = Vector2( 2879.09, 1336.48 )
-frame = 1
+frame = 5
+flip_h = true
 
 [node name="LemonCookieSmall3" parent="Obstacles" instance=ExtResource( 19 )]
 position = Vector2( 4830.89, 2694 )
-frame = 2
+frame = 5
 
 [node name="LemonCookieSmall4" parent="Obstacles" instance=ExtResource( 19 )]
 position = Vector2( 1988.69, 1666.52 )
-frame = 3
+frame = 5
 
 [node name="LemonCookieSmall5" parent="Obstacles" instance=ExtResource( 19 )]
 position = Vector2( 2590.42, 1614.2 )
-frame = 4
+frame = 2
+flip_h = true
 
 [node name="LemonCookieSmall6" parent="Obstacles" instance=ExtResource( 19 )]
 position = Vector2( 3464.18, 1498.21 )
-frame = 5
+frame = 1
 
 [node name="LemonCookieSmall7" parent="Obstacles" instance=ExtResource( 19 )]
 position = Vector2( 2133.77, 1756.9 )
-scale = Vector2( -1, 1 )
+frame = 5
+flip_h = true
 
 [node name="LemonCookieSmall8" parent="Obstacles" instance=ExtResource( 19 )]
 position = Vector2( 1868.73, 1819 )
-scale = Vector2( -1, 1 )
-frame = 1
+frame = 3
+flip_h = true
 
 [node name="LemonCookieSmall9" parent="Obstacles" instance=ExtResource( 19 )]
 position = Vector2( 3594.11, 2446.64 )
-scale = Vector2( -1, 1 )
 frame = 2
 
 [node name="LemonCookieSmall10" parent="Obstacles" instance=ExtResource( 19 )]
 position = Vector2( 3740.08, 1983.41 )
-scale = Vector2( -1, 1 )
-frame = 3
+frame = 5
 
 [node name="LemonCookieSmall11" parent="Obstacles" instance=ExtResource( 19 )]
 position = Vector2( 2330.01, 1533.38 )
-scale = Vector2( -1, 1 )
-frame = 4
+frame = 5
+flip_h = true
 
 [node name="LemonCookieSmall12" parent="Obstacles" instance=ExtResource( 19 )]
 position = Vector2( 3260.38, 2081.41 )
-scale = Vector2( -1, 1 )
-frame = 5
 
 [node name="LemonCookieLarge1" parent="Obstacles" instance=ExtResource( 20 )]
 position = Vector2( 1597.22, 1677.94 )
+flip_h = true
 
 [node name="LemonCookieLarge2" parent="Obstacles" instance=ExtResource( 20 )]
 position = Vector2( 3305.59, 2150.28 )
 frame = 1
+flip_h = true
 
 [node name="LemonCookieLarge3" parent="Obstacles" instance=ExtResource( 20 )]
 position = Vector2( 4253.12, 2783.85 )
-frame = 2
+frame = 3
+flip_h = true
 
 [node name="LemonCookieLarge4" parent="Obstacles" instance=ExtResource( 20 )]
 position = Vector2( 2027.05, 1202.1 )
-frame = 3
+frame = 2
+flip_h = true
 
 [node name="LemonCookieLarge5" parent="Obstacles" instance=ExtResource( 20 )]
 position = Vector2( 3118.79, 1432 )
-scale = Vector2( -1, 1 )
+flip_h = true
 
 [node name="LemonCookieLarge6" parent="Obstacles" instance=ExtResource( 20 )]
 position = Vector2( 2513.6, 1188.61 )
-scale = Vector2( -1, 1 )
-frame = 1
+frame = 3
 
 [node name="LemonCookieLarge7" parent="Obstacles" instance=ExtResource( 20 )]
 position = Vector2( 3687.05, 2735.49 )
-scale = Vector2( -1, 1 )
 frame = 2
 
 [node name="LemonCookieLarge8" parent="Obstacles" instance=ExtResource( 20 )]
 position = Vector2( 761.041, 1431.09 )
-scale = Vector2( -1, 1 )
-frame = 3
+frame = 2
 
 [node name="LemonLemon1" parent="Obstacles" instance=ExtResource( 21 )]
 position = Vector2( 2172.29, 1197.71 )
+frame = 1
 
 [node name="LemonLemon2" parent="Obstacles" instance=ExtResource( 21 )]
 position = Vector2( 2377.48, 1572.08 )
@@ -365,68 +369,68 @@ frame = 1
 
 [node name="LemonLemon3" parent="Obstacles" instance=ExtResource( 21 )]
 position = Vector2( 4155.74, 2270.55 )
-frame = 2
+flip_h = true
 
 [node name="LemonLemon4" parent="Obstacles" instance=ExtResource( 21 )]
 position = Vector2( 4185.94, 2723.61 )
-frame = 2
+frame = 1
+flip_h = true
 
 [node name="LemonLemon5" parent="Obstacles" instance=ExtResource( 21 )]
 position = Vector2( 4398.28, 2966.86 )
-scale = Vector2( -1, 1 )
+frame = 3
 
 [node name="LemonLemon6" parent="Obstacles" instance=ExtResource( 21 )]
 position = Vector2( 4418.97, 2928.95 )
-scale = Vector2( -1, 1 )
-frame = 1
+frame = 2
+flip_h = true
 
 [node name="LemonLemon7" parent="Obstacles" instance=ExtResource( 21 )]
 position = Vector2( 3900.18, 2068.77 )
-scale = Vector2( -1, 1 )
-frame = 2
+flip_h = true
 
 [node name="LemonLemon8" parent="Obstacles" instance=ExtResource( 21 )]
 position = Vector2( 2711.44, 1899.78 )
-scale = Vector2( -1, 1 )
-frame = 2
+flip_h = true
 
 [node name="LemonLemon9" parent="Obstacles" instance=ExtResource( 21 )]
 position = Vector2( 882.339, 1557.2 )
+frame = 1
+flip_h = true
 
 [node name="LemonLemon10" parent="Obstacles" instance=ExtResource( 21 )]
 position = Vector2( 1489.49, 1767.17 )
-frame = 1
+frame = 2
+flip_h = true
 
 [node name="LemonLemon11" parent="Obstacles" instance=ExtResource( 21 )]
 position = Vector2( 3059.21, 1917.37 )
-frame = 2
 
 [node name="LemonLemon12" parent="Obstacles" instance=ExtResource( 21 )]
 position = Vector2( 3531.23, 1786.23 )
-frame = 2
+frame = 3
+flip_h = true
 
 [node name="LemonLemon13" parent="Obstacles" instance=ExtResource( 21 )]
 position = Vector2( 3820.72, 2480.97 )
 rotation = 3.14159
-scale = Vector2( 1, -1 )
+frame = 2
+flip_h = true
 
 [node name="LemonLemon14" parent="Obstacles" instance=ExtResource( 21 )]
 position = Vector2( 3743.25, 2503.48 )
 rotation = 3.14159
-scale = Vector2( 1, -1 )
-frame = 1
+frame = 3
+flip_h = true
 
 [node name="LemonLemon15" parent="Obstacles" instance=ExtResource( 21 )]
 position = Vector2( 3744.08, 2464.86 )
 rotation = 3.14159
-scale = Vector2( 1, -1 )
-frame = 2
 
 [node name="LemonLemon16" parent="Obstacles" instance=ExtResource( 21 )]
 position = Vector2( 3260.33, 1646.82 )
 rotation = 3.14159
-scale = Vector2( 1, -1 )
-frame = 2
+frame = 3
 
 [node name="Spawns" type="Node2D" parent="."]
 

--- a/project/src/main/world/environment/lemon/LemonRestaurantEnvironment.tscn
+++ b/project/src/main/world/environment/lemon/LemonRestaurantEnvironment.tscn
@@ -94,53 +94,60 @@ grass_tile_index = 7
 
 [node name="LemonTree1" parent="Obstacles" instance=ExtResource( 18 )]
 position = Vector2( -86.3109, 41.9036 )
-mouth_type = 3
+leaf_type = 3
+mouth_type = 6
 
 [node name="LemonTree2" parent="Obstacles" instance=ExtResource( 18 )]
 position = Vector2( 79.3962, 6.26767 )
-leaf_type = 1
-mouth_type = 3
+mouth_type = 8
 
 [node name="LemonTree3" parent="Obstacles" instance=ExtResource( 18 )]
 position = Vector2( 398.338, 72.1942 )
-mouth_type = 4
+leaf_type = 2
+mouth_type = 9
 
 [node name="LemonTree4" parent="Obstacles" instance=ExtResource( 18 )]
 position = Vector2( 740.443, 27.6492 )
-mouth_type = 3
+leaf_type = 3
+mouth_type = 7
 
 [node name="LemonTree5" parent="Obstacles" instance=ExtResource( 18 )]
 position = Vector2( 993.458, 326.991 )
-mouth_type = 4
+leaf_type = 0
+mouth_type = 8
 
 [node name="LemonTree6" parent="Obstacles" instance=ExtResource( 18 )]
 position = Vector2( 353.655, 576.178 )
-leaf_type = 1
-mouth_type = 4
+leaf_type = 4
+mouth_type = 6
 
 [node name="LemonTree7" parent="Obstacles" instance=ExtResource( 18 )]
 position = Vector2( 227.939, 654.75 )
+leaf_type = 3
+mouth_type = 2
 
 [node name="LemonTree8" parent="Obstacles" instance=ExtResource( 18 )]
 position = Vector2( -180.637, 412.298 )
+leaf_type = 2
 mouth_type = 2
 
 [node name="LemonTree9" parent="Obstacles" instance=ExtResource( 18 )]
 position = Vector2( 795.905, 493.115 )
-leaf_type = 2
-mouth_type = 2
+leaf_type = 3
+mouth_type = 9
 
 [node name="LemonCookieSmall1" parent="Obstacles" instance=ExtResource( 17 )]
 position = Vector2( 263.698, 116.868 )
-frame = 4
+frame = 3
 
 [node name="LemonCookieLarge1" parent="Obstacles" instance=ExtResource( 19 )]
 position = Vector2( 51.22, 331.94 )
-frame = 3
+frame = 1
+flip_h = true
 
 [node name="LemonLemon1" parent="Obstacles" instance=ExtResource( 20 )]
 position = Vector2( 578.26, 285.7 )
-frame = 3
+frame = 1
 
 [node name="Spawns" type="Node2D" parent="."]
 

--- a/project/src/main/world/environment/lemon/LemonTree.tscn
+++ b/project/src/main/world/environment/lemon/LemonTree.tscn
@@ -315,7 +315,6 @@ vframes = 3
 
 [node name="Lemons" type="Sprite" parent="."]
 position = Vector2( 0, -80 )
-scale = Vector2( -1, 1 )
 texture = ExtResource( 5 )
 hframes = 5
 vframes = 3

--- a/project/src/main/world/environment/lemon/LemonWinEnvironment.tscn
+++ b/project/src/main/world/environment/lemon/LemonWinEnvironment.tscn
@@ -103,3 +103,5 @@ dna = {
 
 [node name="LemonTree1" parent="Obstacles" instance=ExtResource( 12 )]
 position = Vector2( 4.17288, 464.939 )
+leaf_type = 2
+mouth_type = 2


### PR DESCRIPTION
Lemon trees persist their horizontal flipped state.

Before, lemon trees were flipping themselves horizontally but this
information was stored in their child nodes in a transient way, and not
persisted to the scene.

Lemon trees now use odd/even numbers to represent whether the underlying
sprite should be flipped or not. This information is persisted to the
scenes. I've also reshuffled all of the lemon trees.

Added a range to LemonTree's leaf_type and mouth_type

Changing LemonTree's leaf/mouth properties now immediately updates its
appearance in the editor.

FrameOverworldObstacle now has a shuffle button.

FrameOverworldObstacle and LemonTree both use flip_h instead of scale.