### PR TITLE
Updated target_properties for Godot 3.5

### DIFF
--- a/project/src/demo/world/environment/marsh/MarshFreeRoamEnvironment.tscn
+++ b/project/src/demo/world/environment/marsh/MarshFreeRoamEnvironment.tscn
@@ -1,20 +1,14 @@
-[gd_scene load_steps=33 format=2]
+[gd_scene load_steps=26 format=2]
 
 [ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/environment/InvisibleObstacleTiler.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/world/environment/GoopOverworldTiler.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/world/environment/OutdoorShadows.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/world/environment/marsh/marsh-terrain-library.tres" type="TileSet" id=5]
-[ext_resource path="res://assets/main/world/environment/marsh/for-lease-sign.png" type="Texture" id=13]
-[ext_resource path="res://assets/main/world/environment/marsh/buttercup-stool-white.png" type="Texture" id=15]
-[ext_resource path="res://assets/main/world/environment/marsh/buttercup-stool-white-occupied.png" type="Texture" id=16]
-[ext_resource path="res://assets/main/world/environment/marsh/buttercup-stool-green-occupied.png" type="Texture" id=17]
-[ext_resource path="res://assets/main/world/environment/marsh/buttercup-stool-green.png" type="Texture" id=22]
 [ext_resource path="res://src/main/world/environment/marsh/marsh-obstacle-library.tres" type="TileSet" id=23]
 [ext_resource path="res://src/main/world/creature/sensei.gd" type="Script" id=25]
 [ext_resource path="res://src/main/world/environment/marsh/ButtercupSign.tscn" type="PackedScene" id=28]
 [ext_resource path="res://src/main/world/Spawn.tscn" type="PackedScene" id=29]
-[ext_resource path="res://src/main/world/ObstacleSpawner.tscn" type="PackedScene" id=30]
 [ext_resource path="res://src/main/world/environment/marsh/ButtercupStoolSpawnerW.tscn" type="PackedScene" id=31]
 [ext_resource path="res://src/main/world/environment/marsh/MarshHouse.tscn" type="PackedScene" id=32]
 [ext_resource path="res://src/main/world/environment/marsh/MarshGroundMap.tscn" type="PackedScene" id=33]
@@ -28,7 +22,6 @@
 [ext_resource path="res://src/main/world/environment/TurboFatRestaurant.tscn" type="PackedScene" id=45]
 [ext_resource path="res://src/main/world/creature/player.gd" type="Script" id=47]
 [ext_resource path="res://src/main/world/environment/marsh/MarshCrystalSpawner.tscn" type="PackedScene" id=48]
-[ext_resource path="res://src/main/world/environment/marsh/ForLeaseSign.tscn" type="PackedScene" id=49]
 [ext_resource path="res://src/main/world/environment/marsh/MarshRippleWaves.tscn" type="PackedScene" id=52]
 [ext_resource path="res://src/main/world/environment/marsh/MarshCrystal.tscn" type="PackedScene" id=53]
 [ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=54]
@@ -210,22 +203,12 @@ shadow_scale = 4.0
 
 [node name="ButtercupStool1" parent="Obstacles" instance=ExtResource( 31 )]
 position = Vector2( 339.509, 1582.36 )
-target_properties = {
-"occupied_texture": ExtResource( 16 ),
-"unoccupied_texture": ExtResource( 15 )
-}
 
 [node name="ButtercupStool2" parent="Obstacles" instance=ExtResource( 41 )]
 position = Vector2( 561.509, 1582.36 )
-target_properties = {
-"occupied_texture": ExtResource( 17 ),
-"unoccupied_texture": ExtResource( 22 )
-}
 
 [node name="ButtercupTable1" parent="Obstacles" instance=ExtResource( 42 )]
 position = Vector2( 449.589, 1635.08 )
-target_properties = {
-}
 
 [node name="ButtercupSign" parent="Obstacles" instance=ExtResource( 28 )]
 position = Vector2( 596.167, 1293.78 )
@@ -271,78 +254,48 @@ target_properties = {
 
 [node name="ButtercupCrystal1" parent="Obstacles" instance=ExtResource( 48 )]
 position = Vector2( 148.917, 1575.15 )
-target_properties = {
-}
 
 [node name="ButtercupCrystal2" parent="Obstacles" instance=ExtResource( 48 )]
 position = Vector2( 577.392, 1088.6 )
-target_properties = {
-}
 
 [node name="ButtercupCrystal3" parent="Obstacles" instance=ExtResource( 48 )]
 position = Vector2( 799.533, 1542.64 )
-target_properties = {
-}
 
 [node name="ButtercupCrystal4" parent="Obstacles" instance=ExtResource( 48 )]
 position = Vector2( -37.5356, 1316.09 )
-target_properties = {
-}
 
 [node name="ButtercupCrystal5" parent="Obstacles" instance=ExtResource( 48 )]
 position = Vector2( 578.976, 1639.99 )
-target_properties = {
-}
 
 [node name="ButtercupCrystal6" parent="Obstacles" instance=ExtResource( 48 )]
 position = Vector2( 749.714, 1234.5 )
-target_properties = {
-}
 
 [node name="ButtercupCrystal7" parent="Obstacles" instance=ExtResource( 48 )]
 position = Vector2( 178.464, 1418.09 )
-target_properties = {
-}
 
 [node name="TurboFatCrystal1" parent="Obstacles" instance=ExtResource( 48 )]
 position = Vector2( 1975.49, 874.757 )
-target_properties = {
-}
 
 [node name="TurboFatCrystal2" parent="Obstacles" instance=ExtResource( 48 )]
 position = Vector2( 1827.16, 996.117 )
-target_properties = {
-}
 
 [node name="TurboFatCrystal3" parent="Obstacles" instance=ExtResource( 48 )]
 position = Vector2( 1756.54, 1036.03 )
-target_properties = {
-}
 
 [node name="TurboFatCrystal4" parent="Obstacles" instance=ExtResource( 48 )]
 position = Vector2( 1780.98, 1216.18 )
-target_properties = {
-}
 
 [node name="TurboFatCrystal5" parent="Obstacles" instance=ExtResource( 48 )]
 position = Vector2( 941.954, 847.977 )
-target_properties = {
-}
 
 [node name="TurboFatCrystal6" parent="Obstacles" instance=ExtResource( 48 )]
 position = Vector2( 1206.64, 682.821 )
-target_properties = {
-}
 
 [node name="TurboFatCrystal7" parent="Obstacles" instance=ExtResource( 48 )]
 position = Vector2( 1499.38, 1292.35 )
-target_properties = {
-}
 
 [node name="TurboFatCrystal8" parent="Obstacles" instance=ExtResource( 48 )]
 position = Vector2( 1238.62, 921.227 )
-target_properties = {
-}
 
 [node name="Spawns" type="Node2D" parent="."]
 

--- a/project/src/main/world/ObstacleSpawner.tscn
+++ b/project/src/main/world/ObstacleSpawner.tscn
@@ -4,5 +4,3 @@
 
 [node name="ObstacleSpawner" type="Sprite"]
 script = ExtResource( 2 )
-target_properties = {
-}

--- a/project/src/main/world/environment/lemon/LemonRestaurantEnvironment.tscn
+++ b/project/src/main/world/environment/lemon/LemonRestaurantEnvironment.tscn
@@ -114,7 +114,6 @@ mouth_type = 7
 
 [node name="LemonTree5" parent="Obstacles" instance=ExtResource( 18 )]
 position = Vector2( 993.458, 326.991 )
-leaf_type = 0
 mouth_type = 8
 
 [node name="LemonTree6" parent="Obstacles" instance=ExtResource( 18 )]

--- a/project/src/main/world/environment/marsh/ButtercupTableSpawner.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupTableSpawner.tscn
@@ -11,5 +11,3 @@ centered = false
 offset = Vector2( -125, -200 )
 script = ExtResource( 2 )
 TargetScene = ExtResource( 3 )
-target_properties = {
-}

--- a/project/src/main/world/environment/marsh/MarshCrystalSpawner.tscn
+++ b/project/src/main/world/environment/marsh/MarshCrystalSpawner.tscn
@@ -11,5 +11,3 @@ centered = false
 offset = Vector2( -70, -102 )
 script = ExtResource( 1 )
 TargetScene = ExtResource( 2 )
-target_properties = {
-}

--- a/project/src/main/world/environment/marsh/MarshEnvironment.tscn
+++ b/project/src/main/world/environment/marsh/MarshEnvironment.tscn
@@ -1,14 +1,11 @@
-[gd_scene load_steps=31 format=2]
+[gd_scene load_steps=27 format=2]
 
 [ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/environment/marsh/marsh-obstacle-library.tres" type="TileSet" id=2]
 [ext_resource path="res://assets/main/world/environment/marsh/for-lease-sign.png" type="Texture" id=3]
 [ext_resource path="res://src/main/world/environment/OutdoorShadows.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/world/environment/marsh/marsh-terrain-library.tres" type="TileSet" id=5]
-[ext_resource path="res://assets/main/world/environment/marsh/buttercup-stool-white.png" type="Texture" id=6]
 [ext_resource path="res://src/main/world/environment/GoopOverworldTiler.tscn" type="PackedScene" id=7]
-[ext_resource path="res://assets/main/world/environment/marsh/buttercup-stool-white-occupied.png" type="Texture" id=8]
-[ext_resource path="res://assets/main/world/environment/marsh/buttercup-stool-green-occupied.png" type="Texture" id=9]
 [ext_resource path="res://src/main/world/OverworldExit.tscn" type="PackedScene" id=10]
 [ext_resource path="res://src/main/world/environment/marsh/MarshCrystal.tscn" type="PackedScene" id=20]
 [ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=23]
@@ -28,7 +25,6 @@
 [ext_resource path="res://src/main/world/environment/marsh/ButtercupSign.tscn" type="PackedScene" id=41]
 [ext_resource path="res://src/main/world/ObstacleSpawner.tscn" type="PackedScene" id=42]
 [ext_resource path="res://src/main/world/environment/marsh/ButtercupStoolSpawnerW.tscn" type="PackedScene" id=43]
-[ext_resource path="res://assets/main/world/environment/marsh/buttercup-stool-green.png" type="Texture" id=45]
 
 [sub_resource type="Curve2D" id=4]
 _data = {
@@ -333,8 +329,6 @@ scale = Vector2( 0.4, 0.4 )
 texture = ExtResource( 3 )
 offset = Vector2( 0, -80 )
 TargetScene = ExtResource( 24 )
-target_properties = {
-}
 spawn_if = "chat_finished chat/career/marsh/60_end"
 
 [node name="ButtercupCrystalSign" parent="Obstacles" instance=ExtResource( 27 )]
@@ -388,16 +382,10 @@ spawn_if = "not chat_finished chat/career/marsh/20"
 
 [node name="ButtercupStool4" parent="Obstacles" instance=ExtResource( 37 )]
 position = Vector2( 4132.8, 1326.5 )
-target_properties = {
-"occupied_texture": ExtResource( 9 ),
-"unoccupied_texture": ExtResource( 45 )
-}
 spawn_if = "not chat_finished chat/career/marsh/60_end"
 
 [node name="ButtercupTable2" parent="Obstacles" instance=ExtResource( 31 )]
 position = Vector2( 4020.88, 1379.22 )
-target_properties = {
-}
 spawn_if = "not chat_finished chat/career/marsh/60_end"
 
 [node name="Jayton" parent="Obstacles" instance=ExtResource( 33 )]
@@ -413,32 +401,18 @@ spawn_if = "not chat_finished chat/career/marsh/60_end"
 
 [node name="ButtercupStool5" parent="Obstacles" instance=ExtResource( 43 )]
 position = Vector2( 3910.69, 1326.71 )
-target_properties = {
-"occupied_texture": ExtResource( 8 ),
-"unoccupied_texture": ExtResource( 6 )
-}
 spawn_if = "not chat_finished chat/career/marsh/60_end"
 
 [node name="ButtercupStool1" parent="Obstacles" instance=ExtResource( 43 )]
 position = Vector2( 4214.87, 1060.61 )
-target_properties = {
-"occupied_texture": ExtResource( 8 ),
-"unoccupied_texture": ExtResource( 6 )
-}
 spawn_if = "not chat_finished chat/career/marsh/60_end"
 
 [node name="ButtercupStool2" parent="Obstacles" instance=ExtResource( 37 )]
 position = Vector2( 4436.87, 1060.61 )
-target_properties = {
-"occupied_texture": ExtResource( 9 ),
-"unoccupied_texture": ExtResource( 45 )
-}
 spawn_if = "not chat_finished chat/career/marsh/60_end"
 
 [node name="ButtercupTable1" parent="Obstacles" instance=ExtResource( 31 )]
 position = Vector2( 4324.95, 1113.33 )
-target_properties = {
-}
 spawn_if = "not chat_finished chat/career/marsh/60_end"
 
 [node name="Spawns" type="Node2D" parent="."]

--- a/project/src/main/world/environment/marsh/MarshIndoorsEnvironment.tscn
+++ b/project/src/main/world/environment/marsh/MarshIndoorsEnvironment.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=38 format=2]
+[gd_scene load_steps=37 format=2]
 
 [ext_resource path="res://src/main/world/restaurant/indoor-obstacle-library.tres" type="TileSet" id=1]
 [ext_resource path="res://src/main/world/restaurant/floor-library.tres" type="TileSet" id=2]
@@ -26,7 +26,6 @@
 [ext_resource path="res://src/main/world/creature/sensei.gd" type="Script" id=25]
 [ext_resource path="res://src/main/world/environment/kitchen-obstacle-tiler.gd" type="Script" id=27]
 [ext_resource path="res://src/main/world/ground-map-indoors.gd" type="Script" id=28]
-[ext_resource path="res://src/main/world/CreatureSpawner.tscn" type="PackedScene" id=30]
 [ext_resource path="res://src/main/world/environment/WoodTable.tscn" type="PackedScene" id=31]
 [ext_resource path="res://src/main/world/environment/WoodPillar.tscn" type="PackedScene" id=32]
 [ext_resource path="res://src/main/world/environment/IndoorStool.tscn" type="PackedScene" id=33]


### PR DESCRIPTION
Godot 3.5 now allows scenes to inherit each other more efficiently.
Child scenes no longer need to define redundant fields like these
'target_properties' fields which are already defined in their parent.