### PR TITLE
Hard-code fat sensei's name in chats. Change name from 'Turbo'.

### DIFF
--- a/project/assets/demo/chat/chat-narrator.chat
+++ b/project/assets/demo/chat/chat-narrator.chat
@@ -1,6 +1,6 @@
 {"version": "2476"}
 
-#narrator#: Most of the Turbo Fat locations gradually developed a loyal following of hungry customers, except for Merrymellow Marsh where business was unusually slow. #sensei# and #player# were on their way to get to the bottom of this mystery.
+#narrator#: Most of the Turbo Fat locations gradually developed a loyal following of hungry customers, except for Merrymellow Marsh where business was unusually slow. Fat Sensei and #player# were on their way to get to the bottom of this mystery.
 #player#: /._. What's next?
 #narrator#: What's next? More narration of course.
 [link]

--- a/project/assets/main/chat/career/marsh/060-end.chat
+++ b/project/assets/main/chat/career/marsh/060-end.chat
@@ -16,7 +16,7 @@ s1: ^__^ Congratulations on the restaurant's success! All your hard work really 
 r: ^O^ Us? Heh what are you talking about! You two did all the work.
 p1: <_< Wait, you didn't do anything? ...We didn't do anything either! Did we?
  (sensei mood /._.)
-b: Well, you and #sensei# got all these customers to come!
+b: Well, you and Fat Sensei got all these customers to come!
 p1: /._. Maybe? I talked to two or three of them at most! ...Were they all friends?
 k: ^y^ You trained us to cook better! I bet that made a difference too.
 [training_good] You improved a lot

--- a/project/assets/main/chat/career/marsh/epilogue.chat
+++ b/project/assets/main/chat/career/marsh/epilogue.chat
@@ -8,7 +8,7 @@ player, p1
 sensei, s1
 narrator, n
 
-n: Instead of spending a week in Merrymellow Marsh like they originally planned, #sensei# and #player# ended up staying for an entire month.\n\n...But for some, even an entire month wasn't enough.
+n: Instead of spending a week in Merrymellow Marsh like they originally planned, Fat Sensei and #player# ended up staying for an entire month.\n\n...But for some, even an entire month wasn't enough.
 p1: u_u I still wish we could have stayed and helped longer. I was finally starting to feel like I belonged there.
 s1: Well, a wise poet once wrote, "Two sofas diverged in a furniture store."
 s1: "I chose the sofa less comfortable, and that has made all the difference."

--- a/project/assets/main/chat/career/marsh/intro-level-end.chat
+++ b/project/assets/main/chat/career/marsh/intro-level-end.chat
@@ -61,5 +61,5 @@ s1: You don't want to give your customers any break. Eating should become an unc
 [oh_okay]
 s: u_u Oh, hmm... okay. Mowr...
 r: ^__^ Hey hey! Don't worry, we'll work on that. Good work everybody!
-r: ^_^ #sensei#, #player# -- see what you can do to drum up more business!
+r: ^_^ Fat Sensei, #player# -- see what you can do to drum up more business!
 r: We'll be here when you feel like training us up again. No hurry!

--- a/project/assets/main/chat/career/marsh/prologue.chat
+++ b/project/assets/main/chat/career/marsh/prologue.chat
@@ -8,7 +8,7 @@ player, p1
 sensei, s1
 narrator, n
 
-n: Most of the Turbo Fat locations gradually developed a loyal following of hungry customers, except for Merrymellow Marsh where business was unusually slow. #sensei# and #player# were on their way to get to the bottom of this mystery.
+n: Most of the Turbo Fat locations gradually developed a loyal following of hungry customers, except for Merrymellow Marsh where business was unusually slow. Fat Sensei and #player# were on their way to get to the bottom of this mystery.
 p1: /._. So we're supposed to get more customers to show up? Like, with advertising or specials or something?
 p1: .__.; ...Fat Sensei, I don't know anything about that stuff!
  (stop_walking)

--- a/project/assets/main/creatures/sensei/creature.json
+++ b/project/assets/main/creatures/sensei/creature.json
@@ -1,8 +1,8 @@
 {
   "version": "375c",
   "id": "#sensei#",
-  "name": "Turbo",
-  "short_name": "Turbo",
+  "name": "Fat Sensei",
+  "short_name": "Fat Sensei",
   "dna": {
     "sensei": "true",
     "belly": "0",

--- a/project/assets/test/ui/chat/cutscene-full.chat
+++ b/project/assets/test/ui/chat/cutscene-full.chat
@@ -57,5 +57,5 @@ s1: You don't want to give them any break. Eating should become an unconscious r
 [oh_okay]
 s: u_u Oh, hmm... okay. Mowr...
 r: ^__^ Hey hey! Don't worry, we'll work on that. Good work everybody!
-r: ^_^ #sensei#, #player# -- see what you can do to drum up more business!
+r: ^_^ Fat Sensei, #player# -- see what you can do to drum up more business!
 r: We'll be here when you feel like training us up again. No hurry!


### PR DESCRIPTION
Fat Sensei's name was going to be in the game code as 'Turbo' as a
misdirect but I'm going to approach this differently.