### PR TITLE
Region fixes: failed level grades, grade hook position

### DIFF
--- a/project/src/main/ui/RegionSelectButton.tscn
+++ b/project/src/main/ui/RegionSelectButton.tscn
@@ -22,11 +22,6 @@ margin_bottom = 290.0
 custom_constants/margin_bottom = 40
 script = ExtResource( 1 )
 
-[node name="GradeHook" type="RemoteTransform2D" parent="."]
-position = Vector2( 12, 6 )
-rotation = -0.261799
-scale = Vector2( 0.7, 0.7 )
-
 [node name="Button" type="Button" parent="."]
 margin_right = 100.0
 margin_bottom = 250.0
@@ -37,6 +32,11 @@ custom_styles/focus = ExtResource( 4 )
 custom_styles/disabled = ExtResource( 7 )
 custom_styles/normal = ExtResource( 2 )
 clip_text = true
+
+[node name="GradeHook" type="RemoteTransform2D" parent="Button"]
+position = Vector2( 12, 6 )
+rotation = -0.261799
+scale = Vector2( 0.7, 0.7 )
 
 [node name="Polygon2D" type="Polygon2D" parent="Button"]
 show_behind_parent = true

--- a/project/src/main/ui/career/hookable-region-grade-label.gd
+++ b/project/src/main/ui/career/hookable-region-grade-label.gd
@@ -21,12 +21,12 @@ func set_button(new_button: RegionSelectButton) -> void:
 		return
 	
 	if button:
-		button.get_node("GradeHook").remote_path = null
+		button.grade_hook.remote_path = null
 		button.disconnect("tree_exited", self, "_on_LevelSelectButton_tree_exited")
 	
 	button = new_button
 	
-	button.get_node("GradeHook").remote_path = button.get_node("GradeHook").get_path_to(self)
+	button.grade_hook.remote_path = button.grade_hook.get_path_to(self)
 	button.connect("tree_exited", self, "_on_LevelSelectButton_tree_exited")
 	
 	_refresh_appearance()

--- a/project/src/main/ui/level-select/hookable-level-grade-label.gd
+++ b/project/src/main/ui/level-select/hookable-level-grade-label.gd
@@ -5,8 +5,8 @@ extends Node2D
 ## This can be something like 'S' or 'B+' if a level has been cleared, or something like a lock/key icon for levels
 ## which haven't yet been cleared.
 
-## the level button this grade label applies to
-var button: LevelSelectButton setget set_button
+## the LevelSelectButton or WorldSelectButton this grade label applies to
+var button: Button setget set_button
 
 var _cleared_texture: Texture = preload("res://assets/main/ui/level-select/cleared.png")
 var _crown_texture: Texture = preload("res://assets/main/ui/level-select/crown.png")
@@ -60,7 +60,7 @@ func _refresh_appearance() -> void:
 			_refresh_grade_text(worst_rank)
 	else:
 		var result := PlayerData.level_history.best_result(button.level_id)
-		if not result:
+		if not result or result.lost:
 			# uncleared levels do not show a grade
 			_refresh_status_icon(button.lock_status)
 		elif button.lock_status == LevelLock.STATUS_CLEARED:

--- a/project/src/main/ui/region-select-button.gd
+++ b/project/src/main/ui/region-select-button.gd
@@ -52,6 +52,8 @@ var ranks := []
 ## A number in the range [0.0, 1.0] for how close the player is to completing the region.
 var completion_percent := 0.0
 
+onready var grade_hook := $Button/GradeHook
+
 onready var _button := $Button
 onready var _button_name_label := $Button/NameLabel
 onready var _button_polygon2d := $Button/Polygon2D


### PR DESCRIPTION
Failed levels (levels where the player does not finish) no longer show a
level grade. This prevents an edge case where the region button shows
a region as 93% complete (because the player failed) but the level
shows they got an SSS (because they played well.) Now, the level will
show no label.

Fixed a bug where the region grade hook was above the button instead of
over top of the button, for buttons which were aligned at the bottom.