### PR TITLE
CustomerQueue has 'priority' and 'standard' queues

### DIFF
--- a/project/src/main/data/player-data.gd
+++ b/project/src/main/data/player-data.gd
@@ -65,13 +65,13 @@ func set_money(new_money: int) -> void:
 ## Returns a random creature definition based on the player's location.
 ##
 ## Parameters:
-## 	'include_secondary_customers': If 'true' the function has a chance to return a creature from a library of
+## 	'include_predefined_customers': If 'true' the function has a chance to return a creature from a library of
 ## 		predefined creatures instead of a randomly generated one.
-func random_customer_def(include_secondary_customers: bool = false) -> CreatureDef:
+func random_customer_def(include_predefined_customers: bool = false) -> CreatureDef:
 	var creature_type: int = Creatures.Type.DEFAULT
 	if PlayerData.career.is_career_mode():
 		creature_type = PlayerData.career.current_region().population.random_creature_type()
-	return CreatureLoader.random_customer_def(include_secondary_customers, creature_type)
+	return CreatureLoader.random_customer_def(include_predefined_customers, creature_type)
 
 
 func _on_SecondsPlayedTimer_timeout() -> void:

--- a/project/src/main/puzzle/customer-queue.gd
+++ b/project/src/main/puzzle/customer-queue.gd
@@ -1,98 +1,98 @@
 class_name CustomerQueue
 ## Queue of creatures who appear when the player solves puzzles.
 ##
-## This includes a 'primary queue' of creatures guaranteed to show up at the start of a puzzle, and a 'secondary queue'
+## This includes a 'priority queue' of creatures guaranteed to show up at the start of a puzzle, and a 'standard queue'
 ## of creatures who randomly show up during a puzzle.
 
-## Path to the directory with secondary creatures. Can be changed for tests.
+## Path to the directory with standard customers. Can be changed for tests.
 const DEFAULT_SECONDARY_CUSTOMERS_PATH := "res://assets/main/creatures/secondary"
 
-## Path to the directory with secondary creatures. Can be changed for tests.
+## Path to the directory with standard customers. Can be changed for tests.
 var secondary_customers_path := DEFAULT_SECONDARY_CUSTOMERS_PATH setget set_secondary_customers_path
 
 ## Queue of creatures who show up at the start of a puzzle.
-var primary_queue := []
-var primary_index: int
+var priority_queue := []
+var priority_index: int
 
 ## Queue of creatures who randomly show up during a puzzle.
-var secondary_queue: Array
-var secondary_index := 0
+var standard_queue: Array
+var standard_index := 0
 
 func _init() -> void:
-	_load_secondary_customers()
+	_load_standard_customers()
 
 
 func set_secondary_customers_path(value: String) -> void:
 	secondary_customers_path = value
-	secondary_queue.clear()
-	secondary_index = 0
-	_load_secondary_customers()
+	standard_queue.clear()
+	standard_index = 0
+	_load_standard_customers()
 
 
-## Returns 'true' if the primary creature queue has any creatures left.
-func has_primary_customer() -> bool:
-	return primary_index < primary_queue.size()
+## Returns 'true' if the priority customer queue has any creatures left.
+func has_priority_customer() -> bool:
+	return priority_index < priority_queue.size()
 
 
-## Returns the next creature in the primary creature queue, and advances the queue.
-func pop_primary_customer() -> CreatureDef:
+## Returns the next creature in the priority customer queue, and advances the queue.
+func pop_priority_customer() -> CreatureDef:
 	var creature_def: CreatureDef
-	if has_primary_customer():
-		creature_def = primary_queue[primary_index]
-		primary_index += 1
+	if has_priority_customer():
+		creature_def = priority_queue[priority_index]
+		priority_index += 1
 	return creature_def
 
 
-## Returns 'true' if the secondary creature queue has any creatures left.
-func has_secondary_customer() -> bool:
-	return secondary_index < secondary_queue.size()
+## Returns 'true' if the standard customer queue has any creatures left.
+func has_standard_customer() -> bool:
+	return standard_index < standard_queue.size()
 
 
-## Returns the next creature in the secondary creature queue, and advances the queue.
-func pop_secondary_customer() -> CreatureDef:
+## Returns the next creature in the standard customer queue, and advances the queue.
+func pop_standard_customer() -> CreatureDef:
 	var creature_def: CreatureDef
-	if has_secondary_customer():
-		creature_def = secondary_queue[secondary_index]
+	if has_standard_customer():
+		creature_def = standard_queue[standard_index]
 		# don't loop back through the queue; we don't want the same customer showing up twice during a puzzle
-		secondary_index += 1
+		standard_index += 1
 	return creature_def
 
 
 ## Empties the queue of creatures who will show up at the start of the next puzzle.
 ##
-## Also rotates the secondary creatures so the same creatures don't show up over and over.
+## Also rotates the standard customers so the same creatures don't show up over and over.
 func clear() -> void:
-	primary_queue = []
-	primary_index = 0
-	reset_secondary_customer_queue()
+	priority_queue = []
+	priority_index = 0
+	reset_standard_customer_queue()
 
 
-## Resets the queue of secondary creatures; recognizable characters who show up now and then, but don't have any chats
+## Resets the queue of standard customers; recognizable characters who show up now and then, but don't have any chats
 ## or levels
 ##
 ## This resets the queue_index to 0, and moves the beginning of the queue to the end.
-func reset_secondary_customer_queue() -> void:
-	if secondary_queue and secondary_index > 0:
+func reset_standard_customer_queue() -> void:
+	if standard_queue and standard_index > 0:
 		var new_queue := []
-		new_queue += secondary_queue.slice(
-				secondary_index, secondary_queue.size() - 1)
-		new_queue += secondary_queue.slice(0, secondary_index - 1)
-		secondary_queue = new_queue
-		secondary_index = 0
+		new_queue += standard_queue.slice(
+				standard_index, standard_queue.size() - 1)
+		new_queue += standard_queue.slice(0, standard_index - 1)
+		standard_queue = new_queue
+		standard_index = 0
 
 
-## Shift secondary creatures in the queue so that they will not be summoned soon.
+## Shift standard customers in the queue so that they will not be summoned soon.
 ##
-## This prevents the player from seeing a random secondary creature at an inopportune time, such as picking a level
-## featuring a creature and then having them show up in the restaurant later during that same level.
+## This prevents the player from seeing a random customer from the standard queue at an inopportune time, such as
+## picking a level featuring a creature and then having them show up in the restaurant later during that same level.
 ##
 ## Parameters:
 ## 	'creature_ids': The ids of creatures who should be shifted in the queue
-func pop_secondary_customers(creature_ids: Array) -> void:
+func pop_standard_customers(creature_ids: Array) -> void:
 	for creature_id in creature_ids:
 		var creature_index := -1
-		for i in range(secondary_queue.size()):
-			if secondary_queue[i].creature_id == creature_id:
+		for i in range(standard_queue.size()):
+			if standard_queue[i].creature_id == creature_id:
 				creature_index = i
 				break
 		
@@ -100,16 +100,16 @@ func pop_secondary_customers(creature_ids: Array) -> void:
 			# creature not found
 			pass
 		else:
-			var creature_def: CreatureDef = secondary_queue[creature_index]
-			secondary_queue.remove(creature_index)
-			if creature_index >= secondary_index:
-				# when moving a creature backwards in the queue, we advance secondary_index
-				secondary_index += 1
-			secondary_queue.insert(secondary_index - 1, creature_def)
+			var creature_def: CreatureDef = standard_queue[creature_index]
+			standard_queue.remove(creature_index)
+			if creature_index >= standard_index:
+				# when moving a creature backwards in the queue, we advance standard_index
+				standard_index += 1
+			standard_queue.insert(standard_index - 1, creature_def)
 
 
-## Loads all secondary creature data from a directory of json files.
-func _load_secondary_customers() -> void:
+## Loads all standard customer data from a directory of json files.
+func _load_standard_customers() -> void:
 	if not secondary_customers_path:
 		return
 	
@@ -124,6 +124,6 @@ func _load_secondary_customers() -> void:
 			var creature_def: CreatureDef = CreatureDef.new()
 			creature_def = creature_def.from_json_path("%s/%s" % [dir.get_current_dir(), file.get_file()])
 			creature_def.creature_id = file.get_file().get_basename()
-			secondary_queue.append(creature_def)
+			standard_queue.append(creature_def)
 	dir.list_dir_end()
-	secondary_queue.shuffle()
+	standard_queue.shuffle()

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -104,10 +104,10 @@ func push_level_trail() -> void:
 		if customer_obj is String:
 			var customer_id: String = customer_obj
 			var creature_def: CreatureDef = PlayerData.creature_library.get_creature_def(customer_id)
-			PlayerData.customer_queue.primary_queue.push_front(creature_def)
+			PlayerData.customer_queue.priority_queue.push_front(creature_def)
 		elif customer_obj is CreatureDef:
 			var creature_def: CreatureDef = customer_obj
-			PlayerData.customer_queue.primary_queue.push_front(creature_def)
+			PlayerData.customer_queue.priority_queue.push_front(creature_def)
 		else:
 			push_warning("Unrecognized customer: %s" % [customer_obj])
 	SceneTransition.push_trail(Global.SCENE_PUZZLE)

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -23,8 +23,8 @@ func _ready() -> void:
 	
 	# set a baseline fatness state
 	PlayerData.creature_library.save_fatness_state()
-	PlayerData.customer_queue.primary_index = 0
-	PlayerData.customer_queue.reset_secondary_customer_queue()
+	PlayerData.customer_queue.priority_index = 0
+	PlayerData.customer_queue.reset_standard_customer_queue()
 	for i in range(_restaurant_view.get_customers().size()):
 		_restaurant_view.summon_customer(i)
 	
@@ -106,30 +106,30 @@ func feed_creature(customer: Creature, food_type: int) -> void:
 
 ## Starts or restarts the puzzle, loading new customers and preparing the level.
 func _start_puzzle() -> void:
-	PlayerData.customer_queue.reset_secondary_customer_queue()
+	PlayerData.customer_queue.reset_standard_customer_queue()
 	var current_customer_ids := []
 	for customer in _restaurant_view.get_customers():
 		current_customer_ids.append(customer.creature_id)
-	PlayerData.customer_queue.pop_secondary_customers(current_customer_ids)
+	PlayerData.customer_queue.pop_standard_customers(current_customer_ids)
 	
 	if not CurrentLevel.keep_retrying:
 		# Reset everyone's fatness. Replaying a puzzle in free roam mode shouldn't make a creature super fat.
 		# Thematically we're turning back time.
 		PlayerData.creature_library.restore_fatness_state()
 	
-	PlayerData.customer_queue.primary_index = 0
+	PlayerData.customer_queue.priority_index = 0
 	_restaurant_view.briefly_suppress_sfx()
 	
-	if PlayerData.customer_queue.primary_queue:
-		var starting_creature_id: String = PlayerData.customer_queue.primary_queue[0].creature_id
+	if PlayerData.customer_queue.priority_queue:
+		var starting_creature_id: String = PlayerData.customer_queue.priority_queue[0].creature_id
 		var starting_creature_index: int = _restaurant_view.find_creature_index_with_id(starting_creature_id)
 		if starting_creature_index == -1:
-			# starting creature isn't found; load them to a different index and advance the primary queue
+			# starting creature isn't found; load them to a different index and advance the priority queue
 			starting_creature_index = _restaurant_view.next_creature_index()
 			_restaurant_view.summon_customer(starting_creature_index)
 		else:
-			# starting creature is found; advance the primary creature queue so we don't see them twice
-			PlayerData.customer_queue.pop_primary_customer()
+			# starting creature is found; advance the priority customer queue so we don't see them twice
+			PlayerData.customer_queue.pop_priority_customer()
 			
 			if PlayerData.creature_library.has_fatness(starting_creature_id):
 				# restore their fatness so they start skinny again when replaying a puzzle

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -98,8 +98,8 @@ func find_creature_index_with_id(creature_id: String) -> int:
 ## properties.
 func summon_customer(creature_index: int = -1) -> void:
 	var creature_def := CreatureDef.new()
-	if PlayerData.customer_queue.has_primary_customer():
-		creature_def = PlayerData.customer_queue.pop_primary_customer()
+	if PlayerData.customer_queue.has_priority_customer():
+		creature_def = PlayerData.customer_queue.pop_priority_customer()
 	else:
 		creature_def = PlayerData.random_customer_def(true)
 	_restaurant_viewport_scene.summon_customer(creature_def, creature_index)

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -78,30 +78,30 @@ var _dna_alternatives := DnaAlternatives.new()
 ## Returns a random creature definition.
 ##
 ## Parameters:
-## 	'include_secondary_customers': If 'true' the function has a chance to return a creature from a library of
+## 	'include_predefined_customers': If 'true' the function has a chance to return a creature from a library of
 ## 		predefined creatures instead of a randomly generated one.
 ##
 ## 	'creature_type': (Optional) The required creature type. If specified, creatures will be skipped in the
 ## 		secondary queue until one conforms to the specified type.
-func random_customer_def(include_secondary_customers: bool = false,
+func random_customer_def(include_predefined_customers: bool = false,
 		creature_type: int = Creatures.Type.DEFAULT) -> CreatureDef:
 	var result: CreatureDef
-	if include_secondary_customers \
-			and PlayerData.customer_queue.has_secondary_customer() \
+	if include_predefined_customers \
+			and PlayerData.customer_queue.has_standard_customer() \
 			and randf() < 0.2:
 		
 		# We check the next 8 creatures for one which matches the specified type. If we check too few creatures, we
 		# won't find one. If we check too many, we'll aggressively advance the creature queue. 8 feels about right.
 		for i in range(8):
-			if PlayerData.customer_queue.secondary_index + i >= PlayerData.customer_queue.secondary_queue.size():
+			if PlayerData.customer_queue.standard_index + i >= PlayerData.customer_queue.standard_queue.size():
 				break
 			var potential_result: CreatureDef = \
-					PlayerData.customer_queue.secondary_queue[PlayerData.customer_queue.secondary_index + i]
+					PlayerData.customer_queue.standard_queue[PlayerData.customer_queue.standard_index + i]
 			if not potential_result.is_customer():
 				continue
 			if DnaUtils.dna_matches_type(potential_result.dna, creature_type):
 				result = potential_result
-				PlayerData.customer_queue.secondary_index += i + 1
+				PlayerData.customer_queue.standard_index += i + 1
 				break
 	
 	if not result:

--- a/project/src/main/world/cutscene-queue.gd
+++ b/project/src/main/world/cutscene-queue.gd
@@ -108,4 +108,4 @@ func _pop_level() -> void:
 		CurrentLevel.customers = level_properties["customers"]
 	if level_properties.has("puzzle_environment_name"):
 		CurrentLevel.puzzle_environment_name = level_properties["puzzle_environment_name"]
-	PlayerData.customer_queue.pop_secondary_customers(CurrentLevel.get_creature_ids())
+	PlayerData.customer_queue.pop_standard_customers(CurrentLevel.get_creature_ids())

--- a/project/src/test/puzzle/test-customer-queue.gd
+++ b/project/src/test/puzzle/test-customer-queue.gd
@@ -6,86 +6,86 @@ func before_each() -> void:
 	customer_queue.secondary_customers_path = ""
 
 
-func test_secondary_queue_has_creatures() -> void:
-	assert_eq(customer_queue.secondary_queue.size(), 0)
+func test_standard_queue_has_creatures() -> void:
+	assert_eq(customer_queue.standard_queue.size(), 0)
 	customer_queue.secondary_customers_path = "res://assets/test/secondary-creatures"
-	assert_eq(customer_queue.secondary_queue.size(), 2)
+	assert_eq(customer_queue.standard_queue.size(), 2)
 
 
-func test_has_secondary_customer() -> void:
-	assert_eq(false, customer_queue.has_secondary_customer())
-	_populate_secondary_queue(["ofa_100"], 0)
-	assert_eq(true, customer_queue.has_secondary_customer())
+func test_has_standard_customer() -> void:
+	assert_eq(false, customer_queue.has_standard_customer())
+	_populate_standard_queue(["ofa_100"], 0)
+	assert_eq(true, customer_queue.has_standard_customer())
 
 
-func test_pop_secondary_customer() -> void:
-	_populate_secondary_queue(["ofa_100"], 0)
+func test_pop_standard_customer() -> void:
+	_populate_standard_queue(["ofa_100"], 0)
 	
 	# should only be able to pop one creature; then the queue is empty
-	_assert_creature_id(customer_queue.pop_secondary_customer(), "ofa_100")
-	_assert_creature_id(customer_queue.pop_secondary_customer(), "")
+	_assert_creature_id(customer_queue.pop_standard_customer(), "ofa_100")
+	_assert_creature_id(customer_queue.pop_standard_customer(), "")
 
 
-func test_reset_secondary_customer_queue() -> void:
-	_populate_secondary_queue(["ofa_100", "ofa_200"], 0)
-	_assert_creature_id(customer_queue.pop_secondary_customer(), "ofa_100")
-	customer_queue.reset_secondary_customer_queue()
+func test_reset_standard_customer_queue() -> void:
+	_populate_standard_queue(["ofa_100", "ofa_200"], 0)
+	_assert_creature_id(customer_queue.pop_standard_customer(), "ofa_100")
+	customer_queue.reset_standard_customer_queue()
 	
 	# resetting should add ofa_100 to the end of the queue again
-	_assert_creature_id(customer_queue.pop_secondary_customer(), "ofa_200")
-	_assert_creature_id(customer_queue.pop_secondary_customer(), "ofa_100")
-	_assert_creature_id(customer_queue.pop_secondary_customer(), "")
+	_assert_creature_id(customer_queue.pop_standard_customer(), "ofa_200")
+	_assert_creature_id(customer_queue.pop_standard_customer(), "ofa_100")
+	_assert_creature_id(customer_queue.pop_standard_customer(), "")
 
 
-## Populates the secondary queue with the specified creature ids and secondary index
-func test_pop_secondary_customers_before() -> void:
-	_populate_secondary_queue(["ofa_100", "ofa_200", "ofa_300"], 2)
-	customer_queue.pop_secondary_customers(["ofa_100"])
+## Populates the standard queue with the specified creature ids and standard index
+func test_pop_standard_customers_before() -> void:
+	_populate_standard_queue(["ofa_100", "ofa_200", "ofa_300"], 2)
+	customer_queue.pop_standard_customers(["ofa_100"])
 	
-	_assert_secondary_queue(["ofa_200", "ofa_100", "ofa_300"], 2)
+	_assert_standard_queue(["ofa_200", "ofa_100", "ofa_300"], 2)
 
 
-func test_pop_secondary_customers_current() -> void:
-	_populate_secondary_queue(["ofa_100", "ofa_200", "ofa_300"], 1)
-	customer_queue.pop_secondary_customers(["ofa_200"])
+func test_pop_standard_customers_current() -> void:
+	_populate_standard_queue(["ofa_100", "ofa_200", "ofa_300"], 1)
+	customer_queue.pop_standard_customers(["ofa_200"])
 	
-	_assert_secondary_queue(["ofa_100", "ofa_200", "ofa_300"], 2)
+	_assert_standard_queue(["ofa_100", "ofa_200", "ofa_300"], 2)
 
 
-func test_pop_secondary_customers_after() -> void:
-	_populate_secondary_queue(["ofa_100", "ofa_200", "ofa_300"], 0)
-	customer_queue.pop_secondary_customers(["ofa_300"])
+func test_pop_standard_customers_after() -> void:
+	_populate_standard_queue(["ofa_100", "ofa_200", "ofa_300"], 0)
+	customer_queue.pop_standard_customers(["ofa_300"])
 	
-	_assert_secondary_queue(["ofa_300", "ofa_100", "ofa_200"], 1)
+	_assert_standard_queue(["ofa_300", "ofa_100", "ofa_200"], 1)
 
 
-func test_pop_secondary_customers_not_found() -> void:
-	_populate_secondary_queue(["ofa_100"], 0)
-	customer_queue.pop_secondary_customers(["ofa_invalid"])
+func test_pop_standard_customers_not_found() -> void:
+	_populate_standard_queue(["ofa_100"], 0)
+	customer_queue.pop_standard_customers(["ofa_invalid"])
 	
-	_assert_secondary_queue(["ofa_100"], 0)
+	_assert_standard_queue(["ofa_100"], 0)
 
 
-func test_pop_secondary_customers_empty() -> void:
-	_populate_secondary_queue(["ofa_100"], 0)
-	customer_queue.pop_secondary_customers([])
+func test_pop_standard_customers_empty() -> void:
+	_populate_standard_queue(["ofa_100"], 0)
+	customer_queue.pop_standard_customers([])
 	
-	_assert_secondary_queue(["ofa_100"], 0)
+	_assert_standard_queue(["ofa_100"], 0)
 
 
-func test_pop_secondary_customers_multiple() -> void:
-	_populate_secondary_queue(["ofa_100", "ofa_200", "ofa_300", "ofa_400", "ofa_500"], 2)
-	customer_queue.pop_secondary_customers(["ofa_200", "ofa_400"])
+func test_pop_standard_customers_multiple() -> void:
+	_populate_standard_queue(["ofa_100", "ofa_200", "ofa_300", "ofa_400", "ofa_500"], 2)
+	customer_queue.pop_standard_customers(["ofa_200", "ofa_400"])
 	
-	_assert_secondary_queue(["ofa_100", "ofa_200", "ofa_400", "ofa_300", "ofa_500"], 3)
+	_assert_standard_queue(["ofa_100", "ofa_200", "ofa_400", "ofa_300", "ofa_500"], 3)
 
 
-func _populate_secondary_queue(new_creature_ids: Array, new_secondary_index: int) -> void:
+func _populate_standard_queue(new_creature_ids: Array, new_standard_index: int) -> void:
 	for creature_id in new_creature_ids:
 		var creature_def := CreatureDef.new()
 		creature_def.creature_id = creature_id
-		customer_queue.secondary_queue.append(creature_def)
-	customer_queue.secondary_index = new_secondary_index
+		customer_queue.standard_queue.append(creature_def)
+	customer_queue.standard_index = new_standard_index
 
 
 ## Asserts a creature's id.
@@ -95,9 +95,9 @@ func _assert_creature_id(creature_def: CreatureDef, expected_id: String) -> void
 	assert_eq("" if not creature_def else creature_def.creature_id, expected_id)
 
 
-func _assert_secondary_queue(expected_ids: Array, expected_secondary_index: int) -> void:
+func _assert_standard_queue(expected_ids: Array, expected_standard_index: int) -> void:
 	var actual_ids := []
-	for creature_def in customer_queue.secondary_queue:
+	for creature_def in customer_queue.standard_queue:
 		actual_ids.append(creature_def.creature_id)
 	assert_eq(actual_ids, expected_ids)
-	assert_eq(customer_queue.secondary_index, expected_secondary_index)
+	assert_eq(customer_queue.standard_index, expected_standard_index)


### PR DESCRIPTION
The names priority/standard are less ambiguous than primary/secondary. They have an analogy with priority passengers on an airplane, they board first. This also disambiguates the idea of the 'secondary queue' with creatures in the 'secondary directory', two concepts which were muddled together.