### PR TITLE
Refactored substitute_variables to remove parameter.

### DIFF
--- a/project/src/main/creature-library.gd
+++ b/project/src/main/creature-library.gd
@@ -179,13 +179,17 @@ func set_creature_def(creature_id: String, creature_def: CreatureDef) -> void:
 ## Substitutes variables in player-visible text.
 ##
 ## Text variables are pound sign delimited: 'Hello #player#'. This matches the syntax of Tracery.
-func substitute_variables(string: String, full_name: bool = false) -> String:
+func substitute_variables(string: String) -> String:
 	var result := string
-	if full_name:
-		result = result.replace(PLAYER_ID, get_player_def().creature_name)
-	else:
-		result = result.replace(PLAYER_ID, get_player_def().creature_short_name)
+	
+	# replace player/sensei name
+	result = result.replace(PLAYER_ID, get_player_def().creature_short_name)
 	result = result.replace(SENSEI_ID, get_sensei_def().creature_short_name)
+	
+	# replace phrases from choices the player's made, such as the proposed restaurant name
+	for phrase in PlayerData.chat_history.phrases:
+		result = result.replace("#%s#" % [phrase], tr(PlayerData.chat_history.phrases[phrase]))
+	
 	return result
 
 

--- a/project/src/main/ui/nametag-panel.gd
+++ b/project/src/main/ui/nametag-panel.gd
@@ -28,7 +28,14 @@ func refresh_chat_theme(chat_theme: ChatTheme) -> void:
 
 ## Assigns the name label's text and updates our nametag_size field to the smallest name label which fit.
 func set_nametag_text(new_text: String) -> void:
-	new_text = PlayerData.creature_library.substitute_variables(new_text, true)
+	# replace unique name for player/sensei
+	match new_text:
+		CreatureLibrary.PLAYER_ID:
+			new_text = PlayerData.creature_library.player_def.creature_name
+		CreatureLibrary.SENSEI_ID:
+			new_text = PlayerData.creature_library.sensei_def.creature_name
+		_:
+			pass
 	
 	if new_text.empty():
 		nametag_size = ChatTheme.NAMETAG_OFF

--- a/project/src/test/test-creature-library.gd
+++ b/project/src/test/test-creature-library.gd
@@ -1,0 +1,20 @@
+extends "res://addons/gut/test.gd"
+
+func before_each() -> void:
+	PlayerData.creature_library.reset()
+
+
+func after_all() -> void:
+	PlayerData.creature_library.reset()
+
+
+func test_substitute_variables_names() -> void:
+	PlayerData.creature_library.player_def.creature_name = "Gegad Hi"
+	PlayerData.creature_library.player_def.creature_short_name = "Gegad"
+	
+	PlayerData.creature_library.sensei_def.creature_name = "Eper Tiv"
+	PlayerData.creature_library.sensei_def.creature_short_name = "Eper"
+	
+	var result := PlayerData.creature_library.substitute_variables(
+			"Let's meet #player# and their sensei #sensei#.")
+	assert_eq(result, "Let's meet Gegad and their sensei Eper.")


### PR DESCRIPTION
This extra 'full_name' parameter was only used in one place, for
substituting long names in nametags. This is easier to do with something
like a match statement rather than having to scan the entire string.

Added missing CreatureLibrary unit test.