### PR TITLE
Paranormal tetrominon box building tweaks.

### DIFF
--- a/project/src/main/puzzle/box-builder.gd
+++ b/project/src/main/puzzle/box-builder.gd
@@ -146,13 +146,17 @@ func process_boxes() -> bool:
 	var dt4 := _filled_rectangles(db, 4)
 	var dt5 := _filled_rectangles(db, 5)
 	
-	for y in range(PuzzleTileMap.ROW_COUNT):
+	for hi_y in range(PuzzleTileMap.ROW_COUNT):
 		for x in range(PuzzleTileMap.COL_COUNT):
-			if dt5[y][x] >= 3 and _process_box(x, y, 3, 5): return true
-			if dt4[y][x] >= 3 and _process_box(x, y, 3, 4): return true
-			if dt3[y][x] >= 3 and _process_box(x, y, 3, 3): return true
-			if dt3[y][x] >= 4 and _process_box(x, y, 4, 3): return true
-			if dt3[y][x] >= 5 and _process_box(x, y, 5, 3): return true
+			# Process boxes from bottom to top, to hopefully match a typical player's intent. If multiple boxes can
+			# be made, it's better to leave an incomplete box at the top of the playfield rather than being buried at
+			# the bottom.
+			var lo_y := PuzzleTileMap.ROW_COUNT - hi_y - 1
+			if dt5[lo_y][x] >= 3 and _process_box(x, lo_y, 3, 5): return true
+			if dt4[lo_y][x] >= 3 and _process_box(x, lo_y, 3, 4): return true
+			if dt3[lo_y][x] >= 3 and _process_box(x, lo_y, 3, 3): return true
+			if dt3[lo_y][x] >= 4 and _process_box(x, lo_y, 4, 3): return true
+			if dt3[lo_y][x] >= 5 and _process_box(x, lo_y, 5, 3): return true
 	return false
 
 

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -191,7 +191,12 @@ func _on_LineClearer_line_deleted(y: int) -> void:
 
 func _on_LineClearer_after_lines_deleted() -> void:
 	emit_signal("after_lines_deleted")
-	PuzzleState.after_piece_written()
+	
+	# On levels with weird pieces, clearing a line can create a box. If this happens we delay the
+	# 'after_piece_written' signal until after the box is built
+	_box_builder.process_boxes()
+	if _box_builder.remaining_box_build_frames <= 0:
+		PuzzleState.after_piece_written()
 
 
 func _on_GoopGlobs_hit_playfield(glob: Node) -> void:


### PR DESCRIPTION
In Paranormal Tetrominon it's possible for a line clear to create a 3x4.
Before, this new box would only be created when the player dropped a
piece which looked strange. It is now created immediately following the
line clear.

In Paranormal Tetrominon it's possible for a piece to build two possible
boxes at once, such as by sliding a second O piece between two horizontal line
pieces. Before, this would always create the top box which was
inconvenient. It now creates the bottom box so the player can continue
working on the top box.