### PR TITLE
Revert "Rewrote tweens to use Godot 3.5 syntax."

### DIFF
--- a/project/src/main/puzzle/GoopGlob.tscn
+++ b/project/src/main/puzzle/GoopGlob.tscn
@@ -7,7 +7,10 @@
 texture = ExtResource( 1 )
 script = ExtResource( 2 )
 
+[node name="Tween" type="Tween" parent="."]
+
 [node name="FadeTimer" type="Timer" parent="."]
 one_shot = true
 
 [connection signal="timeout" from="FadeTimer" to="." method="_on_FadeTimer_timeout"]
+[connection signal="tween_all_completed" from="Tween" to="." method="_on_Tween_tween_all_completed"]

--- a/project/src/main/puzzle/HudFlash.tscn
+++ b/project/src/main/puzzle/HudFlash.tscn
@@ -8,3 +8,5 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
 script = ExtResource( 1 )
+
+[node name="Tween" type="Tween" parent="."]

--- a/project/src/main/puzzle/LeafPoof.tscn
+++ b/project/src/main/puzzle/LeafPoof.tscn
@@ -71,3 +71,7 @@ script = ExtResource( 2 )
 autoplay = "play"
 anims/RESET = SubResource( 2 )
 anims/play = SubResource( 1 )
+
+[node name="Tween" type="Tween" parent="."]
+
+[connection signal="tween_all_completed" from="Tween" to="." method="_on_Tween_tween_all_completed"]

--- a/project/src/main/puzzle/Pickup.tscn
+++ b/project/src/main/puzzle/Pickup.tscn
@@ -33,3 +33,7 @@ avg_pulse_period = 4.28
 
 [node name="FoodItem" parent="." instance=ExtResource( 1 )]
 visible = false
+
+[node name="StarColorTween" type="Tween" parent="."]
+
+[connection signal="tween_all_completed" from="StarColorTween" to="." method="_on_StarColorTween_tween_all_completed"]

--- a/project/src/main/puzzle/Playfield.tscn
+++ b/project/src/main/puzzle/Playfield.tscn
@@ -233,6 +233,8 @@ __meta__ = {
 
 [node name="Tween" type="Tween" parent="TileMapClip/PlayfieldFx/BgStrobe"]
 
+[node name="GlowTween" type="Tween" parent="TileMapClip/PlayfieldFx"]
+
 [node name="LeafPoofs" type="Node2D" parent="TileMapClip"]
 position = Vector2( 0, -96 )
 z_index = 5

--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -388,6 +388,9 @@ margin_top = 28.0
 margin_right = 688.0
 margin_bottom = 572.0
 script = ExtResource( 18 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 _puzzle_tile_map_path = NodePath("../Playfield/TileMapClip/TileMap")
 StarSeedScene = ExtResource( 72 )
 
@@ -617,6 +620,8 @@ results_label_path = NodePath("../Center/ResultsHud/ResultsLabel")
 [node name="MoneyLabel" parent="Hud/PuzzleMoneyHud" instance=ExtResource( 76 )]
 margin_top = -32.0
 margin_bottom = 0.0
+
+[node name="MoneyLabelTween" type="Tween" parent="Hud/PuzzleMoneyHud"]
 
 [node name="TouchButtons" parent="Hud" instance=ExtResource( 10 )]
 

--- a/project/src/main/puzzle/food-item.gd
+++ b/project/src/main/puzzle/food-item.gd
@@ -30,6 +30,9 @@ var food_type: int setget set_food_type
 ## Food items pulse and rotate. This field is used to calculate the pulse/rotation amount
 var _total_time := 0.0
 
+## Tweens the food's position to fly into the customer's mouth.
+var _flying_tween: Tween
+
 ## This func ref and array correspond to a callback which return the position of the customer's mouth.
 var _get_target_pos: FuncRef
 var _target_pos_arg_array: Array
@@ -136,9 +139,13 @@ func fly_to_target(new_get_target_pos: FuncRef, target_pos_arg_array: Array,
 	velocity = Vector2.ZERO
 	
 	_source_pos = position
-	var flying_tween := create_tween().set_trans(Tween.TRANS_QUAD).set_ease(Tween.EASE_IN)
-	flying_tween.tween_property(self, "_flight_percent", 1.0, duration)
-	flying_tween.tween_callback(self, "queue_free").set_delay(0.03)
+	_flying_tween = Tween.new()
+	add_child(_flying_tween)
+	
+	_flying_tween.interpolate_property(self, "_flight_percent", 0.0, 1.0, duration, Tween.TRANS_QUAD, Tween.EASE_IN)
+	# linger at the destination for a few frames before deleting
+	_flying_tween.interpolate_callback(self, duration + 0.03, "queue_free")
+	_flying_tween.start()
 
 
 func _refresh_scale() -> void:

--- a/project/src/main/puzzle/goop-glob.gd
+++ b/project/src/main/puzzle/goop-glob.gd
@@ -42,7 +42,7 @@ var velocity := Vector2.ZERO
 ## time in milliseconds between the engine starting and this node being initialized
 var _creation_time := 0.0
 
-onready var _tween: SceneTreeTween
+onready var _tween: Tween = $Tween
 onready var _fade_timer: Timer = $FadeTimer
 
 ## Populates this object from another GoopGlob instance.
@@ -107,9 +107,10 @@ func fall() -> void:
 	falling = true
 	smear_time = min(rand_range(0.0, FALL_DURATION * 0.7), rand_range(0.0, FALL_DURATION * 1.2))
 	
-	_tween = Utils.recreate_tween(self, _tween).set_trans(Tween.TRANS_CIRC).set_ease(Tween.EASE_IN)
-	_tween.tween_property(self, "modulate", Utils.to_transparent(modulate), FALL_DURATION * rand_range(0.8, 1.2))
-	_tween.connect("finished", self, "_on_SceneTreeTween_finished")
+	_tween.remove_all()
+	_tween.interpolate_property(self, "modulate", modulate, Utils.to_transparent(modulate), \
+			FALL_DURATION * rand_range(0.8, 1.2), Tween.TRANS_CIRC, Tween.EASE_IN)
+	_tween.start()
 
 
 ## Makes this goop glob fade away and disappear.
@@ -118,6 +119,11 @@ func fall() -> void:
 func fade() -> void:
 	falling = false
 	_fade_timer.start(FADE_DELAY * rand_range(0.8, 1.2))
+	
+	# No Tween.start() call; Tween is started once timer finishes
+	_tween.remove_all()
+	_tween.interpolate_property(self, "modulate", modulate, Utils.to_transparent(modulate), \
+			FADE_DURATION * rand_range(0.8, 1.2), Tween.TRANS_LINEAR, Tween.EASE_IN)
 
 
 ## Applies gravity and checks for collisions.
@@ -140,11 +146,9 @@ func _process(delta: float) -> void:
 		emit_signal("hit_wall", self)
 
 
-func _on_SceneTreeTween_finished() -> void:
+func _on_Tween_tween_all_completed() -> void:
 	queue_free()
 
 
 func _on_FadeTimer_timeout() -> void:
-	_tween = Utils.recreate_tween(self, _tween).set_ease(Tween.EASE_IN)
-	_tween.tween_property(self, "modulate", Utils.to_transparent(modulate), \
-			FADE_DURATION * rand_range(0.8, 1.2))
+	_tween.start()

--- a/project/src/main/puzzle/hud-flash.gd
+++ b/project/src/main/puzzle/hud-flash.gd
@@ -2,11 +2,9 @@ class_name HudFlash
 extends ColorRect
 ## Flashes the screen briefly. Used to transition between tutorial sections.
 
-var _tween: SceneTreeTween
-
 ## Flashes the screen briefly. Used to transition between tutorial sections.
 func flash() -> void:
 	modulate.a = 0.25
-	
-	_tween = Utils.recreate_tween(self, _tween)
-	_tween.tween_property(self, "modulate:a", 0.0, 1.0)
+	$Tween.remove_all()
+	$Tween.interpolate_property(self, "modulate:a", modulate.a, 0.0, 1.0)
+	$Tween.start()

--- a/project/src/main/puzzle/leaf-poof.gd
+++ b/project/src/main/puzzle/leaf-poof.gd
@@ -12,7 +12,7 @@ var leaf_frame: int setget set_leaf_frame
 var leaf_type: int
 
 ## turns the leaf invisible
-onready var _tween: SceneTreeTween
+onready var _tween: Tween = $Tween
 
 ## animates and flips the leaf
 onready var _animation_player: AnimationPlayer = $AnimationPlayer
@@ -48,9 +48,10 @@ func _update_tween_and_animation() -> void:
 		return
 	
 	_animation_player.advance(randf() * 10)
-	_tween = Utils.recreate_tween(self, _tween).set_trans(Tween.TRANS_QUAD).set_ease(Tween.EASE_IN)
-	_tween.tween_property(self, "modulate", Utils.to_transparent(modulate), LIFETIME)
-	_tween.connect("finished", self, "_on_SceneTreeTween_finished")
+	_tween.remove_all()
+	_tween.interpolate_property(self, "modulate", modulate, Utils.to_transparent(modulate),
+			LIFETIME, Tween.TRANS_QUAD, Tween.EASE_IN)
+	_tween.start()
 
 
 func _refresh_frame() -> void:
@@ -64,5 +65,5 @@ func _physics_process(delta: float) -> void:
 	position += delta * velocity
 
 
-func _on_SceneTreeTween_finished() -> void:
+func _on_Tween_tween_all_completed() -> void:
 	queue_free()

--- a/project/src/main/puzzle/pickup.gd
+++ b/project/src/main/puzzle/pickup.gd
@@ -19,7 +19,7 @@ onready var _star := $Star
 onready var _food_item := $FoodItem
 
 ## tween used to update the star's color
-onready var _star_color_tween: SceneTreeTween
+onready var _star_color_tween := $StarColorTween
 
 func _ready() -> void:
 	_seed.visible = true
@@ -77,16 +77,16 @@ func _refresh_appearance() -> void:
 ## Gradually changes the star to a new color.
 func _launch_star_color_tween(var initial_launch := false) -> void:
 	var new_star_color_index := (_star_color_index + 1) % _star_colors.size()
-	
-	_star_color_tween = Utils.recreate_tween(self, _star_color_tween).set_trans(Tween.TRANS_SINE)
+	_star_color_tween.remove_all()
 	# for the initial launch, the duration has more variance so that different stars will start out of sync
 	var duration_min := STAR_COLOR_CHANGE_DURATION * (0.0 if initial_launch else 0.8)
 	var duration_max := STAR_COLOR_CHANGE_DURATION * 1.2
-	_star_color_tween.tween_property(_star, "modulate", \
-			_star_colors[new_star_color_index], rand_range(duration_min, duration_max))
-	_star_color_tween.connect("finished", self, "_on_StarColorTween_finished")
+	_star_color_tween.interpolate_property(_star, "modulate", \
+			_star.modulate, _star_colors[new_star_color_index], rand_range(duration_min, duration_max),
+			Tween.TRANS_SINE)
+	_star_color_tween.start()
 	_star_color_index = new_star_color_index
 
 
-func _on_StarColorTween_finished() -> void:
+func _on_StarColorTween_tween_all_completed() -> void:
 	_launch_star_color_tween()

--- a/project/src/main/puzzle/playfield-fx.gd
+++ b/project/src/main/puzzle/playfield-fx.gd
@@ -87,7 +87,7 @@ onready var _glow_map: TileMap = $GlowMap
 onready var _bg_strobe: ColorRect = $BgStrobe
 
 ## gradually dims the glowiness
-onready var _glow_tween: SceneTreeTween
+onready var _glow_tween: Tween = $GlowTween
 
 func _ready() -> void:
 	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
@@ -152,14 +152,14 @@ func _init_tile(color: Color) -> void:
 ## Starts the glow tween, causing the lights to slowly dim.
 func _start_glow_tween() -> void:
 	if _brightness > 0 and _glow_duration > 0.0:
-		_light_map.modulate.a = 1.00
-		_glow_map.modulate.a = 0.75
-		_bg_strobe.color.a = 0.33
-		
-		_glow_tween = Utils.recreate_tween(self, _glow_tween).set_trans(Tween.TRANS_CIRC).set_ease(Tween.EASE_OUT)
-		_glow_tween.tween_property(_light_map, "modulate:a", 0.50, _glow_duration)
-		_glow_tween.parallel().tween_property(_glow_map, "modulate:a", 0.125, _glow_duration)
-		_glow_tween.parallel().tween_property(_bg_strobe, "color:a", 0.00, _glow_duration)
+		_glow_tween.remove_all()
+		_glow_tween.interpolate_property(_light_map, "modulate:a", 1.00, 0.50,
+			_glow_duration, Tween.TRANS_CIRC, Tween.EASE_OUT)
+		_glow_tween.interpolate_property(_glow_map, "modulate:a", 0.75, 0.125,
+			_glow_duration, Tween.TRANS_CIRC, Tween.EASE_OUT)
+		_glow_tween.interpolate_property(_bg_strobe, "color:a", 0.33, 0.00,
+			_glow_duration, Tween.TRANS_CIRC, Tween.EASE_OUT)
+		_glow_tween.start()
 
 
 ## Calculates the light color for a row in the playfield.

--- a/project/src/main/puzzle/puzzle-money-hud.gd
+++ b/project/src/main/puzzle/puzzle-money-hud.gd
@@ -8,7 +8,7 @@ const TWEEN_DURATION := 0.1
 export (NodePath) var results_label_path: NodePath
 
 onready var _money_label := $MoneyLabel
-onready var _money_label_tween: SceneTreeTween
+onready var _money_label_tween := $MoneyLabelTween
 onready var _results_label: ResultsLabel = get_node(results_label_path)
 
 func _ready() -> void:
@@ -23,14 +23,18 @@ func _ready() -> void:
 ## shown.
 func _show_money(rank_result: RankResult) -> void:
 	_money_label.set_shown_money(PlayerData.money - rank_result.score)
-	_money_label_tween = Utils.recreate_tween(self, _money_label_tween)
-	_money_label_tween.tween_property(_money_label, "rect_position:y", 0.0, TWEEN_DURATION)
+	_money_label_tween.remove_all()
+	_money_label_tween.interpolate_property(_money_label, "rect_position:y",
+			_money_label.rect_position.y, 0, TWEEN_DURATION)
+	_money_label_tween.start()
 
 
 ## Hides the money label.
 func _hide_money() -> void:
-	_money_label_tween = Utils.recreate_tween(self, _money_label_tween)
-	_money_label_tween.tween_property(_money_label, "rect_position:y", -32.0, TWEEN_DURATION)
+	_money_label_tween.remove_all()
+	_money_label_tween.interpolate_property(_money_label, "rect_position:y",
+			_money_label.rect_position.y, -32.0, TWEEN_DURATION)
+	_money_label_tween.start()
 
 
 func _on_PuzzleState_game_prepared() -> void:

--- a/project/src/main/puzzle/tutorial/SkillTallyItem.tscn
+++ b/project/src/main/puzzle/tutorial/SkillTallyItem.tscn
@@ -74,7 +74,11 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[node name="Tween" type="Tween" parent="."]
+
 [node name="TaskCompleteSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 3 )
 volume_db = -4.0
 bus = "Sound Bus"
+
+[connection signal="tween_all_completed" from="Tween" to="." method="_on_Tween_tween_all_completed"]

--- a/project/src/main/puzzle/tutorial/skill-tally-item.gd
+++ b/project/src/main/puzzle/tutorial/skill-tally-item.gd
@@ -20,11 +20,11 @@ var _piece_manager: PieceManager
 ## When the player performs a skill enough times, the skill tally plays a noise and lights up more brightly. This
 ## property is 'true' if the skill tally is lit up brightly.
 var _bright_tween_active: bool
-var _tween: SceneTreeTween
 
 onready var _blink_panel := $Blink
 onready var _label := $Label
 onready var _task_complete_sound := $TaskCompleteSound
+onready var _tween := $Tween
 
 func _ready() -> void:
 	reset()
@@ -109,21 +109,21 @@ func _blink(bright: bool = false) -> void:
 	if _bright_tween_active:
 		return
 	
-	_tween = Utils.recreate_tween(self, _tween)
+	_tween.remove_all()
 	_blink_panel.rect_scale = Vector2(1, 1)
 	if bright:
 		_bright_tween_active = true
 		_blink_panel.modulate = Color.white
-		_tween.tween_property(_blink_panel, "rect_scale", Vector2(2.0, 2.0), 1.2)
-		_tween.parallel().tween_property(_blink_panel, "modulate", Color(0.111, 0.888, 0.111, 0.0), 1.2) \
-				.set_trans(Tween.TRANS_CIRC).set_ease(Tween.EASE_IN_OUT)
-		$TaskCompleteSound.play()
+		_tween.interpolate_property(_blink_panel, "rect_scale", _blink_panel.rect_scale, Vector2(2.0, 2.0), 1.2)
+		_tween.interpolate_property(_blink_panel, "modulate", _blink_panel.modulate, Color(0.111, 0.888, 0.111, 0.0),
+				1.2, Tween.TRANS_CIRC, Tween.EASE_IN_OUT)
+		_task_complete_sound.play()
 	else:
 		_blink_panel.modulate = Color(0.111, 0.888, 0.111, 0.5)
-		_tween.tween_property(_blink_panel, "rect_scale", Vector2(1.5, 1.5), 0.6)
-		_tween.parallel().tween_property(_blink_panel, "modulate:a", 0.0, 0.6) \
-				.set_trans(Tween.TRANS_CIRC).set_ease(Tween.EASE_IN_OUT)
-	_tween.connect("finished", self, "_on_Tween_tween_all_completed")
+		_tween.interpolate_property(_blink_panel, "rect_scale", _blink_panel.rect_scale, Vector2(1.5, 1.5), 0.6)
+		_tween.interpolate_property(_blink_panel, "modulate:a", _blink_panel.modulate.a, 0.0,
+				0.6, Tween.TRANS_CIRC, Tween.EASE_IN_OUT)
+	_tween.start()
 
 
 func _on_PuzzleState_game_prepared() -> void:

--- a/project/src/main/ui/MoneyLabel.tscn
+++ b/project/src/main/ui/MoneyLabel.tscn
@@ -10,6 +10,9 @@ margin_bottom = 32.0
 rect_min_size = Vector2( 0, 32 )
 mouse_filter = 2
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="TextureRect" type="Control" parent="."]
 margin_right = 32.0

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -926,6 +926,8 @@ size_flags_stretch_ratio = 0.74
 text = "Copied!"
 valign = 1
 
+[node name="CopiedTween" type="Tween" parent="Window/UiArea/TabContainer/Misc/CopySaveData/HBoxContainer"]
+
 [node name="Bottom" type="Control" parent="Window/UiArea"]
 margin_top = 254.0
 margin_right = 570.0

--- a/project/src/main/ui/settings/settings-copy-save-data.gd
+++ b/project/src/main/ui/settings/settings-copy-save-data.gd
@@ -7,7 +7,7 @@ export var _save_slot_control_path: NodePath
 onready var _save_slot_control: SaveSlotControl = get_node(_save_slot_control_path)
 
 onready var _copied_label: Label = $HBoxContainer/Copied
-var _copied_tween: SceneTreeTween
+onready var _copied_tween: Tween = $HBoxContainer/CopiedTween
 
 func _ready() -> void:
 	# hide the 'Copied!' message until we need to display it
@@ -22,5 +22,5 @@ func _on_Button_pressed() -> void:
 	
 	# display the 'Copied!' message, and gradually fade it out
 	_copied_label.modulate = Color.white
-	_copied_tween = Utils.recreate_tween(self, _copied_tween)
-	_copied_tween.tween_property(_copied_label, "modulate", Color.transparent, 3.0)
+	_copied_tween.interpolate_property(_copied_label, "modulate", Color.white, Color.transparent, 3.0)
+	_copied_tween.start()

--- a/project/src/main/utils/utils.gd
+++ b/project/src/main/utils/utils.gd
@@ -325,23 +325,3 @@ static func ui_released_dir(event: InputEvent = null) -> bool:
 		if Input.is_action_just_released("ui_right"):
 			ui_dir += Vector2.RIGHT
 	return ui_dir.length() > 0
-
-
-## Creates/recreates a tween, invalidating it if it is already active.
-##
-## This is useful for SceneTreeTweens. These are designed to be created and thrown away, but tweening the same
-## property with multiple tweens creates unpredictable behavior. This recreate_tween method lets us ensure each
-## property is only being modified by a single tween.
-##
-## Parameters:
-## 	'node': The scene tree node which the tween should be bound to. This affects details like whether the tween
-## 		stops if the player pauses the game.
-##
-## 	'tween': The tween to invalidate. Can be null.
-##
-## Returns:
-## 	A new SceneTreeTween bound to the specified node.
-static func recreate_tween(node: Node, tween: SceneTreeTween) -> SceneTreeTween:
-	if tween:
-		tween.kill()
-	return node.create_tween()

--- a/project/src/main/world/creature/Creature.tscn
+++ b/project/src/main/world/creature/Creature.tscn
@@ -374,6 +374,8 @@ one_shot = true
 shape = SubResource( 1 )
 script = ExtResource( 8 )
 
+[node name="FadeTween" type="Tween" parent="."]
+
 [connection signal="food_eaten" from="." to="CreatureSfx" method="_on_Creature_food_eaten"]
 [connection signal="landed" from="." to="CreatureSfx" method="_on_Creature_landed"]
 [connection signal="timeout" from="CreatureSfx/SuppressSfxTimer" to="CreatureSfx" method="_on_SuppressSfxTimer_timeout"]

--- a/project/src/main/world/creature/CreatureVisuals.tscn
+++ b/project/src/main/world/creature/CreatureVisuals.tscn
@@ -741,6 +741,8 @@ script = ExtResource( 33 )
 emote_player_path = NodePath("../EmotePlayer")
 creature_visuals_path = NodePath("../..")
 
+[node name="Tween" type="Tween" parent="Animations"]
+
 [node name="EmotePlayer" parent="Animations" instance=ExtResource( 3 )]
 creature_animations_path = NodePath("..")
 

--- a/project/src/main/world/creature/EmotePlayer.tscn
+++ b/project/src/main/world/creature/EmotePlayer.tscn
@@ -4472,6 +4472,10 @@ anims/yes1 = SubResource( 62 )
 script = ExtResource( 12 )
 creature_visuals_path = NodePath("../..")
 
+[node name="ResetTween" type="Tween" parent="."]
+
+[node name="VolumeDbTween" type="Tween" parent="."]
+
 [node name="EmoteSfx" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 11 )
 bus = "Sound Bus"

--- a/project/src/main/world/creature/creature-animations.gd
+++ b/project/src/main/world/creature/creature-animations.gd
@@ -35,7 +35,7 @@ var creature_sfx: CreatureSfx setget set_creature_sfx
 onready var _idle_timer: Timer = $IdleTimer
 
 ## recoils the creature's head
-onready var _tween: SceneTreeTween
+onready var _tween: Tween = $Tween
 
 ## EmotePlayer which animates moods: blinking, smiling, sweating, etc.
 onready var _emote_player: AnimationPlayer = $EmotePlayer
@@ -110,9 +110,10 @@ func play_mood(mood: int) -> void:
 ## The 'feed' animation causes a few side-effects. The creature's head recoils and some sounds play. This method
 ## controls all of those secondary visual effects of the creature being fed.
 func show_food_effects() -> void:
-	_head_bobber.position.x = clamp(_head_bobber.position.x - 6, -20, 0)
-	_tween = Utils.recreate_tween(self, _tween).set_trans(Tween.TRANS_QUINT).set_ease(Tween.EASE_IN_OUT)
-	_tween.tween_property(_head_bobber, "position:x", 0.0, 0.5)
+	_tween.interpolate_property(_head_bobber, "position:x",
+			clamp(_head_bobber.position.x - 6, -20, 0), 0, 0.5,
+			Tween.TRANS_QUINT, Tween.EASE_IN_OUT)
+	_tween.start()
 
 
 ## Plays a movement animation with the specified animation name, such as 'run-sw'.

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -104,7 +104,7 @@ var _creature_outline: CreatureOutline
 onready var _creature_sfx: CreatureSfx = $CreatureSfx
 onready var _collision_shape: CollisionShape2D = $CollisionShape2D
 onready var _mouth_hook: Node2D = $MouthHook
-onready var _fade_tween: SceneTreeTween
+onready var _fade_tween: Tween = $FadeTween
 
 func _ready() -> void:
 	var creature_outline_scene_path := "res://src/main/world/creature/ViewportCreatureOutline.tscn"
@@ -130,6 +130,7 @@ func _ready() -> void:
 	
 	SceneTransition.connect("fade_in_started", self, "_on_SceneTransition_fade_in_started")
 	
+	_fade_tween.connect("tween_all_completed", self, "_on_FadeTween_tween_all_completed")
 	if creature_id:
 		_refresh_creature_id()
 	else:
@@ -439,9 +440,9 @@ func get_eating_delay() -> float:
 
 ## Starts a tween which changes this creature's opacity.
 func _launch_fade_tween(new_alpha: float, duration: float) -> void:
-	_fade_tween = Utils.recreate_tween(self, _fade_tween)
-	_fade_tween.connect("finished", self, "_on_FadeTween_finished")
-	_fade_tween.tween_property(self, "modulate", Utils.to_transparent(modulate, new_alpha), duration)
+	_fade_tween.remove_all()
+	_fade_tween.interpolate_property(self, "modulate", modulate, Utils.to_transparent(modulate, new_alpha), duration)
+	_fade_tween.start()
 
 
 func _refresh_creature_id() -> void:
@@ -595,14 +596,12 @@ func _on_CreatureVisuals_movement_mode_changed(_old_mode: int, new_mode: int) ->
 		set_elevation(0)
 
 
-func _on_FadeTween_finished() -> void:
+func _on_FadeTween_tween_all_completed() -> void:
 	if modulate.a == 0.0:
 		visible = false
 		emit_signal("fade_out_finished")
 	else:
 		emit_signal("fade_in_finished")
-
-
 func _on_CreatureVisuals_talking_changed() -> void:
 	emit_signal("talking_changed")
 

--- a/project/src/main/world/environment/ripple-sprite.gd
+++ b/project/src/main/world/environment/ripple-sprite.gd
@@ -9,7 +9,7 @@ const FADE_DURATION := 0.3
 
 export (Ripples.RippleState) var ripple_state := Ripples.RippleState.OFF setget set_ripple_state
 
-onready var _fade_tween: SceneTreeTween
+onready var _fade_tween: Tween = $FadeTween
 
 func _ready() -> void:
 	modulate = Color.transparent
@@ -34,8 +34,8 @@ func _refresh_ripple_state() -> void:
 	# fade the sprite in or out
 	var new_modulate := Color.transparent if ripple_state == Ripples.RippleState.OFF else Color.white
 	if modulate != new_modulate:
-		_fade_tween = Utils.recreate_tween(self, _fade_tween)
-		_fade_tween.tween_property(self, "modulate", new_modulate, FADE_DURATION)
+		_fade_tween.interpolate_property(self, "modulate", modulate, new_modulate, FADE_DURATION)
+		_fade_tween.start()
 	
 	# determine the animation to play. we change the animation if the sprite is flipped
 	var new_anim := ""


### PR DESCRIPTION
This reverts commit a1b1dbb8162c689787cea538a33916c818af4710.

Godot 3.5 introduced SceneTreeTweens, but these are still buggy and result in reference leaks. When running Turbo Fat's puzzle mode, the number of nodes gradually increases from 1,000 to 2,000, 3,000, and keeps growing without limit. After a few minutes the game becomes choppy and unplayable.

Removing the SceneTreeTweens fixes the problem. We can restore this code once Godot #52699 is closed, and SceneTreeTweens work as intended.

See https://github.com/godotengine/godot/issues/52699