### PR TITLE
Bug: successful_levels entries missing from finished_levels

### DIFF
--- a/project/assets/test/turbofat-375c.json
+++ b/project/assets/test/turbofat-375c.json
@@ -1,0 +1,26 @@
+[
+  {
+    "type": "version",
+    "value": "375c"
+  },
+  {
+    "type": "successful_levels",
+    "value": {
+      "practice/marathon_normal": {
+        "year": 2020,
+        "month": 9,
+        "day": 24,
+        "weekday": 4,
+        "dst": false,
+        "hour": 19,
+        "minute": 49,
+        "second": 36
+      }
+    }
+  },
+  {
+    "type": "finished_levels",
+    "value": {
+    }
+  }
+]

--- a/project/src/main/player-save-upgrader.gd
+++ b/project/src/main/player-save-upgrader.gd
@@ -23,7 +23,8 @@ const PREFIX_REPLACEMENTS_2743 := {
 ## Creates and configures a SaveItemUpgrader capable of upgrading older player save formats.
 func new_save_item_upgrader() -> SaveItemUpgrader:
 	var upgrader := SaveItemUpgrader.new()
-	upgrader.current_version = "375c"
+	upgrader.current_version = "3776"
+	upgrader.add_upgrade_method(self, "_upgrade_375c", "375c", "3776")
 	upgrader.add_upgrade_method(self, "_upgrade_36c3", "36c3", "375c")
 	upgrader.add_upgrade_method(self, "_upgrade_27bb", "27bb", "36c3")
 	upgrader.add_upgrade_method(self, "_upgrade_2783", "2783", "27bb")
@@ -41,7 +42,25 @@ func new_save_item_upgrader() -> SaveItemUpgrader:
 	return upgrader
 
 
-func _upgrade_36c3(save_item: SaveItem) -> SaveItem:
+## Save data prior to 375c had a bug where successful levels weren't recorded as finished levels. We locate the
+## successful levels entries and copy them over to the finished levels to fill in the gaps.
+func _upgrade_375c(old_save_items: Array, save_item: SaveItem) -> SaveItem:
+	match save_item.type:
+		"finished_levels":
+			# locate the successful_levels entries
+			var successful_levels := {}
+			for old_save_item in old_save_items:
+				if old_save_item.get("type", "") == "successful_levels":
+					successful_levels = old_save_item.value
+			
+			# copy over any missing successful_levels entries to finished_levels
+			for key in successful_levels:
+				if not save_item.value.has(key):
+					save_item.value[key] = successful_levels[key]
+	return save_item
+
+
+func _upgrade_36c3(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"creature_library":
 			if save_item.value.has("#player#"):
@@ -51,7 +70,7 @@ func _upgrade_36c3(save_item: SaveItem) -> SaveItem:
 	return save_item
 
 
-func _upgrade_27bb(save_item: SaveItem) -> SaveItem:
+func _upgrade_27bb(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"career":
 			save_item.value["best_distance_travelled"] = save_item.value.get("max_distance_travelled", 0)
@@ -59,7 +78,7 @@ func _upgrade_27bb(save_item: SaveItem) -> SaveItem:
 	return save_item
 
 
-func _upgrade_2783(save_item: SaveItem) -> SaveItem:
+func _upgrade_2783(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"player_info":
 			var money: int = save_item.value.get("money", 0)
@@ -75,7 +94,7 @@ func _upgrade_2783(save_item: SaveItem) -> SaveItem:
 	return save_item
 
 
-func _upgrade_2743(save_item: SaveItem) -> SaveItem:
+func _upgrade_2743(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"chat_history":
 			_replace_chat_history_prefixes_for_2743(save_item.value)
@@ -114,7 +133,7 @@ func _replace_fatness_keys_for_2743(dict: Dictionary) -> void:
 			dict.erase(key)
 
 
-func _upgrade_24cc(save_item: SaveItem) -> SaveItem:
+func _upgrade_24cc(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"chat_history":
 			_replace_dialog_with_chat(save_item.value.get("history_items", {}))
@@ -131,7 +150,7 @@ func _replace_dialog_with_chat(dict: Dictionary) -> void:
 			dict.erase(key)
 
 
-func _upgrade_245b(save_item: SaveItem) -> SaveItem:
+func _upgrade_245b(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"level_history":
 			if save_item.key in [
@@ -144,7 +163,7 @@ func _upgrade_245b(save_item: SaveItem) -> SaveItem:
 	return save_item
 
 
-func _upgrade_1b3c(save_item: SaveItem) -> SaveItem:
+func _upgrade_1b3c(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"level_history":
 			save_item.key = _upgrade_1b3c_level_id(save_item.key)
@@ -165,7 +184,7 @@ func _upgrade_1b3c_level_id(value: String) -> String:
 	return new_value
 
 
-func _upgrade_19c5(save_item: SaveItem) -> SaveItem:
+func _upgrade_19c5(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"level_history":
 			save_item.key = _upgrade_199c_level_id(save_item.key)
@@ -179,7 +198,7 @@ func _upgrade_19c5(save_item: SaveItem) -> SaveItem:
 	return save_item
 
 
-func _upgrade_199c(save_item: SaveItem) -> SaveItem:
+func _upgrade_199c(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"scenario_history":
 			save_item.type = "level_history"
@@ -206,7 +225,7 @@ func _upgrade_199c_level_id(value: String) -> String:
 	return new_value
 
 
-func _upgrade_1922(save_item: SaveItem) -> SaveItem:
+func _upgrade_1922(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"chat_history":
 			_replace_dialog_with_creatures_primary(save_item.value)
@@ -225,7 +244,7 @@ func _replace_dialog_with_creatures_primary(dict: Dictionary) -> void:
 					sub_dict.erase(key)
 
 
-func _upgrade_1682(save_item: SaveItem) -> SaveItem:
+func _upgrade_1682(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"chat-history":
 			save_item.type = StringUtils.hyphens_to_underscores(save_item.type)
@@ -248,7 +267,7 @@ func _replace_key_hyphens_with_underscores(dict: Dictionary) -> void:
 			dict.erase(key)
 
 
-func _upgrade_163e(save_item: SaveItem) -> SaveItem:
+func _upgrade_163e(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"scenario-history":
 			for rank_result_obj in save_item.value:
@@ -258,7 +277,7 @@ func _upgrade_163e(save_item: SaveItem) -> SaveItem:
 	return save_item
 
 
-func _upgrade_15d2(save_item: SaveItem) -> SaveItem:
+func _upgrade_15d2(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"scenario-history":
 			match save_item.key:

--- a/project/src/main/player-save.gd
+++ b/project/src/main/player-save.gd
@@ -5,7 +5,7 @@ extends Node
 
 ## Current version for saved player data. Should be updated if and only if the player format changes.
 ## This version number follows a 'ymdh' hex date format which is documented in issue #234.
-const PLAYER_DATA_VERSION := "375c"
+const PLAYER_DATA_VERSION := "3776"
 
 var rolling_backups := RollingBackups.new()
 

--- a/project/src/main/puzzle/level/level-history.gd
+++ b/project/src/main/puzzle/level/level-history.gd
@@ -100,7 +100,7 @@ func add_result(level_id: String, rank_result: RankResult) -> void:
 	rank_results[level_id].push_front(rank_result)
 	if rank_result.success and not successful_levels.has(level_id):
 		successful_levels[level_id] = OS.get_datetime()
-	if not rank_result.lost and not successful_levels.has(level_id):
+	if not rank_result.lost and not finished_levels.has(level_id):
 		finished_levels[level_id] = OS.get_datetime()
 
 

--- a/project/src/main/save-item-upgrader.gd
+++ b/project/src/main/save-item-upgrader.gd
@@ -31,9 +31,9 @@ var current_version := ""
 ## SaveItemUpgrader does not have logic for upgrading specific save data versions. This upgrade logic must be defined
 ## on an external object and incorporated via this 'add_upgrade_method' method.
 ##
-## The specified upgrade method should accept a SaveData object and return a modified SaveData object. The upgrade
-## method can also return null, in which case SaveItemUpgrader will omit the SaveData object from the list of upgraded
-## save items.
+## The specified upgrade method should accept an Array of source data and a SaveData object, and return a modified
+## SaveData object. The upgrade method can also return null, in which case SaveItemUpgrader will omit the SaveData
+## object from the list of upgraded save items.
 ##
 ## Parameters:
 ## 	'object': The object containing the method
@@ -87,7 +87,7 @@ func upgrade(json_save_items: Array) -> Array:
 				"version":
 					save_item.value = upgrade_method.new_version
 				_:
-					save_item = upgrade_method.object.call(upgrade_method.method, save_item)
+					save_item = upgrade_method.object.call(upgrade_method.method, old_save_items, save_item)
 			
 			if save_item:
 				new_save_items.append(save_item.to_json_dict())

--- a/project/src/main/system-save-upgrader.gd
+++ b/project/src/main/system-save-upgrader.gd
@@ -23,14 +23,14 @@ func new_save_item_upgrader() -> SaveItemUpgrader:
 	return upgrader
 
 
-func _upgrade_2783(save_item: SaveItem) -> SaveItem:
+func _upgrade_2783(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"chat_history", "creature_library", "finished_levels", "level_history", "player_info", "successful_levels":
 			save_item = null
 	return save_item
 
 
-func _upgrade_2743(save_item: SaveItem) -> SaveItem:
+func _upgrade_2743(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"miscellaneous_settings":
 			save_item.type = "misc_settings"

--- a/project/src/test/puzzle/level/test-level-history.gd
+++ b/project/src/test/puzzle/level/test-level-history.gd
@@ -70,3 +70,12 @@ func test_daily_best_no_duplicates() -> void:
 	
 	var best_results := _level_history.best_results("level_895", true)
 	assert_eq(best_results.size(), 2)
+
+
+func test_finished_successful() -> void:
+	var result := rank_result()
+	result.lost = false
+	result.success = true
+	_level_history.add_result("level_895", result)
+	assert_eq(_level_history.finished_levels.keys(), ["level_895"])
+	assert_eq(_level_history.successful_levels.keys(), ["level_895"])

--- a/project/src/test/test-player-save-upgrader.gd
+++ b/project/src/test/test-player-save-upgrader.gd
@@ -159,3 +159,10 @@ func test_36c3() -> void:
 	assert_eq(PlayerData.creature_library.player_def.chat_theme.accent_texture_index, 13)
 	assert_eq(PlayerData.creature_library.player_def.chat_theme.color, Color("907027"))
 	assert_eq(PlayerData.creature_library.player_def.chat_theme.dark, false)
+
+
+func test_375c() -> void:
+	load_legacy_player_data("turbofat-375c.json")
+	
+	# added missing 'finished_level' entries -- successful levels weren't recorded as finished
+	assert_eq(PlayerData.level_history.finished_levels.keys(), ["practice/marathon_normal"])


### PR DESCRIPTION
A typo in the LevelHistory script made it so that if the player was
successful in a level (e.g clearing 100 lines in Marathon Normal) the
level was added to LevelHistory.successful_levels, but not to
LevelHistory.finished_levels. I've fixed the bug.

This bug affects player save data, as any finished levels in earlier
versions were not recorded. I've upgraded the player data to 3776 and
added a translation step which fills any gaps in finished_levels with
their entries from successful_levels.