### PR TITLE
Refactored piece kick tables.

### DIFF
--- a/project/src/main/puzzle/piece/active-piece.gd
+++ b/project/src/main/puzzle/piece/active-piece.gd
@@ -152,14 +152,7 @@ func perform_lock_reset() -> void:
 func kick_piece(kicks: Array = []) -> void:
 	if kicks == []:
 		if _trace_kicks: print("%s to %s -> %s" % [type.string, orientation, target_orientation])
-		if target_orientation == get_cw_orientation():
-			kicks = type.cw_kicks[orientation]
-		elif target_orientation == get_ccw_orientation():
-			kicks = type.ccw_kicks[target_orientation]
-		elif target_orientation == get_flip_orientation():
-			kicks = type.flips[orientation]
-		else:
-			kicks = []
+		kicks = type.kicks.get(orientation * 10 + target_orientation)
 	else:
 		if _trace_kicks: print("%s to: %s" % [type.string, kicks])
 	

--- a/project/src/main/puzzle/piece/piece-type.gd
+++ b/project/src/main/puzzle/piece/piece-type.gd
@@ -11,41 +11,32 @@ var pos_arr: Array
 ## array of vectors representing the autotile coordinates of used cells
 var color_arr: Array
 
-## array of piece kicks to try when rotating clockwise
-var cw_kicks: Array
-
-## array of piece kicks to try when rotating counterclockwise
-var ccw_kicks: Array
-
-## array of piece kicks to try when rotating 180
-var flips: Array
+## dictionary of kicks to try when rotating or flipping
+## key: (int) number representing the source/destination rotation.
+## 	kicks[12] = piece kicks to try when rotating clockwise from orientation R to orientation 2
+## 	kicks[03] = piece kicks to try when rotating counter-clockwise from orientation 0 to orientation L
+## 	kicks[20] = piece kicks to try when flipping from orientation 2 to orientation 0
+## values: (Array, Vector2) kicks to try
+var kicks: Dictionary
 
 ## maximum number of 'floor kicks', kicks which move the piece upward
 var max_floor_kicks: int
 
 func _init(init_string: String, init_pos_arr: Array, init_color_arr: Array,
-		init_kicks: Array, init_flips: Array, init_max_floor_kicks := 3) -> void:
+		init_kicks: Dictionary, init_max_floor_kicks := 3) -> void:
 	string = init_string
 	pos_arr = init_pos_arr
 	color_arr = init_color_arr
-	if init_kicks.size() == pos_arr.size() * 2:
-		# store cw kicks and ccw kicks from input array
-		cw_kicks = []
-		ccw_kicks = []
-		for _i in range(pos_arr.size()):
-			cw_kicks.append(init_kicks[_i * 2])
-			ccw_kicks.append(init_kicks[_i * 2 + 1])
-	else:
-		# store cw kicks from input array; calculate ccw kicks
-		cw_kicks = init_kicks
-		ccw_kicks = []
-		for cw_kick in cw_kicks:
-			var ccw_kick: Array = cw_kick.duplicate()
-			# invert all kicks but the first one (the first one is the floor kick)
-			for i in range(cw_kick.size()):
-				ccw_kick[i] = Vector2(-cw_kick[i].x, -cw_kick[i].y)
-			ccw_kicks += [ccw_kick]
-	flips = init_flips
+	
+	# store kicks and create inverse kicks, if absent
+	kicks = init_kicks.duplicate()
+	for kick_key in kicks:
+		var inverse_key: int = (kick_key % 10) * 10 + int(kick_key / 10)
+		if kicks.has(kick_key) and not kicks.has(inverse_key):
+			kicks[inverse_key] = []
+			for kick in kicks[kick_key]:
+				kicks[inverse_key].append(Vector2(-kick.x, -kick.y))
+	
 	max_floor_kicks = init_max_floor_kicks
 
 

--- a/project/src/main/puzzle/piece/piece-types.gd
+++ b/project/src/main/puzzle/piece/piece-types.gd
@@ -2,82 +2,92 @@ extends Node
 ## Stores information on the various piece shapes. This includes information on their appearance, how they rotate, and
 ## how they 'kick' when they're blocked from rotating.
 
-const KICKS_I := [
-		[Vector2(-2,  0), Vector2( 1,  0), Vector2(-2,  1), Vector2( 1, -2)],
-		[Vector2(-1,  0), Vector2( 2,  0), Vector2(-1, -2), Vector2( 2,  1)],
-		[Vector2( 2,  0), Vector2(-1,  0), Vector2( 2, -1), Vector2(-1,  2)],
-		[Vector2( 1,  0), Vector2(-2,  0), Vector2( 1,  2), Vector2(-2, -1)],
-]
+const KICKS_I := {
+		01: [Vector2(-2,  0), Vector2( 1,  0), Vector2(-2,  1), Vector2( 1, -2)],
+		12: [Vector2(-1,  0), Vector2( 2,  0), Vector2(-1, -2), Vector2( 2,  1)],
+		23: [Vector2( 2,  0), Vector2(-1,  0), Vector2( 2, -1), Vector2(-1,  2)],
+		30: [Vector2( 1,  0), Vector2(-2,  0), Vector2( 1,  2), Vector2(-2, -1)],
+	}
 
-const KICKS_JLSZ := [
-		[Vector2( 1,  0), Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1), Vector2( 0, -1), Vector2(-1,  1)],
-		[Vector2( 1,  0), Vector2( 1,  1), Vector2( 1, -1), Vector2( 0, -1), Vector2( 0,  1), Vector2(-1,  0),
+const KICKS_JLSZ := {
+		01: [Vector2( 1,  0), Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1), Vector2( 0, -1), Vector2(-1,  1)],
+		12: [Vector2( 1,  0), Vector2( 1,  1), Vector2( 1, -1), Vector2( 0, -1), Vector2( 0,  1), Vector2(-1,  0),
 				Vector2( 0, -2), Vector2( 1, -2)],
-		[Vector2( 1,  0), Vector2( 1, -1), Vector2( 1,  1), Vector2( 0, -1), Vector2( 0,  1), Vector2(-1,  0),
+		23: [Vector2( 1,  0), Vector2( 1, -1), Vector2( 1,  1), Vector2( 0, -1), Vector2( 0,  1), Vector2(-1,  0),
 				Vector2( 0,  2), Vector2( 1,  2)],
-		[Vector2( 1,  0), Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1), Vector2(-1, -1)],
-	]
+		30: [Vector2( 1,  0), Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1), Vector2(-1, -1)],
+		
+		02: [Vector2( 0, -1)],
+		13: [Vector2( 1,  0)],
+	}
 
-const KICKS_U := [
-		[Vector2( 1,  0), Vector2( 1, -1), Vector2( 0, -1), Vector2( 0,  1), Vector2( 1, -2), ],
-		[Vector2( 1,  0), Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1), ],
-		[Vector2( 1,  0), Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1), Vector2( 0, -1), ],
-		[Vector2( 1,  0), Vector2( 1,  1), Vector2( 0, -1), Vector2( 0,  1), Vector2( 1,  2), ],
-	]
+const KICKS_P := {
+		01: [Vector2( 0, -1), Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1)],
+		12: [Vector2( 1,  0), Vector2( 1, -1), Vector2( 0, -1), Vector2( 0,  1)],
+		23: [Vector2( 0,  1), Vector2( 1,  0), Vector2( 1,  1), Vector2( 0, -1)],
+		30: [Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1)],
+	
+		02: [Vector2( 0, -1), Vector2( 1, -1)],
+		13: [Vector2( 1,  0), Vector2( 1,  1)],
+	}
 
-const KICKS_P := [
-		[Vector2( 0, -1), Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1)],
-		[Vector2( 1,  0), Vector2( 1, -1), Vector2( 0, -1), Vector2( 0,  1)],
-		[Vector2( 0,  1), Vector2( 1,  0), Vector2( 1,  1), Vector2( 0, -1)],
-		[Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1)],
-	]
+const KICKS_Q := {
+		01: [Vector2(-1,  0), Vector2(-1, -1), Vector2( 0, -1), Vector2( 0,  1)],
+		12: [Vector2( 0, -1), Vector2( 1,  0), Vector2( 1, -1), Vector2( 0,  1)],
+		23: [Vector2( 1,  0), Vector2( 1,  1), Vector2( 0,  1), Vector2( 0, -1)],
+		30: [Vector2( 0,  1), Vector2(-1,  0), Vector2(-1,  1), Vector2( 0, -1)],
+		
+		02: [Vector2( 0, -1), Vector2(-1, -1)],
+		13: [Vector2( 1,  0), Vector2( 1, -1)],
+	}
 
-const KICKS_Q := [
-		[Vector2(-1,  0), Vector2(-1, -1), Vector2( 0, -1), Vector2( 0,  1)],
-		[Vector2( 0, -1), Vector2( 1,  0), Vector2( 1, -1), Vector2( 0,  1)],
-		[Vector2( 1,  0), Vector2( 1,  1), Vector2( 0,  1), Vector2( 0, -1)],
-		[Vector2( 0,  1), Vector2(-1,  0), Vector2(-1,  1), Vector2( 0, -1)],
-	]
+const KICKS_T := {
+		01: [Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1), Vector2( 0, -1)],
+		12: [Vector2( 1,  0), Vector2( 1, -1), Vector2( 0, -1), Vector2(-1,  0)],
+		23: [Vector2( 1,  0), Vector2( 1,  1), Vector2( 0,  1), Vector2(-1,  0)],
+		30: [Vector2(-1,  0), Vector2(-1,  1), Vector2( 0, -1), Vector2( 0,  1)],
+		
+		02: [Vector2(0, -1)],
+		13: [Vector2(1, 0)],
+	}
 
-const KICKS_T := [
-		[Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1), Vector2( 0, -1)],
-		[Vector2( 1,  0), Vector2( 1, -1), Vector2( 0, -1), Vector2(-1,  0)],
-		[Vector2( 1,  0), Vector2( 1,  1), Vector2( 0,  1), Vector2(-1,  0)],
-		[Vector2(-1,  0), Vector2(-1,  1), Vector2( 0, -1), Vector2( 0,  1)],
-	]
+const KICKS_U := {
+		01: [Vector2( 1,  0), Vector2( 1, -1), Vector2( 0, -1), Vector2( 0,  1), Vector2( 1, -2)],
+		12: [Vector2( 1,  0), Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1)],
+		23: [Vector2( 1,  0), Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1), Vector2( 0, -1)],
+		30: [Vector2( 1,  0), Vector2( 1,  1), Vector2( 0, -1), Vector2( 0,  1), Vector2( 1,  2)],
+		
+		02: [Vector2(0, -1)],
+		13: [Vector2(-1, 0)],
+	}
 
-const KICKS_V := [
+const KICKS_V := {
 		# these kicks should be symmetrical over the y-axis
-		[Vector2(-1,  0), Vector2( 1,  1), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1),
-				Vector2( 0,  2)], # 0 -> R
-		[Vector2(-1,  0), Vector2( 1, -1), Vector2(-1, -1), Vector2( 0, -1), Vector2( 0,  1),
-				Vector2( 0, -2)], # R -> 0
+		01: [Vector2(-1,  0), Vector2( 1,  1), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1),
+				Vector2( 0,  2)],
+		10: [Vector2(-1,  0), Vector2( 1, -1), Vector2(-1, -1), Vector2( 0, -1), Vector2( 0,  1),
+				Vector2( 0, -2)],
 		
 		# these kicks should be symmetrical over the x-axis
-		[Vector2( 0, -1), Vector2(-1,  0), Vector2( 1,  0), Vector2(-1, -1), Vector2(-1,  1),
-				Vector2(-1, -2), Vector2(-2,  0)], # R -> 2
-		[Vector2( 0, -1), Vector2( 1,  0), Vector2(-1,  0), Vector2( 1, -1), Vector2( 1,  1),
-				Vector2( 1, -2), Vector2( 2,  0)], # 2 -> R
+		12: [Vector2( 0, -1), Vector2(-1,  0), Vector2( 1,  0), Vector2(-1, -1), Vector2(-1,  1),
+				Vector2(-1, -2), Vector2(-2,  0)],
+		21: [Vector2( 0, -1), Vector2( 1,  0), Vector2(-1,  0), Vector2( 1, -1), Vector2( 1,  1),
+				Vector2( 1, -2), Vector2( 2,  0)],
 
 		# these kicks should be symmetrical over the y-axis
-		[Vector2( 1,  0), Vector2(-1, -1), Vector2( 1, -1), Vector2( 0, -1), Vector2( 0,  1),
-				Vector2( 0, -2)], # 2 -> L
-		[Vector2( 1,  0), Vector2(-1,  1), Vector2( 1,  1), Vector2( 0,  1), Vector2( 0, -1),
-				Vector2( 0,  2)], # L -> 2
+		23: [Vector2( 1,  0), Vector2(-1, -1), Vector2( 1, -1), Vector2( 0, -1), Vector2( 0,  1),
+				Vector2( 0, -2)],
+		32: [Vector2( 1,  0), Vector2(-1,  1), Vector2( 1,  1), Vector2( 0,  1), Vector2( 0, -1),
+				Vector2( 0,  2)],
 		
 		# these kicks should be symmetrical over the x-axis
-		[Vector2( 0,  1), Vector2( 1,  0), Vector2(-1,  0), Vector2( 1,  1), Vector2( 1, -1),
-				Vector2( 1,  2), Vector2( 2,  0)], # L -> 0
-		[Vector2( 0,  1), Vector2(-1,  0), Vector2( 1,  0), Vector2(-1,  1), Vector2(-1, -1),
-				Vector2(-1,  2), Vector2(-2,  0)], # 0 -> L
-	]
+		30: [Vector2( 0,  1), Vector2( 1,  0), Vector2(-1,  0), Vector2( 1,  1), Vector2( 1, -1),
+				Vector2( 1,  2), Vector2( 2,  0)],
+		03: [Vector2( 0,  1), Vector2(-1,  0), Vector2( 1,  0), Vector2(-1,  1), Vector2(-1, -1),
+				Vector2(-1,  2), Vector2(-2,  0)],
+	}
 
-const KICKS_NONE := [
-		[],
-		[],
-		[],
-		[],
-	]
+const KICKS_NONE := {}
 
 var piece_i := PieceType.new("i",
 		# shape data
@@ -89,13 +99,13 @@ var piece_i := PieceType.new("i",
 		],
 		# color data
 		[
-			[Vector2(8, 3), Vector2(12, 3), Vector2(12, 3), Vector2(4, 3)],
-			[Vector2(2, 3), Vector2(3, 3), Vector2(3, 3), Vector2(1, 3)],
-			[Vector2(8, 3), Vector2(12, 3), Vector2(12, 3), Vector2(4, 3)],
-			[Vector2(2, 3), Vector2(3, 3), Vector2(3, 3), Vector2(1, 3)],
+			[Vector2( 8, 3), Vector2(12, 3), Vector2(12, 3), Vector2( 4, 3)],
+			[Vector2( 2, 3), Vector2( 3, 3), Vector2( 3, 3), Vector2( 1, 3)],
+			[Vector2( 8, 3), Vector2(12, 3), Vector2(12, 3), Vector2( 4, 3)],
+			[Vector2( 2, 3), Vector2( 3, 3), Vector2( 3, 3), Vector2( 1, 3)],
 		],
 		KICKS_I,
-		KICKS_NONE
+		5 # i-piece allows additional floor kicks because it kicks the floor twice if you rotate it four times
 	)
 
 var piece_j := PieceType.new("j",
@@ -108,13 +118,12 @@ var piece_j := PieceType.new("j",
 		],
 		# color data
 		[
-			[Vector2(2, 1), Vector2(9, 1), Vector2(12, 1), Vector2(4, 1)],
-			[Vector2(10, 1), Vector2(4, 1), Vector2(3, 1), Vector2(1, 1)],
-			[Vector2(8, 1), Vector2(12, 1), Vector2(6, 1), Vector2(1, 1)],
-			[Vector2(2, 1), Vector2(3, 1), Vector2(8, 1), Vector2(5, 1)],
+			[Vector2( 2, 1), Vector2( 9, 1), Vector2(12, 1), Vector2( 4, 1)],
+			[Vector2(10, 1), Vector2( 4, 1), Vector2( 3, 1), Vector2( 1, 1)],
+			[Vector2( 8, 1), Vector2(12, 1), Vector2( 6, 1), Vector2( 1, 1)],
+			[Vector2( 2, 1), Vector2( 3, 1), Vector2( 8, 1), Vector2( 5, 1)],
 		],
-		KICKS_JLSZ,
-		[[Vector2(0, -1)], [Vector2(1, 0)], [Vector2(0, 1)], [Vector2(-1, 0)]]
+		KICKS_JLSZ
 	)
 
 var piece_l := PieceType.new("l",
@@ -127,13 +136,12 @@ var piece_l := PieceType.new("l",
 		],
 		# color data
 		[
-			[Vector2(2, 0), Vector2(8, 0), Vector2(12, 0), Vector2(5, 0)],
-			[Vector2(2, 0), Vector2(3, 0), Vector2(9, 0), Vector2(4, 0)],
-			[Vector2(10, 0), Vector2(12, 0), Vector2(4, 0), Vector2(1, 0)],
-			[Vector2(8, 0), Vector2(6, 0), Vector2(3, 0), Vector2(1, 0)],
+			[Vector2( 2, 0), Vector2( 8, 0), Vector2(12, 0), Vector2( 5, 0)],
+			[Vector2( 2, 0), Vector2( 3, 0), Vector2( 9, 0), Vector2( 4, 0)],
+			[Vector2(10, 0), Vector2(12, 0), Vector2( 4, 0), Vector2( 1, 0)],
+			[Vector2( 8, 0), Vector2( 6, 0), Vector2( 3, 0), Vector2( 1, 0)],
 		],
-		KICKS_JLSZ,
-		[[Vector2(0, -1)], [Vector2(1, 0)], [Vector2(0, 1)], [Vector2(-1, 0)]]
+		KICKS_JLSZ
 	)
 
 var piece_o := PieceType.new("o",
@@ -146,12 +154,11 @@ var piece_o := PieceType.new("o",
 		],
 		# color data
 		[
-			[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)],
-			[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)],
-			[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)],
-			[Vector2(10, 3), Vector2(6, 3), Vector2(9, 3), Vector2(5, 3)],
+			[Vector2(10, 3), Vector2( 6, 3), Vector2( 9, 3), Vector2( 5, 3)],
+			[Vector2(10, 3), Vector2( 6, 3), Vector2( 9, 3), Vector2( 5, 3)],
+			[Vector2(10, 3), Vector2( 6, 3), Vector2( 9, 3), Vector2( 5, 3)],
+			[Vector2(10, 3), Vector2( 6, 3), Vector2( 9, 3), Vector2( 5, 3)],
 		],
-		KICKS_NONE,
 		KICKS_NONE
 	)
 
@@ -165,19 +172,12 @@ var piece_p := PieceType.new("p",
 		],
 		# color data
 		[
-			[Vector2(8, 1), Vector2(14, 1), Vector2(6, 1), Vector2(9, 1), Vector2(5, 1)],
-			[Vector2(2, 1), Vector2(10, 1), Vector2(7, 1), Vector2(9, 1), Vector2(5, 1)],
-			[Vector2(10, 1), Vector2(6, 1), Vector2(9, 1), Vector2(13, 1), Vector2(4, 1)],
-			[Vector2(10, 1), Vector2(6, 1), Vector2(11, 1), Vector2(5, 1), Vector2(1, 1)],
+			[Vector2( 8, 1), Vector2(14, 1), Vector2( 6, 1), Vector2( 9, 1), Vector2( 5, 1)],
+			[Vector2( 2, 1), Vector2(10, 1), Vector2( 7, 1), Vector2( 9, 1), Vector2( 5, 1)],
+			[Vector2(10, 1), Vector2( 6, 1), Vector2( 9, 1), Vector2(13, 1), Vector2( 4, 1)],
+			[Vector2(10, 1), Vector2( 6, 1), Vector2(11, 1), Vector2( 5, 1), Vector2( 1, 1)],
 		],
-		KICKS_P,
-		# flip kick data
-		[
-			[Vector2(0, -1), Vector2(1, -1)],
-			[Vector2(1, 0), Vector2(1, 1)],
-			[Vector2(0, 1), Vector2(-1, 1)],
-			[Vector2(-1, 0), Vector2(-1, -1)],
-		]
+		KICKS_P
 	)
 
 var piece_q := PieceType.new("q",
@@ -190,19 +190,12 @@ var piece_q := PieceType.new("q",
 		],
 		# color data
 		[
-			[Vector2(10, 0), Vector2(14, 0), Vector2(4, 0), Vector2(9, 0), Vector2(5, 0)],
-			[Vector2(10, 0), Vector2(6, 0), Vector2(9, 0), Vector2(7, 0), Vector2(1, 0)],
-			[Vector2(10, 0), Vector2(6, 0), Vector2(8, 0), Vector2(13, 0), Vector2(5, 0)],
-			[Vector2(2, 0), Vector2(11, 0), Vector2(6, 0), Vector2(9, 0), Vector2(5, 0)],
+			[Vector2(10, 0), Vector2(14, 0), Vector2( 4, 0), Vector2( 9, 0), Vector2( 5, 0)],
+			[Vector2(10, 0), Vector2( 6, 0), Vector2( 9, 0), Vector2( 7, 0), Vector2( 1, 0)],
+			[Vector2(10, 0), Vector2( 6, 0), Vector2( 8, 0), Vector2(13, 0), Vector2( 5, 0)],
+			[Vector2( 2, 0), Vector2(11, 0), Vector2( 6, 0), Vector2( 9, 0), Vector2( 5, 0)],
 		],
-		KICKS_Q,
-		# flip kick data
-		[
-			[Vector2(0, -1), Vector2(-1, -1)],
-			[Vector2(1, 0), Vector2(1, -1)],
-			[Vector2(0, 1), Vector2(1, 1)],
-			[Vector2(-1, 0), Vector2(-1, 1)],
-		]
+		KICKS_Q
 	)
 	
 var piece_s := PieceType.new("s",
@@ -215,13 +208,12 @@ var piece_s := PieceType.new("s",
 		],
 		# color data
 		[
-			[Vector2(10, 2), Vector2(4, 2), Vector2(8, 2), Vector2(5, 2)],
-			[Vector2(2, 2), Vector2(9, 2), Vector2(6, 2), Vector2(1, 2)],
-			[Vector2(10, 2), Vector2(4, 2), Vector2(8, 2), Vector2(5, 2)],
-			[Vector2(2, 2), Vector2(9, 2), Vector2(6, 2), Vector2(1, 2)],
+			[Vector2(10, 2), Vector2( 4, 2), Vector2( 8, 2), Vector2( 5, 2)],
+			[Vector2( 2, 2), Vector2( 9, 2), Vector2( 6, 2), Vector2( 1, 2)],
+			[Vector2(10, 2), Vector2( 4, 2), Vector2( 8, 2), Vector2( 5, 2)],
+			[Vector2( 2, 2), Vector2( 9, 2), Vector2( 6, 2), Vector2( 1, 2)],
 		],
-		KICKS_JLSZ,
-		KICKS_NONE
+		KICKS_JLSZ
 	)
 
 var piece_t := PieceType.new("t",
@@ -234,13 +226,12 @@ var piece_t := PieceType.new("t",
 		],
 		# color data
 		[
-			[Vector2(2, 2), Vector2(8, 2), Vector2(13, 2), Vector2(4, 2)],
-			[Vector2(2, 2), Vector2(11, 2), Vector2(4, 2), Vector2(1, 2)],
-			[Vector2(8, 2), Vector2(14, 2), Vector2(4, 2), Vector2(1, 2)],
-			[Vector2(2, 2), Vector2(8, 2), Vector2(7, 2), Vector2(1, 2)],
+			[Vector2( 2, 2), Vector2( 8, 2), Vector2(13, 2), Vector2( 4, 2)],
+			[Vector2( 2, 2), Vector2(11, 2), Vector2( 4, 2), Vector2( 1, 2)],
+			[Vector2( 8, 2), Vector2(14, 2), Vector2( 4, 2), Vector2( 1, 2)],
+			[Vector2( 2, 2), Vector2( 8, 2), Vector2( 7, 2), Vector2( 1, 2)],
 		],
-		KICKS_T,
-		[[Vector2(0, -1)], [Vector2(1, 0)], [Vector2(0, 1)], [Vector2(-1, 0)]]
+		KICKS_T
 	)
 
 var piece_u := PieceType.new("u",
@@ -253,14 +244,12 @@ var piece_u := PieceType.new("u",
 		],
 		# color data
 		[
-			[Vector2(10, 2), Vector2(12, 2), Vector2(6, 2), Vector2(1, 2), Vector2(1, 2)],
-			[Vector2(8, 2), Vector2(6, 2), Vector2(3, 2), Vector2(8, 2), Vector2(5, 2)],
-			[Vector2(2, 2), Vector2(2, 2), Vector2(9, 2), Vector2(12, 2), Vector2(5, 2)],
-			[Vector2(10, 2), Vector2(4, 2), Vector2(3, 2), Vector2(9, 2), Vector2(4, 2)],
+			[Vector2(10, 2), Vector2(12, 2), Vector2( 6, 2), Vector2( 1, 2), Vector2( 1, 2)],
+			[Vector2( 8, 2), Vector2( 6, 2), Vector2( 3, 2), Vector2( 8, 2), Vector2( 5, 2)],
+			[Vector2( 2, 2), Vector2( 2, 2), Vector2( 9, 2), Vector2(12, 2), Vector2( 5, 2)],
+			[Vector2(10, 2), Vector2( 4, 2), Vector2( 3, 2), Vector2( 9, 2), Vector2( 4, 2)],
 		],
 		KICKS_U,
-		# flip kick data
-		[[Vector2(0, -1)], [Vector2(-1, 0)], [Vector2(0, 1)], [Vector2(1, 0)],],
 		5 # u-piece allows additional floor kicks because it kicks the floor twice if you rotate it four times
 	)
 
@@ -274,13 +263,12 @@ var piece_v := PieceType.new("v",
 		],
 		# color data
 		[
-			[Vector2(2, 3), Vector2(3, 3), Vector2(9, 3), Vector2(12, 3), Vector2(4, 3)],
-			[Vector2(10, 3), Vector2(12, 3), Vector2(4, 3), Vector2(3, 3), Vector2(1, 3)],
-			[Vector2(8, 3), Vector2(12, 3), Vector2(6, 3), Vector2(3, 3), Vector2(1, 3)],
-			[Vector2(2, 3), Vector2(3, 3), Vector2(8, 3), Vector2(12, 3), Vector2(5, 3)],
+			[Vector2( 2, 3), Vector2( 3, 3), Vector2( 9, 3), Vector2(12, 3), Vector2( 4, 3)],
+			[Vector2(10, 3), Vector2(12, 3), Vector2( 4, 3), Vector2( 3, 3), Vector2( 1, 3)],
+			[Vector2( 8, 3), Vector2(12, 3), Vector2( 6, 3), Vector2( 3, 3), Vector2( 1, 3)],
+			[Vector2( 2, 3), Vector2( 3, 3), Vector2( 8, 3), Vector2(12, 3), Vector2( 5, 3)],
 		],
-		KICKS_V,
-		KICKS_NONE
+		KICKS_V
 	)
 
 var piece_z := PieceType.new("z",
@@ -293,16 +281,15 @@ var piece_z := PieceType.new("z",
 		],
 		# color data
 		[
-			[Vector2(8, 2), Vector2(6, 2), Vector2(9, 2), Vector2(4, 2)],
-			[Vector2(2, 2), Vector2(10, 2), Vector2(5, 2), Vector2(1, 2)],
-			[Vector2(8, 2), Vector2(6, 2), Vector2(9, 2), Vector2(4, 2)],
-			[Vector2(2, 2), Vector2(10, 2), Vector2(5, 2), Vector2(1, 2)],
+			[Vector2( 8, 2), Vector2( 6, 2), Vector2( 9, 2), Vector2( 4, 2)],
+			[Vector2( 2, 2), Vector2(10, 2), Vector2( 5, 2), Vector2( 1, 2)],
+			[Vector2( 8, 2), Vector2( 6, 2), Vector2( 9, 2), Vector2( 4, 2)],
+			[Vector2( 2, 2), Vector2(10, 2), Vector2( 5, 2), Vector2( 1, 2)],
 		],
-		KICKS_JLSZ,
-		KICKS_NONE
+		KICKS_JLSZ
 	)
 
-var piece_null := PieceType.new("_", [[]], [[]], KICKS_NONE, [])
+var piece_null := PieceType.new("_", [[]], [[]], KICKS_NONE)
 var default_types := [piece_j, piece_l, piece_o, piece_p, piece_q, piece_t, piece_u, piece_v];
 
 var pieces_by_string := {


### PR DESCRIPTION
https://github.com/26F-Studio/Techmino/blob/e1885bdb609706783f6ba83ebf52dd003c1f1894/parts/RSlist.lua

Taking inspiration from Techmino, Turbo Fat's piece kick tables are now
stored as dictionaries with a 'from' and 'to' orientation as the key.
This simplifies a lot of things:

 - We don't need a separate table for piece flips

 - It simplifies the process for detecting the presence/absence of
   inverse piece kicks

 - We don't need to store redundant entries for inverse flip kicks

 - It is more human readable because each line of code says which
   orientation the kicks apply to

 - It is easier to look up the kicks for a specific orientation since
   they are all in one place