### PR TITLE
CreatureEditor randomizes chat themes.

### DIFF
--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -71,8 +71,9 @@ func mutate_all_creatures() -> void:
 func _mutate_creature(creature: Creature) -> void:
 	var new_palette: Dictionary = _palette()
 	
-	# copy the center creature's dna, name, weight
+	# copy the center creature's dna, name, weight, chat theme
 	creature.creature_def = center_creature.creature_def
+	
 	var dna := {}
 	for allele in DnaUtils.ALLELES:
 		if center_creature.dna.has(allele):
@@ -83,7 +84,7 @@ func _mutate_creature(creature: Creature) -> void:
 		_mutate_allele(creature, dna, new_palette, allele)
 	
 	creature.dna = dna
-	creature.chat_theme.from_json_dict(dna.get("chat_theme", {}))
+	creature.chat_theme = CreatureLoader.chat_theme(dna) # generate a new chat theme
 
 
 ## Mutate a single allele.
@@ -228,8 +229,9 @@ func _tweak_creature(creature: Creature, allele: String, color_mode: int) -> voi
 		# leave the line color alone
 		palette["line_rgb"] = center_creature.dna["line_rgb"]
 	
-	# copy the center creature's dna, name, weight
+	# copy the center creature's dna, name, weight, chat theme
 	creature.creature_def = center_creature.creature_def
+	
 	var dna := {}
 	for allele in DnaUtils.ALLELES:
 		if center_creature.dna.has(allele):
@@ -285,7 +287,7 @@ func _tweak_creature(creature: Creature, allele: String, color_mode: int) -> voi
 				_recent_tweaked_allele_values[allele].append(dna[allele])
 	
 	creature.dna = dna
-	creature.chat_theme.from_json_dict(dna.get("chat_theme", {}))
+	creature.chat_theme = CreatureLoader.chat_theme(dna) # generate a new chat theme
 
 
 ## Randomly calculates a set of alleles to mutate.

--- a/project/src/main/world/creature/creature-def.gd
+++ b/project/src/main/world/creature/creature-def.gd
@@ -143,7 +143,6 @@ func from_json_path(path: String) -> Object:
 		if not creature_short_name:
 			creature_short_name = DEFAULT_NAME
 		if not parsed.has("chat_theme"):
-			chat_theme = ChatTheme.new()
 			chat_theme.from_json_dict(DEFAULT_CHAT_THEME_JSON)
 	else:
 		result = null

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -115,8 +115,17 @@ func random_def(include_secondary_creatures: bool = false, creature_type: int = 
 ## Returns a chat theme definition for a generated creature.
 func chat_theme(dna: Dictionary) -> ChatTheme:
 	var new_theme := ChatTheme.new()
-	new_theme.from_json_dict(PlayerData.creature_library.player_def.chat_theme.to_json_dict())
+	new_theme.accent_scale = Utils.rand_value([
+			0.50, 0.58, 0.67, 0.75, 0.88,
+			1.00, 1.15, 1.33, 1.50, 1.75,
+			2.00, 2.30, 2.66, 3.00, 3.50,
+			4.00, 4.60, 5.33, 6.00, 7.00,
+			8.00
+	])
+	new_theme.accent_swapped = randf() > 0.5
+	new_theme.accent_texture_index = randi() % ChatLinePanel.CHAT_TEXTURE_COUNT
 	new_theme.color = dna.body_rgb
+	new_theme.dark = randf() > 0.5
 	return new_theme
 
 


### PR DESCRIPTION
The CreatureEditor has no way of editing chat themes, so it was giving
all creatures the same theme. It now randomizes the themes.