### PR TITLE
Moved close buttons to corner. Changed shortcut.

### DIFF
--- a/project/src/main/ui/menu/CareerRegionSelectMenu.tscn
+++ b/project/src/main/ui/menu/CareerRegionSelectMenu.tscn
@@ -112,10 +112,8 @@ margin_top = 132.0
 margin_right = 398.0
 margin_bottom = 158.0
 rect_min_size = Vector2( 24, 24 )
-focus_mode = 0
 size_flags_vertical = 4
 theme = ExtResource( 15 )
-enabled_focus_mode = 0
 text = "<"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="RegionSelect/VBoxContainer/Top/RegionButtons"]
@@ -134,10 +132,8 @@ margin_top = 132.0
 margin_right = 530.0
 margin_bottom = 158.0
 rect_min_size = Vector2( 24, 24 )
-focus_mode = 0
 size_flags_vertical = 4
 theme = ExtResource( 15 )
-enabled_focus_mode = 0
 text = ">"
 
 [node name="GradeLabels" type="Control" parent="RegionSelect/VBoxContainer/Top"]
@@ -241,8 +237,8 @@ alignment = 2
 [node name="BackButton" parent="Buttons/Northeast" instance=ExtResource( 6 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_left = 292.0
-margin_right = 392.0
+margin_left = 402.0
+margin_right = 502.0
 margin_bottom = 100.0
 size_flags_horizontal = 0
 shortcut = SubResource( 2 )
@@ -252,14 +248,7 @@ normal_icon = ExtResource( 8 )
 pressed_icon = ExtResource( 9 )
 
 [node name="ShortcutHelper" parent="Buttons/Northeast/BackButton" instance=ExtResource( 1 )]
-action = "phone"
-
-[node name="Spacer" type="Control" parent="Buttons/Northeast"]
-margin_left = 402.0
-margin_right = 502.0
-margin_bottom = 100.0
-rect_min_size = Vector2( 100, 100 )
-mouse_filter = 2
+action = "ui_cancel"
 
 [node name="MusicPopup" parent="." instance=ExtResource( 3 )]
 

--- a/project/src/main/ui/menu/TutorialMenu.tscn
+++ b/project/src/main/ui/menu/TutorialMenu.tscn
@@ -67,8 +67,8 @@ __meta__ = {
 [node name="BackButton" parent="Buttons/Northeast" instance=ExtResource( 2 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_left = 292.0
-margin_right = 392.0
+margin_left = 402.0
+margin_right = 502.0
 margin_bottom = 100.0
 size_flags_horizontal = 0
 shortcut = SubResource( 2 )
@@ -78,14 +78,7 @@ normal_icon = ExtResource( 4 )
 pressed_icon = ExtResource( 5 )
 
 [node name="ShortcutHelper" parent="Buttons/Northeast/BackButton" instance=ExtResource( 1 )]
-action = "phone"
-
-[node name="Spacer" type="Control" parent="Buttons/Northeast"]
-margin_left = 402.0
-margin_right = 502.0
-margin_bottom = 100.0
-rect_min_size = Vector2( 100, 100 )
-mouse_filter = 2
+action = "ui_cancel"
 
 [node name="MusicPopup" parent="." instance=ExtResource( 7 )]
 


### PR DESCRIPTION
The first 'Close' button was made to close the map menu so it had some
weird idiosyncracies. It had a small gap left for the settings menu, and
it closed with the 'Tab' key because this is the way the menu was
opened. None of these idiosyncracies make sense for the
Tutorial/CareerRegion menu, so I've reverted them. The buttons are in
the corner, and the menus close with escape not tab.