### PR TITLE
U pieces now rotate like J/L pieces.

### DIFF
--- a/project/src/main/puzzle/piece/active-piece.gd
+++ b/project/src/main/puzzle/piece/active-piece.gd
@@ -1,6 +1,8 @@
 class_name ActivePiece
 ## Contains the settings and state for the currently active piece.
 
+const MAX_FLOOR_KICKS := 3
+
 ## The current position/orientation. For most pieces, orientation will range from
 ## [0, 1, 2, 3] for [unrotated, clockwise, flipped, counterclockwise]
 var pos := Vector2(3, 3)
@@ -174,7 +176,7 @@ func kick_piece(kicks: Array = []) -> void:
 
 
 func can_floor_kick() -> bool:
-	return floor_kicks < type.max_floor_kicks
+	return floor_kicks < MAX_FLOOR_KICKS
 
 
 ## Returns 'true' if the piece is blocked from moving in all four directions.

--- a/project/src/main/puzzle/piece/piece-type.gd
+++ b/project/src/main/puzzle/piece/piece-type.gd
@@ -19,11 +19,8 @@ var color_arr: Array
 ## values: (Array, Vector2) kicks to try
 var kicks: Dictionary
 
-## maximum number of 'floor kicks', kicks which move the piece upward
-var max_floor_kicks: int
-
 func _init(init_string: String, init_pos_arr: Array, init_color_arr: Array,
-		init_kicks: Dictionary, init_max_floor_kicks := 3) -> void:
+		init_kicks: Dictionary) -> void:
 	string = init_string
 	pos_arr = init_pos_arr
 	color_arr = init_color_arr
@@ -36,8 +33,6 @@ func _init(init_string: String, init_pos_arr: Array, init_color_arr: Array,
 			kicks[inverse_key] = []
 			for kick in kicks[kick_key]:
 				kicks[inverse_key].append(Vector2(-kick.x, -kick.y))
-	
-	max_floor_kicks = init_max_floor_kicks
 
 
 ## Returns the position of the specified cell.

--- a/project/src/main/puzzle/piece/piece-types.gd
+++ b/project/src/main/puzzle/piece/piece-types.gd
@@ -52,13 +52,13 @@ const KICKS_T := {
 	}
 
 const KICKS_U := {
-		01: [Vector2( 1,  0), Vector2( 1, -1), Vector2( 0, -1), Vector2( 0,  1), Vector2( 1, -2)],
-		12: [Vector2( 1,  0), Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1)],
-		23: [Vector2( 1,  0), Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1), Vector2( 0, -1)],
-		30: [Vector2( 1,  0), Vector2( 1,  1), Vector2( 0, -1), Vector2( 0,  1), Vector2( 1,  2)],
+		01: [Vector2( 1,  0), Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1), Vector2( 0, -1)],
+		12: [Vector2( 1, -1), Vector2( 0, -1), Vector2( 1,  0), Vector2( 0, -2), Vector2( 1,  1)],
+		23: [Vector2( 1,  1), Vector2( 0,  1), Vector2( 1,  0), Vector2( 0,  2), Vector2( 1, -1)],
+		30: [Vector2( 1,  0), Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1)],
 		
 		02: [Vector2( 0, -1)],
-		13: [Vector2(-1,  0)],
+		13: [Vector2( 1,  0)],
 	}
 
 const KICKS_V := {
@@ -104,8 +104,7 @@ var piece_i := PieceType.new("i",
 			[Vector2( 8, 3), Vector2(12, 3), Vector2(12, 3), Vector2( 4, 3)],
 			[Vector2( 2, 3), Vector2( 3, 3), Vector2( 3, 3), Vector2( 1, 3)],
 		],
-		KICKS_I,
-		5 # i-piece allows additional floor kicks because it kicks the floor twice if you rotate it four times
+		KICKS_I
 	)
 
 var piece_j := PieceType.new("j",
@@ -237,20 +236,19 @@ var piece_t := PieceType.new("t",
 var piece_u := PieceType.new("u",
 		# shape data
 		[
-			[Vector2(0, 0), Vector2(1, 0), Vector2(2, 0), Vector2(0, 1), Vector2(2, 1)],
-			[Vector2(0, 0), Vector2(1, 0), Vector2(1, 1), Vector2(0, 2), Vector2(1, 2)],
 			[Vector2(0, 0), Vector2(2, 0), Vector2(0, 1), Vector2(1, 1), Vector2(2, 1)],
 			[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(1, 2), Vector2(2, 2)],
+			[Vector2(0, 1), Vector2(1, 1), Vector2(2, 1), Vector2(0, 2), Vector2(2, 2)],
+			[Vector2(0, 0), Vector2(1, 0), Vector2(1, 1), Vector2(0, 2), Vector2(1, 2)],
 		],
 		# color data
 		[
-			[Vector2(10, 2), Vector2(12, 2), Vector2( 6, 2), Vector2( 1, 2), Vector2( 1, 2)],
-			[Vector2( 8, 2), Vector2( 6, 2), Vector2( 3, 2), Vector2( 8, 2), Vector2( 5, 2)],
 			[Vector2( 2, 2), Vector2( 2, 2), Vector2( 9, 2), Vector2(12, 2), Vector2( 5, 2)],
 			[Vector2(10, 2), Vector2( 4, 2), Vector2( 3, 2), Vector2( 9, 2), Vector2( 4, 2)],
+			[Vector2(10, 2), Vector2(12, 2), Vector2( 6, 2), Vector2( 1, 2), Vector2( 1, 2)],
+			[Vector2( 8, 2), Vector2( 6, 2), Vector2( 3, 2), Vector2( 8, 2), Vector2( 5, 2)],
 		],
-		KICKS_U,
-		5 # u-piece allows additional floor kicks because it kicks the floor twice if you rotate it four times
+		KICKS_U
 	)
 
 var piece_v := PieceType.new("v",

--- a/project/src/test/puzzle/piece/test-piece-kicks-u.gd
+++ b/project/src/test/puzzle/piece/test-piece-kicks-u.gd
@@ -43,9 +43,9 @@ func test_wall_kick_r0_0() -> void:
 	]
 	to_grid = [
 		"    ",
+		"    ",
 		"uuu ",
 		"u u ",
-		"    ",
 		"    ",
 	]
 	assert_kick()
@@ -133,9 +133,9 @@ func test_wall_kick_l0_1() -> void:
 	]
 	to_grid = [
 		"    ",
+		"    ",
 		" uuu",
 		" u u",
-		"    ",
 		"    ",
 	]
 	assert_kick()
@@ -343,9 +343,9 @@ func test_diagonalnw_kick_l0() -> void:
 	]
 	to_grid = [
 		"::  ",
-		":uuu",
-		" u u",
-		"   :",
+		":   ",
+		"uuu ",
+		"u u:",
 		"  ::",
 	]
 	assert_kick()
@@ -360,10 +360,10 @@ func test_diagonalne_kick_0r() -> void:
 		"::   ",
 	]
 	to_grid = [
-		"   ::",
-		"  uu:",
-		":  u ",
-		"::uu ",
+		" uu::",
+		"  u :",
+		":uu  ",
+		"::   ",
 	]
 	assert_kick()
 
@@ -597,16 +597,30 @@ func test_flip_kick_02_narrow() -> void:
 	assert_kick()
 
 
-func test_flip_kick_02_wide() -> void:
+func test_flip_kick_02_floor() -> void:
 	from_grid = [
 		"   ",
 		"uuu",
 		"u u",
 	]
 	to_grid = [
+		"u u",
+		"uuu",
+		"   ",
+	]
+	assert_kick()
+
+
+func test_flip_kick_20_floor() -> void:
+	from_grid = [
 		"   ",
 		"u u",
 		"uuu",
+	]
+	to_grid = [
+		"   ",
+		"uuu",
+		"u u",
 	]
 	assert_kick()
 


### PR DESCRIPTION
U pieces used to spawn pointy-side down, and kick the floor twice during
a full 360 degree rotation. They now spawn flat-side down, and only kick
the floor once. This provides a few benefits:

 - The piece movement now resembles J/L pieces so it will be more
   familiar

 - U pieces no longer need to permit extra floor kicks. They used to
   permit 5 floor kicks because otherwise they were too unforgiving at
   20G compared to other pieces

 - U pieces now look like a 'U' in the next piece queue :)

There is one drawback: U pieces and T pieces no longer interlock when hard
dropping without the rotate key. But, this is a rather superficial drawback in
my opinion. We could preserve it if we spawned the U piece in its '2'
orientation, but then the piece rotates off the top of the screen which
is disorienting.