### PR TITLE
Bug: Chef always appears sad on game over

### DIFF
--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -173,7 +173,8 @@ func _on_PuzzleState_combo_changed(value: int) -> void:
 
 
 func _on_PuzzleState_topped_out() -> void:
-	get_chef().play_mood(Creatures.Mood.CRY0)
+	if PuzzleState.game_active:
+		get_chef().play_mood(Creatures.Mood.CRY0)
 
 
 ## When clearing lines, the chef smiles if they're scoring a lot of bonus points.


### PR DESCRIPTION
The chef used to randomly be angry/confused. But at some point the 'top
out' emotion of being sad overwrote the random emotion.

Closes #1585.