### PR TITLE
Fixed backwards arms/legs in FreeRoam.

### DIFF
--- a/project/src/main/world/creature/MovementPlayer.tscn
+++ b/project/src/main/world/creature/MovementPlayer.tscn
@@ -171,7 +171,7 @@ tracks/0/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
 "update": 1,
-"values": [ 1 ]
+"values": [ 2 ]
 }
 tracks/1/type = "value"
 tracks/1/path = NodePath("FarArm:frame")
@@ -183,7 +183,7 @@ tracks/1/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
 "update": 1,
-"values": [ 1 ]
+"values": [ 2 ]
 }
 tracks/2/type = "value"
 tracks/2/path = NodePath("NearLeg:frame")
@@ -195,7 +195,7 @@ tracks/2/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
 "update": 1,
-"values": [ 1 ]
+"values": [ 2 ]
 }
 tracks/3/type = "value"
 tracks/3/path = NodePath("NearArm:frame")
@@ -207,7 +207,7 @@ tracks/3/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
 "update": 1,
-"values": [ 1 ]
+"values": [ 2 ]
 }
 tracks/4/type = "value"
 tracks/4/path = NodePath("Neck0/HeadBobber:head_bob_mode")


### PR DESCRIPTION
When facing away from the camera, characters had the wrong arm/leg
sprites. This bug was introduced in f367881d when adding 'RESET'
animations.