### PR TITLE
New 'refresh on top out' logic.

### DIFF
--- a/project/assets/main/puzzle/levels/career/fruit-on-the-top.json
+++ b/project/assets/main/puzzle/levels/career/fruit-on-the-top.json
@@ -8,7 +8,8 @@
     "value": "50"
   },
   "blocks_during": [
-    "fill_lines 0"
+    "fill_lines 0",
+    "refresh_on_top_out"
   ],
   "combo_break": [
     "pieces 0"

--- a/project/src/main/puzzle/level/blocks-during-rules.gd
+++ b/project/src/main/puzzle/level/blocks-during-rules.gd
@@ -31,6 +31,9 @@ var line_clear_type: int = LineClearType.DEFAULT
 ## whether pickups move with the playfield blocks
 var pickup_type: int = PickupType.DEFAULT
 
+## if true, the entire playfield is refreshed when the player tops out
+var refresh_on_top_out := false
+
 ## whether inserted rows should start from a random row in the source tiles instead of starting from the top
 var shuffle_inserted_lines: int = ShuffleLinesType.NONE
 
@@ -42,11 +45,12 @@ var _rule_parser: RuleParser
 func _init() -> void:
 	_rule_parser = RuleParser.new(self)
 	_rule_parser.add_bool("clear_on_top_out")
+	_rule_parser.add_string("fill_lines")
 	_rule_parser.add_enum("line_clear_type", LineClearType)
 	_rule_parser.add_enum("pickup_type", PickupType)
+	_rule_parser.add_bool("refresh_on_top_out")
 	_rule_parser.add_enum("shuffle_inserted_lines", ShuffleLinesType) \
 			.implied(ShuffleLinesType.BAG)
-	_rule_parser.add_string("fill_lines")
 	_rule_parser.add_enum("shuffle_filled_lines", ShuffleLinesType) \
 			.implied(ShuffleLinesType.BAG)
 

--- a/project/src/main/puzzle/piece/piece-speed.gd
+++ b/project/src/main/puzzle/piece/piece-speed.gd
@@ -46,3 +46,8 @@ func _init(init_id: String, init_gravity: int, init_appearance_delay: int, init_
 ## number of frames to spend clearing the entire playfield during after a top out
 func playfield_clear_delay() -> int:
 	return appearance_delay + lock_delay
+
+
+## number of frames to spend refilling the entire playfield after a top out
+func playfield_refill_delay() -> int:
+	return appearance_delay + lock_delay

--- a/project/src/main/puzzle/top-out-tracker.gd
+++ b/project/src/main/puzzle/top-out-tracker.gd
@@ -15,11 +15,17 @@ func _on_PuzzleState_topped_out() -> void:
 	Utils.rand_value(_game_over_voices).play()
 	
 	if not PuzzleState.level_performance.lost:
+		var top_out_delay := PieceSpeeds.current_speed.playfield_clear_delay()
 		_playfield.break_combo()
-		if CurrentLevel.settings.blocks_during.clear_on_top_out:
+		if CurrentLevel.settings.blocks_during.refresh_on_top_out:
+			top_out_delay += PieceSpeeds.current_speed.playfield_refill_delay()
+			
+			_playfield.schedule_line_clears(range(PuzzleTileMap.ROW_COUNT),
+					PieceSpeeds.current_speed.playfield_clear_delay(), false)
+		elif CurrentLevel.settings.blocks_during.clear_on_top_out:
 			_playfield.schedule_line_clears(range(PuzzleTileMap.ROW_COUNT),
 					PieceSpeeds.current_speed.playfield_clear_delay(), false)
 		else:
 			_playfield.schedule_line_clears(range(PuzzleTileMap.ROW_COUNT - LINES_CLEARED_ON_TOP_OUT, PuzzleTileMap.ROW_COUNT),
 					PieceSpeeds.current_speed.playfield_clear_delay(), false)
-		_piece_manager.enter_top_out_state(PieceSpeeds.current_speed.playfield_clear_delay())
+		_piece_manager.enter_top_out_state(top_out_delay)


### PR DESCRIPTION
This new flag enables levels which want to reset the playfield when the
player tops out. For example, a level might start with 6 'garbage rows'
but if the player digs past them, higher scoring rows start to spawn.
The default top out logic would reward a player who tops out by deleting
these garbage rows for them. With this new flag, a player who tops out
will lose their progress and have to try again (which is perhaps
preferable.)