### PR TITLE
UI refactoring: 'Control', compact

### DIFF
--- a/project/src/main/ui/overworld-ui.gd
+++ b/project/src/main/ui/overworld-ui.gd
@@ -76,7 +76,7 @@ func start_chat(new_chat_tree: ChatTree, target: Node2D) -> void:
 	emit_signal("chat_started")
 	
 	# reset state variables
-	$Control/ChatUi.play_chat_tree(_current_chat_tree)
+	$ChatUi.play_chat_tree(_current_chat_tree)
 
 
 func set_show_version(new_show_version: bool) -> void:
@@ -204,8 +204,8 @@ func _assign_nametag_sides(new_chat_tree: ChatTree) -> void:
 
 ## Updates the different UI components to be visible/invisible based on the UI's current state.
 func _update_visible() -> void:
-	$Control/ChatUi.visible = true if chatters else false
-	$Control/Labels/SoutheastLabels/VersionLabel.visible = _show_version and not chatters
+	$ChatUi.visible = true if chatters else false
+	$Labels/SoutheastLabels/VersionLabel.visible = _show_version and not chatters
 
 
 ## Returns the chat tree corresponding to the curently focused chattable.
@@ -348,11 +348,11 @@ func _on_SettingsMenu_quit_pressed() -> void:
 
 
 func _on_CellPhoneButton_pressed() -> void:
-	$Control/CellPhoneMenu.show()
+	$CellPhoneMenu.show()
 
 
 func _on_SettingsButton_pressed() -> void:
-	$Control/SettingsMenu.show()
+	$SettingsMenu.show()
 
 
 ## When the player hits the 'talk' button we either launch a level or start a chat.

--- a/project/src/main/world/CareerMap.tscn
+++ b/project/src/main/world/CareerMap.tscn
@@ -115,6 +115,7 @@ __meta__ = {
 }
 
 [node name="Money" parent="Ui/Control/StatusBar" instance=ExtResource( 42 )]
+compact = true
 
 [node name="Distance" type="Control" parent="Ui/Control/StatusBar"]
 anchor_left = 0.5

--- a/project/src/main/world/CutsceneUi.tscn
+++ b/project/src/main/world/CutsceneUi.tscn
@@ -12,20 +12,11 @@
 [node name="CutsceneUi" type="CanvasLayer" groups=["overworld_ui"]]
 script = ExtResource( 1 )
 
-[node name="Control" type="Control" parent="."]
-anchor_right = 1.0
-anchor_bottom = 1.0
-__meta__ = {
-"_edit_group_": true,
-"_edit_lock_": true,
-"_edit_use_anchors_": false
-}
-
-[node name="Labels" type="Control" parent="Control"]
+[node name="Labels" type="Control" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
 
-[node name="SoutheastLabels" type="VBoxContainer" parent="Control/Labels"]
+[node name="SoutheastLabels" type="VBoxContainer" parent="Labels"]
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
@@ -38,7 +29,7 @@ mouse_filter = 2
 theme = ExtResource( 5 )
 alignment = 2
 
-[node name="FpsLabel" parent="Control/Labels/SoutheastLabels" instance=ExtResource( 18 )]
+[node name="FpsLabel" parent="Labels/SoutheastLabels" instance=ExtResource( 18 )]
 visible = false
 anchor_left = 0.0
 anchor_top = 0.0
@@ -49,7 +40,7 @@ margin_top = 236.0
 margin_right = 492.0
 margin_bottom = 256.0
 
-[node name="VersionLabel" parent="Control/Labels/SoutheastLabels" instance=ExtResource( 19 )]
+[node name="VersionLabel" parent="Labels/SoutheastLabels" instance=ExtResource( 19 )]
 anchor_left = 0.0
 anchor_top = 0.0
 anchor_right = 0.0
@@ -59,19 +50,18 @@ margin_top = 260.0
 margin_right = 492.0
 margin_bottom = 280.0
 
-[node name="ChatUi" parent="Control" instance=ExtResource( 15 )]
+[node name="ChatUi" parent="." instance=ExtResource( 15 )]
 visible = false
-margin_bottom = 1.99976
 
-[node name="CheatCodeDetector" parent="Control" instance=ExtResource( 20 )]
+[node name="CheatCodeDetector" parent="." instance=ExtResource( 20 )]
 codes = [ "bigfps" ]
 
-[node name="MusicPopup" parent="Control" instance=ExtResource( 13 )]
+[node name="MusicPopup" parent="." instance=ExtResource( 13 )]
 
-[node name="SceneTransitionCover" parent="Control" instance=ExtResource( 14 )]
+[node name="SceneTransitionCover" parent="." instance=ExtResource( 14 )]
 
-[connection signal="chat_choice_chosen" from="Control/ChatUi" to="." method="_on_ChatUi_chat_choice_chosen"]
-[connection signal="chat_event_played" from="Control/ChatUi" to="." method="_on_ChatUi_chat_event_played"]
-[connection signal="chat_finished" from="Control/ChatUi" to="." method="_on_ChatUi_chat_finished"]
-[connection signal="showed_choices" from="Control/ChatUi" to="." method="_on_ChatUi_showed_choices"]
-[connection signal="cheat_detected" from="Control/CheatCodeDetector" to="Control/Labels/SoutheastLabels/FpsLabel" method="_on_CheatCodeDetector_cheat_detected"]
+[connection signal="chat_choice_chosen" from="ChatUi" to="." method="_on_ChatUi_chat_choice_chosen"]
+[connection signal="chat_event_played" from="ChatUi" to="." method="_on_ChatUi_chat_event_played"]
+[connection signal="chat_finished" from="ChatUi" to="." method="_on_ChatUi_chat_finished"]
+[connection signal="showed_choices" from="ChatUi" to="." method="_on_ChatUi_showed_choices"]
+[connection signal="cheat_detected" from="CheatCodeDetector" to="Labels/SoutheastLabels/FpsLabel" method="_on_CheatCodeDetector_cheat_detected"]

--- a/project/src/main/world/FreeRoamUi.tscn
+++ b/project/src/main/world/FreeRoamUi.tscn
@@ -78,23 +78,11 @@ shortcut = SubResource( 13 )
 [node name="OverworldUi" type="CanvasLayer" groups=["overworld_ui"]]
 script = ExtResource( 1 )
 
-[node name="Control" type="Control" parent="."]
+[node name="Labels" type="Control" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-__meta__ = {
-"_edit_group_": true,
-"_edit_lock_": true,
-"_edit_use_anchors_": false
-}
 
-[node name="Labels" type="Control" parent="Control"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="SoutheastLabels" type="VBoxContainer" parent="Control/Labels"]
+[node name="SoutheastLabels" type="VBoxContainer" parent="Labels"]
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
@@ -110,7 +98,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="FpsLabel" parent="Control/Labels/SoutheastLabels" instance=ExtResource( 19 )]
+[node name="FpsLabel" parent="Labels/SoutheastLabels" instance=ExtResource( 19 )]
 visible = false
 anchor_left = 0.0
 anchor_top = 0.0
@@ -121,7 +109,7 @@ margin_top = 236.0
 margin_right = 492.0
 margin_bottom = 256.0
 
-[node name="VersionLabel" parent="Control/Labels/SoutheastLabels" instance=ExtResource( 14 )]
+[node name="VersionLabel" parent="Labels/SoutheastLabels" instance=ExtResource( 14 )]
 anchor_left = 0.0
 anchor_top = 0.0
 anchor_right = 0.0
@@ -131,7 +119,7 @@ margin_top = 260.0
 margin_right = 492.0
 margin_bottom = 280.0
 
-[node name="NorthwestLabels" type="VBoxContainer" parent="Control/Labels"]
+[node name="NorthwestLabels" type="VBoxContainer" parent="Labels"]
 margin_left = 10.0
 margin_top = 10.0
 margin_right = 512.0
@@ -142,27 +130,23 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="MoneyLabel" parent="Control/Labels/NorthwestLabels" instance=ExtResource( 15 )]
+[node name="MoneyLabel" parent="Labels/NorthwestLabels" instance=ExtResource( 15 )]
 margin_right = 502.0
 compact = true
 
-[node name="ChatUi" parent="Control" instance=ExtResource( 16 )]
+[node name="ChatUi" parent="." instance=ExtResource( 16 )]
 visible = false
-margin_bottom = 1.99976
 
-[node name="TouchButtons" parent="Control" instance=ExtResource( 11 )]
+[node name="TouchButtons" parent="." instance=ExtResource( 11 )]
 
-[node name="Buttons" type="Control" parent="Control"]
+[node name="Buttons" type="Control" parent="."]
 modulate = Color( 1, 1, 1, 0.627451 )
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Northeast" type="HBoxContainer" parent="Control/Buttons"]
+[node name="Northeast" type="HBoxContainer" parent="Buttons"]
 anchor_left = 1.0
 anchor_right = 1.0
 margin_left = -512.0
@@ -177,7 +161,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="PhoneButton" parent="Control/Buttons/Northeast" instance=ExtResource( 3 )]
+[node name="PhoneButton" parent="Buttons/Northeast" instance=ExtResource( 3 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_left = 292.0
@@ -196,7 +180,7 @@ expand_icon = true
 normal_icon = ExtResource( 23 )
 pressed_icon = ExtResource( 21 )
 
-[node name="SettingsButton" parent="Control/Buttons/Northeast" instance=ExtResource( 3 )]
+[node name="SettingsButton" parent="Buttons/Northeast" instance=ExtResource( 3 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_left = 402.0
@@ -214,7 +198,7 @@ expand_icon = true
 normal_icon = ExtResource( 7 )
 pressed_icon = ExtResource( 8 )
 
-[node name="Southeast" type="HBoxContainer" parent="Control/Buttons"]
+[node name="Southeast" type="HBoxContainer" parent="Buttons"]
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
@@ -231,7 +215,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="TalkButton" parent="Control/Buttons/Southeast" instance=ExtResource( 3 )]
+[node name="TalkButton" parent="Buttons/Southeast" instance=ExtResource( 3 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_left = 402.0
@@ -249,16 +233,16 @@ expand_icon = true
 normal_icon = ExtResource( 6 )
 pressed_icon = ExtResource( 9 )
 
-[node name="CheatCodeDetector" parent="Control" instance=ExtResource( 20 )]
+[node name="CheatCodeDetector" parent="." instance=ExtResource( 20 )]
 codes = [ "bigfps" ]
 
-[node name="SettingsMenu" parent="Control" instance=ExtResource( 12 )]
+[node name="SettingsMenu" parent="." instance=ExtResource( 12 )]
 quit_type = 1
 
-[node name="CellPhoneMenu" type="CanvasLayer" parent="Control"]
+[node name="CellPhoneMenu" type="CanvasLayer" parent="."]
 script = ExtResource( 10 )
 
-[node name="Bg" type="ColorRect" parent="Control/CellPhoneMenu"]
+[node name="Bg" type="ColorRect" parent="CellPhoneMenu"]
 visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -267,11 +251,11 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="LevelSelect" parent="Control/CellPhoneMenu" instance=ExtResource( 18 )]
+[node name="LevelSelect" parent="CellPhoneMenu" instance=ExtResource( 18 )]
 visible = false
 custom_styles/panel = SubResource( 12 )
 
-[node name="Buttons" type="Control" parent="Control/CellPhoneMenu"]
+[node name="Buttons" type="Control" parent="CellPhoneMenu"]
 visible = false
 modulate = Color( 1, 1, 1, 0.627451 )
 anchor_right = 1.0
@@ -281,7 +265,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Northeast" type="HBoxContainer" parent="Control/CellPhoneMenu/Buttons"]
+[node name="Northeast" type="HBoxContainer" parent="CellPhoneMenu/Buttons"]
 anchor_left = 1.0
 anchor_right = 1.0
 margin_left = -512.0
@@ -296,7 +280,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="BackButton" parent="Control/CellPhoneMenu/Buttons/Northeast" instance=ExtResource( 3 )]
+[node name="BackButton" parent="CellPhoneMenu/Buttons/Northeast" instance=ExtResource( 3 )]
 margin_left = 292.0
 margin_right = 392.0
 margin_bottom = 100.0
@@ -312,10 +296,10 @@ expand_icon = true
 normal_icon = ExtResource( 24 )
 pressed_icon = ExtResource( 22 )
 
-[node name="ShortcutHelper" parent="Control/CellPhoneMenu/Buttons/Northeast/BackButton" instance=ExtResource( 4 )]
+[node name="ShortcutHelper" parent="CellPhoneMenu/Buttons/Northeast/BackButton" instance=ExtResource( 4 )]
 action = "phone"
 
-[node name="Spacer" parent="Control/CellPhoneMenu/Buttons/Northeast" instance=ExtResource( 3 )]
+[node name="Spacer" parent="CellPhoneMenu/Buttons/Northeast" instance=ExtResource( 3 )]
 margin_left = 402.0
 margin_right = 502.0
 margin_bottom = 100.0
@@ -327,29 +311,29 @@ custom_styles/disabled = SubResource( 4 )
 custom_styles/normal = SubResource( 5 )
 disabled = true
 
-[node name="MusicPopup" parent="Control" instance=ExtResource( 17 )]
+[node name="MusicPopup" parent="." instance=ExtResource( 17 )]
 
-[node name="SceneTransitionCover" parent="Control" instance=ExtResource( 13 )]
+[node name="SceneTransitionCover" parent="." instance=ExtResource( 13 )]
 
-[connection signal="pressed" from="Control/Buttons/Northeast/PhoneButton" to="." method="_on_CellPhoneButton_pressed"]
-[connection signal="pressed" from="Control/Buttons/Northeast/SettingsButton" to="." method="_on_SettingsButton_pressed"]
-[connection signal="pressed" from="Control/Buttons/Southeast/TalkButton" to="." method="_on_TalkButton_pressed"]
-[connection signal="hide" from="Control/CellPhoneMenu" to="." method="_on_CellPhoneMenu_hide"]
-[connection signal="hide" from="Control/CellPhoneMenu" to="Control/Buttons" method="_on_Menu_hide"]
-[connection signal="hide" from="Control/CellPhoneMenu" to="Control/TouchButtons" method="_on_Menu_hide"]
-[connection signal="show" from="Control/CellPhoneMenu" to="." method="_on_CellPhoneMenu_show"]
-[connection signal="show" from="Control/CellPhoneMenu" to="Control/Buttons" method="_on_Menu_show"]
-[connection signal="show" from="Control/CellPhoneMenu" to="Control/TouchButtons" method="_on_Menu_show"]
-[connection signal="pressed" from="Control/CellPhoneMenu/Buttons/Northeast/BackButton" to="Control/CellPhoneMenu" method="_on_BackButton_pressed"]
-[connection signal="chat_choice_chosen" from="Control/ChatUi" to="." method="_on_ChatUi_chat_choice_chosen"]
-[connection signal="chat_event_played" from="Control/ChatUi" to="." method="_on_ChatUi_chat_event_played"]
-[connection signal="chat_finished" from="Control/ChatUi" to="." method="_on_ChatUi_chat_finished"]
-[connection signal="showed_choices" from="Control/ChatUi" to="." method="_on_ChatUi_showed_choices"]
-[connection signal="cheat_detected" from="Control/CheatCodeDetector" to="Control/Labels/SoutheastLabels/FpsLabel" method="_on_CheatCodeDetector_cheat_detected"]
-[connection signal="hide" from="Control/SettingsMenu" to="." method="_on_SettingsMenu_hide"]
-[connection signal="hide" from="Control/SettingsMenu" to="Control/Buttons" method="_on_Menu_hide"]
-[connection signal="hide" from="Control/SettingsMenu" to="Control/TouchButtons" method="_on_Menu_hide"]
-[connection signal="quit_pressed" from="Control/SettingsMenu" to="." method="_on_SettingsMenu_quit_pressed"]
-[connection signal="show" from="Control/SettingsMenu" to="." method="_on_SettingsMenu_show"]
-[connection signal="show" from="Control/SettingsMenu" to="Control/Buttons" method="_on_Menu_show"]
-[connection signal="show" from="Control/SettingsMenu" to="Control/TouchButtons" method="_on_Menu_show"]
+[connection signal="pressed" from="Buttons/Northeast/PhoneButton" to="." method="_on_CellPhoneButton_pressed"]
+[connection signal="pressed" from="Buttons/Northeast/SettingsButton" to="." method="_on_SettingsButton_pressed"]
+[connection signal="pressed" from="Buttons/Southeast/TalkButton" to="." method="_on_TalkButton_pressed"]
+[connection signal="hide" from="CellPhoneMenu" to="." method="_on_CellPhoneMenu_hide"]
+[connection signal="hide" from="CellPhoneMenu" to="Buttons" method="_on_Menu_hide"]
+[connection signal="hide" from="CellPhoneMenu" to="TouchButtons" method="_on_Menu_hide"]
+[connection signal="show" from="CellPhoneMenu" to="." method="_on_CellPhoneMenu_show"]
+[connection signal="show" from="CellPhoneMenu" to="Buttons" method="_on_Menu_show"]
+[connection signal="show" from="CellPhoneMenu" to="TouchButtons" method="_on_Menu_show"]
+[connection signal="pressed" from="CellPhoneMenu/Buttons/Northeast/BackButton" to="CellPhoneMenu" method="_on_BackButton_pressed"]
+[connection signal="chat_choice_chosen" from="ChatUi" to="." method="_on_ChatUi_chat_choice_chosen"]
+[connection signal="chat_event_played" from="ChatUi" to="." method="_on_ChatUi_chat_event_played"]
+[connection signal="chat_finished" from="ChatUi" to="." method="_on_ChatUi_chat_finished"]
+[connection signal="showed_choices" from="ChatUi" to="." method="_on_ChatUi_showed_choices"]
+[connection signal="cheat_detected" from="CheatCodeDetector" to="Labels/SoutheastLabels/FpsLabel" method="_on_CheatCodeDetector_cheat_detected"]
+[connection signal="hide" from="SettingsMenu" to="." method="_on_SettingsMenu_hide"]
+[connection signal="hide" from="SettingsMenu" to="Buttons" method="_on_Menu_hide"]
+[connection signal="hide" from="SettingsMenu" to="TouchButtons" method="_on_Menu_hide"]
+[connection signal="quit_pressed" from="SettingsMenu" to="." method="_on_SettingsMenu_quit_pressed"]
+[connection signal="show" from="SettingsMenu" to="." method="_on_SettingsMenu_show"]
+[connection signal="show" from="SettingsMenu" to="Buttons" method="_on_Menu_show"]
+[connection signal="show" from="SettingsMenu" to="TouchButtons" method="_on_Menu_show"]


### PR DESCRIPTION
Removed redundant 'control' node from CutsceneUi, FreeRoamUi.

Enabled 'compact' setting for CareerMap money label. This setting was
already enabled for cutscenes and the free roam ui.