### PR TITLE
Fixed tutorial 'Ready?' bug

### DIFF
--- a/project/src/main/puzzle/puzzle-messages.gd
+++ b/project/src/main/puzzle/puzzle-messages.gd
@@ -103,7 +103,9 @@ func _on_Back_pressed() -> void:
 
 func _on_PuzzleState_game_prepared() -> void:
 	hide_buttons()
-	show_message(PuzzleMessage.NEUTRAL, tr("Ready?"))
+	
+	if not CurrentLevel.settings.other.skip_intro:
+		show_message(PuzzleMessage.NEUTRAL, tr("Ready?"))
 
 
 func _on_PuzzleState_game_started() -> void:


### PR DESCRIPTION
Fixed a bug where the 'Ready?' message would appear at the start of
tutorials and never disappear.