### PR TITLE
Tracery. #player.possessive# works.

### DIFF
--- a/delint.sh
+++ b/delint.sh
@@ -83,6 +83,7 @@ RESULT=$(grep -R -n "var [^:]* = " --include="*.gd" project/src \
   | grep -v "utils.gd.*var tmp = arr\[i\]" \
   | grep -v "dna-loader.gd.*var property_value =" \
   | grep -v "career-data.gd.*var chat_tree = ChatLibrary.chat" \
+  | grep -v "tracery.gd.*var selected_rule = match_name" \
   | grep -v "dna-loader.gd.*var shader_value =")
 if [ -n "$RESULT" ]
 then

--- a/license/asset-license.txt
+++ b/license/asset-license.txt
@@ -27,6 +27,8 @@ $ Various icons by Freepik (https://www.flaticon.com/authors/freepik) (Unlimited
 $ Paws by Solid Icon Co (https://www.flaticon.com/authors/solid-icon-co) (Unlimited use without attribution)
 
 Other:
+$ GDTracery by Althar93 (https://github.com/Althar93/GDTracery) (Apache-2.0 license)
+$ Tracery by Kate Compton (https://github.com/galaxykate/tracery/tree/tracery2) (Apache-2.0 license)
 $ Smooth HSV to RGB conversion by Inigo Quilez (https://www.shadertoy.com/view/MsS3Wc) (MIT License)
 $$ Gut by Tom "Butch" Wesley (MIT License)
 $$$ Godot Engine (MIT license)
@@ -129,5 +131,5 @@ project/assets/main/ui/schoolbell-regular.ttf Schoolbell by Font Diner
 Other
 --------------------------------------------------------------------------------
 project/src/main/puzzle/rainbow-metaball.shader.hsv2rgb "Smooth HSV to RGB conversion" by Iniqo Quilez (https://www.shadertoy.com/view/MsS3Wc)
+project/src/main/tracery.gd "GDTracery" by Althar93, an adaptation of Tracery by Kate Compton (https://github.com/Althar93/GDTracery) (https://github.com/galaxykate/tracery/tree/tracery2)
 project/addons/gut "Gut" by Tom "Butch" Wesley
-

--- a/project/project.godot
+++ b/project/project.godot
@@ -1019,6 +1019,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/settings/touch-settings.gd"
 }, {
+"base": "Reference",
+"class": "Tracery",
+"language": "GDScript",
+"path": "res://src/main/tracery.gd"
+}, {
 "base": "Control",
 "class": "TutorialDiagram",
 "language": "GDScript",
@@ -1267,6 +1272,7 @@ _global_script_class_icons={
 "TechMoveBurst": "",
 "TechMoveDetector": "",
 "TouchSettings": "",
+"Tracery": "",
 "TutorialDiagram": "",
 "TutorialHud": "",
 "TutorialMessages": "",

--- a/project/src/main/creature-library.gd
+++ b/project/src/main/creature-library.gd
@@ -180,17 +180,14 @@ func set_creature_def(creature_id: String, creature_def: CreatureDef) -> void:
 ##
 ## Text variables are pound sign delimited: 'Hello #player#'. This matches the syntax of Tracery.
 func substitute_variables(string: String) -> String:
-	var result := string
-	
-	# replace player/sensei name
-	result = result.replace(PLAYER_ID, get_player_def().creature_short_name)
-	result = result.replace(SENSEI_ID, get_sensei_def().creature_short_name)
-	
-	# replace phrases from choices the player's made, such as the proposed restaurant name
+	var rules := {}
+	rules["player"] = get_player_def().creature_short_name
+	rules["sensei"] = get_sensei_def().creature_short_name
 	for phrase in PlayerData.chat_history.phrases:
-		result = result.replace("#%s#" % [phrase], tr(PlayerData.chat_history.phrases[phrase]))
-	
-	return result
+		rules[phrase] = tr(PlayerData.chat_history.phrases[phrase])
+	var grammar := Tracery.Grammar.new(rules)
+	grammar.add_modifiers(Tracery.Modifiers.get_modifiers())
+	return grammar.flatten(string)
 
 
 ## Populates the fatness for randomly generated filler creatures.

--- a/project/src/main/tracery.gd
+++ b/project/src/main/tracery.gd
@@ -1,0 +1,167 @@
+class_name Tracery
+extends Reference
+## Implementation of Kate Compton's Tracery.
+##
+## Tracery is a JavaScript library by GalaxyKate that uses grammars to generate text. This specific implementation is
+## adapted from Althar93's GDTracery, a GDscript port of Tracery for Godot Engine 3.1.
+## https://github.com/Althar93/GDTracery/blob/f6191894781625b8a8c45923b11f0f79394a896d/scripts/tracery.gd
+
+
+## A collection of Tracery modifiers.
+##
+## A Tracery modifier is a function that takes a string (and optionally parameters) and returns a string. A set of
+## these is included in mods-eng-basic.js. Modifiers are applied, in order, after a tag is fully expanded.
+class Modifiers extends Reference:
+	
+	## Returns a collection of Tracery modifiers for the current locale.
+	static func get_modifiers() -> Dictionary:
+		var result: Dictionary
+		match TranslationServer.get_locale():
+			"es":
+				result = {} # spanish lacks a possessive suffix
+			_, "en":
+				result = {
+					"possessive": [Modifiers, "_en_possessive"],
+				}
+		return result
+
+
+	## Applies an English possessive suffix to a word.
+	##
+	## _en_possessive("Erik")    = "Erik's"
+	## _en_possessive("Doris")   = "Doris'"
+	static func _en_possessive(s: String) -> String:
+		if s and s[s.length() - 1] == "s":
+			return s + "'"
+		else:
+			return s + "'s"
+
+
+## An implementation of a Tracery grammar.
+##
+## A Grammar is:
+## 	* a dictionary of symbols: a key-value object matching keys (the names of symbols) to expansion rules
+## 	* optional metadata such as a title, edit data, and author
+## 	* optional connectivity graphs describing how symbols call each other
+##
+## clearState: symbols and rulesets have state (the stack, and possible ruleset state recording recently called
+## rules). This function clears any state, returning the dictionary to its original state;
+##
+## Grammars are usually created by feeding in a raw JSON grammar, which is then parsed into symbols and rules. You can
+## also build your own Grammar objects from scratch, without using this utility function, and can always edit the
+## grammar after creating it.
+class Grammar extends Reference:
+	var rng: RandomNumberGenerator
+	
+	## Lookup table for Tracery modifiers such as 's' or 'possessive'.
+	##
+	## key: (String) Tracery modifier key such as 's' or 'possessive'.
+	## value: (Array) Array of two elements defining the modifier function.
+	## 	value[0]: (Object) Script containing the modifier function.
+	## 	value[1]: (String) Modifier method name.
+	var _modifier_lookup: Dictionary = {}
+	
+	## key: (String) Match name
+	## value: (Array/String) Either a single string rule, or an array of possible rules.
+	var _rules: Dictionary = {}
+	
+	## key: (String) Match name
+	## value: (Array/String) Either a single string rule, or an array of possible rules.
+	var _save_data: Dictionary = {}
+	var _expansion_regex: RegEx
+	var _save_symbol_regex: RegEx
+
+
+	func _init(rules: Dictionary) -> void:
+		_expansion_regex = RegEx.new()
+		_expansion_regex.compile("(?<!\\[|:)(?!\\])#.+?(?<!\\[|:)#(?!\\])")
+		
+		_save_symbol_regex = RegEx.new()
+		_save_symbol_regex.compile("\\[.+?\\]")
+		
+		rng = RandomNumberGenerator.new()
+		rng.randomize()
+		
+		_rules = rules.duplicate(true)
+
+
+	func add_modifier(key: String, object: Object, function: String) -> void:
+		_modifier_lookup[key] = [object, function]
+
+
+	func add_modifiers(modifiers: Dictionary) -> void:
+		for k in modifiers:
+			_modifier_lookup[k] = modifiers[k]
+
+
+	func flatten(rule: String) -> String:
+		var expansion_matches := _expansion_regex.search_all(rule)
+		if expansion_matches.empty():
+			_resolve_save_symbols(rule)
+		
+		for match_result in expansion_matches:
+			var match_value: String = match_result.strings[0]
+			_resolve_save_symbols(match_value)
+			
+			# Remove the # surrounding the symbol name
+			var match_name := match_value.replace("#", "")
+			
+			# Remove the save symbols
+			match_name = _save_symbol_regex.sub(match_name, "", true)
+			
+			# Take match name until the first '.' if it exists
+			var dot_index := match_name.find(".")
+			if dot_index >= 0:
+				match_name = match_name.substr(0, dot_index)
+			
+			var modifiers := _get_modifiers(match_value)
+			
+			# Look for the selected rule in either the rules, saved data or as a standalone rule
+			var selected_rule = match_name
+			if _rules.has(match_name):
+				selected_rule = _rules[match_name]
+			elif _save_data.has(match_name):
+				selected_rule = _save_data[match_name]
+			
+			# For array rules, select a random item in the array
+			if typeof(selected_rule) == TYPE_ARRAY:
+				var rand_index: int = rng.randi() % selected_rule.size()
+				selected_rule = selected_rule[rand_index] as String
+			
+			var resolved := flatten(selected_rule)
+			resolved = _apply_modifiers(resolved, modifiers)
+			rule = rule.replace(match_value, resolved)
+		
+		return rule
+
+
+	func _resolve_save_symbols(rule: String) -> void:
+		var save_matches := _save_symbol_regex.search_all(rule)
+		for match_result in save_matches:
+			var match_value: String = match_result.strings[0]
+			var save := match_value.replace("[", "").replace("]", "")
+			var save_split := save.split(":")
+			
+			if save_split.size() == 2:
+				var name := save_split[0]
+				var data := flatten(save_split[1])
+				_save_data[name] = data
+			else:
+				var name := save
+				var data := flatten("#" + save + "#")
+				_save_data[name] = data
+
+
+	func _get_modifiers(symbol: String) -> PoolStringArray:
+		var modifiers := symbol.replace("#", "").split(".")
+		modifiers.remove(0)
+		return modifiers
+
+
+	func _apply_modifiers(resolved: String, modifiers: PoolStringArray) -> String:
+		for m in modifiers:
+			if _modifier_lookup.has(m):
+				var object: Object = _modifier_lookup[m][0]
+				var function: String = _modifier_lookup[m][1]
+				resolved = object.call(function, resolved)
+		return resolved

--- a/project/src/main/ui/chat/career-cutscene-library.gd
+++ b/project/src/main/ui/chat/career-cutscene-library.gd
@@ -27,9 +27,9 @@ extends Node
 ## 	|\-career/marsh/010_c
 ## 	|...
 ##
-## These cutscenes are ordered such that numeric siblings are always played in ascending order (000, 010, 011, 020..) but
-## alphabetic siblings are played in random order (c, a, b...). These ordering rules apply both to leaf nodes as well
-## as parent nodes.
+## These cutscenes are ordered such that numeric siblings are always played in ascending order (000, 010, 011, 020..)
+## but alphabetic siblings are played in random order (c, a, b...). These ordering rules apply both to leaf nodes as
+## well as parent nodes.
 ##
 ## Nodes starting with a number 100 or greater are 'post-boss cutscenes' and will not play unless the player has
 ## cleared the region's boss level.

--- a/project/src/test/test-creature-library.gd
+++ b/project/src/test/test-creature-library.gd
@@ -21,8 +21,16 @@ func test_substitute_variables_names() -> void:
 
 
 func test_substitute_variables_phrases() -> void:
-	PlayerData.chat_history.set_phrase("favorite_animal_plural", "classy rabbits")
+	PlayerData.chat_history.set_phrase("silly_name", "Gomot Ocedut")
 	
 	var result := PlayerData.creature_library.substitute_variables(
-			"I sure love #favorite_animal_plural#.")
-	assert_eq(result, "I sure love classy rabbits.")
+			"Please call me #silly_name#.")
+	assert_eq(result, "Please call me Gomot Ocedut.")
+
+
+func test_substitute_possessive() -> void:
+	PlayerData.creature_library.player_def.creature_short_name = "Gegad"
+	
+	var result := PlayerData.creature_library.substitute_variables(
+			"This is all #player.possessive# fault.")
+	assert_eq(result, "This is all Gegad's fault.")

--- a/project/src/test/test-tracery.gd
+++ b/project/src/test/test-tracery.gd
@@ -1,0 +1,50 @@
+extends "res://addons/gut/test.gd"
+
+var rules := {}
+
+# GDTracery's original set_rng() implementation had a bug
+# https://github.com/Althar93/GDTracery/issues/2
+func test_set_rng() -> void:
+	var grammar := Tracery.Grammar.new(rules)
+	var new_rng := RandomNumberGenerator.new()
+	grammar.rng = new_rng
+	assert_eq(grammar.rng, new_rng)
+
+
+func test_simple() -> void:
+	rules["favorite_color"] = ["blue"]
+	
+	assert_flatten("My favorite color is #favorite_color#.",
+			"My favorite color is blue.")
+
+
+func test_modifier_possessive() -> void:
+	rules["person"] = ["Erik"]
+	assert_flatten("What's #person.possessive# problem?", "What's Erik's problem?")
+	
+	rules["person"] = ["Doris"]
+	assert_flatten("What's #person.possessive# problem?", "What's Doris' problem?")
+	
+	rules["person"] = [""]
+	assert_flatten("What's #person.possessive# problem?", "What's 's problem?")
+
+
+## Spanish has no possessive modifier. Returning the unmodified input is grammatically correct.
+func test_modifier_possessive_es() -> void:
+	var original_locale := TranslationServer.get_locale()
+	TranslationServer.set_locale("es")
+	rules["person"] = ["Erik"]
+	assert_flatten("¿Dónde está el lápiz de #person.possessive#?", "¿Dónde está el lápiz de Erik?")
+	
+	rules["person"] = ["Doris"]
+	assert_flatten("¿Dónde está el lápiz de #person.possessive#?", "¿Dónde está el lápiz de Doris?")
+	
+	rules["person"] = [""]
+	assert_flatten("¿Dónde está el lápiz de #person.possessive#?", "¿Dónde está el lápiz de ?")
+	TranslationServer.set_locale(original_locale)
+
+
+func assert_flatten(rule: String, expected: String) -> void:
+	var grammar := Tracery.Grammar.new(rules)
+	grammar.add_modifiers(Tracery.Modifiers.get_modifiers())
+	assert_eq(grammar.flatten(rule), expected)


### PR DESCRIPTION
https://github.com/Althar93/GDTracery

Added GDTracery. We were already using tracery-like syntax for things
like #player# and #sensei#, but the new cutscenes also needed to be able
to say things like "I'm Tom's business partner" which was not possible.

I've modified the tracery implementation in a few ways:

  * I've added localization. English and spanish have their own modifiers for how
    to make a word possessive, and it is easy to add more.
  * I've removed most modifiers, even common ones such as '-ed' and '-s'. We can
    reintroduce these as necessary, but if we have 10 modifiers and 10 languages
    that is 100 functions to write. Fewer is better.
  * Bugfixes, specifically a flaw in GDTracery's 'set_rng' function.
    This flawed setter was unnecessary so I've removed it.

Tracery may be overkill for our game as it includes a lot of features we
are not using, such as randomly generated text. Once our game is more
mature we should consider stripping out the parts we're not using.