### PR TITLE
Fixed bug where inserting lines converted pieces to veggies

### DIFF
--- a/project/assets/demo/puzzle/levels/experiment.json
+++ b/project/assets/demo/puzzle/levels/experiment.json
@@ -13,18 +13,6 @@
         "line_cleared"
       ],
       "effect": "insert_line y=2 tiles_key=0"
-    },
-    {
-      "phases": [
-        "line_cleared"
-      ],
-      "effect": "insert_line y=4 tiles_key=0"
-    },
-    {
-      "phases": [
-        "line_cleared"
-      ],
-      "effect": "insert_line y=6 tiles_key=0"
     }
   ],
   "tiles": {


### PR DESCRIPTION
Inserting lines converted ALL adjacent pieces to veggies -- even if they were not broken. I've changed the logic so that pieces are only converted if they are interrupted by the inserted line.