### PR TITLE
Fixed bug where line inserter/filler did not handle pickup rows

### DIFF
--- a/project/src/main/puzzle/Playfield.tscn
+++ b/project/src/main/puzzle/Playfield.tscn
@@ -157,9 +157,6 @@ margin_top = -272.0
 margin_right = 162.0
 margin_bottom = 272.0
 script = ExtResource( 27 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 puzzle_tile_map_path = NodePath("../TileMap")
 PickupScene = ExtResource( 26 )
 
@@ -373,6 +370,7 @@ bus = "Sound Bus"
 
 [node name="LineFiller" type="Node" parent="."]
 script = ExtResource( 29 )
+pickups_path = NodePath("../TileMapClip/Pickups")
 tile_map_path = NodePath("../TileMapClip/TileMap")
 
 [node name="LineFillSound1" type="AudioStreamPlayer" parent="LineFiller"]

--- a/project/src/main/puzzle/line-filler.gd
+++ b/project/src/main/puzzle/line-filler.gd
@@ -14,6 +14,8 @@ signal line_filled(y, tiles_key, src_y)
 ## emitted after a set of lines are filled, either following a topout/refresh or line clear
 signal after_lines_filled
 
+export (NodePath) var pickups_path: NodePath
+
 export (NodePath) var tile_map_path: NodePath
 
 ## 'True' if the current set of lines being deleted are being deleted as a result of a top out.
@@ -43,6 +45,7 @@ var _filled_line_index := 0
 ## The index of the next line fill sound to play.
 var _line_fill_sfx_index := 0
 
+onready var _pickups: Pickups = get_node(pickups_path)
 onready var _tile_map: PuzzleTileMap = get_node(tile_map_path)
 onready var _line_fill_sounds := [$LineFillSound1, $LineFillSound2, $LineFillSound3]
 onready var _line_fill_sfx_reset_timer := $LineFillSfxResetTimer
@@ -94,7 +97,7 @@ func _fill_empty_lines() -> void:
 	# fill the empty rows from bottom to top
 	var y := PuzzleTileMap.ROW_COUNT - 1
 	while y >= 0:
-		if _tile_map.row_is_empty(y):
+		if _tile_map.row_is_empty(y) and _pickups.row_is_empty(y):
 			_fill_line(_fill_lines_tiles_key(), y)
 		y -= 1
 	
@@ -185,10 +188,14 @@ func _reset() -> void:
 			var min_y := PuzzleTileMap.ROW_COUNT - 1
 			for cell in CurrentLevel.settings.tiles.bunches[tiles_key].block_tiles:
 				min_y = int(min(min_y, cell.y))
+			for cell in CurrentLevel.settings.tiles.bunches[tiles_key].pickups:
+				min_y = int(min(min_y, cell.y))
 			_row_count_by_tiles_key[tiles_key] = PuzzleTileMap.ROW_COUNT - min_y
 		else:
 			var max_y := 0
 			for cell in CurrentLevel.settings.tiles.bunches[tiles_key].block_tiles:
+				max_y = int(max(max_y, cell.y))
+			for cell in CurrentLevel.settings.tiles.bunches[tiles_key].pickups:
 				max_y = int(max(max_y, cell.y))
 			_row_count_by_tiles_key[tiles_key] = max_y + 1
 	

--- a/project/src/main/puzzle/line-inserter.gd
+++ b/project/src/main/puzzle/line-inserter.gd
@@ -151,6 +151,8 @@ func _reset() -> void:
 		var max_y := 0
 		for cell in CurrentLevel.settings.tiles.bunches[tiles_key].block_tiles:
 			max_y = int(max(max_y, cell.y))
+		for cell in CurrentLevel.settings.tiles.bunches[tiles_key].pickups:
+			max_y = int(max(max_y, cell.y))
 		_row_count_by_tiles_key[tiles_key] = max_y + 1
 	
 	# initialize _row_index_by_tiles_key


### PR DESCRIPTION
Lines with only pickups were considered empty by the line inserter and line filler, so the logic for iterating over multiple lines wouldn't work properly. The inserter and filler now considered pickups when determining if a line is empty.