### PR TITLE
Fixed hard-to-read chat themes.

### DIFF
--- a/project/src/demo/ui/chat/chat-frame-demo.gd
+++ b/project/src/demo/ui/chat/chat-frame-demo.gd
@@ -48,7 +48,7 @@ const NAMES := [
 const COLORS := [
 	"b23823", "eeda4d", "41a740", "b47922", "6f83db",
 	"a854cb", "f57e7d", "f9bb4a", "8fea40", "feceef",
-	"b1edee", "f9f7d9", "1a1a1e", "7a8289", "0b45a6",
+	"b1edee", "f9f7d9", "1a1a1e", "000020", "dfffdf",
 ]
 
 const SCALES := [
@@ -98,7 +98,11 @@ func _input(event: InputEvent) -> void:
 			print(_chat_theme.to_json_dict())
 		KEY_R:
 			_color_index = randi() % COLORS.size()
+			_chat_theme.color = COLORS[_color_index]
+			
 			_scale_index = randi() % SCALES.size()
+			_chat_theme.accent_scale = SCALES[_scale_index]
+			
 			_chat_theme.accent_swapped = randf() > 0.5
 			_chat_theme.accent_texture_index = randi() % ChatLinePanel.CHAT_TEXTURE_COUNT
 			_chat_theme.dark = randf() > 0.5
@@ -116,17 +120,25 @@ func _input(event: InputEvent) -> void:
 			_play_chat_event()
 		KEY_RIGHT:
 			_color_index = wrapi(_color_index + 1, 0, COLORS.size())
+			_chat_theme.color = COLORS[_color_index]
+			
 			_play_chat_event()
 		KEY_LEFT:
 			_color_index = wrapi(_color_index - 1, 0, COLORS.size())
+			_chat_theme.color = COLORS[_color_index]
+			
 			_play_chat_event()
 		KEY_UP:
 			if _scale_index < SCALES.size():
 				_scale_index += 1
+				_chat_theme.accent_scale = SCALES[_scale_index]
+				
 				_play_chat_event()
 		KEY_DOWN:
 			if _scale_index > 0:
 				_scale_index -= 1
+				_chat_theme.accent_scale = SCALES[_scale_index]
+				
 				_play_chat_event()
 		KEY_Z:
 			_squished = not _squished
@@ -138,9 +150,6 @@ func _play_chat_event() -> void:
 	var creature_def := CreatureDef.new()
 	creature_def.creature_name = NAMES[_name_index]
 	PlayerData.creature_library.set_creature_def("lorum", creature_def)
-	
-	_chat_theme.color = COLORS[_color_index]
-	_chat_theme.accent_scale = SCALES[_scale_index]
 	
 	var chat_event := ChatEvent.new()
 	chat_event.who = "lorum"

--- a/project/src/main/ui/chat/chat-line-panel.gd
+++ b/project/src/main/ui/chat/chat-line-panel.gd
@@ -45,7 +45,7 @@ func update_appearance(chat_theme: ChatTheme, chat_line_size: int) -> void:
 	rect_pivot_offset = rect_size * 0.5
 	rect_position = get_parent().rect_size / 2 - rect_size / 2
 	
-	material.set_shader_param("accent_amount", 0.40 if chat_theme.dark else 0.24)
+	material.set_shader_param("accent_amount", chat_theme.accent_amount)
 	material.set_shader_param("accent_color", chat_theme.accent_color)
 	material.set_shader_param("accent_scale", chat_theme.accent_scale)
 	material.set_shader_param("accent_swapped", chat_theme.accent_swapped)

--- a/project/src/main/utils.gd
+++ b/project/src/main/utils.gd
@@ -7,6 +7,19 @@ const NUM_SCANCODES := {
 	KEY_5: 5, KEY_6: 6, KEY_7: 7, KEY_8: 8, KEY_9: 9,
 }
 
+## Returns the perceived brightness of a color.
+##
+## This allows UI elements to avoid combinations like dark blue on black or light green on white.
+##
+## Parameters:
+## 	'color': The color whose brightness should be calculated. The alpha component is ignored.
+##
+## Returns:
+## 	A number in the range [0.0, 1.0] corresponding to the color's perceived brightness.
+static func brightness(color: Color) -> float:
+	return clamp(color.r * 0.2990 + color.g * 0.5871 + color.b * 0.1140, 0.0, 1.0)
+
+
 static func print_json(value) -> String:
 	return JSON.print(value, "  ")
 

--- a/project/src/test/test-utils.gd
+++ b/project/src/test/test-utils.gd
@@ -86,3 +86,14 @@ func test_seeded_shuffle_different_seed() -> void:
 	Utils.seeded_shuffle(shuffled2, 18)
 	
 	assert_false(shuffled1 == shuffled2, "different seed resulted in same output (%s, %s)" % [shuffled1, shuffled2])
+
+
+func test_brightness() -> void:
+	# white and black should return exactly 0.0 and 1.0
+	assert_eq(Utils.brightness(Color("000000")), 0.0)
+	assert_eq(Utils.brightness(Color("ffffff")), 1.0)
+	
+	# green is brighter than red, red is brighter than blue
+	assert_almost_eq(Utils.brightness(Color("800000")), 0.15, 0.1)
+	assert_almost_eq(Utils.brightness(Color("008000")), 0.29, 0.1)
+	assert_almost_eq(Utils.brightness(Color("000080")), 0.05, 0.1)

--- a/project/src/test/ui/chat/test-chat-theme.gd
+++ b/project/src/test/ui/chat/test-chat-theme.gd
@@ -1,0 +1,66 @@
+extends "res://addons/gut/test.gd"
+
+var chat_theme := ChatTheme.new()
+
+func test_border_color_dark() -> void:
+	chat_theme.dark = true
+	
+	# very bright; no adjustment
+	chat_theme.color = Color("e8e3ee")
+	assert_eq("ffe8e3ee", chat_theme.border_color.to_html())
+	
+	# dim; border color is brightened
+	chat_theme.color = Color("48336e")
+	assert_eq("ff635184", chat_theme.border_color.to_html())
+	
+	# black; border color is brightened
+	chat_theme.color = Color("000000")
+	assert_eq("ff666666", chat_theme.border_color.to_html())
+
+
+func test_accent_color_dark() -> void:
+	chat_theme.dark = true
+	
+	# very bright; accent color is darkened
+	chat_theme.color = Color("e8e3ee")
+	assert_eq("ffd1ccd6", chat_theme.accent_color.to_html())
+	
+	# dim; accent color is lightened
+	chat_theme.color = Color("48336e")
+	assert_eq("ff635184", chat_theme.accent_color.to_html())
+	
+	# black; accent color is lightened
+	chat_theme.color = Color("000000")
+	assert_eq("ff666666", chat_theme.accent_color.to_html())
+
+
+func test_border_color_light() -> void:
+	chat_theme.dark = false
+	
+	# very dark; no adjustment
+	chat_theme.color = Color("18131e")
+	assert_eq("ff18131e", chat_theme.border_color.to_html())
+	
+	# bright; border color is darkened
+	chat_theme.color = Color("b8c39e")
+	assert_eq("ff8d9579", chat_theme.border_color.to_html())
+	
+	# white; border color is darkened
+	chat_theme.color = Color("ffffff")
+	assert_eq("ff808080", chat_theme.border_color.to_html())
+
+
+func test_accent_color_light() -> void:
+	chat_theme.dark = false
+	
+	# very dark; accent color is lightened
+	chat_theme.color = Color("18131e")
+	assert_eq("ff3e3a43", chat_theme.accent_color.to_html())
+	
+	# bright; accent color is darkened
+	chat_theme.color = Color("b8c39e")
+	assert_eq("ff8d9579", chat_theme.accent_color.to_html())
+	
+	# white; accent color is darkened
+	chat_theme.color = Color("ffffff")
+	assert_eq("ff808080", chat_theme.accent_color.to_html())


### PR DESCRIPTION
Chat themes with green on black and red on black looked OK, but
blue/purple on black was hard to read. The border_color/accent_color
logic now incorporates a brightness calculation which distinguishes
between the brightness of different hues.