### PR TITLE
Changed 'chat_theme_def' to 'chat_theme' globally. 375c.

### DIFF
--- a/project/assets/main/creatures/primary/bones/creature.json
+++ b/project/assets/main/creatures/primary/bones/creature.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "bones",
   "name": "Bones",
   "short_name": "Bones",
@@ -28,7 +28,7 @@
     "eye_rgb": "b8260b f45e40",
     "horn_rgb": "282828"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/primary/diota/creature.json
+++ b/project/assets/main/creatures/primary/diota/creature.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "diota",
   "name": "Diota",
   "short_name": "Diota",
@@ -28,7 +28,7 @@
     "eye_rgb": "74a27f fffaff",
     "horn_rgb": "fde9e7"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/primary/jayton/creature.json
+++ b/project/assets/main/creatures/primary/jayton/creature.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "jayton",
   "name": "Jayton",
   "short_name": "Jayton",
@@ -28,7 +28,7 @@
     "eye_rgb": "276127 97ad89",
     "horn_rgb": "9787a2"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/primary/richie/creature.json
+++ b/project/assets/main/creatures/primary/richie/creature.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "richie",
   "name": "Richie",
   "short_name": "Richie",
@@ -28,7 +28,7 @@
     "eye_rgb": "7c4725 b8ad9f",
     "horn_rgb": "4c5245"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/primary/shirts/creature.json
+++ b/project/assets/main/creatures/primary/shirts/creature.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "shirts",
   "name": "Shirts",
   "short_name": "Shirts",
@@ -28,7 +28,7 @@
     "eye_rgb": "131414 617d7c",
     "horn_rgb": "fecbd3"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/primary/skins/creature.json
+++ b/project/assets/main/creatures/primary/skins/creature.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "skins",
   "name": "Skins",
   "short_name": "Skins",
@@ -28,7 +28,7 @@
     "eye_rgb": "d5c26a ffffff",
     "horn_rgb": "4c5245"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/primary/wesker/creature.json
+++ b/project/assets/main/creatures/primary/wesker/creature.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "wesker",
   "name": "Wesker",
   "short_name": "Wesker",
@@ -26,7 +26,7 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/alber.json
+++ b/project/assets/main/creatures/secondary/alber.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "alber",
   "name": "Alber",
   "short_name": "Alber",
@@ -26,7 +26,7 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/alexander.json
+++ b/project/assets/main/creatures/secondary/alexander.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "alexander",
   "name": "Alexander",
   "short_name": "Alexander",
@@ -26,7 +26,7 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/beats.json
+++ b/project/assets/main/creatures/secondary/beats.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "beats",
   "name": "Beats",
   "short_name": "Beats",
@@ -28,7 +28,7 @@
     "eye_rgb": "0d0d0d 20383f",
     "horn_rgb": "b8ae81"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/boatricia.json
+++ b/project/assets/main/creatures/secondary/boatricia.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "boatricia",
   "name": "Boatricia",
   "short_name": "Boatricia",
@@ -22,7 +22,7 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 0.67,
     "accent_swapped": true,
     "accent_texture": 1,

--- a/project/assets/main/creatures/secondary/bort.json
+++ b/project/assets/main/creatures/secondary/bort.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "bort",
   "name": "Bort",
   "short_name": "Bort",
@@ -22,10 +22,8 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 2.6,
-    "accent_swapped": false,
-    "accent_texture": 0,
     "color": "70843a"
   },
   "fatness": 1.5

--- a/project/assets/main/creatures/secondary/bundles.json
+++ b/project/assets/main/creatures/secondary/bundles.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "bundles",
   "name": "Bundles",
   "short_name": "Bundles",
@@ -28,7 +28,7 @@
     "eye_rgb": "282828 dedede",
     "horn_rgb": "b47922"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/carry.json
+++ b/project/assets/main/creatures/secondary/carry.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "carry",
   "name": "Carry",
   "short_name": "Carry",
@@ -28,7 +28,7 @@
     "eye_rgb": "f0f3bd ffffff",
     "horn_rgb": "383838"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/cast.json
+++ b/project/assets/main/creatures/secondary/cast.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "cast",
   "name": "Cast",
   "short_name": "Cast",
@@ -28,7 +28,7 @@
     "eye_rgb": "d25e00 ffebff",
     "horn_rgb": "fa6400"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/chelle.json
+++ b/project/assets/main/creatures/secondary/chelle.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "chelle",
   "name": "Chelle",
   "short_name": "Chelle",
@@ -28,7 +28,7 @@
     "eye_rgb": "5ba964 a9e0bb",
     "horn_rgb": "fde9e7"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/chinta.json
+++ b/project/assets/main/creatures/secondary/chinta.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "chinta",
   "name": "Chinta",
   "short_name": "Chinta",
@@ -28,7 +28,7 @@
     "eye_rgb": "f2c12a ffffa2",
     "horn_rgb": "486965"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/cold.json
+++ b/project/assets/main/creatures/secondary/cold.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "cold",
   "name": "Cold",
   "short_name": "Cold",
@@ -28,7 +28,7 @@
     "eye_rgb": "415a73 c8cbd6",
     "horn_rgb": "ffe7e5"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/cough.json
+++ b/project/assets/main/creatures/secondary/cough.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "cough",
   "name": "Cough",
   "short_name": "Cough",
@@ -28,7 +28,7 @@
     "eye_rgb": "546127 a8ad89",
     "horn_rgb": "2b2b2b"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/darry.json
+++ b/project/assets/main/creatures/secondary/darry.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "darry",
   "name": "Darry",
   "short_name": "Darry",
@@ -28,7 +28,7 @@
     "eye_rgb": "e6c670 ffffd2",
     "horn_rgb": "bfb6b2"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/dingold.json
+++ b/project/assets/main/creatures/secondary/dingold.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "dingold",
   "name": "Dingold",
   "short_name": "Dingold",
@@ -26,7 +26,7 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/dreadhark.json
+++ b/project/assets/main/creatures/secondary/dreadhark.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "dreadhark",
   "name": "Dreadhark",
   "short_name": "Dreadhark",
@@ -28,7 +28,7 @@
     "eye_rgb": "4e8eee f8ffff",
     "horn_rgb": "f1e398"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/dusty.json
+++ b/project/assets/main/creatures/secondary/dusty.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "dusty",
   "name": "Dusty",
   "short_name": "Dusty",
@@ -28,7 +28,7 @@
     "eye_rgb": "25291b 606060",
     "horn_rgb": "e38a61"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/ebe.json
+++ b/project/assets/main/creatures/secondary/ebe.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "ebe",
   "name": "Ebe",
   "short_name": "Ebe",
@@ -24,7 +24,7 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.75,
     "accent_swapped": true,
     "accent_texture": 15,

--- a/project/assets/main/creatures/secondary/eech.json
+++ b/project/assets/main/creatures/secondary/eech.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "eech",
   "name": "Eech",
   "short_name": "Eech",
@@ -28,7 +28,7 @@
     "eye_rgb": "924a51 ffe8eb",
     "horn_rgb": "383838"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/eeeroy.json
+++ b/project/assets/main/creatures/secondary/eeeroy.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "eeeroy",
   "name": "Eeeroy",
   "short_name": "Eeeroy",
@@ -28,7 +28,7 @@
     "eye_rgb": "87b8f6 ffffff",
     "horn_rgb": "ffffff"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/flutter.json
+++ b/project/assets/main/creatures/secondary/flutter.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "flutter",
   "name": "Flutter",
   "short_name": "Flutter",
@@ -26,7 +26,7 @@
     "horn_rgb": "f4e6db",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/gall.json
+++ b/project/assets/main/creatures/secondary/gall.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "gall",
   "name": "Gall",
   "short_name": "Gall",
@@ -28,7 +28,7 @@
     "eye_rgb": "25291b 606060",
     "horn_rgb": "b9b9b9"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/goldfince.json
+++ b/project/assets/main/creatures/secondary/goldfince.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "goldfince",
   "name": "Goldfince",
   "short_name": "Goldfince",
@@ -28,7 +28,7 @@
     "eye_rgb": "74a27f fffaff",
     "horn_rgb": "e8a261"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/gongo.json
+++ b/project/assets/main/creatures/secondary/gongo.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "name": "Gongo",
   "short_name": "Gongo",
   "dna": {
@@ -27,7 +27,7 @@
     "eye_rgb": "ad1000 b73a36",
     "horn_rgb": "282727"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/gordo.json
+++ b/project/assets/main/creatures/secondary/gordo.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "gordo",
   "name": "Gordo",
   "short_name": "Gordo",
@@ -28,7 +28,7 @@
     "eye_rgb": "c09a2f f1e398",
     "horn_rgb": "d3af43"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/goris.json
+++ b/project/assets/main/creatures/secondary/goris.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "goris",
   "name": "Goris",
   "short_name": "Goris",
@@ -26,7 +26,7 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/i-n-cognito.json
+++ b/project/assets/main/creatures/secondary/i-n-cognito.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "i_n_cognito",
   "name": "I. N. Cognito",
   "short_name": "I. N. Cognito",
@@ -28,7 +28,7 @@
     "eye_rgb": "ce4224 fff6e3",
     "horn_rgb": "090909"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/kurtles.json
+++ b/project/assets/main/creatures/secondary/kurtles.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "name": "Kurtles",
   "short_name": "Kurtles",
   "dna": {
@@ -27,7 +27,7 @@
     "eye_rgb": "374265 eaf2f4",
     "horn_rgb": "c4c4c5"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/lango.json
+++ b/project/assets/main/creatures/secondary/lango.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "lango",
   "name": "Lango",
   "short_name": "Lango",
@@ -28,7 +28,7 @@
     "eye_rgb": "54c35c cdffd0",
     "horn_rgb": "529e43"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/leentil.json
+++ b/project/assets/main/creatures/secondary/leentil.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "leentil",
   "name": "Leentil",
   "short_name": "Leentil",
@@ -28,7 +28,7 @@
     "eye_rgb": "373535 879f9d",
     "horn_rgb": "f1e398"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/lisk.json
+++ b/project/assets/main/creatures/secondary/lisk.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "lisk",
   "name": "Lisk",
   "short_name": "Lisk",
@@ -28,7 +28,7 @@
     "eye_rgb": "7d4c21 e5cd7d",
     "horn_rgb": "e8a261"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/logana.json
+++ b/project/assets/main/creatures/secondary/logana.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "logana",
   "name": "Logana",
   "short_name": "Logana",
@@ -28,7 +28,7 @@
     "eye_rgb": "8458b9 daaed8",
     "horn_rgb": "529e43"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/magpird.json
+++ b/project/assets/main/creatures/secondary/magpird.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "magpird",
   "name": "Magpird",
   "short_name": "Magpird",
@@ -26,7 +26,7 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/mara.json
+++ b/project/assets/main/creatures/secondary/mara.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "mara",
   "name": "Mara",
   "short_name": "Mara",
@@ -28,7 +28,7 @@
     "eye_rgb": "282828 dedede",
     "horn_rgb": "f1e398"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/mcgoat.json
+++ b/project/assets/main/creatures/secondary/mcgoat.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "mcgoat",
   "name": "McGoat",
   "short_name": "McGoat",
@@ -28,7 +28,7 @@
     "eye_rgb": "c1f1f2 ffffff",
     "horn_rgb": "e1f9f9"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/mewow.json
+++ b/project/assets/main/creatures/secondary/mewow.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "mewow",
   "name": "Mewow",
   "short_name": "Mewow",
@@ -26,7 +26,7 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/minimax.json
+++ b/project/assets/main/creatures/secondary/minimax.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "minimax",
   "name": "Minimax",
   "short_name": "Minimax",
@@ -28,7 +28,7 @@
     "eye_rgb": "b8260b f45e40",
     "horn_rgb": "282828"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/miteby.json
+++ b/project/assets/main/creatures/secondary/miteby.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "miteby",
   "name": "Miteby",
   "short_name": "Miteby",
@@ -28,7 +28,7 @@
     "eye_rgb": "a6001e ff9c9c",
     "horn_rgb": "63426b"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/mocha.json
+++ b/project/assets/main/creatures/secondary/mocha.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "mocha",
   "name": "Mocha",
   "short_name": "Mocha",
@@ -26,7 +26,7 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/namory.json
+++ b/project/assets/main/creatures/secondary/namory.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "namory",
   "name": "Namory",
   "short_name": "Namory",
@@ -28,7 +28,7 @@
     "eye_rgb": "a58900 e3d48e",
     "horn_rgb": "b3b2b5"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/nard.json
+++ b/project/assets/main/creatures/secondary/nard.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "nard",
   "name": "Nard",
   "short_name": "Nard",
@@ -28,7 +28,7 @@
     "eye_rgb": "f0f3bd ffffff",
     "horn_rgb": "383838"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/nardine.json
+++ b/project/assets/main/creatures/secondary/nardine.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "nardine",
   "name": "Nardine",
   "short_name": "Nardine",
@@ -26,7 +26,7 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/nictor.json
+++ b/project/assets/main/creatures/secondary/nictor.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "nictor",
   "name": "Nictor",
   "short_name": "Nictor",
@@ -28,7 +28,7 @@
     "eye_rgb": "f9ca37 f3f39d",
     "horn_rgb": "202e2c"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/pairet.json
+++ b/project/assets/main/creatures/secondary/pairet.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "pairet",
   "name": "Pairet",
   "short_name": "Pairet",
@@ -28,7 +28,7 @@
     "eye_rgb": "8bb253 ffebff",
     "horn_rgb": "caf877"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/pandon.json
+++ b/project/assets/main/creatures/secondary/pandon.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "pandon",
   "name": "Pandon",
   "short_name": "Pandon",
@@ -26,7 +26,7 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/phoena.json
+++ b/project/assets/main/creatures/secondary/phoena.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "phoena",
   "name": "Phoena",
   "short_name": "Phoena",
@@ -28,7 +28,7 @@
     "eye_rgb": "7d4c21 e5cd7d",
     "horn_rgb": "c9d9bd"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/phthalo.json
+++ b/project/assets/main/creatures/secondary/phthalo.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "phthalo",
   "name": "Phthalo",
   "short_name": "Phthalo",
@@ -28,7 +28,7 @@
     "eye_rgb": "473b76 aba4ce",
     "horn_rgb": "fbc8cf"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/pipedro.json
+++ b/project/assets/main/creatures/secondary/pipedro.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "pipedro",
   "name": "Pipedro",
   "short_name": "Pipedro",
@@ -28,7 +28,7 @@
     "eye_rgb": "91e6ff ffffff",
     "horn_rgb": "fdfcec"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/ranpo.json
+++ b/project/assets/main/creatures/secondary/ranpo.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "ranpo",
   "name": "Ranpo",
   "short_name": "Ranpo",
@@ -28,7 +28,7 @@
     "eye_rgb": "5adf5a e4e4c8",
     "horn_rgb": "f7ecf1"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/raymon.json
+++ b/project/assets/main/creatures/secondary/raymon.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "raymon",
   "name": "Raymon",
   "short_name": "Raymon",
@@ -28,7 +28,7 @@
     "eye_rgb": "a58900 e3d48e",
     "horn_rgb": "c9d9bd"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/redo.json
+++ b/project/assets/main/creatures/secondary/redo.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "redo",
   "name": "Redo",
   "short_name": "Redo",
@@ -28,7 +28,7 @@
     "eye_rgb": "fad541 ffffff",
     "horn_rgb": "49663a"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/rex.json
+++ b/project/assets/main/creatures/secondary/rex.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "rex",
   "name": "Rex",
   "short_name": "Rex",
@@ -28,7 +28,7 @@
     "eye_rgb": "084f10 dedede",
     "horn_rgb": "f1e398"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/rhinosaur.json
+++ b/project/assets/main/creatures/secondary/rhinosaur.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "rhinosaur",
   "name": "Rhinosaur",
   "short_name": "Rhinosaur",
@@ -28,7 +28,7 @@
     "eye_rgb": "282828 dedede",
     "horn_rgb": "f1e398"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/rhonk.json
+++ b/project/assets/main/creatures/secondary/rhonk.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "rhonk",
   "name": "Rhonk",
   "short_name": "Rhonk",
@@ -26,7 +26,7 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/rice.json
+++ b/project/assets/main/creatures/secondary/rice.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "rice",
   "name": "Rice",
   "short_name": "Rice",
@@ -28,7 +28,7 @@
     "eye_rgb": "9d0505 ec3333",
     "horn_rgb": "f1e398"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/ricket.json
+++ b/project/assets/main/creatures/secondary/ricket.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "ricket",
   "name": "Ricket",
   "short_name": "Ricket",
@@ -28,7 +28,7 @@
     "eye_rgb": "3c3b30 828fac",
     "horn_rgb": "d4dedd"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/sandrew.json
+++ b/project/assets/main/creatures/secondary/sandrew.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "sandrew",
   "name": "Sandrew",
   "short_name": "Sandrew",
@@ -26,7 +26,7 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/sergia.json
+++ b/project/assets/main/creatures/secondary/sergia.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "sergia",
   "name": "Sergia",
   "short_name": "Sergia",
@@ -28,7 +28,7 @@
     "eye_rgb": "7ac252 e9f4dc",
     "horn_rgb": "bdc6c5"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/shinies.json
+++ b/project/assets/main/creatures/secondary/shinies.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "shinies",
   "name": "Shinies",
   "short_name": "Shinies",
@@ -28,7 +28,7 @@
     "eye_rgb": "9cc6ef dedede",
     "horn_rgb": "f1e398"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/sidger.json
+++ b/project/assets/main/creatures/secondary/sidger.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "sidger",
   "name": "Sidger",
   "short_name": "Sidger",
@@ -28,7 +28,7 @@
     "eye_rgb": "121011 4d6c6a",
     "horn_rgb": "828863"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/snorz.json
+++ b/project/assets/main/creatures/secondary/snorz.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "snorz",
   "name": "Snorz",
   "short_name": "Snorz",
@@ -26,7 +26,7 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/spood.json
+++ b/project/assets/main/creatures/secondary/spood.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "spood",
   "name": "Spood",
   "short_name": "Spood",
@@ -28,7 +28,7 @@
     "eye_rgb": "c1f1f2 ffffff",
     "horn_rgb": "f1e398"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/squawkapus.json
+++ b/project/assets/main/creatures/secondary/squawkapus.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "squawkapus",
   "name": "Sir Clarnacle Squawkapus George Rufus Branley VIII",
   "short_name": "Squawkapus",
@@ -26,7 +26,7 @@
     "horn_rgb": "caf877",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/stunker.json
+++ b/project/assets/main/creatures/secondary/stunker.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "stunker",
   "name": "Stunker",
   "short_name": "Stunker",
@@ -28,7 +28,7 @@
     "eye_rgb": "2c8619 a0e99f",
     "horn_rgb": "ac4577"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/terpion.json
+++ b/project/assets/main/creatures/secondary/terpion.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "terpion",
   "name": "Terpion",
   "short_name": "Terpion",
@@ -28,7 +28,7 @@
     "eye_rgb": "7d4c21 e5cd7d",
     "horn_rgb": "f1e398"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/toat.json
+++ b/project/assets/main/creatures/secondary/toat.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "toat",
   "name": "Toat",
   "short_name": "Toat",
@@ -28,7 +28,7 @@
     "eye_rgb": "ce4224 fff6e3",
     "horn_rgb": "e8a261"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/tork.json
+++ b/project/assets/main/creatures/secondary/tork.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "tork",
   "name": "Tork",
   "short_name": "Tork",
@@ -28,7 +28,7 @@
     "eye_rgb": "f5f0d1 ffffff",
     "horn_rgb": "282828"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/tunathy.json
+++ b/project/assets/main/creatures/secondary/tunathy.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "tunathy",
   "name": "Tunathy",
   "short_name": "Tunathy",
@@ -28,7 +28,7 @@
     "eye_rgb": "a7b958 ecf1bf",
     "horn_rgb": "f1e398"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/secondary/vile.json
+++ b/project/assets/main/creatures/secondary/vile.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "vile",
   "name": "Vile",
   "short_name": "Vile",
@@ -28,7 +28,7 @@
     "eye_rgb": "f6f200 faffa3",
     "horn_rgb": "fcfcfb"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/main/creatures/sensei/creature.json
+++ b/project/assets/main/creatures/sensei/creature.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "#sensei#",
   "name": "Turbo",
   "short_name": "Turbo",
@@ -26,12 +26,11 @@
     "bellybutton": "0",
     "accessory": "0"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.5,
     "accent_swapped": true,
     "accent_texture": 6,
-    "color": "a854cb",
-    "dark": false
+    "color": "a854cb"
   },
   "weight_gain_scale": 0
 }

--- a/project/assets/test/secondary-creatures/cold.json
+++ b/project/assets/test/secondary-creatures/cold.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "cold",
   "name": "Cold",
   "short_name": "Cold",
@@ -28,7 +28,7 @@
     "eye_rgb": "415a73 c8cbd6",
     "horn_rgb": "ffe7e5"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/test/secondary-creatures/cough.json
+++ b/project/assets/test/secondary-creatures/cough.json
@@ -1,5 +1,5 @@
 {
-  "version": "19dd",
+  "version": "375c",
   "id": "cough",
   "name": "Cough",
   "short_name": "Cough",
@@ -28,7 +28,7 @@
     "eye_rgb": "546127 a8ad89",
     "horn_rgb": "2b2b2b"
   },
-  "chat_theme_def": {
+  "chat_theme": {
     "accent_scale": 1.33,
     "accent_swapped": true,
     "accent_texture": 13,

--- a/project/assets/test/turbofat-36c3.json
+++ b/project/assets/test/turbofat-36c3.json
@@ -1,0 +1,51 @@
+[
+  {
+    "type": "version",
+    "value": "36c3"
+  },
+  {
+    "type": "creature_library",
+    "value": {
+      "#player#": {
+        "version": "19dd",
+        "id": "#player#",
+        "name": "Gong",
+        "short_name": "Gong",
+        "dna": {
+          "belly": "0",
+          "bellybutton": "1",
+          "body": "1",
+          "cheek": "4",
+          "collar": "0",
+          "ear": "9",
+          "eye": "8",
+          "hair": "0",
+          "head": "1",
+          "horn": "2",
+          "mouth": "3",
+          "nose": "2",
+          "tail": "7",
+          "accessory": "0",
+          "line_rgb": "41281e",
+          "body_rgb": "907027",
+          "belly_rgb": "e5d6b7",
+          "cloth_rgb": "d5c26a",
+          "glass_rgb": "232221",
+          "plastic_rgb": "d5c26a",
+          "hair_rgb": "544e42",
+          "eye_rgb": "d5c26a ffffff",
+          "horn_rgb": "afa7ae"
+        },
+        "chat_theme_def": {
+          "accent_scale": 1.33,
+          "accent_swapped": true,
+          "accent_texture": 13,
+          "color": "907027"
+        },
+        "fatness": 1,
+        "weight_gain_scale": 1,
+        "metabolism_scale": 1
+      }
+    }
+  }
+]

--- a/project/src/main/creature-library.gd
+++ b/project/src/main/creature-library.gd
@@ -88,7 +88,7 @@ func reset() -> void:
 	new_player_def.rename(CreatureDef.DEFAULT_NAME)
 	new_player_def.dna = CreatureDef.DEFAULT_DNA.duplicate()
 	new_player_def.min_fatness = 1.0
-	new_player_def.chat_theme_def = CreatureDef.DEFAULT_CHAT_THEME_DEF.duplicate()
+	new_player_def.chat_theme.from_json_dict(CreatureDef.DEFAULT_CHAT_THEME_JSON.duplicate())
 	set_player_def(new_player_def)
 	
 	var creature_def_paths := []

--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -83,7 +83,7 @@ func _mutate_creature(creature: Creature) -> void:
 		_mutate_allele(creature, dna, new_palette, allele)
 	
 	creature.dna = dna
-	creature.chat_theme_def = CreatureLoader.chat_theme_def(dna.get("chat_theme_def", {}))
+	creature.chat_theme.from_json_dict(dna.get("chat_theme", {}))
 
 
 ## Mutate a single allele.
@@ -285,7 +285,7 @@ func _tweak_creature(creature: Creature, allele: String, color_mode: int) -> voi
 				_recent_tweaked_allele_values[allele].append(dna[allele])
 	
 	creature.dna = dna
-	creature.chat_theme_def = CreatureLoader.chat_theme_def(dna.get("chat_theme_def", {}))
+	creature.chat_theme.from_json_dict(dna.get("chat_theme", {}))
 
 
 ## Randomly calculates a set of alleles to mutate.

--- a/project/src/main/player-save-upgrader.gd
+++ b/project/src/main/player-save-upgrader.gd
@@ -23,7 +23,8 @@ const PREFIX_REPLACEMENTS_2743 := {
 ## Creates and configures a SaveItemUpgrader capable of upgrading older player save formats.
 func new_save_item_upgrader() -> SaveItemUpgrader:
 	var upgrader := SaveItemUpgrader.new()
-	upgrader.current_version = "36c3"
+	upgrader.current_version = "375c"
+	upgrader.add_upgrade_method(self, "_upgrade_36c3", "36c3", "375c")
 	upgrader.add_upgrade_method(self, "_upgrade_27bb", "27bb", "36c3")
 	upgrader.add_upgrade_method(self, "_upgrade_2783", "2783", "27bb")
 	upgrader.add_upgrade_method(self, "_upgrade_2743", "2743", "2783")
@@ -38,6 +39,16 @@ func new_save_item_upgrader() -> SaveItemUpgrader:
 	upgrader.add_upgrade_method(self, "_upgrade_163e", "163e", "1682")
 	upgrader.add_upgrade_method(self, "_upgrade_15d2", "15d2", "163e")
 	return upgrader
+
+
+func _upgrade_36c3(save_item: SaveItem) -> SaveItem:
+	match save_item.type:
+		"creature_library":
+			if save_item.value.has("#player#"):
+				var creature_def := CreatureDef.new()
+				creature_def.from_json_dict(save_item.value["#player#"])
+				save_item.value["#player#"] = creature_def.to_json_dict()
+	return save_item
 
 
 func _upgrade_27bb(save_item: SaveItem) -> SaveItem:

--- a/project/src/main/player-save.gd
+++ b/project/src/main/player-save.gd
@@ -5,7 +5,7 @@ extends Node
 
 ## Current version for saved player data. Should be updated if and only if the player format changes.
 ## This version number follows a 'ymdh' hex date format which is documented in issue #234.
-const PLAYER_DATA_VERSION := "36c3"
+const PLAYER_DATA_VERSION := "375c"
 
 var rolling_backups := RollingBackups.new()
 

--- a/project/src/main/puzzle/tutorial/tutorial-messages.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-messages.gd
@@ -16,14 +16,14 @@ var _normal_font := preload("res://src/main/ui/blogger-sans-medium-30.tres")
 var _message_queue := []
 
 ## theme which affects the color and texture of chat messages
-var _sensei_chat_theme: ChatTheme
+var _sensei_chat_theme := ChatTheme.new()
 
 ## 'true' after pop_in is called, and 'false' after pop_out is called
 var _popped_in: bool
 
 func _ready() -> void:
 	var sensei_creature_def: CreatureDef = CreatureDef.new().from_json_path(Creatures.SENSEI_PATH)
-	_sensei_chat_theme = ChatTheme.new(sensei_creature_def.chat_theme_def)
+	_sensei_chat_theme = sensei_creature_def.chat_theme
 	_hide_message()
 
 

--- a/project/src/main/ui/chat/chat-event.gd
+++ b/project/src/main/ui/chat/chat-event.gd
@@ -35,15 +35,9 @@ var link_moods: Array
 var link_metas: Array
 
 ## The chat window changes its appearance based on who's talking. For example, one character's speech might be blue
-## with a black background, and giant blue soccer balls in the background. The 'chat_theme_def' property defines the
-## chat window's appearance, such as 'blue', 'soccer balls' and 'giant'.
-##
-## 'chat_theme_def/accent_scale': The scale of the accent's background texture
-## 'chat_theme_def/accent_swapped': If 'true', the accent's foreground/background colors will be swapped
-## 'chat_theme_def/accent_texture': A number in the range [0, 15] referring to a background texture
-## 'chat_theme_def/color': The color of the chat window
-## 'chat_theme_def/dark': True/false for whether the chat line window's background should be black/white
-var chat_theme_def: Dictionary
+## with a black background, and giant blue soccer balls in the background. The chat theme defines the chat window's
+## appearance, such as 'blue', 'soccer balls' and 'giant'.
+var chat_theme: ChatTheme = ChatTheme.new()
 
 func add_link(link: String, link_text: String, link_mood: int) -> void:
 	links.append(link)

--- a/project/src/main/ui/chat/chat-frame.gd
+++ b/project/src/main/ui/chat/chat-frame.gd
@@ -3,7 +3,7 @@ extends Control
 ## Window which displays a chat line.
 ##
 ## The chat window is decorated with objects in the background called 'accents'. These accents can be injected with the
-## chat_event.chat_theme_def property to configure the chat window's appearance.
+## chat_event.chat_theme property to configure the chat window's appearance.
 
 signal pop_out_completed
 
@@ -59,8 +59,6 @@ func play_chat_event(chat_event: ChatEvent, squished: bool) -> void:
 			$SquishTween.unsquish()
 		_squished = squished
 	
-	var chat_theme := ChatTheme.new(chat_event.chat_theme_def)
-	
 	# add lull characters
 	var text_with_lulls := ChatLibrary.add_lull_characters(chat_event.text)
 	
@@ -75,10 +73,10 @@ func play_chat_event(chat_event: ChatEvent, squished: bool) -> void:
 	$ChatLinePanel/NametagPanel.set_nametag_text(creature_name)
 	
 	# update the UI's appearance
-	$ChatLineLabel.update_appearance(chat_theme)
-	$ChatLinePanel.update_appearance(chat_theme, chat_line_size)
+	$ChatLineLabel.update_appearance(chat_event.chat_theme)
+	$ChatLinePanel.update_appearance(chat_event.chat_theme, chat_line_size)
 	var nametag_right: bool = chat_event.nametag_side == ChatEvent.NametagSide.RIGHT
-	$ChatLinePanel/NametagPanel.show_label(chat_theme, nametag_right)
+	$ChatLinePanel/NametagPanel.show_label(chat_event.chat_theme, nametag_right)
 
 
 func is_chat_window_showing() -> bool:

--- a/project/src/main/ui/chat/chatscript-parser.gd
+++ b/project/src/main/ui/chat/chatscript-parser.gd
@@ -239,7 +239,7 @@ class ChatState extends AbstractState:
 		_event.text = _event.text.c_unescape() # turn '\n' characters into newlines
 		var creature_def: CreatureDef = PlayerData.creature_library.get_creature_def(_event.who)
 		if creature_def:
-			_event.chat_theme_def = creature_def.chat_theme_def
+			_event.chat_theme = creature_def.chat_theme
 		var mood_prefix := StringUtils.substring_before(_event.text, " ")
 		if mood_prefix in MOOD_PREFIXES:
 			_event.mood = MOOD_PREFIXES[mood_prefix]
@@ -290,7 +290,7 @@ class ChatState extends AbstractState:
 		_event.text = _event.text.c_unescape() # turn '\n' characters into newlines
 		var creature_def: CreatureDef = PlayerData.creature_library.get_player_def()
 		if creature_def:
-			_event.chat_theme_def = creature_def.chat_theme_def
+			_event.chat_theme = creature_def.chat_theme
 		chat_tree.append(_branch_key, _event)
 	
 	

--- a/project/src/main/ui/nametag-panel.gd
+++ b/project/src/main/ui/nametag-panel.gd
@@ -18,7 +18,7 @@ onready var _labels := {
 
 func refresh_creature(creature: Creature) -> void:
 	set_nametag_text(creature.creature_name)
-	refresh_chat_theme(ChatTheme.new(creature.chat_theme_def))
+	refresh_chat_theme(creature.chat_theme)
 
 
 func refresh_chat_theme(chat_theme: ChatTheme) -> void:

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -105,7 +105,7 @@ func random_def(include_secondary_creatures: bool = false, creature_type: int = 
 		result = CreatureDef.new()
 		result.dna = DnaUtils.random_dna(creature_type)
 		result.rename(NameGeneratorLibrary.generate_name(creature_type))
-		result.chat_theme_def = chat_theme_def(result.dna)
+		result.chat_theme = chat_theme(result.dna)
 		# set the filler ID, but not the fatness. the fatness attribute in the CreatureDef is the creature's natural
 		# fatness -- not their fatness after being stuffed
 		result.creature_id = PlayerData.creature_library.next_filler_id()
@@ -113,10 +113,11 @@ func random_def(include_secondary_creatures: bool = false, creature_type: int = 
 
 
 ## Returns a chat theme definition for a generated creature.
-func chat_theme_def(dna: Dictionary) -> Dictionary:
-	var new_def: Dictionary = PlayerData.creature_library.player_def.chat_theme_def.duplicate()
-	new_def.color = dna.body_rgb
-	return new_def
+func chat_theme(dna: Dictionary) -> ChatTheme:
+	var new_theme := ChatTheme.new()
+	new_theme.from_json_dict(PlayerData.creature_library.player_def.chat_theme.to_json_dict())
+	new_theme.color = dna.body_rgb
+	return new_theme
 
 
 ## Returns an AnimationPlayer for the specified type type of mouth.

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -61,7 +61,7 @@ var chat_selectors: Array setget set_chat_selectors
 
 var creature_name: String setget set_creature_name
 var creature_short_name: String
-var chat_theme_def: Dictionary setget set_chat_theme_def
+var chat_theme := ChatTheme.new() setget set_chat_theme
 var chat_extents: Vector2 setget ,get_chat_extents
 
 ## the direction the creature wants to move, in isometric and non-isometric coordinates
@@ -233,9 +233,9 @@ func set_creature_name(new_creature_name: String) -> void:
 	emit_signal("creature_name_changed")
 
 
-func set_chat_theme_def(new_chat_theme_def: Dictionary) -> void:
-	chat_theme_def = new_chat_theme_def
-	set_meta("chat_theme_def", chat_theme_def)
+func set_chat_theme(new_chat_theme: ChatTheme) -> void:
+	chat_theme = new_chat_theme
+	set_meta("chat_theme", chat_theme)
 
 
 ## Plays a movement animation with the specified prefix and direction, such as a 'run' animation going left.
@@ -343,7 +343,7 @@ func restart_idle_timer() -> void:
 func set_creature_def(new_creature_def: CreatureDef) -> void:
 	creature_id = new_creature_def.creature_id
 	set_dna(new_creature_def.dna)
-	set_chat_theme_def(new_creature_def.chat_theme_def)
+	set_chat_theme(new_creature_def.chat_theme)
 	set_creature_name(new_creature_def.creature_name)
 	creature_short_name = new_creature_def.creature_short_name
 	set_chat_selectors(new_creature_def.chat_selectors)
@@ -364,7 +364,8 @@ func get_creature_def() -> CreatureDef:
 	var result := CreatureDef.new()
 	result.creature_id = creature_id
 	result.dna = DnaUtils.trim_dna(dna)
-	result.chat_theme_def = chat_theme_def
+	# create a copy to prevent our chat theme from being modified accidentally
+	result.chat_theme.from_json_dict(chat_theme.to_json_dict())
 	result.creature_name = creature_name
 	result.creature_short_name = creature_short_name
 	result.chat_selectors = chat_selectors

--- a/project/src/test/test-player-save-upgrader.gd
+++ b/project/src/test/test-player-save-upgrader.gd
@@ -148,3 +148,14 @@ func test_27bb() -> void:
 	
 	# changed 'max_distance_travelled' to 'best_distance_travelled'
 	assert_eq(PlayerData.career.best_distance_travelled, 167)
+
+
+func test_36c3() -> void:
+	load_legacy_player_data("turbofat-36c3.json")
+	
+	# changed 'chat_theme_def' to 'chat_theme
+	assert_eq(PlayerData.creature_library.player_def.chat_theme.accent_scale, 1.33)
+	assert_eq(PlayerData.creature_library.player_def.chat_theme.accent_swapped, true)
+	assert_eq(PlayerData.creature_library.player_def.chat_theme.accent_texture_index, 13)
+	assert_eq(PlayerData.creature_library.player_def.chat_theme.color, Color("907027"))
+	assert_eq(PlayerData.creature_library.player_def.chat_theme.dark, false)


### PR DESCRIPTION
Before, we were storing dictionaries and only converting them to chat
themes on demand, resulting in effectively two distinct data models we
had to toggle between, and opening the door for mistyped strings instead
of strongly typed variable names.

We now store chat themes as objects throughout our code, they are only
stored as dictionaries briefly while being parsed or stored as json.

Changed 'chat_theme_def' in our json files to 'chat_theme' as well.
Upgraded all creatures to version 375c. This also requires a player dat
upgrade, as each save file defines the player's appearance and chat
theme.