### PR TITLE
Fixed bug with mole pickups overlapping the active piece.

### DIFF
--- a/project/src/main/puzzle/Playfield.tscn
+++ b/project/src/main/puzzle/Playfield.tscn
@@ -160,7 +160,7 @@ script = ExtResource( 27 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
-_puzzle_tile_map_path = NodePath("../TileMap")
+puzzle_tile_map_path = NodePath("../TileMap")
 PickupScene = ExtResource( 26 )
 
 [node name="Visuals" type="Control" parent="TileMapClip/Pickups"]

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -14,8 +14,7 @@ func _ready() -> void:
 	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")
 	PuzzleState.connect("after_level_changed", self, "_on_PuzzleState_after_level_changed")
 	$Fg/Playfield/TileMapClip/TileMap/Viewport/ShadowMap.piece_tile_map = $Fg/PieceManager/TileMap
-	$Fg/PieceManager.connect(
-			"piece_disturbed", $Fg/Playfield.pickups, "_on_PieceManager_piece_disturbed")
+	$Fg/Playfield.pickups.piece_manager_path = $Fg/Playfield.pickups.get_path_to($Fg/PieceManager)
 	CurrentLevel.puzzle = self
 	
 	# reset the current puzzle, so transient data doesn't carry over from scene to scene


### PR DESCRIPTION
Fixed a bug where if the mole dug up a pickup while a piece was overlapping them, the pickup would appear 'behind' the piece.