### PR TITLE
Remove player/sensei before playing cutscenes

### DIFF
--- a/project/src/main/world/cutscene-world.gd
+++ b/project/src/main/world/cutscene-world.gd
@@ -38,10 +38,9 @@ func _launch_cutscene() -> void:
 ## Removes all creatures from the overworld except for the player and sensei.
 func _remove_all_creatures() -> void:
 	for node in get_tree().get_nodes_in_group("creatures"):
-		if node != CreatureManager.player and node != CreatureManager.sensei:
-			# remove it immediately so we don't find it in the tree later
-			node.get_parent().remove_child(node)
-			node.queue_free()
+		# remove it immediately so we don't find it in the tree later
+		node.get_parent().remove_child(node)
+		node.queue_free()
 	
 	for node in get_tree().get_nodes_in_group("creature_spawners"):
 		node.get_parent().remove_child(node)


### PR DESCRIPTION
This 'remove all characters but the player and sensei' logic was for
when freeroam scenes doubled as cutscene scenes, but now it doesn't
really make sense because these scenes are single-purpose