### PR TITLE
Renamed level trigger phases: 'line_cleared', 'piece_written'

### DIFF
--- a/project/src/demo/puzzle/PuzzleDemo.tscn
+++ b/project/src/demo/puzzle/PuzzleDemo.tscn
@@ -5,6 +5,6 @@
 
 [node name="PuzzleDemo" type="Node"]
 script = ExtResource( 2 )
-level_path = "res://assets/main/puzzle/levels/career/fruit-on-the-top.json"
+level_path = "res://assets/demo/puzzle/levels/oafish-wary.json"
 
 [node name="Puzzle" parent="." instance=ExtResource( 1 )]

--- a/project/src/main/puzzle/level/level-settings-upgrader.gd
+++ b/project/src/main/puzzle/level/level-settings-upgrader.gd
@@ -21,6 +21,7 @@ var current_version: String
 
 func _init() -> void:
 	current_version = Levels.LEVEL_DATA_VERSION
+	_add_upgrade_method("_upgrade_392b", "392b", "39e5")
 	_add_upgrade_method("_upgrade_2cb4", "2cb4", "392b")
 	_add_upgrade_method("_upgrade_297a", "297a", "2cb4")
 	_add_upgrade_method("_upgrade_19c5", "19c5", "297a")
@@ -90,6 +91,23 @@ func _add_upgrade_method(method: String, old_version: String, new_version: Strin
 	upgrade_method.old_version = old_version
 	upgrade_method.new_version = new_version
 	_upgrade_methods[old_version] = upgrade_method
+
+
+func _upgrade_392b(old_json: Dictionary, old_key: String, new_json: Dictionary) -> Dictionary:
+	match old_key:
+		"triggers":
+			var new_value: Array = old_json[old_key].duplicate(true)
+			for trigger in new_value:
+				for phase_index in range(trigger.get("phases", []).size()):
+					var phase: String = trigger["phases"][phase_index]
+					if phase.begins_with("after_line_cleared "):
+						trigger["phases"][phase_index] = phase.replace("after_line_cleared", "line_cleared")
+					if phase.begins_with("after_piece_written "):
+						trigger["phases"][phase_index] = phase.replace("after_piece_written", "piece_written")
+			new_json[old_key] = new_value
+		_:
+			new_json[old_key] = old_json[old_key]
+	return new_json
 
 
 func _upgrade_2cb4(old_json: Dictionary, old_key: String, new_json: Dictionary) -> Dictionary:

--- a/project/src/main/puzzle/level/level-trigger.gd
+++ b/project/src/main/puzzle/level/level-trigger.gd
@@ -7,11 +7,11 @@ class_name LevelTrigger
 
 ## phases when a level trigger can fire
 enum LevelTriggerPhase {
-	AFTER_PIECE_WRITTEN, # after the piece is written, and all boxes are made, and all lines are cleared
-	AFTER_LINE_CLEARED,
 	INITIAL_ROTATED_CW, # when the piece is rotated clockwise using initial DAS
 	INITIAL_ROTATED_CCW, # when the piece is rotated counterclockwise using initial DAS
 	INITIAL_ROTATED_180, # when the piece is flipped using initial DAS
+	LINE_CLEARED, # after the line is erased for a line clear, but before the lines above are shifted
+	PIECE_WRITTEN, # after the piece is written, and all boxes are made, and all lines are cleared
 	ROTATED_CW, # when the piece is rotated clockwise
 	ROTATED_CCW, # when the piece is rotated counterclockwise
 	ROTATED_180, # when the piece is flipped
@@ -20,11 +20,11 @@ enum LevelTriggerPhase {
 	TIMER_2, # when timer 2 times out
 }
 
-const AFTER_PIECE_WRITTEN := LevelTriggerPhase.AFTER_PIECE_WRITTEN
-const AFTER_LINE_CLEARED := LevelTriggerPhase.AFTER_LINE_CLEARED
 const INITIAL_ROTATED_CW := LevelTriggerPhase.INITIAL_ROTATED_CW
 const INITIAL_ROTATED_CCW := LevelTriggerPhase.INITIAL_ROTATED_CCW
 const INITIAL_ROTATED_180 := LevelTriggerPhase.INITIAL_ROTATED_180
+const LINE_CLEARED := LevelTriggerPhase.LINE_CLEARED
+const PIECE_WRITTEN := LevelTriggerPhase.PIECE_WRITTEN
 const ROTATED_CW := LevelTriggerPhase.ROTATED_CW
 const ROTATED_CCW := LevelTriggerPhase.ROTATED_CCW
 const ROTATED_180 := LevelTriggerPhase.ROTATED_180

--- a/project/src/main/puzzle/level/levels.gd
+++ b/project/src/main/puzzle/level/levels.gd
@@ -15,4 +15,4 @@ enum Result {
 
 ## Current version for saved level data. Should be updated if and only if the level format changes.
 ## This version number follows a 'ymdh' hex date format which is documented in issue #234.
-const LEVEL_DATA_VERSION := "392b"
+const LEVEL_DATA_VERSION := "39e5"

--- a/project/src/main/puzzle/level/phase-conditions.gd
+++ b/project/src/main/puzzle/level/phase-conditions.gd
@@ -3,7 +3,7 @@ extends Node
 ##
 ## These conditions are each mapped to a unique string so that they can be referenced from json.
 
-class AfterPieceWrittenPhaseCondition extends PhaseCondition:
+class PieceWrittenPhaseCondition extends PhaseCondition:
 	## We precalculate which pieces will trigger the rule, up to this number of pieces.
 	## 20,000 corresponds to an expert player playing at ~200 PPM for two hours.
 	const MAX_PIECE_INDEX := 20000
@@ -22,7 +22,7 @@ class AfterPieceWrittenPhaseCondition extends PhaseCondition:
 	## value: (bool) true
 	var _combos_to_run := {}
 	
-	## Creates a new AfterPieceWrittenPhaseCondition instance with the specified configuration.
+	## Creates a new PieceWrittenPhaseCondition instance with the specified configuration.
 	##
 	## The phase_config parameter accepts an optional 'n' expression defining which pieces will fire this trigger.
 	## 0 is the first piece placed.
@@ -120,12 +120,12 @@ class AfterPieceWrittenPhaseCondition extends PhaseCondition:
 		return result
 
 
-class AfterLineClearedPhaseCondition extends PhaseCondition:
+class LineClearedPhaseCondition extends PhaseCondition:
 	## key: (int) a line which causes the trigger to fire when cleared. 0 is the highest line in the playfield.
 	## value: (bool) true
 	var which_lines := {}
 	
-	## Creates a new AfterLineClearedPhaseCondition instance with the specified configuration.
+	## Creates a new LineClearedPhaseCondition instance with the specified configuration.
 	##
 	## The phase_config parameter accepts an optional 'y' expression defining which line clears will fire this trigger.
 	## Commas and hyphens are accepted, 0 is the lowest line in the playfield.
@@ -170,8 +170,8 @@ class AfterLineClearedPhaseCondition extends PhaseCondition:
 		return {"y": y_expression}
 
 var phase_conditions_by_string := {
-	"after_line_cleared": AfterLineClearedPhaseCondition,
-	"after_piece_written": AfterPieceWrittenPhaseCondition,
+	"piece_written": PieceWrittenPhaseCondition,
+	"line_cleared": LineClearedPhaseCondition,
 }
 
 ## Creates a new PhaseCondition instance.

--- a/project/src/main/puzzle/line-clearer.gd
+++ b/project/src/main/puzzle/line-clearer.gd
@@ -117,7 +117,7 @@ func clear_line(y: int, total_lines: int, remaining_lines: int) -> void:
 func schedule_full_row_line_clears() -> void:
 	var lines_to_clear := []
 	for y in range(PuzzleTileMap.ROW_COUNT):
-		if _tile_map.playfield_row_is_full(y):
+		if _tile_map.row_is_full(y):
 			lines_to_clear.append(y)
 	if lines_to_clear:
 		schedule_line_clears(lines_to_clear, PieceSpeeds.current_speed.line_clear_delay)
@@ -136,7 +136,7 @@ func schedule_line_clears(lines_to_clear: Array, line_clear_delay: int, award_po
 	var unscheduled_erases := []
 	if award_points:
 		for y in lines_to_clear:
-			if _box_ints(y) or _tile_map.playfield_row_is_full(y):
+			if _box_ints(y) or _tile_map.row_is_full(y):
 				unscheduled_clears.append(y)
 			else:
 				unscheduled_erases.append(y)
@@ -190,7 +190,7 @@ func _per_line_frame_delay() -> float:
 ## increase the combo or award points.
 func _erase_line(y: int, total_lines: int, remaining_lines: int) -> void:
 	var box_ints:= _box_ints(y)
-	_tile_map.erase_playfield_row(y)
+	_tile_map.erase_row(y)
 	if _rows_to_preserve_at_end:
 		_rows_to_preserve_at_end.erase(y)
 	emit_signal("line_erased", y, total_lines, remaining_lines, box_ints)
@@ -213,7 +213,7 @@ func _delete_lines(old_lines_being_cleared: Array, _old_lines_being_erased: Arra
 	old_lines_being_deleted.sort()
 	var max_line: int = old_lines_being_deleted.back() if old_lines_being_deleted else -1
 	for y in range(max_line):
-		if not _tile_map.playfield_row_is_empty(y) and not old_lines_being_deleted.has(y):
+		if not _tile_map.row_is_empty(y) and not old_lines_being_deleted.has(y):
 			play_sound = true
 			break
 	
@@ -240,7 +240,7 @@ func _delete_lines(old_lines_being_cleared: Array, _old_lines_being_erased: Arra
 	
 	if old_lines_being_cleared:
 		for line in old_lines_being_cleared:
-			CurrentLevel.settings.triggers.run_triggers(LevelTrigger.AFTER_LINE_CLEARED, {"y": line})
+			CurrentLevel.settings.triggers.run_triggers(LevelTrigger.LINE_CLEARED, {"y": line})
 	
 	for i in range(lines_being_deleted_during_trigger.size()):
 		emit_signal("line_deleted", lines_being_deleted_during_trigger[i])
@@ -287,7 +287,7 @@ func schedule_finish_line_clears() -> void:
 	var full_lines := []
 	var box_lines := []
 	for y in range(PuzzleTileMap.ROW_COUNT):
-		if _tile_map.playfield_row_is_full(y):
+		if _tile_map.row_is_full(y):
 			full_lines.append(y)
 		elif _box_ints(y) and not _rows_to_preserve_at_end.has(y):
 			box_lines.append(y)

--- a/project/src/main/puzzle/line-filler.gd
+++ b/project/src/main/puzzle/line-filler.gd
@@ -94,7 +94,7 @@ func _fill_empty_lines() -> void:
 	# fill the empty rows from bottom to top
 	var y := PuzzleTileMap.ROW_COUNT - 1
 	while y >= 0:
-		if _tile_map.playfield_row_is_empty(y):
+		if _tile_map.row_is_empty(y):
 			_fill_line(_fill_lines_tiles_key(), y)
 		y -= 1
 	

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -234,7 +234,7 @@ func _on_Pickups_food_spawned(cell: Vector2, remaining_food: int, food_type: int
 
 
 func _on_PuzzleState_after_piece_written() -> void:
-	CurrentLevel.settings.triggers.run_triggers(LevelTrigger.AFTER_PIECE_WRITTEN)
+	CurrentLevel.settings.triggers.run_triggers(LevelTrigger.PIECE_WRITTEN)
 
 
 func _on_LineClearer_all_lines_cleared() -> void:

--- a/project/src/main/puzzle/puzzle-tile-map.gd
+++ b/project/src/main/puzzle/puzzle-tile-map.gd
@@ -122,13 +122,13 @@ func build_box(rect: Rect2, box_type: int) -> void:
 
 ## Deletes the row at the specified location, lowering all higher rows to fill the gap.
 func delete_row(y: int) -> void:
-	erase_playfield_row(y)
-	_shift_rows(y - 1, Vector2.DOWN)
+	erase_row(y)
+	shift_rows(y - 1, Vector2.DOWN)
 
 
 ## Inserts a blank row at the specified location, raising all higher rows to make room.
 func insert_row(y: int) -> void:
-	_shift_rows(y, Vector2.UP)
+	shift_rows(y, Vector2.UP)
 
 
 ## Deletes the specified row in the tilemap, dropping all higher rows down to fill the gap.
@@ -151,7 +151,7 @@ func is_cell_obstructed(pos: Vector2) -> bool:
 
 
 ## Returns true if the specified row has no empty cells.
-func playfield_row_is_full(y: int) -> bool:
+func row_is_full(y: int) -> bool:
 	var row_is_full := true
 	for x in range(COL_COUNT):
 		if is_cell_empty(Vector2(x, y)):
@@ -161,7 +161,7 @@ func playfield_row_is_full(y: int) -> bool:
 
 
 ## Returns true if the specified row has only empty cells.
-func playfield_row_is_empty(y: int) -> bool:
+func row_is_empty(y: int) -> bool:
 	var row_is_empty := true
 	for x in range(COL_COUNT):
 		if not is_cell_empty(Vector2(x, y)):
@@ -171,7 +171,7 @@ func playfield_row_is_empty(y: int) -> bool:
 
 
 ## Erases all cells in the specified row.
-func erase_playfield_row(y: int) -> void:
+func erase_row(y: int) -> void:
 	for x in range(COL_COUNT):
 		if get_cellv(Vector2(x, y)) == 0:
 			_convert_piece_to_veg(Vector2(x, y))
@@ -269,7 +269,7 @@ func _disconnect_block(pos: Vector2, dir_mask: int = 15) -> void:
 ## 	'bottom_row': The lowest row to shift. All rows at or above this row will be shifted.
 ##
 ## 	'direction': The direction to shift the rows, such as Vector2.UP or Vector2.DOWN.
-func _shift_rows(bottom_row: int, direction: Vector2) -> void:
+func shift_rows(bottom_row: int, direction: Vector2) -> void:
 	# First, erase and store all the old cells which are shifting
 	var piece_colors_to_set := {}
 	var autotile_coords_to_set := {}

--- a/project/src/test/puzzle/level/test-level-settings.gd
+++ b/project/src/test/puzzle/level/test-level-settings.gd
@@ -35,6 +35,18 @@ func test_load_297a_data() -> void:
 	
 	assert_eq(settings.blocks_during.shuffle_inserted_lines, BlocksDuringRules.ShuffleLinesType.SLICE, \
 			"settings.blocks_during.shuffle_inserted_lines")
+	
+	var phases := settings.triggers.triggers.keys()
+	assert_eq(phases, [LevelTrigger.LINE_CLEARED])
+	var triggers: Array = settings.triggers.triggers[LevelTrigger.LINE_CLEARED]
+	assert_eq(1, triggers.size())
+	assert_eq_shallow({
+			"phases": [
+				"line_cleared y=0-8"
+			],
+			"effect": "insert_line tiles_key=0",
+		},
+		triggers[0].to_json_dict())
 
 
 func test_load_2cb4_data() -> void:
@@ -133,7 +145,7 @@ func test_to_json_rules() -> void:
 	settings.speed.set_start_speed("6")
 	settings.timers.timers = [{"interval": 5}]
 	settings.triggers.from_json_array(
-			[{"phases": ["after_line_cleared y=0-5"], "effect": "insert_line tiles_key=0"}])
+			[{"phases": ["line_cleared y=0-5"], "effect": "insert_line tiles_key=0"}])
 	_convert_to_json_and_back()
 	
 	assert_eq(settings.blocks_during.clear_on_top_out, true)
@@ -146,4 +158,4 @@ func test_to_json_rules() -> void:
 	assert_eq(settings.score.cake_points, 30)
 	assert_eq(settings.speed.get_start_speed(), "6")
 	assert_eq_deep(settings.timers.timers, [{"interval": 5}])
-	assert_eq(settings.triggers.triggers.keys(), [LevelTrigger.AFTER_LINE_CLEARED])
+	assert_eq(settings.triggers.triggers.keys(), [LevelTrigger.LINE_CLEARED])

--- a/project/src/test/puzzle/level/test-level-trigger.gd
+++ b/project/src/test/puzzle/level/test-level-trigger.gd
@@ -1,50 +1,50 @@
 extends "res://addons/gut/test.gd"
 
-func test_after_line_cleared_012345() -> void:
+func test_line_cleared_012345() -> void:
 	var json_dict := {
-		"phases": ["after_line_cleared y=0-5"],
+		"phases": ["line_cleared y=0-5"],
 		"effect": "insert_line"
 	}
 	
 	var trigger := LevelTrigger.new()
 	trigger.from_json_dict(json_dict)
-	assert_true(trigger.should_run(LevelTrigger.AFTER_LINE_CLEARED, {"y": 19}), "should_run y=0")
-	assert_true(trigger.should_run(LevelTrigger.AFTER_LINE_CLEARED, {"y": 16}), "should_run y=3")
-	assert_true(trigger.should_run(LevelTrigger.AFTER_LINE_CLEARED, {"y": 14}), "should_run y=5")
-	assert_false(trigger.should_run(LevelTrigger.AFTER_LINE_CLEARED, {"y": 13}), "should_run y=6")
+	assert_true(trigger.should_run(LevelTrigger.LINE_CLEARED, {"y": 19}), "should_run y=0")
+	assert_true(trigger.should_run(LevelTrigger.LINE_CLEARED, {"y": 16}), "should_run y=3")
+	assert_true(trigger.should_run(LevelTrigger.LINE_CLEARED, {"y": 14}), "should_run y=5")
+	assert_false(trigger.should_run(LevelTrigger.LINE_CLEARED, {"y": 13}), "should_run y=6")
 
 
-func test_after_line_cleared_135() -> void:
+func test_line_cleared_135() -> void:
 	var json_dict := {
-		"phases": ["after_line_cleared y=1,3,5"],
+		"phases": ["line_cleared y=1,3,5"],
 		"effect": "insert_line"
 	}
 	
 	var trigger := LevelTrigger.new()
 	trigger.from_json_dict(json_dict)
-	assert_false(trigger.should_run(LevelTrigger.AFTER_LINE_CLEARED, {"y": 19}), "should_run y=0")
-	assert_true(trigger.should_run(LevelTrigger.AFTER_LINE_CLEARED, {"y": 16}), "should_run y=3")
-	assert_true(trigger.should_run(LevelTrigger.AFTER_LINE_CLEARED, {"y": 14}), "should_run y=5")
-	assert_false(trigger.should_run(LevelTrigger.AFTER_LINE_CLEARED, {"y": 13}), "should_run y=6")
+	assert_false(trigger.should_run(LevelTrigger.LINE_CLEARED, {"y": 19}), "should_run y=0")
+	assert_true(trigger.should_run(LevelTrigger.LINE_CLEARED, {"y": 16}), "should_run y=3")
+	assert_true(trigger.should_run(LevelTrigger.LINE_CLEARED, {"y": 14}), "should_run y=5")
+	assert_false(trigger.should_run(LevelTrigger.LINE_CLEARED, {"y": 13}), "should_run y=6")
 
 
-func test_after_line_cleared_0456() -> void:
+func test_line_cleared_0456() -> void:
 	var json_dict := {
-		"phases": ["after_line_cleared y=1,4-6"],
+		"phases": ["line_cleared y=1,4-6"],
 		"effect": "insert_line"
 	}
 	
 	var trigger := LevelTrigger.new()
 	trigger.from_json_dict(json_dict)
-	assert_false(trigger.should_run(LevelTrigger.AFTER_LINE_CLEARED, {"y": 19}), "should_run y=0")
-	assert_false(trigger.should_run(LevelTrigger.AFTER_LINE_CLEARED, {"y": 16}), "should_run y=3")
-	assert_true(trigger.should_run(LevelTrigger.AFTER_LINE_CLEARED, {"y": 14}), "should_run y=5")
-	assert_true(trigger.should_run(LevelTrigger.AFTER_LINE_CLEARED, {"y": 13}), "should_run y=6")
+	assert_false(trigger.should_run(LevelTrigger.LINE_CLEARED, {"y": 19}), "should_run y=0")
+	assert_false(trigger.should_run(LevelTrigger.LINE_CLEARED, {"y": 16}), "should_run y=3")
+	assert_true(trigger.should_run(LevelTrigger.LINE_CLEARED, {"y": 14}), "should_run y=5")
+	assert_true(trigger.should_run(LevelTrigger.LINE_CLEARED, {"y": 13}), "should_run y=6")
 
 
-func test_after_line_cleared_to_json_dict() -> void:
+func test_line_cleared_to_json_dict() -> void:
 	var json_dict := {
-		"phases": ["after_line_cleared y=1,4-6"],
+		"phases": ["line_cleared y=1,4-6"],
 		"effect": "insert_line"
 	}
 	

--- a/project/src/test/puzzle/level/test-level-triggers.gd
+++ b/project/src/test/puzzle/level/test-level-triggers.gd
@@ -9,7 +9,7 @@ func before_each() -> void:
 func test_is_default() -> void:
 	assert_eq(triggers.is_default(), true)
 	triggers.from_json_array(
-			[{"phases": ["after_line_cleared y=0-5"], "effect": "insert_line tiles_key=0"}])
+			[{"phases": ["line_cleared y=0-5"], "effect": "insert_line tiles_key=0"}])
 	assert_eq(triggers.is_default(), false)
 
 
@@ -19,18 +19,18 @@ func test_to_json_empty() -> void:
 
 func test_convert_to_json_and_back_complex() -> void:
 	triggers.from_json_array(
-			[{"phases": ["after_line_cleared y=0-5"], "effect": "insert_line tiles_key=0"}])
+			[{"phases": ["line_cleared y=0-5"], "effect": "insert_line tiles_key=0"}])
 	_convert_to_json_and_back()
 	
-	assert_eq(triggers.triggers.keys(), [LevelTrigger.AFTER_LINE_CLEARED])
-	assert_eq(triggers.triggers[LevelTrigger.AFTER_LINE_CLEARED].size(), 1)
-	var trigger: LevelTrigger = triggers.triggers[LevelTrigger.AFTER_LINE_CLEARED][0]
+	assert_eq(triggers.triggers.keys(), [LevelTrigger.LINE_CLEARED])
+	assert_eq(triggers.triggers[LevelTrigger.LINE_CLEARED].size(), 1)
+	var trigger: LevelTrigger = triggers.triggers[LevelTrigger.LINE_CLEARED][0]
 	assert_eq(trigger.phases.size(), 1)
-	assert_eq(trigger.phases[LevelTrigger.AFTER_LINE_CLEARED].size(), 1)
-	assert_is(trigger.phases[LevelTrigger.AFTER_LINE_CLEARED][0], PhaseConditions.AfterLineClearedPhaseCondition)
-	assert_eq(trigger.phases[LevelTrigger.AFTER_LINE_CLEARED][0].which_lines.keys(), [19, 18, 17, 16, 15, 14])
+	assert_eq(trigger.phases[LevelTrigger.LINE_CLEARED].size(), 1)
+	assert_is(trigger.phases[LevelTrigger.LINE_CLEARED][0], PhaseConditions.LineClearedPhaseCondition)
+	assert_eq(trigger.phases[LevelTrigger.LINE_CLEARED][0].which_lines.keys(), [19, 18, 17, 16, 15, 14])
 	assert_is(trigger.effect, LevelTriggerEffects.InsertLineEffect)
-	assert_eq(trigger.effect.tiles_key, "0")
+	assert_eq(trigger.effect.tiles_keys, ["0"])
 
 
 func test_convert_to_json_and_back_simple() -> void:

--- a/project/src/test/puzzle/level/test-phase-conditions.gd
+++ b/project/src/test/puzzle/level/test-phase-conditions.gd
@@ -5,29 +5,29 @@ func before_each() -> void:
 
 
 func test_after_lines_cleared_phase_config() -> void:
-	var condition: PhaseConditions.AfterLineClearedPhaseCondition
-	condition = PhaseConditions.AfterLineClearedPhaseCondition.new({"y": "2"})
+	var condition: PhaseConditions.LineClearedPhaseCondition
+	condition = PhaseConditions.LineClearedPhaseCondition.new({"y": "2"})
 	assert_eq_shallow(condition.get_phase_config(), {"y": "2"})
 	
-	condition = PhaseConditions.AfterLineClearedPhaseCondition.new({"y": "1,3,5"})
+	condition = PhaseConditions.LineClearedPhaseCondition.new({"y": "1,3,5"})
 	assert_eq_shallow(condition.get_phase_config(), {"y": "1,3,5"})
 	
-	condition = PhaseConditions.AfterLineClearedPhaseCondition.new({"y": "0-3"})
+	condition = PhaseConditions.LineClearedPhaseCondition.new({"y": "0-3"})
 	assert_eq_shallow(condition.get_phase_config(), {"y": "0-3"})
 	
-	condition = PhaseConditions.AfterLineClearedPhaseCondition.new({"y": "0,4-6"})
+	condition = PhaseConditions.LineClearedPhaseCondition.new({"y": "0,4-6"})
 	assert_eq_shallow(condition.get_phase_config(), {"y": "0,4-6"})
 
 
-func test_after_piece_written_phase_condition() -> void:
-	var condition: PhaseConditions.AfterPieceWrittenPhaseCondition
-	condition = PhaseConditions.AfterPieceWrittenPhaseCondition.new({"n": "6"})
+func test_piece_written_phase_condition() -> void:
+	var condition: PhaseConditions.PieceWrittenPhaseCondition
+	condition = PhaseConditions.PieceWrittenPhaseCondition.new({"n": "6"})
 	assert_eq_shallow(condition.get_phase_config(), {"n": "6"})
 
 
-func test_after_piece_written_phase_condition_count_by_sixes() -> void:
-	var condition: PhaseConditions.AfterPieceWrittenPhaseCondition
-	condition = PhaseConditions.AfterPieceWrittenPhaseCondition.new({"n": "5,11,17..."})
+func test_piece_written_phase_condition_count_by_sixes() -> void:
+	var condition: PhaseConditions.PieceWrittenPhaseCondition
+	condition = PhaseConditions.PieceWrittenPhaseCondition.new({"n": "5,11,17..."})
 	
 	PuzzleState.level_performance.pieces = 1
 	assert_eq(condition.should_run({}), false, "5,11,17...: 0")
@@ -45,9 +45,9 @@ func test_after_piece_written_phase_condition_count_by_sixes() -> void:
 	assert_eq(condition.should_run({}), true, "5,11,17...: 41")
 
 
-func test_after_piece_written_specific_values() -> void:
-	var condition: PhaseConditions.AfterPieceWrittenPhaseCondition
-	condition = PhaseConditions.AfterPieceWrittenPhaseCondition.new({"n": "0,1,2"})
+func test_piece_written_specific_values() -> void:
+	var condition: PhaseConditions.PieceWrittenPhaseCondition
+	condition = PhaseConditions.PieceWrittenPhaseCondition.new({"n": "0,1,2"})
 	
 	PuzzleState.level_performance.pieces = 1
 	assert_eq(condition.should_run({}), true, "0,1,2: 0")
@@ -62,9 +62,9 @@ func test_after_piece_written_specific_values() -> void:
 	assert_eq(condition.should_run({}), false, "0,1,2: 3")
 
 
-func test_after_piece_written_skip_early_values() -> void:
-	var condition: PhaseConditions.AfterPieceWrittenPhaseCondition
-	condition = PhaseConditions.AfterPieceWrittenPhaseCondition.new({"n": "10,11,12..."})
+func test_piece_written_skip_early_values() -> void:
+	var condition: PhaseConditions.PieceWrittenPhaseCondition
+	condition = PhaseConditions.PieceWrittenPhaseCondition.new({"n": "10,11,12..."})
 	
 	PuzzleState.level_performance.pieces = 1
 	assert_eq(condition.should_run({}), false, "10,11,12...: 0")


### PR DESCRIPTION
These phases explicitly specified 'AFTER line cleared' and 'AFTER piece written' in anticipation of other more granular phase conditions being written some day. However, I don't see a need for those.

Additionally, the timing of these triggers needs to be very specific to avoid unwanted side effects. The 'after line cleared' phase condition used to coincide with the after_line_cleared signal, but they now occur at different times, so I'm renaming these phase conditions to avoid confusion.