### PR TITLE
Player data is saved during scene transitions.

### DIFF
--- a/project/src/main/career/career-flow.gd
+++ b/project/src/main/career/career-flow.gd
@@ -83,7 +83,7 @@ func _preapply_failure_penalties() -> void:
 	var temp_hours_passed := career_data.hours_passed
 	career_data.advance_clock(0, false)
 	career_data.skipped_previous_level = true
-	PlayerSave.save_player_data()
+	PlayerSave.schedule_save()
 	career_data.distance_earned = temp_distance_earned
 	career_data.distance_travelled = temp_distance_travelled
 	career_data.hours_passed = temp_hours_passed

--- a/project/src/main/editor/creature/dialogs.gd
+++ b/project/src/main/editor/creature/dialogs.gd
@@ -68,4 +68,4 @@ func _on_SaveButton_pressed() -> void:
 ## Updates the player character and writes it to their save file.
 func _on_SaveConfirmation_confirmed() -> void:
 	PlayerData.creature_library.player_def = _creature_editor.center_creature.creature_def
-	PlayerSave.save_player_data()
+	PlayerSave.schedule_save()

--- a/project/src/main/ui/career/career-win.gd
+++ b/project/src/main/ui/career/career-win.gd
@@ -14,7 +14,7 @@ func _ready() -> void:
 	_refresh_mood()
 	
 	PlayerData.career.advance_calendar()
-	PlayerSave.save_player_data()
+	PlayerSave.schedule_save()
 	
 	_button.grab_focus()
 


### PR DESCRIPTION
Writing the player save JSON file takes about 50 ms, which is enough to
cause a noticable stutter. When adding a 'swoosh' effect to end-of-level
messages, for example, this effect was interrupted by the save data
being written.

Player data saves are now scheduled to occur between levels. I think
this might also help the HTML5 builds, where these stutters would affect
music playback.