### PR TITLE
Fixed conflict with after_piece_written and clear_filled_lines

### DIFF
--- a/project/src/main/puzzle/level/level-trigger.gd
+++ b/project/src/main/puzzle/level/level-trigger.gd
@@ -7,12 +7,13 @@ class_name LevelTrigger
 
 ## phases when a level trigger can fire
 enum LevelTriggerPhase {
+	AFTER_PIECE_WRITTEN, # after the piece is written, and all boxes are made, and all lines are cleared
 	BOX_BUILT, # when a snack/cake box is built
 	INITIAL_ROTATED_CW, # when the piece is rotated clockwise using initial DAS
 	INITIAL_ROTATED_CCW, # when the piece is rotated counterclockwise using initial DAS
 	INITIAL_ROTATED_180, # when the piece is flipped using initial DAS
 	LINE_CLEARED, # after the line is erased for a line clear, but before the lines above are shifted
-	PIECE_WRITTEN, # after the piece is written, and all boxes are made, and all lines are cleared
+	PIECE_WRITTEN, # when the piece is written, but before any boxes are made or lines are cleared
 	ROTATED_CW, # when the piece is rotated clockwise
 	ROTATED_CCW, # when the piece is rotated counterclockwise
 	ROTATED_180, # when the piece is flipped
@@ -21,6 +22,7 @@ enum LevelTriggerPhase {
 	TIMER_2, # when timer 2 times out
 }
 
+const AFTER_PIECE_WRITTEN := LevelTriggerPhase.AFTER_PIECE_WRITTEN
 const BOX_BUILT := LevelTriggerPhase.BOX_BUILT
 const INITIAL_ROTATED_CW := LevelTriggerPhase.INITIAL_ROTATED_CW
 const INITIAL_ROTATED_CCW := LevelTriggerPhase.INITIAL_ROTATED_CCW
@@ -79,6 +81,15 @@ func from_json_dict(json: Dictionary) -> void:
 	var effect_key: String = effect_split[0]
 	var effect_config: Dictionary = dict_config_from_array(effect_split.slice(1, effect_split.size()))
 	effect = LevelTriggerEffects.create(effect_key, effect_config)
+	
+	# handle special cases
+	if phases.has("piece_written"):
+		# 'piece_written' triggers should typically happen after the piece is written, except for clearing filled lines
+		if effect_key in ["clear_filled_lines"]:
+			pass
+		else:
+			phases["after_piece_written"] = phases["piece_written"]
+			phases.erase("piece_written")
 
 
 func to_json_dict() -> Dictionary:

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -133,6 +133,8 @@ func write_piece(pos: Vector2, orientation: int, type: PieceType, death_piece :=
 	
 	PuzzleState.before_piece_written()
 	
+	CurrentLevel.settings.triggers.run_triggers(LevelTrigger.PIECE_WRITTEN)
+	
 	if _box_builder.remaining_box_build_frames == 0 and line_clearer.remaining_line_erase_frames == 0:
 		# If any boxes are being built or lines are being cleared, we emit the
 		# signal later. Otherwise we emit it now.
@@ -235,7 +237,7 @@ func _on_Pickups_food_spawned(cell: Vector2, remaining_food: int, food_type: int
 
 
 func _on_PuzzleState_after_piece_written() -> void:
-	CurrentLevel.settings.triggers.run_triggers(LevelTrigger.PIECE_WRITTEN)
+	CurrentLevel.settings.triggers.run_triggers(LevelTrigger.AFTER_PIECE_WRITTEN)
 
 
 func _on_LineClearer_all_lines_cleared() -> void:


### PR DESCRIPTION
Clearing lines results in an after_piece_written signal sometimes, so triggers were being called twice. Rather than requiring levels to explicitly specify some triggers as 'after_piece_written' and other triggers as 'piece_written', I've pushed this complexity into the LevelTrigger parser.