### PR TITLE
Refactoring: Removed/moved code from CareerData.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -829,6 +829,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/ui/rect-fit-label.gd"
 }, {
+"base": "Reference",
+"class": "RegionCompletion",
+"language": "GDScript",
+"path": "res://src/main/region-completion.gd"
+}, {
 "base": "MarginContainer",
 "class": "RegionSelectButton",
 "language": "GDScript",
@@ -1214,6 +1219,7 @@ _global_script_class_icons={
 "RankResult": "",
 "RankRules": "",
 "RectFitLabel": "",
+"RegionCompletion": "",
 "RegionSelectButton": "",
 "RestaurantPuzzleScene": "",
 "RestaurantView": "",

--- a/project/src/main/career-flow.gd
+++ b/project/src/main/career-flow.gd
@@ -24,7 +24,7 @@ func push_career_trail() -> void:
 		CutsceneQueue.push_trail()
 		redirected = true
 	
-	if not redirected and career_data.should_play_prologue():
+	if not redirected and should_play_prologue():
 		# If they haven't seen the region's prologue cutscene, we show it.
 		var region: CareerRegion = career_data.current_region()
 		var prologue_chat_key: String = region.get_prologue_chat_key()
@@ -66,6 +66,14 @@ func process_puzzle_result() -> void:
 	if skip_remaining_cutscenes:
 		# skip career cutscenes if they skip a level, or if they fail a boss level
 		CutsceneQueue.reset()
+
+
+## Returns 'true' if the current career region has a prologue the player hasn't seen.
+func should_play_prologue() -> bool:
+	var region: CareerRegion = career_data.current_region()
+	var prologue_chat_key: String = region.get_prologue_chat_key()
+	return ChatLibrary.chat_exists(prologue_chat_key) \
+			and not PlayerData.chat_history.is_chat_finished(prologue_chat_key)
 
 
 ## Applies penalties for skipping a level to the player's save data, so they can't quit and retry.

--- a/project/src/main/region-completion.gd
+++ b/project/src/main/region-completion.gd
@@ -1,0 +1,48 @@
+## Data about which parts of a region are complete/incomplete.
+class_name RegionCompletion
+
+# how many interlude cutscenes the player's viewed in a region
+var cutscene_completion: int = 0
+
+# how many interlude cutscenes the player can potentially view in a region
+var potential_cutscene_completion: int = 0
+
+# how many levels the player has finished in a region
+var level_completion: int = 0
+
+# how many levels the player can potentially finish in a region
+var potential_level_completion: int = 0
+
+## Returns a number in the range [0.0, 1.0] for how close the player is to completing the region.
+##
+## This includes how many levels they've cleared and how many interlude cutscenes they've viewed.
+func completion_percent() -> float:
+	# We combine the raw cutscene count and level count. This means for regions with many cutscenes and few
+	# levels, a player might clear every level and only have 20% completion.
+	var completion := cutscene_completion + level_completion
+	var potential_completion := potential_cutscene_completion + potential_level_completion
+	
+	if potential_completion == 0.0:
+		# avoid divide-by-zero for regions with no levels and no cutscenes
+		return 1.0
+	else:
+		return completion / float(potential_completion)
+
+
+## Returns a number in the range [0.0, 1.0] for how close the player is to viewing all of a region's interlude
+## cutscenes.
+func cutscene_completion_percent() -> float:
+	if potential_cutscene_completion == 0.0:
+		# avoid divide-by-zero for regions with no cutscenes
+		return 1.0
+	else:
+		return cutscene_completion / float(potential_cutscene_completion)
+
+
+## Returns a number in the range [0.0, 1.0] for how close the player is to playing all of a region's levels.
+func level_completion_percent() -> float:
+	if potential_level_completion == 0.0:
+		# avoid divide-by-zero for regions with no levels
+		return 1.0
+	else:
+		return level_completion / float(potential_level_completion)

--- a/project/src/main/world/cutscene-ui.gd
+++ b/project/src/main/world/cutscene-ui.gd
@@ -91,7 +91,7 @@ func _on_ChatUi_chat_finished() -> void:
 			and Breadcrumb.trail.size() >= 2 and Breadcrumb.trail[1] == Global.SCENE_CUTSCENE_DEMO:
 		# go back to CutsceneDemo after playing the cutscene
 		SceneTransition.pop_trail()
-	elif PlayerData.career.is_career_cutscene():
+	elif PlayerData.career.is_career_mode():
 		# launch the next scene in career mode after playing the cutscene
 		PlayerData.career.push_career_trail()
 	else:


### PR DESCRIPTION
Pulled RegionCompletion out into its own script. CareerData is large
(~500 SLOC) and this is something easy to pull out.

Moved 'should_play_prologue' method into CareerFlow. CareerFlow is
responsible for redirecting the player to prologues/cutscenes so this
seems like it fits here, and it keeps CareerData smaller.

Removed redundant is_career_cutscene method.