### PR TITLE
New 'quirky customer' cutscene logic. New cyclio cheat.

### DIFF
--- a/project/assets/main/puzzle/career-worlds.json
+++ b/project/assets/main/puzzle/career-worlds.json
@@ -147,6 +147,14 @@
       "overworld_environment": "marsh",
       "piece_speed": "3-7",
       "cutscene_path": "chat/career/marsh",
+      "chefs": [
+        "(quirky) skins",
+        "bones 25%",
+        "shirts 25%"
+      ],
+      "customers": [
+        "rhonk 10%"
+      ],
       "intro_level": {
         "id": "career/curly_queue",
         "chef_id": "skins",
@@ -168,36 +176,28 @@
           "id": "career/cleaning_duty"
         },
         {
-          "id": "career/unfresh_fruits_2",
-          "chef_id": "bones"
+          "id": "career/unfresh_fruits_2"
         },
         {
-          "id": "career/cocoa_canyon",
-          "chef_id": "bones"
+          "id": "career/cocoa_canyon"
         },
         {
-          "id": "career/just_cream",
-          "chef_id": "bones"
+          "id": "career/just_cream"
         },
         {
-          "id": "career/tempting_jellies",
-          "chef_id": "bones"
+          "id": "career/tempting_jellies"
         },
         {
-          "id": "career/90_second_sprint",
-          "chef_id": "shirts"
+          "id": "career/90_second_sprint"
         },
         {
-          "id": "career/strawberry_shortcut",
-          "chef_id": "shirts"
+          "id": "career/strawberry_shortcut"
         },
         {
-          "id": "career/a_little_garbage",
-          "chef_id": "shirts"
+          "id": "career/a_little_garbage"
         },
         {
-          "id": "career/real_meal",
-          "chef_id": "shirts"
+          "id": "career/real_meal"
         },
         {
           "id": "career/curly_queue",

--- a/project/assets/test/ui/level-select/career-worlds-simple.json
+++ b/project/assets/test/ui/level-select/career-worlds-simple.json
@@ -5,13 +5,21 @@
       "start": 0,
       "icon": "forest",
       "piece_speed": "0",
-      "boss_level":
-      {
-        "id": "boss_211"
-      },
+      "chefs": [
+        "(quirky) chef_38",
+        "chef_36 25%"
+      ],
+      "customers": [
+        "customer_77 10%",
+        "(quirky) customer_90"
+      ],
       "intro_level":
       {
         "id": "intro_211"
+      },
+      "boss_level":
+      {
+        "id": "boss_211"
       },
       "levels": [
         {
@@ -27,13 +35,13 @@
       "start": 10,
       "icon": "cactus",
       "piece_speed": "0-3",
-      "boss_level":
-      {
-        "id": "boss_311"
-      },
       "intro_level":
       {
         "id": "intro_311"
+      },
+      "boss_level":
+      {
+        "id": "boss_311"
       },
       "levels": [
         {

--- a/project/project.godot
+++ b/project/project.godot
@@ -429,6 +429,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/ui/level-select/level-lock.gd"
 }, {
+"base": "Reference",
+"class": "LevelPosse",
+"language": "GDScript",
+"path": "res://src/main/world/level-posse.gd"
+}, {
 "base": "Button",
 "class": "LevelSelectButton",
 "language": "GDScript",
@@ -1099,6 +1104,7 @@ _global_script_class_icons={
 "LevelEditor": "",
 "LevelHistory": "",
 "LevelLock": "",
+"LevelPosse": "",
 "LevelSelectButton": "",
 "LevelSettings": "",
 "LevelSettingsUpgrader": "",

--- a/project/src/main/ui/career/career-map-ui.gd
+++ b/project/src/main/ui/career/career-map-ui.gd
@@ -1,7 +1,7 @@
 extends CanvasLayer
 ## UI elements for the career map's settings menu.
 
-## Alter the player's career mode data to force a cutscene.
+## Alters the player's career mode data to force a cutscene.
 ##
 ## This is triggered by a cheat code.
 ##
@@ -63,7 +63,7 @@ func _find_region_with_boss_level() -> CareerRegion:
 	return result
 
 
-## Alter the player's career mode data to force a boss level.
+## Alters the player's career mode data to force a boss level.
 ##
 ## This is triggered by a cheat code.
 ##
@@ -116,7 +116,7 @@ func _find_region_with_epilogue() -> CareerRegion:
 	return result
 
 
-## Alter the player's career mode data to force an epilogue cutscene to play.
+## Alters the player's career mode data to force an epilogue cutscene to play.
 ##
 ## This is triggered by a cheat code.
 ##
@@ -155,6 +155,14 @@ func _force_epilogue_level() -> bool:
 	return true if new_region else false
 
 
+## Summons new levels, customers and chefs.
+##
+## This works by adjusting the daily earnings which affects the random seed.
+func _cycle_levels() -> void:
+	PlayerData.career.daily_earnings += 1
+	SceneTransition.change_scene()
+
+
 func _on_SettingsButton_pressed() -> void:
 	$SettingsMenu.show()
 
@@ -187,3 +195,6 @@ func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDete
 		"epilio":
 			var cheat_successful := _force_epilogue_level()
 			detector.play_cheat_sound(cheat_successful)
+		"cyclio":
+			_cycle_levels()
+			detector.play_cheat_sound(true)

--- a/project/src/main/ui/chat/career-cutscene-library.gd
+++ b/project/src/main/ui/chat/career-cutscene-library.gd
@@ -127,7 +127,7 @@ func potential_chat_key_pairs(chat_key_roots: Array, chef_id: String = "", custo
 		if not chef_id and not customer_id:
 			# no criteria specified; accept all chat key pairs
 			accept_chat_key_pair = true
-		elif customer_id == CareerLevel.ANONYMOUS_CUSTOMER:
+		elif customer_id == CareerLevel.NONQUIRKY_CUSTOMER:
 			# anonymous customer; only accept chat key pairs with no named chefs/customers
 			accept_chat_key_pair = true
 			for chat_key in potential_chat_key_pair.chat_keys():

--- a/project/src/main/ui/level-select/career-level.gd
+++ b/project/src/main/ui/level-select/career-level.gd
@@ -1,8 +1,8 @@
 class_name CareerLevel
 ## Stores career-mode-specific information about a level.
 
-## Unique customer ID assigned to levels with no named chefs or customers.
-const ANONYMOUS_CUSTOMER := "#anonymous_customer#"
+## Unique customer ID assigned to levels with no quirky chefs or customers.
+const NONQUIRKY_CUSTOMER := "#nonquirky_customer#"
 
 var level_id: String
 

--- a/project/src/main/ui/level-select/career-region.gd
+++ b/project/src/main/ui/level-select/career-region.gd
@@ -13,6 +13,36 @@ const BOSS_LEVEL_CHAT_KEY_NAME := "boss_level"
 ## Chat key containing each region's epilogue cutscene, which plays after all other cutscenes/levels
 const EPILOGUE_CHAT_KEY_NAME := "epilogue"
 
+## A chef/customer who appears in a career region.
+class CreatureAppearance:
+	## the id of the creature who appears
+	var id: String
+	
+	## number in the range [0.0, 1.0] describing how often the creature appears
+	var chance: float = 0.0
+	
+	## True if this creature is tightly coupled to specific levels.
+	##
+	## 'Quirky' creatures only appear when their levels are selected, and they never appear if their levels are not
+	## selected.
+	var quirky: bool = false
+	
+	func from_json_string(json: String) -> void:
+		# parse a string like '(quirky) skins'
+		if json.begins_with("(quirky)"):
+			quirky = true
+			json = StringUtils.substring_after(json, "(quirky)").strip_edges()
+		
+		# parse a string like 'bones 35%'
+		if " " in json and json.ends_with("%"):
+			var percent_string := StringUtils.substring_after_last(json, " ")
+			# convert a string like '35%' to a number like 0.35
+			chance = float(percent_string.rstrip("%")) / 100
+			json = StringUtils.substring_before_last(json, " ")
+		
+		id = json
+
+
 ## A human-readable region name, such as 'Lemony Thickets'
 var name: String
 
@@ -52,6 +82,12 @@ var intro_level: CareerLevel
 var min_piece_speed := "0"
 var max_piece_speed := "0"
 
+## CreatureAppearance instances for chefs who randomly show up in levels
+var chefs := []
+
+## CreatureAppearance instances for customers who randomly show up in levels
+var customers := []
+
 func from_json_dict(json: Dictionary) -> void:
 	name = json.get("name", "")
 	cutscene_path = json.get("cutscene_path", "")
@@ -76,6 +112,16 @@ func from_json_dict(json: Dictionary) -> void:
 	if json.has("intro_level"):
 		intro_level = CareerLevel.new()
 		intro_level.from_json_dict(json.get("intro_level"))
+	if json.has("chefs"):
+		for chef_string in json.get("chefs"):
+			var creature_appearance := CreatureAppearance.new()
+			creature_appearance.from_json_string(chef_string)
+			chefs.append(creature_appearance)
+	if json.has("customers"):
+		for customer_string in json.get("customers"):
+			var creature_appearance := CreatureAppearance.new()
+			creature_appearance.from_json_string(customer_string)
+			customers.append(creature_appearance)
 
 
 func get_prologue_chat_key() -> String:
@@ -104,3 +150,84 @@ func get_epilogue_chat_key() -> String:
 
 func get_end() -> int:
 	return start + length - 1
+
+
+## Returns 'true' if this region has a quirky chef with the specified id.
+##
+## 'Quirky chefs' are chefs which impose special rules on the player. They show up for their own levels, but they
+## don't show up for random levels.
+func has_quirky_chef(chef_id: String) -> bool:
+	var result := false
+	for chef_obj in chefs:
+		var chef: CreatureAppearance = chef_obj
+		if chef.id == chef_id:
+			result = chef.quirky
+			break
+	return result
+
+
+## Returns 'true' if this region has a quirky customer with the specified id.
+##
+## 'Quirky customers' are customers which impose special rules on the player. They show up for their own levels, but
+## they don't show up for random levels.
+func has_quirky_customer(customer_id: String) -> bool:
+	var result := false
+	for customer_obj in customers:
+		var customer: CreatureAppearance = customer_obj
+		if customer.id == customer_id:
+			result = customer.quirky
+			break
+	return result
+
+
+## Returns a random nonquirky chef from this region's list of chefs.
+##
+## Returns null if this region does not define any nonquirky chefs.
+func random_chef() -> CreatureAppearance:
+	return _random_creature(chefs)
+
+
+## Returns a random nonquirky customer from this region's list of customers.
+##
+## Returns null if this region does not define any nonquirky customers.
+func random_customer() -> CreatureAppearance:
+	return _random_creature(customers)
+
+
+## Returns a random nonquirky appearance from the specified list.
+##
+## The randomly selected appearance is weighted based on their 'chance' values. If the chance values add up to more
+## than 1.0, one of the appearances will be returned. If the chance values add up to less than 1.0, it is possible
+## none of the appearances will be selected in which case a value of 'null' will be returned instead.
+##
+## Parameters:
+## 	'appearances': A list of CreatureAppearance instances
+##
+## Returns:
+## 	A CreatureAppearance from the specified list. Returns 'null' if list has no nonquirky appearances, or if their
+## 	chance values add up to less than 1.0 and none of the creatures are randomly selected.
+func _random_creature(appearances: Array) -> CreatureAppearance:
+	var result: CreatureAppearance = null
+	
+	# Calculate the sum of the appearances' "chance" values.
+	#
+	# These values *should* add up to less than 1.0, in which case we'll pick a random number in the range [0.0, 1.0]
+	# But if someone mistakenly gave ten creatures a 13% chance of showing up we'll pick a random number in the range
+	# [0.0, 1.3] instead.
+	var total_chance := 0.0
+	for appearance in appearances:
+		total_chance += appearance.chance
+	total_chance = max(1.0, total_chance)
+	
+	# Select a random appearance.
+	#
+	# We pick a random number in the range [0.0, 1.0], decrementing it based on each appearance's 'chance' value until
+	# it drops below 0.0.
+	var remaining_chance := rand_range(0.0, total_chance)
+	for appearance in appearances:
+		remaining_chance -= appearance.chance
+		if remaining_chance <= 0.0:
+			result = appearance
+			break
+	
+	return result

--- a/project/src/main/world/CareerMap.tscn
+++ b/project/src/main/world/CareerMap.tscn
@@ -272,7 +272,7 @@ quit_type = 3
 layer = 10
 
 [node name="CheatCodeDetector" parent="Ui" instance=ExtResource( 5 )]
-codes = [ "bossio", "cambra", "cutsio", "epilio", "moveme" ]
+codes = [ "bossio", "cambra", "cutsio", "cyclio", "epilio", "moveme" ]
 
 [connection signal="level_button_focused" from="LevelSelect" to="Ui/Control/StatusBar/Distance" method="_on_LevelSelect_level_button_focused"]
 [connection signal="level_button_focused" from="LevelSelect" to="World" method="_on_LevelSelect_level_button_focused"]

--- a/project/src/main/world/level-posse.gd
+++ b/project/src/main/world/level-posse.gd
@@ -1,0 +1,8 @@
+class_name LevelPosse
+## Creatures which appear for a career level.
+##
+## This can potentially include creatures which are important to a level, creatures which appear in a cutscene, or
+## creatures which randomly show up sometimes in a region.
+
+var chef_id := ""
+var customer_ids := []

--- a/project/src/test/ui/chat/test-career-cutscene-library.gd
+++ b/project/src/test/ui/chat/test-career-cutscene-library.gd
@@ -212,7 +212,7 @@ func test_potential_chat_keys_includes_unnamed_customers() -> void:
 	]
 	_assert_eq_ckp(CareerCutsceneLibrary.potential_chat_key_pairs([
 		"ui/chat/fake_career_2"
-	], "", CareerLevel.ANONYMOUS_CUSTOMER), [
+	], "", CareerLevel.NONQUIRKY_CUSTOMER), [
 		# only return scenes with no named chefs/customers
 		_interlude("ui/chat/fake_career_2/c", ""),
 	])

--- a/project/src/test/ui/level-select/test-career-level-library.gd
+++ b/project/src/test/ui/level-select/test-career-level-library.gd
@@ -13,7 +13,7 @@ func after_each() -> void:
 func test_regions() -> void:
 	CareerLevelLibrary.worlds_path = "res://assets/test/ui/level-select/career-worlds-simple.json"
 	
-	assert_eq(3, CareerLevelLibrary.regions.size())
+	assert_eq(CareerLevelLibrary.regions.size(), 3)
 	
 	var region_1: CareerRegion = CareerLevelLibrary.regions[1]
 	assert_eq(region_1.name, "Even World")
@@ -22,6 +22,36 @@ func test_regions() -> void:
 	assert_eq(region_1.max_piece_speed, "3")
 	assert_eq(region_1.length, 10)
 	assert_eq(region_1.levels.size(), 3)
+
+
+func test_region_chefs() -> void:
+	CareerLevelLibrary.worlds_path = "res://assets/test/ui/level-select/career-worlds-simple.json"
+	
+	var region_0: CareerRegion = CareerLevelLibrary.regions[0]
+	assert_eq(region_0.chefs.size(), 2)
+	
+	assert_eq(region_0.chefs[0].id, "chef_38")
+	assert_eq(region_0.chefs[0].chance, 0.0)
+	assert_eq(region_0.chefs[0].quirky, true)
+	
+	assert_eq(region_0.chefs[1].id, "chef_36")
+	assert_eq(region_0.chefs[1].chance, 0.25)
+	assert_eq(region_0.chefs[1].quirky, false)
+
+
+func test_region_customers() -> void:
+	CareerLevelLibrary.worlds_path = "res://assets/test/ui/level-select/career-worlds-simple.json"
+	
+	var region_0: CareerRegion = CareerLevelLibrary.regions[0]
+	assert_eq(region_0.customers.size(), 2)
+	
+	assert_eq(region_0.customers[0].id, "customer_77")
+	assert_eq(region_0.customers[0].chance, 0.10)
+	assert_eq(region_0.customers[0].quirky, false)
+	
+	assert_eq(region_0.customers[1].id, "customer_90")
+	assert_eq(region_0.customers[1].chance, 0.0)
+	assert_eq(region_0.customers[1].quirky, true)
 
 
 ## increasing the weight selects faster speeds
@@ -78,6 +108,10 @@ func test_region_weight_for_distance() -> void:
 
 
 func test_trim_levels_by_characters_customer() -> void:
+	var region := CareerRegion.new()
+	region.customers.append(CareerRegion.CreatureAppearance.new())
+	region.customers.back().from_json_string("(quirky) customer_211")
+	
 	var all_levels := []
 	all_levels.append(CareerLevel.new())
 	all_levels.back().from_json_dict({
@@ -87,18 +121,22 @@ func test_trim_levels_by_characters_customer() -> void:
 	all_levels.append(CareerLevel.new())
 	all_levels.back().from_json_dict({
 		"id": "level_212",
+		"customer_ids": ["customer_212"],
 	})
 	all_levels.append(CareerLevel.new())
 	all_levels.back().from_json_dict({
 		"id": "level_213",
 	})
-	
-	var trimmed_levels := CareerLevelLibrary.trim_levels_by_characters(all_levels, [], ["customer_211"])
+	var trimmed_levels := CareerLevelLibrary.trim_levels_by_characters(region, all_levels, [], ["customer_211"])
 	assert_eq(trimmed_levels.size(), 1)
 	assert_eq(trimmed_levels[0].level_id, "level_211")
 
 
 func test_trim_levels_by_characters_chef() -> void:
+	var region := CareerRegion.new()
+	region.chefs.append(CareerRegion.CreatureAppearance.new())
+	region.chefs.back().from_json_string("(quirky) chef_211")
+	
 	var all_levels := []
 	all_levels.append(CareerLevel.new())
 	all_levels.back().from_json_dict({
@@ -108,18 +146,25 @@ func test_trim_levels_by_characters_chef() -> void:
 	all_levels.append(CareerLevel.new())
 	all_levels.back().from_json_dict({
 		"id": "level_212",
+		"chef_id": "chef_212",
 	})
 	all_levels.append(CareerLevel.new())
 	all_levels.back().from_json_dict({
 		"id": "level_213",
 	})
 	
-	var trimmed_levels := CareerLevelLibrary.trim_levels_by_characters(all_levels, ["chef_211"], [])
+	var trimmed_levels := CareerLevelLibrary.trim_levels_by_characters(region, all_levels, ["chef_211"], [])
 	assert_eq(trimmed_levels.size(), 1)
 	assert_eq(trimmed_levels[0].level_id, "level_211")
 
 
 func test_trim_levels_by_characters_anonymous_customer() -> void:
+	var region := CareerRegion.new()
+	region.chefs.append(CareerRegion.CreatureAppearance.new())
+	region.chefs.back().from_json_string("(quirky) chef_211")
+	region.customers.append(CareerRegion.CreatureAppearance.new())
+	region.customers.back().from_json_string("(quirky) customer_212")
+	
 	var all_levels := []
 	all_levels.append(CareerLevel.new())
 	all_levels.back().from_json_dict({
@@ -134,15 +179,28 @@ func test_trim_levels_by_characters_anonymous_customer() -> void:
 	all_levels.append(CareerLevel.new())
 	all_levels.back().from_json_dict({
 		"id": "level_213",
+		"chef_id": "chef_213",
+		"customer_ids": ["customer_213"],
+	})
+	all_levels.append(CareerLevel.new())
+	all_levels.back().from_json_dict({
+		"id": "level_214",
 	})
 	
 	var trimmed_levels := CareerLevelLibrary.trim_levels_by_characters(
-			all_levels, [], [CareerLevel.ANONYMOUS_CUSTOMER])
-	assert_eq(trimmed_levels.size(), 1)
+			region, all_levels, [], [CareerLevel.NONQUIRKY_CUSTOMER])
+	assert_eq(trimmed_levels.size(), 2)
 	assert_eq(trimmed_levels[0].level_id, "level_213")
+	assert_eq(trimmed_levels[1].level_id, "level_214")
 
 
 func test_trim_levels_by_characters_all() -> void:
+	var region := CareerRegion.new()
+	region.chefs.append(CareerRegion.CreatureAppearance.new())
+	region.chefs.back().from_json_string("(quirky) chef_211")
+	region.customers.append(CareerRegion.CreatureAppearance.new())
+	region.customers.back().from_json_string("(quirky) customer_212")
+	
 	var all_levels := []
 	all_levels.append(CareerLevel.new())
 	all_levels.back().from_json_dict({
@@ -159,7 +217,7 @@ func test_trim_levels_by_characters_all() -> void:
 		"id": "level_213",
 	})
 	
-	var trimmed_levels := CareerLevelLibrary.trim_levels_by_characters(all_levels, [], [])
+	var trimmed_levels := CareerLevelLibrary.trim_levels_by_characters(region, all_levels, [], [])
 	assert_eq(trimmed_levels.size(), 3)
 
 


### PR DESCRIPTION
Regions can define quirky chefs and customers who only show up for specific
levels. They can also define regular chefs and customers who show up for other
levels.

When limiting the player's level selection, the game only considers
'quirky characters'. When cosmetically deciding which chefs/customers
will show up for fun, the game considers characters in cutscenes and
characters defined for the region.

Added new 'CYCLIO' cheat for cycling through levels/chefs/customers
without advancing the clock.