### PR TITLE
Apply das/buffered inputs after top out.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -495,6 +495,11 @@ _global_script_classes=[ {
 "path": "res://src/main/puzzle/line-clearer.gd"
 }, {
 "base": "Node",
+"class": "LineFiller",
+"language": "GDScript",
+"path": "res://src/main/puzzle/line-filler.gd"
+}, {
+"base": "Node",
 "class": "LineInserter",
 "language": "GDScript",
 "path": "res://src/main/puzzle/line-inserter.gd"
@@ -1127,6 +1132,7 @@ _global_script_class_icons={
 "LevelTriggers": "",
 "Levels": "",
 "LineClearer": "",
+"LineFiller": "",
 "LineInserter": "",
 "LockAlleleButton": "",
 "LoseConditionRules": "",

--- a/project/src/main/puzzle/Playfield.tscn
+++ b/project/src/main/puzzle/Playfield.tscn
@@ -367,7 +367,7 @@ bus = "Sound Bus"
 
 [node name="LineFiller" type="Node" parent="."]
 script = ExtResource( 29 )
-playfield_path = NodePath("..")
+tile_map_path = NodePath("../TileMapClip/TileMap")
 
 [node name="LineFillSound1" type="AudioStreamPlayer" parent="LineFiller"]
 stream = ExtResource( 6 )
@@ -414,6 +414,7 @@ one_shot = true
 [connection signal="line_clears_scheduled" from="LineClearer" to="." method="_on_LineClearer_line_clears_scheduled"]
 [connection signal="line_deleted" from="LineClearer" to="." method="_on_LineClearer_line_deleted"]
 [connection signal="line_erased" from="LineClearer" to="." method="_on_LineClearer_line_erased"]
+[connection signal="after_lines_filled" from="LineFiller" to="." method="_on_LineFiller_after_lines_filled"]
 [connection signal="line_filled" from="LineFiller" to="." method="_on_LineFiller_line_filled"]
 [connection signal="timeout" from="LineFiller/LineFillSfxResetTimer" to="LineFiller" method="_on_LineFillSfxResetTimer_timeout"]
 [connection signal="line_inserted" from="LineInserter" to="." method="_on_LineInserter_line_inserted"]

--- a/project/src/main/puzzle/line-clearer.gd
+++ b/project/src/main/puzzle/line-clearer.gd
@@ -19,6 +19,7 @@ signal line_erased(y, total_lines, remaining_lines, box_ints)
 ## emitted when an erased line is deleted, causing the rows above it to drop down
 signal line_deleted(y)
 
+## emitted after a set of lines is deleted
 signal after_lines_deleted
 
 ## percent of the line clear delay which should be spent erasing lines.

--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -110,12 +110,23 @@ func write_piece_to_playfield() -> void:
 	_clear_piece()
 
 
-## Called when the player tops out, but doesn't lose.
+## Immobilizes the piece when the player tops out.
 ##
-## Enters a state which waits for the _playfield to make room for the current piece.
-func enter_top_out_state(top_out_frames: int) -> void:
+## When the player tops out but doesn't lose, the playfield deletes some lines to make space. During this time the
+## piece enters a state of immobility. This 'enter_top_out_state' function makes the piece temporarily immobile.
+func enter_top_out_state() -> void:
 	_states.set_state(_states.top_out)
-	piece.spawn_delay = top_out_frames
+	
+	# prevent the piece from spawning until the playfield is ready
+	piece.spawn_delay = 999999
+
+
+## Restores piece mobility after the player finishes topping out.
+##
+## When the player tops out but doesn't lose, the playfield deletes some lines to make space. During this time the
+## piece enters a state of immobility. This 'exit_top_out_state()' function makes the piece mobile again.
+func exit_top_out_state() -> void:
+	piece.spawn_delay = 0
 
 
 ## Spawns a new piece at the top of the _playfield.
@@ -125,8 +136,14 @@ func spawn_piece() -> bool:
 	var next_piece := _piece_queue.pop_next_piece()
 	piece = ActivePiece.new(next_piece.type, funcref(_playfield.tile_map, "is_cell_blocked"))
 	piece.orientation = next_piece.orientation
-	var success := _physics.spawn_piece(piece)
+	var success := _physics.initially_move_piece(piece)
 	emit_signal("piece_spawned")
+	emit_signal("piece_disturbed", piece)
+	return success
+
+
+func initially_move_piece() -> bool:
+	var success := _physics.initially_move_piece(piece)
 	emit_signal("piece_disturbed", piece)
 	return success
 

--- a/project/src/main/puzzle/piece/piece-physics.gd
+++ b/project/src/main/puzzle/piece/piece-physics.gd
@@ -14,10 +14,10 @@ onready var squisher := $Squisher
 
 onready var _states: PieceStates = get_node(piece_states_path)
 
-## Spawns a new piece at the top of the _playfield.
+## Positions a new piece at the top of the _playfield.
 ##
 ## Returns 'true' if the piece was spawned successfully, or 'false' if the player topped out.
-func spawn_piece(piece: ActivePiece) -> bool:
+func initially_move_piece(piece: ActivePiece) -> bool:
 	rotator.apply_initial_rotate_input(piece)
 	
 	# relocate piece to the top of the playfield
@@ -41,7 +41,7 @@ func spawn_piece(piece: ActivePiece) -> bool:
 ## If any move/rotate keys were pressed, this method will move the block accordingly. Gravity will then be applied.
 ##
 ## Returns 'true' if the piece was interacted with successfully resulting in a movement change, orientation change, or
-## 	lock reset
+## lock reset
 func move_piece(piece: ActivePiece) -> bool:
 	var old_piece_pos := piece.pos
 	var old_piece_orientation := piece.orientation

--- a/project/src/main/puzzle/piece/states/move-piece.gd
+++ b/project/src/main/puzzle/piece/states/move-piece.gd
@@ -2,9 +2,11 @@ extends State
 ## State: The player is moving the piece around the playfield.
 
 func enter(piece_manager: PieceManager, prev_state_name: String) -> void:
-	if prev_state_name == "Prespawn":
-		# apply an immediate frame of player movement and gravity to prevent the piece from flickering at the top of
-		# the screen at 20G or when hard drop is held
+	if prev_state_name == "Prespawn" or prev_state_name == "TopOut":
+		# Apply an immediate frame of player movement and gravity.
+		#
+		# This applies the player's buffered inputs if they tap a movement/rotation key while a piece is locking. It
+		# also prevents the piece from flickering at the top of the screen at 20G or when hard drop is held.
 		update(piece_manager)
 
 

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -21,11 +21,17 @@ signal line_erased(y, total_lines, remaining_lines, box_ints)
 ## emitted when an erased line is deleted, causing the rows above it to drop down
 signal line_deleted(y)
 
+## emitted after a set of lines is deleted
+signal after_lines_deleted
+
 ## emitted when lines are inserted. some levels insert lines, but most do not
 signal line_inserted(y, tiles_key, src_y)
 
 ## emitted when lines are filled in from the top. some levels fill in lines, but most do not
 signal line_filled(y, tiles_key, src_y)
+
+## emitted after a set of lines are filled, either following a topout/refresh or line clear
+signal after_lines_filled
 
 ## emitted when a food item should be spawned because the player collects a pickup
 signal food_spawned(cell, remaining_food, food_type)
@@ -184,6 +190,7 @@ func _on_LineClearer_line_deleted(y: int) -> void:
 
 
 func _on_LineClearer_after_lines_deleted() -> void:
+	emit_signal("after_lines_deleted")
 	PuzzleState.after_piece_written()
 
 
@@ -199,6 +206,10 @@ func _on_Pauser_paused_changed(value: bool) -> void:
 
 func _on_LineFiller_line_filled(y: int, tiles_key: String, src_y: int) -> void:
 	emit_signal("line_filled", y, tiles_key, src_y)
+
+
+func _on_LineFiller_after_lines_filled() -> void:
+	emit_signal("after_lines_filled")
 
 
 func _on_LineInserter_line_inserted(y: int, tiles_key: String, src_y: int) -> void:

--- a/project/src/main/puzzle/top-out-tracker.gd
+++ b/project/src/main/puzzle/top-out-tracker.gd
@@ -2,6 +2,9 @@ extends Node
 
 const LINES_CLEARED_ON_TOP_OUT := 10
 
+## 'True' if the playfield is currently going through the top out process, but the player hasn't lost.
+var _topping_out := false
+
 onready var _game_over_voices := [$GameOverVoice0, $GameOverVoice1, $GameOverVoice2, $GameOverVoice3, $GameOverVoice4]
 onready var _puzzle: Puzzle = $".."
 onready var _playfield: Playfield = _puzzle.get_playfield()
@@ -9,17 +12,18 @@ onready var _piece_manager: PieceManager = _puzzle.get_piece_manager()
 
 func _ready() -> void:
 	PuzzleState.connect("topped_out", self, "_on_PuzzleState_topped_out")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
+	_playfield.connect("after_lines_deleted", self, "_on_Playfield_after_lines_deleted")
+	_playfield.connect("after_lines_filled", self, "_on_Playfield_after_lines_filled")
 
 
 func _on_PuzzleState_topped_out() -> void:
 	Utils.rand_value(_game_over_voices).play()
 	
 	if not PuzzleState.level_performance.lost:
-		var top_out_delay := PieceSpeeds.current_speed.playfield_clear_delay()
+		_topping_out = true
 		_playfield.break_combo()
 		if CurrentLevel.settings.blocks_during.refresh_on_top_out:
-			top_out_delay += PieceSpeeds.current_speed.playfield_refill_delay()
-			
 			_playfield.schedule_line_clears(range(PuzzleTileMap.ROW_COUNT),
 					PieceSpeeds.current_speed.playfield_clear_delay(), false)
 		elif CurrentLevel.settings.blocks_during.clear_on_top_out:
@@ -28,4 +32,21 @@ func _on_PuzzleState_topped_out() -> void:
 		else:
 			_playfield.schedule_line_clears(range(PuzzleTileMap.ROW_COUNT - LINES_CLEARED_ON_TOP_OUT, PuzzleTileMap.ROW_COUNT),
 					PieceSpeeds.current_speed.playfield_clear_delay(), false)
-		_piece_manager.enter_top_out_state(top_out_delay)
+		_piece_manager.enter_top_out_state()
+
+
+func _on_PuzzleState_game_prepared() -> void:
+	_topping_out = false
+
+
+func _on_Playfield_after_lines_deleted() -> void:
+	if _topping_out and not CurrentLevel.settings.blocks_during.refresh_on_top_out:
+		# The current level's top out process ends with the lines which were just deleted. Restore piece mobility.
+		_topping_out = false
+		_piece_manager.exit_top_out_state()
+
+
+func _on_Playfield_after_lines_filled() -> void:
+	if _topping_out and CurrentLevel.settings.blocks_during.refresh_on_top_out:
+		# The current level's top out process ends with the lines which were just filled. Restore piece mobility.
+		_piece_manager.exit_top_out_state()

--- a/project/src/main/puzzle/top-out.gd
+++ b/project/src/main/puzzle/top-out.gd
@@ -3,7 +3,12 @@ extends State
 ## the current piece.
 
 func update(piece_manager: PieceManager) -> String:
+	piece_manager.buffer_inputs()
 	var new_state_name := ""
 	if frames >= piece_manager.piece.spawn_delay:
-		new_state_name = "MovePiece"
+		piece_manager.pop_buffered_inputs()
+		if piece_manager.initially_move_piece():
+			new_state_name = "MovePiece"
+		else:
+			new_state_name = "TopOut"
 	return new_state_name


### PR DESCRIPTION
When the player tops out but doesn't die, they can now buffer inputs by
tapping the rotate/move/drop keys with remarkable timing -- or they can
activate DAS by holding the rotate/move/drop keys.

This prevents a frustrating case where the player would watch a length
top out animation while holding a movement direction, and then after the
top out animation finished the piece still wouldn't move (unless they pressed
the key again.)