### PR TITLE
Line insert improvements: multiline, bugfixes, random veg

### DIFF
--- a/project/src/main/editor/puzzle/editor-playfield.gd
+++ b/project/src/main/editor/puzzle/editor-playfield.gd
@@ -94,7 +94,7 @@ func drop_data(pos: Vector2, data: Object) -> void:
 		# change vegetable data avoid repeating the same vegetables
 		for cell in _prev_dropped_data.used_cells:
 			if _prev_dropped_data.tiles[cell] == PuzzleTileMap.TILE_VEG:
-				_prev_dropped_data.autotile_coords[cell] = Vector2(randi() % 18, randi() % 4)
+				_prev_dropped_data.autotile_coords[cell] = PuzzleTileMap.random_veg_autotile_coord()
 
 
 ## If the player clicks and drags on the playfield, we reuse the previously dropped data.

--- a/project/src/main/editor/puzzle/veg-level-chunk-control.gd
+++ b/project/src/main/editor/puzzle/veg-level-chunk-control.gd
@@ -18,7 +18,7 @@ func set_veg_size(new_veg_size: Vector2) -> void:
 func _refresh_tile_map() -> void:
 	for x in range(veg_size.x):
 		for y in range(veg_size.y):
-			$TileMap.set_block(Vector2(x, y), PuzzleTileMap.TILE_VEG, Vector2(randi() % 18, randi() % 4))
+			$TileMap.set_block(Vector2(x, y), PuzzleTileMap.TILE_VEG, PuzzleTileMap.random_veg_autotile_coord())
 
 
 func _on_RotateButton_pressed() -> void:

--- a/project/src/main/puzzle/level/level-trigger-effects.gd
+++ b/project/src/main/puzzle/level/level-trigger-effects.gd
@@ -176,6 +176,9 @@ class InsertLineEffect extends LevelTriggerEffect:
 	## (Optional) target row
 	var y: int = PuzzleTileMap.ROW_COUNT - 1
 	
+	## (Optional) number of lines to insert
+	var count: int = 1
+	
 	## (Optional) keys corresponding to sets of tiles in LevelTiles for the tiles to insert
 	var tiles_keys: Array = []
 	
@@ -197,11 +200,14 @@ class InsertLineEffect extends LevelTriggerEffect:
 			tiles_keys = new_config["tiles_keys"].split(",")
 		if new_config.has("y"):
 			y = ConfigStringUtils.invert_puzzle_row_index(int(new_config["y"]))
+		if new_config.has("count"):
+			count = new_config["count"].to_int()
 	
 	
 	## Inserts a new line at the bottom of the playfield.
 	func run() -> void:
-		CurrentLevel.puzzle.get_playfield().line_inserter.insert_line(tiles_keys, y)
+		for _i in range(count):
+			CurrentLevel.puzzle.get_playfield().line_inserter.insert_line(tiles_keys, y)
 	
 	
 	func get_config() -> Dictionary:
@@ -214,7 +220,9 @@ class InsertLineEffect extends LevelTriggerEffect:
 			_:
 				result["tiles_keys"] = PoolStringArray(tiles_keys).join(",")
 		if y != PuzzleTileMap.ROW_COUNT - 1:
-			result["y"] = ConfigStringUtils.invert_puzzle_row_index(y)
+			result["y"] = str(ConfigStringUtils.invert_puzzle_row_index(y))
+		if count != 1:
+			result["count"] = str(count)
 		return result
 
 

--- a/project/src/main/puzzle/line-filler.gd
+++ b/project/src/main/puzzle/line-filler.gd
@@ -119,7 +119,11 @@ func _fill_line(tiles_key: String, dest_y: int) -> void:
 	for x in range(PuzzleTileMap.COL_COUNT):
 		var src_pos := Vector2(x, src_y)
 		var tile: int = tiles.block_tiles.get(src_pos, -1)
-		var autotile_coord: Vector2 = tiles.block_autotile_coords.get(src_pos, Vector2.ZERO)
+		var autotile_coord: Vector2
+		if tile == PuzzleTileMap.TILE_VEG:
+			autotile_coord = PuzzleTileMap.random_veg_autotile_coord()
+		else:
+			autotile_coord = tiles.block_autotile_coords.get(src_pos, Vector2.ZERO)
 		_tile_map.set_block(Vector2(x, dest_y), tile, autotile_coord)
 	
 	emit_signal("line_filled", dest_y, tiles_key, src_y)

--- a/project/src/main/puzzle/line-inserter.gd
+++ b/project/src/main/puzzle/line-inserter.gd
@@ -67,12 +67,16 @@ func insert_line(tiles_keys: Array = [], dest_y: int = PuzzleTileMap.ROW_COUNT -
 		for x in range(PuzzleTileMap.COL_COUNT):
 			var src_pos := Vector2(x, src_y)
 			var tile: int = tiles.block_tiles.get(src_pos, -1)
-			var autotile_coord: Vector2 = tiles.block_autotile_coords.get(src_pos, Vector2.ZERO)
+			var autotile_coord: Vector2
+			if tile == PuzzleTileMap.TILE_VEG:
+				autotile_coord = PuzzleTileMap.random_veg_autotile_coord()
+			else:
+				autotile_coord = tiles.block_autotile_coords.get(src_pos, Vector2.ZERO)
 			_tile_map.set_block(Vector2(x, dest_y), tile, autotile_coord)
 	else:
 		# fill bottom row with random veggie garbage
 		for x in range(PuzzleTileMap.COL_COUNT):
-			var veg_autotile_coord := Vector2(randi() % 18, randi() % 4)
+			var veg_autotile_coord := PuzzleTileMap.random_veg_autotile_coord()
 			_tile_map.set_block(Vector2(x, dest_y), PuzzleTileMap.TILE_VEG, veg_autotile_coord)
 		_tile_map.set_block(Vector2(randi() % PuzzleTileMap.COL_COUNT, dest_y), -1)
 	

--- a/project/src/main/puzzle/pickups.gd
+++ b/project/src/main/puzzle/pickups.gd
@@ -102,6 +102,16 @@ func set_piece_manager_path(new_piece_manager_path: NodePath) -> void:
 	_refresh_piece_manager_path()
 
 
+## Returns true if the specified row has no pickups.
+func row_is_empty(y: int) -> bool:
+	var row_is_empty := true
+	for x in range(PuzzleTileMap.COL_COUNT):
+		if not get_pickup(Vector2(x, y)) == TileMap.INVALID_CELL:
+			row_is_empty = false
+			break
+	return row_is_empty
+
+
 func _refresh_piece_manager_path() -> void:
 	if not is_inside_tree():
 		return

--- a/project/src/main/puzzle/puzzle-tile-map.gd
+++ b/project/src/main/puzzle/puzzle-tile-map.gd
@@ -253,6 +253,31 @@ func shift_rows(bottom_row: int, direction: Vector2) -> void:
 		set_block(cell, piece_colors_to_set[cell], autotile_coords_to_set[cell])
 
 
+## Returns the PuzzleTileMap's contents as a multi-row string.
+##
+## This string can be displayed (preferably using a fixed-width font) which helps in debugging.
+func contents_as_string() -> String:
+	var str_rows := []
+	for y in range(get_used_rect().position.y, get_used_rect().position.y + get_used_rect().size.y):
+		str_rows.append("")
+		for x in range(get_used_rect().position.x, get_used_rect().position.x + get_used_rect().size.x):
+			var cell_str: String = "."
+			match get_cell(x, y):
+				INVALID_CELL: cell_str = "."
+				TILE_PIECE: cell_str = "u"
+				TILE_BOX: cell_str = "w"
+				TILE_VEG: cell_str = "v"
+				_: cell_str = "?"
+			str_rows[str_rows.size() - 1] += cell_str
+	
+	var result := ""
+	for str_row in str_rows:
+		if result:
+			result += "\n"
+		result += str_row
+	return result
+
+
 ## Disconnects a row from any empty neighbors.
 ##
 ## Disconnected boxes have their connections updated. Disconnected pieces are converted to vegetable blocks.
@@ -353,3 +378,8 @@ static func has_cake_box(box_types: Array) -> bool:
 			result = true
 			break
 	return result
+
+
+## Returns a random autotile coordinate for a vegetable tile.
+static func random_veg_autotile_coord() -> Vector2:
+	return Vector2(randi() % 18, randi() % 4)

--- a/project/src/main/puzzle/star-seeds.gd
+++ b/project/src/main/puzzle/star-seeds.gd
@@ -100,8 +100,8 @@ func _prepare_star_seeds_for_level() -> void:
 ## Parameters:
 ## 	'rect_range': Cell coordinates defining the cells to search.
 func _add_star_seeds_for_boxes(rect_range: Rect2) -> void:
-	for x in range(rect_range.position.x, rect_range.position.x + rect_range.size.x):
-		for y in range(rect_range.position.y, rect_range.position.y + rect_range.size.y):
+	for y in range(rect_range.position.y, rect_range.position.y + rect_range.size.y):
+		for x in range(rect_range.position.x, rect_range.position.x + rect_range.size.x):
 			var cell_contents := _puzzle_tile_map.get_cellv(Vector2(x, y))
 			if cell_contents != PuzzleTileMap.TILE_BOX:
 				continue

--- a/project/src/test/puzzle/level/test-level-trigger-effects.gd
+++ b/project/src/test/puzzle/level/test-level-trigger-effects.gd
@@ -20,6 +20,10 @@ func test_insert_line_get_config() -> void:
 	assert_eq_shallow(effect.get_config(), {})
 	
 	effect = LevelTriggerEffects.InsertLineEffect.new()
+	effect.set_config({"count": "5"})
+	assert_eq_shallow(effect.get_config(), {"count": "5"})
+	
+	effect = LevelTriggerEffects.InsertLineEffect.new()
 	effect.set_config({"tiles_key": "0"})
 	assert_eq_shallow(effect.get_config(), {"tiles_key": "0"})
 	
@@ -28,8 +32,8 @@ func test_insert_line_get_config() -> void:
 	assert_eq_shallow(effect.get_config(), {"tiles_keys": "0,1"})
 	
 	effect = LevelTriggerEffects.InsertLineEffect.new()
-	effect.set_config({"y": 5})
-	assert_eq_shallow(effect.get_config(), {"y": 5})
+	effect.set_config({"y": "5"})
+	assert_eq_shallow(effect.get_config(), {"y": "5"})
 
 
 func test_add_moles_set_config() -> void:


### PR DESCRIPTION
LineInserter now accepts 'count' parameter for inserting multiple lines.

Fixed bug where inserting lines in response to line clears could result in blank lines being inserted.

Fixed bug where LineClearer was assigning 'true' into a dictionary which was supposed to have numeric values only.

LineInserter/LineFiller now randomize vegetables.