### PR TITLE
ResourceCache: threaded, load_seconds, low_priority

### DIFF
--- a/project/src/main/ResourceCache.tscn
+++ b/project/src/main/ResourceCache.tscn
@@ -4,4 +4,6 @@
 
 [node name="ResourceCache" type="Node"]
 script = ExtResource( 1 )
+low_priority_resource_paths = [ "res://src/main/puzzle/Puzzle.tscn", "res://src/main/editor/puzzle/LevelEditor.tscn" ]
 skipped_resource_paths = [ "res://assets/main/world/environment", "res://src/main/world/environment" ]
+threaded = true


### PR DESCRIPTION
Added ResourceCache.threaded flag. ResourceCache can be configured to be
threaded or non-threaded. This allows us to disable threading even for
targets which support it.

Added ResourceCache.load_seconds flag. ResourceCache can be configured
to load resources gradually. This makes the loading screen less
stuttery.

Added ResourceCache.low_priority_resource_paths parameter. ResourceCache
has a few resources such as 'Puzzle.tscn' which, if loaded too early,
take a long time to cache because they load other scenes and resources.
Loading them last results in fewer stutters when caching resources.