### PR TITLE
Blue level selection color tweak.

### DIFF
--- a/project/src/main/ui/chat/ChatChoiceButton.tscn
+++ b/project/src/main/ui/chat/ChatChoiceButton.tscn
@@ -234,7 +234,6 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = ExtResource( 1 )
 script = ExtResource( 4 )
-choice_text = "Are you kidding me? That's not even close to what I said!"
 
 [node name="FontFitLabel" type="Label" parent="."]
 anchor_right = 1.0
@@ -252,9 +251,6 @@ valign = 1
 autowrap = true
 max_lines_visible = 1
 script = ExtResource( 11 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 fonts = [ ExtResource( 5 ), ExtResource( 9 ), ExtResource( 8 ), ExtResource( 3 ), ExtResource( 10 ) ]
 
 [node name="MoodSprite" type="Control" parent="."]

--- a/project/src/main/ui/level-select/LevelSelectButtonFocus.tres
+++ b/project/src/main/ui/level-select/LevelSelectButtonFocus.tres
@@ -1,12 +1,12 @@
 [gd_resource type="StyleBoxFlat" format=2]
 
 [resource]
-bg_color = Color( 0, 0.8, 1, 0.25098 )
+bg_color = Color( 0, 0.766667, 1, 0.25098 )
 border_width_left = 4
 border_width_top = 4
 border_width_right = 4
 border_width_bottom = 4
-border_color = Color( 0.4, 0.878431, 1, 1 )
+border_color = Color( 0.501961, 0.882353, 1, 1 )
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8

--- a/project/src/main/ui/level-select/LevelSelectButtonPressed.tres
+++ b/project/src/main/ui/level-select/LevelSelectButtonPressed.tres
@@ -1,12 +1,12 @@
 [gd_resource type="StyleBoxFlat" format=2]
 
 [resource]
-bg_color = Color( 0, 0.8, 1, 0.25098 )
+bg_color = Color( 0.5, 0.883333, 1, 0.501961 )
 border_width_left = 4
 border_width_top = 4
 border_width_right = 4
 border_width_bottom = 4
-border_color = Color( 0.4, 0.88, 1, 1 )
+border_color = Color( 0.501961, 0.882353, 1, 1 )
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8


### PR DESCRIPTION
The focused/pressed blue selection colors had some variance which was
seemingly incidental and not deliberate. The pressed background color is
now brighter and more opaque, so the button lights up when you press it.

Removed default 'choice_text' from ChatChoiceButton.