### PR TITLE
Register creatures even if they're not chattables.

### DIFF
--- a/project/src/main/world/environment/overworld-environment.gd
+++ b/project/src/main/world/environment/overworld-environment.gd
@@ -60,7 +60,7 @@ func add_creature(creature_id: String = "", chattable: bool = true) -> Creature:
 		creature.add_to_group("chattables")
 		var chat_bubble_type := ChatLibrary.chat_icon_for_creature(creature)
 		creature.set_meta("chat_bubble_type", chat_bubble_type)
-		ChattableManager.register_creature(creature)
+	ChattableManager.register_creature(creature)
 	process_new_obstacle(creature)
 	return creature
 


### PR DESCRIPTION
ChattableManager provides a 'get_creature_by_id' functionality. This
functionality is important even in cutscenes and other contexts where
creatures aren't necessarily in the chattables list.