### PR TITLE
CustomerQueue, CutsceneQueue are reset on data load.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -265,6 +265,11 @@ _global_script_classes=[ {
 "path": "res://src/main/world/cutscene-camera.gd"
 }, {
 "base": "Reference",
+"class": "CutsceneQueue",
+"language": "GDScript",
+"path": "res://src/main/world/cutscene-queue.gd"
+}, {
+"base": "Reference",
 "class": "CutsceneSearchFlags",
 "language": "GDScript",
 "path": "res://src/main/chat/cutscene-search-flags.gd"
@@ -1176,6 +1181,7 @@ _global_script_class_icons={
 "CrumbCluster": "",
 "CustomerQueue": "",
 "CutsceneCamera": "",
+"CutsceneQueue": "",
 "CutsceneSearchFlags": "",
 "CutsceneWorld": "",
 "DnaAlternatives": "",
@@ -1377,7 +1383,6 @@ CreatureLoader="*res://src/main/world/creature/creature-loader.gd"
 CrumbDefinitions="*res://src/main/puzzle/crumb-definitions.gd"
 CurrentCutscene="*res://src/main/world/current-cutscene.gd"
 CurrentLevel="*res://src/main/puzzle/level/current-level.gd"
-CutsceneQueue="*res://src/main/world/cutscene-queue.gd"
 DnaUtils="*res://src/main/world/creature/dna-utils.gd"
 KeybindManager="*res://src/main/settings/keybind-manager.gd"
 MilestoneManager="*res://src/main/puzzle/milestone-manager.gd"

--- a/project/src/main/career/career-flow.gd
+++ b/project/src/main/career/career-flow.gd
@@ -13,15 +13,15 @@ func push_career_trail() -> void:
 		Breadcrumb.trail.pop_front()
 	
 	var redirected := false
-	if not redirected and not CutsceneQueue.is_queue_empty():
+	if not redirected and not PlayerData.cutscene_queue.is_queue_empty():
 		# If there are pending puzzles/cutscenes, show them.
 		
 		# If the player is playing a puzzle, we immediately apply failure penalties to the player's save data so they
 		# can't quit and retry.
-		if CutsceneQueue.is_front_level():
+		if PlayerData.cutscene_queue.is_front_level():
 			_preapply_failure_penalties()
 		
-		CutsceneQueue.push_trail()
+		PlayerData.cutscene_queue.push_trail()
 		redirected = true
 	
 	if not redirected and should_play_prologue():
@@ -53,19 +53,19 @@ func process_puzzle_result() -> void:
 		career_data.advance_clock(0, false)
 		career_data.skipped_previous_level = true
 	
-	if CutsceneQueue.has_cutscene_flag("intro_level") \
+	if PlayerData.cutscene_queue.has_cutscene_flag("intro_level") \
 			and not CurrentLevel.best_result in [Levels.Result.FINISHED, Levels.Result.WON]:
 		# player lost an intro level
 		skip_remaining_cutscenes = true
 	
-	if CutsceneQueue.has_cutscene_flag("boss_level") \
+	if PlayerData.cutscene_queue.has_cutscene_flag("boss_level") \
 			and not CurrentLevel.best_result == Levels.Result.WON:
 		# player didn't meet the win criteria for a boss level
 		skip_remaining_cutscenes = true
 	
 	if skip_remaining_cutscenes:
 		# skip career cutscenes if they skip a level, or if they fail a boss level
-		CutsceneQueue.reset()
+		PlayerData.cutscene_queue.reset()
 
 
 ## Returns 'true' if the current career region has a prologue the player hasn't seen.

--- a/project/src/main/data/player-data.gd
+++ b/project/src/main/data/player-data.gd
@@ -21,6 +21,7 @@ var chat_history := ChatHistory.new()
 
 var creature_library := CreatureLibrary.new()
 var customer_queue := CustomerQueue.new()
+var cutscene_queue := CutsceneQueue.new()
 
 var career: CareerData
 var practice := PracticeData.new()
@@ -49,6 +50,8 @@ func reset() -> void:
 	level_history.reset()
 	chat_history.reset()
 	creature_library.reset()
+	customer_queue.reset()
+	cutscene_queue.reset()
 	career.reset()
 	practice.reset()
 	money = 0

--- a/project/src/main/puzzle/customer-queue.gd
+++ b/project/src/main/puzzle/customer-queue.gd
@@ -64,7 +64,7 @@ func pop_standard_customer() -> CreatureDef:
 ## Empties the queue of creatures who will show up at the start of the next puzzle.
 ##
 ## Also rotates the standard customers so the same creatures don't show up over and over.
-func clear() -> void:
+func reset() -> void:
 	priority_queue = []
 	priority_index = 0
 	reset_standard_customer_queue()

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -167,15 +167,15 @@ func _quit_puzzle() -> void:
 		PlayerData.career.process_puzzle_result()
 	
 	CurrentLevel.reset()
-	PlayerData.customer_queue.clear()
+	PlayerData.customer_queue.reset()
 	
 	if PlayerData.career.is_career_mode():
 		# career mode; defer to CareerData to decide the next scene.
 		PlayerData.career.push_career_trail()
 	else:
 		# not career mode; play a cutscene or return to the previous scene
-		if CutsceneQueue.is_front_cutscene():
-			CutsceneQueue.replace_trail()
+		if PlayerData.cutscene_queue.is_front_cutscene():
+			PlayerData.cutscene_queue.replace_trail()
 		else:
 			SceneTransition.pop_trail()
 

--- a/project/src/main/ui/menu/main-menu-play.gd
+++ b/project/src/main/ui/menu/main-menu-play.gd
@@ -4,7 +4,7 @@ extends VBoxContainer
 const WORLD0_ID := "world0"
 
 func _on_Career_pressed() -> void:
-	PlayerData.customer_queue.clear()
+	PlayerData.customer_queue.reset()
 	CurrentLevel.reset()
 	
 	# Launch the first scene in career mode. This is probably the career map, but in some edge cases it could be a

--- a/project/src/main/ui/menu/splash-screen.gd
+++ b/project/src/main/ui/menu/splash-screen.gd
@@ -19,7 +19,7 @@ func _exit_tree() -> void:
 
 
 func _launch_tutorial() -> void:
-	PlayerData.customer_queue.clear()
+	PlayerData.customer_queue.reset()
 	CurrentLevel.set_launched_level(OtherLevelLibrary.BEGINNER_TUTORIAL)
 	CurrentLevel.push_level_trail()
 

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -385,12 +385,12 @@ func _on_LevelSelectButton_level_chosen(level_index: int) -> void:
 	var preroll_key: String = chat_key_pair.preroll
 	var postroll_key: String = chat_key_pair.postroll
 	
-	CutsceneQueue.reset()
+	PlayerData.cutscene_queue.reset()
 	
 	if preroll_key:
-		CutsceneQueue.enqueue_cutscene(ChatLibrary.chat_tree_for_key(preroll_key))
+		PlayerData.cutscene_queue.enqueue_cutscene(ChatLibrary.chat_tree_for_key(preroll_key))
 	
-	CutsceneQueue.enqueue_level({
+	PlayerData.cutscene_queue.enqueue_level({
 		"level_id": level_settings.id,
 		"piece_speed": _piece_speed,
 		"chef_id": CurrentLevel.chef_id,
@@ -399,18 +399,18 @@ func _on_LevelSelectButton_level_chosen(level_index: int) -> void:
 	})
 	
 	if postroll_key:
-		CutsceneQueue.enqueue_cutscene(ChatLibrary.chat_tree_for_key(postroll_key))
+		PlayerData.cutscene_queue.enqueue_cutscene(ChatLibrary.chat_tree_for_key(postroll_key))
 	
 	if preroll_key or postroll_key:
 		match chat_key_pair.type:
 			ChatKeyPair.INTRO_LEVEL:
-				CutsceneQueue.set_cutscene_flag("intro_level")
+				PlayerData.cutscene_queue.set_cutscene_flag("intro_level")
 			ChatKeyPair.BOSS_LEVEL:
-				CutsceneQueue.set_cutscene_flag("boss_level")
+				PlayerData.cutscene_queue.set_cutscene_flag("boss_level")
 	
 	if _should_play_epilogue(chat_key_pair):
 		var region := PlayerData.career.current_region()
-		CutsceneQueue.enqueue_cutscene(ChatLibrary.chat_tree_for_key(region.get_epilogue_chat_key()))
+		PlayerData.cutscene_queue.enqueue_cutscene(ChatLibrary.chat_tree_for_key(region.get_epilogue_chat_key()))
 	
 	PlayerData.career.push_career_trail()
 

--- a/project/src/main/world/cutscene-queue.gd
+++ b/project/src/main/world/cutscene-queue.gd
@@ -1,4 +1,4 @@
-extends Node
+class_name CutsceneQueue
 ## Maintains a queue of pending cutscenes and levels.
 ##
 ## When the game plays cutscenes, it plays one or more cutscenes and sometimes plays a level or returns to a different

--- a/project/src/main/world/overworld-ui.gd
+++ b/project/src/main/world/overworld-ui.gd
@@ -145,7 +145,7 @@ func _apply_chat_event_meta(_chat_event: ChatEvent, meta_item: String) -> void:
 			var next_scene_key := meta_item_split[1]
 			var next_scene_chat_tree: ChatTree = ChatLibrary.chat_tree_for_key(next_scene_key)
 			# insert the chat tree to ensure it happens before any enqueued levels
-			CutsceneQueue.insert_cutscene(0, next_scene_chat_tree)
+			PlayerData.cutscene_queue.insert_cutscene(0, next_scene_chat_tree)
 		"creature_enter":
 			var creature_id := meta_item_split[1]
 			var creature: Creature = CreatureManager.get_creature_by_id(creature_id)


### PR DESCRIPTION
Moved CutsceneQueue into PlayerData. This is unsuitable as an autoload singleton because it's stateful and needs to be managed alongside the player's data. If the player loads their save data or switches to a new save slot, the CutsceneQueue needs to be reset too.