### PR TITLE
Refactor: FreeRoam breadcrumb trail, prepare_environment_resource

### DIFF
--- a/project/src/main/ui/career/career-win-world.gd
+++ b/project/src/main/ui/career/career-win-world.gd
@@ -15,12 +15,6 @@ const ENVIRONMENT_PATH_BY_NAME := {
 }
 
 
-# Loads the cutscene's environment, replacing the current one in the scene tree.
-func prepare_environment_resource() -> void:
-	var loaded_environment_path := _career_environment_path()
-	EnvironmentScene = load(loaded_environment_path)
-
-
-func _career_environment_path() -> String:
+func initial_environment_path() -> String:
 	var environment_name := PlayerData.career.current_region().overworld_environment_name
 	return ENVIRONMENT_PATH_BY_NAME.get(environment_name, DEFAULT_ENVIRONMENT_PATH)

--- a/project/src/main/world/CareerMap.tscn
+++ b/project/src/main/world/CareerMap.tscn
@@ -50,7 +50,7 @@ action = "ui_cancel"
 [sub_resource type="ShortCut" id=14]
 shortcut = SubResource( 22 )
 
-[node name="Node" type="Node"]
+[node name="CareerMap" type="Node"]
 script = ExtResource( 2 )
 
 [node name="Bg" parent="." instance=ExtResource( 4 )]

--- a/project/src/main/world/FreeRoam.tscn
+++ b/project/src/main/world/FreeRoam.tscn
@@ -1,14 +1,18 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://src/main/world/ChatIcons.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/FreeRoamUi.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/world/ChatLetters.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/world/OverworldBg.tscn" type="PackedScene" id=4]
+[ext_resource path="res://src/main/world/free-roam.gd" type="Script" id=5]
 [ext_resource path="res://src/main/world/environment/marsh/MarshFreeRoamEnvironment.tscn" type="PackedScene" id=6]
+[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=7]
+[ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=8]
 [ext_resource path="res://src/main/world/free-roam-camera.gd" type="Script" id=21]
 [ext_resource path="res://src/main/world/free-roam-world.gd" type="Script" id=51]
 
 [node name="FreeRoam" type="Node"]
+script = ExtResource( 5 )
 
 [node name="Bg" parent="." instance=ExtResource( 4 )]
 
@@ -16,7 +20,11 @@
 script = ExtResource( 51 )
 EnvironmentScene = ExtResource( 6 )
 
-[node name="Environment" parent="World" instance=ExtResource( 6 )]
+[node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 6 )]
+script = ExtResource( 8 )
+environment_shadows_path = NodePath("Ground/Shadows")
+obstacles_path = NodePath("Obstacles")
+CreatureScene = ExtResource( 7 )
 
 [node name="ChatLetters" parent="World" instance=ExtResource( 3 )]
 

--- a/project/src/main/world/career-world.gd
+++ b/project/src/main/world/career-world.gd
@@ -74,10 +74,8 @@ func _input(event: InputEvent) -> void:
 			_move_objects_to_path()
 
 
-# Loads the cutscene's environment, replacing the current one in the scene tree.
-func prepare_environment_resource() -> void:
-	var environment_path := _career_environment_path()
-	EnvironmentScene = load(environment_path)
+func initial_environment_path() -> String:
+	return _career_environment_path()
 
 
 ## Refreshes the environment and creatures based on the player's progress through career mode.
@@ -87,8 +85,7 @@ func prepare_environment_resource() -> void:
 ## 		many level creatures show up.
 func refresh_from_career_data(pickable_career_levels: Array) -> void:
 	if EnvironmentScene.resource_path != _career_environment_path():
-		prepare_environment_resource()
-		refresh_environment_scene()
+		set_environment_scene(load(initial_environment_path()))
 		_fill_environment_scene()
 	_move_objects_to_path()
 	

--- a/project/src/main/world/cutscene-world.gd
+++ b/project/src/main/world/cutscene-world.gd
@@ -17,10 +17,8 @@ func _ready() -> void:
 	_launch_cutscene()
 
 
-# Loads the cutscene's environment, replacing the current one in the scene tree.
-func prepare_environment_resource() -> void:
-	var environment_path := CurrentCutscene.chat_tree.chat_environment_path()
-	EnvironmentScene = load(environment_path)
+func initial_environment_path() -> String:
+	return CurrentCutscene.chat_tree.chat_environment_path()
 
 
 ## Starts the cutscene.

--- a/project/src/main/world/free-roam-world.gd
+++ b/project/src/main/world/free-roam-world.gd
@@ -4,16 +4,6 @@ extends OverworldWorld
 ## Populates/unpopulates the creatures and obstacles on the free roam overworld.
 
 func _ready() -> void:
-	if Engine.is_editor_hint():
-		return
-	
-	if not Breadcrumb.trail:
-		# For developers accessing the FreeRoam scene directly, we initialize a default Breadcrumb trail.
-		# For regular players the Breadcrumb trail will already be initialized by the menus.
-		Breadcrumb.initialize_trail()
-	
-	MusicPlayer.play_chill_bgm()
-	
 	ChattableManager.refresh_creatures()
 	if PlayerData.free_roam.player_spawn_id:
 		overworld_environment.move_creature_to_spawn(ChattableManager.player, PlayerData.free_roam.player_spawn_id)
@@ -23,7 +13,5 @@ func _ready() -> void:
 	
 	$Camera.position = ChattableManager.player.position
 
-
-func prepare_environment_resource() -> void:
-	if PlayerData.free_roam.environment_path:
-		EnvironmentScene = load(PlayerData.free_roam.environment_path)
+func initial_environment_path() -> String:
+	return PlayerData.free_roam.environment_path

--- a/project/src/main/world/free-roam.gd
+++ b/project/src/main/world/free-roam.gd
@@ -1,0 +1,13 @@
+extends Node
+## Scene which lets the player freely run around, talk to creatures and interact with objects.
+
+func _ready() -> void:
+	if Engine.is_editor_hint():
+		return
+	
+	if not Breadcrumb.trail:
+		# For developers accessing the FreeRoam scene directly, we initialize a default Breadcrumb trail.
+		# For regular players the Breadcrumb trail will already be initialized by the menus.
+		Breadcrumb.initialize_trail()
+	
+	MusicPlayer.play_chill_bgm()

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -12,25 +12,26 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 	
-	prepare_environment_resource()
-	refresh_environment_scene()
+	var initial_environment_path := initial_environment_path()
+	if initial_environment_path:
+		set_environment_scene(load(initial_environment_path()))
 
 
 func set_environment_scene(new_environment_scene: Resource) -> void:
 	EnvironmentScene = new_environment_scene
-	refresh_environment_scene()
+	_refresh_environment_scene()
 
 
 ## Overridden by child implementations to substitute their own EnvironmentScene resource at runtime.
-func prepare_environment_resource() -> void:
-	pass
+func initial_environment_path() -> String:
+	return ""
 
 
 ## Loads a new environment, replacing the current one in the scene tree.
 ##
 ## The environment loaded is the one defined by EnvironmentScene. To substitute a different scene at runtime, child
-## implementations can override prepare_environment_resource.
-func refresh_environment_scene() -> void:
+## implementations can override initial_environment_path.
+func _refresh_environment_scene() -> void:
 	if not is_inside_tree():
 		return
 	

--- a/project/src/main/world/puzzle-world.gd
+++ b/project/src/main/world/puzzle-world.gd
@@ -27,11 +27,8 @@ func _ready() -> void:
 	_spawn_customers()
 
 
-# Loads the cutscene's environment, replacing the current one in the scene tree.
-func prepare_environment_resource() -> void:
-	var environment_path: String = ENVIRONMENT_PATH_BY_NAME.get(
-			CurrentLevel.puzzle_environment_name, DEFAULT_PUZZLE_ENVIRONMENT_PATH)
-	EnvironmentScene = load(environment_path)
+func initial_environment_path() -> String:
+	return ENVIRONMENT_PATH_BY_NAME.get(CurrentLevel.puzzle_environment_name, DEFAULT_PUZZLE_ENVIRONMENT_PATH)
 
 
 ## Removes all creatures from the overworld.


### PR DESCRIPTION
FreeRoam's breadcrumb trail is no longer initialized by FreeRoamWorld.
I've split a new 'free-roam' script out of the old 'free-roam-world'
script which handles non-environmental things like the breadcrumb trail
and music.

Replaced OverworldWorld.prepare_environment_resource() with
initial_environment_path(). This method name isn't perfect but instead
of child classes needing to load and assign an environment scene, they
just return the path of the resource they want to load. It's slightly
less repetitive code this way.