### PR TITLE
Avoid repeating secondary creatures.

### DIFF
--- a/project/src/main/creature-queue.gd
+++ b/project/src/main/creature-queue.gd
@@ -81,6 +81,33 @@ func reset_secondary_creature_queue() -> void:
 		secondary_index = 0
 
 
+## Shift secondary creatures in the queue so that they will not be summoned soon.
+##
+## This prevents the player from seeing a random secondary creature at an inopportune time, such as picking a level
+## featuring a creature and then having them show up in the restaurant later during that same level.
+##
+## Parameters:
+## 	'creature_ids': The ids of creatures who should be shifted in the queue
+func pop_secondary_creatures(creature_ids: Array) -> void:
+	for creature_id in creature_ids:
+		var creature_index := -1
+		for i in range(secondary_queue.size()):
+			if secondary_queue[i].creature_id == creature_id:
+				creature_index = i
+				break
+		
+		if creature_index == -1:
+			# creature not found
+			pass
+		else:
+			var creature_def: CreatureDef = secondary_queue[creature_index]
+			secondary_queue.remove(creature_index)
+			if creature_index >= secondary_index:
+				# when moving a creature backwards in the queue, we advance secondary_index
+				secondary_index += 1
+			secondary_queue.insert(secondary_index - 1, creature_def)
+
+
 ## Loads all secondary creature data from a directory of json files.
 func _load_secondary_creatures() -> void:
 	if not secondary_creatures_path:

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -127,6 +127,28 @@ func set_best_result(new_best_result: int) -> void:
 	emit_signal("best_result_changed")
 
 
+## Returns a list of all creature ids in the level.
+##
+## This includes the creature the player interacted with to launch the level, the chef, and any customers. Empty
+## creature ids are not included.
+func get_creature_ids() -> Array:
+	var result := {}
+	if creature_id:
+		result[creature_id] = true
+	if chef_id:
+		result[chef_id] = true
+	for customer_obj in customers:
+		if customer_obj is String:
+			result[customer_obj] = true
+		elif customer_obj is CreatureDef:
+			result[customer_obj.creature_id] = true
+		else:
+			push_warning("Unrecognized customer: %s" % [customer_obj])
+	if result.has(""):
+		result.erase("")
+	return result.keys()
+
+
 ## Purges all node instances from the singleton.
 ##
 ## Because CurrentLevel is a singleton, node instances should be purged before changing scenes. Otherwise they'll

--- a/project/src/main/world/cutscene-queue.gd
+++ b/project/src/main/world/cutscene-queue.gd
@@ -129,6 +129,7 @@ func _pop_level() -> void:
 		CurrentLevel.cutscene_force = level_properties["cutscene_force"]
 	if level_properties.has("puzzle_environment_name"):
 		CurrentLevel.puzzle_environment_name = level_properties["puzzle_environment_name"]
+	PlayerData.creature_queue.pop_secondary_creatures(CurrentLevel.get_creature_ids())
 
 
 ## Assign the player and sensei spawn IDs based on the specified chat tree.

--- a/project/src/test/test-creature-queue.gd
+++ b/project/src/test/test-creature-queue.gd
@@ -38,6 +38,48 @@ func test_reset_secondary_creature_queue() -> void:
 
 
 ## Populates the secondary queue with the specified creature ids and secondary index
+func test_pop_secondary_creatures_before() -> void:
+	_populate_secondary_queue(["ofa_100", "ofa_200", "ofa_300"], 2)
+	creature_queue.pop_secondary_creatures(["ofa_100"])
+	
+	_assert_secondary_queue(["ofa_200", "ofa_100", "ofa_300"], 2)
+
+
+func test_pop_secondary_creatures_current() -> void:
+	_populate_secondary_queue(["ofa_100", "ofa_200", "ofa_300"], 1)
+	creature_queue.pop_secondary_creatures(["ofa_200"])
+	
+	_assert_secondary_queue(["ofa_100", "ofa_200", "ofa_300"], 2)
+
+
+func test_pop_secondary_creatures_after() -> void:
+	_populate_secondary_queue(["ofa_100", "ofa_200", "ofa_300"], 0)
+	creature_queue.pop_secondary_creatures(["ofa_300"])
+	
+	_assert_secondary_queue(["ofa_300", "ofa_100", "ofa_200"], 1)
+
+
+func test_pop_secondary_creatures_not_found() -> void:
+	_populate_secondary_queue(["ofa_100"], 0)
+	creature_queue.pop_secondary_creatures(["ofa_invalid"])
+	
+	_assert_secondary_queue(["ofa_100"], 0)
+
+
+func test_pop_secondary_creatures_empty() -> void:
+	_populate_secondary_queue(["ofa_100"], 0)
+	creature_queue.pop_secondary_creatures([])
+	
+	_assert_secondary_queue(["ofa_100"], 0)
+
+
+func test_pop_secondary_creatures_multiple() -> void:
+	_populate_secondary_queue(["ofa_100", "ofa_200", "ofa_300", "ofa_400", "ofa_500"], 2)
+	creature_queue.pop_secondary_creatures(["ofa_200", "ofa_400"])
+	
+	_assert_secondary_queue(["ofa_100", "ofa_200", "ofa_400", "ofa_300", "ofa_500"], 3)
+
+
 func _populate_secondary_queue(new_creature_ids: Array, new_secondary_index: int) -> void:
 	for creature_id in new_creature_ids:
 		var creature_def := CreatureDef.new()
@@ -51,3 +93,11 @@ func _populate_secondary_queue(new_creature_ids: Array, new_secondary_index: int
 ## A null id can be asserted; this assertion is successful if the creature or its id is null.
 func _assert_creature_id(creature_def: CreatureDef, expected_id: String) -> void:
 	assert_eq("" if not creature_def else creature_def.creature_id, expected_id)
+
+
+func _assert_secondary_queue(expected_ids: Array, expected_secondary_index: int) -> void:
+	var actual_ids := []
+	for creature_def in creature_queue.secondary_queue:
+		actual_ids.append(creature_def.creature_id)
+	assert_eq(actual_ids, expected_ids)
+	assert_eq(creature_queue.secondary_index, expected_secondary_index)


### PR DESCRIPTION
When the player picks a career level, we now push any matching secondary
creatures to the end of the queue so they won't be picked. This prevents
the player from picking a level with a creature, and then having that
creature immediately visit the restaurant again during the same puzzle.