### PR TITLE
Update two-digit chat history entries

### DIFF
--- a/project/assets/test/turbofat-37b3.json
+++ b/project/assets/test/turbofat-37b3.json
@@ -1,0 +1,42 @@
+[
+  {
+    "type": "version",
+    "value": "37b3"
+  },
+  {
+    "type": "chat_history",
+    "value": {
+      "history_items": {
+        "chat/career/general/00_b": 0,
+        "chat/career/marsh/10_c_end": 3,
+        "chat/career/marsh/10_a_end": 3,
+        "chat/career/marsh/10_b": 4,
+        "chat/career/marsh/10_d": 5,
+        "chat/career/marsh/20": 5,
+        "chat/career/marsh/20_end": 5,
+        "chat/career/marsh/30_a_end": 5,
+        "chat/career/marsh/30_b_end": 5,
+        "chat/career/marsh/30_c_end": 5,
+        "chat/career/marsh/30_d": 5,
+        "chat/career/marsh/40_end": 5,
+        "chat/career/marsh/50_a_end": 5,
+        "chat/career/marsh/50_b_end": 5,
+        "chat/career/marsh/50_c_end": 5,
+        "chat/career/marsh/50_d": 5,
+        "chat/career/marsh/prologue": 6,
+        "chat/career/lemon/prologue": 0,
+        "chat/career/lemon/10_a": 1,
+        "chat/career/general/00_a": 6,
+        "chat/career/lemon/10_b_end": 2,
+        "chat/career/lemon/20_b": 3,
+        "chat/career/lemon/20_b_end": 4,
+        "chat/career/lemon/20_a": 5,
+        "chat/career/marsh/60_end": 9,
+        "chat/career/marsh/epilogue": 10,
+        "chat/career/lemon/30_a_end": 6,
+        "chat/career/lemon/30_c": 7,
+        "chat/career/lemon/30_b": 8
+      }
+    }
+  }
+]

--- a/project/src/main/player-save.gd
+++ b/project/src/main/player-save.gd
@@ -5,7 +5,7 @@ extends Node
 
 ## Current version for saved player data. Should be updated if and only if the player format changes.
 ## This version number follows a 'ymdh' hex date format which is documented in issue #234.
-const PLAYER_DATA_VERSION := "37b3"
+const PLAYER_DATA_VERSION := "38c3"
 
 var rolling_backups := RollingBackups.new()
 

--- a/project/src/test/test-player-save-upgrader.gd
+++ b/project/src/test/test-player-save-upgrader.gd
@@ -169,7 +169,28 @@ func test_3776_chat_history_purged() -> void:
 	load_legacy_player_data("turbofat-3776.json")
 	
 	# chat history
-	assert_eq(PlayerData.chat_history.chat_history.has("chat/career/marsh/10_b"), true)
+	assert_eq(PlayerData.chat_history.chat_history.has("chat/career/marsh/010_b"), true)
 	assert_eq(PlayerData.chat_history.chat_history.has("chat/level_select"), false)
 	assert_eq(PlayerData.chat_history.chat_history.has("creature/bort/filler_000"), false)
 	assert_eq(PlayerData.chat_history.chat_history.has("level/marsh/pulling_for_everyone_100"), false)
+
+
+func test_37b3_chat_history_migrated() -> void:
+	load_legacy_player_data("turbofat-37b3.json")
+	
+	assert_eq(PlayerData.chat_history.chat_age("chat/career/general/000_b"), 10)
+	assert_eq(PlayerData.chat_history.chat_age("chat/career/marsh/010_c_end"), 7)
+	assert_eq(PlayerData.chat_history.chat_age("chat/career/marsh/060_end"), 1)
+	assert_eq(PlayerData.chat_history.chat_age("chat/career/marsh/epilogue"), 0)
+
+
+func test_prepend_third_zero() -> void:
+	var upgrader: PlayerSaveUpgrader = PlayerSaveUpgrader.new()
+	assert_eq(upgrader.prepend_third_zero("ilesa/sin/00_ibo_suture"), "ilesa/sin/000_ibo_suture")
+	assert_eq(upgrader.prepend_third_zero("ilesa_40"), "ilesa_040")
+	assert_eq(upgrader.prepend_third_zero("ilesa_21_sin"), "ilesa_021_sin")
+	assert_eq(upgrader.prepend_third_zero("93_ilesa"), "093_ilesa")
+	assert_eq(upgrader.prepend_third_zero("36_ilesa_72"), "036_ilesa_072")
+	assert_eq(upgrader.prepend_third_zero("ilesa"), "ilesa")
+	assert_eq(upgrader.prepend_third_zero("ilesa_443_sin"), "ilesa_443_sin")
+	assert_eq(upgrader.prepend_third_zero("ilesa_8_sin"), "ilesa_8_sin")


### PR DESCRIPTION
Two-digit cutscenes were expanded to three digits in fd6b909f, but the
player's chat history was not updated. This meant players who'd played
the game previously would lose all their cutscene progress and have to
rewatch all the same cutscenes again.