### PR TITLE
Cutscene bugfixes+enhancements: matching, signals

### DIFF
--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -246,12 +246,7 @@ func _apply_chat_event_meta(_chat_event: ChatEvent, meta_item: String) -> void:
 			var next_scene_key := meta_item_split[1]
 			var next_scene_chat_tree: ChatTree = ChatLibrary.chat_tree_for_key(next_scene_key)
 			# insert the chat tree to ensure it happens before any enqueued levels
-			if PlayerData.career.is_career_mode():
-				PlayerData.career.insert_cutscene(0, {
-					"chat_key": next_scene_key
-				})
-			else:
-				CutsceneQueue.insert_cutscene(0, next_scene_chat_tree)
+			CutsceneQueue.insert_cutscene(0, next_scene_chat_tree)
 		"creature_enter":
 			var creature_id := meta_item_split[1]
 			var creature: Creature = ChattableManager.get_creature_by_id(creature_id)
@@ -261,7 +256,8 @@ func _apply_chat_event_meta(_chat_event: ChatEvent, meta_item: String) -> void:
 			var creature_id := meta_item_split[1]
 			var creature: Creature = ChattableManager.get_creature_by_id(creature_id)
 			creature.fade_out()
-			creature.connect("fade_out_finished", self, "_on_Creature_fade_out_finished", [creature])
+			if not creature.is_connected("fade_out_finished", self, "_on_Creature_fade_out_finished"):
+				creature.connect("fade_out_finished", self, "_on_Creature_fade_out_finished", [creature])
 		"creature_mood":
 			var creature_id: String = meta_item_split[1]
 			var creature: Creature = ChattableManager.get_creature_by_id(creature_id)
@@ -331,6 +327,8 @@ func _on_ChatUi_chat_event_played(chat_event: ChatEvent) -> void:
 
 
 func _on_Creature_fade_out_finished(_creature: Creature) -> void:
+	if _creature.is_connected("fade_out_finished", self, "_on_Creature_fade_out_finished"):
+		_creature.disconnect("fade_out_finished", self, "_on_Creature_fade_out_finished")
 	emit_signal("visible_chatters_changed")
 
 

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -232,11 +232,11 @@ func _interlude_chat_key_pair(career_level: CareerLevel) -> ChatKeyPair:
 	if region.cutscene_path:
 		# find a region-specific cutscene
 		result = CareerCutsceneLibrary.next_interlude_chat_key_pair(
-				[region.cutscene_path], chef_id, customer_id)
+				[region.cutscene_path], chef_id, customer_id, observer_id)
 	if result.empty():
 		# no region-specific cutscene available; find a general cutscene
 		result = CareerCutsceneLibrary.next_interlude_chat_key_pair(
-				[CareerData.GENERAL_CHAT_KEY_ROOT], chef_id, customer_id)
+				[CareerData.GENERAL_CHAT_KEY_ROOT], chef_id, customer_id, observer_id)
 	if not result.empty():
 		result.type = ChatKeyPair.INTERLUDE
 	

--- a/project/src/main/world/creature/CreatureVisuals.tscn
+++ b/project/src/main/world/creature/CreatureVisuals.tscn
@@ -802,5 +802,7 @@ one_shot = true
 [connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ0" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Neck0/HeadBobber/HornZ1" method="_on_CreatureVisuals_orientation_changed"]
 [connection signal="orientation_changed" from="." to="Neck0/HeadBobber/Nose" method="_on_CreatureVisuals_orientation_changed"]
+[connection signal="idle_animation_started" from="Animations/IdleTimer" to="Animations/EmotePlayer" method="_on_IdleTimer_idle_animation_started"]
+[connection signal="idle_animation_stopped" from="Animations/IdleTimer" to="Animations/EmotePlayer" method="_on_IdleTimer_idle_animation_stopped"]
 
 [editable path="Body"]


### PR DESCRIPTION
Fixed bug where nonquirky levels were still not matching up with
nonquirky cutscenes. The old potential_chat_key_pairs implementation was
still just checking whether the chat tree specified ANY
chef/customer/observer, not specifically quirky ones. It now checks if
the creatures are quirky, making the matching logic more lenient.

CareerCutsceneLibrary no longer treats scenes with names like
`intro_level_2` or `boss_level_end_2` as interludes. Some boss levels or
epilogue cutscenes may involve multiple consecutive scenes with names
like this.

Fixed bug where CareerMap was not passing quirky observer IDs into the
`next_interlude_chat_key_pair()` function. We don't yet have any levels
with quirky observers, but this would have caused their levels/cutscenes
to match improperly.

Fixed outdated `CareerData.insert_cutscene()` reference in OverworldUi.

Restored missing CreatureVisuals listeners.