### PR TITLE
Added script to fix /story /nonstory creatures.

### DIFF
--- a/project/src/demo/toolkit/extract-localizables-button.gd
+++ b/project/src/demo/toolkit/extract-localizables-button.gd
@@ -69,8 +69,8 @@ func _extract_localizables_from_levels() -> void:
 		var level_settings := LevelSettings.new()
 		level_settings.load_from_resource(level_id)
 		
-		# extract level's title and description as localizables
-		_localizables.append(level_settings.title)
+		# extract level's name and description as localizables
+		_localizables.append(level_settings.name)
 		_localizables.append(level_settings.description)
 
 

--- a/project/src/demo/toolkit/fix-creatures-button.gd
+++ b/project/src/demo/toolkit/fix-creatures-button.gd
@@ -1,10 +1,12 @@
 extends Button
-## Upgrades old creatures to the newest format.
+## Fixes and reports problems with creature files.
 ##
 ## Recursively searches for creatures, upgrading them if they are out of date.
+##
+## Reports any creature files which are in the wrong directory.
 
 ## directories containing creatures which should be upgraded
-const CREATURE_DIRS := ["res://assets/main/creatures", "res://assets/test/secondary-creatures"]
+const CREATURE_DIRS := ["res://assets/main/creatures", "res://assets/test/nonstory-creatures"]
 
 export (NodePath) var output_label_path: NodePath
 
@@ -14,7 +16,7 @@ var _converted := []
 ## label for outputting messages to the user
 onready var _output_label: Label = get_node(output_label_path)
 
-## Upgrades all creatures to the newest version.
+## Recursively searches for creatures, upgrading them if they are out of date.
 func _upgrade_creatures() -> void:
 	_converted.clear()
 	
@@ -22,11 +24,12 @@ func _upgrade_creatures() -> void:
 	for creature_path in creature_paths:
 		_upgrade_creature(creature_path)
 	
+	if _output_label.text:
+		_output_label.text += "\n"
+	
 	if _converted:
-		_output_label.text = "Upgraded %d creatures to settings version %s." \
+		_output_label.text += "Upgraded %d creatures to settings version %s." \
 				% [_converted.size(), Creatures.CREATURE_DATA_VERSION]
-	else:
-		_output_label.text = "No creatures required upgrading."
 
 
 ## Upgrades a creature to the newest version.
@@ -81,5 +84,71 @@ func _find_creature_paths() -> Array:
 	return result
 
 
+## Reports any creature files which are in the wrong directory.
+func _report_story_creatures() -> void:
+	var career_creature_ids := _career_creature_ids()
+	
+	# get a list of creature ids from the /story/ directory
+	var story_ids := _creature_ids_from_directory("res://assets/main/creatures/story")
+	
+	# report any story creatures who are not in our list of career creature ids
+	var move_to_nonstory_ids := Utils.subtract(story_ids, career_creature_ids)
+	move_to_nonstory_ids.sort()
+	if move_to_nonstory_ids:
+		if _output_label.text:
+			_output_label.text += "\n"
+		_output_label.text += "%s creatures should be moved from /story to /nonstory: %s" \
+				% [move_to_nonstory_ids.size(), move_to_nonstory_ids]
+	
+	# get a list of creature ids from the /nonstory/ directory
+	var nonstory_ids := _creature_ids_from_directory("res://assets/main/creatures/nonstory")
+	
+	# report any story creatures who are in our list of career creature ids
+	var move_to_story_ids := Utils.intersection(nonstory_ids, career_creature_ids)
+	if move_to_story_ids:
+		if _output_label.text:
+			_output_label.text += "\n"
+		_output_label.text += "%s creatures should be moved from /nonstory to /story: %s" \
+				% [move_to_story_ids.size(), move_to_story_ids]
+
+
+## Returns a list of creature ids which appear in career mode's story.
+func _career_creature_ids() -> Array:
+	var result := {}
+	# get a list of 'story creature ids' from the cutscenes
+	for path in CareerCutsceneLibrary.find_career_cutscene_resource_paths():
+		var chat_tree := ChatLibrary.chat_tree_from_file(path)
+		for creature_id in _creature_ids_from_chat_tree(chat_tree):
+			result[creature_id] = true
+	return result.keys()
+
+
+## Returns a list of creature ids in a chat tree.
+func _creature_ids_from_chat_tree(chat_tree: ChatTree) -> Array:
+	return chat_tree.spawn_locations.keys()
+
+
+## Returns a list of creature ids in all creature files in a directory.
+func _creature_ids_from_directory(dir_string: String) -> Array:
+	var result := {}
+	var dir := Directory.new()
+	dir.open(dir_string)
+	dir.list_dir_begin(true, true)
+	while true:
+		var file := dir.get_next()
+		if not file:
+			break
+		else:
+			var creature_def: CreatureDef = CreatureDef.new()
+			creature_def = creature_def.from_json_path("%s/%s" % [dir.get_current_dir(), file.get_file()])
+			result[creature_def.creature_id] = true
+	dir.list_dir_end()
+	return result.keys()
+
+
 func _on_pressed() -> void:
+	_output_label.text = ""
 	_upgrade_creatures()
+	_report_story_creatures()
+	if not _output_label.text:
+		_output_label.text = "No creature files have problems."

--- a/project/src/main/utils/utils.gd
+++ b/project/src/main/utils/utils.gd
@@ -149,6 +149,25 @@ static func subtract(a: Array, b: Array) -> Array:
 	return result
 
 
+## Returns a new array containing the intersection of the given arrays.
+##
+## The input arrays are not modified. This code is adapted from Apache Common Collections.
+static func intersection(a: Array, b: Array) -> Array:
+	var result := []
+	var bag := {}
+	for item in b:
+		if not bag.has(item):
+			bag[item] = 0
+		bag[item] += 1
+	for item in a:
+		if bag.has(item):
+			bag[item] -= 1
+			if bag[item] == 0:
+				bag.erase(item)
+			result.append(item)
+	return result
+
+
 ## Assigns a default path for a FileDialog.
 ##
 ## At runtime, this will default to the user data directory. During development, this will default to a resource path

--- a/project/src/test/utils/test-utils.gd
+++ b/project/src/test/utils/test-utils.gd
@@ -29,6 +29,19 @@ func test_subtract_duplicates() -> void:
 	assert_eq(Utils.subtract([1, 1, 1, 1, 1], [1, 1]), [1, 1, 1])
 
 
+func test_intersection() -> void:
+	assert_eq(Utils.intersection([1, 2, 3], [2, 3, 4]), [2, 3])
+	assert_eq(Utils.intersection([1, 2, 3], [2]), [2])
+	assert_eq(Utils.intersection([2], [1, 2, 3]), [2])
+	assert_eq(Utils.intersection([], [1]), [])
+	assert_eq(Utils.intersection([1], []), [])
+
+
+func test_intersection_duplicates() -> void:
+	assert_eq(Utils.intersection([1, 1, 1], [1, 1]), [1, 1])
+	assert_eq(Utils.intersection([1, 2, 2, 3, 3, 3], [1, 1, 1, 2, 2, 3]), [1, 2, 2, 3])
+
+
 func test_remove_all() -> void:
 	assert_eq([4, 10, 15], Utils.remove_all([1, 4, 10, 1, 15], 1))
 


### PR DESCRIPTION
ReleaseToolkit's 'Fix Creatures' button will now look for creatures which are in the inappropriate directory. Creatures who have cutscenes should be in the /story directory. Creatures with no cutscenes should be in the /nonstory directory.