### PR TITLE
Fixed bug where intro level cutscenes could be skipped

### DIFF
--- a/project/src/main/career/career-calendar.gd
+++ b/project/src/main/career/career-calendar.gd
@@ -25,13 +25,21 @@ func advance_clock(new_distance_earned: int, success: bool) -> void:
 	career_data.hours_passed += 1
 	
 	if career_data.is_boss_level():
-		var boss_region: CareerRegion = career_data.current_region()
+		var region: CareerRegion = career_data.current_region()
 		if success:
 			# if they pass a boss level, update best_distance_travelled to mark the region as cleared
-			career_data.best_distance_travelled = max(career_data.best_distance_travelled, boss_region.end + 1)
+			career_data.best_distance_travelled = max(career_data.best_distance_travelled, region.end + 1)
 		else:
 			# if they fail a boss level, they lose 1-2 days worth of progress
-			career_data.distance_earned = -int(max(boss_region.length * rand_range(0.125, 0.25), 2))
+			career_data.distance_earned = -int(max(region.length * rand_range(0.125, 0.25), 2))
+	elif career_data.is_intro_level():
+		var region: CareerRegion = career_data.current_region()
+		if new_distance_earned > 0:
+			# if they finish an intro level, update best_distance_travelled to mark the intro as cleared
+			career_data.best_distance_travelled = max(career_data.best_distance_travelled, region.start + 1)
+		else:
+			# if the fail an intro level, leave them where they are
+			pass
 	
 	if career_data.distance_earned > 0:
 		# if they make forward progress, they also spend their banked steps

--- a/project/src/main/career/career-data.gd
+++ b/project/src/main/career/career-data.gd
@@ -255,15 +255,20 @@ func is_boss_level() -> bool:
 func is_intro_level() -> bool:
 	var result := true
 	var region: CareerRegion = current_region()
-	if not region.intro_level:
+	if distance_travelled != region.start:
+		# the player is not at the start of the region
+		result = false
+	elif not region.intro_level:
+		# the region has no intro level
 		result = false
 	elif is_intro_level_finished(region):
+		# the player has already cleared this intro level
 		result = false
 	return result
 
 
 func is_intro_level_finished(region: CareerRegion) -> bool:
-	return region.intro_level and PlayerData.level_history.is_level_finished(region.intro_level.level_id)
+	return region.intro_level and best_distance_travelled > region.start
 
 
 ## Returns the number of levels the player can choose between, based on their current distance and progress.

--- a/project/src/test/world/test-career-data.gd
+++ b/project/src/test/world/test-career-data.gd
@@ -50,31 +50,13 @@ func test_advance_clock_stops_at_boss_level_1() -> void:
 	assert_eq(_data.banked_steps, 2)
 
 
-func test_advance_clock_stops_at_boss_level_2() -> void:
-	_data.best_distance_travelled = 10 # they've cleared the first boss level
-	_data.remain_in_region = true
-	_data.advance_clock(50, true)
-	assert_eq(_data.distance_earned, 50)
-	assert_eq(_data.distance_travelled, 9)
-	assert_eq(_data.banked_steps, 41)
-
-
-## The player skips one boss level, but gets stopped by the next boss level
-func test_advance_clock_skips_boss_level() -> void:
-	_data.best_distance_travelled = 10 # they've only cleared the first boss level
-	_data.advance_clock(50, false)
-	assert_eq(_data.distance_earned, 50)
-	assert_eq(_data.distance_travelled, 19)
-	assert_eq(_data.banked_steps, 31)
-
-
 func test_advance_clock_clears_boss_level() -> void:
 	_data.best_distance_travelled = 0
 	_data.distance_travelled = 9 # boss level
 	_data.advance_clock(4, true)
 	assert_eq(_data.distance_earned, 4)
-	assert_eq(_data.distance_travelled, 13)
-	assert_eq(_data.banked_steps, 0)
+	assert_eq(_data.distance_travelled, 10)
+	assert_eq(_data.banked_steps, 3)
 
 
 func test_advance_clock_fails_boss_level() -> void:
@@ -88,13 +70,50 @@ func test_advance_clock_fails_boss_level() -> void:
 	assert_eq(_data.banked_steps, 0)
 
 
-func test_advance_clock_stops_at_intro_level() -> void:
+func test_advance_clock_stops_at_unbeaten_intro_level() -> void:
 	_data.best_distance_travelled = 10
+	
 	PlayerData.level_history.delete_results("intro_311")
+	
 	_data.advance_clock(50, false)
 	assert_eq(_data.distance_earned, 50)
 	assert_eq(_data.distance_travelled, 10)
 	assert_eq(_data.banked_steps, 40)
+
+
+# Even if the intro level is a level the player has somehow played before in practice mode, it should still stop them.
+func test_advance_clock_stops_at_beaten_intro_level() -> void:
+	_data.best_distance_travelled = 10
+	
+	var result := RankResult.new()
+	PlayerData.level_history.add_result("intro_311", result)
+	
+	_data.advance_clock(50, false)
+	assert_eq(_data.distance_earned, 50)
+	assert_eq(_data.distance_travelled, 10)
+	assert_eq(_data.banked_steps, 40)
+
+
+func test_advance_clock_clears_intro_level() -> void:
+	_data.distance_travelled = 10
+	_data.best_distance_travelled = 10
+	_data.banked_steps = 5
+	
+	_data.advance_clock(1, false)
+	assert_eq(_data.distance_earned, 6)
+	assert_eq(_data.distance_travelled, 16)
+	assert_eq(_data.banked_steps, 0)
+
+
+func test_advance_clock_fails_intro_level() -> void:
+	_data.distance_travelled = 10
+	_data.best_distance_travelled = 10
+	_data.banked_steps = 5
+	
+	_data.advance_clock(0, false)
+	assert_eq(_data.distance_earned, 0)
+	assert_eq(_data.distance_travelled, 10)
+	assert_eq(_data.banked_steps, 5)
 
 
 func test_advance_clock_banked_steps_for_failed_boss_level() -> void:
@@ -172,9 +191,8 @@ func test_distance_penalties_negative() -> void:
 
 
 func test_distance_penalties_boss_level() -> void:
-	_data.distance_travelled = 8
-	_data.best_distance_travelled = 0
-	_data.advance_clock(50, false)
+	_data.distance_travelled = 9
+	_data.best_distance_travelled = 9
 	assert_eq(_data.distance_penalties(), [0, 0, 0])
 
 


### PR DESCRIPTION
Intro level cutscenes were dependent on whether the player had played
that specific level before. This meant intro cinematics could be skipped
if the intro level was recycled or if the player tried it in practice
mode.

The intro level cutscenes are now dependent on whether the player has progressed
through career mode or not. This makes many of the existing career tests
redundant or overly convoluted, such as tests where the player progresses
through several boss levels in regions with no intro level. I've removed these
tests, because I anticipate most regions having an intro level anyways so the
tests aren't worth preserving.