### PR TITLE
ReleaseToolkit detects chatscript hyphens.

### DIFF
--- a/project/src/main/career/career-level-library.gd
+++ b/project/src/main/career/career-level-library.gd
@@ -109,11 +109,11 @@ func set_worlds_path(new_worlds_path: String) -> void:
 ##
 ## Returns:
 ## 	A dictionary with three entries:
-## 		'chef_ids' lists ids for creatures who acts as the chef for a cutscene.
+## 		'chef_ids' lists ids for quirky creatures who act as the chef for a cutscene.
 ##
-## 		'customer_ids' lists ids for creatures who act as the main customer for a cutscene.
+## 		'customer_ids' lists ids for quirky creatures who act as the main customer for a cutscene.
 ##
-## 		'observer_ids' lists ids for creatures who act as the observer for a cutscene.
+## 		'observer_ids' lists ids for quirky creatures who act as the observer for a cutscene.
 func required_cutscene_characters(region: CareerRegion) -> Dictionary:
 	var chef_ids := []
 	var customer_ids := []

--- a/project/src/main/ui/chat/career-cutscene-library.gd
+++ b/project/src/main/ui/chat/career-cutscene-library.gd
@@ -180,6 +180,7 @@ func _chat_key_pair_is_nonquirky(chat_key_pair: ChatKeyPair) -> bool:
 			for customer_id in chat_tree.customer_ids:
 				if region.population.has_quirky_customer(customer_id):
 					quirky = true
+					break
 		
 		if not quirky and chat_tree.observer_id:
 			# If a cutscene defines a quirky observer, it must be accompanied by a level with their quirks.


### PR DESCRIPTION
ReleaseToolkit clears chatscript problems each time the button is
pressed. It also no longer counts files more than once. Before, its
counts would be inflated and increase continuously.

ReleaseToolkit detects unusual hyphens in chatscript files, such as the
kind that were fixed in [#1435](https://github.com/Poobslag/turbofat/pull/1435)

Fixed comments in CareerLevelLibrary.required_cutscene_characters() to
make it clear this refers to quirky characters.

Added break statement to CareerCutsceneLibrary 'quirky' logic. We do not
need to continue looping after we find a quirky character.