### PR TITLE
Fixed bug with PuzzleDemo's line clear key

### DIFF
--- a/project/src/demo/puzzle/puzzle-demo.gd
+++ b/project/src/demo/puzzle/puzzle-demo.gd
@@ -80,7 +80,6 @@ func _insert_line(tiles_key: String, y: int) -> void:
 
 
 func _clear_line(cleared_line: int) -> void:
-	$Puzzle/Fg/Playfield/LineClearer.lines_being_cleared = range(cleared_line, cleared_line + _line_clear_count)
 	$Puzzle/Fg/Playfield/LineClearer.clear_line(cleared_line, 1, 0)
 
 


### PR DESCRIPTION
The 'FINISH' cheat in PuzzleDemo caused the game to crash, because the
line clear key was manipulating LineClearer's internal state in an
illegal way. This appears to be an unnecessary step which was added in
2020 when the LineClearer was less mature.