### PR TITLE
Fixed playfield combo strobe for infinite combo levels.

### DIFF
--- a/project/src/demo/puzzle/PuzzleDemo.tscn
+++ b/project/src/demo/puzzle/PuzzleDemo.tscn
@@ -5,6 +5,6 @@
 
 [node name="PuzzleDemo" type="Node"]
 script = ExtResource( 2 )
-level_path = "res://assets/demo/puzzle/levels/experiment.json"
+level_path = "res://assets/main/puzzle/levels/career/curly-queue.json"
 
 [node name="Puzzle" parent="." instance=ExtResource( 1 )]

--- a/project/src/main/puzzle/playfield-fx.gd
+++ b/project/src/main/puzzle/playfield-fx.gd
@@ -211,11 +211,10 @@ func _refresh_tile_maps() -> void:
 	var old_pattern := _pattern
 	var new_pattern: Array = OFF_PATTERN
 	
-	if CurrentLevel.settings.combo_break.pieces != ComboBreakRules.UNLIMITED_PIECES:
-		if _combo_tracker.combo_break == CurrentLevel.settings.combo_break.pieces - 1:
-			new_pattern = HALF_PATTERN
-		elif _combo_tracker.combo_break < CurrentLevel.settings.combo_break.pieces - 1:
-			new_pattern = ON_PATTERN
+	if _combo_tracker.combo_break == CurrentLevel.settings.combo_break.pieces - 1:
+		new_pattern = HALF_PATTERN
+	elif _combo_tracker.combo_break < CurrentLevel.settings.combo_break.pieces - 1:
+		new_pattern = ON_PATTERN
 	
 	if old_pattern == OFF_PATTERN and new_pattern == OFF_PATTERN:
 		# no need to refresh if all the lights remain off


### PR DESCRIPTION
The combo strobe was invisible for infinite combo levels. It should always be on. This 'always on' behavior occurs with the current if/else logic, so I've removed the unnecessary conditional.