### PR TITLE
Level button refactorings: interlude comments, private methods

### DIFF
--- a/project/src/main/ui/chat/career-cutscene-library.gd
+++ b/project/src/main/ui/chat/career-cutscene-library.gd
@@ -45,14 +45,15 @@ const SPECIAL_CHAT_KEY_NAMES := [
 ## Resource path containing career cutscenes. Can be changed for tests.
 var career_cutscene_root_path := DEFAULT_CAREER_CUTSCENE_ROOT_PATH setget set_career_cutscene_root_path
 
-## Ordered list of ChatKeyPairs, from earliest cutscenes to latest cutscenes
+## Ordered list of interlude ChatKeyPairs, from earliest cutscenes to latest cutscenes
 ##
 ## Each entry in this array is a ChatKeyPair defining preroll and postroll cutscenes.
 ##
 ## This is calculated based on the contents of the filesystem, but can be overridden for tests.
 var all_chat_key_pairs := [] setget set_all_chat_key_pairs
 
-## key: (String) A preroll chat key like 'chat/career/general_00_a'. For the case where a level has a postroll cutscene
+## key: (String) An interlude preroll chat key like 'chat/career/general_00_a'. For the case where a level has a
+## 	postroll cutscene
 ## 	but no preroll cutscene, this chat key may actually correspond to a non-existent preroll cutscene.
 ##
 ## value: (ChatKeyPair) A ChatKeyPair defining preroll and postroll cutscenes.
@@ -60,16 +61,17 @@ var _chat_key_pairs_by_preroll := {}
 
 ## Defines a hierarchy of preroll cutscenes.
 ##
-## key: (String) A preroll chat key like 'chat/career/general_00_a', or a parent path like 'chat/career/general'.
+## key: (String) An interlude preroll chat key like 'chat/career/general_00_a', or a parent path like
+## 	'chat/career/general'.
 ##
 ## value: (Array) A list of child chat key fragments, like ['00', '01', '02']. Each fragment corresponds to a suffix
 ## 	which can be appended to the chat key, along with an appropriate delimeter, to create a new path.
 var _preroll_tree := {}
 
-## List of String chat keys in the 'general' chat key root path featuring fat sensei
+## List of String interlude chat keys in the 'general' chat key root path featuring fat sensei
 var _general_sensei_chat_keys := []
 
-## List of String chat keys in the 'general' chat key root path featuring the restaurant
+## List of String interlude chat keys in the 'general' chat key root path featuring the restaurant
 var _general_restaurant_chat_keys := []
 
 func _ready() -> void:
@@ -84,7 +86,7 @@ func set_career_cutscene_root_path(new_career_cutscene_root_path: String) -> voi
 	_refresh_chat_key_pairs()
 
 
-## Calculates the list of potential ChatKeyPairs, and returns a random one.
+## Calculates the list of potential interlude ChatKeyPairs, and returns a random one.
 ##
 ## The optional 'chef_id' and 'customer_ids' parameters force the responses to feature those creatures as
 ## participants. This ensures levels are paired up with appropriate cutscenes.
@@ -107,7 +109,7 @@ func next_interlude_chat_key_pair(chat_key_roots: Array,
 	return Utils.rand_value(potential_chat_key_pairs) if potential_chat_key_pairs else ChatKeyPair.new()
 
 
-## Calculates the list of potential ChatKeyPairs.
+## Calculates the list of potential interlude ChatKeyPairs.
 ##
 ## The optional 'chef_id' and 'customer_ids' parameters force the responses to feature those creatures as
 ## participants. This ensures levels are paired up with appropriate cutscenes.
@@ -216,7 +218,7 @@ func _chat_key_pair_has_creatures(chat_key_pair: ChatKeyPair,
 	return matches
 
 
-## Assigns the list of ChatKeyPairs, and regenerates all internal fields such as the preroll tree.
+## Assigns the list of interlude ChatKeyPairs, and regenerates all internal fields such as the preroll tree.
 func set_all_chat_key_pairs(new_all_chat_key_pairs: Array) -> void:
 	all_chat_key_pairs = new_all_chat_key_pairs
 	
@@ -256,7 +258,7 @@ func set_all_chat_key_pairs(new_all_chat_key_pairs: Array) -> void:
 				_general_restaurant_chat_keys.append(chat_key)
 
 
-## Returns a collection of preroll chat keys for cutscenes the player has already seen.
+## Returns a collection of interlude preroll chat keys for cutscenes the player has already seen.
 ##
 ## Parameters:
 ## 	'chat_key_roots': An array of string chat key roots like 'chat/career/marsh' which correspond to a group of
@@ -298,7 +300,7 @@ func exhausted_chat_keys(chat_key_roots: Array) -> Dictionary:
 	return excluded_chat_keys
 
 
-## Returns a list of all chat keys in _preroll_tree in preroll order (leaves first.)
+## Returns a list of all interlude chat keys in _preroll_tree in preroll order (leaves first.)
 ##
 ## Parameters:
 ## 	'chat_key_roots': An array of string chat key roots like 'chat/career/marsh' which correspond to a group of
@@ -321,7 +323,7 @@ func chat_keys(chat_key_roots: Array) -> Array:
 	return chat_keys
 
 
-## Filters the list of potential ChatKeyPairs, excluding the specified chat keys.
+## Filters the list of potential interlude ChatKeyPairs, excluding the specified chat keys.
 ##
 ## The returned list includes only the earliest numeric keys in each branch, because numeric siblings are always
 ## played in ascending order. However, it includes ALL alphabetic keys in each branch, because alphabetic siblings are
@@ -334,8 +336,8 @@ func chat_keys(chat_key_roots: Array) -> Array:
 ## 	'search_flags': A set of flags defining search behavior.
 ##
 ## Returns:
-## 	A filtered list of ChatKeyPair instances which define chat keys for cutscenes which play before or after a
-## 	level.
+## 	A filtered list of ChatKeyPair instances which define chat keys for interlude cutscenes which play before or
+## 	after a level.
 func find_chat_key_pairs(chat_key_roots: Array, search_flags: CutsceneSearchFlags) -> Array:
 	var potential_chat_key_pairs := []
 	
@@ -434,7 +436,7 @@ func _is_special_chat_key(chat_key: String) -> bool:
 	return result
 
 
-## Finds all ChatKeyPairs by searching for resources under the career_cutscene_root_path.
+## Finds all interlude ChatKeyPairs by searching for resources under the career_cutscene_root_path.
 ##
 ## Also regenerates all internal fields such as the preroll tree.
 func _refresh_chat_key_pairs() -> void:

--- a/project/src/main/ui/level-select/level-buttons.gd
+++ b/project/src/main/ui/level-select/level-buttons.gd
@@ -109,6 +109,7 @@ func _add_buttons() -> void:
 			
 			# warning-ignore:integer_division
 			if i == (shown_level_ids.size() - 1) / 2:
+				# add world button in the middle of the level buttons
 				last_world_button = _world_button(world_id)
 				_add_button_to_column(last_world_button)
 	
@@ -149,7 +150,7 @@ func _world_button(world_id: String) -> WorldSelectButton:
 	for level_id in world_lock.level_ids:
 		var settings: LevelSettings = LevelLibrary.level_settings(level_id)
 		var best_result := PlayerData.level_history.best_result(settings.id)
-		var rank := 999.0
+		var rank := RankResult.WORST_RANK
 		if best_result:
 			rank = best_result.seconds_rank if best_result.compare == "-seconds" else best_result.score_rank
 		ranks.append(rank)
@@ -191,6 +192,7 @@ func _lowlight_unrelated_buttons(world_id: String) -> void:
 		else:
 			level_select_button.lowlight = true
 
+
 ## When the player clicks a level button twice, we launch the selected level
 func _on_LevelSelectButton_level_started(settings: LevelSettings) -> void:
 	CutsceneQueue.reset()
@@ -203,6 +205,7 @@ func _on_LevelSelectButton_level_started(settings: LevelSettings) -> void:
 		"cutscene_force": SystemData.misc_settings.cutscene_force,
 	})
 	CutsceneQueue.push_trail()
+
 
 ## When the player clicks a level button once, we emit a signal to show more information.
 func _on_LevelSelectButton_focus_entered(settings: LevelSettings) -> void:

--- a/project/src/main/ui/level-select/level-description-panel.gd
+++ b/project/src/main/ui/level-select/level-description-panel.gd
@@ -14,15 +14,17 @@ func set_text(new_text: String) -> void:
 	_refresh_text()
 
 
-func update_unlocked_level_text(settings: LevelSettings) -> void:
-	set_text(settings.description)
-
-
 func _refresh_text() -> void:
 	if _label:
 		_label.text = text
 
 
+## Updates the text box to show the level's description.
+func _update_unlocked_level_text(settings: LevelSettings) -> void:
+	set_text(settings.description)
+
+
+## Updates the text box to show a teaser message about all tutorials.
 func _update_tutorial_world_text(ranks: Array) -> void:
 	var new_text := ""
 	
@@ -40,6 +42,7 @@ func _update_tutorial_world_text(ranks: Array) -> void:
 	set_text(new_text)
 
 
+## Updates the text box to show a teaser message about all levels in a world.
 func _update_world_text(ranks: Array) -> void:
 	var new_text := ""
 	
@@ -61,7 +64,7 @@ func _update_world_text(ranks: Array) -> void:
 
 ## When an unlocked level is selected, we display the level's description.
 func _on_LevelButtons_unlocked_level_selected(_level_lock: LevelLock, settings: LevelSettings) -> void:
-	update_unlocked_level_text(settings)
+	_update_unlocked_level_text(settings)
 
 
 ## When a locked level is selected, we tell the player how to unlock it.

--- a/project/src/main/ui/level-select/level-info-panel.gd
+++ b/project/src/main/ui/level-select/level-info-panel.gd
@@ -29,6 +29,7 @@ func _refresh_text() -> void:
 		_label.text = text
 
 
+## Updates the text box to show the tutorial's information.
 func _update_tutorial_level_text(settings: LevelSettings) -> void:
 	var new_text := ""
 	if PlayerData.level_history.is_level_finished(settings.id):
@@ -43,7 +44,8 @@ func _update_tutorial_level_text(settings: LevelSettings) -> void:
 	set_text(new_text)
 
 
-func update_unlocked_level_text(settings: LevelSettings) -> void:
+## Updates the text box to show the level's information.
+func _update_unlocked_level_text(settings: LevelSettings) -> void:
 	var new_text := ""
 	var difficulty_string := tr("Unknown")
 	match settings.get_difficulty():
@@ -81,6 +83,7 @@ func update_unlocked_level_text(settings: LevelSettings) -> void:
 	set_text(new_text)
 
 
+## Updates the text box to show information for all tutorials.
 func _update_tutorial_world_text(ranks: Array) -> void:
 	var new_text := ""
 	
@@ -95,6 +98,7 @@ func _update_tutorial_world_text(ranks: Array) -> void:
 	set_text(new_text)
 
 
+## Updates the text box to show information for all levels in a world.
 func _update_world_text(ranks: Array) -> void:
 	var new_text := ""
 	
@@ -135,7 +139,7 @@ func _on_LevelButtons_unlocked_level_selected(_level_lock: LevelLock, settings: 
 	if settings.other.tutorial:
 		_update_tutorial_level_text(settings)
 	else:
-		update_unlocked_level_text(settings)
+		_update_unlocked_level_text(settings)
 
 
 ## When a locked level is selected, we clear out the info panel.

--- a/project/src/main/ui/level-select/level-select-button.gd
+++ b/project/src/main/ui/level-select/level-select-button.gd
@@ -5,6 +5,9 @@ extends Button
 ## emitted when a level is launched.
 signal level_started
 
+## Emitted when a button is 'lowlighted'.
+##
+## Lowlighted buttons are unrelated to the currently selected world and fade into the background.
 signal lowlight_changed
 
 ## short levels have smaller buttons; long levels have larger buttons
@@ -40,7 +43,7 @@ var level_title: String setget set_level_title
 ## 'true' if this button should be darkened so that it doesn't draw the player's attention.
 var lowlight: bool setget set_lowlight
 
-## 'true' if this button just received focus this frame. a mouse click which grants focus doesn't emit a 'level
+## 'true' if this button just received focus this frame. A mouse click which grants focus doesn't emit a 'level
 ## started' event
 var _focus_just_entered := false
 
@@ -83,6 +86,9 @@ func set_level_duration(new_level_duration: int) -> void:
 	_refresh_appearance()
 
 
+## Updates the button to be 'lowlighted'.
+##
+## Lowlighted buttons are unrelated to the currently selected world and fade into the background.
 func set_lowlight(new_lowlight: bool) -> void:
 	lowlight = new_lowlight
 	modulate = Color("50ffffff") if lowlight else Color.white

--- a/project/src/main/ui/level-select/level-select.gd
+++ b/project/src/main/ui/level-select/level-select.gd
@@ -28,7 +28,3 @@ func _refresh_levels_to_include() -> void:
 		return
 	
 	_level_buttons.levels_to_include = levels_to_include
-
-
-func _on_SettingsMenu_quit_pressed() -> void:
-	SceneTransition.pop_trail()

--- a/project/src/main/ui/level-select/world-select-button.gd
+++ b/project/src/main/ui/level-select/world-select-button.gd
@@ -2,7 +2,7 @@ class_name WorldSelectButton
 extends LevelSelectButton
 ## A button on the level select screen which displays world information.
 
-## an array of level ranks. incomplete levels are treated as rank 999
+## An array of level ranks for levels in this world. Incomplete levels are treated as rank 999.
 var ranks: Array
 
 ## Workaround for Godot #21789 to make get_class return class_name

--- a/project/src/main/utils.gd
+++ b/project/src/main/utils.gd
@@ -140,9 +140,9 @@ static func weighted_rand_value(weights_map: Dictionary):
 
 ## Returns the array index whose contents are closest to a target number.
 ##
-## Utils.find_closest([1.0, 2.0, 4.0, 8.0], 6.0) = 2
-## Utils.find_closest([1.0, 2.0, 4.0, 8.0], 100) = 3
-## Utils.find_closest([], 100)                   = -1
+## find_closest([1.0, 2.0, 4.0, 8.0], 6.0) = 2
+## find_closest([1.0, 2.0, 4.0, 8.0], 100) = 3
+## find_closest([], 100)                   = -1
 static func find_closest(values: Array, target: float) -> int:
 	if not values:
 		return -1


### PR DESCRIPTION
CareerCutsceneLibrary comments now explicitly mention 'interlude
cutscenes' in more places. Most of this script's functionality centers around
interludes, and excludes things like epilogues and intro cutscenes. Its
comments now communicate this better.

Fixed unnecessary public methods in level-description-panel.gd,
level-info-panel.gd

Added missing comments. Added comments describing what 'lowlighted level
buttons' mean, because I couldn't remember.

Removed unreachable code from level-select.gd