### PR TITLE
Refactor: export range, indoor autotile.

### DIFF
--- a/project/src/main/world/creature-spawner.gd
+++ b/project/src/main/world/creature-spawner.gd
@@ -22,7 +22,7 @@ export (String) var spawn_if: String
 
 ## Maximum fatness for a spawned creature.
 ## If a fatter creature spawns here, they will spontaneously and permanently slim down.
-export (float) var max_fatness := 10.0
+export (float, 1.0, 10.0) var max_fatness := 10.0
 
 export (PackedScene) var CreatureScene: PackedScene
 

--- a/project/src/main/world/creature/creature-visuals.gd
+++ b/project/src/main/world/creature/creature-visuals.gd
@@ -58,7 +58,7 @@ export (Creatures.Orientation) var orientation := Creatures.SOUTHEAST setget set
 export (Dictionary) var dna: Dictionary setget set_dna
 
 ## how fat the creature looks right now; gradually approaches the 'fatness' property
-export (float) var visual_fatness := 1.0 setget set_visual_fatness
+export (float, 1.0, 10.0) var visual_fatness := 1.0 setget set_visual_fatness
 
 ## how fat the creature will become eventually; visual_fatness gradually approaches this value
 var fatness := 1.0 setget set_fatness, get_fatness

--- a/project/src/main/world/environment/grass-overworld-tiler.gd
+++ b/project/src/main/world/environment/grass-overworld-tiler.gd
@@ -18,8 +18,8 @@ const AUTOTILE_COORDS_GOOPY_GRASS := [
 
 export (NodePath) var ground_map_path: NodePath
 
-## A number in the range [0.0, 1.0] describing what percent of cake tiles should have grass
-export (float) var grass_density := 0.03
+## Percent of cake tiles which should have grass
+export (float, 0.0, 1.0) var grass_density := 0.03
 
 ## The ground tilemap's tile ID for goopless blocks
 export (int) var ground_no_goop_tile_index: int

--- a/project/src/main/world/environment/invisible-obstacle-tiler.gd
+++ b/project/src/main/world/environment/invisible-obstacle-tiler.gd
@@ -22,10 +22,6 @@ onready var _tile_map: TileMap = get_parent()
 ## https://github.com/godotengine/godot/issues/11855
 export (bool) var _autotile: bool setget autotile
 
-func _ready() -> void:
-	autotile(true)
-
-
 ## Preemptively initializes onready variables to avoid null references.
 func _enter_tree() -> void:
 	_initialize_onready_variables()

--- a/project/src/main/world/environment/kitchen-obstacle-tiler.gd
+++ b/project/src/main/world/environment/kitchen-obstacle-tiler.gd
@@ -183,10 +183,6 @@ export (bool) var _autotile: bool setget autotile
 ## tilemap containing obstacles
 onready var _tile_map: TileMap = get_parent()
 
-func _ready() -> void:
-	autotile(true)
-
-
 ## Preemptively initializes onready variables to avoid null references.
 func _enter_tree() -> void:
 	_initialize_onready_variables()

--- a/project/src/main/world/environment/pebble-overworld-tiler.gd
+++ b/project/src/main/world/environment/pebble-overworld-tiler.gd
@@ -6,8 +6,8 @@ extends Node
 
 export (NodePath) var ground_map_path: NodePath
 
-## A number in the range [0.0, 1.0] describing what percent of cake tiles should have pebbles
-export (float) var pebble_density := 0.03
+## Percent of cake tiles which should have pebbles
+export (float, 0.0, 1.0) var pebble_density := 0.03
 
 ## The ground tilemap's tile ID for goopless blocks
 export (int) var ground_no_goop_tile_index: int

--- a/project/src/main/world/letter-shooter.gd
+++ b/project/src/main/world/letter-shooter.gd
@@ -5,8 +5,11 @@ extends Node
 ## the scene describing the letters to emit
 export (PackedScene) var LetterProjectileScene: PackedScene
 
-## The approximate direction the letter should move, in radians
-export (float) var letter_angle := 0.0
+## The approximate direction the letter should move, in radians.
+##
+## Note: PI and TAU are not supported in export ranges, see Godot-Proposals #1147
+## (https://github.com/godotengine/godot-proposals/issues/1147)
+export (float, -6.28318530717959, 6.28318530717959) var letter_angle := 0.0
 
 ## The approximate position where the letter should spawn.
 export (Vector2) var letter_position: Vector2


### PR DESCRIPTION
Added range to some export hints. Fatness is always 1-10.

MarshIndoorsEnvironment no longer autotiles when it is loaded. This was
causing the tiles to be constantly swapped out resulting in unnecessary
noise in git diffs.