### PR TITLE
Added 'customer_if' flags

### DIFF
--- a/project/assets/main/creatures/primary/bones.json
+++ b/project/assets/main/creatures/primary/bones.json
@@ -34,5 +34,6 @@
     "accent_texture": 2,
     "color": "1a1a1e",
     "dark": true
-  }
+  },
+  "customer_if": "false"
 }

--- a/project/assets/main/creatures/primary/diota.json
+++ b/project/assets/main/creatures/primary/diota.json
@@ -33,5 +33,6 @@
     "accent_texture": 1,
     "color": "ffbfcb"
   },
+  "customer_if": "region_cleared marsh",
   "fatness": 1.1
 }

--- a/project/assets/main/creatures/primary/richie.json
+++ b/project/assets/main/creatures/primary/richie.json
@@ -35,5 +35,6 @@
     "color": "b24b10",
     "dark": true
   },
+  "customer_if": "false",
   "fatness": 1.4
 }

--- a/project/assets/main/creatures/primary/shirts.json
+++ b/project/assets/main/creatures/primary/shirts.json
@@ -34,5 +34,6 @@
     "accent_texture": 7,
     "color": "3c3a7f",
     "dark": true
-  }
+  },
+  "customer_if": "false"
 }

--- a/project/assets/main/creatures/primary/sidger.json
+++ b/project/assets/main/creatures/primary/sidger.json
@@ -36,5 +36,6 @@
     "color": "48366e",
     "dark": true
   },
+  "customer_if": "false",
   "fatness": 2
 }

--- a/project/assets/main/creatures/primary/skins.json
+++ b/project/assets/main/creatures/primary/skins.json
@@ -33,5 +33,6 @@
     "accent_texture": 10,
     "color": "b24b10",
     "dark": true
-  }
+  },
+  "customer_if": "false"
 }

--- a/project/assets/main/creatures/primary/tunathy.json
+++ b/project/assets/main/creatures/primary/tunathy.json
@@ -35,5 +35,6 @@
     "color": "b23823",
     "dark": true
   },
+  "customer_if": "region_started lemon_2",
   "fatness": 1.2
 }

--- a/project/assets/main/creatures/secondary/rhonk.json
+++ b/project/assets/main/creatures/secondary/rhonk.json
@@ -32,6 +32,7 @@
     "accent_texture": 11,
     "color": "ffa32c"
   },
+  "customer_if": "region_started marsh",
   "weight_gain_scale": 0.25,
   "metabolism_scale": 4
 }

--- a/project/assets/main/creatures/sensei/creature.json
+++ b/project/assets/main/creatures/sensei/creature.json
@@ -32,5 +32,6 @@
     "accent_texture": 7,
     "color": "a854cb"
   },
+  "customer_if": "false",
   "weight_gain_scale": 0
 }

--- a/project/src/main/editor/creature/dialogs.gd
+++ b/project/src/main/editor/creature/dialogs.gd
@@ -56,7 +56,9 @@ func _on_ExportButton_pressed() -> void:
 ## Imports the currently edited creature to a file.
 func _on_ExportDialog_file_selected(path: String) -> void:
 	var exported_creature: Creature = _creature_editor.center_creature
-	var exported_json := exported_creature.creature_def.to_json_dict()
+	var exported_creature_def := exported_creature.creature_def
+	exported_creature_def.customer_if = "true"
+	var exported_json := exported_creature_def.to_json_dict()
 	FileUtils.write_file(path, Utils.print_json(exported_json))
 	_preserve_file_dialog_paths(_export_dialog)
 
@@ -67,5 +69,7 @@ func _on_SaveButton_pressed() -> void:
 
 ## Updates the player character and writes it to their save file.
 func _on_SaveConfirmation_confirmed() -> void:
-	PlayerData.creature_library.player_def = _creature_editor.center_creature.creature_def
+	var saved_creature_def := _creature_editor.center_creature.creature_def
+	saved_creature_def.customer_if = "false"
+	PlayerData.creature_library.player_def = saved_creature_def
 	PlayerSave.schedule_save()

--- a/project/src/main/world/creature/creature-def.gd
+++ b/project/src/main/world/creature/creature-def.gd
@@ -57,6 +57,12 @@ var chat_theme := ChatTheme.new()
 ## dictionaries containing metadata for which chat sequences should be launched in which order
 var chat_selectors: Array
 
+## A boolean condition which enables this creature to appear as a random customer, such as
+## 'chat_finished chat/career/marsh/30_c_end'
+##
+## 'false' if they should never be a customer.
+var customer_if := "true"
+
 ## how fat the creature's body is; 5.0 = 5x normal size
 var min_fatness := 1.0
 
@@ -98,6 +104,7 @@ func from_json_dict(json: Dictionary) -> void:
 	dna = json.get("dna", {})
 	chat_theme.from_json_dict(json.get("chat_theme", DEFAULT_CHAT_THEME_JSON))
 	chat_selectors = json.get("chat_selectors", [])
+	customer_if = json.get("customer_if", "true")
 	min_fatness = json.get("fatness", 1.0)
 	weight_gain_scale = json.get("weight_gain_scale", 1.0)
 	metabolism_scale = json.get("metabolism_scale", 1.0)
@@ -117,6 +124,7 @@ func to_json_dict() -> Dictionary:
 	var chat_theme_json := chat_theme.to_json_dict()
 	if chat_theme_json: result["chat_theme"] = chat_theme_json
 	if chat_selectors: result["chat_selectors"] = chat_selectors
+	if not customer_if in ["True", "TRUE", "true", "1"]: result["customer_if"] = customer_if
 	if min_fatness != 1.0: result["fatness"] = min_fatness
 	if weight_gain_scale != 1.0: result["weight_gain_scale"] = weight_gain_scale
 	if metabolism_scale != 1.0: result["metabolism_scale"] = metabolism_scale
@@ -151,3 +159,8 @@ func rename(new_creature_name: String) -> void:
 	creature_name = new_creature_name
 	creature_short_name = NameUtils.sanitize_short_name(creature_name)
 	creature_id = NameUtils.short_name_to_id(creature_short_name)
+
+
+## Returns true if this creature can show up as a random customer.
+func is_customer() -> bool:
+	return BoolExpressionEvaluator.evaluate(customer_if)

--- a/project/src/main/world/creature/creature-library.gd
+++ b/project/src/main/world/creature/creature-library.gd
@@ -89,6 +89,7 @@ func reset() -> void:
 	new_player_def.dna = CreatureDef.DEFAULT_DNA.duplicate()
 	new_player_def.min_fatness = 1.0
 	new_player_def.chat_theme.from_json_dict(CreatureDef.DEFAULT_CHAT_THEME_JSON.duplicate())
+	new_player_def.customer_if = "false"
 	set_player_def(new_player_def)
 	
 	var creature_def_paths := []

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -97,6 +97,8 @@ func random_customer_def(include_secondary_customers: bool = false,
 				break
 			var potential_result: CreatureDef = \
 					PlayerData.customer_queue.secondary_queue[PlayerData.customer_queue.secondary_index + i]
+			if not potential_result.is_customer():
+				continue
 			if DnaUtils.dna_matches_type(potential_result.dna, creature_type):
 				result = potential_result
 				PlayerData.customer_queue.secondary_index += i + 1


### PR DESCRIPTION
Creatures can now define a customer_if flag. It defaults to 'true' so all existing creature definitions are customers. Setting it to 'false' will prevent them from appearing as a random customer. It can also be set to an expression like 'region_cleared marsh' which will make the customer appear once the criteria are met. (Or, prevent the customer from appearing once the criteria stop being met.)