### PR TITLE
Fixed bug when squishing/rotating simultaneously.

### DIFF
--- a/project/src/main/puzzle/line-clearer.gd
+++ b/project/src/main/puzzle/line-clearer.gd
@@ -116,6 +116,13 @@ func schedule_full_row_line_clears() -> void:
 
 
 ## Schedules the specified lines to be cleared later.
+##
+## Parameters:
+## 	'lines_to_clear': Row indexes to clear from the puzzle tilemap
+##
+## 	'line_clear_delay': Number of frames to spend erasing and deleting lines
+##
+## 	'award_points': 'true' if these line clears should score points
 func schedule_line_clears(lines_to_clear: Array, line_clear_delay: int, award_points: bool = true) -> void:
 	var unscheduled_clears := []
 	var unscheduled_erases := []
@@ -350,4 +357,9 @@ func _on_Playfield_line_inserted(y: int, _tiles_key: String, _src_y: int) -> voi
 		if i <= y:
 			_rows_to_preserve_at_end.erase(i)
 			_rows_to_preserve_at_end[i-1] = true
+	_rows_to_preserve_at_end[y] = true
+
+
+## When lines are filled, we mark them so they're preserved at the end.
+func _on_Playfield_line_filled(y: int, _tiles_key: String, _src_y: int) -> void:
 	_rows_to_preserve_at_end[y] = true

--- a/project/src/main/puzzle/piece/piece-physics.gd
+++ b/project/src/main/puzzle/piece/piece-physics.gd
@@ -46,11 +46,12 @@ func move_piece(piece: ActivePiece) -> bool:
 	var old_piece_pos := piece.pos
 	var old_piece_orientation := piece.orientation
 	
+	# Squish first to avoid bugs when squishing/rotating/moving in the same frame.
+	squisher.attempt_squish(piece)
 	if _states.get_state() == _states.move_piece:
 		rotator.apply_rotate_input(piece)
 		mover.apply_move_input(piece)
 		dropper.apply_hard_drop_input(piece)
-	squisher.attempt_squish(piece)
 	dropper.apply_gravity(piece)
 	
 	var result := false

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -76,6 +76,14 @@ func add_misc_delay_frames(frames: int) -> void:
 	_remaining_misc_delay_frames += frames
 
 
+## Schedules the specified lines to be cleared later.
+##
+## Parameters:
+## 	'lines_to_clear': Row indexes to clear from the puzzle tilemap
+##
+## 	'line_clear_delay': Number of frames to spend erasing and deleting lines
+##
+## 	'award_points': 'true' if these line clears should score points
 func schedule_line_clears(lines_to_clear: Array, line_clear_delay: int, award_points: bool = true) -> void:
 	line_clearer.schedule_line_clears(lines_to_clear, line_clear_delay, award_points)
 


### PR DESCRIPTION
When the player rotated and squished in the same frame, such as when
inserting the final Q piece in a PQV box, the piece could clip into
other pieces. This occurred because the squish target is only calculated
once a frame when the 'piece_disturbed' signal fires. Rotating the piece
would result in the piece squishing to its old squish target before it
was recalculated.

I fixed the bug by changing the logic to squish before rotating, so its
squish target is always accurate. Squishing first has other intuitive
benefits -- namely that the player can press the rotate and squish
buttons simultaneously to squish and rotate a Q piece into a PQV box as
described above.

Added comments to 'schedule_line_clears' function.