### PR TITLE
Fixed autoadvancement bug which skipped regions

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -314,11 +314,6 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/free-roam-data.gd"
 }, {
-"base": "CanvasLayer",
-"class": "FreeRoamUi",
-"language": "GDScript",
-"path": "res://src/main/ui/overworld-ui.gd"
-}, {
 "base": "OverworldWorld",
 "class": "FreeRoamWorld",
 "language": "GDScript",
@@ -653,6 +648,11 @@ _global_script_classes=[ {
 "class": "OverworldObstacle",
 "language": "GDScript",
 "path": "res://src/main/world/environment/overworld-obstacle.gd"
+}, {
+"base": "CanvasLayer",
+"class": "OverworldUi",
+"language": "GDScript",
+"path": "res://src/main/ui/overworld-ui.gd"
 }, {
 "base": "Node",
 "class": "OverworldWorld",
@@ -1146,7 +1146,6 @@ _global_script_class_icons={
 "Foods": "",
 "FrameInput": "",
 "FreeRoamData": "",
-"FreeRoamUi": "",
 "FreeRoamWorld": "",
 "GameplaySettings": "",
 "GoopGlob": "",
@@ -1214,6 +1213,7 @@ _global_script_class_icons={
 "OvalShadow": "",
 "OverworldEnvironment": "",
 "OverworldObstacle": "",
+"OverworldUi": "",
 "OverworldWorld": "",
 "PackedSprite": "",
 "PagedLevelButtons": "",

--- a/project/src/main/career/career-level-library.gd
+++ b/project/src/main/career/career-level-library.gd
@@ -223,6 +223,22 @@ func trim_levels_by_available_if(levels: Array) -> Array:
 	return trimmed_levels
 
 
+## Returns the CareerRegion with the specified cutscene.
+##
+## Parameters:
+## 	'chat_key': A chat key such as 'chat/career/marsh/epilogue' identifying a cutscene
+##
+## Returns:
+## 	A CareerRegion with the specified cutscene. Returns null if no CareerRegion could be found
+func region_for_chat_key(chat_key: String) -> CareerRegion:
+	var result: CareerRegion
+	for region in regions:
+		if region.cutscene_path and chat_key.begins_with(region.cutscene_path):
+			result = region
+			break
+	return result
+
+
 ## Loads the list of levels from JSON.
 func _load_raw_json_data() -> void:
 	regions.clear()

--- a/project/src/test/career/test-career-level-library.gd
+++ b/project/src/test/career/test-career-level-library.gd
@@ -289,3 +289,14 @@ func test_trim_levels_by_available_if() -> void:
 	var trimmed_levels := CareerLevelLibrary.trim_levels_by_available_if(all_levels)
 	assert_eq(trimmed_levels.size(), 1)
 	assert_eq(trimmed_levels[0].level_id, "level_211")
+
+
+func test_region_for_chat_key() -> void:
+	CareerLevelLibrary.regions_path = "res://assets/test/career/career-regions-simple.json"
+	
+	CareerLevelLibrary.regions[0].cutscene_path = "chat/career/permissible"
+	CareerLevelLibrary.regions[2].cutscene_path = "chat/career/cherries"
+	
+	assert_eq(CareerLevelLibrary.region_for_chat_key("chat/career/permissible/10_b"), CareerLevelLibrary.regions[0])
+	assert_eq(CareerLevelLibrary.region_for_chat_key("chat/career/cherries/20_a"), CareerLevelLibrary.regions[2])
+	assert_eq(CareerLevelLibrary.region_for_chat_key("chat/career/bogus/30_c"), null)

--- a/project/src/test/world/test-career-data.gd
+++ b/project/src/test/world/test-career-data.gd
@@ -185,3 +185,31 @@ func test_distance_penalties_cant_cross_regions() -> void:
 	
 	_data.distance_travelled = 12
 	assert_eq(_data.distance_penalties(), [2, 2, 0])
+
+
+func test_advance_past_chat_region() -> void:
+	CareerLevelLibrary.regions[0].cutscene_path = "chat/career/permissible"
+	_data.distance_travelled = 3
+	_data.best_distance_travelled = 3
+	_data.distance_earned = 2
+	_data.remain_in_region = true
+	_data.advance_past_chat_region("chat/career/permissible/boss_level_end_2")
+	
+	assert_eq(_data.distance_travelled, 10)
+	assert_eq(_data.best_distance_travelled, 10)
+	assert_eq(_data.distance_earned, 9)
+	assert_eq(_data.remain_in_region, false)
+
+
+func test_advance_past_chat_region_previous_region() -> void:
+	CareerLevelLibrary.regions[0].cutscene_path = "chat/career/permissible"
+	_data.distance_travelled = 13
+	_data.best_distance_travelled = 13
+	_data.distance_earned = 2
+	_data.remain_in_region = false
+	_data.advance_past_chat_region("chat/career/permissible/boss_level_end_2")
+	
+	assert_eq(_data.distance_travelled, 13)
+	assert_eq(_data.best_distance_travelled, 13)
+	assert_eq(_data.distance_earned, 2)
+	assert_eq(_data.remain_in_region, false)


### PR DESCRIPTION
Before, beating Lemony Thickets' boss level on a new save game file would skip a
skilled player to distance 25, instead of halting them at distance 24.
This bug occurred because there are cutscenes marked as 'skip the player
to the next region' but because the player had already advanced from
Lemony Thickets to the next region, it would skip them even further.

The new skip logic locates the region corresponding to the cutscene and
only skips them past THAT region, not past their current region.