### PR TITLE
Upgrade old sandbox data to 'M' rank.

### DIFF
--- a/project/assets/test/turbofat-375c.json
+++ b/project/assets/test/turbofat-375c.json
@@ -4,6 +4,48 @@
     "value": "375c"
   },
   {
+    "type": "level_history",
+    "key": "practice/sandbox_normal",
+    "value": [
+      {
+        "box_score": 445,
+        "box_score_per_line": 11.710526,
+        "box_score_per_line_rank": 999,
+        "combo_score": 160,
+        "combo_score_per_line": 4.848485,
+        "combo_score_per_line_rank": 999,
+        "pickup_score": 0,
+        "pickup_score_per_line": 0,
+        "pickup_score_rank": 999,
+        "compare": "+score",
+        "leftover_score": 0,
+        "lines": 38,
+        "lines_rank": 999,
+        "pieces": 86,
+        "pieces_rank": 999,
+        "lost": false,
+        "score": 643,
+        "score_rank": 999,
+        "seconds": 80.783338,
+        "seconds_rank": 0,
+        "speed": 28.223642,
+        "speed_rank": 999,
+        "success": false,
+        "timestamp": {
+          "year": 2022,
+          "month": 7,
+          "day": 15,
+          "weekday": 5,
+          "dst": true,
+          "hour": 15,
+          "minute": 21,
+          "second": 20
+        },
+        "top_out_count": 0
+      }
+    ]
+  },
+  {
     "type": "successful_levels",
     "value": {
       "practice/marathon_normal": {

--- a/project/src/main/player-save-upgrader.gd
+++ b/project/src/main/player-save-upgrader.gd
@@ -42,11 +42,12 @@ func new_save_item_upgrader() -> SaveItemUpgrader:
 	return upgrader
 
 
-## Save data prior to 375c had a bug where successful levels weren't recorded as finished levels. We locate the
-## successful levels entries and copy them over to the finished levels to fill in the gaps.
 func _upgrade_375c(old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"finished_levels":
+			# Save data prior to 375c had a bug where successful levels weren't recorded as finished levels. We locate
+			# the successful levels entries and copy them over to the finished levels to fill in the gaps.
+			
 			# locate the successful_levels entries
 			var successful_levels := {}
 			for old_save_item in old_save_items:
@@ -57,6 +58,12 @@ func _upgrade_375c(old_save_items: Array, save_item: SaveItem) -> SaveItem:
 			for key in successful_levels:
 				if not save_item.value.has(key):
 					save_item.value[key] = successful_levels[key]
+		
+		"level_history":
+			# Older versions of the sandbox levels would give the player an unranked grade instead of a master rank.
+			if save_item.key.begins_with("practice/sandbox_"):
+				for level_history_entry in save_item.value:
+					level_history_entry["score_rank"] = 0.0
 	return save_item
 
 

--- a/project/src/test/test-player-save-upgrader.gd
+++ b/project/src/test/test-player-save-upgrader.gd
@@ -166,3 +166,7 @@ func test_375c() -> void:
 	
 	# added missing 'finished_level' entries -- successful levels weren't recorded as finished
 	assert_eq(PlayerData.level_history.finished_levels.keys(), ["practice/marathon_normal"])
+	
+	# update sandbox data to 'm' rank
+	var best_result := PlayerData.level_history.best_result("practice/sandbox_normal")
+	assert_eq(best_result.score_rank, 0)


### PR DESCRIPTION
Older versions of sandbox mode awarded the player a failing grade
because they technically 'lost' (they did not finish an unfinishable
mode.) Newer versions award them an 'M' rank, but players who played the
older versions may still have bad ranks floating around in their save
data. These ranks will now be replaced with master ranks.