### PR TITLE
Fixed bug with inserted lines not pushing pieces.

### DIFF
--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -250,7 +250,7 @@ func _shift_piece_for_inserted_line(inserted_line: int) -> void:
 		var block_pos := piece.type.get_cell_position(piece.orientation, i)
 		highest_piece_cell_y = min(highest_piece_cell_y, piece.pos.y + block_pos.y)
 	
-	if highest_piece_cell_y > inserted_line and highest_piece_cell_y > 0 and not piece.can_move_to_target():
+	if highest_piece_cell_y <= inserted_line and highest_piece_cell_y > 0 and not piece.can_move_to_target():
 		piece.target_pos.y -= 1
 	piece.move_to_target()
 


### PR DESCRIPTION
Inserted lines were intended to push pieces above them, but the logic was flipped where they were only pushing pieces below them. (And more importantly, NOT pushing pieces above them resulting in pieces clipping into the playfield.)