### PR TITLE
Add unused career levels; perfect_fit, fruit_on_the_top

### DIFF
--- a/project/assets/main/puzzle/career-regions.json
+++ b/project/assets/main/puzzle/career-regions.json
@@ -54,7 +54,7 @@
           "id": "career/donuts"
         },
         {
-          "id": "career/fat_stacks"
+          "id": "career/perfect_fit"
         },
         {
           "id": "career/just_bread"
@@ -175,7 +175,7 @@
           "id": "career/creeping_crevice"
         },
         {
-          "id": "career/lets_all_get_merry"
+          "id": "career/fruit_on_the_top"
         },
         {
           "id": "career/strawberry_shortcut"
@@ -432,7 +432,7 @@
           "id": "career/wedding_cake_for_one"
         },
         {
-          "id": "career/paranormal_tetrominon"
+          "id": "career/fruit_on_the_top"
         }
       ]
     },

--- a/project/src/demo/puzzle/PuzzleDemo.tscn
+++ b/project/src/demo/puzzle/PuzzleDemo.tscn
@@ -5,6 +5,6 @@
 
 [node name="PuzzleDemo" type="Node"]
 script = ExtResource( 2 )
-level_path = "res://assets/demo/puzzle/levels/oafish-wary.json"
+level_path = "res://assets/main/puzzle/levels/career/fruit-on-the-top.json"
 
 [node name="Puzzle" parent="." instance=ExtResource( 1 )]

--- a/project/src/main/career/career-level-library.gd
+++ b/project/src/main/career/career-level-library.gd
@@ -24,6 +24,10 @@ func all_level_ids() -> Array:
 	for region in regions:
 		for career_level in region.levels:
 			result[career_level.level_id] = true
+		if region.boss_level:
+			result[region.boss_level.level_id] = true
+		if region.intro_level:
+			result[region.intro_level.level_id] = true
 	return result.keys()
 
 


### PR DESCRIPTION
These were added to the career folder, but never assigned regions. I've updated the ReleaseToolkit to detect unused levels.