### PR TITLE
Reorganized piece-types.gd arrays.

### DIFF
--- a/project/src/main/puzzle/piece/piece-types.gd
+++ b/project/src/main/puzzle/piece/piece-types.gd
@@ -81,143 +81,183 @@ const KICKS_NONE := [
 
 var piece_i := PieceType.new("i",
 		# shape data
-		[[Vector2(0, 1), Vector2(1, 1), Vector2(2, 1), Vector2(3, 1)],
-		[Vector2(2, 0), Vector2(2, 1), Vector2(2, 2), Vector2(2, 3)],
-		[Vector2(0, 2), Vector2(1, 2), Vector2(2, 2), Vector2(3, 2)],
-		[Vector2(1, 0), Vector2(1, 1), Vector2(1, 2), Vector2(1, 3)]],
+		[
+			[Vector2(0, 1), Vector2(1, 1), Vector2(2, 1), Vector2(3, 1)],
+			[Vector2(2, 0), Vector2(2, 1), Vector2(2, 2), Vector2(2, 3)],
+			[Vector2(0, 2), Vector2(1, 2), Vector2(2, 2), Vector2(3, 2)],
+			[Vector2(1, 0), Vector2(1, 1), Vector2(1, 2), Vector2(1, 3)],
+		],
 		# color data
-		[[Vector2(8, 3), Vector2(12, 3), Vector2(12, 3), Vector2(4, 3)],
-		[Vector2(2, 3), Vector2(3, 3), Vector2(3, 3), Vector2(1, 3)],
-		[Vector2(8, 3), Vector2(12, 3), Vector2(12, 3), Vector2(4, 3)],
-		[Vector2(2, 3), Vector2(3, 3), Vector2(3, 3), Vector2(1, 3)]],
+		[
+			[Vector2(8, 3), Vector2(12, 3), Vector2(12, 3), Vector2(4, 3)],
+			[Vector2(2, 3), Vector2(3, 3), Vector2(3, 3), Vector2(1, 3)],
+			[Vector2(8, 3), Vector2(12, 3), Vector2(12, 3), Vector2(4, 3)],
+			[Vector2(2, 3), Vector2(3, 3), Vector2(3, 3), Vector2(1, 3)],
+		],
 		KICKS_I,
 		KICKS_NONE
 	)
 
 var piece_j := PieceType.new("j",
 		# shape data
-		[[Vector2(0, 0), Vector2(0, 1), Vector2(1, 1), Vector2(2, 1)],
-		[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(1, 2)],
-		[Vector2(0, 1), Vector2(1, 1), Vector2(2, 1), Vector2(2, 2)],
-		[Vector2(1, 0), Vector2(1, 1), Vector2(0, 2), Vector2(1, 2)]],
+		[
+			[Vector2(0, 0), Vector2(0, 1), Vector2(1, 1), Vector2(2, 1)],
+			[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(1, 2)],
+			[Vector2(0, 1), Vector2(1, 1), Vector2(2, 1), Vector2(2, 2)],
+			[Vector2(1, 0), Vector2(1, 1), Vector2(0, 2), Vector2(1, 2)],
+		],
 		# color data
-		[[Vector2(2, 1), Vector2(9, 1), Vector2(12, 1), Vector2(4, 1)],
-		[Vector2(10, 1), Vector2(4, 1), Vector2(3, 1), Vector2(1, 1)],
-		[Vector2(8, 1), Vector2(12, 1), Vector2(6, 1), Vector2(1, 1)],
-		[Vector2(2, 1), Vector2(3, 1), Vector2(8, 1), Vector2(5, 1)]],
+		[
+			[Vector2(2, 1), Vector2(9, 1), Vector2(12, 1), Vector2(4, 1)],
+			[Vector2(10, 1), Vector2(4, 1), Vector2(3, 1), Vector2(1, 1)],
+			[Vector2(8, 1), Vector2(12, 1), Vector2(6, 1), Vector2(1, 1)],
+			[Vector2(2, 1), Vector2(3, 1), Vector2(8, 1), Vector2(5, 1)],
+		],
 		KICKS_JLSZ,
 		[[Vector2(0, -1)], [Vector2(1, 0)], [Vector2(0, 1)], [Vector2(-1, 0)]]
 	)
 
 var piece_l := PieceType.new("l",
 		# shape data
-		[[Vector2(2, 0), Vector2(0, 1), Vector2(1, 1), Vector2(2, 1)],
-		[Vector2(1, 0), Vector2(1, 1), Vector2(1, 2), Vector2(2, 2)],
-		[Vector2(0, 1), Vector2(1, 1), Vector2(2, 1), Vector2(0, 2)],
-		[Vector2(0, 0), Vector2(1, 0), Vector2(1, 1), Vector2(1, 2)]],
+		[
+			[Vector2(2, 0), Vector2(0, 1), Vector2(1, 1), Vector2(2, 1)],
+			[Vector2(1, 0), Vector2(1, 1), Vector2(1, 2), Vector2(2, 2)],
+			[Vector2(0, 1), Vector2(1, 1), Vector2(2, 1), Vector2(0, 2)],
+			[Vector2(0, 0), Vector2(1, 0), Vector2(1, 1), Vector2(1, 2)],
+		],
 		# color data
-		[[Vector2(2, 0), Vector2(8, 0), Vector2(12, 0), Vector2(5, 0)],
-		[Vector2(2, 0), Vector2(3, 0), Vector2(9, 0), Vector2(4, 0)],
-		[Vector2(10, 0), Vector2(12, 0), Vector2(4, 0), Vector2(1, 0)],
-		[Vector2(8, 0), Vector2(6, 0), Vector2(3, 0), Vector2(1, 0)]],
+		[
+			[Vector2(2, 0), Vector2(8, 0), Vector2(12, 0), Vector2(5, 0)],
+			[Vector2(2, 0), Vector2(3, 0), Vector2(9, 0), Vector2(4, 0)],
+			[Vector2(10, 0), Vector2(12, 0), Vector2(4, 0), Vector2(1, 0)],
+			[Vector2(8, 0), Vector2(6, 0), Vector2(3, 0), Vector2(1, 0)],
+		],
 		KICKS_JLSZ,
 		[[Vector2(0, -1)], [Vector2(1, 0)], [Vector2(0, 1)], [Vector2(-1, 0)]]
 	)
 
 var piece_o := PieceType.new("o",
 		# shape data, four states so that the rotate button has an effect and can distinguish cw/ccw rotation
-		[[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)],
-		[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)],
-		[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)],
-		[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)]],
+		[
+			[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)],
+			[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)],
+			[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)],
+			[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)],
+		],
 		# color data
-		[[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)],
-		[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)],
-		[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)],
-		[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)]],
+		[
+			[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)],
+			[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)],
+			[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)],
+			[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)],
+		],
 		KICKS_NONE,
 		KICKS_NONE
 	)
 
 var piece_p := PieceType.new("p",
 		# shape data
-		[[Vector2(0, 0), Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)],
-		[Vector2(2, 0), Vector2(1, 1), Vector2(2, 1), Vector2(1, 2), Vector2(2, 2)],
-		[Vector2(0, 1), Vector2(1, 1), Vector2(0, 2), Vector2(1, 2), Vector2(2, 2)],
-		[Vector2(0, 0), Vector2(1, 0), Vector2(0, 1), Vector2(1, 1), Vector2(0, 2)]],
+		[
+			[Vector2(0, 0), Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)],
+			[Vector2(2, 0), Vector2(1, 1), Vector2(2, 1), Vector2(1, 2), Vector2(2, 2)],
+			[Vector2(0, 1), Vector2(1, 1), Vector2(0, 2), Vector2(1, 2), Vector2(2, 2)],
+			[Vector2(0, 0), Vector2(1, 0), Vector2(0, 1), Vector2(1, 1), Vector2(0, 2)],
+		],
 		# color data
-		[[Vector2(8, 1), Vector2(14, 1), Vector2(6, 1), Vector2(9, 1), Vector2(5, 1)],
-		[Vector2(2, 1), Vector2(10, 1), Vector2(7, 1), Vector2(9, 1), Vector2(5, 1)],
-		[Vector2(10, 1), Vector2(6, 1), Vector2(9, 1), Vector2(13, 1), Vector2(4, 1)],
-		[Vector2(10, 1), Vector2(6, 1), Vector2(11, 1), Vector2(5, 1), Vector2(1, 1)]],
+		[
+			[Vector2(8, 1), Vector2(14, 1), Vector2(6, 1), Vector2(9, 1), Vector2(5, 1)],
+			[Vector2(2, 1), Vector2(10, 1), Vector2(7, 1), Vector2(9, 1), Vector2(5, 1)],
+			[Vector2(10, 1), Vector2(6, 1), Vector2(9, 1), Vector2(13, 1), Vector2(4, 1)],
+			[Vector2(10, 1), Vector2(6, 1), Vector2(11, 1), Vector2(5, 1), Vector2(1, 1)],
+		],
 		KICKS_P,
 		# flip kick data
-		[[Vector2(0, -1), Vector2(1, -1)],
-		[Vector2(1, 0), Vector2(1, 1)],
-		[Vector2(0, 1), Vector2(-1, 1)],
-		[Vector2(-1, 0), Vector2(-1, -1)]]
+		[
+			[Vector2(0, -1), Vector2(1, -1)],
+			[Vector2(1, 0), Vector2(1, 1)],
+			[Vector2(0, 1), Vector2(-1, 1)],
+			[Vector2(-1, 0), Vector2(-1, -1)],
+		]
 	)
 
 var piece_q := PieceType.new("q",
 		# shape data
-		[[Vector2(0, 0), Vector2(1, 0), Vector2(2, 0), Vector2(0, 1), Vector2(1, 1)],
-		[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1), Vector2(2, 2)],
-		[Vector2(1, 1), Vector2(2, 1), Vector2(0, 2), Vector2(1, 2), Vector2(2, 2)],
-		[Vector2(0, 0), Vector2(0, 1), Vector2(1, 1), Vector2(0, 2), Vector2(1, 2)]],
+		[
+			[Vector2(0, 0), Vector2(1, 0), Vector2(2, 0), Vector2(0, 1), Vector2(1, 1)],
+			[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1), Vector2(2, 2)],
+			[Vector2(1, 1), Vector2(2, 1), Vector2(0, 2), Vector2(1, 2), Vector2(2, 2)],
+			[Vector2(0, 0), Vector2(0, 1), Vector2(1, 1), Vector2(0, 2), Vector2(1, 2)],
+		],
 		# color data
-		[[Vector2(10, 0), Vector2(14, 0), Vector2(4, 0), Vector2(9, 0), Vector2(5, 0)],
-		[Vector2(10, 0), Vector2(6, 0), Vector2(9, 0), Vector2(7, 0), Vector2(1, 0)],
-		[Vector2(10, 0), Vector2(6, 0), Vector2(8, 0), Vector2(13, 0), Vector2(5, 0)],
-		[Vector2(2, 0), Vector2(11, 0), Vector2(6, 0), Vector2(9, 0), Vector2(5, 0)]],
+		[
+			[Vector2(10, 0), Vector2(14, 0), Vector2(4, 0), Vector2(9, 0), Vector2(5, 0)],
+			[Vector2(10, 0), Vector2(6, 0), Vector2(9, 0), Vector2(7, 0), Vector2(1, 0)],
+			[Vector2(10, 0), Vector2(6, 0), Vector2(8, 0), Vector2(13, 0), Vector2(5, 0)],
+			[Vector2(2, 0), Vector2(11, 0), Vector2(6, 0), Vector2(9, 0), Vector2(5, 0)],
+		],
 		KICKS_Q,
 		# flip kick data
-		[[Vector2(0, -1), Vector2(-1, -1)],
-		[Vector2(1, 0), Vector2(1, -1)],
-		[Vector2(0, 1), Vector2(1, 1)],
-		[Vector2(-1, 0), Vector2(-1, 1)]]
+		[
+			[Vector2(0, -1), Vector2(-1, -1)],
+			[Vector2(1, 0), Vector2(1, -1)],
+			[Vector2(0, 1), Vector2(1, 1)],
+			[Vector2(-1, 0), Vector2(-1, 1)],
+		]
 	)
 	
 var piece_s := PieceType.new("s",
 		# shape data
-		[[Vector2(1, 0), Vector2(2, 0), Vector2(0, 1), Vector2(1, 1)],
-		[Vector2(1, 0), Vector2(1, 1), Vector2(2, 1), Vector2(2, 2)],
-		[Vector2(1, 1), Vector2(2, 1), Vector2(0, 2), Vector2(1, 2)],
-		[Vector2(0, 0), Vector2(0, 1), Vector2(1, 1), Vector2(1, 2)]],
+		[
+			[Vector2(1, 0), Vector2(2, 0), Vector2(0, 1), Vector2(1, 1)],
+			[Vector2(1, 0), Vector2(1, 1), Vector2(2, 1), Vector2(2, 2)],
+			[Vector2(1, 1), Vector2(2, 1), Vector2(0, 2), Vector2(1, 2)],
+			[Vector2(0, 0), Vector2(0, 1), Vector2(1, 1), Vector2(1, 2)],
+		],
 		# color data
-		[[Vector2(10, 2), Vector2(4, 2), Vector2(8, 2), Vector2(5, 2)],
-		[Vector2(2, 2), Vector2(9, 2), Vector2(6, 2), Vector2(1, 2)],
-		[Vector2(10, 2), Vector2(4, 2), Vector2(8, 2), Vector2(5, 2)],
-		[Vector2(2, 2), Vector2(9, 2), Vector2(6, 2), Vector2(1, 2)]],
+		[
+			[Vector2(10, 2), Vector2(4, 2), Vector2(8, 2), Vector2(5, 2)],
+			[Vector2(2, 2), Vector2(9, 2), Vector2(6, 2), Vector2(1, 2)],
+			[Vector2(10, 2), Vector2(4, 2), Vector2(8, 2), Vector2(5, 2)],
+			[Vector2(2, 2), Vector2(9, 2), Vector2(6, 2), Vector2(1, 2)],
+		],
 		KICKS_JLSZ,
 		KICKS_NONE
 	)
 
 var piece_t := PieceType.new("t",
 		# shape data
-		[[Vector2(1, 0), Vector2(0, 1), Vector2(1, 1), Vector2(2, 1)],
-		[Vector2(1, 0), Vector2(1, 1), Vector2(2, 1), Vector2(1, 2)],
-		[Vector2(0, 1), Vector2(1, 1), Vector2(2, 1), Vector2(1, 2)],
-		[Vector2(1, 0), Vector2(0, 1), Vector2(1, 1), Vector2(1, 2)]],
+		[
+			[Vector2(1, 0), Vector2(0, 1), Vector2(1, 1), Vector2(2, 1)],
+			[Vector2(1, 0), Vector2(1, 1), Vector2(2, 1), Vector2(1, 2)],
+			[Vector2(0, 1), Vector2(1, 1), Vector2(2, 1), Vector2(1, 2)],
+			[Vector2(1, 0), Vector2(0, 1), Vector2(1, 1), Vector2(1, 2)],
+		],
 		# color data
-		[[Vector2(2, 2), Vector2(8, 2), Vector2(13, 2), Vector2(4, 2)],
-		[Vector2(2, 2), Vector2(11, 2), Vector2(4, 2), Vector2(1, 2)],
-		[Vector2(8, 2), Vector2(14, 2), Vector2(4, 2), Vector2(1, 2)],
-		[Vector2(2, 2), Vector2(8, 2), Vector2(7, 2), Vector2(1, 2)]],
+		[
+			[Vector2(2, 2), Vector2(8, 2), Vector2(13, 2), Vector2(4, 2)],
+			[Vector2(2, 2), Vector2(11, 2), Vector2(4, 2), Vector2(1, 2)],
+			[Vector2(8, 2), Vector2(14, 2), Vector2(4, 2), Vector2(1, 2)],
+			[Vector2(2, 2), Vector2(8, 2), Vector2(7, 2), Vector2(1, 2)],
+		],
 		KICKS_T,
 		[[Vector2(0, -1)], [Vector2(1, 0)], [Vector2(0, 1)], [Vector2(-1, 0)]]
 	)
 
 var piece_u := PieceType.new("u",
 		# shape data
-		[[Vector2(0, 0), Vector2(1, 0), Vector2(2, 0), Vector2(0, 1), Vector2(2, 1)],
-		[Vector2(0, 0), Vector2(1, 0), Vector2(1, 1), Vector2(0, 2), Vector2(1, 2)],
-		[Vector2(0, 0), Vector2(2, 0), Vector2(0, 1), Vector2(1, 1), Vector2(2, 1)],
-		[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(1, 2), Vector2(2, 2)]],
+		[
+			[Vector2(0, 0), Vector2(1, 0), Vector2(2, 0), Vector2(0, 1), Vector2(2, 1)],
+			[Vector2(0, 0), Vector2(1, 0), Vector2(1, 1), Vector2(0, 2), Vector2(1, 2)],
+			[Vector2(0, 0), Vector2(2, 0), Vector2(0, 1), Vector2(1, 1), Vector2(2, 1)],
+			[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(1, 2), Vector2(2, 2)],
+		],
 		# color data
-		[[Vector2(10, 2), Vector2(12, 2), Vector2(6, 2), Vector2(1, 2), Vector2(1, 2)],
-		[Vector2(8, 2), Vector2(6, 2), Vector2(3, 2), Vector2(8, 2), Vector2(5, 2)],
-		[Vector2(2, 2), Vector2(2, 2), Vector2(9, 2), Vector2(12, 2), Vector2(5, 2)],
-		[Vector2(10, 2), Vector2(4, 2), Vector2(3, 2), Vector2(9, 2), Vector2(4, 2)]],
+		[
+			[Vector2(10, 2), Vector2(12, 2), Vector2(6, 2), Vector2(1, 2), Vector2(1, 2)],
+			[Vector2(8, 2), Vector2(6, 2), Vector2(3, 2), Vector2(8, 2), Vector2(5, 2)],
+			[Vector2(2, 2), Vector2(2, 2), Vector2(9, 2), Vector2(12, 2), Vector2(5, 2)],
+			[Vector2(10, 2), Vector2(4, 2), Vector2(3, 2), Vector2(9, 2), Vector2(4, 2)],
+		],
 		KICKS_U,
 		# flip kick data
 		[[Vector2(0, -1)], [Vector2(-1, 0)], [Vector2(0, 1)], [Vector2(1, 0)],],
@@ -226,30 +266,38 @@ var piece_u := PieceType.new("u",
 
 var piece_v := PieceType.new("v",
 		# shape data
-		[[Vector2(0, 0), Vector2(0, 1), Vector2(0, 2), Vector2(1, 2), Vector2(2, 2)],
-		[Vector2(0, 0), Vector2(1, 0), Vector2(2, 0), Vector2(0, 1), Vector2(0, 2)],
-		[Vector2(0, 0), Vector2(1, 0), Vector2(2, 0), Vector2(2, 1), Vector2(2, 2)],
-		[Vector2(2, 0), Vector2(2, 1), Vector2(0, 2), Vector2(1, 2), Vector2(2, 2)]],
+		[
+			[Vector2(0, 0), Vector2(0, 1), Vector2(0, 2), Vector2(1, 2), Vector2(2, 2)],
+			[Vector2(0, 0), Vector2(1, 0), Vector2(2, 0), Vector2(0, 1), Vector2(0, 2)],
+			[Vector2(0, 0), Vector2(1, 0), Vector2(2, 0), Vector2(2, 1), Vector2(2, 2)],
+			[Vector2(2, 0), Vector2(2, 1), Vector2(0, 2), Vector2(1, 2), Vector2(2, 2)],
+		],
 		# color data
-		[[Vector2(2, 3), Vector2(3, 3), Vector2(9, 3), Vector2(12, 3), Vector2(4, 3)],
-		[Vector2(10, 3), Vector2(12, 3), Vector2(4, 3), Vector2(3, 3), Vector2(1, 3)],
-		[Vector2(8, 3), Vector2(12, 3), Vector2(6, 3), Vector2(3, 3), Vector2(1, 3)],
-		[Vector2(2, 3), Vector2(3, 3), Vector2(8, 3), Vector2(12, 3), Vector2(5, 3)]],
+		[
+			[Vector2(2, 3), Vector2(3, 3), Vector2(9, 3), Vector2(12, 3), Vector2(4, 3)],
+			[Vector2(10, 3), Vector2(12, 3), Vector2(4, 3), Vector2(3, 3), Vector2(1, 3)],
+			[Vector2(8, 3), Vector2(12, 3), Vector2(6, 3), Vector2(3, 3), Vector2(1, 3)],
+			[Vector2(2, 3), Vector2(3, 3), Vector2(8, 3), Vector2(12, 3), Vector2(5, 3)],
+		],
 		KICKS_V,
-		[[Vector2(0, 0)], [Vector2(0, 0)], [Vector2(0, 0)], [Vector2(0, 0)]]
+		KICKS_NONE
 	)
 
 var piece_z := PieceType.new("z",
 		# shape data
-		[[Vector2(0, 0), Vector2(1, 0), Vector2(1, 1), Vector2(2, 1)],
-		[Vector2(2, 0), Vector2(1, 1), Vector2(2, 1), Vector2(1, 2)],
-		[Vector2(0, 1), Vector2(1, 1), Vector2(1, 2), Vector2(2, 2)],
-		[Vector2(1, 0), Vector2(0, 1), Vector2(1, 1), Vector2(0, 2)]],
+		[
+			[Vector2(0, 0), Vector2(1, 0), Vector2(1, 1), Vector2(2, 1)],
+			[Vector2(2, 0), Vector2(1, 1), Vector2(2, 1), Vector2(1, 2)],
+			[Vector2(0, 1), Vector2(1, 1), Vector2(1, 2), Vector2(2, 2)],
+			[Vector2(1, 0), Vector2(0, 1), Vector2(1, 1), Vector2(0, 2)],
+		],
 		# color data
-		[[Vector2(8, 2), Vector2(6, 2), Vector2(9, 2), Vector2(4, 2)],
-		[Vector2(2, 2), Vector2(10, 2), Vector2(5, 2), Vector2(1, 2)],
-		[Vector2(8, 2), Vector2(6, 2), Vector2(9, 2), Vector2(4, 2)],
-		[Vector2(2, 2), Vector2(10, 2), Vector2(5, 2), Vector2(1, 2)]],
+		[
+			[Vector2(8, 2), Vector2(6, 2), Vector2(9, 2), Vector2(4, 2)],
+			[Vector2(2, 2), Vector2(10, 2), Vector2(5, 2), Vector2(1, 2)],
+			[Vector2(8, 2), Vector2(6, 2), Vector2(9, 2), Vector2(4, 2)],
+			[Vector2(2, 2), Vector2(10, 2), Vector2(5, 2), Vector2(1, 2)],
+		],
 		KICKS_JLSZ,
 		KICKS_NONE
 	)


### PR DESCRIPTION
Organizing these so they're consistently one-item-per-line with a comma
at the end makes it easier to reorder them. It also means Git's diffs
are cleaner.