### PR TITLE
Move O and I pieces left. Flip V piece.

### DIFF
--- a/project/src/main/puzzle/piece/piece-types.gd
+++ b/project/src/main/puzzle/piece/piece-types.gd
@@ -63,28 +63,28 @@ const KICKS_U := {
 
 const KICKS_V := {
 		# these kicks should be symmetrical over the y-axis
-		01: [Vector2(-1,  0), Vector2( 1,  1), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1),
-				Vector2( 0,  2)],
-		10: [Vector2(-1,  0), Vector2( 1, -1), Vector2(-1, -1), Vector2( 0, -1), Vector2( 0,  1),
+		01: [Vector2( 1,  0), Vector2(-1, -1), Vector2( 1, -1), Vector2( 0, -1), Vector2( 0,  1),
 				Vector2( 0, -2)],
-		
-		# these kicks should be symmetrical over the x-axis
-		12: [Vector2( 0, -1), Vector2(-1,  0), Vector2( 1,  0), Vector2(-1, -1), Vector2(-1,  1),
-				Vector2(-1, -2), Vector2(-2,  0)],
-		21: [Vector2( 0, -1), Vector2( 1,  0), Vector2(-1,  0), Vector2( 1, -1), Vector2( 1,  1),
-				Vector2( 1, -2), Vector2( 2,  0)],
-
-		# these kicks should be symmetrical over the y-axis
-		23: [Vector2( 1,  0), Vector2(-1, -1), Vector2( 1, -1), Vector2( 0, -1), Vector2( 0,  1),
-				Vector2( 0, -2)],
-		32: [Vector2( 1,  0), Vector2(-1,  1), Vector2( 1,  1), Vector2( 0,  1), Vector2( 0, -1),
+		10: [Vector2( 1,  0), Vector2(-1,  1), Vector2( 1,  1), Vector2( 0,  1), Vector2( 0, -1),
 				Vector2( 0,  2)],
 		
 		# these kicks should be symmetrical over the x-axis
-		30: [Vector2( 0,  1), Vector2( 1,  0), Vector2(-1,  0), Vector2( 1,  1), Vector2( 1, -1),
+		12: [Vector2( 0,  1), Vector2( 1,  0), Vector2(-1,  0), Vector2( 1,  1), Vector2( 1, -1),
 				Vector2( 1,  2), Vector2( 2,  0)],
-		03: [Vector2( 0,  1), Vector2(-1,  0), Vector2( 1,  0), Vector2(-1,  1), Vector2(-1, -1),
+		21: [Vector2( 0,  1), Vector2(-1,  0), Vector2( 1,  0), Vector2(-1,  1), Vector2(-1, -1),
 				Vector2(-1,  2), Vector2(-2,  0)],
+		
+		# these kicks should be symmetrical over the y-axis
+		23: [Vector2(-1,  0), Vector2( 1,  1), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1),
+				Vector2( 0,  2)],
+		32: [Vector2(-1,  0), Vector2( 1, -1), Vector2(-1, -1), Vector2( 0, -1), Vector2( 0,  1),
+				Vector2( 0, -2)],
+		
+		# these kicks should be symmetrical over the x-axis
+		30: [Vector2( 0, -1), Vector2(-1,  0), Vector2( 1,  0), Vector2(-1, -1), Vector2(-1,  1),
+				Vector2(-1, -2), Vector2(-2,  0)],
+		03: [Vector2( 0, -1), Vector2( 1,  0), Vector2(-1,  0), Vector2( 1, -1), Vector2( 1,  1),
+				Vector2( 1, -2), Vector2( 2,  0)],
 	}
 
 const KICKS_NONE := {}
@@ -92,10 +92,10 @@ const KICKS_NONE := {}
 var piece_i := PieceType.new("i",
 		# shape data
 		[
-			[Vector2(0, 1), Vector2(1, 1), Vector2(2, 1), Vector2(3, 1)],
-			[Vector2(2, 0), Vector2(2, 1), Vector2(2, 2), Vector2(2, 3)],
-			[Vector2(0, 2), Vector2(1, 2), Vector2(2, 2), Vector2(3, 2)],
+			[Vector2(-1, 1), Vector2(0, 1), Vector2(1, 1), Vector2(2, 1)],
 			[Vector2(1, 0), Vector2(1, 1), Vector2(1, 2), Vector2(1, 3)],
+			[Vector2(-1, 2), Vector2(0, 2), Vector2(1, 2), Vector2(2, 2)],
+			[Vector2(0, 0), Vector2(0, 1), Vector2(0, 2), Vector2(0, 3)],
 		],
 		# color data
 		[
@@ -146,10 +146,10 @@ var piece_l := PieceType.new("l",
 var piece_o := PieceType.new("o",
 		# shape data, four states so that the rotate button has an effect and can distinguish cw/ccw rotation
 		[
-			[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)],
-			[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)],
-			[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)],
-			[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(2, 1)],
+			[Vector2(0, 0), Vector2(1, 0), Vector2(0, 1), Vector2(1, 1)],
+			[Vector2(0, 0), Vector2(1, 0), Vector2(0, 1), Vector2(1, 1)],
+			[Vector2(0, 0), Vector2(1, 0), Vector2(0, 1), Vector2(1, 1)],
+			[Vector2(0, 0), Vector2(1, 0), Vector2(0, 1), Vector2(1, 1)],
 		],
 		# color data
 		[
@@ -254,17 +254,17 @@ var piece_u := PieceType.new("u",
 var piece_v := PieceType.new("v",
 		# shape data
 		[
-			[Vector2(0, 0), Vector2(0, 1), Vector2(0, 2), Vector2(1, 2), Vector2(2, 2)],
-			[Vector2(0, 0), Vector2(1, 0), Vector2(2, 0), Vector2(0, 1), Vector2(0, 2)],
 			[Vector2(0, 0), Vector2(1, 0), Vector2(2, 0), Vector2(2, 1), Vector2(2, 2)],
 			[Vector2(2, 0), Vector2(2, 1), Vector2(0, 2), Vector2(1, 2), Vector2(2, 2)],
+			[Vector2(0, 0), Vector2(0, 1), Vector2(0, 2), Vector2(1, 2), Vector2(2, 2)],
+			[Vector2(0, 0), Vector2(1, 0), Vector2(2, 0), Vector2(0, 1), Vector2(0, 2)],
 		],
 		# color data
 		[
-			[Vector2( 2, 3), Vector2( 3, 3), Vector2( 9, 3), Vector2(12, 3), Vector2( 4, 3)],
-			[Vector2(10, 3), Vector2(12, 3), Vector2( 4, 3), Vector2( 3, 3), Vector2( 1, 3)],
 			[Vector2( 8, 3), Vector2(12, 3), Vector2( 6, 3), Vector2( 3, 3), Vector2( 1, 3)],
 			[Vector2( 2, 3), Vector2( 3, 3), Vector2( 8, 3), Vector2(12, 3), Vector2( 5, 3)],
+			[Vector2( 2, 3), Vector2( 3, 3), Vector2( 9, 3), Vector2(12, 3), Vector2( 4, 3)],
+			[Vector2(10, 3), Vector2(12, 3), Vector2( 4, 3), Vector2( 3, 3), Vector2( 1, 3)],
 		],
 		KICKS_V
 	)

--- a/project/src/test/puzzle/piece/test-active-piece.gd
+++ b/project/src/test/puzzle/piece/test-active-piece.gd
@@ -61,11 +61,11 @@ func test_is_sealed_false_right() -> void:
 func test_center_o() -> void:
 	# the O piece's center x and y coordinates are in between two grid coordinates
 	var piece := ActivePiece.new(PieceTypes.piece_o, null)
-	assert_eq(piece.center(), Vector2(4.5, 3.5))
+	assert_eq(piece.center(), Vector2(3.5, 3.5))
 	
 	# when moved, the O piece's center moves too
 	piece.pos = Vector2(2, 2)
-	assert_eq(piece.center(), Vector2(3.5, 2.5))
+	assert_eq(piece.center(), Vector2(2.5, 2.5))
 
 
 func test_center_t() -> void:


### PR DESCRIPTION
This makes the pieces more consistent in two ways.

Moving the O and I piece to the left gives the game a 'leftward bias' which is
consistent with other similar games, where pieces spawn to the left if they
cannot spawn exactly in the center.

Flipping the V piece makes it so most Turbo Fat pieces stack nicely with
the tetromino on the bottom and pentomino on the top, the only exception
being the U/T pieces which are necessary for a different reason.
Flipping the V piece also makes it it so most pentominos spawn
flat-side-up.