### PR TITLE
Squish move bugs: sfx, mid-air locks

### DIFF
--- a/project/src/main/puzzle/piece/piece-squisher.gd
+++ b/project/src/main/puzzle/piece/piece-squisher.gd
@@ -81,6 +81,7 @@ func _squish_to(piece: ActivePiece, target_pos: Vector2) -> void:
 	piece.target_pos = target_pos
 	piece.move_to_target()
 	piece.gravity = 0
+	piece.lock = 0
 	emit_signal("squish_moved", piece, old_pos)
 
 

--- a/project/src/main/puzzle/piece/presquish-sfx.gd
+++ b/project/src/main/puzzle/piece/presquish-sfx.gd
@@ -18,3 +18,7 @@ func start_presquish_sfx() -> void:
 func stop_presquish_sfx() -> void:
 	sfx_started = false
 	stop()
+	
+	# Workaround for Godot #37148 to stop playback if playback was started in the same frame
+	# https://github.com/godotengine/godot/issues/37148
+	seek(-1)


### PR DESCRIPTION
Fixed bug where pieces could lock in mid air with a squish move. This
would occur if the player exhausted all of the piece's lock resets and
then performed a squish move which left the piece in mid-air.

Fixed bug where squish sound effects would sometimes continue after the
squish was completed or cancelled. This was caused by Godot  #37148, a
bug which causes the 'AudioStreamPlayer.stop()' to malfunction if
playback was started in the same frame
(https://github.com/godotengine/godot/issues/37148)