### PR TITLE
Added current_version property to upgraders.

### DIFF
--- a/project/src/main/player-save-upgrader.gd
+++ b/project/src/main/player-save-upgrader.gd
@@ -23,6 +23,7 @@ const PREFIX_REPLACEMENTS_2743 := {
 ## Creates and configures a SaveItemUpgrader capable of upgrading older player save formats.
 func new_save_item_upgrader() -> SaveItemUpgrader:
 	var upgrader := SaveItemUpgrader.new()
+	upgrader.current_version = "36c3"
 	upgrader.add_upgrade_method(self, "_upgrade_27bb", "27bb", "36c3")
 	upgrader.add_upgrade_method(self, "_upgrade_2783", "2783", "27bb")
 	upgrader.add_upgrade_method(self, "_upgrade_2743", "2743", "2783")

--- a/project/src/main/puzzle/level/level-settings-upgrader.gd
+++ b/project/src/main/puzzle/level/level-settings-upgrader.gd
@@ -16,7 +16,11 @@ class UpgradeMethod:
 ## value: a UpgradeMethod corresponding to the method to call
 var _upgrade_methods := {}
 
+## The newest version which everything should upgrade to.
+var current_version: String
+
 func _init() -> void:
+	current_version = Levels.LEVEL_DATA_VERSION
 	_add_upgrade_method("_upgrade_297a", "297a", "2cb4")
 	_add_upgrade_method("_upgrade_19c5", "19c5", "297a")
 	_add_upgrade_method("_upgrade_1922", "1922", "19c5")
@@ -55,7 +59,7 @@ func upgrade(json_settings: Dictionary) -> Dictionary:
 func needs_upgrade(json_settings: Dictionary) -> bool:
 	var result: bool = false
 	var version := _get_version_string(json_settings)
-	if version == Levels.LEVEL_DATA_VERSION:
+	if version == current_version:
 		result = false
 	elif _upgrade_methods.has(version):
 		result = true

--- a/project/src/main/save-item-upgrader.gd
+++ b/project/src/main/save-item-upgrader.gd
@@ -23,6 +23,9 @@ class UpgradeMethod:
 ## value: a UpgradeMethod corresponding to the method to call
 var _upgrade_methods := {}
 
+## The newest version which everything should upgrade to.
+var current_version := ""
+
 ## Adds a new externally defined method which provides version-specific updates.
 ##
 ## SaveItemUpgrader does not have logic for upgrading specific save data versions. This upgrade logic must be defined
@@ -54,7 +57,7 @@ func add_upgrade_method(object: Object, method: String, old_version: String, new
 func needs_upgrade(json_save_items: Array) -> bool:
 	var result: bool = false
 	var version := _get_version_string(json_save_items)
-	if version == PlayerSave.PLAYER_DATA_VERSION:
+	if version == current_version:
 		result = false
 	elif _upgrade_methods.has(version):
 		result = true

--- a/project/src/main/system-save-upgrader.gd
+++ b/project/src/main/system-save-upgrader.gd
@@ -7,6 +7,7 @@ class_name SystemSaveUpgrader
 ## Creates and configures a SaveItemUpgrader capable of upgrading older system save formats.
 func new_save_item_upgrader() -> SaveItemUpgrader:
 	var upgrader := SaveItemUpgrader.new()
+	upgrader.current_version = "27bb"
 	upgrader.add_upgrade_method(self, "_upgrade_2783", "2783", "27bb")
 	upgrader.add_upgrade_method(self, "_upgrade_2743", "2743", "2783")
 	upgrader.add_upgrade_method(self, "_upgrade_2743", "252a", "2783")


### PR DESCRIPTION
Upgraders used to compare the newest version to a constant which worked
because SystemSaveUpgrader and PlayerSaveUpgrader were in sync. After
making a change where the player save data uses a different version, the
SystemSaveUpgrader started complaining that it didn't know about version
27bb, even though 27bb was the newest version of the system data.

I've changed upgraders to compare the newest version to a
current_version variable. I've also made this change in
LevelSettingsUpgrader for symmetry, even though it's unnecessary there
because its upgrader is not reused.