### PR TITLE
Player can retry levels in career mode.

### DIFF
--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -38,6 +38,9 @@ var chef_id: String
 ## Tracks when the player finishes a level.
 var best_result: int = Levels.Result.NONE setget set_best_result
 
+## How many times the player has tried the level in this session.
+var attempt_count := 0
+
 ## Tracks whether or not the player wants to play or skip this level's cutscene.
 var cutscene_force: int = Levels.CutsceneForce.NONE
 
@@ -68,6 +71,7 @@ func set_launched_level(new_level_id: String) -> void:
 		level_lock = LevelLibrary.level_lock(level_id)
 	
 	set_best_result(Levels.Result.NONE)
+	attempt_count = 0
 	cutscene_force = Levels.CutsceneForce.NONE
 	puzzle_environment_name = ""
 	

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -274,12 +274,13 @@ func _on_PuzzleState_game_ended() -> void:
 	PlayerData.emit_signal("level_history_changed")
 	PlayerData.money = int(clamp(PlayerData.money + rank_result.score, 0, PlayerData.MAX_MONEY))
 	
-	if PlayerData.career.is_career_mode():
+	if PlayerData.career.is_career_mode() and CurrentLevel.attempt_count == 0:
 		_update_career_data(rank_result)
 	
 	if not PuzzleState.level_performance.lost and _overall_rank(rank_result) < 24: $ApplauseSound.play()
 	
 	CurrentLevel.best_result = max(CurrentLevel.best_result, PuzzleState.end_result())
+	CurrentLevel.attempt_count += 1
 
 
 func _overall_rank(rank_result: RankResult) -> float:

--- a/project/src/main/puzzle/step-meter.gd
+++ b/project/src/main/puzzle/step-meter.gd
@@ -67,6 +67,10 @@ func _boss_level_percent() -> float:
 
 ## Recalculates the player's projected rank and update the UI
 func _recalculate() -> void:
+	if PlayerData.career.is_career_mode() and CurrentLevel.attempt_count >= 1:
+		# Player has already finished their only career attempt. Leave the meter at its old value.
+		return
+	
 	var boss_level_progress := _boss_level_percent()
 	if boss_level_progress < 1.0:
 		var rank_milestone := CareerData.RANK_MILESTONE_FAIL


### PR DESCRIPTION
Retrying doesn't affect how far they advance, and the meter stays still.
But it lets them retry a level if they want to get better at it, even if
it doesn't count.