### PR TITLE
Chat bugfixes: chat_count, unit test fix

### DIFF
--- a/project/src/main/ui/chat/chat-history.gd
+++ b/project/src/main/ui/chat/chat-history.gd
@@ -19,6 +19,7 @@ var _chat_count := 0
 
 func reset() -> void:
 	chat_history.clear()
+	_chat_count = 0
 
 
 func add_history_item(chat_key: String) -> void:

--- a/project/src/test/ui/chat/test-chatscript-parser.gd
+++ b/project/src/test/ui/chat/test-chatscript-parser.gd
@@ -10,10 +10,12 @@ const CHAT_THOUGHT := "res://assets/test/ui/chat/chat-thought.chat"
 
 func before_each() -> void:
 	ChatLibrary.chat_key_root_path = "res://assets/test"
+	PlayerData.chat_history.reset()
 
 
 func after_each() -> void:
 	ChatLibrary.chat_key_root_path = ChatLibrary.DEFAULT_CHAT_KEY_ROOT_PATH
+	PlayerData.chat_history.reset()
 
 
 func _chat_tree_from_file(path: String) -> ChatTree:


### PR DESCRIPTION
ChatHistory.reset() now resets the chat_count

test-chatscript-parser now resets the chat history

Neither of these were causing immediate problems but they would have
made tests more unreliable as we added more