### PR TITLE
SystemSave upgrade method name. Underscores in comments.

### DIFF
--- a/project/src/main/music/checkpoint-song.gd
+++ b/project/src/main/music/checkpoint-song.gd
@@ -6,7 +6,7 @@ extends AudioStreamPlayer
 ## tracks which parts of the song have been played so the MusicPlayer can skip to the parts which have been played the
 ## least.
 
-## we measure which 'chunks' of music have been _played the least, this defines the chunk size
+## we measure which 'chunks' of music have been played the least, this defines the chunk size
 const CHUNK_SIZE := 6.0
 
 ## array of floats corresponding to good start positions in each song
@@ -16,10 +16,10 @@ export (Array, float) var checkpoints: Array = []
 export var song_title: String
 export var song_color: Color
 
-## array of ints corresponding to how much each 'chunk' of music has been _played
+## array of ints corresponding to how much each 'chunk' of music has been played
 var _staleness_record: Array
 
-## 'true' if the BGM node has been _played
+## 'true' if the BGM node has been played
 var _played: bool
 
 func _ready() -> void:

--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -137,7 +137,7 @@ func exit_top_out_state() -> void:
 	piece.spawn_delay = 0
 
 
-## Spawns a new piece at the top of the _playfield.
+## Spawns a new piece at the top of the playfield.
 ##
 ## Returns 'true' if the piece was spawned successfully, or 'false' if the player topped out.
 func spawn_piece() -> bool:

--- a/project/src/main/puzzle/piece/piece-physics.gd
+++ b/project/src/main/puzzle/piece/piece-physics.gd
@@ -14,7 +14,7 @@ onready var squisher := $Squisher
 
 onready var _states: PieceStates = get_node(piece_states_path)
 
-## Positions a new piece at the top of the _playfield.
+## Positions a new piece at the top of the playfield.
 ##
 ## Returns 'true' if the piece was spawned successfully, or 'false' if the player topped out.
 func initially_move_piece(piece: ActivePiece) -> bool:

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -50,7 +50,7 @@ signal combo_changed(value)
 ## it's possible for a combo to end without being reset to zero.
 signal combo_ended
 
-## emitted when the current piece can't be placed in the _playfield
+## emitted when the current piece can't be placed in the playfield
 signal topped_out
 
 const DELAY_NONE := 0.00

--- a/project/src/main/system-save-upgrader.gd
+++ b/project/src/main/system-save-upgrader.gd
@@ -8,7 +8,7 @@ class_name SystemSaveUpgrader
 func new_save_item_upgrader() -> SaveItemUpgrader:
 	var upgrader := SaveItemUpgrader.new()
 	upgrader.current_version = "37b3"
-	upgrader.add_upgrade_method(self, "_upgrade_37b3", "27bb", "37b3")
+	upgrader.add_upgrade_method(self, "_upgrade_27bb", "27bb", "37b3")
 	upgrader.add_upgrade_method(self, "_upgrade_2783", "2783", "27bb")
 	upgrader.add_upgrade_method(self, "_upgrade_2743", "2743", "2783")
 	upgrader.add_upgrade_method(self, "_upgrade_2743", "252a", "2783")
@@ -24,7 +24,7 @@ func new_save_item_upgrader() -> SaveItemUpgrader:
 	return upgrader
 
 
-func _upgrade_37b3(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
+func _upgrade_27bb(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
 	match save_item.type:
 		"keybind_settings":
 			if save_item.value.get("custom_keybinds") is Dictionary:


### PR DESCRIPTION
SystemSaveUpgrader had an upgrade method which was named in an
inconsistent way.

Some comments had an underscore at the beginning of a regular word, like
'Music has been _played'. I've removed some of these frivolous
underscores.