### PR TITLE
Split PuzzleCritterDemo from PuzzleDemo.

### DIFF
--- a/project/src/demo/puzzle/PuzzleCritterDemo.tscn
+++ b/project/src/demo/puzzle/PuzzleCritterDemo.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://src/demo/puzzle/puzzle-critter-demo.gd" type="Script" id=1]
+[ext_resource path="res://src/main/puzzle/Puzzle.tscn" type="PackedScene" id=2]
+
+[node name="PuzzleCritterDemo" type="Node"]
+script = ExtResource( 1 )
+
+[node name="Puzzle" parent="." instance=ExtResource( 2 )]

--- a/project/src/demo/puzzle/puzzle-critter-demo.gd
+++ b/project/src/demo/puzzle/puzzle-critter-demo.gd
@@ -1,0 +1,53 @@
+extends Node
+## Shows off the puzzle critters.
+##
+## The letter keys A-Z toggle between different critters. The non-letter keys add and manipulate those critters. For
+## example, you can add a mole to the playfield by pressing 'M' for mole, and then '1' to add a mole.
+##
+## Keys:
+## 	[M]: Manipulate moles
+## 	[M] -> [1]: Add a mole
+## 	[M] -> ']': Advance moles
+
+enum CritterType {
+	NONE,
+	MOLE,
+}
+
+var critter_type: int = CritterType.NONE
+
+onready var _tutorial_hud: TutorialHud = $Puzzle/Hud/Center/TutorialHud
+
+## a local path to a json level resource to demo
+export (String, FILE, "*.json") var level_path: String
+
+func _ready() -> void:
+	var settings: LevelSettings = LevelSettings.new()
+	if level_path:
+		var json_text := FileUtils.get_file_as_text(level_path)
+		var json_dict: Dictionary = parse_json(json_text)
+		var level_key := LevelSettings.level_key_from_path(level_path)
+		settings.from_json_dict(level_key, json_dict)
+		# Ignore the start_level property so we can test the middle parts of tutorials
+		settings.other.start_level = ""
+	
+	CurrentLevel.keep_retrying = true
+	CurrentLevel.start_level(settings)
+	_tutorial_hud.replace_tutorial_module()
+
+
+func _input(event: InputEvent) -> void:
+	match Utils.key_scancode(event):
+		KEY_M: critter_type = CritterType.MOLE
+	
+	match critter_type:
+		CritterType.MOLE: _mole_input(event)
+
+
+func _mole_input(event: InputEvent) -> void:
+	match Utils.key_scancode(event):
+		KEY_1:
+			var mole_config := MoleConfig.new()
+			$Puzzle/Fg/Critters/Moles.add_moles(mole_config)
+		KEY_BRACKETRIGHT:
+			$Puzzle/Fg/Critters/Moles.advance_moles()

--- a/project/src/demo/puzzle/puzzle-demo.gd
+++ b/project/src/demo/puzzle/puzzle-demo.gd
@@ -11,8 +11,6 @@ extends Node
 ## 	[J]: Generate a food item
 ## 	[K]: Cycle to the next food item
 ## 	[L]: Level up
-## 	[M]: Add a mole
-## 	[,]: Advance moles
 
 var _line_clear_count := 1
 var _box_type := 0
@@ -72,11 +70,6 @@ func _input(event: InputEvent) -> void:
 		
 		KEY_L:
 			PuzzleState.set_speed_index((PuzzleState.speed_index + 1) % CurrentLevel.settings.speed.speed_ups.size())
-		
-		KEY_M:
-			$Puzzle/Fg/Critters/Moles.add_moles()
-		KEY_COMMA:
-			$Puzzle/Fg/Critters/Moles.advance_moles()
 
 
 func _build_box(y: int) -> void:


### PR DESCRIPTION
I'm about to add a second critter type with several variations i want to test in the editor -- if we have 2 keys for moles, 6 keys for this new critter and so on, we will run out of PuzzleDemo keys very quickly.

I've designed PuzzleCritterDemo to toggle 26 different critters (one for each letter A-Z) with the remaining non-letter keys used to manipulate those critters.