### PR TITLE
Fixed bug with 'click' sounds at top of playfield.

### DIFF
--- a/project/src/main/puzzle/piece/piece-mover.gd
+++ b/project/src/main/puzzle/piece/piece-mover.gd
@@ -43,7 +43,8 @@ const SPAWN_RIGHT := [
 		Vector2(0, 0), Vector2(0, -1), Vector2(-1, 0), Vector2(-1, -1),
 	]
 
-func apply_initial_move_input(piece: ActivePiece) -> void:
+func apply_initial_move_input(piece: ActivePiece) -> String:
+	var movement_signal: String = ""
 	var initial_das_dir := 0
 	if input.is_left_das_active():
 		input.set_left_input_as_handled()
@@ -55,24 +56,27 @@ func apply_initial_move_input(piece: ActivePiece) -> void:
 	match initial_das_dir:
 		-1:
 			# player is holding left; start piece on the left side
-			var old_pos := piece.pos
-			piece.reset_target()
+			var old_pos := piece.target_pos
 			piece.kick_piece(SPAWN_LEFT)
-			piece.move_to_target()
-			if old_pos != piece.pos:
-				emit_signal("initial_das_moved_left")
+			if old_pos != piece.target_pos:
+				movement_signal = "initial_das_moved_left"
 		0:
-			piece.reset_target()
 			piece.kick_piece(SPAWN_CENTER)
-			piece.move_to_target()
 		1:
 			# player is holding right; start piece on the right side
-			var old_pos := piece.pos
-			piece.reset_target()
+			var old_pos := piece.target_pos
 			piece.kick_piece(SPAWN_RIGHT)
-			piece.move_to_target()
-			if old_pos != piece.pos:
-				emit_signal("initial_das_moved_right")
+			if old_pos != piece.target_pos:
+				movement_signal = "initial_das_moved_right"
+	
+	return movement_signal
+
+
+func emit_initial_move_signal(piece: ActivePiece, movement_signal: String) -> void:
+	if not movement_signal:
+		return
+	
+	emit_signal(movement_signal)
 
 
 func apply_move_input(piece: ActivePiece) -> void:

--- a/project/src/main/puzzle/piece/piece-physics.gd
+++ b/project/src/main/puzzle/piece/piece-physics.gd
@@ -18,21 +18,25 @@ onready var _states: PieceStates = get_node(piece_states_path)
 ##
 ## Returns 'true' if the piece was spawned successfully, or 'false' if the player topped out.
 func initially_move_piece(piece: ActivePiece) -> bool:
-	rotator.apply_initial_rotate_input(piece)
+	var rotation_signal: String = rotator.apply_initial_rotate_input(piece)
 	
 	# relocate piece to the top of the playfield
 	var highest_pos := 3
-	for pos_arr_item in piece.get_pos_arr():
+	for pos_arr_item in piece.get_target_pos_arr():
 		if pos_arr_item.y < highest_pos:
 			highest_pos = pos_arr_item.y
 	piece.pos.y -= highest_pos
 	
-	mover.apply_initial_move_input(piece)
+	var movement_signal: String = mover.apply_initial_move_input(piece)
 	
 	var success := true
 	if not piece.can_move_to_target():
 		PuzzleState.top_out()
 		success = false
+	else:
+		piece.move_to_target()
+		rotator.emit_initial_rotate_signal(piece, rotation_signal)
+		mover.emit_initial_move_signal(piece, movement_signal)
 	return success
 
 

--- a/project/src/main/puzzle/piece/piece-rotator.gd
+++ b/project/src/main/puzzle/piece/piece-rotator.gd
@@ -19,9 +19,9 @@ export (NodePath) var input_path: NodePath
 
 onready var input: PieceInput = get_node(input_path)
 
-func apply_initial_rotate_input(piece: ActivePiece) -> void:
+func apply_initial_rotate_input(piece: ActivePiece) -> String:
 	if not input.is_cw_pressed() and not input.is_ccw_pressed():
-		return
+		return ""
 	
 	var rotation_signal: String
 	
@@ -44,18 +44,24 @@ func apply_initial_rotate_input(piece: ActivePiece) -> void:
 			input.set_ccw_input_as_handled()
 			piece.target_orientation = piece.get_flip_orientation()
 	
-	if rotation_signal:
-		match CurrentLevel.settings.other.suppress_piece_initial_rotation:
-			OtherRules.SuppressPieceRotation.ROTATION_AND_SIGNALS:
-				# 'suppress piece initial rotation and signals' is enabled; do nothing
-				pass
-			OtherRules.SuppressPieceRotation.ROTATION:
-				# 'suppress piece initial rotation' is enabled; emit rotation signals but don't rotate
-				emit_signal(rotation_signal)
-			_:
-				# rotate the piece and emit rotation signals
-				piece.move_to_target()
-				emit_signal(rotation_signal)
+	return rotation_signal
+
+
+func emit_initial_rotate_signal(piece: ActivePiece, rotation_signal: String) -> void:
+	if not rotation_signal:
+		return
+
+	match CurrentLevel.settings.other.suppress_piece_initial_rotation:
+		OtherRules.SuppressPieceRotation.ROTATION_AND_SIGNALS:
+			# 'suppress piece initial rotation and signals' is enabled; do nothing
+			pass
+		OtherRules.SuppressPieceRotation.ROTATION:
+			# 'suppress piece initial rotation' is enabled; emit rotation signals but don't rotate
+			emit_signal(rotation_signal)
+		_:
+			# rotate the piece and emit rotation signals
+			piece.move_to_target()
+			emit_signal(rotation_signal)
 	
 	match rotation_signal:
 		"initial_rotated_ccw": CurrentLevel.settings.triggers.run_triggers(LevelTrigger.INITIAL_ROTATED_CCW)


### PR DESCRIPTION
The rotate/move signals were emitted incorrectly, causing PieceSfx to
emit the 'click' sound at times when it wasn't supposed to. More
specifically, the 'rotate' signal would be emitted between initial
rotation and initial movement, when the piece could still be obstructing
another piece.

Initial rotation and initial movement signals are now emitted after the
piece's movement is complete, and only in the case where the piece does
not cause a top out.