### PR TITLE
Fixed bug with PuzzleState.speed_index going OOB

### DIFF
--- a/project/src/main/puzzle/milestone-manager.gd
+++ b/project/src/main/puzzle/milestone-manager.gd
@@ -65,7 +65,12 @@ func progress_value(milestone: Milestone) -> float:
 ##
 ## This controls the speed at which the pieces move.
 func prev_milestone() -> Milestone:
-	return CurrentLevel.settings.speed.speed_ups[PuzzleState.speed_index]
+	var milestone: Milestone
+	if PuzzleState.speed_index < CurrentLevel.settings.speed.speed_ups.size():
+		milestone = CurrentLevel.settings.speed.speed_ups[PuzzleState.speed_index]
+	else:
+		milestone = CurrentLevel.settings.speed.speed_ups.back()
+	return milestone
 
 
 ## Returns the next upcoming milestone. This is reflected in the UI.


### PR DESCRIPTION
This OOB bug happens when quitting a puzzle after leveling up. It was
introduced in 6db9a46e when CurrentLevel was modified to erase more of
its metadata.