### PR TITLE
Mole cleanup: StateMachine scene, Playfield.pickups

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -704,6 +704,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/editor/puzzle/pickup-level-chunk-control.gd"
 }, {
+"base": "Control",
+"class": "Pickups",
+"language": "GDScript",
+"path": "res://src/main/puzzle/pickups.gd"
+}, {
 "base": "Node",
 "class": "PieceInput",
 "language": "GDScript",
@@ -1234,6 +1239,7 @@ _global_script_class_icons={
 "Pickup": "",
 "PickupLevelChunk": "",
 "PickupLevelChunkControl": "",
+"Pickups": "",
 "PieceInput": "",
 "PieceManager": "",
 "PieceMover": "",

--- a/project/src/main/puzzle/pickups.gd
+++ b/project/src/main/puzzle/pickups.gd
@@ -1,3 +1,4 @@
+class_name Pickups
 extends Control
 ## Creates pickups on the playfield for certain levels.
 ##
@@ -46,6 +47,15 @@ func _ready() -> void:
 	_prepare_pickups_for_level()
 
 
+## Returns the pickup at the specified playfield cell.
+##
+## Returns TileMap.INVALID_CELL if the specified cell has no pickup.
+func get_pickup(cell: Vector2) -> int:
+	if not _pickups_by_cell.has(cell):
+		return TileMap.INVALID_CELL
+	return _pickups_by_cell[cell].food_type
+
+
 ## Adds or replaces a pickup in a playfield cell.
 func set_pickup(cell: Vector2, box_type: int) -> void:
 	remove_pickup(cell)
@@ -81,7 +91,7 @@ func clear() -> void:
 
 ## Spawns any pickups necessary for starting the current level.
 func _prepare_pickups_for_level() -> void:
-	var src_pickups := CurrentLevel.settings.tiles.blocks_start().pickups
+	var src_pickups: Dictionary = CurrentLevel.settings.tiles.blocks_start().pickups
 	
 	var pickups_to_add := []
 	var pickups_to_remove := []
@@ -302,7 +312,7 @@ func _on_Playfield_line_inserted(y: int, tiles_key: String, src_y: int) -> void:
 	_shift_rows(y, Vector2.UP)
 	
 	# fill in the new gaps with pickups
-	var block_bunch := CurrentLevel.settings.tiles.get_tiles(tiles_key)
+	var block_bunch: LevelTiles.BlockBunch = CurrentLevel.settings.tiles.get_tiles(tiles_key)
 	for x in range(PuzzleTileMap.COL_COUNT):
 		var src_pos := Vector2(x, src_y)
 		if not block_bunch.pickups.has(src_pos):
@@ -322,7 +332,7 @@ func _on_Pauser_paused_changed(value: bool) -> void:
 
 func _on_Playfield_line_filled(y: int, tiles_key: String, src_y: int) -> void:
 	# fill in the new gaps with pickups
-	var block_bunch := CurrentLevel.settings.tiles.get_tiles(tiles_key)
+	var block_bunch: LevelTiles.BlockBunch = CurrentLevel.settings.tiles.get_tiles(tiles_key)
 	for x in range(PuzzleTileMap.COL_COUNT):
 		var src_pos := Vector2(x, src_y)
 		if not block_bunch.pickups.has(src_pos):

--- a/project/src/main/puzzle/piece/PieceManager.tscn
+++ b/project/src/main/puzzle/piece/PieceManager.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=41 format=2]
+[gd_scene load_steps=42 format=2]
 
 [ext_resource path="res://src/main/puzzle/piece/squish-fx.gd" type="Script" id=1]
 [ext_resource path="res://assets/main/filled-circle-8.png" type="Texture" id=2]
@@ -34,6 +34,7 @@
 [ext_resource path="res://src/main/puzzle/piece/tech-move-detector.gd" type="Script" id=32]
 [ext_resource path="res://assets/main/puzzle/rotate-sealed.wav" type="AudioStream" id=33]
 [ext_resource path="res://assets/main/puzzle/tech-move.wav" type="AudioStream" id=34]
+[ext_resource path="res://src/main/utils/StateMachine.tscn" type="PackedScene" id=35]
 
 [sub_resource type="ShaderMaterial" id=1]
 resource_local_to_scene = true
@@ -116,7 +117,7 @@ autostart = true
 stream = ExtResource( 25 )
 script = ExtResource( 24 )
 
-[node name="States" type="Node" parent="."]
+[node name="States" parent="." instance=ExtResource( 35 )]
 script = ExtResource( 19 )
 
 [node name="None" type="Node" parent="States"]

--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -188,7 +188,7 @@ func apply_lock() -> void:
 
 
 func is_playfield_clearing_lines() -> bool:
-	return _playfield.get_remaining_line_erase_frames() > 0
+	return _playfield.is_clearing_lines()
 
 
 ## Returns the y coordinate of lines currently being cleared.

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -44,14 +44,14 @@ signal blocks_prepared
 ## remaining frames to delay for something besides making boxes/clearing lines
 var _remaining_misc_delay_frames := 0
 
-onready var tile_map := $TileMapClip/TileMap
-onready var pickups := $TileMapClip/Pickups
-onready var line_inserter := $LineInserter
+onready var tile_map: PuzzleTileMap = $TileMapClip/TileMap
+onready var pickups: Pickups = $TileMapClip/Pickups
+onready var line_inserter: LineInserter = $LineInserter
+onready var line_clearer: LineClearer = $LineClearer
 
 onready var _bg_glob_viewports: GoopViewports = $BgGlobViewports
 onready var _box_builder: BoxBuilder = $BoxBuilder
 onready var _combo_tracker: ComboTracker = $ComboTracker
-onready var line_clearer: LineClearer = $LineClearer
 
 func _ready() -> void:
 	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
@@ -76,8 +76,8 @@ func _physics_process(delta: float) -> void:
 		_remaining_misc_delay_frames -= 1
 
 
-func get_remaining_line_erase_frames() -> int:
-	return line_clearer.remaining_line_erase_frames
+func is_clearing_lines() -> bool:
+	return line_clearer.remaining_line_erase_frames > 0
 
 
 ## Returns the y coordinate of lines currently being cleared.
@@ -85,8 +85,8 @@ func get_lines_being_cleared() -> Array:
 	return line_clearer.lines_being_cleared
 
 
-func get_remaining_box_build_frames() -> int:
-	return _box_builder.remaining_box_build_frames
+func is_building_boxes() -> bool:
+	return _box_builder.remaining_box_build_frames > 0
 
 
 func add_misc_delay_frames(frames: int) -> void:

--- a/project/src/main/puzzle/puzzle-tile-map.gd
+++ b/project/src/main/puzzle/puzzle-tile-map.gd
@@ -48,6 +48,14 @@ func _ready() -> void:
 	clear()
 
 
+func is_cake_cell(cell: Vector2) -> bool:
+	return get_cellv(cell) == TILE_BOX and Foods.is_cake_box(get_cell_autotile_coord(cell.x, cell.y).y)
+
+
+func is_snack_cell(cell: Vector2) -> bool:
+	return get_cellv(cell) == TILE_BOX and Foods.is_snack_box(get_cell_autotile_coord(cell.x, cell.y).y)
+
+
 func set_ghost_shadow_offset(new_ghost_shadow_offset: Vector2) -> void:
 	ghost_shadow_offset = new_ghost_shadow_offset
 
@@ -171,6 +179,7 @@ func erase_playfield_row(y: int) -> void:
 			_disconnect_box(Vector2(x, y))
 		
 		set_block(Vector2(x, y), -1)
+
 
 ## Sets the whiteness property to make the tilemap flash or blink.
 func set_whiteness(new_whiteness: float) -> void:

--- a/project/src/main/puzzle/puzzle-trace.gd
+++ b/project/src/main/puzzle/puzzle-trace.gd
@@ -13,8 +13,8 @@ func _process(_delta: float) -> void:
 		var new_text := ""
 		
 		new_text += "%1d" % [min(9, _combo_tracker.combo_break)]
-		new_text += "l" if _playfield.get_remaining_line_erase_frames() > 0 else "-"
-		new_text += "b" if _playfield.get_remaining_box_build_frames() > 0 else "-"
+		new_text += "l" if _playfield.is_clearing_lines() else "-"
+		new_text += "b" if _playfield.is_building_boxes() else "-"
 		new_text += "r" if _playfield.ready_for_new_piece() else "-"
 		new_text += " %s(%02d)" % [_piece_manager.get_state().name.left(4), min(99, _piece_manager.get_state().frames)]
 		new_text += "\n"

--- a/project/src/main/utils/StateMachine.tscn
+++ b/project/src/main/utils/StateMachine.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/main/utils/state-machine.gd" type="Script" id=1]
+
+[node name="States" type="Node"]
+script = ExtResource( 1 )

--- a/project/src/test/puzzle/level/test-level-trigger-effects.gd
+++ b/project/src/test/puzzle/level/test-level-trigger-effects.gd
@@ -1,6 +1,6 @@
 extends "res://addons/gut/test.gd"
 
-func test_rotate_next_pieces_to_json_string() -> void:
+func test_rotate_next_pieces_get_config() -> void:
 	var effect: LevelTriggerEffects.RotateNextPiecesEffect
 	effect = LevelTriggerEffects.RotateNextPiecesEffect.new()
 	assert_eq_shallow(effect.get_config(), {"0": "none"})
@@ -14,7 +14,7 @@ func test_rotate_next_pieces_to_json_string() -> void:
 	assert_eq_shallow(effect.get_config(), {"0": "180"})
 
 
-func test_insert_line_to_json_string_0() -> void:
+func test_insert_line_get_config_0() -> void:
 	var effect: LevelTriggerEffects.InsertLineEffect
 	effect = LevelTriggerEffects.InsertLineEffect.new()
 	assert_eq_shallow(effect.get_config(), {})
@@ -24,7 +24,7 @@ func test_insert_line_to_json_string_0() -> void:
 	assert_eq_shallow(effect.get_config(), {"tiles_key": "0"})
 
 
-func test_insert_line_to_json_string_1() -> void:
+func test_insert_line_get_config_1() -> void:
 	var effect: LevelTriggerEffects.InsertLineEffect
 	effect = LevelTriggerEffects.InsertLineEffect.new()
 	assert_eq_shallow(effect.get_config(), {})


### PR DESCRIPTION
Extracted StateMachine scene.

Explicit typing for Playfield.pickups field.

Exposed new methods: Pickups.get_pickup, PuzzleTileMap.is_cake_cell, PuzzleTileMap.is_snack_cell. This basic functionality is needed for new puzzle mechanics.

Replaced Playfield.get_remaining_line_erase_frames, Playfield.get_remaining_box_build_frames with less granular 'is_clearing_lines' 'is_building_boxes' functionality. Nobody outside Playfield needs a more granular level of information than this.

Renamed LevelTriggerEffect test methods; the old test names referenced 'to_json_string' which does not match the method being tested.