### PR TITLE
Fixed LineInserter bug with tiles_key arrays. invert_lines typo.

### DIFF
--- a/project/src/main/puzzle/level/level-trigger-effects.gd
+++ b/project/src/main/puzzle/level/level-trigger-effects.gd
@@ -14,7 +14,7 @@ class AddMolesEffect extends LevelTriggerEffect:
 			config.home = Utils.enum_from_snake_case(MoleConfig.Home, new_config["home"])
 		if new_config.has("y"):
 			var inverted_lines := ConfigStringUtils.ints_from_config_string(new_config["y"])
-			config.lines = ConfigStringUtils.invert_lines(inverted_lines)
+			config.lines = ConfigStringUtils.invert_puzzle_row_indexes(inverted_lines)
 		if new_config.has("x"):
 			config.columns = ConfigStringUtils.ints_from_config_string(new_config["x"])
 		if new_config.has("dig_duration"):
@@ -35,7 +35,7 @@ class AddMolesEffect extends LevelTriggerEffect:
 		if config.home != MoleConfig.Home.ANY:
 			result["home"] = Utils.enum_to_snake_case(MoleConfig.Home, config.home)
 		if config.lines:
-			var inverted_lines: Array = ConfigStringUtils.invert_lines(config.lines)
+			var inverted_lines: Array = ConfigStringUtils.invert_puzzle_row_indexes(config.lines)
 			result["y"] = ConfigStringUtils.config_string_from_ints(inverted_lines)
 		if config.columns:
 			result["x"] = ConfigStringUtils.config_string_from_ints(config.columns)

--- a/project/src/main/puzzle/line-inserter.gd
+++ b/project/src/main/puzzle/line-inserter.gd
@@ -24,8 +24,13 @@ var _row_bag_by_tiles_key := {}
 ## value: (int) the total number of rows in the referenced tiles
 var _row_count_by_tiles_key := {}
 
-var _prev_tiles_key := ""
-var _prev_tiles_key_insert_count := 0
+## key: (Array) a tiles_keys array previously provided to the insert_line() method
+## value: (String) the previous tiles key referenced that tiles keys array
+var _prev_tiles_key_by_tiles_keys := {}
+
+## key: (Array) a tiles_keys array previously provided to the insert_line() method
+## value: (String) the number of insert statements from that tiles keys array
+var _prev_tiles_key_insert_count_by_tiles_keys := {}
 
 onready var _tile_map: PuzzleTileMap = get_node(tile_map_path)
 onready var _line_insert_sound := $LineInsertSound
@@ -71,7 +76,7 @@ func insert_line(tiles_keys: Array = [], dest_y: int = PuzzleTileMap.ROW_COUNT -
 			_tile_map.set_block(Vector2(x, dest_y), PuzzleTileMap.TILE_VEG, veg_autotile_coord)
 		_tile_map.set_block(Vector2(randi() % PuzzleTileMap.COL_COUNT, dest_y), -1)
 	
-	_prev_tiles_key = tiles_key
+	_prev_tiles_key_by_tiles_keys[tiles_keys] = tiles_key
 	emit_signal("line_inserted", dest_y, tiles_key, src_y)
 
 
@@ -82,21 +87,23 @@ func insert_line(tiles_keys: Array = [], dest_y: int = PuzzleTileMap.ROW_COUNT -
 func _determine_tiles_key(tiles_keys: Array) -> String:
 	var result: String
 	
+	var prev_tiles_key: String = _prev_tiles_key_by_tiles_keys.get(tiles_keys, "")
+	var prev_tiles_key_insert_count: int = _prev_tiles_key_insert_count_by_tiles_keys.get(tiles_keys, 0)
+	
 	if not tiles_keys:
 		result = ""
-		_prev_tiles_key_insert_count = 0
-	elif _prev_tiles_key and _prev_tiles_key_insert_count < _row_count_by_tiles_key[_prev_tiles_key]:
+	elif prev_tiles_key and prev_tiles_key_insert_count < _row_count_by_tiles_key[prev_tiles_key]:
 		# the previously used tiles key isn't exhausted, continue using it
-		result = _prev_tiles_key
-		_prev_tiles_key_insert_count += 1
+		result = prev_tiles_key
+		_prev_tiles_key_insert_count_by_tiles_keys[tiles_keys] = prev_tiles_key_insert_count + 1
 	else:
 		# the previously used tiles key is exhausted, pick a new tiles key.
 		var possible_tiles_keys := tiles_keys.duplicate()
-		if possible_tiles_keys.size() > 1 and _prev_tiles_key:
+		if possible_tiles_keys.size() > 1 and prev_tiles_key:
 			# avoid picking the same key twice
-			possible_tiles_keys.remove(possible_tiles_keys.find(_prev_tiles_key))
+			possible_tiles_keys.remove(possible_tiles_keys.find(prev_tiles_key))
 		result = Utils.rand_value(possible_tiles_keys)
-		_prev_tiles_key_insert_count = 1
+		_prev_tiles_key_insert_count_by_tiles_keys[tiles_keys] = 1
 	
 	return result
 
@@ -136,8 +143,8 @@ func _reset() -> void:
 	_row_bag_by_tiles_key.clear()
 	_row_count_by_tiles_key.clear()
 	
-	_prev_tiles_key = ""
-	_prev_tiles_key_insert_count = 0
+	_prev_tiles_key_by_tiles_keys.clear()
+	_prev_tiles_key_insert_count_by_tiles_keys.clear()
 	
 	# initialize _row_count_by_tiles_key
 	for tiles_key in CurrentLevel.settings.tiles.bunches:


### PR DESCRIPTION
Fixed bug where if levels had multiple tiles_keys arrays, LineInserter would continue using the previously used one. This was because it could only keep track of one 'previous tiles key' even if there were multiple arrays in use.

The new implementation stores one 'previous tiles key' for each tiles keys array. This works because we always pass in the same tiles key reference from our configuration.