### PR TITLE
insert_line level trigger effect accepts 'y'

### DIFF
--- a/project/src/main/puzzle/level/config-string-utils.gd
+++ b/project/src/main/puzzle/level/config-string-utils.gd
@@ -94,5 +94,14 @@ static func ints_from_config_string(config_string: String) -> Array:
 static func invert_puzzle_row_indexes(lines: Array) -> Array:
 	var new_lines := []
 	for line in lines:
-		new_lines.append(PuzzleTileMap.ROW_COUNT - line - 1)
+		new_lines.append(invert_puzzle_row_index(line))
 	return new_lines
+
+
+## Converts a user-friendly puzzle row index like 0 into row numbers like 19 or vice-versa.
+##
+## Our config files use coordinates where '0' is the bottom row of the playfield and '16' is the top. But our tilemap
+## represents '19' as the bottom row of the playfield and '3' as the highest visible row. (There are three additional
+## rows above it.)
+static func invert_puzzle_row_index(line: int) -> int:
+	return PuzzleTileMap.ROW_COUNT - line - 1

--- a/project/src/main/puzzle/level/level-trigger-effects.gd
+++ b/project/src/main/puzzle/level/level-trigger-effects.gd
@@ -123,13 +123,13 @@ class RotateNextPiecesEffect extends LevelTriggerEffect:
 		return result
 
 
-## Inserts a new line at the bottom of the playfield.
+## Inserts a new line.
 class InsertLineEffect extends LevelTriggerEffect:
-	## (Optional) key corresponding to a set of tiles in LevelTiles for the tiles to insert
-	var tiles_key: String
+	## (Optional) target row
+	var y: int = PuzzleTileMap.ROW_COUNT - 1
 	
 	## (Optional) keys corresponding to sets of tiles in LevelTiles for the tiles to insert
-	var tiles_keys: Array
+	var tiles_keys: Array = []
 	
 	## Updates the effect's configuration.
 	##
@@ -143,26 +143,30 @@ class InsertLineEffect extends LevelTriggerEffect:
 	##
 	## Example: ["tiles_keys=0,1"]
 	func set_config(new_config: Dictionary = {}) -> void:
-		tiles_key = new_config.get("tiles_key", "")
-		tiles_keys = new_config["tiles_keys"].split(",") if new_config.has("tiles_keys") else []
+		if new_config.has("tiles_key"):
+			tiles_keys = [new_config["tiles_key"]]
+		if new_config.has("tiles_keys"):
+			tiles_keys = new_config["tiles_keys"].split(",")
+		if new_config.has("y"):
+			y = ConfigStringUtils.invert_puzzle_row_index(int(new_config["y"]))
 	
 	
 	## Inserts a new line at the bottom of the playfield.
 	func run() -> void:
-		if tiles_key:
-			CurrentLevel.puzzle.get_playfield().line_inserter.insert_line([tiles_key])
-		elif tiles_keys:
-			CurrentLevel.puzzle.get_playfield().line_inserter.insert_line(tiles_keys)
-		else:
-			CurrentLevel.puzzle.get_playfield().line_inserter.insert_line([])
+		CurrentLevel.puzzle.get_playfield().line_inserter.insert_line(tiles_keys, y)
 	
 	
 	func get_config() -> Dictionary:
 		var result := {}
-		if tiles_key:
-			result["tiles_key"] = tiles_key
-		if tiles_keys:
-			result["tiles_keys"] = PoolStringArray(tiles_keys).join(",")
+		match tiles_keys.size():
+			0:
+				pass
+			1:
+				result["tiles_key"] = tiles_keys[0]
+			_:
+				result["tiles_keys"] = PoolStringArray(tiles_keys).join(",")
+		if y != PuzzleTileMap.ROW_COUNT - 1:
+			result["y"] = ConfigStringUtils.invert_puzzle_row_index(y)
 		return result
 
 

--- a/project/src/test/puzzle/level/test-level-trigger-effects.gd
+++ b/project/src/test/puzzle/level/test-level-trigger-effects.gd
@@ -14,7 +14,7 @@ func test_rotate_next_pieces_get_config() -> void:
 	assert_eq_shallow(effect.get_config(), {"0": "180"})
 
 
-func test_insert_line_get_config_0() -> void:
+func test_insert_line_get_config() -> void:
 	var effect: LevelTriggerEffects.InsertLineEffect
 	effect = LevelTriggerEffects.InsertLineEffect.new()
 	assert_eq_shallow(effect.get_config(), {})
@@ -22,16 +22,14 @@ func test_insert_line_get_config_0() -> void:
 	effect = LevelTriggerEffects.InsertLineEffect.new()
 	effect.set_config({"tiles_key": "0"})
 	assert_eq_shallow(effect.get_config(), {"tiles_key": "0"})
-
-
-func test_insert_line_get_config_1() -> void:
-	var effect: LevelTriggerEffects.InsertLineEffect
-	effect = LevelTriggerEffects.InsertLineEffect.new()
-	assert_eq_shallow(effect.get_config(), {})
 	
 	effect = LevelTriggerEffects.InsertLineEffect.new()
 	effect.set_config({"tiles_keys": "0,1"})
 	assert_eq_shallow(effect.get_config(), {"tiles_keys": "0,1"})
+	
+	effect = LevelTriggerEffects.InsertLineEffect.new()
+	effect.set_config({"y": 5})
+	assert_eq_shallow(effect.get_config(), {"y": 5})
 
 
 func test_add_moles_set_config() -> void:


### PR DESCRIPTION
Adding a 'y' coordinate highlighted some bugs in the timing of inserts/line_cleared triggers. More specifically, saying something like 'when line 5 is deleted, insert a new line at row 5' didn't work because all of the line_cleared signals were fired at the end, after the lines have already shifted.

line_cleared triggers are now fired at a very specific timing -- after the lines are erased but before the lines are deleted. This required exposing some internals of PuzzleTileMap to LineClearer.

Additionally, we don't want 'line_cleared' signals to fire when resetting a level, so I've added a top out detector similar to what exists in line_filler.