### PR TITLE
Level/region buttons receive default focus.

### DIFF
--- a/project/src/main/ui/menu/paged-level-buttons.gd
+++ b/project/src/main/ui/menu/paged-level-buttons.gd
@@ -104,6 +104,10 @@ func _add_buttons() -> void:
 		
 		_grid_container.add_child(new_level_button)
 		emit_signal("button_added", new_level_button)
+	
+	# assign default focus to the first button
+	if _grid_container.get_child_count():
+		_grid_container.get_children().front().grab_focus()
 
 
 ## Removes all buttons/placeholders in preparation for loading a new set of level buttons.

--- a/project/src/main/ui/menu/paged-region-buttons.gd
+++ b/project/src/main/ui/menu/paged-region-buttons.gd
@@ -113,6 +113,10 @@ func _add_buttons() -> void:
 				i, _regions_by_page[_page][i])
 		_hbox_container.add_child(new_region_button)
 		emit_signal("button_added", new_region_button)
+	
+	# assing default focus to the first button
+	if _hbox_container.get_child_count():
+		_hbox_container.get_children().front().grab_focus()
 
 
 ## Enables/disables the paging arrows, hiding them if the player only has access to a single page of regions.

--- a/project/src/main/ui/menu/region-submenu.gd
+++ b/project/src/main/ui/menu/region-submenu.gd
@@ -26,10 +26,8 @@ func popup(default_region_id: String) -> void:
 			regions.append(region)
 	regions.append_array(CareerLevelLibrary.regions)
 	_region_buttons.regions = regions
-	
 	if default_region_id:
 		_region_buttons.focus_region(default_region_id)
-	
 	show()
 
 


### PR DESCRIPTION
Before, drilling down into the practice menu often resulted in no
buttons being focused, which meant you had to use the mouse.