### PR TITLE
Puzzle clears out chefs/customers when quitting.

### DIFF
--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -46,8 +46,17 @@ func _ready() -> void:
 
 
 ## Unsets all of the 'launched level' data.
-func clear_launched_level() -> void:
-	set_launched_level("")
+func reset() -> void:
+	keep_retrying = false
+	settings == LevelSettings.new()
+	puzzle = null
+	level_id = ""
+	piece_speed = ""
+	customers = []
+	chef_id = ""
+	best_result = Levels.Result.NONE
+	attempt_count = 0
+	puzzle_environment_name = ""
 
 
 ## Stores the launched level data, so the level can be played later.
@@ -57,11 +66,8 @@ func clear_launched_level() -> void:
 ## Parameters:
 ## 	'level_id': The level to launch
 func set_launched_level(new_level_id: String) -> void:
+	reset()
 	level_id = new_level_id
-	piece_speed = ""
-	set_best_result(Levels.Result.NONE)
-	attempt_count = 0
-	puzzle_environment_name = ""
 	
 	if new_level_id:
 		var level_settings := LevelSettings.new()

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -158,7 +158,7 @@ func _quit_puzzle() -> void:
 	if PlayerData.career.is_career_mode():
 		PlayerData.career.process_puzzle_result()
 	
-	CurrentLevel.clear_launched_level()
+	CurrentLevel.reset()
 	PlayerData.creature_queue.clear()
 	
 	if PlayerData.career.is_career_mode():

--- a/project/src/main/ui/menu/main-menu-play.gd
+++ b/project/src/main/ui/menu/main-menu-play.gd
@@ -5,7 +5,7 @@ const WORLD0_ID := "world0"
 
 func _on_Career_pressed() -> void:
 	PlayerData.creature_queue.clear()
-	CurrentLevel.clear_launched_level()
+	CurrentLevel.reset()
 	
 	# Launch the first scene in career mode. This is probably the career map, but in some edge cases it could be a
 	# cutscene or victory screen.


### PR DESCRIPTION
This fixes a bug when playing a level in Career mode with a special
chef/customer. If you quit and then played practice mode, the same
chef/customer would appear.

Closes #1584.