### PR TITLE
Extracted common 'paged-level-panel'.

### DIFF
--- a/project/src/main/ui/menu/PagedLevelPanel.tscn
+++ b/project/src/main/ui/menu/PagedLevelPanel.tscn
@@ -1,0 +1,220 @@
+[gd_scene load_steps=15 format=2]
+
+[ext_resource path="res://src/main/ui/level-select/LevelSelectButton.tscn" type="PackedScene" id=1]
+[ext_resource path="res://src/main/ui/level-select/HookableLevelGradeLabel.tscn" type="PackedScene" id=2]
+[ext_resource path="res://src/main/ui/menu/paged-level-buttons.gd" type="Script" id=5]
+[ext_resource path="res://src/main/ui/menu/paged-level-panel.gd" type="Script" id=7]
+[ext_resource path="res://src/main/ui/level-select/level-submenu-info-panel.gd" type="Script" id=8]
+[ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=9]
+[ext_resource path="res://src/main/ui/level-select/level-grade-labels.gd" type="Script" id=10]
+[ext_resource path="res://src/main/ui/level-select/level-submenu-description-panel.gd" type="Script" id=11]
+[ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=12]
+[ext_resource path="res://src/main/ui/theme/h2.theme" type="Theme" id=13]
+[ext_resource path="res://src/main/ui/theme/h4.theme" type="Theme" id=14]
+
+[sub_resource type="StyleBoxFlat" id=2]
+content_margin_left = 5.0
+content_margin_right = 5.0
+content_margin_top = 5.0
+content_margin_bottom = 5.0
+bg_color = Color( 0.1, 0.094, 0.094, 1 )
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color( 1, 1, 1, 1 )
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+
+[sub_resource type="DynamicFont" id=1]
+outline_size = 2
+outline_color = Color( 0.423529, 0.262745, 0.192157, 1 )
+font_data = ExtResource( 12 )
+
+[sub_resource type="StyleBoxFlat" id=3]
+resource_local_to_scene = true
+bg_color = Color( 0.321569, 0.686275, 0.890196, 1 )
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color( 0.423529, 0.262745, 0.192157, 1 )
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
+
+[node name="Panel" type="Panel"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 50.0
+margin_top = 50.0
+margin_right = -50.0
+margin_bottom = -50.0
+custom_styles/panel = SubResource( 2 )
+script = ExtResource( 7 )
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 10.0
+margin_top = 10.0
+margin_right = -10.0
+margin_bottom = -10.0
+rect_min_size = Vector2( -10, 0 )
+
+[node name="Label" type="Label" parent="VBoxContainer"]
+margin_right = 904.0
+margin_bottom = 45.0
+theme = ExtResource( 13 )
+text = "Level Select"
+align = 1
+
+[node name="Top" type="Control" parent="VBoxContainer"]
+margin_top = 49.0
+margin_right = 904.0
+margin_bottom = 376.0
+size_flags_vertical = 3
+
+[node name="LevelButtons" type="HBoxContainer" parent="VBoxContainer/Top"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -452.0
+margin_top = -145.0
+margin_right = 452.0
+margin_bottom = 145.0
+alignment = 1
+script = ExtResource( 5 )
+LevelButtonScene = ExtResource( 1 )
+
+[node name="LeftArrow" type="Button" parent="VBoxContainer/Top/LevelButtons"]
+margin_left = 354.0
+margin_top = 132.0
+margin_right = 378.0
+margin_bottom = 158.0
+rect_min_size = Vector2( 24, 24 )
+size_flags_vertical = 4
+theme = ExtResource( 14 )
+text = "<"
+
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer/Top/LevelButtons"]
+margin_left = 382.0
+margin_top = 115.0
+margin_right = 522.0
+margin_bottom = 175.0
+size_flags_vertical = 4
+columns = 6
+
+[node name="Button" parent="VBoxContainer/Top/LevelButtons/GridContainer" instance=ExtResource( 1 )]
+margin_right = 140.0
+margin_bottom = 60.0
+rect_min_size = Vector2( 140, 60 )
+custom_fonts/font = SubResource( 1 )
+custom_styles/hover = SubResource( 3 )
+custom_styles/normal = SubResource( 3 )
+
+[node name="RightArrow" type="Button" parent="VBoxContainer/Top/LevelButtons"]
+margin_left = 526.0
+margin_top = 132.0
+margin_right = 550.0
+margin_bottom = 158.0
+rect_min_size = Vector2( 24, 24 )
+size_flags_vertical = 4
+theme = ExtResource( 14 )
+text = ">"
+
+[node name="GradeLabels" type="Control" parent="VBoxContainer/Top"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+script = ExtResource( 10 )
+GradeLabelScene = ExtResource( 2 )
+
+[node name="Bottom" type="Control" parent="VBoxContainer"]
+margin_top = 380.0
+margin_right = 904.0
+margin_bottom = 480.0
+rect_min_size = Vector2( 0, 100 )
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/Bottom"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Description" type="Panel" parent="VBoxContainer/Bottom/HBoxContainer"]
+margin_right = 450.0
+margin_bottom = 100.0
+size_flags_horizontal = 3
+custom_styles/panel = ExtResource( 9 )
+script = ExtResource( 11 )
+
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/Bottom/HBoxContainer/Description"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_right = 20
+custom_constants/margin_top = 5
+custom_constants/margin_left = 20
+custom_constants/margin_bottom = 5
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Label" type="Label" parent="VBoxContainer/Bottom/HBoxContainer/Description/MarginContainer"]
+margin_left = 20.0
+margin_top = 5.0
+margin_right = 430.0
+margin_bottom = 95.0
+size_flags_vertical = 1
+theme = ExtResource( 14 )
+align = 1
+valign = 1
+autowrap = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Info" type="Panel" parent="VBoxContainer/Bottom/HBoxContainer"]
+margin_left = 454.0
+margin_right = 904.0
+margin_bottom = 100.0
+size_flags_horizontal = 3
+custom_styles/panel = ExtResource( 9 )
+script = ExtResource( 8 )
+
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/Bottom/HBoxContainer/Info"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_right = 20
+custom_constants/margin_top = 5
+custom_constants/margin_left = 20
+custom_constants/margin_bottom = 5
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Label" type="Label" parent="VBoxContainer/Bottom/HBoxContainer/Info/MarginContainer"]
+margin_left = 20.0
+margin_top = 5.0
+margin_right = 430.0
+margin_bottom = 95.0
+size_flags_vertical = 1
+theme = ExtResource( 14 )
+valign = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[connection signal="button_added" from="VBoxContainer/Top/LevelButtons" to="VBoxContainer/Top/GradeLabels" method="_on_LevelButtons_button_added"]
+[connection signal="level_chosen" from="VBoxContainer/Top/LevelButtons" to="." method="_on_LevelButtons_level_chosen"]
+[connection signal="locked_level_chosen" from="VBoxContainer/Top/LevelButtons" to="VBoxContainer/Bottom/HBoxContainer/Description" method="_on_LevelButtons_locked_level_chosen"]
+[connection signal="locked_level_chosen" from="VBoxContainer/Top/LevelButtons" to="VBoxContainer/Bottom/HBoxContainer/Info" method="_on_LevelButtons_locked_level_chosen"]
+[connection signal="unlocked_level_chosen" from="VBoxContainer/Top/LevelButtons" to="VBoxContainer/Bottom/HBoxContainer/Description" method="_on_LevelButtons_unlocked_level_chosen"]
+[connection signal="unlocked_level_chosen" from="VBoxContainer/Top/LevelButtons" to="VBoxContainer/Bottom/HBoxContainer/Info" method="_on_LevelButtons_unlocked_level_chosen"]
+[connection signal="pressed" from="VBoxContainer/Top/LevelButtons/LeftArrow" to="VBoxContainer/Top/LevelButtons" method="_on_LeftArrow_pressed"]
+[connection signal="pressed" from="VBoxContainer/Top/LevelButtons/RightArrow" to="VBoxContainer/Top/LevelButtons" method="_on_RightArrow_pressed"]

--- a/project/src/main/ui/menu/PracticeMenu.tscn
+++ b/project/src/main/ui/menu/PracticeMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=41 format=2]
+[gd_scene load_steps=34 format=2]
 
 [ext_resource path="res://src/main/ui/RegionSelectButton.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/ui/ImageButton.tscn" type="PackedScene" id=2]
@@ -14,20 +14,15 @@
 [ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=12]
 [ext_resource path="res://src/main/ui/HighScoreTable.tscn" type="PackedScene" id=13]
 [ext_resource path="res://src/main/ui/menu/mode-buttongroup.tres" type="ButtonGroup" id=14]
-[ext_resource path="res://src/main/ui/level-select/HookableLevelGradeLabel.tscn" type="PackedScene" id=15]
+[ext_resource path="res://src/main/ui/menu/PagedLevelPanel.tscn" type="PackedScene" id=15]
 [ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=16]
 [ext_resource path="res://src/main/ui/theme/h2-font-outline.tres" type="DynamicFont" id=17]
 [ext_resource path="res://src/main/ui/SceneTransitionCover.tscn" type="PackedScene" id=18]
-[ext_resource path="res://src/main/ui/level-select/LevelSelectButton.tscn" type="PackedScene" id=19]
 [ext_resource path="res://src/main/ui/level-select/HookableRegionGradeLabel.tscn" type="PackedScene" id=20]
 [ext_resource path="res://src/main/ui/menu/paged-region-buttons.gd" type="Script" id=21]
 [ext_resource path="res://src/main/ui/menu/region-submenu.gd" type="Script" id=22]
-[ext_resource path="res://src/main/ui/level-select/level-submenu-description-panel.gd" type="Script" id=23]
 [ext_resource path="res://src/main/ui/menu/level-submenu.gd" type="Script" id=24]
 [ext_resource path="res://src/main/ui/menu/region-grade-labels.gd" type="Script" id=25]
-[ext_resource path="res://src/main/ui/menu/paged-level-buttons.gd" type="Script" id=26]
-[ext_resource path="res://src/main/ui/level-select/level-submenu-info-panel.gd" type="Script" id=27]
-[ext_resource path="res://src/main/ui/level-select/level-grade-labels.gd" type="Script" id=28]
 [ext_resource path="res://src/main/ui/menu/region-info-panel.gd" type="Script" id=29]
 [ext_resource path="res://src/main/ui/menu/region-description-panel.gd" type="Script" id=30]
 [ext_resource path="res://assets/main/ui/touch/close.png" type="Texture" id=31]
@@ -57,35 +52,6 @@ action = "ui_cancel"
 
 [sub_resource type="ShortCut" id=5]
 shortcut = SubResource( 4 )
-
-[sub_resource type="StyleBoxFlat" id=2]
-content_margin_left = 5.0
-content_margin_right = 5.0
-content_margin_top = 5.0
-content_margin_bottom = 5.0
-bg_color = Color( 0.1, 0.094, 0.094, 1 )
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color( 1, 1, 1, 1 )
-corner_radius_top_left = 4
-corner_radius_top_right = 4
-corner_radius_bottom_right = 4
-corner_radius_bottom_left = 4
-
-[sub_resource type="StyleBoxFlat" id=3]
-resource_local_to_scene = true
-bg_color = Color( 0.321569, 0.686275, 0.890196, 1 )
-border_width_left = 4
-border_width_top = 4
-border_width_right = 4
-border_width_bottom = 4
-border_color = Color( 0.423529, 0.262745, 0.192157, 1 )
-corner_radius_top_left = 8
-corner_radius_top_right = 8
-corner_radius_bottom_right = 8
-corner_radius_bottom_left = 8
 
 [node name="PracticeMenu" type="Control"]
 anchor_right = 1.0
@@ -538,177 +504,13 @@ visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource( 24 )
-level_buttons_path = NodePath("Panel/VBoxContainer/Top/LevelButtons")
 
 [node name="Backdrop" type="ColorRect" parent="LevelSubmenu"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 color = Color( 0, 0, 0, 0.752941 )
 
-[node name="Panel" type="Panel" parent="LevelSubmenu"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 50.0
-margin_top = 50.0
-margin_right = -50.0
-margin_bottom = -50.0
-custom_styles/panel = SubResource( 2 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="VBoxContainer" type="VBoxContainer" parent="LevelSubmenu/Panel"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 10.0
-margin_top = 10.0
-margin_right = -10.0
-margin_bottom = -10.0
-rect_min_size = Vector2( -10, 0 )
-
-[node name="Label" type="Label" parent="LevelSubmenu/Panel/VBoxContainer"]
-margin_right = 904.0
-margin_bottom = 45.0
-theme = ExtResource( 35 )
-text = "Level Select"
-align = 1
-
-[node name="Top" type="Control" parent="LevelSubmenu/Panel/VBoxContainer"]
-margin_top = 49.0
-margin_right = 904.0
-margin_bottom = 376.0
-size_flags_vertical = 3
-
-[node name="LevelButtons" type="HBoxContainer" parent="LevelSubmenu/Panel/VBoxContainer/Top"]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -452.0
-margin_top = -145.0
-margin_right = 452.0
-margin_bottom = 145.0
-alignment = 1
-script = ExtResource( 26 )
-LevelButtonScene = ExtResource( 19 )
-
-[node name="LeftArrow" type="Button" parent="LevelSubmenu/Panel/VBoxContainer/Top/LevelButtons"]
-margin_left = 354.0
-margin_top = 132.0
-margin_right = 378.0
-margin_bottom = 158.0
-rect_min_size = Vector2( 24, 24 )
-size_flags_vertical = 4
-theme = ExtResource( 6 )
-text = "<"
-
-[node name="GridContainer" type="GridContainer" parent="LevelSubmenu/Panel/VBoxContainer/Top/LevelButtons"]
-margin_left = 382.0
-margin_top = 115.0
-margin_right = 522.0
-margin_bottom = 175.0
-size_flags_vertical = 4
-columns = 6
-
-[node name="Button" parent="LevelSubmenu/Panel/VBoxContainer/Top/LevelButtons/GridContainer" instance=ExtResource( 19 )]
-margin_right = 140.0
-margin_bottom = 60.0
-rect_min_size = Vector2( 140, 60 )
-custom_styles/hover = SubResource( 3 )
-custom_styles/normal = SubResource( 3 )
-
-[node name="RightArrow" type="Button" parent="LevelSubmenu/Panel/VBoxContainer/Top/LevelButtons"]
-margin_left = 526.0
-margin_top = 132.0
-margin_right = 550.0
-margin_bottom = 158.0
-rect_min_size = Vector2( 24, 24 )
-size_flags_vertical = 4
-theme = ExtResource( 6 )
-text = ">"
-
-[node name="GradeLabels" type="Control" parent="LevelSubmenu/Panel/VBoxContainer/Top"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-script = ExtResource( 28 )
-GradeLabelScene = ExtResource( 15 )
-
-[node name="Bottom" type="Control" parent="LevelSubmenu/Panel/VBoxContainer"]
-margin_top = 380.0
-margin_right = 904.0
-margin_bottom = 480.0
-rect_min_size = Vector2( 0, 100 )
-
-[node name="HBoxContainer" type="HBoxContainer" parent="LevelSubmenu/Panel/VBoxContainer/Bottom"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Description" type="Panel" parent="LevelSubmenu/Panel/VBoxContainer/Bottom/HBoxContainer"]
-margin_right = 450.0
-margin_bottom = 100.0
-size_flags_horizontal = 3
-custom_styles/panel = ExtResource( 12 )
-script = ExtResource( 23 )
-
-[node name="MarginContainer" type="MarginContainer" parent="LevelSubmenu/Panel/VBoxContainer/Bottom/HBoxContainer/Description"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-custom_constants/margin_right = 20
-custom_constants/margin_top = 5
-custom_constants/margin_left = 20
-custom_constants/margin_bottom = 5
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Label" type="Label" parent="LevelSubmenu/Panel/VBoxContainer/Bottom/HBoxContainer/Description/MarginContainer"]
-margin_left = 20.0
-margin_top = 5.0
-margin_right = 430.0
-margin_bottom = 95.0
-size_flags_vertical = 1
-theme = ExtResource( 6 )
-align = 1
-valign = 1
-autowrap = true
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Info" type="Panel" parent="LevelSubmenu/Panel/VBoxContainer/Bottom/HBoxContainer"]
-margin_left = 454.0
-margin_right = 904.0
-margin_bottom = 100.0
-size_flags_horizontal = 3
-custom_styles/panel = ExtResource( 12 )
-script = ExtResource( 27 )
-
-[node name="MarginContainer" type="MarginContainer" parent="LevelSubmenu/Panel/VBoxContainer/Bottom/HBoxContainer/Info"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-custom_constants/margin_right = 20
-custom_constants/margin_top = 5
-custom_constants/margin_left = 20
-custom_constants/margin_bottom = 5
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Label" type="Label" parent="LevelSubmenu/Panel/VBoxContainer/Bottom/HBoxContainer/Info/MarginContainer"]
-margin_left = 20.0
-margin_top = 5.0
-margin_right = 430.0
-margin_bottom = 95.0
-size_flags_vertical = 1
-theme = ExtResource( 6 )
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
+[node name="Panel" parent="LevelSubmenu" instance=ExtResource( 15 )]
 
 [node name="Buttons" type="Control" parent="LevelSubmenu"]
 modulate = Color( 1, 1, 1, 0.627451 )
@@ -753,14 +555,7 @@ action = "ui_cancel"
 [connection signal="level_chosen" from="LevelSubmenu" to="." method="_on_LevelSelect_level_chosen"]
 [connection signal="visibility_changed" from="LevelSubmenu" to="." method="_on_LevelSubmenu_visibility_changed"]
 [connection signal="pressed" from="LevelSubmenu/Buttons/Northeast/BackButton" to="LevelSubmenu" method="_on_BackButton_pressed"]
-[connection signal="button_added" from="LevelSubmenu/Panel/VBoxContainer/Top/LevelButtons" to="LevelSubmenu/Panel/VBoxContainer/Top/GradeLabels" method="_on_LevelButtons_button_added"]
-[connection signal="level_chosen" from="LevelSubmenu/Panel/VBoxContainer/Top/LevelButtons" to="LevelSubmenu" method="_on_LevelButtons_level_chosen"]
-[connection signal="locked_level_chosen" from="LevelSubmenu/Panel/VBoxContainer/Top/LevelButtons" to="LevelSubmenu/Panel/VBoxContainer/Bottom/HBoxContainer/Description" method="_on_LevelButtons_locked_level_chosen"]
-[connection signal="locked_level_chosen" from="LevelSubmenu/Panel/VBoxContainer/Top/LevelButtons" to="LevelSubmenu/Panel/VBoxContainer/Bottom/HBoxContainer/Info" method="_on_LevelButtons_locked_level_chosen"]
-[connection signal="unlocked_level_chosen" from="LevelSubmenu/Panel/VBoxContainer/Top/LevelButtons" to="LevelSubmenu/Panel/VBoxContainer/Bottom/HBoxContainer/Description" method="_on_LevelButtons_unlocked_level_chosen"]
-[connection signal="unlocked_level_chosen" from="LevelSubmenu/Panel/VBoxContainer/Top/LevelButtons" to="LevelSubmenu/Panel/VBoxContainer/Bottom/HBoxContainer/Info" method="_on_LevelButtons_unlocked_level_chosen"]
-[connection signal="pressed" from="LevelSubmenu/Panel/VBoxContainer/Top/LevelButtons/LeftArrow" to="LevelSubmenu/Panel/VBoxContainer/Top/LevelButtons" method="_on_LeftArrow_pressed"]
-[connection signal="pressed" from="LevelSubmenu/Panel/VBoxContainer/Top/LevelButtons/RightArrow" to="LevelSubmenu/Panel/VBoxContainer/Top/LevelButtons" method="_on_RightArrow_pressed"]
+[connection signal="level_chosen" from="LevelSubmenu/Panel" to="LevelSubmenu" method="_on_Panel_level_chosen"]
 [connection signal="pressed" from="MainMenu/VBoxContainer/Level/ButtonHolder/Button" to="." method="_on_LevelButton_pressed"]
 [connection signal="speed_changed" from="MainMenu/VBoxContainer/Speed" to="." method="_on_SpeedSelector_speed_changed"]
 [connection signal="value_changed" from="MainMenu/VBoxContainer/Speed/Slider" to="MainMenu/VBoxContainer/Speed" method="_on_Slider_value_changed"]

--- a/project/src/main/ui/menu/TutorialMenu.tscn
+++ b/project/src/main/ui/menu/TutorialMenu.tscn
@@ -1,52 +1,14 @@
-[gd_scene load_steps=23 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/ui/ImageButton.tscn" type="PackedScene" id=2]
-[ext_resource path="res://src/main/ui/level-select/level-submenu-description-panel.gd" type="Script" id=3]
+[ext_resource path="res://src/main/ui/menu/PagedLevelPanel.tscn" type="PackedScene" id=3]
 [ext_resource path="res://assets/main/ui/touch/close.png" type="Texture" id=4]
 [ext_resource path="res://assets/main/ui/touch/close-pressed.png" type="Texture" id=5]
 [ext_resource path="res://src/main/ui/menu/tutorial-menu.gd" type="Script" id=6]
 [ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=7]
-[ext_resource path="res://src/main/ui/menu/drop-panel.tres" type="StyleBox" id=8]
 [ext_resource path="res://src/main/ui/SceneTransitionCover.tscn" type="PackedScene" id=9]
-[ext_resource path="res://src/main/ui/menu/paged-level-buttons.gd" type="Script" id=10]
-[ext_resource path="res://src/main/ui/level-select/level-submenu-info-panel.gd" type="Script" id=11]
-[ext_resource path="res://src/main/ui/level-select/HookableLevelGradeLabel.tscn" type="PackedScene" id=12]
-[ext_resource path="res://src/main/ui/level-select/LevelSelectButton.tscn" type="PackedScene" id=13]
-[ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=14]
-[ext_resource path="res://src/main/ui/theme/h2.theme" type="Theme" id=15]
 [ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=16]
-[ext_resource path="res://src/main/ui/theme/h4.theme" type="Theme" id=17]
-[ext_resource path="res://src/main/ui/level-select/level-grade-labels.gd" type="Script" id=18]
-
-[sub_resource type="StyleBoxFlat" id=3]
-content_margin_left = 5.0
-content_margin_right = 5.0
-content_margin_top = 5.0
-content_margin_bottom = 5.0
-bg_color = Color( 0.1, 0.094, 0.094, 1 )
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color( 1, 1, 1, 1 )
-corner_radius_top_left = 4
-corner_radius_top_right = 4
-corner_radius_bottom_right = 4
-corner_radius_bottom_left = 4
-
-[sub_resource type="StyleBoxFlat" id=4]
-resource_local_to_scene = true
-bg_color = Color( 0.321569, 0.686275, 0.890196, 1 )
-border_width_left = 4
-border_width_top = 4
-border_width_right = 4
-border_width_bottom = 4
-border_color = Color( 0.423529, 0.262745, 0.192157, 1 )
-corner_radius_top_left = 8
-corner_radius_top_right = 8
-corner_radius_bottom_right = 8
-corner_radius_bottom_left = 8
 
 [sub_resource type="InputEventAction" id=1]
 action = "ui_cancel"
@@ -59,183 +21,10 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 rect_min_size = Vector2( 1024, 600 )
 script = ExtResource( 6 )
-level_buttons_path = NodePath("LevelSelect/VBoxContainer/Top/LevelButtons")
 
 [node name="Wallpaper" parent="." instance=ExtResource( 16 )]
 
-[node name="Panel" type="Panel" parent="."]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 10.0
-margin_top = 10.0
-margin_right = -10.0
-margin_bottom = -10.0
-custom_styles/panel = ExtResource( 8 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="LevelSelect" type="Panel" parent="."]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 50.0
-margin_top = 50.0
-margin_right = -50.0
-margin_bottom = -50.0
-custom_styles/panel = SubResource( 3 )
-
-[node name="VBoxContainer" type="VBoxContainer" parent="LevelSelect"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 10.0
-margin_top = 10.0
-margin_right = -10.0
-margin_bottom = -10.0
-rect_min_size = Vector2( -10, 0 )
-
-[node name="Label" type="Label" parent="LevelSelect/VBoxContainer"]
-margin_right = 904.0
-margin_bottom = 45.0
-theme = ExtResource( 15 )
-text = "Level Select"
-align = 1
-
-[node name="Top" type="Control" parent="LevelSelect/VBoxContainer"]
-margin_top = 49.0
-margin_right = 904.0
-margin_bottom = 376.0
-size_flags_vertical = 3
-
-[node name="LevelButtons" type="HBoxContainer" parent="LevelSelect/VBoxContainer/Top"]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -452.0
-margin_top = -145.0
-margin_right = 452.0
-margin_bottom = 145.0
-alignment = 1
-script = ExtResource( 10 )
-LevelButtonScene = ExtResource( 13 )
-
-[node name="LeftArrow" type="Button" parent="LevelSelect/VBoxContainer/Top/LevelButtons"]
-margin_left = 354.0
-margin_top = 132.0
-margin_right = 378.0
-margin_bottom = 158.0
-rect_min_size = Vector2( 24, 24 )
-size_flags_vertical = 4
-theme = ExtResource( 17 )
-text = "<"
-
-[node name="GridContainer" type="GridContainer" parent="LevelSelect/VBoxContainer/Top/LevelButtons"]
-margin_left = 382.0
-margin_top = 115.0
-margin_right = 522.0
-margin_bottom = 175.0
-size_flags_vertical = 4
-columns = 6
-
-[node name="Button" parent="LevelSelect/VBoxContainer/Top/LevelButtons/GridContainer" instance=ExtResource( 13 )]
-margin_right = 140.0
-margin_bottom = 60.0
-rect_min_size = Vector2( 140, 60 )
-custom_styles/hover = SubResource( 4 )
-custom_styles/normal = SubResource( 4 )
-
-[node name="RightArrow" type="Button" parent="LevelSelect/VBoxContainer/Top/LevelButtons"]
-margin_left = 526.0
-margin_top = 132.0
-margin_right = 550.0
-margin_bottom = 158.0
-rect_min_size = Vector2( 24, 24 )
-size_flags_vertical = 4
-theme = ExtResource( 17 )
-text = ">"
-
-[node name="GradeLabels" type="Control" parent="LevelSelect/VBoxContainer/Top"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-script = ExtResource( 18 )
-GradeLabelScene = ExtResource( 12 )
-
-[node name="Bottom" type="Control" parent="LevelSelect/VBoxContainer"]
-margin_top = 380.0
-margin_right = 904.0
-margin_bottom = 480.0
-rect_min_size = Vector2( 0, 100 )
-
-[node name="HBoxContainer" type="HBoxContainer" parent="LevelSelect/VBoxContainer/Bottom"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Description" type="Panel" parent="LevelSelect/VBoxContainer/Bottom/HBoxContainer"]
-margin_right = 450.0
-margin_bottom = 100.0
-size_flags_horizontal = 3
-custom_styles/panel = ExtResource( 14 )
-script = ExtResource( 3 )
-
-[node name="MarginContainer" type="MarginContainer" parent="LevelSelect/VBoxContainer/Bottom/HBoxContainer/Description"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-custom_constants/margin_right = 20
-custom_constants/margin_top = 5
-custom_constants/margin_left = 20
-custom_constants/margin_bottom = 5
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Label" type="Label" parent="LevelSelect/VBoxContainer/Bottom/HBoxContainer/Description/MarginContainer"]
-margin_left = 20.0
-margin_top = 5.0
-margin_right = 430.0
-margin_bottom = 95.0
-size_flags_vertical = 1
-theme = ExtResource( 17 )
-align = 1
-valign = 1
-autowrap = true
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Info" type="Panel" parent="LevelSelect/VBoxContainer/Bottom/HBoxContainer"]
-margin_left = 454.0
-margin_right = 904.0
-margin_bottom = 100.0
-size_flags_horizontal = 3
-custom_styles/panel = ExtResource( 14 )
-script = ExtResource( 11 )
-
-[node name="MarginContainer" type="MarginContainer" parent="LevelSelect/VBoxContainer/Bottom/HBoxContainer/Info"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-custom_constants/margin_right = 20
-custom_constants/margin_top = 5
-custom_constants/margin_left = 20
-custom_constants/margin_bottom = 5
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Label" type="Label" parent="LevelSelect/VBoxContainer/Bottom/HBoxContainer/Info/MarginContainer"]
-margin_left = 20.0
-margin_top = 5.0
-margin_right = 430.0
-margin_bottom = 95.0
-size_flags_vertical = 1
-theme = ExtResource( 17 )
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
+[node name="Panel" parent="." instance=ExtResource( 3 )]
 
 [node name="Buttons" type="Control" parent="."]
 modulate = Color( 1, 1, 1, 0.627451 )
@@ -282,11 +71,4 @@ action = "ui_cancel"
 [node name="SceneTransitionCover" parent="." instance=ExtResource( 9 )]
 
 [connection signal="pressed" from="Buttons/Northeast/BackButton" to="." method="_on_BackButton_pressed"]
-[connection signal="button_added" from="LevelSelect/VBoxContainer/Top/LevelButtons" to="LevelSelect/VBoxContainer/Top/GradeLabels" method="_on_LevelButtons_button_added"]
-[connection signal="level_chosen" from="LevelSelect/VBoxContainer/Top/LevelButtons" to="." method="_on_LevelButtons_level_chosen"]
-[connection signal="locked_level_chosen" from="LevelSelect/VBoxContainer/Top/LevelButtons" to="LevelSelect/VBoxContainer/Bottom/HBoxContainer/Description" method="_on_LevelButtons_locked_level_chosen"]
-[connection signal="locked_level_chosen" from="LevelSelect/VBoxContainer/Top/LevelButtons" to="LevelSelect/VBoxContainer/Bottom/HBoxContainer/Info" method="_on_LevelButtons_locked_level_chosen"]
-[connection signal="unlocked_level_chosen" from="LevelSelect/VBoxContainer/Top/LevelButtons" to="LevelSelect/VBoxContainer/Bottom/HBoxContainer/Description" method="_on_LevelButtons_unlocked_level_chosen"]
-[connection signal="unlocked_level_chosen" from="LevelSelect/VBoxContainer/Top/LevelButtons" to="LevelSelect/VBoxContainer/Bottom/HBoxContainer/Info" method="_on_LevelButtons_unlocked_level_chosen"]
-[connection signal="pressed" from="LevelSelect/VBoxContainer/Top/LevelButtons/LeftArrow" to="LevelSelect/VBoxContainer/Top/LevelButtons" method="_on_LeftArrow_pressed"]
-[connection signal="pressed" from="LevelSelect/VBoxContainer/Top/LevelButtons/RightArrow" to="LevelSelect/VBoxContainer/Top/LevelButtons" method="_on_RightArrow_pressed"]
+[connection signal="level_chosen" from="Panel" to="." method="_on_Panel_level_chosen"]

--- a/project/src/main/ui/menu/level-submenu.gd
+++ b/project/src/main/ui/menu/level-submenu.gd
@@ -1,20 +1,18 @@
 extends Control
 ## A level select screen which shows buttons and level info. Used in the practice menu.
 
-## Emitted when the player 'starts' a level, choosing it for practice.
+## Emitted when the player finishes choosing a level to play.
 ##
 ## Parameters:
 ## 	'region': A CareerRegion or OtherRegion instance for the chosen region.
 ##
 ## 	'level_id': The chosen level id
-signal level_chosen(region, level_id)
-
-export (NodePath) var level_buttons_path: NodePath
+signal level_chosen(region, settings)
 
 ## A CareerRegion/OtherRegion instance for the region whose levels should be shown
 var _region: Object
 
-onready var _level_buttons: PagedLevelButtons = get_node(level_buttons_path)
+onready var _paged_level_panel := $Panel
 
 ## Populates this submenu with levels and shows it to the player.
 ##
@@ -26,22 +24,12 @@ onready var _level_buttons: PagedLevelButtons = get_node(level_buttons_path)
 ##
 ## 	'default_level_id': The level whose button is focused after showing the menu
 func popup(new_region: Object, default_level_id: String = "") -> void:
-	var level_ids := []
 	_region = new_region
-	if _region is CareerRegion:
-		for career_level in _region.levels:
-			level_ids.append(career_level.level_id)
-	else:
-		level_ids.append_array(_region.level_ids)
-	
-	_level_buttons.region = _region
-	_level_buttons.level_ids = level_ids
-	if default_level_id:
-		_level_buttons.focus_level(default_level_id)
+	_paged_level_panel.populate(new_region, default_level_id)
 	show()
 
 
-func _on_LevelButtons_level_chosen(settings: LevelSettings) -> void:
+func _on_Panel_level_chosen(settings: LevelSettings) -> void:
 	emit_signal("level_chosen", _region, settings)
 
 

--- a/project/src/main/ui/menu/paged-level-buttons.gd
+++ b/project/src/main/ui/menu/paged-level-buttons.gd
@@ -6,7 +6,7 @@ extends HBoxContainer
 
 const MAX_LEVELS_PER_PAGE := 18
 
-## Emitted when the player 'starts' a level, choosing it for practice.
+## Emitted when the player finishes choosing a level to play.
 signal level_chosen(settings)
 
 ## Emitted when the player highlights a locked level to show more information.

--- a/project/src/main/ui/menu/paged-level-panel.gd
+++ b/project/src/main/ui/menu/paged-level-panel.gd
@@ -1,0 +1,40 @@
+extends Control
+## A level select panel which shows buttons and level info. Used in the practice/tutorial menus.
+
+## Emitted when the player finishes choosing a level to play.
+##
+## Parameters:
+## 	'settings': The chosen level settings
+signal level_chosen(settings)
+
+## A CareerRegion/OtherRegion instance for the region whose levels should be shown
+var _region: Object
+
+onready var _level_buttons: PagedLevelButtons = $VBoxContainer/Top/LevelButtons
+
+## Populates this submenu with levels in to show it to the player.
+##
+## We create a button for each level defined in the region. If the player has selected a level before, we focus the
+## level they previously chose.
+##
+## Parameters:
+## 	'new_region': A CareerRegion/OtherRegion instance for the region whose levels should be shown
+##
+## 	'default_level_id': The level whose button is focused after showing the menu
+func populate(new_region: Object, default_level_id: String = "") -> void:
+	var level_ids := []
+	_region = new_region
+	if _region is CareerRegion:
+		for career_level in _region.levels:
+			level_ids.append(career_level.level_id)
+	else:
+		level_ids.append_array(_region.level_ids)
+	
+	_level_buttons.region = _region
+	_level_buttons.level_ids = level_ids
+	if default_level_id:
+		_level_buttons.focus_level(default_level_id)
+
+
+func _on_LevelButtons_level_chosen(settings: LevelSettings) -> void:
+	emit_signal("level_chosen", settings)

--- a/project/src/main/ui/menu/paged-region-buttons.gd
+++ b/project/src/main/ui/menu/paged-region-buttons.gd
@@ -7,7 +7,7 @@ extends HBoxContainer
 ## Emitted when the player highlights a region to show more information.
 signal region_focused(region)
 
-## Emitted when the player 'starts' a region, choosing it for practice.
+## Emitted when the player finishes choosing a region to play.
 signal region_chosen(region)
 
 ## Emitted when a new region button is added.

--- a/project/src/main/ui/menu/practice-menu.gd
+++ b/project/src/main/ui/menu/practice-menu.gd
@@ -22,6 +22,9 @@ onready var _level_description_label: Label = get_node(_level_description_label_
 onready var _speed_selector: PracticeSpeedSelector = get_node(_speed_selector_path)
 onready var _start_button: Button = get_node(_start_button_path)
 
+onready var _level_submenu := $LevelSubmenu
+onready var _region_submenu := $RegionSubmenu
+
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
 	MusicPlayer.play_chill_bgm()
@@ -77,7 +80,7 @@ func _load_recent_data() -> void:
 ## When submenus appear over top of the main menu, we temporarily disable focus for all sliders/buttons/etc on the
 ## main menu to avoid them from grabbing keyboard focus.
 func _refresh_input_focus_mode() -> void:
-	var submenu_visible: bool = $LevelSubmenu.visible or $RegionSubmenu.visible
+	var submenu_visible: bool = _level_submenu.visible or _region_submenu.visible
 	for node in get_tree().get_nodes_in_group("main_practice_inputs"):
 		node.focus_mode = FOCUS_NONE if submenu_visible else FOCUS_ALL
 
@@ -151,18 +154,18 @@ func _on_Start_pressed() -> void:
 
 # When the player clicks the 'Level Selection' button up top, we launch a series of submenus
 func _on_LevelButton_pressed() -> void:
-	$RegionSubmenu.popup(_region.id)
+	_region_submenu.popup(_region.id)
 
 
 # When the player selects their region from the region submenu, we launch the level submenu
 func _on_RegionSubmenu_region_chosen(region: Object) -> void:
-	$RegionSubmenu.hide()
-	$LevelSubmenu.popup(region, _level_settings.id)
+	_region_submenu.hide()
+	_level_submenu.popup(region, _level_settings.id)
 
 
 func _on_RegionSubmenu_visibility_changed() -> void:
 	_refresh_input_focus_mode()
-	if not $RegionSubmenu.visible:
+	if not _region_submenu.visible:
 		_level_button.grab_focus()
 
 
@@ -171,7 +174,7 @@ func _on_LevelSelect_level_chosen(region: Object, settings: LevelSettings) -> vo
 	PlayerData.practice.region_id = _region.id
 	_level_settings = settings
 	PlayerData.practice.level_id = settings.id
-	$LevelSubmenu.hide()
+	_level_submenu.hide()
 	_refresh_level_button()
 	_refresh_speed_selector()
 	_refresh_high_scores()
@@ -180,7 +183,7 @@ func _on_LevelSelect_level_chosen(region: Object, settings: LevelSettings) -> vo
 
 func _on_LevelSubmenu_visibility_changed() -> void:
 	_refresh_input_focus_mode()
-	if not $LevelSubmenu.visible:
+	if not _level_submenu.visible:
 		_level_button.grab_focus()
 
 

--- a/project/src/main/ui/menu/region-submenu.gd
+++ b/project/src/main/ui/menu/region-submenu.gd
@@ -1,7 +1,7 @@
 extends Control
 ## A region select screen which shows buttons and region info. Used in the practice menu.
 
-## Emitted when the player 'starts' a region, choosing it for practice.
+## Emitted when the player finishes choosing a region to play.
 ##
 ## Parameters:
 ## 	'region': A CareerRegion or OtherRegion instance for the chosen region.

--- a/project/src/main/ui/menu/tutorial-menu.gd
+++ b/project/src/main/ui/menu/tutorial-menu.gd
@@ -1,9 +1,7 @@
 extends Control
 ## Scene which lets the player launch tutorials.
 
-export (NodePath) var level_buttons_path
-
-onready var level_buttons: PagedLevelButtons = get_node(level_buttons_path)
+onready var _paged_level_panel := $Panel
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
@@ -38,9 +36,7 @@ func _assign_default_recent_data(tutorial_region: OtherRegion) -> void:
 
 
 func _populate_level_buttons(tutorial_region: OtherRegion) -> void:
-	level_buttons.set_region(tutorial_region)
-	level_buttons.set_level_ids(tutorial_region.level_ids)
-	level_buttons.focus_level(PlayerData.practice.tutorial_level_id)
+	_paged_level_panel.populate(tutorial_region, PlayerData.practice.tutorial_level_id)
 
 
 func _exit_tree() -> void:
@@ -51,7 +47,7 @@ func _on_BackButton_pressed() -> void:
 	SceneTransition.pop_trail(true)
 
 
-func _on_LevelButtons_level_chosen(settings: LevelSettings) -> void:
+func _on_Panel_level_chosen(settings: LevelSettings) -> void:
 	PlayerData.practice.tutorial_level_id = settings.id
 	CurrentLevel.set_launched_level(settings.id)
 	CurrentLevel.push_level_trail()


### PR DESCRIPTION
This avoids some copy/pasted node trees in PracticeMenu and TutorialMenu. They still need a little duplication because they have slightly different UI -- the tutorial menu has a round splash panel while the practice menu has a black backdrop.