### PR TITLE
Extracted ConfigStringUtils.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -174,6 +174,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/puzzle/combo-tracker.gd"
 }, {
+"base": "Reference",
+"class": "ConfigStringUtils",
+"language": "GDScript",
+"path": "res://src/main/puzzle/level/config-string-utils.gd"
+}, {
 "base": "KinematicBody2D",
 "class": "Creature",
 "language": "GDScript",
@@ -1123,6 +1128,7 @@ _global_script_class_icons={
 "ComboBreakRules": "",
 "ComboBurst": "",
 "ComboTracker": "",
+"ConfigStringUtils": "",
 "Creature": "",
 "CreatureAnimations": "",
 "CreatureCurve": "",

--- a/project/src/main/puzzle/level/config-string-utils.gd
+++ b/project/src/main/puzzle/level/config-string-utils.gd
@@ -1,0 +1,98 @@
+class_name ConfigStringUtils
+## Utilities for level config strings.
+
+## Converts a series of ints like [2, 3, 4, 5, 7] into a config string like '2-5,7'.
+##
+## config_string_from_ints([2, 3, 4])       = '2-4'
+## config_string_from_ints([3, 5, 7])       = '3,5,7'
+## config_string_from_ints([2, 3, 4, 5, 7]) = '2-5,7'
+## config_string_from_ints([7, 2, 4, 3, 5]) = '2-5,7'
+## config_string_from_ints([])              = ''
+##
+## Parameters:
+## 	'ints': A series of ints like [2, 3, 4, 5, 7].
+##
+## Returns:
+## 	A config string like '2-5,7'
+static func config_string_from_ints(ints: Array) -> String:
+	if not ints:
+		return ""
+	
+	var config_string := ""
+	ints = ints.duplicate()
+	ints.sort()
+	
+	var range_start: int = ints[0]
+	for i in range(ints.size()):
+		var include_next: bool = i < ints.size() - 1 and ints[i + 1] == ints[i] + 1
+		
+		if not include_next:
+			var range_end: int = ints[i]
+			if config_string:
+				config_string += ","
+			if range_start == range_end:
+				# isolated values are output as "1,3,5"
+				config_string += str(range_start)
+			else:
+				# adjacent values are hyphenated as "1-3, 5-9"
+				config_string += "%s-%s" % [range_start, range_end]
+			
+			if i < ints.size() - 1:
+				range_start = ints[i + 1]
+	
+	return config_string
+
+
+## Converts a config string like '2-5,7' into a series of ints like [2, 3, 4, 5, 7].
+##
+## ints_from_config_string('2-4')   = [2, 3, 4]
+## ints_from_config_string('3,5,7') = [3, 5, 7]
+## ints_from_config_string('2-5,7') = [2, 3, 4, 5, 7]
+## ints_from_config_string('7,2-5') = [2, 3, 4, 5, 7]
+## ints_from_config_string('')      = []
+##
+## Parameters:
+## 	'config_string': A config string like '2-5,7'
+##
+## Returns:
+## 	A series of ints like [2, 3, 4, 5, 7]
+static func ints_from_config_string(config_string: String) -> Array:
+	if not config_string:
+		return []
+	
+	var ints := {}
+	
+	for sub_expression in config_string.split(","):
+		var lo: int
+		var hi: int
+		if "-" in sub_expression:
+			lo = int(StringUtils.substring_before(sub_expression, "-"))
+			hi = int(StringUtils.substring_after(sub_expression, "-")) + 1
+		else:
+			lo = int(sub_expression)
+			hi = int(sub_expression) + 1
+		for y in range(lo, hi):
+			ints[y] = true
+	
+	var result := ints.keys()
+	result.sort()
+	return result
+
+
+## Converts an array of user-friendly puzzle row indexes like [0, 1] into row numbers like [19, 18] or vice-versa.
+##
+## Our config files use coordinates where '0' is the bottom row of the playfield and '16' is the top. But our tilemap
+## represents '19' as the bottom row of the playfield and '3' as the highest visible row. (There are three additional
+## rows above it.)
+##
+## Parameters:
+## 	'lines': A list of puzzle row indexes -- either indexes where '0' is the bottom row, or indexes where '19' is
+## 		the bottom row.
+##
+## Returns:
+## 	The opposite type of puzzle row indexes to the ones passed in.
+static func invert_puzzle_row_indexes(lines: Array) -> Array:
+	var new_lines := []
+	for line in lines:
+		new_lines.append(PuzzleTileMap.ROW_COUNT - line - 1)
+	return new_lines

--- a/project/src/test/puzzle/level/test-config-string-utils.gd
+++ b/project/src/test/puzzle/level/test-config-string-utils.gd
@@ -1,0 +1,20 @@
+extends "res://addons/gut/test.gd"
+
+func test_ints_from_config_string() -> void:
+	assert_eq([], ConfigStringUtils.ints_from_config_string(""))
+	assert_eq([2], ConfigStringUtils.ints_from_config_string("2"))
+	assert_eq([1, 3, 5], ConfigStringUtils.ints_from_config_string("1,3,5"))
+	assert_eq([0, 1, 2, 3], ConfigStringUtils.ints_from_config_string("0-3"))
+	assert_eq([1, 2, 4, 5], ConfigStringUtils.ints_from_config_string("1-2,4-5"))
+	assert_eq([0, 4, 5, 6], ConfigStringUtils.ints_from_config_string("0,4-6"))
+	assert_eq([2, 3, 4, 6, 13], ConfigStringUtils.ints_from_config_string("6,2-4,13"))
+
+
+func test_config_string_from_ints() -> void:
+	assert_eq("", ConfigStringUtils.config_string_from_ints([]))
+	assert_eq("2", ConfigStringUtils.config_string_from_ints([2]))
+	assert_eq("1,3,5", ConfigStringUtils.config_string_from_ints([1, 3, 5]))
+	assert_eq("1-2,4-5", ConfigStringUtils.config_string_from_ints([1, 2, 4, 5]))
+	assert_eq("0-3", ConfigStringUtils.config_string_from_ints([0, 1, 2, 3]))
+	assert_eq("0,4-6", ConfigStringUtils.config_string_from_ints([0, 4, 5, 6]))
+	assert_eq("2-4,6,13", ConfigStringUtils.config_string_from_ints([4, 3, 6, 13, 2]))


### PR DESCRIPTION
This breaks the AfterLineCleared phase condition into three simple easy-to-understand parts -- translating strings to int arrays, inverting the int arrays, and combining those two pieces in the AfterLineCleared phase condition. The first two parts are generic and can be reused by other phase conditions or effects in the future.