### PR TITLE
Bug: Piece spawn delay removed after topping out

### DIFF
--- a/project/src/main/puzzle/top-out-tracker.gd
+++ b/project/src/main/puzzle/top-out-tracker.gd
@@ -49,4 +49,5 @@ func _on_Playfield_after_lines_deleted(_lines: Array) -> void:
 func _on_Playfield_after_lines_filled() -> void:
 	if _topping_out and CurrentLevel.settings.blocks_during.refresh_on_top_out:
 		# The current level's top out process ends with the lines which were just filled. Restore piece mobility.
+		_topping_out = false
 		_piece_manager.exit_top_out_state()


### PR DESCRIPTION
Piece spawn delay was irreversibly set to 0 after topping out. It's supposed to be temporarily set to 0 and then set back, but a line of code was missing.