### PR TITLE
Replace top out rank penalty with money penalty

### DIFF
--- a/project/src/demo/puzzle/ScoreDemo.tscn
+++ b/project/src/demo/puzzle/ScoreDemo.tscn
@@ -1,0 +1,28 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://src/main/puzzle/Score.tscn" type="PackedScene" id=1]
+[ext_resource path="res://src/demo/puzzle/score-demo.gd" type="Script" id=2]
+
+[node name="ScoreDemo" type="Node"]
+script = ExtResource( 2 )
+
+[node name="ColorRect" type="ColorRect" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -135.0
+margin_top = -47.0
+margin_right = 135.0
+margin_bottom = 47.0
+color = Color( 0.458824, 0.25098, 0.501961, 1 )
+
+[node name="Score" parent="ColorRect" instance=ExtResource( 1 )]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -125.0
+margin_top = -37.0
+margin_right = 125.0
+margin_bottom = 37.0

--- a/project/src/demo/puzzle/score-demo.gd
+++ b/project/src/demo/puzzle/score-demo.gd
@@ -1,0 +1,22 @@
+extends Node
+## A demo which lets you test the puzzle scoreboard.
+##
+## Keys:
+## 	[1-4]: Adds ¥10, ¥200, ¥300, or ¥4,000 to the current combo
+## 	[Enter]: Ends the current combo, incrementing the score
+## 	[R]: Resets the level
+## 	[T]: Tops out
+
+onready var _score := $ColorRect/Score
+
+func _input(event: InputEvent) -> void:
+	match Utils.key_scancode(event):
+		KEY_1: PuzzleState.add_line_score(1, 1)
+		KEY_2: PuzzleState.add_line_score(20, 20)
+		KEY_3: PuzzleState.add_line_score(300, 300)
+		KEY_4: PuzzleState.add_line_score(4000, 4000)
+		
+		KEY_ENTER: PuzzleState.end_combo()
+		
+		KEY_R: PuzzleState.reset()
+		KEY_T: PuzzleState.top_out()

--- a/project/src/main/puzzle/Score.tscn
+++ b/project/src/main/puzzle/Score.tscn
@@ -1,37 +1,136 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://src/main/puzzle/score-value-label.gd" type="Script" id=1]
 [ext_resource path="res://src/main/ui/theme/h3.theme" type="Theme" id=2]
 [ext_resource path="res://src/main/puzzle/combo-score-value-label.gd" type="Script" id=3]
 [ext_resource path="res://src/main/ui/theme/h2.theme" type="Theme" id=4]
 
+[sub_resource type="Gradient" id=5]
+offsets = PoolRealArray( 0, 0.695652 )
+colors = PoolColorArray( 1, 1, 1, 1, 1, 1, 1, 0 )
+
+[sub_resource type="GradientTexture" id=4]
+gradient = SubResource( 5 )
+
+[sub_resource type="ParticlesMaterial" id=6]
+flag_disable_z = true
+direction = Vector3( -100, -40, 0 )
+spread = 15.0
+gravity = Vector3( 0, 0, 0 )
+initial_velocity = 600.0
+initial_velocity_random = 0.5
+orbit_velocity = 0.0
+orbit_velocity_random = 0.0
+scale = 5.0
+color_ramp = SubResource( 4 )
+
+[sub_resource type="ParticlesMaterial" id=7]
+flag_disable_z = true
+direction = Vector3( 100, -40, 0 )
+spread = 15.0
+gravity = Vector3( 0, 0, 0 )
+initial_velocity = 600.0
+initial_velocity_random = 0.5
+orbit_velocity = 0.0
+orbit_velocity_random = 0.0
+scale = 5.0
+color_ramp = SubResource( 4 )
+
+[sub_resource type="ParticlesMaterial" id=8]
+flag_disable_z = true
+direction = Vector3( -100, 40, 0 )
+spread = 15.0
+gravity = Vector3( 0, 0, 0 )
+initial_velocity = 600.0
+initial_velocity_random = 0.5
+orbit_velocity = 0.0
+orbit_velocity_random = 0.0
+scale = 5.0
+color_ramp = SubResource( 4 )
+
+[sub_resource type="ParticlesMaterial" id=9]
+flag_disable_z = true
+direction = Vector3( 100, 40, 0 )
+spread = 15.0
+gravity = Vector3( 0, 0, 0 )
+initial_velocity = 600.0
+initial_velocity_random = 0.5
+orbit_velocity = 0.0
+orbit_velocity_random = 0.0
+scale = 5.0
+color_ramp = SubResource( 4 )
+
 [node name="Score" type="Control"]
 margin_right = 250.0
 margin_bottom = 74.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="ScoreValueLabel" type="Label" parent="."]
-margin_right = 250.0
-margin_bottom = 44.0
+anchor_left = 1.0
+anchor_right = 1.0
+margin_left = -79.0
+margin_bottom = 45.0
+size_flags_horizontal = 4
 theme = ExtResource( 4 )
 text = "¥616"
 align = 2
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+
+[node name="TopOutParticles" type="Control" parent="ScoreValueLabel"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+
+[node name="Nw" type="Particles2D" parent="ScoreValueLabel/TopOutParticles"]
+emitting = false
+amount = 2
+lifetime = 0.6
+one_shot = true
+explosiveness = 1.0
+process_material = SubResource( 6 )
+
+[node name="Ne" type="Particles2D" parent="ScoreValueLabel/TopOutParticles"]
+emitting = false
+amount = 2
+lifetime = 0.6
+one_shot = true
+explosiveness = 1.0
+process_material = SubResource( 7 )
+
+[node name="Sw" type="Particles2D" parent="ScoreValueLabel/TopOutParticles"]
+emitting = false
+amount = 2
+lifetime = 0.6
+one_shot = true
+explosiveness = 1.0
+process_material = SubResource( 8 )
+
+[node name="Se" type="Particles2D" parent="ScoreValueLabel/TopOutParticles"]
+emitting = false
+amount = 2
+lifetime = 0.6
+one_shot = true
+explosiveness = 1.0
+process_material = SubResource( 9 )
 
 [node name="ComboScoreValueLabel" type="Label" parent="."]
 modulate = Color( 1, 1, 1, 0.501961 )
-margin_top = 36.0
-margin_right = 250.0
-margin_bottom = 66.0
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -55.0
+margin_top = -38.0
+margin_bottom = -7.99456
+size_flags_horizontal = 4
 theme = ExtResource( 2 )
 text = "+¥55"
 align = 2
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+
+[node name="PenaltyTimer" type="Timer" parent="ComboScoreValueLabel"]
+wait_time = 2.0
+one_shot = true
+
+[connection signal="resized" from="ComboScoreValueLabel" to="ComboScoreValueLabel" method="_on_resized"]
+[connection signal="resized" from="ScoreValueLabel" to="ScoreValueLabel" method="_on_resized"]

--- a/project/src/main/puzzle/combo-score-value-label.gd
+++ b/project/src/main/puzzle/combo-score-value-label.gd
@@ -3,12 +3,18 @@ extends Label
 ##
 ## This only includes bonuses and should be a round number like +55 or +130 for visual aesthetics.
 
+## Enforces a minimum time that we show the top out penalty. Without this, the player might not notice the penalty if
+## their score changed a split second later (or worse yet, on the exact same frame).
+onready var _penalty_timer := $PenaltyTimer
+
 func _ready() -> void:
 	PuzzleState.connect("score_changed", self, "_on_PuzzleState_score_changed")
+	PuzzleState.connect("topped_out", self, "_on_PuzzleState_topped_out")
 	text = "-"
 
 
-func _on_PuzzleState_score_changed() -> void:
+func _refresh_score() -> void:
+	modulate = Color("80ffffff")
 	var bonus_score := PuzzleState.get_bonus_score()
 	if bonus_score == 0:
 		# zero is displayed as '-'
@@ -19,3 +25,22 @@ func _on_PuzzleState_score_changed() -> void:
 	else:
 		# negative values (which should never show up) are displayed as '-¥1,025'
 		text = StringUtils.format_money(bonus_score)
+
+
+func _on_resized() -> void:
+	margin_left = -rect_size.x
+
+
+func _on_PuzzleState_score_changed() -> void:
+	if not _penalty_timer.is_stopped():
+		# if the player tops out, we show the penalty value for a few seconds
+		return
+	
+	_refresh_score()
+
+
+func _on_PuzzleState_topped_out() -> void:
+	modulate = Color("80ff5555")
+	text = StringUtils.format_money(-1 * PuzzleState.TOP_OUT_PENALTY)
+	rect_size = Vector2(0, 0)
+	_penalty_timer.start()

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -59,6 +59,9 @@ const DELAY_LONG := 3.30
 
 const READY_DURATION := 1.4
 
+## Number of points deducted from the player's score if they top out.
+const TOP_OUT_PENALTY := 100
+
 ## the current input frame for recording/replaying the player's inputs. a value of '-1' indicates that no input should
 ## be recorded or replayed yet.
 var input_frame := -1
@@ -130,9 +133,11 @@ func set_speed_index(new_speed_index: int) -> void:
 
 func top_out() -> void:
 	level_performance.top_out_count += 1
+	level_performance.score = max(level_performance.score - TOP_OUT_PENALTY, 0)
 	if level_performance.top_out_count >= CurrentLevel.settings.lose_condition.top_out:
 		make_player_lose()
 	emit_signal("topped_out")
+	emit_signal("score_changed")
 
 
 func make_player_lose() -> void:

--- a/project/src/main/puzzle/rank-calculator.gd
+++ b/project/src/main/puzzle/rank-calculator.gd
@@ -386,7 +386,6 @@ func _populate_rank_fields(rank_result: RankResult, lenient: bool) -> void:
 		else:
 			rank_result.score_rank -= CurrentLevel.settings.rank.success_bonus
 	
-	_apply_top_out_penalty(rank_result)
 	_clamp_result(rank_result, lenient)
 
 
@@ -426,28 +425,6 @@ func target_lines_for_score(box_score_per_line: float, combo_score_per_line: flo
 		result = max(1, result - (CurrentLevel.settings.rank.preplaced_pieces / 2.0))
 	
 	return result
-
-
-## Reduces the player's ranks if they topped out.
-##
-## Each time the player tops out, all of their ranks are reduced by a certain amount.
-##
-## It's also possible for the player to lose without topping out, if they either met a special lose condition or hit
-## 'esc' to give up on the level. In this case, we still apply one top out penalty. This prevents people from losing on
-## purpose to achieve a good rank.
-func _apply_top_out_penalty(rank_result: RankResult) -> void:
-	if rank_result.topped_out() or rank_result.lost:
-		var penalty_count := max(1, rank_result.top_out_count)
-		var settings: LevelSettings = CurrentLevel.settings
-		var all_penalty := penalty_count * settings.rank.top_out_penalty
-		rank_result.speed_rank = rank_result.speed_rank + all_penalty
-		rank_result.lines_rank = rank_result.lines_rank + all_penalty
-		rank_result.pieces_rank = rank_result.pieces_rank + all_penalty
-		rank_result.box_score_per_line_rank = rank_result.box_score_per_line_rank + all_penalty
-		rank_result.combo_score_per_line_rank = rank_result.combo_score_per_line_rank + all_penalty
-		rank_result.pickup_score_rank = rank_result.pickup_score_rank + all_penalty
-		rank_result.score_rank = rank_result.score_rank + all_penalty
-		rank_result.seconds_rank = rank_result.seconds_rank + all_penalty
 
 
 ## Clamps the player's ranks within [0, 999] to avoid edge cases.

--- a/project/src/main/puzzle/results-hud.gd
+++ b/project/src/main/puzzle/results-hud.gd
@@ -68,44 +68,34 @@ func _append_customer_scores(rank_result: RankResult, customer_scores: Array, \
 
 func _append_grade_information(rank_result: RankResult, _customer_scores: Array, \
 		finish_condition_type: int, text: String) -> String:
-	# We add a '?' to make the player aware if their rank is adjusted because they topped out or lost.
-	var topped_out := ""
-	if rank_result.topped_out() and CurrentLevel.settings.rank.top_out_penalty > 0:
-		topped_out = "?"
-	
 	text += "\n"
 	
 	if _speed_shown(finish_condition_type):
 		text += "|||||" + tr("Speed: %d") % round(rank_result.speed * 200 / 60)
-		text += topped_out
 		if not CurrentLevel.settings.rank.unranked:
 			text += " (%s)" % RankCalculator.grade(rank_result.speed_rank)
 		text += "\n"
 	
 	if _pieces_shown(finish_condition_type):
 		text += "|||||" + tr("Pieces: %d") % rank_result.pieces
-		text += topped_out
 		if not CurrentLevel.settings.rank.unranked:
 			text += " (%s)" % RankCalculator.grade(rank_result.pieces_rank)
 		text += "\n"
 	
 	if _lines_shown(finish_condition_type):
 		text += "|||||" + tr("Lines: %d") % rank_result.lines
-		text += topped_out
 		if not CurrentLevel.settings.rank.unranked:
 			text += " (%s)" % RankCalculator.grade(rank_result.lines_rank)
 		text += "\n"
 	
 	if _boxes_shown():
 		text += "|||||" + tr("Boxes: %d") % round(rank_result.box_score_per_line * 10)
-		text += topped_out
 		if not CurrentLevel.settings.rank.unranked:
 			text += " (%s)" % RankCalculator.grade(rank_result.box_score_per_line_rank)
 		text += "\n"
 	
 	if _combos_shown():
 		text += "|||||" + tr("Combos: %d") % round(rank_result.combo_score_per_line * 10)
-		text += topped_out
 		if not CurrentLevel.settings.rank.unranked:
 			text += " (%s)" % RankCalculator.grade(rank_result.combo_score_per_line_rank)
 		text += "\n"
@@ -120,7 +110,6 @@ func _append_grade_information(rank_result: RankResult, _customer_scores: Array,
 			shown_pickup_score = float(rank_result.pickup_score)
 		
 		text += "|||||" + tr("Pickups: %d") % shown_pickup_score
-		text += topped_out
 		if not CurrentLevel.settings.rank.unranked:
 			text += " (%s)" % RankCalculator.grade(rank_result.pickup_score_rank)
 		text += "\n"
@@ -130,7 +119,7 @@ func _append_grade_information(rank_result: RankResult, _customer_scores: Array,
 		text += "||||||||||"
 		if finish_condition_type == Milestone.SCORE:
 			var duration := StringUtils.format_duration(rank_result.seconds)
-			text += "%s%s (%s)\n" % [duration, topped_out, RankCalculator.grade(rank_result.seconds_rank)]
+			text += "%s (%s)\n" % [duration, RankCalculator.grade(rank_result.seconds_rank)]
 		else:
 			text += "(%s)\n" % RankCalculator.grade(rank_result.score_rank)
 	return text

--- a/project/src/main/puzzle/score-value-label.gd
+++ b/project/src/main/puzzle/score-value-label.gd
@@ -1,10 +1,33 @@
 extends Label
 ## Displays the player's score.
 
+onready var _top_out_particles := $TopOutParticles
+
 func _ready() -> void:
 	PuzzleState.connect("score_changed", self, "_on_PuzzleState_score_changed")
+	PuzzleState.connect("topped_out", self, "_on_PuzzleState_topped_out")
 	text = StringUtils.format_money(0)
+	
+	# Workaround for Godot #40357 to force the label to shrink to its minimum size. Otherwise, the ScoreParticles
+	# will be positioned incorrectly if the text ever shrinks.
+	rect_size = Vector2(0, 0)
+
+
+func _on_resized() -> void:
+	margin_left = -rect_size.x
+	_top_out_particles.rect_position = rect_size * 0.5
 
 
 func _on_PuzzleState_score_changed() -> void:
 	text = StringUtils.format_money(PuzzleState.get_score())
+	
+	# Workaround for Godot #40357 to force the label to shrink to its minimum size. Otherwise, the ScoreParticles
+	# will be positioned incorrectly if the text ever shrinks.
+	rect_size = Vector2(0, 0)
+
+
+func _on_PuzzleState_topped_out() -> void:
+	for particles_2d_node in _top_out_particles.get_children():
+		var particles_2d: Particles2D = particles_2d_node
+		particles_2d.restart()
+		particles_2d.emitting = true

--- a/project/src/test/puzzle/test-rank-calculator.gd
+++ b/project/src/test/puzzle/test-rank-calculator.gd
@@ -130,23 +130,14 @@ func test_calculate_rank_sprint_120_top_out() -> void:
 	assert_eq(RankCalculator.grade(rank1.combo_score_per_line_rank), "SS")
 	assert_eq(RankCalculator.grade(rank1.score_rank), "S+")
 	
-	# after topping out, ranks decrease
+	# even when topping out, ranks stay the same
 	PuzzleState.level_performance.top_out_count = 1
 	var rank2 := _rank_calculator.calculate_rank()
-	assert_eq(RankCalculator.grade(rank2.speed_rank), "S+")
-	assert_eq(RankCalculator.grade(rank2.lines_rank), "SS")
-	assert_eq(RankCalculator.grade(rank2.box_score_per_line_rank), "S-")
-	assert_eq(RankCalculator.grade(rank2.combo_score_per_line_rank), "S+")
-	assert_eq(RankCalculator.grade(rank2.score_rank), "S")
-	
-	# after topping out again, ranks decrease further
-	PuzzleState.level_performance.top_out_count = 2
-	var rank3 := _rank_calculator.calculate_rank()
-	assert_eq(RankCalculator.grade(rank3.speed_rank), "S+")
-	assert_eq(RankCalculator.grade(rank3.lines_rank), "S+")
-	assert_eq(RankCalculator.grade(rank3.box_score_per_line_rank), "AA+")
-	assert_eq(RankCalculator.grade(rank3.combo_score_per_line_rank), "S")
-	assert_eq(RankCalculator.grade(rank3.score_rank), "S-")
+	assert_eq(RankCalculator.grade(rank2.speed_rank), "SS+")
+	assert_eq(RankCalculator.grade(rank2.lines_rank), "SS+")
+	assert_eq(RankCalculator.grade(rank2.box_score_per_line_rank), "S")
+	assert_eq(RankCalculator.grade(rank2.combo_score_per_line_rank), "SS")
+	assert_eq(RankCalculator.grade(rank2.score_rank), "S+")
 
 
 func test_calculate_rank_ultra_200() -> void:
@@ -162,21 +153,6 @@ func test_calculate_rank_ultra_200() -> void:
 	assert_eq(rank.combo_score_per_line, 20.0)
 	assert_eq(RankCalculator.grade(rank.combo_score_per_line_rank), "M")
 	assert_eq(RankCalculator.grade(rank.seconds_rank), "SS+")
-
-
-func test_calculate_rank_ultra_200_lost() -> void:
-	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 200)
-	PuzzleState.level_performance.seconds = 60
-	PuzzleState.level_performance.lines = 10
-	PuzzleState.level_performance.box_score = 80
-	PuzzleState.level_performance.combo_score = 60
-	PuzzleState.level_performance.score = 150
-	PuzzleState.level_performance.lost = true
-	var rank := _rank_calculator.calculate_rank()
-	assert_eq(RankCalculator.grade(rank.speed_rank), "S-")
-	assert_eq(rank.seconds_rank, 999.0)
-	assert_eq(RankCalculator.grade(rank.box_score_per_line_rank), "S-")
-	assert_eq(RankCalculator.grade(rank.combo_score_per_line_rank), "S")
 
 
 ## This is an edge case where, if the player clears too many lines for ultra, they can sort of be robbed of a master


### PR DESCRIPTION
Topping out no longer affects the rank algorithm. Instead, it takes away ¥100 and plays a long 'top out' animation which takes some time anyways. This is enough of a penalty.

The score panel now shows a red number and particle effect when the player tops out.