### PR TITLE
Centralized piece speed matrix.

### DIFF
--- a/project/src/main/puzzle/level/level-speed-adjuster.gd
+++ b/project/src/main/puzzle/level/level-speed-adjuster.gd
@@ -1,19 +1,8 @@
 class_name LevelSpeedAdjuster
 ## Adjusts a LevelSettings to use faster or slower piece speeds
 
-## Matrix of piece speed adjustments.
-##
-## Each row in the matrix represents a set of speeds in order from slowest to fastest. Speeds which cannot be
-## adjusted, such as the tutorial speed, appear in a row by themselves.
-var _speed_matrix := [
-	["T"], # 25 ppm
-	["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"], # 25 ppm
-	["A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "AA", "AB", "AC", "AD", "AE", "AF"], # 35-50 ppm
-	["F0", "F1", "FA", "FB", "FC", "FD", "FE", "FF", "FFF"], # 50-134 ppm
-]
-
 ## key: (String) speed id
-## value: (Vector2) x/y coordinates for an entry in _speed_matrix
+## value: (Vector2) x/y coordinates for an entry in PieceSpeeds.speed_id_matrix
 var _coordinates_by_speed := {}
 
 ## the settings to adjust
@@ -22,10 +11,10 @@ var settings: LevelSettings
 func _init(init_settings: LevelSettings) -> void:
 	settings = init_settings
 	
-	# initialize the _coordinates_by_speed matrix based on the contents of _speed_matrix
-	for y in range(_speed_matrix.size()):
-		for x in range(_speed_matrix[y].size()):
-			_coordinates_by_speed[_speed_matrix[y][x]] = Vector2(x, y)
+	# initialize the _coordinates_by_speed matrix based on the entries in PieceSpeeds.speed_id_matrix
+	for row in range(PieceSpeeds.speed_id_matrix.size()):
+		for col in range(PieceSpeeds.speed_id_matrix[row].size()):
+			_coordinates_by_speed[PieceSpeeds.speed_id_matrix[row][col]] = Vector2(col, row)
 
 
 ## Adjusts the piece speeds of our LevelSettings instance.
@@ -82,5 +71,5 @@ func get_adjusted_speed(speed: String, adjustment: int) -> String:
 		return speed
 	
 	var coord: Vector2 = _coordinates_by_speed[speed]
-	coord.x = clamp(coord.x + adjustment, 0, _speed_matrix[coord.y].size() - 1)
-	return _speed_matrix[coord.y][coord.x]
+	coord.x = clamp(coord.x + adjustment, 0, PieceSpeeds.speed_id_matrix[coord.y].size() - 1)
+	return PieceSpeeds.speed_id_matrix[coord.y][coord.x]

--- a/project/src/main/puzzle/piece/piece-speeds.gd
+++ b/project/src/main/puzzle/piece/piece-speeds.gd
@@ -25,13 +25,22 @@ var current_speed: PieceSpeed
 ## Array of speed ids in ascending order
 var speed_ids := []
 
+## Matrix of piece speed adjustments.
+##
+## Each row in the matrix represents a set of speeds in order from slowest to fastest. Speeds which give the player a
+## speed advantage are given their own group (e.g playing with a 200 ms appearance delay instead of a 300 ms
+## appearance delay.)
+var speed_id_matrix := []
+
 var _speeds := {}
 
 func _ready() -> void:
 	# tutorial; piece does not drop
+	_add_speed_group()
 	_add_speed(PieceSpeed.new("T",   0, 20, 36, 7, 16, 60, 24, 12))
 	
 	# beginner; 10-30 pieces per minute
+	_add_speed_group()
 	_add_speed(PieceSpeed.new("0",   4, 20, 36, 7, 16, 60, 24, 12))
 	_add_speed(PieceSpeed.new("1",   5, 20, 36, 7, 16, 60, 24, 12))
 	_add_speed(PieceSpeed.new("2",   6, 20, 36, 7, 16, 60, 24, 12))
@@ -44,6 +53,7 @@ func _ready() -> void:
 	_add_speed(PieceSpeed.new("9",  48, 20, 36, 7, 16, 60, 24, 12))
 	
 	# normal; 30-60 pieces per minute
+	_add_speed_group()
 	_add_speed(PieceSpeed.new("A0",    4, 20, 20, 7, 16, 60, 24, 12))
 	_add_speed(PieceSpeed.new("A1",   32, 20, 20, 7, 16, 40, 24, 12))
 	_add_speed(PieceSpeed.new("A2",   48, 20, 20, 7, 16, 40, 24, 12))
@@ -64,6 +74,7 @@ func _ready() -> void:
 	_add_speed(PieceSpeed.new("AF", 20*G, 16, 12, 7, 10, 30, 12,  6))
 	
 	# crazy; 120-250 pieces per minute
+	_add_speed_group()
 	_add_speed(PieceSpeed.new( "F0",    4, 10, 6, 7,  8, 60, 6, 3))
 	_add_speed(PieceSpeed.new( "F1",  1*G, 10, 6, 7,  8, 40, 6, 3))
 	_add_speed(PieceSpeed.new( "FA", 20*G, 10, 6, 7,  8, 24, 6, 3))
@@ -83,8 +94,13 @@ func speed(string: String) -> PieceSpeed:
 	return _speeds[string]
 
 
+func _add_speed_group() -> void:
+	speed_id_matrix.append([])
+
+
 func _add_speed(speed: PieceSpeed) -> void:
 	speed_ids.append(speed.id)
+	speed_id_matrix.back().append(speed.id)
 	_speeds[speed.id] = speed
 
 

--- a/project/src/main/ui/menu/practice-menu.gd
+++ b/project/src/main/ui/menu/practice-menu.gd
@@ -1,16 +1,6 @@
 extends Control
 ## Scene which lets the player repeatedly play a set of levels.
 
-## Matrix of piece speed adjustments.
-##
-## Each row in the matrix represents a set of speeds in order from slowest to fastest.
-var _speed_matrix := [
-	["T"], # 25 ppm
-	["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"], # 25 ppm
-	["A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "AA", "AB", "AC", "AD", "AE", "AF"], # 35-50 ppm
-	["F0", "F1", "FA", "FB", "FC", "FD", "FE", "FF", "FFF"], # 67-134 ppm
-]
-
 export (NodePath) var _high_scores_path: NodePath
 export (NodePath) var _level_button_path: NodePath
 export (NodePath) var _level_description_label_path: NodePath
@@ -128,7 +118,7 @@ func _refresh_speed_selector() -> void:
 	else:
 		# Constrain the speed selector. We default to the level's speed, but usually allow faster speeds within a
 		# threshold.
-		for next_speed_matrix_row in _speed_matrix:
+		for next_speed_matrix_row in PieceSpeeds.speed_id_matrix:
 			if next_speed_matrix_row.has(selected_speed):
 				speed_names = next_speed_matrix_row.duplicate()
 				break

--- a/project/src/test/puzzle/piece/test-piece-speeds.gd
+++ b/project/src/test/puzzle/piece/test-piece-speeds.gd
@@ -1,0 +1,10 @@
+extends "res://addons/gut/test.gd"
+
+## This matrix is generated in a complex way, so we test its contents.
+func test_speed_id_matrix() -> void:
+	assert_eq(PieceSpeeds.speed_id_matrix, [
+		["T"],
+		["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
+		["A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "AA", "AB", "AC", "AD", "AE", "AF"],
+		["F0", "F1", "FA", "FB", "FC", "FD", "FE", "FF", "FFF"],
+	])


### PR DESCRIPTION
This piece speed matrix was copy/pasted in LevelSpeedAdjuster and PracticeMenu. It is now centralized in PieceSpeeds and generated in a better way to avoid repetition.