### PR TITLE
Added decorative exits to environments

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -419,7 +419,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/world/letter-shooter.gd"
 }, {
-"base": "Reference",
+"base": "Control",
 "class": "LevelButtons",
 "language": "GDScript",
 "path": "res://src/main/ui/level-select/scrolling-level-buttons.gd"

--- a/project/src/main/world/environment/lemon/LemonEnvironment.tscn
+++ b/project/src/main/world/environment/lemon/LemonEnvironment.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=28 format=2]
+[gd_scene load_steps=29 format=2]
 
 [ext_resource path="res://src/main/world/environment/lemon/lemon-obstacle-library.tres" type="TileSet" id=1]
 [ext_resource path="res://src/main/world/environment/GoopOverworldTiler.tscn" type="PackedScene" id=2]
@@ -10,6 +10,7 @@
 [ext_resource path="res://src/main/world/environment/OutdoorShadows.tscn" type="PackedScene" id=8]
 [ext_resource path="res://src/main/world/environment/lemon/LemonCookieSmall.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/world/environment/lemon/LemonLemon.tscn" type="PackedScene" id=10]
+[ext_resource path="res://src/main/world/FreeRoamExit.tscn" type="PackedScene" id=11]
 [ext_resource path="res://src/main/world/environment/lemon/BrotSpotStool.tscn" type="PackedScene" id=12]
 [ext_resource path="res://src/main/world/environment/lemon/BrotSpot.tscn" type="PackedScene" id=13]
 [ext_resource path="res://assets/main/world/environment/lemon/brot-spot-stool-orange.png" type="Texture" id=14]
@@ -109,6 +110,45 @@ ground_map_path = NodePath("../../../Ground/GroundMap")
 grass_density = 0.04
 ground_no_goop_tile_index = 1
 grass_tile_index = 7
+
+[node name="Exit0" parent="Obstacles" instance=ExtResource( 11 )]
+position = Vector2( 244.964, 1525.82 )
+destination_environment_path = "res://src/main/world/environment/marsh/MarshFreeRoamEnvironment.tscn"
+exit_direction = 7
+player_spawn_id = "restaurant_player"
+sensei_spawn_id = "restaurant_sensei"
+
+[node name="Exit1" parent="Obstacles" instance=ExtResource( 11 )]
+position = Vector2( 5061.51, 3607.66 )
+destination_environment_path = "res://src/main/world/environment/marsh/MarshFreeRoamEnvironment.tscn"
+exit_direction = 3
+player_spawn_id = "restaurant_player"
+sensei_spawn_id = "restaurant_sensei"
+
+[node name="Exit2" parent="Obstacles" instance=ExtResource( 11 )]
+position = Vector2( 3563.94, 1266.17 )
+destination_environment_path = "res://src/main/world/environment/marsh/MarshFreeRoamEnvironment.tscn"
+exit_direction = 1
+player_spawn_id = "restaurant_player"
+sensei_spawn_id = "restaurant_sensei"
+
+[node name="Exit3" parent="Obstacles" instance=ExtResource( 11 )]
+position = Vector2( 485.181, 1437.24 )
+destination_environment_path = "res://src/main/world/environment/marsh/MarshFreeRoamEnvironment.tscn"
+player_spawn_id = "restaurant_player"
+sensei_spawn_id = "restaurant_sensei"
+
+[node name="Exit4" parent="Obstacles" instance=ExtResource( 11 )]
+position = Vector2( 1364.91, 1496.94 )
+destination_environment_path = "res://src/main/world/environment/marsh/MarshFreeRoamEnvironment.tscn"
+player_spawn_id = "restaurant_player"
+sensei_spawn_id = "restaurant_sensei"
+
+[node name="Exit5" parent="Obstacles" instance=ExtResource( 11 )]
+position = Vector2( 4468.65, 2463.38 )
+destination_environment_path = "res://src/main/world/environment/marsh/MarshFreeRoamEnvironment.tscn"
+player_spawn_id = "restaurant_player"
+sensei_spawn_id = "restaurant_sensei"
 
 [node name="BrotSpot" parent="Obstacles" instance=ExtResource( 13 )]
 position = Vector2( 1394.09, 1375.69 )

--- a/project/src/main/world/environment/marsh/MarshEnvironment.tscn
+++ b/project/src/main/world/environment/marsh/MarshEnvironment.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=30 format=2]
+[gd_scene load_steps=31 format=2]
 
 [ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/environment/marsh/marsh-obstacle-library.tres" type="TileSet" id=2]
@@ -9,6 +9,7 @@
 [ext_resource path="res://src/main/world/environment/GoopOverworldTiler.tscn" type="PackedScene" id=7]
 [ext_resource path="res://assets/main/world/environment/marsh/buttercup-stool-white-occupied.png" type="Texture" id=8]
 [ext_resource path="res://assets/main/world/environment/marsh/buttercup-stool-green-occupied.png" type="Texture" id=9]
+[ext_resource path="res://src/main/world/FreeRoamExit.tscn" type="PackedScene" id=10]
 [ext_resource path="res://src/main/world/environment/marsh/MarshCrystal.tscn" type="PackedScene" id=20]
 [ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=23]
 [ext_resource path="res://src/main/world/environment/marsh/ForLeaseSign.tscn" type="PackedScene" id=24]
@@ -109,6 +110,38 @@ position = Vector2( 471.085, 1219.45 )
 creature_id = "#sensei#"
 dna = {
 }
+
+[node name="Exit0" parent="Obstacles" instance=ExtResource( 10 )]
+position = Vector2( 31.4402, 1073.84 )
+destination_environment_path = "res://src/main/world/environment/marsh/MarshFreeRoamEnvironment.tscn"
+player_spawn_id = "restaurant_player"
+sensei_spawn_id = "restaurant_sensei"
+
+[node name="Exit1" parent="Obstacles" instance=ExtResource( 10 )]
+position = Vector2( 1891.49, 1132.19 )
+destination_environment_path = "res://src/main/world/environment/marsh/MarshFreeRoamEnvironment.tscn"
+player_spawn_id = "restaurant_player"
+sensei_spawn_id = "restaurant_sensei"
+
+[node name="Exit2" parent="Obstacles" instance=ExtResource( 10 )]
+position = Vector2( 5553.59, 1072.96 )
+destination_environment_path = "res://src/main/world/environment/marsh/MarshFreeRoamEnvironment.tscn"
+exit_direction = 2
+player_spawn_id = "restaurant_player"
+sensei_spawn_id = "restaurant_sensei"
+
+[node name="Exit3" parent="Obstacles" instance=ExtResource( 10 )]
+position = Vector2( -997.007, 1179.2 )
+destination_environment_path = "res://src/main/world/environment/marsh/MarshFreeRoamEnvironment.tscn"
+exit_direction = 7
+player_spawn_id = "restaurant_player"
+sensei_spawn_id = "restaurant_sensei"
+
+[node name="Exit4" parent="Obstacles" instance=ExtResource( 10 )]
+position = Vector2( 4042.15, 1078.19 )
+destination_environment_path = "res://src/main/world/environment/marsh/MarshFreeRoamEnvironment.tscn"
+player_spawn_id = "restaurant_player"
+sensei_spawn_id = "restaurant_sensei"
 
 [node name="MarshTree" parent="Obstacles" instance=ExtResource( 40 )]
 position = Vector2( 1918.11, 1408.69 )


### PR DESCRIPTION
FreeRoam mode and cutscenes can still benefit from exits because they
give context to the buildings, so you know characters are at an
entrance/exit