### PR TITLE
Line clear refactorings: row->line, comments, reorder

### DIFF
--- a/project/src/main/puzzle/critter/moles.gd
+++ b/project/src/main/puzzle/critter/moles.gd
@@ -421,5 +421,5 @@ func _on_Playfield_line_filled(_y: int, _tiles_key: String, _src_y: int) -> void
 	_refresh_moles_for_playfield()
 
 
-func _on_Playfield_after_lines_deleted() -> void:
+func _on_Playfield_after_lines_deleted(_lines: Array) -> void:
 	_refresh_moles_for_playfield()

--- a/project/src/main/puzzle/level/blocks-during-rules.gd
+++ b/project/src/main/puzzle/level/blocks-during-rules.gd
@@ -22,7 +22,7 @@ enum PickupType {
 ## if true, the entire playfield is cleared when the player tops out
 var clear_on_top_out := false
 
-## tiles key for filled lines
+## tiles key for 'filled' lines -- lines which fill from the top for levels with narrow playfields
 var fill_lines: String
 
 ## whether blocks drop following a line clear

--- a/project/src/main/puzzle/level/level-trigger-effects.gd
+++ b/project/src/main/puzzle/level/level-trigger-effects.gd
@@ -7,6 +7,20 @@ extends Node
 class AddMolesEffect extends LevelTriggerEffect:
 	var config: MoleConfig = MoleConfig.new()
 	
+	## Updates the effect's configuration.
+	##
+	## This effect's configuration accepts the following parameters:
+	##
+	## [count]: (Optional) How many moles appear during a single 'add moles' effect. Defaults to 1.
+	## [home]: (Optional) Restricts which types of tiles moles can appear: 'any', 'veg', 'box', 'surface', 'cake' or
+	## 	'hole'.
+	## [y]: (Optional) Restricts which rows the moles appear on, where '0' is the bottom row of the playfield and '16'
+	## 	is the top.
+	## [x]: (Optional) Restricts which columns the moles appear on, where '0' is the leftmost column of the playfield.
+	## [dig_duration]: (Optional) How many turns/seconds/cycles the moles dig for. Defaults to 3.
+	## [reward]: (Optional) The reward the moles dig up: 'seed' or 'star'. Defaults to 'star'.
+	##
+	## Example: ["add_moles count=2 reward=seed"]
 	func set_config(new_config: Dictionary = {}) -> void:
 		if new_config.has("count"):
 			config.count = new_config["count"].to_int()
@@ -23,6 +37,7 @@ class AddMolesEffect extends LevelTriggerEffect:
 			config.reward = Utils.enum_from_snake_case(MoleConfig.Reward, new_config["reward"])
 	
 	
+	## Adds one or more moles to the playfield.
 	func run() -> void:
 		CurrentLevel.puzzle.get_moles().add_moles(config)
 	
@@ -50,6 +65,7 @@ class AddMolesEffect extends LevelTriggerEffect:
 ## Advances all moles on the playfield, allowing them to dig up pickups.
 class AdvanceMolesEffect extends LevelTriggerEffect:
 	
+	## Advances all moles on the playfield, allowing them to dig up pickups.
 	func run() -> void:
 		CurrentLevel.puzzle.get_moles().advance_moles()
 

--- a/project/src/main/puzzle/line-filler.gd
+++ b/project/src/main/puzzle/line-filler.gd
@@ -209,7 +209,7 @@ func _reset() -> void:
 			_row_index_by_tiles_key[tiles_key] = randi() % _row_count_by_tiles_key[tiles_key]
 
 
-## Returns the tiles key for filled lines.
+## Returns the tiles key for 'filled' lines -- lines which fill from the top for levels with narrow playfields
 func _fill_lines_tiles_key() -> String:
 	return CurrentLevel.settings.blocks_during.fill_lines
 
@@ -224,7 +224,7 @@ func _on_Level_settings_changed() -> void:
 	_reset()
 
 
-func _on_LineClearer_after_lines_deleted() -> void:
+func _on_LineClearer_after_lines_deleted(_lines: Array) -> void:
 	if _topping_out and CurrentLevel.settings.blocks_during.refresh_on_top_out:
 		_topping_out = false
 		

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -25,7 +25,7 @@ signal line_erased(y, total_lines, remaining_lines, box_ints)
 signal line_deleted(y)
 
 ## emitted after a set of lines is deleted
-signal after_lines_deleted
+signal after_lines_deleted(lines)
 
 ## emitted when lines are inserted. some levels insert lines, but most do not
 signal line_inserted(y, tiles_key, src_y)
@@ -128,7 +128,7 @@ func write_piece(pos: Vector2, orientation: int, type: PieceType, death_piece :=
 	
 	if not death_piece:
 		_box_builder.process_boxes()
-		line_clearer.schedule_full_row_line_clears()
+		line_clearer.schedule_filled_line_clears()
 	
 	PuzzleState.before_piece_written()
 	
@@ -197,8 +197,8 @@ func _on_LineClearer_line_deleted(y: int) -> void:
 	emit_signal("line_deleted", y)
 
 
-func _on_LineClearer_after_lines_deleted() -> void:
-	emit_signal("after_lines_deleted")
+func _on_LineClearer_after_lines_deleted(lines: Array) -> void:
+	emit_signal("after_lines_deleted", lines)
 	
 	# On levels with weird pieces, clearing a line can create a box. If this happens we delay the
 	# 'after_piece_written' signal until after the box is built

--- a/project/src/main/puzzle/top-out-tracker.gd
+++ b/project/src/main/puzzle/top-out-tracker.gd
@@ -39,7 +39,7 @@ func _on_PuzzleState_game_prepared() -> void:
 	_topping_out = false
 
 
-func _on_Playfield_after_lines_deleted() -> void:
+func _on_Playfield_after_lines_deleted(_lines: Array) -> void:
 	if _topping_out and not CurrentLevel.settings.blocks_during.refresh_on_top_out:
 		# The current level's top out process ends with the lines which were just deleted. Restore piece mobility.
 		_topping_out = false


### PR DESCRIPTION
LineClearer refers to 'lines' instead of 'rows' in more places.

Disambiguated 'filled lines' -- out of context it's ambiguous whether these are lines which the player filled with pieces, or lines which are filled from the top by LineFiller

Added missing level trigger comments.

Reordered some LineClearer methods; private methods should be below public ones.

Added after_lines_deleted signal parameter.

Replaced PuzzleTileMap -1 references with INVALID_TILE

Added PuzzleTileMap.erase_cell method. This will be useful for levels which erase cells.