### PR TITLE
Creature editor chat theme bugfix. Chat frame comment.

### DIFF
--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -83,7 +83,7 @@ func _mutate_creature(creature: Creature) -> void:
 		_mutate_allele(creature, dna, new_palette, allele)
 	
 	creature.dna = dna
-	creature.chat_theme_def = CreatureLoader.chat_theme_def(dna)
+	creature.chat_theme_def = CreatureLoader.chat_theme_def(dna.get("chat_theme_def", {}))
 
 
 ## Mutate a single allele.
@@ -285,7 +285,7 @@ func _tweak_creature(creature: Creature, allele: String, color_mode: int) -> voi
 				_recent_tweaked_allele_values[allele].append(dna[allele])
 	
 	creature.dna = dna
-	creature.chat_theme_def = CreatureLoader.chat_theme_def(dna)
+	creature.chat_theme_def = CreatureLoader.chat_theme_def(dna.get("chat_theme_def", {}))
 
 
 ## Randomly calculates a set of alleles to mutate.

--- a/project/src/main/ui/chat/chat-frame.gd
+++ b/project/src/main/ui/chat/chat-frame.gd
@@ -3,7 +3,7 @@ extends Control
 ## Window which displays a chat line.
 ##
 ## The chat window is decorated with objects in the background called 'accents'. These accents can be injected with the
-## set_chat_theme_def function to configure the chat window's appearance.
+## chat_event.chat_theme_def property to configure the chat window's appearance.
 
 signal pop_out_completed
 


### PR DESCRIPTION
Fixed bug where the creature editor would not load chat themes property.
It was trying to load the creature's DNA as a chat theme instead of
drilling down into its chat theme def.

Fixed inaccurate comment in chat-frame.gd