### PR TITLE
epilogue logic tweaks, advance_region flag

### DIFF
--- a/project/assets/main/chat/career/lemon/boss-level-end-2.chat
+++ b/project/assets/main/chat/career/lemon/boss-level-end-2.chat
@@ -1,4 +1,4 @@
-{"version": "2476"}
+{"version": "2476", "advance_region": true}
 
 [location]
 lemon/walk

--- a/project/assets/main/chat/career/marsh/epilogue.chat
+++ b/project/assets/main/chat/career/marsh/epilogue.chat
@@ -1,10 +1,7 @@
-{"version": "2476", "fixed_zoom": 1.0}
+{"version": "2476", "fixed_zoom": 1.0, "advance_region": true}
 
 [location]
 marsh/walk
-
-[destination]
-marsh
 
 [characters]
 player, p1

--- a/project/assets/main/chat/career/marsh/prologue.chat
+++ b/project/assets/main/chat/career/marsh/prologue.chat
@@ -3,9 +3,6 @@
 [location]
 marsh/walk
 
-[destination]
-marsh
-
 [characters]
 player, p1
 sensei, s1

--- a/project/src/main/career-data.gd
+++ b/project/src/main/career-data.gd
@@ -331,11 +331,19 @@ func set_hours_passed(new_hours_passed: int) -> void:
 	emit_signal("hours_passed_changed")
 
 
-## When an epilogue cutscene is played, we advance the player to the next region
+## When a cutscene shows the player advancing to the next region, we automatically advance them through career mode
+##
+## This is an important gameplay consideration if the player is stuck in a difficult area -- finishing every cutscene
+## lets them see the rest of the game. It's more of a quirk otherwise, and might even frustrate the player if they
+## still want to play a specific region. But it would be confusing and weird if they watched a cutscene saying 'Well,
+## that's enough of that area! Goodbye!' and then they remained there to play more levels.
 func _on_CurrentCutscene_cutscene_played(chat_key: String) -> void:
 	var region: CareerRegion = current_region()
-	if chat_key == region.get_epilogue_chat_key():
-		# advance the player to the next region
+	
+	var chat_tree: ChatTree = ChatLibrary.chat_tree_for_key(chat_key)
+	if chat_tree.meta.get("advance_region", false):
+		# The cutscene shows the player advancing to the next region. Forcibly advance the player to the next region.
+		remain_in_region = false
 		var old_distance_travelled := distance_travelled
 		distance_travelled = max(distance_travelled, region.end + 1)
 		max_distance_travelled = max(max_distance_travelled, distance_travelled)

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -212,9 +212,6 @@ func _should_play_epilogue() -> bool:
 	var world_lock: WorldLock = LevelLibrary.world_lock_for_level(CurrentLevel.level_id)
 	if not world_lock:
 		result = false
-	elif not LevelLibrary.is_world_finished(world_lock.world_id):
-		# player hasn't beaten the world yet; don't play the epilogue
-		result = false
 	elif not world_lock.epilogue_chat_key:
 		# the world has no epilogue assigned; don't play the epilogue
 		result = false


### PR DESCRIPTION
Replaced epilogue check with 'advance_region' flag. Some cutscenes other
than the epilogue (such as the Lemony Thickets boss region flag) should
also force the player to advance.

Fixed bug which which prevented the 'Epilogue Skips The Chapter' logic
from triggering after a puzzle. Puzzles were checking whether a player
had cleared the region, but finishing every cutscene in a region is
supposed to act as an alternative to clearing the region for players who
aren't skilled enough to advance far enough normally.

Removed unnecessary 'destination' flag from career cutscenes. This flag
is only used in free roam mode.