### PR TITLE
Chatscript: default_phrase, has_phrase

### DIFF
--- a/project/assets/demo/chat/tableside.chat
+++ b/project/assets/demo/chat/tableside.chat
@@ -8,4 +8,5 @@ player, p1, table_10
 mara, m, table_seat_left
 
 p1: Oh hey Mara! Don't worry, this one will be on the house~
-m: ^_^/ Oh that's alright.
+m: ^_^/ Oh that's alright. I know you like #favorite_animal#.
+ (default_phrase favorite_animal classy kittens)

--- a/project/assets/test/ui/chat/chat-default-phrase.chat
+++ b/project/assets/test/ui/chat/chat-default-phrase.chat
@@ -1,0 +1,6 @@
+{"version": "2476"}
+
+player: Hello!
+boatricia: Hello, nice to meet you!
+ (default_phrase tall_cluttered Frequent Straw)
+ 

--- a/project/assets/test/ui/chat/chat-set-phrase.chat
+++ b/project/assets/test/ui/chat/chat-set-phrase.chat
@@ -3,3 +3,7 @@
 player: Hello!
 boatricia: Hello, nice to meet you!
  (set_phrase tall_cluttered Frequent Straw)
+  
+[alternate_start]
+boatricia: I remember you!
+ (start_if has_phrase tall_cluttered)

--- a/project/src/demo/toolkit/extract-localizables-button.gd
+++ b/project/src/demo/toolkit/extract-localizables-button.gd
@@ -110,6 +110,12 @@ func _extract_localizables_from_chat_event(event: ChatEvent) -> void:
 								% [args.size()])
 					
 					_localizables.append(PoolStringArray(args.slice(1, args.size())).join(" "))
+				"default_phrase":
+					if args.size() < 2:
+						push_warning("Invalid token count for default_phrase call. Expected 2 but was %s"
+								% [args.size()])
+					
+					_localizables.append(PoolStringArray(args.slice(1, args.size())).join(" "))
 
 
 ## Extract localizables from OS.get_scancode_string()

--- a/project/src/main/ui/bool-expression-parser.gd
+++ b/project/src/main/ui/bool-expression-parser.gd
@@ -93,6 +93,16 @@ class HasFlagExpression extends BoolExpression:
 		return PlayerData.chat_history.has_flag(args[0].string)
 
 
+class HasPhraseExpression extends BoolExpression:
+	func _init(new_token: BoolToken, flag: BoolToken) -> void:
+		token = new_token
+		args = [flag]
+	
+	
+	func evaluate() -> bool:
+		return PlayerData.chat_history.has_phrase(args[0].string)
+
+
 class IsFlagExpression extends BoolExpression:
 	func _init(new_token: BoolToken, flag: BoolToken, value: BoolToken) -> void:
 		token = new_token
@@ -193,6 +203,8 @@ func _parse_function() -> BoolExpression:
 			expression = ChatFinishedExpression.new(_get_next_token(), _get_next_token())
 		"has_flag":
 			expression = HasFlagExpression.new(_get_next_token(), _get_next_token())
+		"has_phrase":
+			expression = HasPhraseExpression.new(_get_next_token(), _get_next_token())
 		"is_flag":
 			expression = IsFlagExpression.new(_get_next_token(), _get_next_token(), _get_next_token())
 		"level_finished":

--- a/project/src/main/ui/chat/chat-history.gd
+++ b/project/src/main/ui/chat/chat-history.gd
@@ -92,6 +92,11 @@ func set_phrase(key: String, value: String) -> void:
 	phrases[key] = value
 
 
+## Returns 'true' of a chat phrase's value is set to a non-empty value.
+func has_phrase(key: String) -> bool:
+	return not get_phrase(key).empty()
+
+
 func get_phrase(key: String) -> String:
 	return phrases.get(key, "")
 

--- a/project/src/main/ui/chat/chat-tree.gd
+++ b/project/src/main/ui/chat/chat-tree.gd
@@ -240,9 +240,22 @@ func _assign_flags_and_phrases() -> void:
 		var args: Array = tokens.slice(1, tokens.size())
 		if tokens:
 			match tokens[0]:
+				"default_phrase": _process_default_phrase_statement(args)
 				"set_flag": _process_set_flag_statement(args)
 				"set_phrase": _process_set_phrase_statement(args)
 				"unset_flag": _process_unset_flag_statement(args)
+
+
+
+func _process_default_phrase_statement(args: Array) -> void:
+	if args.size() < 2:
+		push_warning("Invalid argument count for default_phrase call. Expected at least 2 but was %s"
+				% [args.size()])
+		return
+	
+	if not PlayerData.chat_history.has_phrase(args[0]):
+		PlayerData.chat_history.set_phrase(
+				args[0], PoolStringArray(args.slice(1, args.size())).join(" "))
 
 
 func _process_set_flag_statement(args: Array) -> void:

--- a/project/src/test/ui/chat/test-chatscript-parser.gd
+++ b/project/src/test/ui/chat/test-chatscript-parser.gd
@@ -274,3 +274,34 @@ func test_set_phrase() -> void:
 	
 	chat_tree.advance()
 	assert_eq(PlayerData.chat_history.get_phrase("tall_cluttered"), "Frequent Straw")
+
+
+func test_has_phrase() -> void:
+	var chat_tree: ChatTree
+	
+	chat_tree = _chat_tree_from_file(CHAT_SET_PHRASE)
+	assert_eq(chat_tree.get_event().text, "Hello!")
+	
+	PlayerData.chat_history.set_phrase("tall_cluttered", "Frequent Straw")
+	
+	chat_tree = _chat_tree_from_file(CHAT_SET_PHRASE)
+	assert_eq(chat_tree.get_event().text, "I remember you!")
+
+
+func test_default_phrase() -> void:
+	var chat_tree := _chat_tree_from_file(CHAT_DEFAULT_PHRASE)
+	assert_eq(PlayerData.chat_history.get_phrase("tall_cluttered"), "")
+	
+	chat_tree.advance()
+	assert_eq(PlayerData.chat_history.get_phrase("tall_cluttered"), "Frequent Straw")
+
+
+func test_default_phrase_doesnt_overwrite() -> void:
+	PlayerData.chat_history.set_phrase("tall_cluttered", "Wreck Lean")
+	
+	var chat_tree := _chat_tree_from_file(CHAT_DEFAULT_PHRASE)
+	assert_eq(PlayerData.chat_history.get_phrase("tall_cluttered"), "Wreck Lean")
+	
+	# the 'default_phrase' meta item should not overwrite a phrase which is already saved
+	chat_tree.advance()
+	assert_eq(PlayerData.chat_history.get_phrase("tall_cluttered"), "Wreck Lean")


### PR DESCRIPTION
If we add cutscenes which reference the player's chosen restaurant name,
people who have already progressed past that part in the story will just
see '#restaurant_name#' or something like that because they made no
selection. The 'default_phrase' meta item helps us fill in this gap.

Ideally, this 'default_phrase' item would not be written to the player's
chat history and maybe even be scoped to a specific variable reference.
But in addition to being more difficult to implement, this would intrude
on localization since a phrase like 'I love eating at
%favorite_restaurant%' is reasonable for a non-coder to localize (just
ignore the weird code-looking part) but a phrase like 'I love eating at
%favorite_restaurant|Junjorito%' requires a deeper understanding of
chatscript nuances.