### PR TITLE
Splash screen scene transition is slower than others.

### DIFF
--- a/project/src/main/music/music-transition.gd
+++ b/project/src/main/music/music-transition.gd
@@ -28,4 +28,4 @@ func _on_SceneTransition_fade_in_started() -> void:
 func _on_SceneTransition_fade_out_started() -> void:
 	if OS.has_feature("web"):
 		_faded_bgm = MusicPlayer.current_bgm
-		MusicPlayer.stop(SceneTransition.SCREEN_FADE_OUT_DURATION * 0.5)
+		MusicPlayer.stop(SceneTransition.next_fade_out_duration * 0.5)

--- a/project/src/main/ui/menu/loading-screen.gd
+++ b/project/src/main/ui/menu/loading-screen.gd
@@ -18,4 +18,14 @@ func _process(_delta: float) -> void:
 
 
 func _on_ResourceCache_finished_loading() -> void:
+	if SystemData.fast_mode:
+		# run faster for debug builds
+		SceneTransition.next_fade_out_duration *= 0.5
+		SceneTransition.next_fade_in_duration *= 0.5
+	else:
+		# This scene transition looks pretty so it's nice to draw attention to it. But we don't want every scene
+		# transition to be this slow or the game will be tedious to navigate. So, we just slow it down for the loading
+		# screen.
+		SceneTransition.next_fade_out_duration += 0.6
+		SceneTransition.next_fade_in_duration += 0.6
 	SceneTransition.push_trail(Global.SCENE_SPLASH)

--- a/project/src/main/ui/scene-transition-cover.gd
+++ b/project/src/main/ui/scene-transition-cover.gd
@@ -17,10 +17,10 @@ func _ready() -> void:
 ## Launches the 'fade out' visual transition.
 func fade_out() -> void:
 	_mask.modulate = SceneTransition.fade_color
-	_animation_player.play("fade-out", -1, 1.0 / SceneTransition.SCREEN_FADE_OUT_DURATION)
+	_animation_player.play("fade-out", -1, 1.0 / SceneTransition.next_fade_out_duration)
 	
 	# play a random part of the scene transition sound effect so it's not as repetitive
-	var max_audio_start := _audio_stream_player.stream.get_length() - SceneTransition.SCREEN_FADE_OUT_DURATION
+	var max_audio_start := max(0.0, _audio_stream_player.stream.get_length() - SceneTransition.next_fade_out_duration)
 	_audio_stream_player.play(rand_range(0.0, max_audio_start))
 
 
@@ -30,7 +30,7 @@ func fade_in() -> void:
 	_animation_player.play("fade-in", -1, 1.0 / SceneTransition.SCREEN_FADE_IN_DURATION)
 	
 	# play a random part of the scene transition sound effect so it's not as repetitive
-	var max_audio_start := _audio_stream_player.stream.get_length() - SceneTransition.SCREEN_FADE_IN_DURATION
+	var max_audio_start := max(0.0, _audio_stream_player.stream.get_length() - SceneTransition.SCREEN_FADE_IN_DURATION)
 	_audio_stream_player.play(rand_range(0.0, max_audio_start))
 
 

--- a/project/src/main/ui/scene-transition.gd
+++ b/project/src/main/ui/scene-transition.gd
@@ -18,6 +18,11 @@ var fade_color: Color = ProjectSettings.get_setting("rendering/environment/defau
 var breadcrumb_method: FuncRef
 var breadcrumb_arg_array: Array
 
+## The duration of the next fade duration (or the current one, if already fading). These can be assigned for a slower
+## or faster fadeout, but they will reset to their default values after the next fade.
+var next_fade_in_duration := SCREEN_FADE_IN_DURATION
+var next_fade_out_duration := SCREEN_FADE_OUT_DURATION
+
 ## Navigates forward one level, appending the new path to the breadcrumb trail after a scene transition.
 ##
 ## Parameters:
@@ -89,6 +94,7 @@ func change_scene(skip_transition: bool = false) -> void:
 
 ## Called when the 'fade out' visual transition ends, triggering a scene transition.
 func end_fade_out() -> void:
+	next_fade_out_duration = SCREEN_FADE_OUT_DURATION
 	if breadcrumb_method:
 		breadcrumb_method.call_funcv(breadcrumb_arg_array)
 
@@ -103,6 +109,7 @@ func fade_in() -> void:
 
 ## Called when the 'fade in' visual transition ends, toggling a state variable.
 func end_fade_in() -> void:
+	next_fade_out_duration = SCREEN_FADE_IN_DURATION
 	fading = false
 
 


### PR DESCRIPTION
This scene transition looks pretty so it's nice to draw attention to it.
But we don't want every scene transition to be this slow or the game
will be tedious to navigate.