### PR TITLE
Conditionally exclude cutscenes with sensei/restaurant

### DIFF
--- a/project/src/main/ui/career/career-win-world.gd
+++ b/project/src/main/ui/career/career-win-world.gd
@@ -18,7 +18,7 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 	
-	if PlayerData.career.current_region().sensei_absent:
+	if PlayerData.career.current_region().has_flag(CareerRegion.FLAG_NO_SENSEI):
 		var sensei := overworld_environment.find_creature(CreatureLibrary.SENSEI_ID)
 		sensei.visible = false
 	

--- a/project/src/main/ui/chat/chat-tree.gd
+++ b/project/src/main/ui/chat/chat-tree.gd
@@ -175,6 +175,20 @@ func reset() -> void:
 	_position.reset()
 
 
+## Returns 'true' if this cutscene is set inside the restaurant.
+##
+## This signifies that this cutscene should not be played if the player does not have a restaurant.
+func inside_restaurant() -> bool:
+	return location_id in ["marsh/inside_turbo_fat"]
+
+
+## Returns 'true' if this cutscene features Fat Sensei.
+##
+## This signifies that this cutscene should not be played if Fat Sensei is not following the player.
+func has_sensei() -> bool:
+	return spawn_locations.has(CreatureLibrary.SENSEI_ID)
+
+
 ## Jump to any chat sequences whose 'start_if' conditions are met.
 func _apply_start_if_conditions() -> void:
 	# look for 'start_if' conditions...

--- a/project/src/main/ui/level-select/career-region.gd
+++ b/project/src/main/ui/level-select/career-region.gd
@@ -1,6 +1,12 @@
 class_name CareerRegion
 ## Stores information about a block of levels for career mode.
 
+## A flag for regions where Fat Sensei is not following the player
+const FLAG_NO_SENSEI := "no_sensei"
+
+## A flag for regions where the player does not operate a restaurant.
+const FLAG_NO_RESTAURANT := "no_restaurant"
+
 ## Chat key containing each region's prologue cutscene, which plays before any other cutscenes/levels
 const PROLOGUE_CHAT_KEY_NAME := "prologue"
 
@@ -73,8 +79,11 @@ var length := 0
 var min_piece_speed := "0"
 var max_piece_speed := "0"
 
-## True if the sensei should not accompany the player on the overworld.
-var sensei_absent := false
+## Returns 'true' if this region has the specified flag.
+##
+## Regions can have flags for unusual qualities, such as regions where Fat Sensei is not following the player, or
+## where the player does not operate a restaurant.
+var flags: Dictionary = {}
 
 ## List of CareerLevel instances which store career-mode-specific information about this region's levels.
 var levels := []
@@ -108,7 +117,8 @@ func from_json_dict(json: Dictionary) -> void:
 	else:
 		min_piece_speed = piece_speed_string
 		max_piece_speed = piece_speed_string
-	sensei_absent = json.get("sensei_absent", false)
+	for flags_string in json.get("flags", []):
+		flags[flags_string] = true
 	for level_json in json.get("levels", []):
 		var level: CareerLevel = CareerLevel.new()
 		level.from_json_dict(level_json)
@@ -224,6 +234,14 @@ func random_customer() -> CreatureAppearance:
 ## Returns null if this region does not define any nonquirky observers.
 func random_observer() -> CreatureAppearance:
 	return _random_creature(observers)
+
+
+## Returns 'true' if this region has the specified flag.
+##
+## Regions can have flags for unusual qualities, such as regions where Fat Sensei is not following the player, or
+## where the player does not operate a restaurant.
+func has_flag(key: String) -> bool:
+	return flags.has(key)
 
 
 ## Returns a random nonquirky appearance from the specified list.

--- a/project/src/main/world/career-world.gd
+++ b/project/src/main/world/career-world.gd
@@ -123,7 +123,7 @@ func _fill_environment_scene() -> void:
 		var player := overworld_environment.add_creature()
 		player.creature_id = CreatureLibrary.PLAYER_ID
 	
-	if PlayerData.career.current_region().sensei_absent:
+	if PlayerData.career.current_region().has_flag(CareerRegion.FLAG_NO_SENSEI):
 		# don't add the sensei if they're not present in this region
 		pass
 	else:
@@ -303,7 +303,7 @@ func _move_level_creature_to_path(creature_index: int, percent: float) -> void:
 func _move_player_to_path(percent: float) -> void:
 	var player := _find_player()
 	var player_range := _camera_x_range()
-	if PlayerData.career.current_region().sensei_absent:
+	if PlayerData.career.current_region().has_flag(CareerRegion.FLAG_NO_SENSEI):
 		# move player slightly left of the center creature
 		player.position.x = lerp(player_range.min_value, player_range.max_value, percent) \
 				- X_DIST_BETWEEN_PLAYER_AND_SENSEI / 2.0

--- a/project/src/test/ui/chat/test-chat-tree.gd
+++ b/project/src/test/ui/chat/test-chat-tree.gd
@@ -1,0 +1,22 @@
+extends "res://addons/gut/test.gd"
+
+var chat_tree := ChatTree.new()
+
+func test_inside_restaurant() -> void:
+	assert_eq(chat_tree.inside_restaurant(), false)
+	
+	chat_tree.location_id = "marsh"
+	assert_eq(chat_tree.inside_restaurant(), false)
+	
+	chat_tree.location_id = "marsh/inside_turbo_fat"
+	assert_eq(chat_tree.inside_restaurant(), true)
+
+
+func test_has_sensei() -> void:
+	assert_eq(chat_tree.has_sensei(), false)
+	
+	chat_tree.spawn_locations[CreatureLibrary.PLAYER_ID] = "kitchen_7"
+	assert_eq(chat_tree.has_sensei(), false)
+	
+	chat_tree.spawn_locations[CreatureLibrary.SENSEI_ID] = "kitchen_5"
+	assert_eq(chat_tree.has_sensei(), true)


### PR DESCRIPTION
Added logic to conditionally exclude cutscenes with Fat Sensei and the
restaurant. Early chapters (and perhaps later chapters) will have the
player by themselves, so we don't want a random cutscene which doesn't
make sense where Fat Sensei shows up.