### PR TITLE
Switch lull from '/' to '|'. Illegal name chars.

### DIFF
--- a/project/assets/main/chat/career/marsh/intro-level-end.chat
+++ b/project/assets/main/chat/career/marsh/intro-level-end.chat
@@ -44,7 +44,7 @@ s: My... my technique?
 s1: You should focus on the piece of food you're cooking. You don't need to flip all those other pieces beforehand.
 s: @_@ But I have to keep them flipped the same way! Otherwise it makes my head all muddy.
 s1: Well, flipping them slows you down.
-s1: That food should be coming out like pap-/pap-/pap-/pap-/pap!/ Right now you're more like pappap,// pappa/ pap.
+s1: That food should be coming out like pap-|pap-|pap-|pap-|pap!| Right now you're more like pappap,|| pappa| pap.
 s1: You don't want to give your customers any break. Eating should become an unconscious reflex to them, like blinking!
 [oh_okay]
 
@@ -54,7 +54,7 @@ s: My... my technique?
 s1: You should focus on the piece of food you're cooking. You don't need to flip all those other pieces beforehand.
 s: @_@ But I have to keep them flipped the same way! Otherwise it makes my head all muddy.
 s1: Well, flipping them slows you down.
-s1: That food should be coming out like pap-/pap-/pap-/pap-/pap!/ Right now you're more like pappap,// pappa/ pap.
+s1: That food should be coming out like pap-|pap-|pap-|pap-|pap!| Right now you're more like pappap,|| pappa| pap.
 s1: You don't want to give your customers any break. Eating should become an unconscious reflex to them, like blinking!
 [oh_okay]
 

--- a/project/assets/test/ui/chat/cutscene-full.chat
+++ b/project/assets/test/ui/chat/cutscene-full.chat
@@ -43,14 +43,14 @@ s: ._.; Uhh I mean like, Richie's been helping me figure out the kitchen stuff. 
 [sensei_answers_praise]
 s1: /._. Hmm. Yes! Pretty good. Your rhythm's ahhh... a little off though!
 s: My... my rhythm?
-s1: Yes!/ That food should be coming out like pap-/pap-/pap-/pap-/pap!/ Right now you're more like pappap,// pappa/ pap.
+s1: Yes!/ That food should be coming out like pap-|pap-|pap-|pap-|pap!| Right now you're more like pappap,|| pappa| pap.
 s1: You don't want to give them any break. Eating should become an unconscious reflex to them, like blinking!
 [oh_okay]
 
 [sensei_answers_insult]
 s1: /._. What I think #player# is trying to say is your rhythm is ahhh... a little off.
 s: My... my rhythm?
-s1: Yes!/ That food should be coming out like pap-/pap-/pap-/pap-/pap!/ Right now you're more like pappap,// pappa/ pap.
+s1: Yes!/ That food should be coming out like pap-|pap-|pap-|pap-|pap!| Right now you're more like pappap,|| pappa| pap.
 s1: You don't want to give them any break. Eating should become an unconscious reflex to them, like blinking!
 [oh_okay]
 

--- a/project/src/demo/puzzle/tutorial/tutorial-hud-demo.gd
+++ b/project/src/demo/puzzle/tutorial/tutorial-hud-demo.gd
@@ -9,18 +9,18 @@ extends Node
 ## 	[F]: Flashes the screen
 
 const TEXTS := [
-	"Oh my,/ you're not supposed to know how to do that!\n\n" \
-			+ "...But yes,/ box clears earn you five times as much money./" \
+	"Oh my, you're not supposed to know how to do that!\n\n" \
+			+ "...But yes, box clears earn you five times as much money." \
 			+ " Maybe more than that if you're clever.",
 	"Clear a row by filling it with blocks.",
 	"Hold soft drop to squish a piece through a narrow gap.",
 	"Build a snack box by arranging two pieces into a square.",
 	"Well done!\n\nSnack boxes earn ¥15 if you clear all three lines.",
-	"Now let's try it for real!/ Serve these creatures and try to earn ¥100.",
-	"Well done!\n\nLine clears earn ¥1./ Maybe more if you can build a combo.",
-	"Well done!\n\nSquish moves can help you out of a jam./ They're also good for certain boxes.",
-	"Welcome to Turbo Fat!/ You seem to already be familiar with this sort of game,/ so let's dive right in.",
-	"Oh my,/ you're not supposed to know how to do that!\n\n...But yes,/ squish moves can help you out of a jam.",
+	"Now let's try it for real! Serve these creatures and try to earn ¥100.",
+	"Well done!\n\nLine clears earn ¥1. Maybe more if you can build a combo.",
+	"Well done!\n\nSquish moves can help you out of a jam. They're also good for certain boxes.",
+	"Welcome to Turbo Fat! You seem to already be familiar with this sort of game, so let's dive right in.",
+	"Oh my, you're not supposed to know how to do that!\n\n...But yes, squish moves can help you out of a jam.",
 ]
 
 ## a tutorial level id to demo, like 'tutorial/basic_0'
@@ -44,7 +44,7 @@ func _input(event: InputEvent) -> void:
 			else:
 				_tutorial_hud.set_message(TEXTS[Utils.key_num(event)])
 		KEY_O:
-			_tutorial_hud.set_big_message("O/H/,/// M/Y/!/!/!")
+			_tutorial_hud.set_big_message("O|H|,||| M|Y|!|!|!")
 		KEY_F:
 			_tutorial_hud.flash_for_level_change()
 		KEY_H:

--- a/project/src/main/name-utils.gd
+++ b/project/src/main/name-utils.gd
@@ -14,8 +14,12 @@ static func sanitize_name(name: String) -> String:
 	
 	# sanitize characters we don't want in names
 	for i in range(name.length()):
-		if utf8[i] < 32 or utf8[i] == 127:
-			# replace sequences of one or more bad characters with a single hyphen
+		if utf8[i] < 32 or utf8[i] in [
+			35, ## number sign; used for tracery
+			124, ## vertical line; 'lull character' when printing text
+			127, ## control character
+			]:
+			# replace sequences of one or more bad characters with a single space
 			if not result.ends_with(" "):
 				result += " "
 		else:

--- a/project/src/main/puzzle/results-hud.gd
+++ b/project/src/main/puzzle/results-hud.gd
@@ -31,14 +31,14 @@ func hide_results_message() -> void:
 
 ## Prepares a game over message to show to the player.
 ##
-## The message is littered with lull characters, '/', which are hidden from the player but result in a brief pause when
+## The message is littered with lull characters, '|', which are hidden from the player but result in a brief pause when
 ## displayed.
 func show_results_message(rank_result: RankResult, customer_scores: Array, finish_condition_type: int) -> void:
 	# Generate post-game message with stats, grades, and a gameplay hint
-	var text := "//////////"
+	var text := "||||||||||"
 	text = _append_customer_scores(rank_result, customer_scores, finish_condition_type, text)
 	text = _append_grade_information(rank_result, customer_scores, finish_condition_type, text)
-	text += "//////////\n"
+	text += "||||||||||\n"
 	text += tr("Hint: %s") % Utils.rand_value(_hints)
 	text += "\n"
 	
@@ -55,7 +55,7 @@ func _append_customer_scores(rank_result: RankResult, customer_scores: Array, \
 			# customer_score can contain zeroes if the player tops out without clearing lines
 			continue
 		var left := tr("Customer #%s") % StringUtils.comma_sep(i + 1)
-		var right := "%s/\n" % StringUtils.format_money(customer_score)
+		var right := "%s|\n" % StringUtils.format_money(customer_score)
 		var middle := " "
 		var period_count := 49 - _period_count(left + right)
 		for _p in range(period_count):
@@ -76,35 +76,35 @@ func _append_grade_information(rank_result: RankResult, _customer_scores: Array,
 	text += "\n"
 	
 	if _speed_shown(finish_condition_type):
-		text += "/////" + tr("Speed: %d") % round(rank_result.speed * 200 / 60)
+		text += "|||||" + tr("Speed: %d") % round(rank_result.speed * 200 / 60)
 		text += topped_out
 		if not CurrentLevel.settings.rank.unranked:
 			text += " (%s)" % RankCalculator.grade(rank_result.speed_rank)
 		text += "\n"
 	
 	if _pieces_shown(finish_condition_type):
-		text += "/////" + tr("Pieces: %d") % rank_result.pieces
+		text += "|||||" + tr("Pieces: %d") % rank_result.pieces
 		text += topped_out
 		if not CurrentLevel.settings.rank.unranked:
 			text += " (%s)" % RankCalculator.grade(rank_result.pieces_rank)
 		text += "\n"
 	
 	if _lines_shown(finish_condition_type):
-		text += "/////" + tr("Lines: %d") % rank_result.lines
+		text += "|||||" + tr("Lines: %d") % rank_result.lines
 		text += topped_out
 		if not CurrentLevel.settings.rank.unranked:
 			text += " (%s)" % RankCalculator.grade(rank_result.lines_rank)
 		text += "\n"
 	
 	if _boxes_shown():
-		text += "/////" + tr("Boxes: %d") % round(rank_result.box_score_per_line * 10)
+		text += "|||||" + tr("Boxes: %d") % round(rank_result.box_score_per_line * 10)
 		text += topped_out
 		if not CurrentLevel.settings.rank.unranked:
 			text += " (%s)" % RankCalculator.grade(rank_result.box_score_per_line_rank)
 		text += "\n"
 	
 	if _combos_shown():
-		text += "/////" + tr("Combos: %d") % round(rank_result.combo_score_per_line * 10)
+		text += "|||||" + tr("Combos: %d") % round(rank_result.combo_score_per_line * 10)
 		text += topped_out
 		if not CurrentLevel.settings.rank.unranked:
 			text += " (%s)" % RankCalculator.grade(rank_result.combo_score_per_line_rank)
@@ -119,15 +119,15 @@ func _append_grade_information(rank_result: RankResult, _customer_scores: Array,
 			# show the 'total' pickup score
 			shown_pickup_score = float(rank_result.pickup_score)
 		
-		text += "/////" + tr("Pickups: %d") % shown_pickup_score
+		text += "|||||" + tr("Pickups: %d") % shown_pickup_score
 		text += topped_out
 		if not CurrentLevel.settings.rank.unranked:
 			text += " (%s)" % RankCalculator.grade(rank_result.pickup_score_rank)
 		text += "\n"
 	
 	if not CurrentLevel.settings.rank.unranked:
-		text += "/////\n" + tr("Overall: ")
-		text += "//////////"
+		text += "|||||\n" + tr("Overall: ")
+		text += "||||||||||"
 		if finish_condition_type == Milestone.SCORE:
 			var duration := StringUtils.format_duration(rank_result.seconds)
 			text += "%s%s (%s)\n" % [duration, topped_out, RankCalculator.grade(rank_result.seconds_rank)]

--- a/project/src/main/puzzle/results-label.gd
+++ b/project/src/main/puzzle/results-label.gd
@@ -6,7 +6,7 @@ extends RichTextLabel
 signal text_shown(new_text)
 
 ## unshown character which causes the output to pause for 0.2 beats
-const LULL_CHARACTER := '/'
+const LULL_CHARACTER := '|'
 
 ## The delay in seconds before displaying the next character
 var _pause := 0.0
@@ -38,7 +38,7 @@ func _process(delta: float) -> void:
 	while _unshown_index < _unshown_text.length() and _pause <= 0.0:
 		# continue showing characters until we hit a pause
 		var unshown_char := _unshown_text[_unshown_index]
-		if unshown_char == '/':
+		if unshown_char == LULL_CHARACTER:
 			_pause += 0.2 * _beat_duration
 		else:
 			text += unshown_char
@@ -58,9 +58,9 @@ func _process(delta: float) -> void:
 
 ## Reveals the label and empties its contents, gradually appending text over time.
 ##
-## The text can include lull characters, '/', which are hidden from the player but result in a brief delay to mimic
+## The text can include lull characters, '|', which are hidden from the player but result in a brief delay to mimic
 ## patterns of speech:
-## 	'Despite the promise of info,/ I was unable to determine what,/ if anything,/ a 'butt/ onion'/ is supposed to be.'
+## 	'Despite the promise of info,| I was unable to determine what,| if anything,| a 'butt| onion'| is supposed to be.'
 func show_text(text_with_lulls: String) -> void:
 	# reset text state before showing new text
 	hide_text()

--- a/project/src/main/ui/chat/chat-library.gd
+++ b/project/src/main/ui/chat/chat-library.gd
@@ -40,28 +40,28 @@ func chat_tree_from_file(path: String) -> ChatTree:
 ## Lull characters make the chat UI briefly pause at parts of the chat line. We add these after periods, commas and
 ## other punctuation.
 func add_lull_characters(s: String) -> String:
-	if "/" in s:
+	if "|" in s:
 		# if the sentence already contains lull characters, we leave it alone
 		return s
 	
 	var transformer := StringTransformer.new(s)
 	
 	# add pauses after certain kinds of punctuation
-	transformer.sub("([!.?,])", "$1/")
+	transformer.sub("([!.?,])", "$1|")
 	
 	# add pauses after dashes, but not in hyphenated words
-	transformer.sub("(-)(?=[/!.?,\\- ])", "$1/")
+	transformer.sub("(-)(?=[|!.?,\\- ])", "$1|")
 	
-	# strip pauses from ellipses which conclude a line, unless the entire sentence is an ellipsis
-	if transformer.search("[^/!.?,\\- ]"):
+	# remove pauses from ellipses which conclude a line, unless the entire sentence is an ellipsis
+	if transformer.search("[^\\|!.?,\\- ]"):
 		for _i in range(10):
 			var old_transformed := transformer.transformed
-			transformer.sub("/([/!.?,\\-]*)$", "$1")
+			transformer.sub("\\|([\\|!.?]*)$", "$1")
 			if old_transformed == transformer.transformed:
 				break
 	
 	# remove lull character from the end of the line
-	transformer.transformed = transformer.transformed.trim_suffix("/")
+	transformer.transformed = transformer.transformed.trim_suffix("|")
 	
 	return transformer.transformed
 
@@ -73,13 +73,13 @@ func add_mega_lull_characters(s: String) -> String:
 	var transformer := StringTransformer.new(s)
 	
 	# long pause between words
-	transformer.sub(" ", "// ")
+	transformer.sub(" ", "|| ")
 	
 	# short pause between letters, punctuation
-	transformer.sub("([^/ ])", "$1/")
+	transformer.sub("([^| ])", "$1|")
 	
 	# remove lull character from the end of the line
-	transformer.transformed = transformer.transformed.trim_suffix("/")
+	transformer.transformed = transformer.transformed.trim_suffix("|")
 	return transformer.transformed
 
 

--- a/project/src/main/ui/chat/label-typer.gd
+++ b/project/src/main/ui/chat/label-typer.gd
@@ -7,10 +7,10 @@ signal all_text_shown
 ## How many seconds to delay when displaying a character.
 const DEFAULT_PAUSE := 0.05
 
-## How many seconds to delay when displaying whitespace or the special lull character, '/'.
+## How many seconds to delay when displaying whitespace or the special lull character, '|'.
 const PAUSE_CHARACTERS := {
 	" ": 0.00,
-	"/": 0.40,
+	"|": 0.40,
 	"\n": 0.80,
 }
 
@@ -62,7 +62,7 @@ func show_message(text_with_lulls: String, initial_pause: float = 0.0) -> void:
 	
 	_label.visible = true
 	set_process(true)
-	_label.text = text_with_lulls.replace("/", "")
+	_label.text = text_with_lulls.replace("|", "")
 	_calculate_pauses(text_with_lulls, initial_pause)
 
 

--- a/project/src/test/test-name-utils.gd
+++ b/project/src/test/test-name-utils.gd
@@ -25,6 +25,8 @@ func test_sanitize_name_first_and_last_character() -> void:
 
 func test_sanitize_name_invalid_characters() -> void:
 	assert_eq(NameUtils.sanitize_name("abc	def"), "abc def")
+	assert_eq(NameUtils.sanitize_name("abc#def"), "abc def")
+	assert_eq(NameUtils.sanitize_name("abc|def"), "abc def")
 
 
 func test_sanitize_name_valid_characters() -> void:
@@ -32,6 +34,7 @@ func test_sanitize_name_valid_characters() -> void:
 	assert_eq(NameUtils.sanitize_name("spoil-633"), "spoil-633")
 	assert_eq(NameUtils.sanitize_name("húsbóndi"), "húsbóndi")
 	assert_eq(NameUtils.sanitize_name("Dr. Smiles"), "Dr. Smiles")
+	assert_eq(NameUtils.sanitize_name("abc/def"), "abc/def")
 
 
 func test_sanitize_short_name() -> void:

--- a/project/src/test/ui/chat/test-chat-library.gd
+++ b/project/src/test/ui/chat/test-chat-library.gd
@@ -8,30 +8,32 @@ func test_add_lull_characters_no_effect() -> void:
 
 
 func test_add_lull_characters_punctuation() -> void:
-	assert_eq(ChatLibrary.add_lull_characters("One two, three four!"), "One two,/ three four!")
-	assert_eq(ChatLibrary.add_lull_characters("One? Two!"), "One?/ Two!")
-	assert_eq(ChatLibrary.add_lull_characters("One! Two! Three."), "One!/ Two!/ Three.")
+	assert_eq(ChatLibrary.add_lull_characters("One two, three four!"), "One two,| three four!")
+	assert_eq(ChatLibrary.add_lull_characters("One? Two!"), "One?| Two!")
+	assert_eq(ChatLibrary.add_lull_characters("One! Two! Three."), "One!| Two!| Three.")
 	
-	assert_eq(ChatLibrary.add_lull_characters("One - two."), "One -/ two.")
-	assert_eq(ChatLibrary.add_lull_characters("One -- two."), "One -/-/ two.")
+	assert_eq(ChatLibrary.add_lull_characters("One - two."), "One -| two.")
+	assert_eq(ChatLibrary.add_lull_characters("One -- two."), "One -|-| two.")
 	assert_eq(ChatLibrary.add_lull_characters("That's a half-baked idea."), "That's a half-baked idea.")
 	
 	# Don't add lull characters if there are already lull characters.
-	assert_eq(ChatLibrary.add_lull_characters("One -///-/// two."), "One -///-/// two.")
-	assert_eq(ChatLibrary.add_lull_characters("O//n//e//.////// Two, three!"), "O//n//e//.////// Two, three!")
+	assert_eq(ChatLibrary.add_lull_characters("One -|||-||| two."), "One -|||-||| two.")
+	assert_eq(ChatLibrary.add_lull_characters("O||n||e||.|||||| Two, three!"), "O||n||e||.|||||| Two, three!")
 
 
 func test_add_lull_characters_ellipses() -> void:
-	assert_eq(ChatLibrary.add_lull_characters("..."), "././.")
-	assert_eq(ChatLibrary.add_lull_characters("...One"), "./././One")
+	assert_eq(ChatLibrary.add_lull_characters("..."), ".|.|.")
+	assert_eq(ChatLibrary.add_lull_characters("...One"), ".|.|.|One")
 	assert_eq(ChatLibrary.add_lull_characters("One..."), "One...")
-	assert_eq(ChatLibrary.add_lull_characters("One... two. ...Three four."), "One./././ two./ ./././Three four.")
+	assert_eq(ChatLibrary.add_lull_characters("One...?"), "One...?")
+	assert_eq(ChatLibrary.add_lull_characters("One...!"), "One...!")
+	assert_eq(ChatLibrary.add_lull_characters("One... two. ...Three four."), "One.|.|.| two.| .|.|.|Three four.")
 
 
 func test_add_mega_lull_characters() -> void:
-	assert_eq(ChatLibrary.add_mega_lull_characters("OH, MY!!!"), "O/H/,/// M/Y/!/!/!")
-	assert_eq(ChatLibrary.add_mega_lull_characters("¡¡¡OH, MI!!!"), "¡/¡/¡/O/H/,/// M/I/!/!/!")
-	assert_eq(ChatLibrary.add_mega_lull_characters("О, МОЙ!"), "О/,/// М/О/Й/!")
+	assert_eq(ChatLibrary.add_mega_lull_characters("OH, MY!!!"), "O|H|,||| M|Y|!|!|!")
+	assert_eq(ChatLibrary.add_mega_lull_characters("¡¡¡OH, MI!!!"), "¡|¡|¡|O|H|,||| M|I|!|!|!")
+	assert_eq(ChatLibrary.add_mega_lull_characters("О, МОЙ!"), "О|,||| М|О|Й|!")
 
 
 func test_chat_key_from_path() -> void:


### PR DESCRIPTION
The forward-slash character has occasional conversational use, like 'I'm
asking you a simple yes/no question!' Or 'I didn't mean to confuse
and/or offend you'. I've changed the lull character to a different
character so that we can use it in dialog. (The lull character is used
to inject pauses into some sentences for dramatic effect.)

I've also changed NameUtils to filter out more special characters,
including the lull character and the number sign (used for Tracery.)