### PR TITLE
U piece spawns smooth-side up.

### DIFF
--- a/project/src/main/puzzle/piece/piece-types.gd
+++ b/project/src/main/puzzle/piece/piece-types.gd
@@ -52,13 +52,13 @@ const KICKS_T := {
 	}
 
 const KICKS_U := {
-		01: [Vector2( 1,  0), Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1), Vector2( 0, -1)],
-		12: [Vector2( 1, -1), Vector2( 0, -1), Vector2( 1,  0), Vector2( 0, -2), Vector2( 1,  1)],
-		23: [Vector2( 1,  1), Vector2( 0,  1), Vector2( 1,  0), Vector2( 0,  2), Vector2( 1, -1)],
-		30: [Vector2( 1,  0), Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1)],
+		01: [Vector2( 1,  1), Vector2( 0,  1), Vector2( 1,  0), Vector2( 0,  2), Vector2( 1, -1)],
+		12: [Vector2( 1,  0), Vector2(-1,  0), Vector2(-1,  1), Vector2( 0,  1), Vector2( 0, -1)],
+		23: [Vector2( 1,  0), Vector2(-1,  0), Vector2(-1, -1), Vector2( 0,  1), Vector2( 0, -1)],
+		30: [Vector2( 1, -1), Vector2( 0, -1), Vector2( 1,  0), Vector2( 0, -2), Vector2( 1,  1)],
 		
-		02: [Vector2( 0, -1)],
-		13: [Vector2( 1,  0)],
+		02: [Vector2( 0,  1)],
+		13: [Vector2(-1,  0)],
 	}
 
 const KICKS_V := {
@@ -236,17 +236,17 @@ var piece_t := PieceType.new("t",
 var piece_u := PieceType.new("u",
 		# shape data
 		[
-			[Vector2(0, 0), Vector2(2, 0), Vector2(0, 1), Vector2(1, 1), Vector2(2, 1)],
-			[Vector2(1, 0), Vector2(2, 0), Vector2(1, 1), Vector2(1, 2), Vector2(2, 2)],
-			[Vector2(0, 1), Vector2(1, 1), Vector2(2, 1), Vector2(0, 2), Vector2(2, 2)],
-			[Vector2(0, 0), Vector2(1, 0), Vector2(1, 1), Vector2(0, 2), Vector2(1, 2)],
+			[Vector2(0,  0), Vector2(1,  0), Vector2(2, 0), Vector2(0, 1), Vector2(2, 1)],
+			[Vector2(0, -1), Vector2(1, -1), Vector2(1, 0), Vector2(0, 1), Vector2(1, 1)],
+			[Vector2(0, -1), Vector2(2, -1), Vector2(0, 0), Vector2(1, 0), Vector2(2, 0)],
+			[Vector2(1, -1), Vector2(2, -1), Vector2(1, 0), Vector2(1, 1), Vector2(2, 1)],
 		],
 		# color data
 		[
-			[Vector2( 2, 2), Vector2( 2, 2), Vector2( 9, 2), Vector2(12, 2), Vector2( 5, 2)],
-			[Vector2(10, 2), Vector2( 4, 2), Vector2( 3, 2), Vector2( 9, 2), Vector2( 4, 2)],
 			[Vector2(10, 2), Vector2(12, 2), Vector2( 6, 2), Vector2( 1, 2), Vector2( 1, 2)],
 			[Vector2( 8, 2), Vector2( 6, 2), Vector2( 3, 2), Vector2( 8, 2), Vector2( 5, 2)],
+			[Vector2( 2, 2), Vector2( 2, 2), Vector2( 9, 2), Vector2(12, 2), Vector2( 5, 2)],
+			[Vector2(10, 2), Vector2( 4, 2), Vector2( 3, 2), Vector2( 9, 2), Vector2( 4, 2)],
 		],
 		KICKS_U
 	)


### PR DESCRIPTION
I tried getting used to the upside-down U piece but it was too
unintuitive. Every other Turbo Fat piece lets you drop the quadromino
and tetromino on top of each other without rotating, but with U pieces
breaking this rule I kept stacking them upside-down, even after
practicing for a few hours.

To prevent the flipped U piece from immediately rotating off the top of the
screen, I've added 'piece nudges' which will push a piece down if it attempts
to rotate offscreen. I hate the idea of messing with piece rotation in such an
unintuitive way so it only happens in a very specific case:

 - the piece is rotating offscreen
 - the piece was not already offscreen
 - the piece is not triggering any piece kicks

In rotating the U piece, I also moved its shape one cell upward.
Otherwise topping out with a U piece was making it appear on the second
row instead of the first row.