### PR TITLE
Eliminated LevelSelectButton.level_column_width

### DIFF
--- a/project/src/demo/ui/level-select/level-select-button-demo.gd
+++ b/project/src/demo/ui/level-select/level-select-button-demo.gd
@@ -42,8 +42,6 @@ func _button() -> LevelSelectButton:
 	var button: LevelSelectButton = LevelButtonScene.instance()
 	button.level_id = "level_%03d" % [button_index]
 	button.level_name = "Level %03d" % [button_index]
-	button.rect_min_size.x = 120
-	button.level_column_width = 120
 	
 	return button
 

--- a/project/src/main/ui/level-select/LevelSelectButton.tscn
+++ b/project/src/main/ui/level-select/LevelSelectButton.tscn
@@ -15,7 +15,7 @@ font_data = ExtResource( 1 )
 [node name="Button" type="Button" groups=["level_select_buttons"]]
 margin_right = 72.0
 margin_bottom = 80.0
-rect_min_size = Vector2( 0, 80 )
+rect_min_size = Vector2( 120, 80 )
 custom_colors/font_color = Color( 1, 1, 1, 1 )
 custom_fonts/font = SubResource( 1 )
 custom_styles/hover = ExtResource( 3 )

--- a/project/src/main/ui/level-select/level-select-button.gd
+++ b/project/src/main/ui/level-select/level-select-button.gd
@@ -1,6 +1,8 @@
 class_name LevelSelectButton
 extends Button
 ## A button on the level select screen which launches a level.
+##
+## The button adjusts its rect_min_size based on level duration.
 
 ## emitted when a level is launched.
 signal level_chosen
@@ -38,15 +40,13 @@ const SHORT := LevelSize.SHORT
 const MEDIUM := LevelSize.MEDIUM
 const LONG := LevelSize.LONG
 
+const MAX_BUTTON_HEIGHT := 120
 const VERTICAL_SPACING := 6
 
 var level_id: String
 
 ## An enum from LevelSize for the duration of the level. this affects the button size
 var level_duration: int = LevelSize.MEDIUM setget set_level_duration
-
-## the width of the column this button is in
-var level_column_width: int = 120
 
 ## the status whether or not this level is locked/unlocked
 var lock_status: int = STATUS_NONE setget set_lock_status
@@ -113,9 +113,9 @@ func _refresh_appearance() -> void:
 		return
 	
 	match level_duration:
-		LevelSize.SHORT: rect_min_size.y = level_column_width * 0.5
-		LevelSize.MEDIUM: rect_min_size.y = level_column_width * 0.75 + VERTICAL_SPACING * 0.5
-		LevelSize.LONG: rect_min_size.y = level_column_width + VERTICAL_SPACING
+		LevelSize.SHORT: rect_min_size.y = MAX_BUTTON_HEIGHT * 0.5
+		LevelSize.MEDIUM: rect_min_size.y = MAX_BUTTON_HEIGHT * 0.75 + VERTICAL_SPACING * 0.5
+		LevelSize.LONG: rect_min_size.y = MAX_BUTTON_HEIGHT + VERTICAL_SPACING
 	
 	_label.text = StringUtils.default_if_empty(level_name, "-")
 	

--- a/project/src/main/ui/menu/paged-level-buttons.gd
+++ b/project/src/main/ui/menu/paged-level-buttons.gd
@@ -172,8 +172,6 @@ func _level_select_button(level_id: String, level_count: int) -> Node:
 	var level_button: LevelSelectButton = LevelButtonScene.instance()
 	level_button.level_id = level_id
 	level_button.level_duration = LevelSelectButton.MEDIUM if level_count >= 10 else LevelSelectButton.LONG
-	level_button.rect_min_size.x = 120
-	level_button.level_column_width = 120
 	level_button.level_name = level_settings.name
 	
 	# calculate the lock status


### PR DESCRIPTION
Levels are no longer strictly arranged in columns, the CareerMap arranges them in a row. This property is redundant with rect_min_size anyways.