### PR TITLE
CutsceneDemo enhancements. Tableside cutscene.

### DIFF
--- a/project/assets/demo/chat/tableside.chat
+++ b/project/assets/demo/chat/tableside.chat
@@ -1,0 +1,11 @@
+{"version": "2476"}
+
+[location]
+marsh/inside_turbo_fat
+
+[characters]
+player, p1, table_10
+mara, m, table_seat_left
+
+p1: Oh hey Mara! Don't worry, this one will be on the house~
+m: ^_^/ Oh that's alright.

--- a/project/src/demo/world/environment/marsh/MarshIndoorsFreeRoamEnvironment.tscn
+++ b/project/src/demo/world/environment/marsh/MarshIndoorsFreeRoamEnvironment.tscn
@@ -814,3 +814,25 @@ id = "kitchen_9"
 [node name="Kitchen11" parent="Spawns" instance=ExtResource( 9 )]
 position = Vector2( 1740.68, 77.2144 )
 id = "kitchen_11"
+
+[node name="TableSeatLeft" parent="Spawns" instance=ExtResource( 9 )]
+position = Vector2( 749.285, 321.719 )
+stool_path = NodePath("../../Obstacles/Stool6")
+id = "table_seat_left"
+elevation = 140.0
+
+[node name="Table2" parent="Spawns" instance=ExtResource( 9 )]
+position = Vector2( 689.515, 237.165 )
+id = "table_2"
+
+[node name="Table10" parent="Spawns" instance=ExtResource( 9 )]
+position = Vector2( 995.141, 231.219 )
+orientation = 1
+id = "table_10"
+
+[node name="TableSeatRight" parent="Spawns" instance=ExtResource( 9 )]
+position = Vector2( 925.285, 321.719 )
+orientation = 1
+stool_path = NodePath("../../Obstacles/Stool5")
+id = "table_seat_right"
+elevation = 140.0

--- a/project/src/main/world/environment/marsh/MarshIndoorsEnvironment.tscn
+++ b/project/src/main/world/environment/marsh/MarshIndoorsEnvironment.tscn
@@ -758,3 +758,25 @@ id = "kitchen_9"
 [node name="Kitchen11" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 1740.68, 77.2144 )
 id = "kitchen_11"
+
+[node name="TableSeatLeft" parent="Spawns" instance=ExtResource( 38 )]
+position = Vector2( 749.285, 321.719 )
+stool_path = NodePath("../../Obstacles/Stool6")
+id = "table_seat_left"
+elevation = 140.0
+
+[node name="Table2" parent="Spawns" instance=ExtResource( 38 )]
+position = Vector2( 689.515, 237.165 )
+id = "table_2"
+
+[node name="Table10" parent="Spawns" instance=ExtResource( 38 )]
+position = Vector2( 995.141, 231.219 )
+orientation = 1
+id = "table_10"
+
+[node name="TableSeatRight" parent="Spawns" instance=ExtResource( 38 )]
+position = Vector2( 925.285, 321.719 )
+orientation = 1
+stool_path = NodePath("../../Obstacles/Stool5")
+id = "table_seat_right"
+elevation = 140.0

--- a/project/src/main/world/environment/marsh/UndecoratedIndoorsEnvironment.tscn
+++ b/project/src/main/world/environment/marsh/UndecoratedIndoorsEnvironment.tscn
@@ -754,3 +754,25 @@ id = "kitchen_9"
 [node name="Kitchen11" parent="Spawns" instance=ExtResource( 30 )]
 position = Vector2( 1740.68, 77.2144 )
 id = "kitchen_11"
+
+[node name="TableSeatLeft" parent="Spawns" instance=ExtResource( 30 )]
+position = Vector2( 749.285, 321.719 )
+stool_path = NodePath("../../Obstacles/Stool6")
+id = "table_seat_left"
+elevation = 140.0
+
+[node name="Table2" parent="Spawns" instance=ExtResource( 30 )]
+position = Vector2( 689.515, 237.165 )
+id = "table_2"
+
+[node name="Table10" parent="Spawns" instance=ExtResource( 30 )]
+position = Vector2( 995.141, 231.219 )
+orientation = 1
+id = "table_10"
+
+[node name="TableSeatRight" parent="Spawns" instance=ExtResource( 30 )]
+position = Vector2( 925.285, 321.719 )
+orientation = 1
+stool_path = NodePath("../../Obstacles/Stool5")
+id = "table_seat_right"
+elevation = 140.0


### PR DESCRIPTION
CutsceneDemo accepts 'best_distance_travelled' flag

CutsceneDemo can load cutscenes from demo folder.

CutsceneDemo correctly assigns focus when a dialog is closed.

CutsceneDemo validates its initial cutscene path, reporting warnings
appropriately.

CutsceneDemo handles invalid cutscene selections differently. Before, it
would pop up a dialog and ignore the player's selection. Now it pops up
the dialog and saves the player's selection, but disables the start
button. This allows better consistency for the case where the player has
bad data already saved.

comments, delint