### PR TITLE
Extracted overall_rank(). Leveraged WORST_RANK in RankResult.

### DIFF
--- a/project/src/main/puzzle/rank-result.gd
+++ b/project/src/main/puzzle/rank-result.gd
@@ -92,26 +92,26 @@ func to_json_dict() -> Dictionary:
 func from_json_dict(json: Dictionary) -> void:
 	box_score = int(json.get("box_score", 0))
 	box_score_per_line = float(json.get("box_score_per_line", 0.0))
-	box_score_per_line_rank = float(json.get("box_score_per_line_rank", 999.0))
+	box_score_per_line_rank = float(json.get("box_score_per_line_rank", WORST_RANK))
 	combo_score = int(json.get("combo_score", 0))
 	combo_score_per_line = float(json.get("combo_score_per_line", 0.0))
-	combo_score_per_line_rank = float(json.get("combo_score_per_line_rank", 999.0))
+	combo_score_per_line_rank = float(json.get("combo_score_per_line_rank", WORST_RANK))
 	pickup_score = int(json.get("pickup_score", 0))
 	pickup_score_per_line = float(json.get("pickup_score_per_line", 0.0))
-	pickup_score_rank = float(json.get("pickup_score_rank", 999.0))
+	pickup_score_rank = float(json.get("pickup_score_rank", WORST_RANK))
 	compare = json.get("compare", "+score")
 	leftover_score = int(json.get("leftover_score", 0))
 	lines = int(json.get("lines", 0))
-	lines_rank = float(json.get("lines_rank", 999.0))
+	lines_rank = float(json.get("lines_rank", WORST_RANK))
 	pieces = int(json.get("pieces", 0))
-	pieces_rank = float(json.get("pieces_rank", 999.0))
+	pieces_rank = float(json.get("pieces_rank", WORST_RANK))
 	lost = bool(json.get("lost", true))
 	score = int(json.get("score", 0))
-	score_rank = float(json.get("score_rank", 999.0))
+	score_rank = float(json.get("score_rank", WORST_RANK))
 	seconds = float(json.get("seconds", 999999.0))
-	seconds_rank = float(json.get("seconds_rank", 999.0))
+	seconds_rank = float(json.get("seconds_rank", WORST_RANK))
 	speed = float(json.get("speed", 0.0))
-	speed_rank = float(json.get("speed_rank", 999.0))
+	speed_rank = float(json.get("speed_rank", WORST_RANK))
 	success = bool(json.get("success", false))
 	timestamp = json.get("timestamp",
 			{"year": 2020, "month": 5, "day": 9, "weekday": 4, "dst": false, "hour": 17, "minute": 43, "second": 51})
@@ -120,3 +120,11 @@ func from_json_dict(json: Dictionary) -> void:
 
 func topped_out() -> bool:
 	return top_out_count > 0
+
+
+## Returns the rank used to evaluate the player's overall level performance.
+##
+## For timed levels, this is the player's seconds_rank which evaluates how fast they were. For all other levels, this
+## is the player's score_rank which evaluates how high their score was.
+func overall_rank() -> float:
+	return seconds_rank if compare == "-seconds" else score_rank

--- a/project/src/main/ui/level-select/hookable-level-grade-label.gd
+++ b/project/src/main/ui/level-select/hookable-level-grade-label.gd
@@ -68,7 +68,7 @@ func _refresh_appearance() -> void:
 			_refresh_status_icon(button.lock_status)
 		else:
 			# cleared levels show a grade
-			_refresh_grade_text(result.seconds_rank if result.compare == "-seconds" else result.score_rank)
+			_refresh_grade_text(result.overall_rank())
 	
 	visible = false if button.lowlight else true
 

--- a/project/src/main/ui/level-select/level-buttons.gd
+++ b/project/src/main/ui/level-select/level-buttons.gd
@@ -150,9 +150,7 @@ func _world_button(world_id: String) -> WorldSelectButton:
 	for level_id in world_lock.level_ids:
 		var settings: LevelSettings = LevelLibrary.level_settings(level_id)
 		var best_result := PlayerData.level_history.best_result(settings.id)
-		var rank := RankResult.WORST_RANK
-		if best_result:
-			rank = best_result.seconds_rank if best_result.compare == "-seconds" else best_result.score_rank
+		var rank := best_result.overall_rank() if best_result else RankResult.WORST_RANK
 		ranks.append(rank)
 	world_select_button.ranks = ranks
 	return world_select_button

--- a/project/src/main/ui/menu/region-buttons.gd
+++ b/project/src/main/ui/menu/region-buttons.gd
@@ -97,9 +97,7 @@ func _region_select_button(button_index: int, region: CareerRegion) -> Node:
 	for career_level_obj in region.levels:
 		var career_level: CareerLevel = career_level_obj
 		var best_result := PlayerData.level_history.best_result(career_level.level_id)
-		var rank := RankResult.WORST_RANK
-		if best_result:
-			rank = best_result.seconds_rank if best_result.compare == "-seconds" else best_result.score_rank
+		var rank := best_result.overall_rank() if best_result else RankResult.WORST_RANK
 		ranks.append(rank)
 	region_button.ranks = ranks
 	region_button.completion_percent = PlayerData.career.region_completion(region).completion_percent()

--- a/project/src/main/ui/menu/region-info-panel.gd
+++ b/project/src/main/ui/menu/region-info-panel.gd
@@ -31,9 +31,7 @@ func _update_region_text(region: CareerRegion) -> void:
 		for level_obj in region.levels:
 			var level: CareerLevel = level_obj
 			var best_result := PlayerData.level_history.best_result(level.level_id)
-			var rank := RankResult.WORST_RANK
-			if best_result:
-				rank = best_result.seconds_rank if best_result.compare == "-seconds" else best_result.score_rank
+			var rank := best_result.overall_rank() if best_result else RankResult.WORST_RANK
 			ranks.append(rank)
 		
 		# calculate the worst rank


### PR DESCRIPTION
Extracted new RankResult.overall_rank() utility method for obtaining the
overall rank for a RankResult -- the time for timed levels and the score
for all other levels.

RankResult now leverages WORST_RANK instead of hard-coding 999.0.