### PR TITLE
Level button/grade color tweaks.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -419,7 +419,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/world/letter-shooter.gd"
 }, {
-"base": "Control",
+"base": "Reference",
 "class": "LevelButtons",
 "language": "GDScript",
 "path": "res://src/main/ui/level-select/level-buttons.gd"

--- a/project/src/demo/ui/level-select/LevelSelectButtonDemo.tscn
+++ b/project/src/demo/ui/level-select/LevelSelectButtonDemo.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://src/demo/ui/level-select/level-select-button-demo.gd" type="Script" id=1]
+[ext_resource path="res://src/main/ui/level-select/LevelSelectButton.tscn" type="PackedScene" id=2]
+[ext_resource path="res://src/main/ui/level-select/HookableLevelGradeLabel.tscn" type="PackedScene" id=3]
+[ext_resource path="res://src/main/ui/level-select/level-grade-labels.gd" type="Script" id=4]
+
+[node name="Demo" type="Node"]
+script = ExtResource( 1 )
+LevelButtonScene = ExtResource( 2 )
+
+[node name="Control" type="Control" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 50.0
+margin_top = 50.0
+margin_right = -50.0
+margin_bottom = -50.0
+
+[node name="GridContainer" type="GridContainer" parent="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_vertical = 4
+columns = 6
+
+[node name="GradeLabels" type="Control" parent="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+script = ExtResource( 4 )
+GradeLabelScene = ExtResource( 3 )

--- a/project/src/demo/ui/level-select/level-select-button-demo.gd
+++ b/project/src/demo/ui/level-select/level-select-button-demo.gd
@@ -1,0 +1,54 @@
+extends Node
+## Non-interactive demo which shows the different labels and icons for level buttons.
+
+export (PackedScene) var LevelButtonScene: PackedScene
+
+onready var _grid_container := $Control/GridContainer
+onready var _grade_labels := $Control/GradeLabels
+
+func _ready() -> void:
+	PlayerData.level_history.reset()
+	
+	# add buttons for different ranks
+	for rank in [
+			0.0,
+			4.0,
+			10.0,
+			20.0,
+			36.0,
+			44.0,
+			60.0,
+			80.0]:
+		var button := _button()
+		var rank_result := RankResult.new()
+		rank_result.score_rank = rank
+		PlayerData.level_history.add_result(button.level_id, rank_result)
+		_add_button(button)
+	
+	for lock_status in [
+			LevelLock.STATUS_KEY,
+			LevelLock.STATUS_CROWN,
+			LevelLock.STATUS_CLEARED,
+			LevelLock.STATUS_SOFT_LOCK]:
+		var button := _button()
+		button.lock_status = lock_status
+		_add_button(button)
+
+
+## Returns a new LevelSelectButton with a default generated level.
+func _button() -> LevelSelectButton:
+	var button_index := _grade_labels.get_child_count()
+	
+	var button: LevelSelectButton = LevelButtonScene.instance()
+	button.level_id = "level_%03d" % [button_index]
+	button.level_title = "Level %03d" % [button_index]
+	button.rect_min_size.x = 120
+	button.level_column_width = 120
+	
+	return button
+
+
+## Adds the specified button and generates a grade label.
+func _add_button(button: LevelSelectButton) -> void:
+	_grid_container.add_child(button)
+	_grade_labels.add_label(button)

--- a/project/src/main/ui/level-select/grade-label.gd
+++ b/project/src/main/ui/level-select/grade-label.gd
@@ -12,19 +12,17 @@ func refresh_color_from_text() -> void:
 	var outline_darkness := 0.2
 	match text:
 		"M":
-			font_color.h = 0.1250 # near-white
-			font_color.s = 0.0600
+			font_color = Color("fffbf0") # near-white
 			outline_darkness = 0.1
 		"SSS":
-			font_color.h = 0.1250 # bright yellow
-			font_color.s = 0.4444
+			font_color = Color("ffe38e") # bright yellow
 			outline_darkness = 0.15
-		"SS+", "SS": font_color.h = 0.1250 # yellow
-		"S+", "S", "S-": font_color.h = 0.2861 # green
-		"AA+", "AA": font_color.h = 0.4667 # cyan
-		"A+", "A", "A-": font_color.h = 0.5889 # blue
-		"B+", "B", "B-": font_color.h = 0.7472 # purple
-		"-": font_color.s = 0.0
+		"SS+", "SS": font_color = Color("ffd249") # yellow
+		"S+", "S", "S-": font_color = Color("7dff49") # green
+		"AA+", "AA": font_color = Color("4affdb") # cyan
+		"A+", "A", "A-": font_color = Color("4a9fff") # blue
+		"B+", "B", "B-": font_color = Color("a24aff") # purple
+		"-": font_color = Color("999999") # grey
 	set("custom_colors/font_color", font_color)
 	
 	# assign the font outline color based on the font color and outline_darkness

--- a/project/src/main/ui/level-select/hookable-level-grade-label.gd
+++ b/project/src/main/ui/level-select/hookable-level-grade-label.gd
@@ -80,26 +80,30 @@ func _refresh_status_icon(lock_status: int) -> void:
 	_grade_label.visible = false
 	_status_icon.visible = true
 	
-	var outline_color: Color = Color("b39a8f")
+	var icon_color := Color("4eff49") # green
+	var outline_darkness := 0.2
+	var outline_color := Color("b39a8f") # light brown tint. the outline is also colored by the modulate property
 	match lock_status:
 		LevelLock.STATUS_NONE:
 			_status_icon.texture = null
-			_status_icon.modulate = Color.white
+			icon_color = Color.white
 		LevelLock.STATUS_CLEARED:
 			_status_icon.texture = _cleared_texture
-			_status_icon.modulate = Color("36d936")
+			icon_color = Color("7dff49") # green
 		LevelLock.STATUS_CROWN:
 			_status_icon.texture = _crown_texture
-			_status_icon.modulate = Color("36d936")
+			icon_color = Color("ffd249") # yellow
 		LevelLock.STATUS_KEY:
 			_status_icon.texture = _key_texture
-			_status_icon.modulate = Color("36d936")
+			icon_color = Color("7dff49") # green
 		LevelLock.STATUS_SOFT_LOCK:
 			_status_icon.texture = _locked_texture
-			_status_icon.modulate = Color("666666")
-			outline_color = Color("808080")
+			icon_color = Color("888888")
+			outline_darkness = 0.00
 		_:
 			push_warning("Unexpected lock status: %s" % [lock_status])
+	
+	_status_icon.modulate = icon_color
 	_status_icon.material.set("shader_param/black", outline_color)
 
 

--- a/project/src/main/ui/level-select/level-select-button.gd
+++ b/project/src/main/ui/level-select/level-select-button.gd
@@ -17,6 +17,13 @@ enum LevelSize {
 	LONG
 }
 
+const BUTTON_COLOR_RED := Color("e35274")
+const BUTTON_COLOR_ORANGE := Color("e37452")
+const BUTTON_COLOR_YELLOW := Color("e3bf52")
+const BUTTON_COLOR_GREEN := Color("7be352")
+const BUTTON_COLOR_BLUE := Color("52afe3")
+const BUTTON_COLOR_PURPLE := Color("9852e3")
+
 const SHORT := LevelSize.SHORT
 const MEDIUM := LevelSize.MEDIUM
 const LONG := LevelSize.LONG
@@ -26,7 +33,7 @@ const VERTICAL_SPACING := 6
 var world_id: String
 var level_id: String
 
-## the duration of the level; this affects the button size
+## an enum from LevelSize for the duration of the level. this affects the button size
 var level_duration: int = LevelSize.MEDIUM setget set_level_duration
 
 ## the width of the column this button is in
@@ -50,6 +57,9 @@ var _focus_just_entered := false
 ## 'true' if the 'level started' signal should be emitted in response to a button click.
 var _emit_level_started := false
 
+## The button's background color. If omitted, the button will use a pseudo-random background color based on its id
+var bg_color: Color setget set_bg_color
+
 onready var _label := $Label
 
 func _ready() -> void:
@@ -61,7 +71,12 @@ func _process(_delta: float) -> void:
 	_focus_just_entered = false
 
 
-func set_bg_color(color: Color) -> void:
+func set_bg_color(new_bg_color: Color) -> void:
+	bg_color = new_bg_color
+	_set_style_color(bg_color)
+
+
+func _set_style_color(color: Color) -> void:
 	get("custom_styles/normal").bg_color = color
 	get("custom_styles/hover").bg_color = color
 
@@ -107,14 +122,18 @@ func _refresh_appearance() -> void:
 	
 	_label.text = StringUtils.default_if_empty(level_title, "-")
 	
-	var new_bg_color: Color = get("custom_styles/normal").bg_color
-	match _label.text.hash() % 5:
-		0: new_bg_color.h = 0.9611 # red
-		1: new_bg_color.h = 0.0389 # orange
-		2: new_bg_color.h = 0.1250 # yellow
-		3: new_bg_color.h = 0.2861 # green
-		4: new_bg_color.h = 0.7472 # purple
-	set_bg_color(new_bg_color)
+	var new_style_color: Color
+	if bg_color:
+		new_style_color = bg_color
+	else:
+		match level_id.hash() % 6:
+			0: new_style_color = BUTTON_COLOR_RED
+			1: new_style_color = BUTTON_COLOR_ORANGE
+			2: new_style_color = BUTTON_COLOR_YELLOW
+			3: new_style_color = BUTTON_COLOR_GREEN
+			4: new_style_color = BUTTON_COLOR_BLUE
+			5: new_style_color = BUTTON_COLOR_PURPLE
+	_set_style_color(new_style_color)
 
 
 func _on_pressed() -> void:


### PR DESCRIPTION
Colors now use color constants like '7dff49' instead of calculated
colors like '4eff49, but with its hue modulated to 0.4667'. This makes
it easier to reuse colors in different places.

Grade label colors more closely match level status icons. The outlines
are still slightly different due to details about how they're rendered.

Added LevelSelectButtonDemo to show off different grades/icons