### PR TITLE
Added missing 'show_pickups_rank' 'hide_box_rank' flags

### DIFF
--- a/project/assets/main/puzzle/levels/career/a-thousand-moles.json
+++ b/project/assets/main/puzzle/levels/career/a-thousand-moles.json
@@ -8,7 +8,8 @@
     "value": "80"
   },
   "rank": [
-    "master_pickup_score_per_line 7.97"
+    "master_pickup_score_per_line 7.97",
+    "show_pickups_rank"
   ],
   "triggers": [
     {

--- a/project/assets/main/puzzle/levels/career/above-and-below.json
+++ b/project/assets/main/puzzle/levels/career/above-and-below.json
@@ -12,7 +12,8 @@
   ],
   "rank" : [
     "extra_seconds_per_piece 0.40",
-    "master_pickup_score_per_line 23.91"
+    "master_pickup_score_per_line 23.91",
+    "show_pickups_rank"
   ],
   "triggers": [
     {

--- a/project/assets/main/puzzle/levels/career/checkerboard-vault.json
+++ b/project/assets/main/puzzle/levels/career/checkerboard-vault.json
@@ -19,7 +19,8 @@
   "rank": [
     "box_factor 0.19",
     "combo_factor 0.68",
-    "master_pickup_score_per_line 4.00"
+    "master_pickup_score_per_line 4.00",
+    "show_pickups_rank"
   ],
   "triggers": [
     {

--- a/project/assets/main/puzzle/levels/career/dark/above-and-below.json
+++ b/project/assets/main/puzzle/levels/career/dark/above-and-below.json
@@ -14,7 +14,8 @@
     "extra_seconds_per_piece 0.40",
     "box_factor 0.71",
     "combo_factor 0.45",
-    "master_pickup_score_per_line 10.77"
+    "master_pickup_score_per_line 10.77",
+    "show_pickups_rank"
   ],
   "triggers": [
     {

--- a/project/assets/main/puzzle/levels/career/dark/fruit-on-the-top.json
+++ b/project/assets/main/puzzle/levels/career/dark/fruit-on-the-top.json
@@ -10,7 +10,8 @@
   "rank": [
     "box_factor 0.33",
     "combo_factor 0.08",
-    "master_pickup_score_per_line 3.66"
+    "master_pickup_score_per_line 3.66",
+    "show_pickups_rank"
   ],
   "blocks_during": [
     "fill_lines 0",

--- a/project/assets/main/puzzle/levels/career/dark/hungry-moles.json
+++ b/project/assets/main/puzzle/levels/career/dark/hungry-moles.json
@@ -11,7 +11,9 @@
     "extra_seconds_per_piece 0.20",
     "box_factor 0.00",
     "combo_factor 1.21",
-    "master_pickup_score_per_line 15.23"
+    "master_pickup_score_per_line 15.23",
+    "hide_boxes_rank",
+    "show_pickups_rank"
   ],
   "score": [
     "cake_all 0",

--- a/project/assets/main/puzzle/levels/career/dark/surprise-guests.json
+++ b/project/assets/main/puzzle/levels/career/dark/surprise-guests.json
@@ -11,7 +11,8 @@
     "extra_seconds_per_piece 0.20",
     "box_factor 0.90",
     "combo_factor 0.90",
-    "master_pickup_score_per_line 9.03"
+    "master_pickup_score_per_line 9.03",
+    "show_pickups_rank"
   ],
   "timers": [
     {

--- a/project/assets/main/puzzle/levels/career/hungry-moles.json
+++ b/project/assets/main/puzzle/levels/career/hungry-moles.json
@@ -10,7 +10,9 @@
   "rank": [
     "extra_seconds_per_piece 0.20",
     "box_factor 0.00",
-    "master_pickup_score_per_line 15.41"
+    "master_pickup_score_per_line 15.41",
+    "hide_boxes_rank",
+    "show_pickups_rank"
   ],
   "score": [
     "cake_all 0",

--- a/project/assets/main/puzzle/levels/career/mole-money-mole-problems.json
+++ b/project/assets/main/puzzle/levels/career/mole-money-mole-problems.json
@@ -10,7 +10,8 @@
   "rank": [
     "box_factor 0.53",
     "combo_factor 1.21",
-    "master_pickup_score_per_line 5.86"
+    "master_pickup_score_per_line 5.86",
+    "show_pickups_rank"
   ],
   "triggers": [
     {

--- a/project/assets/main/puzzle/levels/career/paranormal-tetrominon.json
+++ b/project/assets/main/puzzle/levels/career/paranormal-tetrominon.json
@@ -17,7 +17,6 @@
   ],
   "rank": [
     "box_factor 0.77",
-    "combo_factor 1.14",
-    "master_pickup_score_per_line 3.14"
+    "combo_factor 1.14"
   ]
 }

--- a/project/assets/main/puzzle/levels/career/rice-bear-island.json
+++ b/project/assets/main/puzzle/levels/career/rice-bear-island.json
@@ -13,7 +13,8 @@
     }
   ],
   "rank" : [
-    "master_pickup_score_per_line 5.31"
+    "master_pickup_score_per_line 5.31",
+    "show_pickups_rank"
   ],
   "triggers": [
     {

--- a/project/assets/main/puzzle/levels/career/shelf.json
+++ b/project/assets/main/puzzle/levels/career/shelf.json
@@ -14,7 +14,8 @@
   "rank": [
     "box_factor 0.73",
     "combo_factor 0.91",
-    "master_pickup_score_per_line 4.65"
+    "master_pickup_score_per_line 4.65",
+    "show_pickups_rank"
   ],
   "triggers": [
     {

--- a/project/assets/main/puzzle/levels/career/slow-service-2.json
+++ b/project/assets/main/puzzle/levels/career/slow-service-2.json
@@ -20,7 +20,8 @@
   "rank": [
     "extra_seconds_per_piece 0.34",
     "box_factor 2.65",
-    "combo_factor 0.00"
+    "combo_factor 0.00",
+    "hide_combos_rank"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/strawberry-slowcake.json
+++ b/project/assets/main/puzzle/levels/career/strawberry-slowcake.json
@@ -31,7 +31,8 @@
   "rank": [
     "box_factor 0.55",
     "combo_factor 0.71",
-    "master_pickup_score_per_line 9.25"
+    "master_pickup_score_per_line 9.25",
+    "show_pickups_rank"
   ],
   "tiles": {
     "0": [

--- a/project/assets/main/puzzle/levels/career/surprise-guests.json
+++ b/project/assets/main/puzzle/levels/career/surprise-guests.json
@@ -11,7 +11,8 @@
     "extra_seconds_per_piece 0.20",
     "box_factor 0.90",
     "combo_factor 0.90",
-    "master_pickup_score_per_line 6.69"
+    "master_pickup_score_per_line 6.69",
+    "show_pickups_rank"
   ],
   "timers": [
     {

--- a/project/assets/main/puzzle/levels/career/three-course-meal.json
+++ b/project/assets/main/puzzle/levels/career/three-course-meal.json
@@ -15,7 +15,8 @@
     "extra_seconds_per_piece 0.64",
     "box_factor 0.73",
     "combo_factor 0.83",
-    "master_pickup_score_per_line 14.88"
+    "master_pickup_score_per_line 14.88",
+    "show_pickups_rank"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/two-box-buffet.json
+++ b/project/assets/main/puzzle/levels/career/two-box-buffet.json
@@ -18,7 +18,8 @@
   "rank": [
     "box_factor 0.67",
     "combo_factor 0.94",
-    "master_pickup_score_per_line 4.72"
+    "master_pickup_score_per_line 4.72",
+    "show_pickups_rank"
   ],
   "tiles": {
     "start": [


### PR DESCRIPTION
Removed errant 'pickups rank' for paranormal tetrominon. Did this level have pickups during its inception?