### PR TITLE
Suppress TurboFatRestaurant OverworldUi warnings

### DIFF
--- a/project/src/main/world/environment/turbo-fat-restaurant.gd
+++ b/project/src/main/world/environment/turbo-fat-restaurant.gd
@@ -32,8 +32,6 @@ func _ready() -> void:
 	
 	if Global.get_overworld_ui():
 		Global.get_overworld_ui().connect("chat_event_meta_played", self, "_on_OverworldUi_chat_event_meta_played")
-	else:
-		push_warning("Cannot find OverworldUi node, chat events will be disabled")
 
 
 func hide_closed_sign() -> void:


### PR DESCRIPTION
These warnings occur on the CareerMap and victory screen because they do
not have an OverworldUi node. A missing OverworldUi node does not
warrant a warning for most of the game.