### PR TITLE
Fixed bug where Spacer could get focus

### DIFF
--- a/project/src/demo/ui/chat/MoodDemo.tscn
+++ b/project/src/demo/ui/chat/MoodDemo.tscn
@@ -9,10 +9,7 @@ script = ExtResource( 3 )
 [node name="ColorRect" type="ColorRect" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-color = Color( 0.109804, 0.890196, 0.109804, 0.329412 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+color = Color( 0, 0, 0, 0.329412 )
 
 [node name="Creature" parent="." instance=ExtResource( 24 )]
 position = Vector2( 512, 420 )

--- a/project/src/main/ui/menu/CareerRegionSelectMenu.tscn
+++ b/project/src/main/ui/menu/CareerRegionSelectMenu.tscn
@@ -112,8 +112,10 @@ margin_top = 132.0
 margin_right = 398.0
 margin_bottom = 158.0
 rect_min_size = Vector2( 24, 24 )
+focus_mode = 0
 size_flags_vertical = 4
 theme = ExtResource( 15 )
+enabled_focus_mode = 0
 text = "<"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="RegionSelect/VBoxContainer/Top/RegionButtons"]
@@ -132,8 +134,10 @@ margin_top = 132.0
 margin_right = 530.0
 margin_bottom = 158.0
 rect_min_size = Vector2( 24, 24 )
+focus_mode = 0
 size_flags_vertical = 4
 theme = ExtResource( 15 )
+enabled_focus_mode = 0
 text = ">"
 
 [node name="GradeLabels" type="Control" parent="RegionSelect/VBoxContainer/Top"]
@@ -233,9 +237,6 @@ rect_min_size = Vector2( 100, 100 )
 mouse_filter = 2
 custom_constants/separation = 10
 alignment = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="BackButton" parent="Buttons/Northeast" instance=ExtResource( 6 )]
 anchor_right = 0.0
@@ -253,14 +254,12 @@ pressed_icon = ExtResource( 9 )
 [node name="ShortcutHelper" parent="Buttons/Northeast/BackButton" instance=ExtResource( 1 )]
 action = "phone"
 
-[node name="Spacer" parent="Buttons/Northeast" instance=ExtResource( 6 )]
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="Spacer" type="Control" parent="Buttons/Northeast"]
 margin_left = 402.0
 margin_right = 502.0
 margin_bottom = 100.0
+rect_min_size = Vector2( 100, 100 )
 mouse_filter = 2
-disabled = true
 
 [node name="MusicPopup" parent="." instance=ExtResource( 3 )]
 

--- a/project/src/main/ui/menu/TutorialMenu.tscn
+++ b/project/src/main/ui/menu/TutorialMenu.tscn
@@ -22,9 +22,6 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 rect_min_size = Vector2( 1024, 600 )
 script = ExtResource( 6 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Wallpaper" parent="." instance=ExtResource( 16 )]
 
@@ -83,14 +80,12 @@ pressed_icon = ExtResource( 5 )
 [node name="ShortcutHelper" parent="Buttons/Northeast/BackButton" instance=ExtResource( 1 )]
 action = "phone"
 
-[node name="Spacer" parent="Buttons/Northeast" instance=ExtResource( 2 )]
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="Spacer" type="Control" parent="Buttons/Northeast"]
 margin_left = 402.0
 margin_right = 502.0
 margin_bottom = 100.0
+rect_min_size = Vector2( 100, 100 )
 mouse_filter = 2
-disabled = true
 
 [node name="MusicPopup" parent="." instance=ExtResource( 7 )]
 

--- a/project/src/main/world/FreeRoamUi.tscn
+++ b/project/src/main/world/FreeRoamUi.tscn
@@ -299,17 +299,14 @@ pressed_icon = ExtResource( 22 )
 [node name="ShortcutHelper" parent="CellPhoneMenu/Buttons/Northeast/BackButton" instance=ExtResource( 4 )]
 action = "phone"
 
-[node name="Spacer" parent="CellPhoneMenu/Buttons/Northeast" instance=ExtResource( 3 )]
+[node name="Spacer" type="Control" parent="CellPhoneMenu/Buttons/Northeast"]
+anchor_right = 1.0
+anchor_bottom = 1.0
 margin_left = 402.0
 margin_right = 502.0
 margin_bottom = 100.0
+rect_min_size = Vector2( 100, 100 )
 mouse_filter = 2
-custom_styles/hover = SubResource( 1 )
-custom_styles/pressed = SubResource( 2 )
-custom_styles/focus = SubResource( 3 )
-custom_styles/disabled = SubResource( 4 )
-custom_styles/normal = SubResource( 5 )
-disabled = true
 
 [node name="MusicPopup" parent="." instance=ExtResource( 17 )]
 


### PR DESCRIPTION
When using the arrow keys on the Chapter Select screen, if you arrowed
off to the right the selection focus would disappear. This is because it
selected an invisible 'Spacer' button in the upper right corner of the
screen. I've changed the Spacer so it is not a button and cannot obtain
focus.

Changed the background of MoodDemo to a more neutral grey. I'm featuring
this in a YouTube video and the old background was kind of ugly.