### PR TITLE
Reorganized piece kick tests.

### DIFF
--- a/project/src/test/puzzle/piece/test-piece-kicks-jl.gd
+++ b/project/src/test/puzzle/piece/test-piece-kicks-jl.gd
@@ -1,7 +1,71 @@
 extends "res://src/test/puzzle/piece/test-piece-kicks.gd"
-## Tests the j/l piece's kick behavior.
+## Tests the j and l pieces' kick behavior.
 
-func test_j_lwallkick_r2() -> void:
+func test_j_floor_kick_0r() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		" j   ",
+		" jjj ",
+	]
+	to_grid = [
+		"     ",
+		" jj  ",
+		" j   ",
+		" j   ",
+	]
+	assert_kick()
+
+
+func test_j_floor_kick_0l() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		" j   ",
+		" jjj ",
+	]
+	to_grid = [
+		"     ",
+		"   j ",
+		"   j ",
+		"  jj ",
+	]
+	assert_kick()
+
+
+func test_l_floor_kick_0r() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"   l ",
+		" lll ",
+	]
+	to_grid = [
+		"     ",
+		" l   ",
+		" l   ",
+		" ll  ",
+	]
+	assert_kick()
+
+
+func test_l_floor_kick_0l() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"   l ",
+		" lll ",
+	]
+	to_grid = [
+		"     ",
+		"  ll ",
+		"   l ",
+		"   l ",
+	]
+	assert_kick()
+
+
+func test_j_wall_kick_r2() -> void:
 	from_grid = [
 		"    ",
 		"jj  ",
@@ -19,7 +83,7 @@ func test_j_lwallkick_r2() -> void:
 	assert_kick()
 
 
-func test_j_lwallkick_r0() -> void:
+func test_j_wall_kick_r0() -> void:
 	from_grid = [
 		"    ",
 		"jj  ",
@@ -37,7 +101,7 @@ func test_j_lwallkick_r0() -> void:
 	assert_kick()
 
 
-func test_l_lwallkick_r0() -> void:
+func test_l_wall_kick_r0() -> void:
 	from_grid = [
 		"    ",
 		"l   ",
@@ -55,7 +119,7 @@ func test_l_lwallkick_r0() -> void:
 	assert_kick()
 
 
-func test_l_lwallkick_r2() -> void:
+func test_l_wall_kick_r2() -> void:
 	from_grid = [
 		"    ",
 		"l   ",
@@ -73,7 +137,7 @@ func test_l_lwallkick_r2() -> void:
 	assert_kick()
 
 
-func test_j_rwallkick_l0() -> void:
+func test_j_wall_kick_l0() -> void:
 	from_grid = [
 		"    ",
 		"   j",
@@ -91,7 +155,7 @@ func test_j_rwallkick_l0() -> void:
 	assert_kick()
 
 
-func test_j_rwallkick_l2() -> void:
+func test_j_wall_kick_l2() -> void:
 	from_grid = [
 		"    ",
 		"   j",
@@ -109,7 +173,7 @@ func test_j_rwallkick_l2() -> void:
 	assert_kick()
 
 
-func test_l_rwallkick_l0() -> void:
+func test_l_wall_kick_l0() -> void:
 	from_grid = [
 		"    ",
 		"  ll",
@@ -127,7 +191,7 @@ func test_l_rwallkick_l0() -> void:
 	assert_kick()
 
 
-func test_l_rwallkick_l2() -> void:
+func test_l_wall_kick_l2() -> void:
 	from_grid = [
 		"    ",
 		"  ll",
@@ -141,70 +205,6 @@ func test_l_rwallkick_l2() -> void:
 		" lll",
 		" l  ",
 		"    ",
-	]
-	assert_kick()
-
-
-func test_j_floorkick_0r() -> void:
-	from_grid = [
-		"     ",
-		"     ",
-		" j   ",
-		" jjj ",
-	]
-	to_grid = [
-		"     ",
-		" jj  ",
-		" j   ",
-		" j   ",
-	]
-	assert_kick()
-
-
-func test_j_floorkick_0l() -> void:
-	from_grid = [
-		"     ",
-		"     ",
-		" j   ",
-		" jjj ",
-	]
-	to_grid = [
-		"     ",
-		"   j ",
-		"   j ",
-		"  jj ",
-	]
-	assert_kick()
-
-
-func test_l_floorkick_0r() -> void:
-	from_grid = [
-		"     ",
-		"     ",
-		"   l ",
-		" lll ",
-	]
-	to_grid = [
-		"     ",
-		" l   ",
-		" l   ",
-		" ll  ",
-	]
-	assert_kick()
-
-
-func test_l_floorkick_0l() -> void:
-	from_grid = [
-		"     ",
-		"     ",
-		"   l ",
-		" lll ",
-	]
-	to_grid = [
-		"     ",
-		"  ll ",
-		"   l ",
-		"   l ",
 	]
 	assert_kick()
 

--- a/project/src/test/puzzle/piece/test-piece-kicks-pq.gd
+++ b/project/src/test/puzzle/piece/test-piece-kicks-pq.gd
@@ -1,7 +1,7 @@
 extends "res://src/test/puzzle/piece/test-piece-kicks.gd"
-## Tests the p/q piece's kick behavior.
+## Tests the p and q pieces' kick behavior.
 
-func test_p_floorkick_cw() -> void:
+func test_p_floor_kick_0r() -> void:
 	from_grid = [
 		"     ",
 		" ppp ",
@@ -15,7 +15,7 @@ func test_p_floorkick_cw() -> void:
 	assert_kick()
 
 
-func test_p_floorkick_ccw() -> void:
+func test_p_floor_kick_0l() -> void:
 	from_grid = [
 		"     ",
 		" ppp ",
@@ -29,7 +29,7 @@ func test_p_floorkick_ccw() -> void:
 	assert_kick()
 
 
-func test_q_floorkick_cw() -> void:
+func test_q_floor_kick_0r() -> void:
 	from_grid = [
 		"     ",
 		" qqq ",
@@ -43,7 +43,7 @@ func test_q_floorkick_cw() -> void:
 	assert_kick()
 
 
-func test_q_floorkick_ccw() -> void:
+func test_q_floor_kick_0l() -> void:
 	from_grid = [
 		"     ",
 		" qqq ",
@@ -57,7 +57,7 @@ func test_q_floorkick_ccw() -> void:
 	assert_kick()
 
 
-func test_p_rwallkick_l0() -> void:
+func test_p_wall_kick_l0() -> void:
 	from_grid = [
 		"    ",
 		"  pp",
@@ -75,7 +75,7 @@ func test_p_rwallkick_l0() -> void:
 	assert_kick()
 
 
-func test_p_rwallkick_l2() -> void:
+func test_p_wall_kick_l2() -> void:
 	from_grid = [
 		"    ",
 		"  pp",
@@ -93,7 +93,7 @@ func test_p_rwallkick_l2() -> void:
 	assert_kick()
 
 
-func test_p_lwallkick_r0() -> void:
+func test_p_wall_kick_r0() -> void:
 	from_grid = [
 		"    ",
 		" p  ",
@@ -111,7 +111,7 @@ func test_p_lwallkick_r0() -> void:
 	assert_kick()
 
 
-func test_q_lwallkick_r2() -> void:
+func test_q_wall_kick_r2() -> void:
 	from_grid = [
 		"    ",
 		"qq  ",
@@ -129,7 +129,7 @@ func test_q_lwallkick_r2() -> void:
 	assert_kick()
 
 
-func test_q_rwallkick_l0() -> void:
+func test_q_wall_kick_l0() -> void:
 	from_grid = [
 		"    ",
 		"  q ",
@@ -147,7 +147,7 @@ func test_q_rwallkick_l0() -> void:
 	assert_kick()
 
 
-func test_q_lwallkick_r0() -> void:
+func test_q_wall_kick_r0() -> void:
 	from_grid = [
 		"    ",
 		"qq  ",

--- a/project/src/test/puzzle/piece/test-piece-kicks-t.gd
+++ b/project/src/test/puzzle/piece/test-piece-kicks-t.gd
@@ -1,206 +1,7 @@
 extends "res://src/test/puzzle/piece/test-piece-kicks.gd"
 ## Tests the t piece's kick behavior.
 
-## A rose kick is when the t piece pivots around the middle of its three extrusions.
-##
-##  T  <--- it rotates around this part. doesn't it look like a rose?
-## ttt
-func test_rose_kick_left() -> void:
-	from_grid = [
-		":: ",
-		"ttt",
-		" t ",
-		" : ",
-	]
-	to_grid = [
-		":: ",
-		"t  ",
-		"tt ",
-		"t: ",
-	]
-	assert_kick()
-
-
-func test_rose_kick_down0() -> void:
-	from_grid = [
-		"   ",
-		"  t",
-		":tt",
-		"  t",
-	]
-	to_grid = [
-		"   ",
-		"   ",
-		":t ",
-		"ttt",
-	]
-	assert_kick()
-
-
-func test_rose_kick_down1() -> void:
-	from_grid = [
-		"   ",
-		"t  ",
-		"tt:",
-		"t  ",
-	]
-	to_grid = [
-		"   ",
-		"   ",
-		" t:",
-		"ttt",
-	]
-	assert_kick()
-
-
-func test_rose_kick_right() -> void:
-	from_grid = [
-		" ::",
-		"ttt",
-		" t ",
-		" : ",
-	]
-	to_grid = [
-		" ::",
-		"  t",
-		" tt",
-		" :t",
-	]
-	assert_kick()
-
-
-## A duck kick is when the T-piece tries to rotate an extrusion towards its flat side, and gets shoved away.
-##
-## This does not replace the usual floor kick, but acts as a replacement if the floor kick fails.
-func test_duck_kick_down0() -> void:
-	from_grid = [
-		"::  ",
-		"ttt ",
-		":t :",
-		": ::"
-	]
-	to_grid = [
-		"::  ",
-		" t  ",
-		":tt:",
-		":t::"
-	]
-	assert_kick()
-
-
-func test_duck_kick_down1() -> void:
-	from_grid = [
-		"  ::",
-		" ttt",
-		": t:",
-		":: :"
-	]
-	to_grid = [
-		"  ::",
-		"  t ",
-		":tt:",
-		"::t:"
-	]
-	assert_kick()
-
-
-func test_duck_kick_left0() -> void:
-	from_grid = [
-		"    ",
-		"  t ",
-		" tt:",
-		" :t:"
-	]
-	to_grid = [
-		"    ",
-		" t  ",
-		"ttt:",
-		" : :"
-	]
-	assert_kick()
-
-
-func test_duck_kick_left1() -> void:
-	from_grid = [
-		"    ",
-		"  t ",
-		" tt:",
-		"  t:"
-	]
-	to_grid = [
-		"    ",
-		"    ",
-		"ttt:",
-		" t :"
-	]
-	assert_kick()
-
-
-func test_duck_kick_right0() -> void:
-	from_grid = [
-		"    ",
-		" t  ",
-		":tt ",
-		":t: "
-	]
-	to_grid = [
-		"    ",
-		"  t ",
-		":ttt",
-		": : "
-	]
-	assert_kick()
-
-
-func test_duck_kick_right1() -> void:
-	from_grid = [
-		"    ",
-		" t  ",
-		":tt ",
-		":t  "
-	]
-	to_grid = [
-		"    ",
-		"    ",
-		":ttt",
-		": t "
-	]
-	assert_kick()
-
-
-func test_duck_kick_up0() -> void:
-	from_grid = [
-		"     ",
-		"::   ",
-		"  t  ",
-		" ttt ",
-	]
-	to_grid = [
-		"     ",
-		"::t  ",
-		"  tt ",
-		"  t  "
-	]
-	assert_kick()
-
-
-func test_duck_kick_up1() -> void:
-	from_grid = [
-		"     ",
-		"   ::",
-		"  t  ",
-		" ttt ",
-	]
-	to_grid = [
-		"     ",
-		"  t::",
-		" tt  ",
-		"  t  "
-	]
-	assert_kick()
-
-
-func test_floorkick_cw() -> void:
+func test_floor_kick_0r() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -216,7 +17,7 @@ func test_floorkick_cw() -> void:
 	assert_kick()
 
 
-func test_floorkick_ccw() -> void:
+func test_floor_kick_0l() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -232,7 +33,23 @@ func test_floorkick_ccw() -> void:
 	assert_kick()
 
 
-func test_lwallkick0() -> void:
+func test_floor_kick_02() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"  t  ",
+		" ttt "
+	]
+	to_grid = [
+		"     ",
+		"     ",
+		" ttt ",
+		"  t  "
+	]
+	assert_kick()
+
+
+func test_wall_kick_r0() -> void:
 	from_grid = [
 		"     ",
 		"t    ",
@@ -250,7 +67,7 @@ func test_lwallkick0() -> void:
 	assert_kick()
 
 
-func test_lwallkick1() -> void:
+func test_wall_kick_r2() -> void:
 	from_grid = [
 		"     ",
 		"t    ",
@@ -268,7 +85,7 @@ func test_lwallkick1() -> void:
 	assert_kick()
 
 
-func test_rwallkick0() -> void:
+func test_wall_kick_l0() -> void:
 	from_grid = [
 		"     ",
 		"    t",
@@ -286,7 +103,7 @@ func test_rwallkick0() -> void:
 	assert_kick()
 
 
-func test_rwallkick1() -> void:
+func test_wall_kick_l2() -> void:
 	from_grid = [
 		"     ",
 		"    t",
@@ -300,6 +117,205 @@ func test_rwallkick1() -> void:
 		"  ttt",
 		"   t ",
 		"     "
+	]
+	assert_kick()
+
+
+## A rose kick is when the t piece pivots around the middle of its three extrusions.
+##
+##  T  <--- it rotates around this part. doesn't it look like a rose?
+## ttt
+func test_rose_kick_r0() -> void:
+	from_grid = [
+		"   ",
+		"t  ",
+		"tt:",
+		"t  ",
+	]
+	to_grid = [
+		"   ",
+		"   ",
+		" t:",
+		"ttt",
+	]
+	assert_kick()
+
+
+func test_rose_kick_2r() -> void:
+	from_grid = [
+		":: ",
+		"ttt",
+		" t ",
+		" : ",
+	]
+	to_grid = [
+		":: ",
+		"t  ",
+		"tt ",
+		"t: ",
+	]
+	assert_kick()
+
+
+func test_rose_kick_2l() -> void:
+	from_grid = [
+		" ::",
+		"ttt",
+		" t ",
+		" : ",
+	]
+	to_grid = [
+		" ::",
+		"  t",
+		" tt",
+		" :t",
+	]
+	assert_kick()
+
+
+func test_rose_kick_l0() -> void:
+	from_grid = [
+		"   ",
+		"  t",
+		":tt",
+		"  t",
+	]
+	to_grid = [
+		"   ",
+		"   ",
+		":t ",
+		"ttt",
+	]
+	assert_kick()
+
+
+## A duck kick is when the T-piece tries to rotate an extrusion towards its flat side, and gets shoved away.
+##
+## This does not replace the usual floor kick, but acts as a replacement if the floor kick fails.
+func test_duck_kick_0r() -> void:
+	from_grid = [
+		"     ",
+		"::   ",
+		"  t  ",
+		" ttt ",
+	]
+	to_grid = [
+		"     ",
+		"::t  ",
+		"  tt ",
+		"  t  "
+	]
+	assert_kick()
+
+
+func test_duck_kick_0l() -> void:
+	from_grid = [
+		"     ",
+		"   ::",
+		"  t  ",
+		" ttt ",
+	]
+	to_grid = [
+		"     ",
+		"  t::",
+		" tt  ",
+		"  t  "
+	]
+	assert_kick()
+
+
+func test_duck_kick_r0() -> void:
+	from_grid = [
+		"    ",
+		" t  ",
+		":tt ",
+		":t: "
+	]
+	to_grid = [
+		"    ",
+		"  t ",
+		":ttt",
+		": : "
+	]
+	assert_kick()
+
+
+func test_duck_kick_r2() -> void:
+	from_grid = [
+		"    ",
+		" t  ",
+		":tt ",
+		":t  "
+	]
+	to_grid = [
+		"    ",
+		"    ",
+		":ttt",
+		": t "
+	]
+	assert_kick()
+
+
+func test_duck_kick_2r() -> void:
+	from_grid = [
+		"::  ",
+		"ttt ",
+		":t :",
+		": ::"
+	]
+	to_grid = [
+		"::  ",
+		" t  ",
+		":tt:",
+		":t::"
+	]
+	assert_kick()
+
+
+func test_duck_kick_2l() -> void:
+	from_grid = [
+		"  ::",
+		" ttt",
+		": t:",
+		":: :"
+	]
+	to_grid = [
+		"  ::",
+		"  t ",
+		":tt:",
+		"::t:"
+	]
+	assert_kick()
+
+
+func test_duck_kick_l0() -> void:
+	from_grid = [
+		"    ",
+		"  t ",
+		" tt:",
+		" :t:"
+	]
+	to_grid = [
+		"    ",
+		" t  ",
+		"ttt:",
+		" : :"
+	]
+	assert_kick()
+
+
+func test_duck_kick_l2() -> void:
+	from_grid = [
+		"    ",
+		"  t ",
+		" tt:",
+		"  t:"
+	]
+	to_grid = [
+		"    ",
+		"    ",
+		"ttt:",
+		" t :"
 	]
 	assert_kick()
 

--- a/project/src/test/puzzle/piece/test-piece-kicks-u.gd
+++ b/project/src/test/puzzle/piece/test-piece-kicks-u.gd
@@ -1,7 +1,7 @@
 extends "res://src/test/puzzle/piece/test-piece-kicks.gd"
 ## Tests the u piece's kick behavior.
 
-func test_floorkick_2l() -> void:
+func test_floor_kick_2l() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -17,7 +17,7 @@ func test_floorkick_2l() -> void:
 	assert_kick()
 
 
-func test_floorkick_2r() -> void:
+func test_floor_kick_2r() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -33,79 +33,7 @@ func test_floorkick_2r() -> void:
 	assert_kick()
 
 
-func test_rwallkick_r0() -> void:
-	from_grid = [
-		"    ",
-		"  uu",
-		"   u",
-		"  uu",
-		"    ",
-	]
-	to_grid = [
-		"    ",
-		" uuu",
-		" u u",
-		"    ",
-		"    ",
-	]
-	assert_kick()
-
-
-func test_rwallkick_r2() -> void:
-	from_grid = [
-		"    ",
-		"  uu",
-		"   u",
-		"  uu",
-		"    ",
-	]
-	to_grid = [
-		"    ",
-		" u u",
-		" uuu",
-		"    ",
-		"    ",
-	]
-	assert_kick()
-
-
-func test_rwallkick_l0() -> void:
-	from_grid = [
-		"    ",
-		"  uu",
-		"  u ",
-		"  uu",
-		"    ",
-	]
-	to_grid = [
-		"    ",
-		" uuu",
-		" u u",
-		"    ",
-		"    ",
-	]
-	assert_kick()
-
-
-func test_rwallkick_l2() -> void:
-	from_grid = [
-		"    ",
-		"  uu",
-		"  u ",
-		"  uu",
-		"    ",
-	]
-	to_grid = [
-		"    ",
-		" u u",
-		" uuu",
-		"    ",
-		"    ",
-	]
-	assert_kick()
-
-
-func test_lwallkick_r0() -> void:
+func test_wall_kick_r0_0() -> void:
 	from_grid = [
 		"    ",
 		"uu  ",
@@ -123,7 +51,25 @@ func test_lwallkick_r0() -> void:
 	assert_kick()
 
 
-func test_lwallkick_r2() -> void:
+func test_wall_kick_r0_1() -> void:
+	from_grid = [
+		"    ",
+		"  uu",
+		"   u",
+		"  uu",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		" uuu",
+		" u u",
+		"    ",
+		"    ",
+	]
+	assert_kick()
+
+
+func test_wall_kick_r2_0() -> void:
 	from_grid = [
 		"    ",
 		"uu  ",
@@ -141,7 +87,25 @@ func test_lwallkick_r2() -> void:
 	assert_kick()
 
 
-func test_lwallkick_l0() -> void:
+func test_wall_kick_r2_1() -> void:
+	from_grid = [
+		"    ",
+		"  uu",
+		"   u",
+		"  uu",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		" u u",
+		" uuu",
+		"    ",
+		"    ",
+	]
+	assert_kick()
+
+
+func test_wall_kick_l0_0() -> void:
 	from_grid = [
 		"    ",
 		"uu  ",
@@ -159,7 +123,25 @@ func test_lwallkick_l0() -> void:
 	assert_kick()
 
 
-func test_lwallkick_l2() -> void:
+func test_wall_kick_l0_1() -> void:
+	from_grid = [
+		"    ",
+		"  uu",
+		"  u ",
+		"  uu",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		" uuu",
+		" u u",
+		"    ",
+		"    ",
+	]
+	assert_kick()
+
+
+func test_wall_kick_l2_0() -> void:
 	from_grid = [
 		"    ",
 		"uu  ",
@@ -171,6 +153,24 @@ func test_lwallkick_l2() -> void:
 		"    ",
 		"u u ",
 		"uuu ",
+		"    ",
+		"    ",
+	]
+	assert_kick()
+
+
+func test_wall_kick_l2_1() -> void:
+	from_grid = [
+		"    ",
+		"  uu",
+		"  u ",
+		"  uu",
+		"    ",
+	]
+	to_grid = [
+		"    ",
+		" u u",
+		" uuu",
 		"    ",
 		"    ",
 	]
@@ -283,40 +283,6 @@ func test_spire_kick_r0() -> void:
 
 
 ## a 'diagonalnw kick' is when the u piece is boxed in by the nw/se corners
-func test_diagonalnw_kick_2l() -> void:
-	from_grid = [
-		"::   ",
-		":u u ",
-		" uuu:",
-		"   ::",
-	]
-	to_grid = [
-		"::   ",
-		":uu  ",
-		" u  :",
-		" uu::",
-	]
-	assert_kick()
-
-
-func test_diagonalnw_kick_l0() -> void:
-	from_grid = [
-		"::  ",
-		":uu ",
-		" u  ",
-		" uu:",
-		"  ::",
-	]
-	to_grid = [
-		"::  ",
-		":uuu",
-		" u u",
-		"   :",
-		"  ::",
-	]
-	assert_kick()
-
-
 func test_diagonalnw_kick_0r() -> void:
 	from_grid = [
 		"::   ",
@@ -351,41 +317,41 @@ func test_diagonalnw_kick_r2() -> void:
 	assert_kick()
 
 
-## a 'diagonalne kick' is when the u piece is boxed in by the ne/sw corners
-func test_diagonalne_kick_2l() -> void:
+func test_diagonalnw_kick_2l() -> void:
 	from_grid = [
+		"::   ",
+		":u u ",
+		" uuu:",
 		"   ::",
-		" u u:",
-		":uuu ",
-		"::   ",
 	]
 	to_grid = [
-		" uu::",
-		" u  :",
+		"::   ",
 		":uu  ",
-		"::   ",
+		" u  :",
+		" uu::",
 	]
 	assert_kick()
 
 
-func test_diagonalne_kick_l0() -> void:
+func test_diagonalnw_kick_l0() -> void:
 	from_grid = [
-		"  ::",
-		" uu:",
-		" u  ",
-		":uu ",
 		"::  ",
+		":uu ",
+		" u  ",
+		" uu:",
+		"  ::",
 	]
 	to_grid = [
-		"  ::",
-		"uuu:",
-		"u u ",
-		":   ",
 		"::  ",
+		":uuu",
+		" u u",
+		"   :",
+		"  ::",
 	]
 	assert_kick()
 
 
+## a 'diagonalne kick' is when the u piece is boxed in by the ne/sw corners
 func test_diagonalne_kick_0r() -> void:
 	from_grid = [
 		"   ::",
@@ -420,39 +386,41 @@ func test_diagonalne_kick_r2() -> void:
 	assert_kick()
 
 
-## a 'shaft kick' is when the u piece rotates after being dropped down a narrow shaft
-func test_shaft_kick_r2_0() -> void:
+func test_diagonalne_kick_2l() -> void:
+	from_grid = [
+		"   ::",
+		" u u:",
+		":uuu ",
+		"::   ",
+	]
+	to_grid = [
+		" uu::",
+		" u  :",
+		":uu  ",
+		"::   ",
+	]
+	assert_kick()
+
+
+func test_diagonalne_kick_l0() -> void:
 	from_grid = [
 		"  ::",
-		"uu::",
+		" uu:",
 		" u  ",
-		"uu  ",
+		":uu ",
+		"::  ",
 	]
 	to_grid = [
 		"  ::",
-		"  ::",
+		"uuu:",
 		"u u ",
-		"uuu ",
+		":   ",
+		"::  ",
 	]
 	assert_kick()
 
 
-func test_shaft_kick_r2_1() -> void:
-	from_grid = [
-		"::  ",
-		"::uu",
-		"   u",
-		"  uu",
-	]
-	to_grid = [
-		"::  ",
-		"::  ",
-		" u u",
-		" uuu",
-	]
-	assert_kick()
-
-
+## a 'shaft kick' is when the u piece rotates after being dropped down a narrow shaft
 func test_shaft_kick_r0_0() -> void:
 	from_grid = [
 		"  ::",
@@ -484,11 +452,12 @@ func test_shaft_kick_r0_1() -> void:
 	]
 	assert_kick()
 
-func test_shaft_kick_l2_0() -> void:
+
+func test_shaft_kick_r2_0() -> void:
 	from_grid = [
 		"  ::",
 		"uu::",
-		"u   ",
+		" u  ",
 		"uu  ",
 	]
 	to_grid = [
@@ -500,11 +469,11 @@ func test_shaft_kick_l2_0() -> void:
 	assert_kick()
 
 
-func test_shaft_kick_l2_1() -> void:
+func test_shaft_kick_r2_1() -> void:
 	from_grid = [
 		"::  ",
 		"::uu",
-		"  u ",
+		"   u",
 		"  uu",
 	]
 	to_grid = [
@@ -544,6 +513,38 @@ func test_shaft_kick_l0_1() -> void:
 		"::  ",
 		" uuu",
 		" u u",
+	]
+	assert_kick()
+
+
+func test_shaft_kick_l2_0() -> void:
+	from_grid = [
+		"  ::",
+		"uu::",
+		"u   ",
+		"uu  ",
+	]
+	to_grid = [
+		"  ::",
+		"  ::",
+		"u u ",
+		"uuu ",
+	]
+	assert_kick()
+
+
+func test_shaft_kick_l2_1() -> void:
+	from_grid = [
+		"::  ",
+		"::uu",
+		"  u ",
+		"  uu",
+	]
+	to_grid = [
+		"::  ",
+		"::  ",
+		" u u",
+		" uuu",
 	]
 	assert_kick()
 

--- a/project/src/test/puzzle/piece/test-piece-kicks-v.gd
+++ b/project/src/test/puzzle/piece/test-piece-kicks-v.gd
@@ -1,6 +1,188 @@
 extends "res://src/test/puzzle/piece/test-piece-kicks.gd"
 ## Tests the v piece's kick behavior.
 
+## The v piece can't technically wall kick, but it can kick against other blocks similar to a wall kick
+func test_wall_kick_0r() -> void:
+	from_grid = [
+		"    :",
+		"    :",
+		"  v :",
+		"  v  ",
+		"  vvv",
+	]
+	to_grid = [
+		"    :",
+		"    :",
+		" vvv:",
+		" v   ",
+		" v   ",
+	]
+	assert_kick()
+
+
+func test_wall_kick_0l() -> void:
+	from_grid = [
+		"    :",
+		"    :",
+		"  v :",
+		"  v  ",
+		"  vvv",
+	]
+	to_grid = [
+		"    :",
+		"    :",
+		"   v:",
+		"   v ",
+		" vvv ",
+	]
+	assert_kick()
+
+
+func test_wall_kick_r2_0() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"  vvv",
+		"  v :",
+		"  v :",
+	]
+	to_grid = [
+		"     ",
+		"     ",
+		" vvv ",
+		"   v:",
+		"   v:",
+	]
+	assert_kick()
+
+
+func test_wall_kick_r2_1() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		" vvv ",
+		" v ::",
+		" v ::",
+	]
+	to_grid = [
+		"     ",
+		"     ",
+		"vvv  ",
+		"  v::",
+		"  v::",
+	]
+	assert_kick()
+
+
+func test_wall_kick_2r_0() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"vvv  ",
+		": v  ",
+		": v  ",
+	]
+	to_grid = [
+		"     ",
+		"     ",
+		" vvv ",
+		":v   ",
+		":v   ",
+	]
+	assert_kick()
+
+
+func test_wall_kick_2r_1() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		" vvv ",
+		":: v ",
+		":: v ",
+	]
+	to_grid = [
+		"     ",
+		"     ",
+		"  vvv",
+		"::v  ",
+		"::v  ",
+	]
+	assert_kick()
+
+
+func test_wall_kick_2l() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"vvv  ",
+		"  v  ",
+		": v  ",
+	]
+	to_grid = [
+		"     ",
+		"     ",
+		"   v ",
+		"   v ",
+		":vvv ",
+	]
+	assert_kick()
+
+
+func test_wall_kick_l0() -> void:
+	from_grid = [
+		":    ",
+		":    ",
+		": v  ",
+		"  v  ",
+		"vvv  ",
+	]
+	to_grid = [
+		":    ",
+		":    ",
+		":v   ",
+		" v   ",
+		" vvv ",
+	]
+	assert_kick()
+
+
+func test_wall_kick_l2() -> void:
+	from_grid = [
+		":    ",
+		":    ",
+		": v  ",
+		"  v  ",
+		"vvv  ",
+	]
+	to_grid = [
+		":    ",
+		":    ",
+		":vvv ",
+		"   v ",
+		"   v ",
+	]
+	assert_kick()
+
+
+
+func test_wall_kick_r0() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"  vvv",
+		"  v  ",
+		"  v :",
+	]
+	to_grid = [
+		"     ",
+		"     ",
+		" v   ",
+		" v   ",
+		" vvv:",
+	]
+	assert_kick()
+
+
 func test_climb_r0_0() -> void:
 	from_grid = [
 		"    ",
@@ -211,7 +393,7 @@ func test_climb_2l_1() -> void:
 
 
 ## A 'snack kick' is when a v piece rotates around an o piece to make a snack block.
-func test_snack_kick_cw() -> void:
+func test_snack_kick_r2() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -229,7 +411,7 @@ func test_snack_kick_cw() -> void:
 	assert_kick()
 
 
-func test_snack_kick_ccw() -> void:
+func test_snack_kick_2r() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -247,7 +429,7 @@ func test_snack_kick_ccw() -> void:
 	assert_kick()
 
 
-func test_snack_kick_down_ccw() -> void:
+func test_snack_kick_r0() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -267,7 +449,7 @@ func test_snack_kick_down_ccw() -> void:
 	assert_kick()
 
 
-func test_snack_kick_down_cw() -> void:
+func test_snack_kick_2l() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -282,211 +464,13 @@ func test_snack_kick_down_cw() -> void:
 		"     ",
 		":::v:",
 		":::v:",
-		" vvv ",
-	]
-	assert_kick()
-
-
-## The v piece can't technically wall kick, but it can kick against other blocks similar to a wall kick
-func test_rwallkick_cw0() -> void:
-	from_grid = [
-		"     ",
-		"     ",
-		" vvv ",
-		" v ::",
-		" v ::",
-	]
-	to_grid = [
-		"     ",
-		"     ",
-		"vvv  ",
-		"  v::",
-		"  v::",
-	]
-	assert_kick()
-
-
-func test_rwallkick_cw1() -> void:
-	from_grid = [
-		"    :",
-		"    :",
-		"  v :",
-		"  v  ",
-		"  vvv",
-	]
-	to_grid = [
-		"    :",
-		"    :",
-		" vvv:",
-		" v   ",
-		" v   ",
-	]
-	assert_kick()
-
-
-func test_rwallkick_cw2() -> void:
-	from_grid = [
-		"     ",
-		"     ",
-		"  vvv",
-		"  v :",
-		"  v :",
-	]
-	to_grid = [
-		"     ",
-		"     ",
-		" vvv ",
-		"   v:",
-		"   v:",
-	]
-	assert_kick()
-
-
-func test_lwallkick_cw3() -> void:
-	from_grid = [
-		"     ",
-		"     ",
-		"vvv  ",
-		"  v  ",
-		": v  ",
-	]
-	to_grid = [
-		"     ",
-		"     ",
-		"   v ",
-		"   v ",
-		":vvv ",
-	]
-	assert_kick()
-
-
-func test_lwallkick_cw4() -> void:
-	from_grid = [
-		":    ",
-		":    ",
-		": v  ",
-		"  v  ",
-		"vvv  ",
-	]
-	to_grid = [
-		":    ",
-		":    ",
-		":v   ",
-		" v   ",
-		" vvv ",
-	]
-	assert_kick()
-
-
-func test_lwallkick_ccw0() -> void:
-	from_grid = [
-		"     ",
-		"     ",
-		" vvv ",
-		":: v ",
-		":: v ",
-	]
-	to_grid = [
-		"     ",
-		"     ",
-		"  vvv",
-		"::v  ",
-		"::v  ",
-	]
-	assert_kick()
-
-
-func test_lwallkick_ccw1() -> void:
-	from_grid = [
-		":    ",
-		":    ",
-		": v  ",
-		"  v  ",
-		"vvv  ",
-	]
-	to_grid = [
-		":    ",
-		":    ",
-		":vvv ",
-		"   v ",
-		"   v ",
-	]
-	assert_kick()
-
-
-func test_lwallkick_ccw2() -> void:
-	from_grid = [
-		"     ",
-		"     ",
-		"vvv  ",
-		": v  ",
-		": v  ",
-	]
-	to_grid = [
-		"     ",
-		"     ",
-		" vvv ",
-		":v   ",
-		":v   ",
-	]
-	assert_kick()
-
-
-
-func test_rwallkick_ccw3() -> void:
-	from_grid = [
-		"     ",
-		"     ",
-		"  vvv",
-		"  v  ",
-		"  v :",
-	]
-	to_grid = [
-		"     ",
-		"     ",
-		" v   ",
-		" v   ",
-		" vvv:",
-	]
-	assert_kick()
-
-
-func test_rwallkick_ccw4() -> void:
-	from_grid = [
-		"    :",
-		"    :",
-		"  v :",
-		"  v  ",
-		"  vvv",
-	]
-	to_grid = [
-		"    :",
-		"    :",
-		"   v:",
-		"   v ",
 		" vvv ",
 	]
 	assert_kick()
 
 
 ## A ritzy kick is when the hinge of the v piece pivots one square diagonally.
-func test_ritzy_kick_cw0() -> void:
-	from_grid = [
-		"    ",
-		"  v ",
-		": v ",
-		"vvv:",
-	]
-	to_grid = [
-		" v  ",
-		" v  ",
-		":vvv",
-		"   :",
-	]
-	assert_kick()
-
-
-func test_ritzy_kick_cw1() -> void:
+func test_ritzy_kick_0r() -> void:
 	from_grid = [
 		"v ::",
 		"v   ",
@@ -502,7 +486,7 @@ func test_ritzy_kick_cw1() -> void:
 	assert_kick()
 
 
-func test_ritzy_kick_cw2() -> void:
+func test_ritzy_kick_r2() -> void:
 	from_grid = [
 		":vvv",
 		" v :",
@@ -518,7 +502,7 @@ func test_ritzy_kick_cw2() -> void:
 	assert_kick()
 
 
-func test_ritzy_kick_cw3() -> void:
+func test_ritzy_kick_2l() -> void:
 	from_grid = [
 		"   :",
 		" vvv",
@@ -534,7 +518,23 @@ func test_ritzy_kick_cw3() -> void:
 	assert_kick()
 
 
-func test_ritzy_kick_ccw0() -> void:
+func test_ritzy_kick_l0() -> void:
+	from_grid = [
+		"    ",
+		"  v ",
+		": v ",
+		"vvv:",
+	]
+	to_grid = [
+		" v  ",
+		" v  ",
+		":vvv",
+		"   :",
+	]
+	assert_kick()
+
+
+func test_ritzy_kick_0l() -> void:
 	from_grid = [
 		"    ",
 		" v  ",
@@ -550,39 +550,7 @@ func test_ritzy_kick_ccw0() -> void:
 	assert_kick()
 
 
-func test_ritzy_kick_ccw1() -> void:
-	from_grid = [
-		":: v",
-		"   v",
-		" vvv",
-		"   :",
-	]
-	to_grid = [
-		"::  ",
-		"vvv ",
-		"  v ",
-		"  v:",
-	]
-	assert_kick()
-
-
-func test_ritzy_kick_ccw2() -> void:
-	from_grid = [
-		"vvv:",
-		": v ",
-		"  v ",
-		"    ",
-	]
-	to_grid = [
-		"   :",
-		":vvv",
-		" v  ",
-		" v  ",
-	]
-	assert_kick()
-
-
-func test_ritzy_kick_ccw3() -> void:
+func test_ritzy_kick_r0() -> void:
 	from_grid = [
 		":   ",
 		"vvv ",
@@ -598,9 +566,91 @@ func test_ritzy_kick_ccw3() -> void:
 	assert_kick()
 
 
+func test_ritzy_kick_2r() -> void:
+	from_grid = [
+		"vvv:",
+		": v ",
+		"  v ",
+		"    ",
+	]
+	to_grid = [
+		"   :",
+		":vvv",
+		" v  ",
+		" v  ",
+	]
+	assert_kick()
+
+
+func test_ritzy_kick_l2() -> void:
+	from_grid = [
+		":: v",
+		"   v",
+		" vvv",
+		"   :",
+	]
+	to_grid = [
+		"::  ",
+		"vvv ",
+		"  v ",
+		"  v:",
+	]
+	assert_kick()
+
+
 ## A plant kick is when the v piece pivots around its hinge like a t block. This is disorienting and should be a last
 ## resort.
-func test_plant_kick_cw0() -> void:
+func test_plant_kick_0r() -> void:
+	from_grid = [
+		"  v::",
+		"::v::",
+		"  vvv",
+		"   ::",
+		"   ::",
+	]
+	to_grid = [
+		"   ::",
+		":: ::",
+		"  vvv",
+		"  v::",
+		"  v::",
+	]
+	assert_kick()
+
+
+func test_plant_kick_0l() -> void:
+	from_grid = [
+		"::v::",
+		"::v::",
+		"  vvv",
+	]
+	to_grid = [
+		"::v::",
+		"::v::",
+		"vvv  ",
+	]
+	assert_kick()
+
+
+func test_plant_kick_r0() -> void:
+	from_grid = [
+		"     ",
+		"     ",
+		"  vvv",
+		"::v::",
+		"::v::",
+	]
+	to_grid = [
+		"  v  ",
+		"  v  ",
+		"  vvv",
+		":: ::",
+		":: ::",
+	]
+	assert_kick()
+
+
+func test_plant_kick_r2() -> void:
 	from_grid = [
 		"::   ",
 		"     ",
@@ -618,7 +668,25 @@ func test_plant_kick_cw0() -> void:
 	assert_kick()
 
 
-func test_plant_kick_cw1() -> void:
+func test_plant_kick_2r() -> void:
+	from_grid = [
+		"   ::",
+		"     ",
+		"vvv  ",
+		"::v::",
+		"::v::",
+	]
+	to_grid = [
+		"   ::",
+		"     ",
+		"  vvv",
+		"::v::",
+		"::v::",
+	]
+	assert_kick()
+
+
+func test_plant_kick_2l() -> void:
 	from_grid = [
 		"     ",
 		"     ",
@@ -636,7 +704,7 @@ func test_plant_kick_cw1() -> void:
 	assert_kick()
 
 
-func test_plant_kick_cw2() -> void:
+func test_plant_kick_l0() -> void:
 	from_grid = [
 		"::v::",
 		"::v::",
@@ -650,75 +718,7 @@ func test_plant_kick_cw2() -> void:
 	assert_kick()
 
 
-func test_plant_kick_cw3() -> void:
-	from_grid = [
-		"  v::",
-		"::v::",
-		"  vvv",
-		"   ::",
-		"   ::",
-	]
-	to_grid = [
-		"   ::",
-		":: ::",
-		"  vvv",
-		"  v::",
-		"  v::",
-	]
-	assert_kick()
-
-
-func test_plant_kick_ccw0() -> void:
-	from_grid = [
-		"   ::",
-		"     ",
-		"vvv  ",
-		"::v::",
-		"::v::",
-	]
-	to_grid = [
-		"   ::",
-		"     ",
-		"  vvv",
-		"::v::",
-		"::v::",
-	]
-	assert_kick()
-
-
-func test_plant_kick_ccw1() -> void:
-	from_grid = [
-		"     ",
-		"     ",
-		"  vvv",
-		"::v::",
-		"::v::",
-	]
-	to_grid = [
-		"  v  ",
-		"  v  ",
-		"  vvv",
-		":: ::",
-		":: ::",
-	]
-	assert_kick()
-
-
-func test_plant_kick_ccw2() -> void:
-	from_grid = [
-		"::v::",
-		"::v::",
-		"  vvv",
-	]
-	to_grid = [
-		"::v::",
-		"::v::",
-		"vvv  ",
-	]
-	assert_kick()
-
-
-func test_plant_kick_ccw3() -> void:
+func test_plant_kick_l2() -> void:
 	from_grid = [
 		"::v  ",
 		"::v::",
@@ -734,4 +734,3 @@ func test_plant_kick_ccw3() -> void:
 		"::v::",
 	]
 	assert_kick()
-


### PR DESCRIPTION
Piece kick tests consistently use '0r' 'r2' notation instead of ambiguous 'cw'
'ccw' notation. Tests consistently have floor kicks/wall kicks before other
tests.

Renamed test-piece-kicks-qp to test-piece-kicks-pq to preserve
alphabetical order convention followed by other similar tests.

Fixed grammar of 'j/l piece's kick behavior' which I don't think should
use the singular possessive.