### PR TITLE
Immediately save after viewing a cutscene.

### DIFF
--- a/project/src/main/world/overworld-ui.gd
+++ b/project/src/main/world/overworld-ui.gd
@@ -181,6 +181,9 @@ func _on_ChatUi_chat_finished() -> void:
 	elif PlayerData.career.is_career_mode():
 		# launch the next scene in career mode after playing the cutscene
 		PlayerData.career.push_career_trail()
+		
+		# save data to record the cutscene as viewed
+		PlayerSave.schedule_save()
 	else:
 		push_warning("Unexpected state after chat finished: %s" % [Breadcrumb.trail])
 		SceneTransition.pop_trail()


### PR DESCRIPTION
Without this code, it's possible for someone to finish a level, watch a cutscene, quit to the main menu and quit the game -- but have to watch the same cutscene next time.