### PR TITLE
Combo patterns now indicate when a combo will break.

### DIFF
--- a/project/src/main/puzzle/playfield-fx.gd
+++ b/project/src/main/puzzle/playfield-fx.gd
@@ -209,11 +209,13 @@ func _refresh_tile_maps() -> void:
 	_bg_strobe.color = Utils.to_transparent(_color)
 	
 	var old_pattern := _pattern
-	var new_pattern: Array
-	match _combo_tracker.combo_break:
-		0: new_pattern = ON_PATTERN
-		1: new_pattern = HALF_PATTERN
-		_: new_pattern = OFF_PATTERN
+	var new_pattern: Array = OFF_PATTERN
+	
+	if CurrentLevel.settings.combo_break.pieces != ComboBreakRules.UNLIMITED_PIECES:
+		if _combo_tracker.combo_break == CurrentLevel.settings.combo_break.pieces - 1:
+			new_pattern = HALF_PATTERN
+		elif _combo_tracker.combo_break < CurrentLevel.settings.combo_break.pieces - 1:
+			new_pattern = ON_PATTERN
 	
 	if old_pattern == OFF_PATTERN and new_pattern == OFF_PATTERN:
 		# no need to refresh if all the lights remain off


### PR DESCRIPTION
For levels which break on 3 or more dropped pieces, the combo patterns now stay in the 'on' pattern until the combo is about to break, and then switch to the 'half' pattern.

For levels which break on 1 dropped piece, the combo patterns now immediately switch to the 'half' pattern.

This helps provide more useful feedback to the player about the current level's rules and state.