### PR TITLE
'Everything we know' dialog tweak

### DIFF
--- a/project/assets/main/chat/career/lemon/20-b-end.chat
+++ b/project/assets/main/chat/career/lemon/20-b-end.chat
@@ -8,11 +8,11 @@ player, p1, grave_3
 mcgoat, m, grave_9
 toat, t, grave_8
 
-p1: Okay, so tell me everything! Who's been feeding you?
+p1: Okay, so tell me everything you know! Who's been feeding you?
 m: /._. (Chitter, chitter...)
  (toat faces left)
 t: /._. (Chitter, chitter...)
-t: They bring us food every day. That's everything we know.
+t: They bring us food every day. ...And that's everything we know.
  (toat faces right)
 p1: @_@ What!? You see them every day, how could you not know ANYTHING!?
 t: .__.; Well! ...They've never attacked us, and we can't eat them. So, details about their name or appearance fall out of our tiny squirrel brains.


### PR DESCRIPTION
Before, the question and punchline both just used the word 'everything'
incidentally. They now use the same short phrase to make the repetition
more deliberate and humorous.