### PR TITLE
Fixed conflict with tracery and lull characters.

### DIFF
--- a/project/src/main/ui/chat/chat-library.gd
+++ b/project/src/main/ui/chat/chat-library.gd
@@ -60,6 +60,11 @@ func add_lull_characters(s: String) -> String:
 			if old_transformed == transformer.transformed:
 				break
 	
+	# remove lull characters from the middle of tracery tags
+	#
+	# '[player.|possessive]' -> '[player.possessive]'
+	transformer.sub("(#[^# ]*)\\.\\|([^# ]*#)", "$1.$2") #ok
+	
 	# remove lull character from the end of the line
 	transformer.transformed = transformer.transformed.trim_suffix("|")
 	

--- a/project/src/test/ui/chat/test-chat-library.gd
+++ b/project/src/test/ui/chat/test-chat-library.gd
@@ -7,6 +7,14 @@ func test_add_lull_characters_no_effect() -> void:
 	assert_eq(ChatLibrary.add_lull_characters("One two."), "One two.")
 
 
+func test_dont_manipulate_tracery_tags() -> void:
+	assert_eq(ChatLibrary.add_lull_characters("I'm your #1 fan"), "I'm your #1 fan")
+	assert_eq(ChatLibrary.add_lull_characters("I'm your #1 fan. #1!"), "I'm your #1 fan.| #1!")
+	assert_eq(ChatLibrary.add_lull_characters("One #two# three"), "One #two# three")
+	assert_eq(ChatLibrary.add_lull_characters("One #two.possessive# three"), "One #two.possessive# three")
+	assert_eq(ChatLibrary.add_lull_characters("One #two.a# #three.a# four"), "One #two.a# #three.a# four")
+
+
 func test_add_lull_characters_punctuation() -> void:
 	assert_eq(ChatLibrary.add_lull_characters("One two, three four!"), "One two,| three four!")
 	assert_eq(ChatLibrary.add_lull_characters("One? Two!"), "One?| Two!")


### PR DESCRIPTION
Our dialog parsing logic adds lull characters after periods. But tracery
uses periods for its modifier syntax. Our dialog parsing logic now
checks for this and removes lull characters from tracery tags.