### PR TITLE
Chatscript delint: hyphens, epilogue walking

### DIFF
--- a/project/assets/main/chat/career/marsh/60-end.chat
+++ b/project/assets/main/chat/career/marsh/60-end.chat
@@ -19,50 +19,50 @@ p1: <_< Wait, you didn't do anything? ...We didn't do anything either! Did we?
 b: Well, you and #sensei# got all these customers to come!
 p1: /._. Maybe? I talked to two or three of them at most! ...Were they all friends?
 k: ^y^ You trained us to cook better! I bet that made a difference too.
-[training-good] You improved a lot
-[training-same] You didn't improve
-[training-bad] You got worse
+[training_good] You improved a lot
+[training_same] You didn't improve
+[training_bad] You got worse
 
-[training-good]
+[training_good]
 p1: ^_^ Yeah! Your cooking's gotten way better. That goes for all of you! I bet that's it.
  (skins mood ^__^, bones mood ^y^)
-[after-training]
+[after_training]
 
-[training-same]
+[training_same]
 p1: ._.; I tried to train you but there's only so much I could teach you in such a short time!
 p1: ^N^ Sorry Skins, I think it was probably something else...
  (skins mood ._.;)
-[after-training]
+[after_training]
 
-[training-bad]
+[training_bad]
 p1: -_- Skins, somehow your cooking actually got worse after our training. Now that you mention it,
 p1: /._. Something brought in even more customers to make up for the ones you drove away.
  (skins mood .__.;)
 k: u_u Mowwr...
-[after-training]
+[after_training]
 
-[after-training]
+[after_training]
 h: /._. I heard the Buttercup Cafe shut down. ...Maybe we just got their leftovers?
-[buttercup-happy] That's great!
-[buttercup-ok] That's interesting
-[buttercup-sad] That's too bad
+[buttercup_happy] That's great!
+[buttercup_ok] That's interesting
+[buttercup_sad] That's too bad
 
-[buttercup-happy]
+[buttercup_happy]
 p1: ^O^ They did? Wow! Good riddens to bad restaurants. Did they finally go out of business?
 r: ^o^ Yeah! They'd been bleeding customers for awhile now.
-[after-buttercup]
+[after_buttercup]
 
-[buttercup-ok]
+[buttercup_ok]
 p1: /._. Oh, I didn't know that. ...Did they just go out of business or what?
 r: ^y^ Yeah! They'd been bleeding customers for awhile now.
-[after-buttercup]
+[after_buttercup]
 
-[buttercup-sad]
+[buttercup_sad]
 p1: u_u They did? Oh no! ...I didn't hear about that. Did something happen? Is Diota okay?
 r: /._. Ehh you didn't know? They'd been bleeding customers for awhile now!
-[after-buttercup]
+[after_buttercup]
 
-[after-buttercup]
+[after_buttercup]
 r: Pretty sure they burned through their savings and couldn't make rent, it's nothing weird.
 r: ^Y^ ...Like I said before, going head to head the garbage food always wins!
 r: ._.; I mean the uhh... the GOURMET food! Our food.

--- a/project/assets/main/chat/career/marsh/epilogue.chat
+++ b/project/assets/main/chat/career/marsh/epilogue.chat
@@ -21,6 +21,7 @@ s1: "I chose the sofa less comfortable, and that has made all the difference."
 
 [i_understand]
 p1: /._. I see... And Merrymellow Marsh is like one of those big squishy beanbag chairs,
+ (stop_walking)
 p1: The kind where you almost pass out in them, and then you have trouble standing up afterwards.
 s1: Yes, something like that.
 [besides_that]
@@ -43,6 +44,7 @@ s1: Hmph.
 
 [besides_that]
 p1: /._. Well, besides that. Did we even do anything while we were there?
+ (start_walking)
 p1: We only finished with a handful of extra customers, and we still don't know why they came.
 p1: <_< They could stop showing up next week, and we'd be back to square one.
  (stop_walking)
@@ -61,3 +63,4 @@ s1: /._. Even the greatest... PESTILENCE begins with a single cough!
 p1: >_< What!? No, we have a NICE restaurant! It's not a pestilence!
 s1: ^O^ Even the greatest MASSACRE begins with...
 p1: @_@ STOP! Augh!
+

--- a/project/assets/main/chat/marsh-epilogue.chat
+++ b/project/assets/main/chat/marsh-epilogue.chat
@@ -21,6 +21,7 @@ s1: "I chose the sofa less comfortable, and that has made all the difference."
 
 [i_understand]
 p1: /._. I see... And Merrymellow Marsh is like one of those big squishy beanbag chairs,
+ (stop_walking)
 p1: The kind where you almost pass out in them, and then you have trouble standing up afterwards.
 s1: Yes, something like that.
 [besides_that]
@@ -43,6 +44,7 @@ s1: Hmph.
 
 [besides_that]
 p1: /._. Well, besides that. Did we even do anything while we were there?
+ (start_walking)
 p1: We only finished with a handful of extra customers, and we still don't know why they came.
 p1: <_< They could stop showing up next week, and we'd be back to square one.
  (stop_walking)

--- a/project/assets/main/creatures/primary/diota/having-trouble.chat
+++ b/project/assets/main/creatures/primary/diota/having-trouble.chat
@@ -17,19 +17,19 @@ d: u_u ...
 s1: We'll go.
  (sensei exits)
 
-[friendship-1]
+[friendship_1]
 s1: /._. Ah, you fixed your sign! ...How's business?
  (start_if (chat_finished chat/meet_the_competition or chat_finished creature/jayton/soliciting_buttercup_customers) and not chat_finished creature/diota/hard_times)
 d: Right, we fixed that like a WEEK ago! ...But yeah, things have been weird!
 d: A bunch of our customers just... like... stopped showing up all of a sudden?
-[trying-a-few-promotions]
+[trying_a_few_promotions]
 
-[friendship-2]
+[friendship_2]
 p1: /._. Any news?
  (start_if chat_finished creature/diota/hard_times)
-[trying-a-few-promotions]
+[trying_a_few_promotions]
 
-[trying-a-few-promotions]
+[trying_a_few_promotions]
 d: u_u So yeah, I mean... We're trying a few promotions to get people back, but I don't know.
 d: I HATE marketing, and I always sort of hoped word of mouth would be enough for a place like this?
 d: @_@ And I mean for a while things were going great! ... ...I don't really get what changed....

--- a/project/assets/main/creatures/primary/jayton/soliciting-buttercup-customers.chat
+++ b/project/assets/main/creatures/primary/jayton/soliciting-buttercup-customers.chat
@@ -41,4 +41,4 @@ d: >__< You just thought you could randomly come to my restaurant and pitch to m
  (player mood ._.;)
 p1: <__< ...Well!
 d: >___< Go away! Just... get out of here, seriously!
- (next_scene creature/jayton/soliciting-buttercup-customers-2)
+ (next_scene creature/jayton/soliciting_buttercup_customers_2)

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/goodbye-everyone-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/goodbye-everyone-100.chat
@@ -19,50 +19,50 @@ p1: <_< Wait, you didn't do anything? ...We didn't do anything either! Did we?
 b: Well, you and #sensei# got all these customers to come!
 p1: /._. Maybe? I talked to two or three of them at most! ...Were they all friends?
 k: ^y^ You trained us to cook better! I bet that made a difference too.
-[training-good] You improved a lot
-[training-same] You didn't improve
-[training-bad] You got worse
+[training_good] You improved a lot
+[training_same] You didn't improve
+[training_bad] You got worse
 
-[training-good]
+[training_good]
 p1: ^_^ Yeah! Your cooking's gotten way better. That goes for all of you! I bet that's it.
  (skins mood ^__^, bones mood ^y^)
-[after-training]
+[after_training]
 
-[training-same]
+[training_same]
 p1: ._.; I tried to train you but there's only so much I could teach you in such a short time!
 p1: ^N^ Sorry Skins, I think it was probably something else...
  (skins mood ._.;)
-[after-training]
+[after_training]
 
-[training-bad]
+[training_bad]
 p1: -_- Skins, somehow your cooking actually got worse after our training. Now that you mention it,
 p1: /._. Something brought in even more customers to make up for the ones you drove away.
  (skins mood .__.;)
 k: u_u Mowwr...
-[after-training]
+[after_training]
 
-[after-training]
+[after_training]
 h: /._. I heard the Buttercup Cafe shut down. ...Maybe we just got their leftovers?
-[buttercup-happy] That's great!
-[buttercup-ok] That's interesting
-[buttercup-sad] That's too bad
+[buttercup_happy] That's great!
+[buttercup_ok] That's interesting
+[buttercup_sad] That's too bad
 
-[buttercup-happy]
+[buttercup_happy]
 p1: ^O^ They did? Wow! Good riddens to bad restaurants. Did they finally go out of business?
 r: ^o^ Yeah! They'd been bleeding customers for awhile now.
-[after-buttercup]
+[after_buttercup]
 
-[buttercup-ok]
+[buttercup_ok]
 p1: /._. Oh, I didn't know that. ...Did they just go out of business or what?
 r: ^y^ Yeah! They'd been bleeding customers for awhile now.
-[after-buttercup]
+[after_buttercup]
 
-[buttercup-sad]
+[buttercup_sad]
 p1: u_u They did? Oh no! ...I didn't hear about that. Did something happen? Is Diota okay?
 r: /._. Ehh you didn't know? They'd been bleeding customers for awhile now!
-[after-buttercup]
+[after_buttercup]
 
-[after-buttercup]
+[after_buttercup]
 r: Pretty sure they burned through their savings and couldn't make rent, it's nothing weird.
 r: ^Y^ ...Like I said before, going head to head the garbage food always wins!
  (say_if chat_finished chat/meet_the_competition)

--- a/project/assets/main/puzzle/levels/cutscenes/marsh/goodbye-shirts-100.chat
+++ b/project/assets/main/puzzle/levels/cutscenes/marsh/goodbye-shirts-100.chat
@@ -115,30 +115,30 @@ s: -__- It's just... (sigh) Whatever. It could be worse.
 p1: ^_^ I'll fart around you!
 s: ^o^ Ha ha. Thanks. I think.
 s: Well anyway, maybe it won't suck as much anymore, I don't know.
-[shields-up]
+[shields_up]
 
 [thats_horrible]
 p1: u_u Ugh, that sounds horrible.
 s: Ahh maybe it won't suck as much anymore, I don't know.
-[shields-up]
+[shields_up]
 
 [awkward_compliment]
 p1: ^__^ Wow, what an insightful monologue. You're so smart! And so beautiful.
 s: ^o^ Ha ha. Thanks. I think.
 s: Well anyway, maybe it won't suck as much anymore, I don't know.
-[shields-up]
+[shields_up]
 
 [ive_been_there]
 p1: >_< Yeah... I've been there before.
 s: Ahh maybe it won't suck as much anymore, I don't know.
-[shields-up]
+[shields_up]
 
 [hmm]
 p1: /._. Hmm...
 s: Well anyway, maybe it won't suck as much anymore, I don't know.
-[shields-up]
+[shields_up]
 
-[shields-up]
+[shields_up]
 s: Just gotta keep those shields up. I'm sure you know the drill.
 s: <__< Anyway, I hate long goodbyes and this one's kind of run its course. Take care of yourself.
 [bye2] You too


### PR DESCRIPTION
Our chatscript files mostly used hyphens instead of underscores, but there were
several mistakes. I changed the hyphens to underscores.

Fixed some branches in the marsh epilogue where the player didn't stop
walking.