### PR TITLE
Renamed spawns from 'SpawnForest' to 'Forest2'

### DIFF
--- a/project/src/main/world/environment/lemon/LemonEnvironment.tscn
+++ b/project/src/main/world/environment/lemon/LemonEnvironment.tscn
@@ -430,53 +430,53 @@ flip_h = true
 
 [node name="Spawns" type="Node2D" parent="."]
 
-[node name="SpawnForest2" parent="Spawns" instance=ExtResource( 25 )]
+[node name="Forest2" parent="Spawns" instance=ExtResource( 25 )]
 position = Vector2( 2436.9, 1278.65 )
 orientation = 1
 id = "forest_2"
 
-[node name="SpawnForest3" parent="Spawns" instance=ExtResource( 25 )]
+[node name="Forest3" parent="Spawns" instance=ExtResource( 25 )]
 position = Vector2( 2504.62, 1318.8 )
 orientation = 1
 id = "forest_3"
 
-[node name="SpawnForest9" parent="Spawns" instance=ExtResource( 25 )]
+[node name="Forest9" parent="Spawns" instance=ExtResource( 25 )]
 position = Vector2( 2237.33, 1335.77 )
 id = "forest_9"
 
-[node name="SpawnGrave1" parent="Spawns" instance=ExtResource( 25 )]
+[node name="Grave1" parent="Spawns" instance=ExtResource( 25 )]
 position = Vector2( 3309.38, 1887.66 )
 orientation = 1
 id = "grave_1"
 
-[node name="SpawnGrave3" parent="Spawns" instance=ExtResource( 25 )]
+[node name="Grave3" parent="Spawns" instance=ExtResource( 25 )]
 position = Vector2( 3423.31, 1977.03 )
 orientation = 1
 id = "grave_3"
 
-[node name="SpawnGrave8" parent="Spawns" instance=ExtResource( 25 )]
+[node name="Grave8" parent="Spawns" instance=ExtResource( 25 )]
 position = Vector2( 3148.85, 1991.83 )
 id = "grave_8"
 
-[node name="SpawnGrave9" parent="Spawns" instance=ExtResource( 25 )]
+[node name="Grave9" parent="Spawns" instance=ExtResource( 25 )]
 position = Vector2( 3091.91, 1955.12 )
 id = "grave_9"
 
-[node name="SpawnPlayerHouse0" parent="Spawns" instance=ExtResource( 25 )]
+[node name="PlayerHouse0" parent="Spawns" instance=ExtResource( 25 )]
 position = Vector2( 487.22, 1426.19 )
 id = "player_house_0"
 
-[node name="SpawnPlayerHouse4" parent="Spawns" instance=ExtResource( 25 )]
+[node name="PlayerHouse4" parent="Spawns" instance=ExtResource( 25 )]
 position = Vector2( 643.242, 1494.66 )
 orientation = 1
 id = "player_house_4"
 
-[node name="SpawnSenseiHouse0" parent="Spawns" instance=ExtResource( 25 )]
+[node name="SenseiHouse0" parent="Spawns" instance=ExtResource( 25 )]
 position = Vector2( 4507.93, 2444.54 )
 orientation = 1
 id = "sensei_house_0"
 
-[node name="SpawnSenseiHouse9" parent="Spawns" instance=ExtResource( 25 )]
+[node name="SenseiHouse9" parent="Spawns" instance=ExtResource( 25 )]
 position = Vector2( 4363.52, 2453.03 )
 id = "sensei_house_9"
 

--- a/project/src/main/world/environment/lemon/LemonRestaurantEnvironment.tscn
+++ b/project/src/main/world/environment/lemon/LemonRestaurantEnvironment.tscn
@@ -151,19 +151,19 @@ frame = 1
 
 [node name="Spawns" type="Node2D" parent="."]
 
-[node name="SpawnChef" parent="Spawns" instance=ExtResource( 16 )]
+[node name="Chef" parent="Spawns" instance=ExtResource( 16 )]
 position = Vector2( 780.481, 272.623 )
 orientation = 1
 id = "chef"
 
-[node name="SpawnCustomer1" parent="Spawns" instance=ExtResource( 16 )]
+[node name="Customer1" parent="Spawns" instance=ExtResource( 16 )]
 position = Vector2( 237.44, 435.216 )
 id = "customer_1"
 
-[node name="SpawnCustomer2" parent="Spawns" instance=ExtResource( 16 )]
+[node name="Customer2" parent="Spawns" instance=ExtResource( 16 )]
 position = Vector2( 86.6673, 212.964 )
 id = "customer_2"
 
-[node name="SpawnCustomer3" parent="Spawns" instance=ExtResource( 16 )]
+[node name="Customer3" parent="Spawns" instance=ExtResource( 16 )]
 position = Vector2( 429.888, 185.507 )
 id = "customer_3"

--- a/project/src/main/world/environment/marsh/MarshEnvironment.tscn
+++ b/project/src/main/world/environment/marsh/MarshEnvironment.tscn
@@ -269,24 +269,24 @@ target_properties = {
 }
 spawn_if = "chat_finished chat/career/marsh/30_b_end"
 
-[node name="SpawnRestaurant1" parent="Obstacles" instance=ExtResource( 39 )]
+[node name="Restaurant1" parent="Obstacles" instance=ExtResource( 39 )]
 position = Vector2( 271.495, 1072.24 )
 scale = Vector2( 0.539, 0.539 )
 orientation = 1
 id = "restaurant_1"
 
-[node name="SpawnRestaurant4" parent="Obstacles" instance=ExtResource( 39 )]
+[node name="Restaurant4" parent="Obstacles" instance=ExtResource( 39 )]
 position = Vector2( 326.432, 1152.12 )
 scale = Vector2( 0.539, 0.539 )
 orientation = 1
 id = "restaurant_4"
 
-[node name="SpawnRestaurant8" parent="Obstacles" instance=ExtResource( 39 )]
+[node name="Restaurant8" parent="Obstacles" instance=ExtResource( 39 )]
 position = Vector2( 81.5159, 1154.66 )
 scale = Vector2( 0.539, 0.539 )
 id = "restaurant_8"
 
-[node name="SpawnRestaurant11" parent="Obstacles" instance=ExtResource( 39 )]
+[node name="Restaurant11" parent="Obstacles" instance=ExtResource( 39 )]
 position = Vector2( 132.969, 1070.01 )
 scale = Vector2( 0.539, 0.539 )
 id = "restaurant_11"
@@ -415,30 +415,30 @@ spawn_if = "not chat_finished chat/career/marsh/60_end"
 
 [node name="Spawns" type="Node2D" parent="."]
 
-[node name="SpawnButtercup1" parent="Spawns" instance=ExtResource( 39 )]
+[node name="Buttercup1" parent="Spawns" instance=ExtResource( 39 )]
 position = Vector2( 3806.9, 1125.61 )
 orientation = 1
 id = "buttercup_1"
 
-[node name="SpawnButtercup3" parent="Spawns" instance=ExtResource( 39 )]
+[node name="Buttercup3" parent="Spawns" instance=ExtResource( 39 )]
 position = Vector2( 3893.95, 1174.2 )
 orientation = 1
 id = "buttercup_3"
 
-[node name="SpawnButtercup5" parent="Spawns" instance=ExtResource( 39 )]
+[node name="Buttercup5" parent="Spawns" instance=ExtResource( 39 )]
 position = Vector2( 3805.07, 1220.75 )
 orientation = 1
 id = "buttercup_5"
 
-[node name="SpawnButtercup6" parent="Spawns" instance=ExtResource( 39 )]
+[node name="Buttercup6" parent="Spawns" instance=ExtResource( 39 )]
 position = Vector2( 3704.68, 1253.05 )
 id = "buttercup_6"
 
-[node name="SpawnButtercup9" parent="Spawns" instance=ExtResource( 39 )]
+[node name="Buttercup9" parent="Spawns" instance=ExtResource( 39 )]
 position = Vector2( 3561.74, 1189.75 )
 id = "buttercup_9"
 
-[node name="SpawnButtercup11" parent="Spawns" instance=ExtResource( 39 )]
+[node name="Buttercup11" parent="Spawns" instance=ExtResource( 39 )]
 position = Vector2( 3633.95, 1137.63 )
 id = "buttercup_11"
 

--- a/project/src/main/world/environment/marsh/MarshFreeRoamEnvironment.tscn
+++ b/project/src/main/world/environment/marsh/MarshFreeRoamEnvironment.tscn
@@ -381,88 +381,88 @@ spawn_if = "level_finished marsh/goodbye_skins"
 
 [node name="Spawns" type="Node2D" parent="."]
 
-[node name="SpawnRestaurant1" parent="Spawns" instance=ExtResource( 29 )]
+[node name="Restaurant1" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 1665.79, 1022.31 )
 orientation = 1
 id = "restaurant_1"
 
-[node name="SpawnRestaurant4" parent="Spawns" instance=ExtResource( 29 )]
+[node name="Restaurant4" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 1715.18, 1110.98 )
 orientation = 1
 id = "restaurant_4"
 
-[node name="SpawnRestaurant8" parent="Spawns" instance=ExtResource( 29 )]
+[node name="Restaurant8" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 1488.44, 1124.45 )
 id = "restaurant_8"
 
-[node name="SpawnRestaurant11" parent="Spawns" instance=ExtResource( 29 )]
+[node name="Restaurant11" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 1524.36, 1023.43 )
 id = "restaurant_11"
 
-[node name="SpawnRestaurantPlayer" parent="Spawns" instance=ExtResource( 29 )]
+[node name="RestaurantPlayer" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 1396.4, 1014.45 )
 orientation = 1
 id = "restaurant_player"
 
-[node name="SpawnRestaurantSensei" parent="Spawns" instance=ExtResource( 29 )]
+[node name="RestaurantSensei" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 1569.4, 1042.45 )
 id = "restaurant_sensei"
 
-[node name="SpawnButtercup1" parent="Spawns" instance=ExtResource( 29 )]
+[node name="Buttercup1" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 710.294, 1360.37 )
 orientation = 1
 id = "buttercup_1"
 
-[node name="SpawnButtercup3" parent="Spawns" instance=ExtResource( 29 )]
+[node name="Buttercup3" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 779.594, 1434.7 )
 orientation = 1
 id = "buttercup_3"
 
-[node name="SpawnButtercup6" parent="Spawns" instance=ExtResource( 29 )]
+[node name="Buttercup6" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 635.089, 1495.06 )
 orientation = 1
 id = "buttercup_6"
 
-[node name="SpawnButtercup7" parent="Spawns" instance=ExtResource( 29 )]
+[node name="Buttercup7" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 526.21, 1473.74 )
 id = "buttercup_7"
 
-[node name="SpawnButtercup9" parent="Spawns" instance=ExtResource( 29 )]
+[node name="Buttercup9" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 455.069, 1418.4 )
 id = "buttercup_9"
 
-[node name="SpawnButtercup11" parent="Spawns" instance=ExtResource( 29 )]
+[node name="Buttercup11" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 532.99, 1349.44 )
 id = "buttercup_11"
 
-[node name="SpawnButtercupSeat" parent="Spawns" instance=ExtResource( 29 )]
+[node name="ButtercupSeat" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 339.509, 1583.36 )
 id = "buttercup_seat"
 elevation = 80.0
 
-[node name="SpawnButtercupFence3" parent="Spawns" instance=ExtResource( 29 )]
+[node name="ButtercupFence3" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 1114.3, 1323.42 )
 orientation = 1
 id = "buttercup_fence_3"
 
-[node name="SpawnButtercupFence12" parent="Spawns" instance=ExtResource( 29 )]
+[node name="ButtercupFence12" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 987.723, 1271.8 )
 id = "buttercup_fence_12"
 
-[node name="SpawnSePlayer" parent="Spawns" instance=ExtResource( 29 )]
+[node name="SePlayer" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 1764.82, 1680.06 )
 orientation = 2
 id = "se_player"
 
-[node name="SpawnSeSensei" parent="Spawns" instance=ExtResource( 29 )]
+[node name="SeSensei" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 1916.18, 1737.24 )
 orientation = 2
 id = "se_sensei"
 
-[node name="SpawnNwPlayer" parent="Spawns" instance=ExtResource( 29 )]
+[node name="NwPlayer" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 932.693, 435.451 )
 id = "nw_player"
 
-[node name="SpawnNwPlayer2" parent="Spawns" instance=ExtResource( 29 )]
+[node name="NwPlayer2" parent="Spawns" instance=ExtResource( 29 )]
 position = Vector2( 826.74, 356.406 )
 id = "nw_sensei"

--- a/project/src/main/world/environment/marsh/MarshIndoorsEnvironment.tscn
+++ b/project/src/main/world/environment/marsh/MarshIndoorsEnvironment.tscn
@@ -742,76 +742,76 @@ position = Vector2( 1383.76, 123.852 )
 
 [node name="Spawns" type="Node2D" parent="."]
 
-[node name="SpawnChef" parent="Spawns" instance=ExtResource( 38 )]
+[node name="Chef" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 1512, 255 )
 orientation = 1
 id = "chef"
 
-[node name="SpawnCustomer1" parent="Spawns" instance=ExtResource( 38 )]
+[node name="Customer1" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 592, 35 )
 stool_path = NodePath("../../Obstacles/Stool2")
 id = "customer_1"
 elevation = 140.0
 
-[node name="SpawnCustomer2" parent="Spawns" instance=ExtResource( 38 )]
+[node name="Customer2" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 349, 322 )
 stool_path = NodePath("../../Obstacles/Stool4")
 id = "customer_2"
 elevation = 140.0
 
-[node name="SpawnCustomer3" parent="Spawns" instance=ExtResource( 38 )]
+[node name="Customer3" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 992, 35 )
 stool_path = NodePath("../../Obstacles/Stool8")
 id = "customer_3"
 elevation = 140.0
 
-[node name="SpawnCustomer4" parent="Spawns" instance=ExtResource( 38 )]
+[node name="Customer4" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 1313, 220 )
 stool_path = NodePath("../../Obstacles/Stool10")
 id = "customer_4"
 elevation = 140.0
 
-[node name="SpawnEntrance2" parent="Spawns" instance=ExtResource( 38 )]
+[node name="Entrance2" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 342.245, 52.3916 )
 orientation = 1
 id = "entrance_2"
 
-[node name="SpawnEntrance5" parent="Spawns" instance=ExtResource( 38 )]
+[node name="Entrance5" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 394.38, 152.458 )
 orientation = 1
 id = "entrance_5"
 
-[node name="SpawnEntrance7" parent="Spawns" instance=ExtResource( 38 )]
+[node name="Entrance7" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 126.975, 170.117 )
 id = "entrance_7"
 
-[node name="SpawnEntrance10" parent="Spawns" instance=ExtResource( 38 )]
+[node name="Entrance10" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 179.111, 52.3916 )
 id = "entrance_10"
 
-[node name="SpawnKitchen1" parent="Spawns" instance=ExtResource( 38 )]
+[node name="Kitchen1" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 1863.6, 75.8002 )
 orientation = 1
 id = "kitchen_1"
 
-[node name="SpawnKitchen3" parent="Spawns" instance=ExtResource( 38 )]
+[node name="Kitchen3" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 1910.61, 182.605 )
 orientation = 1
 id = "kitchen_3"
 
-[node name="SpawnKitchen5" parent="Spawns" instance=ExtResource( 38 )]
+[node name="Kitchen5" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 1955.82, 282.207 )
 orientation = 1
 id = "kitchen_5"
 
-[node name="SpawnKitchen7" parent="Spawns" instance=ExtResource( 38 )]
+[node name="Kitchen7" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 1596.46, 279.091 )
 id = "kitchen_7"
 
-[node name="SpawnKitchen9" parent="Spawns" instance=ExtResource( 38 )]
+[node name="Kitchen9" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 1667.9, 173.54 )
 id = "kitchen_9"
 
-[node name="SpawnKitchen11" parent="Spawns" instance=ExtResource( 38 )]
+[node name="Kitchen11" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 1740.68, 77.2144 )
 id = "kitchen_11"


### PR DESCRIPTION
These spawn nodes are now grouped under a parent 'Spawns' node so the old naming
convention is redundant.