### PR TITLE
Refactor: find_creature, register_creature

### DIFF
--- a/project/src/main/ui/career/career-win-world.gd
+++ b/project/src/main/ui/career/career-win-world.gd
@@ -19,7 +19,7 @@ func _ready() -> void:
 		return
 	
 	if PlayerData.career.current_region().has_flag(CareerRegion.FLAG_NO_SENSEI):
-		var sensei := overworld_environment.find_creature(CreatureLibrary.SENSEI_ID)
+		var sensei := CreatureManager.get_creature_by_id(CreatureLibrary.SENSEI_ID)
 		sensei.visible = false
 	
 	_refresh_mood()
@@ -32,8 +32,8 @@ func initial_environment_path() -> String:
 
 ## Updates the creature moods based on the player's performance.
 func _refresh_mood() -> void:
-	var player := overworld_environment.find_creature(CreatureLibrary.PLAYER_ID)
-	var sensei := overworld_environment.find_creature(CreatureLibrary.SENSEI_ID)
+	var player := CreatureManager.get_player()
+	var sensei := CreatureManager.get_sensei()
 	if PlayerData.career.daily_steps >= CareerData.DAILY_STEPS_GOOD:
 		player.play_mood(Creatures.Mood.LAUGH0)
 		if sensei:

--- a/project/src/main/world/career-world.gd
+++ b/project/src/main/world/career-world.gd
@@ -120,7 +120,7 @@ func get_visible_customers(level_index: int) -> Array:
 func _fill_environment_scene() -> void:
 	_level_creatures.clear()
 	
-	if not _find_player():
+	if not CreatureManager.get_player():
 		var player := overworld_environment.add_creature()
 		player.creature_id = CreatureLibrary.PLAYER_ID
 	
@@ -128,7 +128,7 @@ func _fill_environment_scene() -> void:
 		# don't add the sensei if they're not present in this region
 		pass
 	else:
-		if not _find_sensei():
+		if not CreatureManager.get_sensei():
 			var sensei := overworld_environment.add_creature()
 			sensei.creature_id = CreatureLibrary.SENSEI_ID
 	
@@ -288,7 +288,7 @@ func _move_level_creature_to_path(creature_index: int, percent: float) -> void:
 		creature.position.y -= Y_DIST_BETWEEN_CUSTOMERS_AND_PATH * 0.4
 	
 	# turn creature towards player
-	var player := _find_player()
+	var player := CreatureManager.get_player()
 	creature.orientation = Creatures.SOUTHEAST if player.position.x > creature.position.x else Creatures.SOUTHWEST
 
 
@@ -297,7 +297,7 @@ func _move_level_creature_to_path(creature_index: int, percent: float) -> void:
 ## Parameters:
 ## 	'percent': A number in the range [0.0, 1.0] describing how far to the right the player should be positioned.
 func _move_player_to_path(percent: float) -> void:
-	var player := _find_player()
+	var player := CreatureManager.get_player()
 	var player_range := _camera_x_range()
 	if PlayerData.career.current_region().has_flag(CareerRegion.FLAG_NO_SENSEI):
 		# move player slightly left of the center creature
@@ -315,7 +315,7 @@ func _move_player_to_path(percent: float) -> void:
 ## Parameters:
 ## 	'percent': A number in the range [0.0, 1.0] describing how far to the right the sensei should be positioned.
 func _move_sensei_to_path(percent: float) -> void:
-	var sensei := _find_sensei()
+	var sensei := CreatureManager.get_sensei()
 	if sensei:
 		var sensei_range := _camera_x_range()
 		sensei.position.x = lerp(sensei_range.min_value, sensei_range.max_value, percent) \
@@ -326,10 +326,10 @@ func _move_sensei_to_path(percent: float) -> void:
 ## Moves the camera so all creatures are visible.
 func _move_camera() -> void:
 	var creatures := []
-	var sensei := _find_sensei()
+	var sensei := CreatureManager.get_sensei()
 	if sensei:
-		creatures.append(_find_sensei())
-	creatures.append(_find_player())
+		creatures.append(CreatureManager.get_sensei())
+	creatures.append(CreatureManager.get_player())
 	creatures.append_array(_level_creatures)
 	_camera.zoom_in_on_creatures(creatures)
 
@@ -392,14 +392,6 @@ func _camera_x_range() -> Dictionary:
 	return result
 
 
-func _find_player() -> Creature:
-	return overworld_environment.find_creature(CreatureLibrary.PLAYER_ID)
-
-
-func _find_sensei() -> Creature:
-	return overworld_environment.find_creature(CreatureLibrary.SENSEI_ID)
-
-
 ## Returns the absolute position of the vertex idx in _player_path2d.
 func _player_path2d_point(idx: int) -> Vector2:
 	return _player_path2d.curve.get_point_position(idx) + _player_path2d.position
@@ -448,9 +440,9 @@ func _update_focused_level_creature_index(button_index: int) -> void:
 func _turn_towards_level_creature() -> void:
 	var level_creature: Creature = _level_creatures[_focused_level_creature_index]
 	
-	var player := _find_player()
+	var player := CreatureManager.get_player()
 	player.orientation = Creatures.SOUTHEAST if level_creature.position.x > player.position.x else Creatures.SOUTHWEST
-	var sensei := _find_sensei()
+	var sensei := CreatureManager.get_sensei()
 	if sensei:
 		sensei.orientation = Creatures.SOUTHEAST if level_creature.position.x > sensei.position.x else Creatures.SOUTHWEST
 

--- a/project/src/main/world/creature-manager.gd
+++ b/project/src/main/world/creature-manager.gd
@@ -9,47 +9,24 @@ var player: Creature setget ,get_player
 ## virtual property; value is only exposed through getters/setters
 var sensei: Creature setget ,get_sensei
 
-## Mapping from creature ids to Creature objects. The player and sensei are omitted from this mapping, as the player
-## can set their own name and it could conflict with overworld creatures.
-##
-## key: (String) creature id as it appears in chat files
-## value: (Creature) creature for the creature id
-var _creatures_by_id := {}
-
-func _ready() -> void:
-	Breadcrumb.connect("before_scene_changed", self, "_on_Breadcrumb_before_scene_changed")
-
-
-## Populates the '_creatures_by_id' mapping.
-func refresh_creatures() -> void:
-	_creatures_by_id.clear()
-	for creature in get_tree().get_nodes_in_group("creatures"):
-		register_creature(creature)
-
-
-func register_creature(creature: Creature) -> void:
-	if creature.creature_id:
-		_creatures_by_id[creature.creature_id] = creature
-
 
 ## Returns the Creature object corresponding to the specified creature id.
 ##
 ## An id of SENSEI_ID or PLAYER_ID will return the sensei or player object.
 func get_creature_by_id(creature_id: String) -> Creature:
-	return _creatures_by_id.get(creature_id)
+	var creature: Creature
+	
+	for creature_node in get_tree().get_nodes_in_group("creatures"):
+		if creature_node.creature_id == creature_id:
+			creature = creature_node
+			break
+	
+	return creature
 
 
 func get_player() -> Creature:
-	return _creatures_by_id.get(CreatureLibrary.PLAYER_ID)
+	return get_creature_by_id(CreatureLibrary.PLAYER_ID)
 
 
 func get_sensei() -> Creature:
-	return _creatures_by_id.get(CreatureLibrary.SENSEI_ID)
-
-
-## Purges all node instances from the manager.
-##
-## Because CreatureManager is a singleton, node instances must be purged before changing scenes. Otherwise it's
-## possible it will provide access to an invisible object from a previous scene.
-func _on_Breadcrumb_before_scene_changed() -> void:
-	_creatures_by_id.clear()
+	return get_creature_by_id(CreatureLibrary.SENSEI_ID)

--- a/project/src/main/world/cutscene-world.gd
+++ b/project/src/main/world/cutscene-world.gd
@@ -54,7 +54,7 @@ func _remove_all_creatures() -> void:
 ## Adds all creatures referenced by the cutscene's chat tree.
 func _add_cutscene_creatures() -> void:
 	for creature_id in CurrentCutscene.chat_tree.spawn_locations:
-		var creature: Creature = overworld_environment.find_creature(creature_id)
+		var creature: Creature = CreatureManager.get_creature_by_id(creature_id)
 		if not creature:
 			creature = overworld_environment.add_creature(creature_id)
 		creature.set_collision_disabled(true)
@@ -63,7 +63,7 @@ func _add_cutscene_creatures() -> void:
 ## Moves all cutscene creatures to their proper locations.
 func _arrange_creatures() -> void:
 	for creature_id in CurrentCutscene.chat_tree.spawn_locations:
-		var creature: Creature = overworld_environment.find_creature(creature_id)
+		var creature: Creature = CreatureManager.get_creature_by_id(creature_id)
 		var spawn_id: String = CurrentCutscene.chat_tree.spawn_locations[creature_id]
 		
 		# move the creature to its spawn location

--- a/project/src/main/world/environment/overworld-environment.gd
+++ b/project/src/main/world/environment/overworld-environment.gd
@@ -51,7 +51,6 @@ func add_creature(creature_id: String = "") -> Creature:
 	var creature: Creature = CreatureScene.instance()
 	creature.creature_id = creature_id
 	_obstacles.add_child(creature)
-	CreatureManager.register_creature(creature)
 	process_new_obstacle(creature)
 	return creature
 
@@ -66,15 +65,3 @@ func process_new_obstacle(obstacle: Node2D) -> void:
 		_environment_shadows.create_creature_shadow(obstacle)
 	else:
 		_environment_shadows.create_shadow_caster_shadow(obstacle)
-
-
-## Locates the creature with the specified creature_id.
-func find_creature(creature_id: String) -> Creature:
-	var creature: Creature
-	
-	for creature_node in get_tree().get_nodes_in_group("creatures"):
-		if creature_node.creature_id == creature_id:
-			creature = creature_node
-			break
-	
-	return creature


### PR DESCRIPTION
Removed redundant OverworldEnvironment.find_creature. This did the same thing as CreatureManager.get_creature_by_id.

Removed CreatureManager.register_creature. OverworldEnvironment's implementation of using node groups was simpler.