### PR TITLE
New level triggers: 'box built', 'line_cleared n=5'

### DIFF
--- a/project/src/main/puzzle/box-builder.gd
+++ b/project/src/main/puzzle/box-builder.gd
@@ -84,6 +84,7 @@ func build_box(rect: Rect2, box_type: int) -> void:
 	# set at least 1 box build frame; processing occurs when the frame goes from 1 -> 0
 	remaining_box_build_frames = max(1, PieceSpeeds.current_speed.box_delay)
 	_tile_map.build_box(rect, box_type)
+	CurrentLevel.settings.triggers.run_triggers(LevelTrigger.BOX_BUILT, {"type": box_type})
 	emit_signal("box_built", rect, box_type)
 
 

--- a/project/src/main/puzzle/level/level-trigger.gd
+++ b/project/src/main/puzzle/level/level-trigger.gd
@@ -7,6 +7,7 @@ class_name LevelTrigger
 
 ## phases when a level trigger can fire
 enum LevelTriggerPhase {
+	BOX_BUILT, # when a snack/cake box is built
 	INITIAL_ROTATED_CW, # when the piece is rotated clockwise using initial DAS
 	INITIAL_ROTATED_CCW, # when the piece is rotated counterclockwise using initial DAS
 	INITIAL_ROTATED_180, # when the piece is flipped using initial DAS
@@ -20,6 +21,7 @@ enum LevelTriggerPhase {
 	TIMER_2, # when timer 2 times out
 }
 
+const BOX_BUILT := LevelTriggerPhase.BOX_BUILT
 const INITIAL_ROTATED_CW := LevelTriggerPhase.INITIAL_ROTATED_CW
 const INITIAL_ROTATED_CCW := LevelTriggerPhase.INITIAL_ROTATED_CCW
 const INITIAL_ROTATED_180 := LevelTriggerPhase.INITIAL_ROTATED_180

--- a/project/src/main/puzzle/level/phase-conditions.gd
+++ b/project/src/main/puzzle/level/phase-conditions.gd
@@ -7,6 +7,7 @@ class PieceWrittenPhaseCondition extends PhaseCondition:
 	## We precalculate which pieces will trigger the rule, up to this number of pieces.
 	## 20,000 corresponds to an expert player playing at ~200 PPM for two hours.
 	const MAX_PIECE_INDEX := 20000
+	const MAX_LINE_INDEX := 10000
 	
 	## The 'n' string read from the json configuration file.
 	var _indexes_string: String
@@ -71,10 +72,59 @@ class PieceWrittenPhaseCondition extends PhaseCondition:
 		return result
 
 
+class BoxBuiltPhaseCondition extends PhaseCondition:
+	
+	enum RequiredBoxType {
+		ANY,
+		SNACK,
+		CAKE,
+	}
+	
+	# an enum from RequiredBoxType defining the box's required type
+	var required_box_type: int = RequiredBoxType.ANY
+	
+	## Creates a new BoxBuiltPhaseCondition instance with the specified configuration.
+	func _init(phase_config: Dictionary).(phase_config) -> void:
+		if phase_config.has("0"):
+			required_box_type = Utils.enum_from_snake_case(RequiredBoxType, phase_config["0"])
+	
+	
+	## Returns 'true' if a trigger should run during this phase, based on the specified metadata.
+	##
+	## Parameters:
+	## 	'event_params': 'type' is an enum from Foods.BoxType defining the box's color
+	func should_run(event_params: Dictionary) -> bool:
+		var actual_box_type: int = event_params["type"]
+		var should_run := false
+		match required_box_type:
+			RequiredBoxType.ANY:
+				should_run = true
+			RequiredBoxType.SNACK:
+				should_run = Foods.is_snack_box(actual_box_type)
+			RequiredBoxType.CAKE:
+				should_run = Foods.is_cake_box(actual_box_type)
+		return should_run
+	
+	
+	## Extracts a set of phase configuration strings from this phase condition.
+	func get_phase_config() -> Dictionary:
+		var result := {}
+		if required_box_type != RequiredBoxType.ANY:
+			result["0"] = Utils.enum_to_snake_case(RequiredBoxType, required_box_type)
+		return result
+
+
 class LineClearedPhaseCondition extends PhaseCondition:
+	
 	## key: (int) a line which causes the trigger to fire when cleared. 0 is the highest line in the playfield.
 	## value: (bool) true
 	var which_lines := {}
+	
+	var how_many_lines_string := ""
+	
+	## key: (int) a line milestone which causes the trigger to fire when cleared.
+	## value: (bool) true
+	var how_many_lines := {}
 	
 	## Creates a new LineClearedPhaseCondition instance with the specified configuration.
 	##
@@ -98,6 +148,9 @@ class LineClearedPhaseCondition extends PhaseCondition:
 			var inverted_which_lines := ConfigStringUtils.ints_from_config_string(y_expression)
 			for which_line in inverted_which_lines:
 				which_lines[ConfigStringUtils.invert_puzzle_row_index(which_line)] = true
+		if phase_config.has("n"):
+			how_many_lines_string = phase_config["n"]
+			how_many_lines = ConfigStringUtils.ints_from_config_string(how_many_lines_string, 2000)
 	
 	
 	## Returns 'true' if a trigger should run during this phase, based on the specified metadata.
@@ -108,6 +161,8 @@ class LineClearedPhaseCondition extends PhaseCondition:
 		var result := true
 		if which_lines:
 			result = result and which_lines.has(event_params["y"])
+		if how_many_lines:
+			result = result and how_many_lines.has(PuzzleState.level_performance.lines)
 		return result
 	
 	
@@ -122,9 +177,12 @@ class LineClearedPhaseCondition extends PhaseCondition:
 		if which_lines:
 			var inverted_which_lines := ConfigStringUtils.invert_puzzle_row_indexes(which_lines.keys())
 			result["y"] = ConfigStringUtils.config_string_from_ints(inverted_which_lines)
+		if how_many_lines_string:
+			result["n"] = how_many_lines_string
 		return result
 
 var phase_conditions_by_string := {
+	"box_built": BoxBuiltPhaseCondition,
 	"piece_written": PieceWrittenPhaseCondition,
 	"line_cleared": LineClearedPhaseCondition,
 }

--- a/project/src/test/puzzle/level/test-phase-conditions.gd
+++ b/project/src/test/puzzle/level/test-phase-conditions.gd
@@ -18,7 +18,22 @@ func test_line_cleared_phase_config() -> void:
 	condition = PhaseConditions.LineClearedPhaseCondition.new({"y": "0,4-6"})
 	assert_eq_shallow(condition.get_phase_config(), {"y": "0,4-6"})
 	
+	condition = PhaseConditions.LineClearedPhaseCondition.new({"n": "1,2,3..."})
+	assert_eq_shallow(condition.get_phase_config(), {"n": "1,2,3..."})
+	
 	condition = PhaseConditions.LineClearedPhaseCondition.new({})
+	assert_eq_shallow(condition.get_phase_config(), {})
+
+
+func test_box_built_phase_condition() -> void:
+	var condition: PhaseConditions.BoxBuiltPhaseCondition
+	condition = PhaseConditions.BoxBuiltPhaseCondition.new({"0": "snack"})
+	assert_eq_shallow(condition.get_phase_config(), {"0": "snack"})
+	
+	condition = PhaseConditions.BoxBuiltPhaseCondition.new({"0": "cake"})
+	assert_eq_shallow(condition.get_phase_config(), {"0": "cake"})
+	
+	condition = PhaseConditions.BoxBuiltPhaseCondition.new({"0": "any"})
 	assert_eq_shallow(condition.get_phase_config(), {})
 
 


### PR DESCRIPTION
This 'box built' phase trigger lets us create levels where special things happen when the player makes snack boxes or cake boxes (or both.) In the future this could be expanded to reward specific boxes (like JLO boxes) but this feels too obscure to be fun.

This 'line cleared' phase trigger lets us create levels where surprises happen after clearing a certain number of lines. Or, after clearing 5, 10, 15... lines.