### PR TITLE
Improved drop signals. Added 'dropped' signal.

### DIFF
--- a/project/src/main/puzzle/piece/PieceManager.tscn
+++ b/project/src/main/puzzle/piece/PieceManager.tscn
@@ -211,6 +211,7 @@ bus = "Sound Bus"
 [connection signal="squish_moved" from="." to="Sfx" method="_on_PieceManager_squish_moved"]
 [connection signal="squish_moved" from="." to="SquishFx" method="_on_PieceManager_squish_moved"]
 [connection signal="tiles_changed" from="." to="SquishFx/SweatDrops" method="_on_PieceManager_tiles_changed"]
+[connection signal="dropped" from="Physics/Dropper" to="." method="_on_Dropper_dropped"]
 [connection signal="hard_drop_target_pos_changed" from="Physics/Dropper" to="GhostMover" method="_on_Dropper_hard_drop_target_pos_changed"]
 [connection signal="hard_dropped" from="Physics/Dropper" to="." method="_on_Dropper_hard_dropped"]
 [connection signal="soft_dropped" from="Physics/Dropper" to="." method="_on_Dropper_soft_dropped"]

--- a/project/src/main/puzzle/piece/active-piece.gd
+++ b/project/src/main/puzzle/piece/active-piece.gd
@@ -91,6 +91,7 @@ func get_pos_arr() -> Array:
 func get_target_pos_arr() -> Array:
 	return type.pos_arr[target_orientation]
 
+
 ## Returns 'true' if the specified position and location is unobstructed, and the piece could fit there. Returns
 ## 'false' if parts of this piece would be out of the playfield or obstructed by blocks.
 ##
@@ -127,6 +128,7 @@ func perform_lock_reset() -> void:
 		return
 	lock = 0
 	lock_resets += 1
+
 
 ## Kicks a rotated piece into a nearby empty space.
 ##

--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -27,8 +27,9 @@ signal moved_right
 signal rotated_ccw
 signal rotated_cw
 signal rotated_180
-signal soft_dropped
-signal hard_dropped
+signal soft_dropped # emitted when the player presses the soft drop key
+signal hard_dropped # emitted when the player presses the hard drop key
+signal dropped # emitted when the piece falls as a result of a soft drop, hard drop, or gravity
 signal squish_moved(piece, old_pos)
 
 ## emitted for piece locks
@@ -284,6 +285,7 @@ func _on_Playfield_line_inserted(_y: int, _tiles_key: String, _src_y: int) -> vo
 
 func _on_Dropper_hard_dropped() -> void: emit_signal("hard_dropped")
 func _on_Dropper_soft_dropped() -> void: emit_signal("soft_dropped")
+func _on_Dropper_dropped() -> void: emit_signal("dropped")
 
 func _on_Squisher_lock_cancelled() -> void: emit_signal("lock_cancelled")
 func _on_Squisher_squish_moved(squished_piece: ActivePiece, old_pos: Vector2) -> void:


### PR DESCRIPTION
Fixed bug where the 'soft_dropped' and 'hard_dropped' signals were
emitted even if the piece's position didn't change. This behavior was
inconsistent with other signals such as 'moved_left' which only fired
when the movement was successful.

Added a new 'dropped' signal which is emitted when the piece falls due
to gravity. There was no signal for this before.