### PR TITLE
Level speed adjustment now adjusts based on start speed.

### DIFF
--- a/project/src/main/puzzle/level/level-speed-adjuster.gd
+++ b/project/src/main/puzzle/level/level-speed-adjuster.gd
@@ -8,11 +8,8 @@ class_name LevelSpeedAdjuster
 var _speed_matrix := [
 	["T"], # 25 ppm
 	["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"], # 25 ppm
-	["A0"], # 25 ppm
-	["A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "AA", "AB", "AC", "AD"], # 35 ppm
-	["AE"], ["AF"], # 50 ppm. these allow faster play than the other 'Ax' speeds
-	["F0"], ["F1"], # 50 ppm. these limit fast play of the other 'Fx' speeds
-	["FA", "FB", "FC", "FD", "FE", "FF", "FFF"], # 67-134 ppm
+	["A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "AA", "AB", "AC", "AD", "AE", "AF"], # 35-50 ppm
+	["F0", "F1", "FA", "FB", "FC", "FD", "FE", "FF", "FFF"], # 50-134 ppm
 ]
 
 ## key: (String) speed id
@@ -30,6 +27,7 @@ func _init(init_settings: LevelSettings) -> void:
 		for x in range(_speed_matrix[y].size()):
 			_coordinates_by_speed[_speed_matrix[y][x]] = Vector2(x, y)
 
+
 ## Adjusts the piece speeds of our LevelSettings instance.
 ##
 ## We calculate the fastest speed of the LevelSettings instance, and compare it to the specified speed to determine
@@ -41,7 +39,7 @@ func _init(init_settings: LevelSettings) -> void:
 ## Passing in an empty speed results in no adjustment.
 ##
 ## Parameters:
-## 	new_speed: The desired fastest speed id for the LevelSettings.
+## 	new_speed: The desired slowest speed id for the LevelSettings.
 func adjust(new_speed: String) -> void:
 	if not new_speed:
 		# empty speed, do not adjust
@@ -49,13 +47,13 @@ func adjust(new_speed: String) -> void:
 	if not _coordinates_by_speed.has(new_speed):
 		push_warning("Unrecognized speed: '%s'" % [new_speed])
 		return
-	if not _coordinates_by_speed.has(settings.speed.get_max_speed()):
-		push_warning("Unrecognized speed: '%s'" % [settings.speed.get_max_speed()])
+	if not _coordinates_by_speed.has(settings.speed.get_start_speed()):
+		push_warning("Unrecognized speed: '%s'" % [settings.speed.get_start_speed()])
 		return
 	
 	var can_adjust := true
 	var new_coord: Vector2 = _coordinates_by_speed[new_speed]
-	var old_coord: Vector2 = _coordinates_by_speed[settings.speed.get_max_speed()]
+	var old_coord: Vector2 = _coordinates_by_speed[settings.speed.get_start_speed()]
 	if new_coord.y != old_coord.y:
 		can_adjust = false
 	

--- a/project/src/test/puzzle/level/test-level-speed-adjuster.gd
+++ b/project/src/test/puzzle/level/test-level-speed-adjuster.gd
@@ -69,40 +69,25 @@ func test_adjust_speed_ups() -> void:
 	add_speed_up("6")
 	adjuster.adjust("5")
 	
-	assert_start_speed("1")
-	assert_speed_up(1, "3")
-	assert_speed_up(2, "5")
+	assert_start_speed("5")
+	assert_speed_up(1, "7")
+	assert_speed_up(2, "9")
 
 
 func test_adjust_speed_ups_too_slow() -> void:
-	set_start_speed("1")
+	set_start_speed("5")
 	add_speed_up("3")
-	add_speed_up("5")
+	add_speed_up("1")
 	adjuster.adjust("1")
 	
-	assert_start_speed("0")
+	assert_start_speed("1")
 	assert_speed_up(1, "0")
-	assert_speed_up(2, "1")
+	assert_speed_up(2, "0")
 
 
 func test_get_adjusted_speed_unique() -> void:
 	assert_eq(adjuster.get_adjusted_speed("T", -1), "T")
 	assert_eq(adjuster.get_adjusted_speed("T", 1), "T")
-	
-	assert_eq(adjuster.get_adjusted_speed("A0", -1), "A0")
-	assert_eq(adjuster.get_adjusted_speed("A0", 1), "A0")
-	
-	assert_eq(adjuster.get_adjusted_speed("AE", -1), "AE")
-	assert_eq(adjuster.get_adjusted_speed("AE", 1), "AE")
-	
-	assert_eq(adjuster.get_adjusted_speed("AF", -1), "AF")
-	assert_eq(adjuster.get_adjusted_speed("AF", 1), "AF")
-	
-	assert_eq(adjuster.get_adjusted_speed("F0", -1), "F0")
-	assert_eq(adjuster.get_adjusted_speed("F0", 1), "F0")
-	
-	assert_eq(adjuster.get_adjusted_speed("F1", -1), "F1")
-	assert_eq(adjuster.get_adjusted_speed("F1", 1), "F1")
 
 
 func test_get_adjusted_speed_3() -> void:
@@ -119,8 +104,8 @@ func test_get_adjusted_speed_AB() -> void:
 	assert_eq(adjuster.get_adjusted_speed("AB", -1), "AA")
 	assert_eq(adjuster.get_adjusted_speed("AB", 1), "AC")
 	
-	assert_eq(adjuster.get_adjusted_speed("AB", -99), "A1")
-	assert_eq(adjuster.get_adjusted_speed("AB", 99), "AD")
+	assert_eq(adjuster.get_adjusted_speed("AB", -99), "A0")
+	assert_eq(adjuster.get_adjusted_speed("AB", 99), "AF")
 
 
 func test_get_adjusted_speed_FC() -> void:
@@ -128,5 +113,5 @@ func test_get_adjusted_speed_FC() -> void:
 	assert_eq(adjuster.get_adjusted_speed("FC", 1), "FD")
 	assert_eq(adjuster.get_adjusted_speed("FC", 3), "FF")
 	
-	assert_eq(adjuster.get_adjusted_speed("FC", -99), "FA")
+	assert_eq(adjuster.get_adjusted_speed("FC", -99), "F0")
 	assert_eq(adjuster.get_adjusted_speed("FC", 99), "FFF")


### PR DESCRIPTION
Level speed adjustment now adjusts based on start speed, not maximum
speed. This results in a more intuitive result for things like Marathon
Normal -- before, adjusting it from speed 0 to 5 resulted in no change.
Now, it results in a level which starts at a faster speed but then tops
out half way.