### PR TITLE
Creature method ordering. Skill tally code cleanup.

### DIFF
--- a/project/src/main/puzzle/tutorial/skill-tally-item.gd
+++ b/project/src/main/puzzle/tutorial/skill-tally-item.gd
@@ -21,6 +21,11 @@ var _piece_manager: PieceManager
 ## property is 'true' if the skill tally is lit up brightly.
 var _bright_tween_active: bool
 
+onready var _blink_panel := $Blink
+onready var _label := $Label
+onready var _task_complete_sound := $TaskCompleteSound
+onready var _tween := $Tween
+
 func _ready() -> void:
 	reset()
 	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
@@ -67,9 +72,9 @@ func update_label() -> void:
 		return
 	
 	if show_as_percent:
-		$Label.text = "%s\n%d%%" % [label_text, int(100 * value / max_value)]
+		_label.text = "%s\n%d%%" % [label_text, int(100 * value / max_value)]
 	else:
-		$Label.text = "%s\n(%d/%d)" % [label_text, value, max_value]
+		_label.text = "%s\n(%d/%d)" % [label_text, value, max_value]
 
 
 ## Initializes this node when the puzzle field is assigned.
@@ -104,21 +109,21 @@ func _blink(bright: bool = false) -> void:
 	if _bright_tween_active:
 		return
 	
-	$Tween.remove_all()
-	$Blink.rect_scale = Vector2(1, 1)
+	_tween.remove_all()
+	_blink_panel.rect_scale = Vector2(1, 1)
 	if bright:
 		_bright_tween_active = true
-		$Blink.modulate = Color.white
-		$Tween.interpolate_property($Blink, "rect_scale", $Blink.rect_scale, Vector2(2.0, 2.0), 1.2)
-		$Tween.interpolate_property($Blink, "modulate", $Blink.modulate, Color(0.111, 0.888, 0.111, 0.0),
+		_blink_panel.modulate = Color.white
+		_tween.interpolate_property(_blink_panel, "rect_scale", _blink_panel.rect_scale, Vector2(2.0, 2.0), 1.2)
+		_tween.interpolate_property(_blink_panel, "modulate", _blink_panel.modulate, Color(0.111, 0.888, 0.111, 0.0),
 				1.2, Tween.TRANS_CIRC, Tween.EASE_IN_OUT)
-		$TaskCompleteSound.play()
+		_task_complete_sound.play()
 	else:
-		$Blink.modulate = Color(0.111, 0.888, 0.111, 0.5)
-		$Tween.interpolate_property($Blink, "rect_scale", $Blink.rect_scale, Vector2(1.5, 1.5), 0.6)
-		$Tween.interpolate_property($Blink, "modulate:a", $Blink.modulate.a, 0.0,
+		_blink_panel.modulate = Color(0.111, 0.888, 0.111, 0.5)
+		_tween.interpolate_property(_blink_panel, "rect_scale", _blink_panel.rect_scale, Vector2(1.5, 1.5), 0.6)
+		_tween.interpolate_property(_blink_panel, "modulate:a", _blink_panel.modulate.a, 0.0,
 				0.6, Tween.TRANS_CIRC, Tween.EASE_IN_OUT)
-	$Tween.start()
+	_tween.start()
 
 
 func _on_PuzzleState_game_prepared() -> void:

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -525,43 +525,6 @@ func _update_animation() -> void:
 		play_movement_animation("idle", _non_iso_velocity)
 
 
-func _on_Creature_fatness_changed() -> void:
-	emit_signal("fatness_changed")
-
-
-func _on_CreatureVisuals_dna_loaded() -> void:
-	visible = true
-	emit_signal("dna_loaded")
-
-
-func _on_CreatureVisuals_food_eaten(food_type: int) -> void:
-	emit_signal("food_eaten", food_type)
-
-
-func _on_CreatureVisuals_landed() -> void:
-	emit_signal("landed")
-
-
-func _on_CreatureVisuals_visual_fatness_changed() -> void:
-	emit_signal("visual_fatness_changed")
-
-
-func _on_CreatureVisuals_movement_mode_changed(_old_mode: int, new_mode: int) -> void:
-	if new_mode in [Creatures.WALK, Creatures.RUN]:
-		# when on two legs, the body is a little higher off the ground
-		set_elevation(35)
-	else:
-		set_elevation(0)
-
-
-func _on_FadeTween_tween_all_completed() -> void:
-	if modulate.a == 0.0:
-		visible = false
-		emit_signal("fade_out_finished")
-	else:
-		emit_signal("fade_in_finished")
-
-
 ## Converts a score in the range [0.0, 5000.0] to a fatness in the range [1.0, 10.0]
 func score_to_fatness(in_score: float) -> float:
 	var result: float
@@ -604,6 +567,41 @@ func body_pos_from_head_pos(v: Vector2) -> Vector2:
 	return _mouth_hook.get_global_transform_with_canvas().xform(v * creature_visuals.scale.y)
 
 
+func _on_Creature_fatness_changed() -> void:
+	emit_signal("fatness_changed")
+
+
+func _on_CreatureVisuals_dna_loaded() -> void:
+	visible = true
+	emit_signal("dna_loaded")
+
+
+func _on_CreatureVisuals_food_eaten(food_type: int) -> void:
+	emit_signal("food_eaten", food_type)
+
+
+func _on_CreatureVisuals_landed() -> void:
+	emit_signal("landed")
+
+
+func _on_CreatureVisuals_visual_fatness_changed() -> void:
+	emit_signal("visual_fatness_changed")
+
+
+func _on_CreatureVisuals_movement_mode_changed(_old_mode: int, new_mode: int) -> void:
+	if new_mode in [Creatures.WALK, Creatures.RUN]:
+		# when on two legs, the body is a little higher off the ground
+		set_elevation(35)
+	else:
+		set_elevation(0)
+
+
+func _on_FadeTween_tween_all_completed() -> void:
+	if modulate.a == 0.0:
+		visible = false
+		emit_signal("fade_out_finished")
+	else:
+		emit_signal("fade_in_finished")
 func _on_CreatureVisuals_talking_changed() -> void:
 	emit_signal("talking_changed")
 


### PR DESCRIPTION
Reordered creature signal methods to be grouped together.

Replaced skill-tally-item.gd 'get_node' references with onready variables.