### PR TITLE
Fixed PuzzleDemo timer visibility bug

### DIFF
--- a/project/src/main/puzzle/puzzle-timer.gd
+++ b/project/src/main/puzzle/puzzle-timer.gd
@@ -2,11 +2,10 @@ extends Label
 ## A UI component showing how long the player has spent on the current puzzle.
 
 func _ready() -> void:
-	if CurrentLevel.settings.finish_condition.type == Milestone.TIME_OVER:
-		# we don't display a timer for timed levels as it would be redundant
-		visible = false
-		set_process(false)
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
+	CurrentLevel.connect("settings_changed", self, "_on_Level_settings_changed")
 	
+	_init_visible()
 	_refresh_text()
 
 
@@ -14,6 +13,22 @@ func _process(_delta: float) -> void:
 	_refresh_text()
 
 
+## Updates the label to be visible/invisible appropriately.
+##
+## We don't display a timer for timed levels as it would be redundant.
+func _init_visible() -> void:
+	visible = CurrentLevel.settings.finish_condition.type != Milestone.TIME_OVER
+	set_process(visible)
+
+
 ## Updates the label to show the number of seconds the player has spent on the current puzzle.
 func _refresh_text() -> void:
 	text = StringUtils.format_duration(int(ceil(PuzzleState.level_performance.seconds)))
+
+
+func _on_PuzzleState_game_prepared() -> void:
+	_init_visible()
+
+
+func _on_Level_settings_changed() -> void:
+	_init_visible()


### PR DESCRIPTION
The timer which counts up as you play a level was made visible/invisible in _ready() and not when a level's settings changed, meaning that if a new level was loaded (such as in the level editor or puzzle demo) the timer would not be reinitialized, and it would be inappropriately visible/invisible