### PR TITLE
ComboCounter -> ComboBurst. Combo colors.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -155,9 +155,9 @@ _global_script_classes=[ {
 "path": "res://src/main/puzzle/level/combo-break-rules.gd"
 }, {
 "base": "Node2D",
-"class": "ComboCounter",
+"class": "ComboBurst",
 "language": "GDScript",
-"path": "res://src/main/puzzle/combo-counter.gd"
+"path": "res://src/main/puzzle/combo-burst.gd"
 }, {
 "base": "Node",
 "class": "ComboTracker",
@@ -1074,7 +1074,7 @@ _global_script_class_icons={
 "CheatCodeDetector": "",
 "CheckpointSong": "",
 "ComboBreakRules": "",
-"ComboCounter": "",
+"ComboBurst": "",
 "ComboTracker": "",
 "Creature": "",
 "CreatureAnimations": "",

--- a/project/src/main/puzzle/ComboBurst.tscn
+++ b/project/src/main/puzzle/ComboBurst.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://src/main/packed-sprite.gd" type="Script" id=1]
 [ext_resource path="res://assets/main/puzzle/combo-accents-packed.png" type="Texture" id=2]
 [ext_resource path="res://assets/main/puzzle/modak-regular.ttf" type="DynamicFontData" id=3]
-[ext_resource path="res://src/main/puzzle/combo-counter.gd" type="Script" id=4]
+[ext_resource path="res://src/main/puzzle/combo-burst.gd" type="Script" id=4]
 
 [sub_resource type="DynamicFont" id=1]
 resource_local_to_scene = true
@@ -85,7 +85,7 @@ orbit_velocity_random = 0.0
 scale = 5.0
 color_ramp = SubResource( 4 )
 
-[node name="ComboCounter" type="Node2D"]
+[node name="ComboBurst" type="Node2D"]
 position = Vector2( 40, 40 )
 script = ExtResource( 4 )
 velocity = Vector2( 0, -30 )

--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -31,7 +31,7 @@
 [ext_resource path="res://assets/main/puzzle/tutorial/tutorial-section-fail.wav" type="AudioStream" id=29]
 [ext_resource path="res://src/main/puzzle/top-out-tracker.gd" type="Script" id=30]
 [ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=31]
-[ext_resource path="res://src/main/puzzle/combo-counters.gd" type="Script" id=32]
+[ext_resource path="res://src/main/puzzle/combo-bursts.gd" type="Script" id=32]
 [ext_resource path="res://src/main/puzzle/step-meter.gd" type="Script" id=33]
 [ext_resource path="res://src/main/ui/menu/theme/h2.theme" type="Theme" id=34]
 [ext_resource path="res://src/main/puzzle/GoopGlob.tscn" type="PackedScene" id=35]
@@ -42,7 +42,7 @@
 [ext_resource path="res://src/main/puzzle/WoodBg.tscn" type="PackedScene" id=40]
 [ext_resource path="res://assets/main/puzzle/playfield-walls.png" type="Texture" id=41]
 [ext_resource path="res://assets/main/puzzle/chalkboard.png" type="Texture" id=42]
-[ext_resource path="res://src/main/puzzle/ComboCounter.tscn" type="PackedScene" id=43]
+[ext_resource path="res://src/main/puzzle/ComboBurst.tscn" type="PackedScene" id=43]
 [ext_resource path="res://assets/main/world/chef/gameover-voice4.wav" type="AudioStream" id=44]
 [ext_resource path="res://assets/main/world/chef/gameover-voice3.wav" type="AudioStream" id=45]
 [ext_resource path="res://assets/main/world/chef/gameover-voice0.wav" type="AudioStream" id=46]
@@ -547,13 +547,13 @@ autostart = true
 wait_time = 0.5
 one_shot = true
 
-[node name="ComboCounters" type="Node2D" parent="Fg"]
+[node name="ComboBursts" type="Node2D" parent="Fg"]
 position = Vector2( 364, 28 )
 z_index = 6
 script = ExtResource( 32 )
 piece_manager_path = NodePath("../PieceManager")
 playfield_path = NodePath("../Playfield")
-ComboCounterScene = ExtResource( 43 )
+ComboBurstScene = ExtResource( 43 )
 
 [node name="FryingPansUi" parent="Fg" instance=ExtResource( 58 )]
 margin_left = 771.0
@@ -779,7 +779,7 @@ script = ExtResource( 19 )
 [connection signal="hit_wall" from="Fg/GoopGlobs" to="Fg/WallGlobViewports" method="_on_GoopGlobs_hit_wall"]
 [connection signal="hit_wall" from="Fg/GoopGlobs" to="GoopSfx" method="_on_GoopGlobs_hit_wall"]
 [connection signal="squish_moved" from="Fg/PieceManager" to="Fg/GoopGlobs" method="_on_PieceManager_squish_moved"]
-[connection signal="before_line_cleared" from="Fg/Playfield" to="Fg/ComboCounters" method="_on_Playfield_before_line_cleared"]
+[connection signal="before_line_cleared" from="Fg/Playfield" to="Fg/ComboBursts" method="_on_Playfield_before_line_cleared"]
 [connection signal="before_line_cleared" from="Fg/Playfield" to="Fg/GoopGlobs" method="_on_Playfield_before_line_cleared"]
 [connection signal="before_line_cleared" from="Fg/Playfield" to="Fg/StarSeeds" method="_on_Playfield_before_line_cleared"]
 [connection signal="blocks_prepared" from="Fg/Playfield" to="Fg/StarSeeds" method="_on_Playfield_blocks_prepared"]

--- a/project/src/main/puzzle/combo-burst.gd
+++ b/project/src/main/puzzle/combo-burst.gd
@@ -1,6 +1,6 @@
-class_name ComboCounter
+class_name ComboBurst
 extends Node2D
-## A combo indicator which appears when the player clears a line in puzzle mode.
+## An indicator like '6x' which appears when the player clears multiple lines in succession.
 ##
 ## The indicator includes some colorful stylized text with an accent shape behind it.
 
@@ -58,22 +58,19 @@ func _refresh_combo() -> void:
 
 func _calculate_colors() -> void:
 	var outline_darkness := 0.2
-	_font_color = Color("4eff49")
 	if combo < COMBO_THRESHOLD_0:
-		_font_color.h = 0.5889 # blue
+		_font_color = Color("4a9fff") # blue
 	elif combo < COMBO_THRESHOLD_1:
-		_font_color.h = 0.4667 # cyan
+		_font_color = Color("4affcf") # cyan
 	elif combo <= COMBO_THRESHOLD_2:
-		_font_color.h = 0.2861 # green
+		_font_color = Color("80ff4a") # green
 	elif combo <= COMBO_THRESHOLD_3:
-		_font_color.h = 0.1250 # yellow
+		_font_color = Color("ffd24a") # yellow
 	elif combo <= COMBO_THRESHOLD_4:
-		_font_color.h = 0.1250 # bright yellow
-		_font_color.s = 0.4444
+		_font_color = Color("ffe38f") # bright yellow
 		outline_darkness = 0.16
 	else:
-		_font_color.h = 0.1250 # near-white
-		_font_color.s = 0.0600
+		_font_color = Color("fffcf0") # near-white
 		outline_darkness = 0.12
 	_accent_color = _font_color
 	_accent_color.s += outline_darkness

--- a/project/src/main/puzzle/combo-bursts.gd
+++ b/project/src/main/puzzle/combo-bursts.gd
@@ -3,7 +3,7 @@ extends Node2D
 
 export (NodePath) var piece_manager_path: NodePath
 export (NodePath) var playfield_path: NodePath
-export (PackedScene) var ComboCounterScene: PackedScene
+export (PackedScene) var ComboBurstScene: PackedScene
 
 ## Stores the x position of the previous combo counter to ensure consecutive counters aren't vertically aligned
 var _previous_cell_x := -1
@@ -65,8 +65,8 @@ func _on_Playfield_before_line_cleared(y: int, _total_lines: int, _remaining_lin
 			target_cell.x += Utils.rand_value([-1, 1])
 	_previous_cell_x = target_cell.x
 	
-	var combo_counter: ComboCounter = ComboCounterScene.instance()
-	combo_counter.position = Utils.map_to_world_centered(_playfield.tile_map, target_cell + Vector2(0, -3))
-	combo_counter.position *= _playfield.tile_map.scale
-	combo_counter.combo = PuzzleState.combo
-	add_child(combo_counter)
+	var combo_burst: ComboBurst = ComboBurstScene.instance()
+	combo_burst.position = Utils.map_to_world_centered(_playfield.tile_map, target_cell + Vector2(0, -3))
+	combo_burst.position *= _playfield.tile_map.scale
+	combo_burst.combo = PuzzleState.combo
+	add_child(combo_burst)


### PR DESCRIPTION
I like the word 'burst' because it sounds more like a UI element,
instead of 'counter' which could just be something which abstractly
counts things like Godot's orphan_counter

Combo burst now uses hard-coded colors like '4a9fff' instead of
calculated colors like '4eff49 with a hue of 0.5889'. This makes the
colors easier to reuse elsewhere.