### PR TITLE
Level editor highlights bad json.

### DIFF
--- a/project/src/main/editor/puzzle/LevelEditor.tscn
+++ b/project/src/main/editor/puzzle/LevelEditor.tscn
@@ -23,9 +23,6 @@ margin_right = 512.0
 margin_bottom = 300.0
 rect_min_size = Vector2( 1024, 600 )
 script = ExtResource( 8 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 PuzzleScene = ExtResource( 17 )
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
@@ -171,6 +168,7 @@ __meta__ = {
 }
 playfield_editor_path = NodePath("../../TabContainer/Playfield")
 properties_editor_path = NodePath("../../TabContainer/Properties")
+test_button_path = NodePath("../Test")
 
 [node name="Settings" type="Button" parent="HBoxContainer/SideButtons"]
 margin_top = 534.0

--- a/project/src/main/editor/puzzle/editor-json.gd
+++ b/project/src/main/editor/puzzle/editor-json.gd
@@ -8,6 +8,7 @@ var _json_tree: Dictionary
 
 export (NodePath) var playfield_editor_path: NodePath
 export (NodePath) var properties_editor_path: NodePath
+export (NodePath) var test_button_path: NodePath
 
 var _tile_map: PuzzleTileMap
 var _pickups: EditorPickups
@@ -18,6 +19,7 @@ var _calculated_pickup_score := 0
 
 onready var _playfield_editor: PlayfieldEditorControl = get_node(playfield_editor_path)
 onready var _properties_editor: PropertiesEditorControl = get_node(properties_editor_path)
+onready var _test_button: Button = get_node(test_button_path)
 
 func _ready() -> void:
 	_tile_map = _playfield_editor.get_tile_map()
@@ -30,6 +32,11 @@ func _ready() -> void:
 func can_parse_json() -> bool:
 	var parsed = parse_json(text)
 	_json_tree = parsed if typeof(parsed) == TYPE_DICTIONARY else {}
+	if _json_tree.empty():
+		set("custom_colors/font_color", Color.red)
+	else:
+		set("custom_colors/font_color", null)
+	
 	return not _json_tree.empty()
 
 
@@ -51,8 +58,10 @@ func refresh_playfield_editor() -> void:
 ## Refreshes the properties editor based on our json text.
 func refresh_properties_editor() -> void:
 	if not can_parse_json():
+		_test_button.disabled = true
 		return
 	
+	_test_button.disabled = false
 	if _json_tree.has("rank"):
 		var rank_rules := RankRules.new()
 		rank_rules.from_json_array(_json_tree["rank"])


### PR DESCRIPTION
Invalid JSON now shows up in red and disables the 'Test' button.

This avoids the frustrating case where the game would crash when testing a level
with a typo. It avoids it in two ways -- by alerting you of your typo and
disabling the button.