### PR TITLE
Fix conflict with number signs in tracery.

### DIFF
--- a/project/src/main/tracery.gd
+++ b/project/src/main/tracery.gd
@@ -73,8 +73,10 @@ class Grammar extends Reference:
 
 
 	func _init(rules: Dictionary) -> void:
+		# This expansion regex is modified from GDTracery to avoid matching spaces. This prevents us from matching
+		# number signs in sentences.
 		_expansion_regex = RegEx.new()
-		_expansion_regex.compile("(?<!\\[|:)(?!\\])#.+?(?<!\\[|:)#(?!\\])")
+		_expansion_regex.compile("(?<!\\[|:)(?!\\])#[^ ]+?(?<!\\[|:)#(?!\\])")
 		
 		_save_symbol_regex = RegEx.new()
 		_save_symbol_regex.compile("\\[.+?\\]")

--- a/project/src/test/test-tracery.gd
+++ b/project/src/test/test-tracery.gd
@@ -2,6 +2,10 @@ extends "res://addons/gut/test.gd"
 
 var rules := {}
 
+func before_each() -> void:
+	rules.clear()
+
+
 # GDTracery's original set_rng() implementation had a bug
 # https://github.com/Althar93/GDTracery/issues/2
 func test_set_rng() -> void:
@@ -14,8 +18,15 @@ func test_set_rng() -> void:
 func test_simple() -> void:
 	rules["favorite_color"] = ["blue"]
 	
-	assert_flatten("My favorite color is #favorite_color#.",
-			"My favorite color is blue.")
+	assert_flatten("My favorite color is #favorite_color#.", "My favorite color is blue.")
+
+
+func test_rule_undefined() -> void:
+	assert_flatten("My favorite color is #favorite_color#.", "My favorite color is favorite_color.")
+
+
+func test_pound_signs() -> void:
+	assert_flatten("I'm your #1 fan. #1!", "I'm your #1 fan. #1!")
 
 
 func test_modifier_possessive() -> void:


### PR DESCRIPTION
Number signs are useful in dialog for phrases like `I'm your #1 fan!`
but they would conflict with Tracery's syntax, and sentences with two
number signs would have their number signs removed.

Tracery's regex now doesn't match pound signs separated by spaces.