### PR TITLE
PuzzleTileMap detaches neighbors when inserting lines.

### DIFF
--- a/project/assets/demo/puzzle/levels/experiment.json
+++ b/project/assets/demo/puzzle/levels/experiment.json
@@ -1,113 +1,36 @@
 {
   "version": "39e5",
   "start_speed": "0",
-  "name": "Rice Bear Island",
-  "description": "What on earth is a rice bear? ...This just seems like a regular island.",
+  "name": "Experiment",
+  "description": "Just goofing around",
   "finish_condition": {
-    "type": "lines",
-    "value": "30"
+    "type": "score",
+    "value": "400"
   },
-  "timers": [
-    {
-      "interval": 1.2
-    }
-  ],
   "triggers": [
     {
       "phases": [
-        "line_cleared n=25"
+        "line_cleared"
       ],
-      "effect": "add_moles count=99 dig_duration=2"
+      "effect": "insert_line y=2 tiles_key=0"
     },
     {
       "phases": [
-        "timer_0"
+        "line_cleared"
       ],
-      "effect": "advance_moles"
+      "effect": "insert_line y=4 tiles_key=0"
+    },
+    {
+      "phases": [
+        "line_cleared"
+      ],
+      "effect": "insert_line y=6 tiles_key=0"
     }
   ],
   "tiles": {
     "start": [
-      {
-        "pos": "1 17",
-        "tile": "2 4 3"
-      },
-      {
-        "pos": "2 17",
-        "tile": "2 13 1"
-      },
-      {
-        "pos": "3 17",
-        "tile": "2 7 1"
-      },
-      {
-        "pos": "4 17",
-        "tile": "2 14 0"
-      },
-      {
-        "pos": "5 17",
-        "tile": "2 6 0"
-      },
-      {
-        "pos": "1 18",
-        "tile": "2 5 0"
-      },
-      {
-        "pos": "2 18",
-        "tile": "2 14 3"
-      },
-      {
-        "pos": "3 18",
-        "tile": "2 12 0"
-      },
-      {
-        "pos": "4 18",
-        "tile": "2 9 1"
-      },
-      {
-        "pos": "5 18",
-        "tile": "2 10 2"
-      },
-      {
-        "pos": "6 18",
-        "tile": "2 7 0"
-      },
-      {
-        "pos": "7 18",
-        "tile": "2 12 0"
-      },
-      {
-        "pos": "1 19",
-        "tile": "1 8 3"
-      },
-      {
-        "pos": "2 19",
-        "tile": "1 12 3"
-      },
-      {
-        "pos": "3 19",
-        "tile": "1 4 3"
-      },
-      {
-        "pos": "4 19",
-        "tile": "2 10 1"
-      },
-      {
-        "pos": "5 19",
-        "tile": "2 17 3"
-      },
-      {
-        "pos": "6 19",
-        "tile": "2 8 1"
-      },
-      {
-        "pos": "7 19",
-        "tile": "2 17 3"
-      },
-      {
-        "pos": "8 19",
-        "tile": "2 6 3"
-      }
+    ],
+    "0": [
     ]
   }
 }


### PR DESCRIPTION
This prevents broken pieces/boxes from showing up during new levels such as 'shelf' which insert empty rows in the middle of the playfield.