### PR TITLE
CreatureQueue tests, improvements

### DIFF
--- a/project/assets/test/secondary-creatures/cold.json
+++ b/project/assets/test/secondary-creatures/cold.json
@@ -1,0 +1,40 @@
+{
+  "version": "19dd",
+  "id": "cold",
+  "name": "Cold",
+  "short_name": "Cold",
+  "dna": {
+    "belly": "1",
+    "bellybutton": "1",
+    "body": "1",
+    "cheek": "3",
+    "collar": "0",
+    "ear": "12",
+    "eye": "2",
+    "hair": "2",
+    "head": "1",
+    "horn": "2",
+    "mouth": "6",
+    "nose": "1",
+    "tail": "4",
+    "accessory": "0",
+    "line_rgb": "6c4331",
+    "body_rgb": "23a2e3",
+    "belly_rgb": "35e1e0",
+    "cloth_rgb": "415a73",
+    "glass_rgb": "bf3a3a",
+    "plastic_rgb": "34373a",
+    "hair_rgb": "ffffff",
+    "eye_rgb": "415a73 c8cbd6",
+    "horn_rgb": "ffe7e5"
+  },
+  "chat_theme_def": {
+    "accent_scale": 1.33,
+    "accent_swapped": true,
+    "accent_texture": 13,
+    "color": "23a2e3"
+  },
+  "fatness": 1,
+  "weight_gain_scale": 1,
+  "metabolism_scale": 1
+}

--- a/project/assets/test/secondary-creatures/cough.json
+++ b/project/assets/test/secondary-creatures/cough.json
@@ -1,0 +1,40 @@
+{
+  "version": "19dd",
+  "id": "cough",
+  "name": "Cough",
+  "short_name": "Cough",
+  "dna": {
+    "belly": "1",
+    "bellybutton": "1",
+    "body": "1",
+    "cheek": "3",
+    "collar": "0",
+    "ear": "12",
+    "eye": "2",
+    "hair": "2",
+    "head": "1",
+    "horn": "2",
+    "mouth": "6",
+    "nose": "1",
+    "tail": "4",
+    "accessory": "0",
+    "line_rgb": "41281e",
+    "body_rgb": "8f1b21",
+    "belly_rgb": "838382",
+    "cloth_rgb": "546127",
+    "glass_rgb": "cbde88",
+    "plastic_rgb": "546127",
+    "hair_rgb": "1e1e1e",
+    "eye_rgb": "546127 a8ad89",
+    "horn_rgb": "2b2b2b"
+  },
+  "chat_theme_def": {
+    "accent_scale": 1.33,
+    "accent_swapped": true,
+    "accent_texture": 13,
+    "color": "8f1b21"
+  },
+  "fatness": 1,
+  "weight_gain_scale": 1,
+  "metabolism_scale": 1
+}

--- a/project/src/main/creature-queue.gd
+++ b/project/src/main/creature-queue.gd
@@ -4,6 +4,12 @@ class_name CreatureQueue
 ## This includes a 'primary queue' of creatures guaranteed to show up at the start of a puzzle, and a 'secondary queue'
 ## of creatures who randomly show up during a puzzle.
 
+## Path to the directory with secondary creatures. Can be changed for tests.
+const DEFAULT_SECONDARY_CREATURES_PATH := "res://assets/main/creatures/secondary"
+
+## Path to the directory with secondary creatures. Can be changed for tests.
+var secondary_creatures_path := DEFAULT_SECONDARY_CREATURES_PATH setget set_secondary_creatures_path
+
 ## Queue of creatures who show up at the start of a puzzle.
 var primary_queue := []
 var primary_index: int
@@ -16,6 +22,13 @@ func _init() -> void:
 	_load_secondary_creatures()
 
 
+func set_secondary_creatures_path(value: String) -> void:
+	secondary_creatures_path = value
+	secondary_queue.clear()
+	secondary_index = 0
+	_load_secondary_creatures()
+
+
 ## Returns 'true' if the primary creature queue has any creatures left.
 func has_primary_creature() -> bool:
 	return primary_index < primary_queue.size()
@@ -25,8 +38,8 @@ func has_primary_creature() -> bool:
 func pop_primary_creature() -> CreatureDef:
 	var creature_def: CreatureDef
 	if has_primary_creature():
-		creature_def = PlayerData.creature_queue.primary_queue[PlayerData.creature_queue.primary_index]
-		PlayerData.creature_queue.primary_index += 1
+		creature_def = primary_queue[primary_index]
+		primary_index += 1
 	return creature_def
 
 
@@ -39,9 +52,9 @@ func has_secondary_creature() -> bool:
 func pop_secondary_creature() -> CreatureDef:
 	var creature_def: CreatureDef
 	if has_secondary_creature():
-		creature_def = PlayerData.creature_queue.secondary_queue[PlayerData.creature_queue.secondary_index]
+		creature_def = secondary_queue[secondary_index]
 		# don't loop back through the queue; we don't want the same customer showing up twice during a puzzle
-		PlayerData.creature_queue.secondary_index += 1
+		secondary_index += 1
 	return creature_def
 
 
@@ -70,8 +83,11 @@ func reset_secondary_creature_queue() -> void:
 
 ## Loads all secondary creature data from a directory of json files.
 func _load_secondary_creatures() -> void:
+	if not secondary_creatures_path:
+		return
+	
 	var dir := Directory.new()
-	dir.open("res://assets/main/creatures/secondary")
+	dir.open(secondary_creatures_path)
 	dir.list_dir_begin(true, true)
 	while true:
 		var file := dir.get_next()

--- a/project/src/test/test-creature-queue.gd
+++ b/project/src/test/test-creature-queue.gd
@@ -1,0 +1,53 @@
+extends "res://addons/gut/test.gd"
+
+var creature_queue := CreatureQueue.new()
+
+func before_each() -> void:
+	creature_queue.secondary_creatures_path = ""
+
+
+func test_secondary_queue_has_creatures() -> void:
+	assert_eq(creature_queue.secondary_queue.size(), 0)
+	creature_queue.secondary_creatures_path = "res://assets/test/secondary-creatures"
+	assert_eq(creature_queue.secondary_queue.size(), 2)
+
+
+func test_has_secondary_creature() -> void:
+	assert_eq(false, creature_queue.has_secondary_creature())
+	_populate_secondary_queue(["ofa_100"], 0)
+	assert_eq(true, creature_queue.has_secondary_creature())
+
+
+func test_pop_secondary_creature() -> void:
+	_populate_secondary_queue(["ofa_100"], 0)
+	
+	# should only be able to pop one creature; then the queue is empty
+	_assert_creature_id(creature_queue.pop_secondary_creature(), "ofa_100")
+	_assert_creature_id(creature_queue.pop_secondary_creature(), "")
+
+
+func test_reset_secondary_creature_queue() -> void:
+	_populate_secondary_queue(["ofa_100", "ofa_200"], 0)
+	_assert_creature_id(creature_queue.pop_secondary_creature(), "ofa_100")
+	creature_queue.reset_secondary_creature_queue()
+	
+	# resetting should add ofa_100 to the end of the queue again
+	_assert_creature_id(creature_queue.pop_secondary_creature(), "ofa_200")
+	_assert_creature_id(creature_queue.pop_secondary_creature(), "ofa_100")
+	_assert_creature_id(creature_queue.pop_secondary_creature(), "")
+
+
+## Populates the secondary queue with the specified creature ids and secondary index
+func _populate_secondary_queue(new_creature_ids: Array, new_secondary_index: int) -> void:
+	for creature_id in new_creature_ids:
+		var creature_def := CreatureDef.new()
+		creature_def.creature_id = creature_id
+		creature_queue.secondary_queue.append(creature_def)
+	creature_queue.secondary_index = new_secondary_index
+
+
+## Asserts a creature's id.
+##
+## A null id can be asserted; this assertion is successful if the creature or its id is null.
+func _assert_creature_id(creature_def: CreatureDef, expected_id: String) -> void:
+	assert_eq("" if not creature_def else creature_def.creature_id, expected_id)


### PR DESCRIPTION
Fixed references from CreatureQueue to PlayerData.creature_queue. These
references are nonsensical and the class should just reference itself.

Added a few CreatureQueue tests. CreatureQueue now exposes a
secondary_creatures_path property which can be injected in unit tests.