### PR TITLE
Level trigger/phase improvements: 'combo_ended', 'pickup_collected'

### DIFF
--- a/project/assets/main/puzzle/levels/career/a-thousand-moles.json
+++ b/project/assets/main/puzzle/levels/career/a-thousand-moles.json
@@ -20,7 +20,7 @@
     },
     {
       "phases": [
-        "piece_written n=47,48,49..."
+        "piece_written n=47..."
       ],
       "effect": "add_moles home=surface dig_duration=1 reward=seed"
     },

--- a/project/assets/main/puzzle/levels/career/mole-money-mole-problems.json
+++ b/project/assets/main/puzzle/levels/career/mole-money-mole-problems.json
@@ -16,7 +16,7 @@
   "triggers": [
     {
       "phases": [
-        "piece_written 0,2,4..."
+        "piece_written n=0,2,4..."
       ],
       "effect": "add_moles home=hole"
     },

--- a/project/src/main/puzzle/combo-tracker.gd
+++ b/project/src/main/puzzle/combo-tracker.gd
@@ -33,15 +33,18 @@ func set_combo_break(new_combo_break: int) -> void:
 
 
 func break_combo() -> void:
-	if PuzzleState.combo >= 20:
+	var old_combo: int = PuzzleState.combo
+	if old_combo >= 20:
 		$Fanfare3.play()
-	elif PuzzleState.combo >= 10:
+	elif old_combo >= 10:
 		$Fanfare2.play()
-	elif PuzzleState.combo >= 5:
+	elif old_combo >= 5:
 		$Fanfare1.play()
 	
-	if PuzzleState.combo > 0:
+	if old_combo > 0:
 		PuzzleState.end_combo()
+		CurrentLevel.settings.triggers.run_triggers(LevelTrigger.COMBO_ENDED, {"combo": old_combo})
+	
 	emit_signal("combo_break_changed", combo_break)
 
 

--- a/project/src/main/puzzle/level-timer-manager.gd
+++ b/project/src/main/puzzle/level-timer-manager.gd
@@ -5,7 +5,7 @@ extends Node
 ## LevelTimers script, but the actual timer objects which count down are kept here.
 
 ## The maximum amount of timers which a level can define
-const MAX_TIMER_COUNT := 3
+const MAX_TIMER_COUNT := 10
 
 ## key: (int) timer index
 ## value: (int) an enum from LevelTriggerPhase for the timer's trigger
@@ -13,6 +13,13 @@ const PHASES_BY_TIMER_INDEX := {
 	0: LevelTrigger.TIMER_0,
 	1: LevelTrigger.TIMER_1,
 	2: LevelTrigger.TIMER_2,
+	3: LevelTrigger.TIMER_3,
+	4: LevelTrigger.TIMER_4,
+	5: LevelTrigger.TIMER_5,
+	6: LevelTrigger.TIMER_6,
+	7: LevelTrigger.TIMER_7,
+	8: LevelTrigger.TIMER_8,
+	9: LevelTrigger.TIMER_9,
 }
 
 func _ready() -> void:

--- a/project/src/main/puzzle/level/config-string-utils.gd
+++ b/project/src/main/puzzle/level/config-string-utils.gd
@@ -87,22 +87,31 @@ static func ints_from_config_string(config_string: String, max_int: int = 0) -> 
 	for _i in range(1 if config_string.ends_with("...") else 0):
 		var ints_split := config_string.trim_suffix("...").split(",")
 		
-		# determine difference of last two values
-		if ints_split.size() < 2:
-			push_warning("index string doesn't have enough values to extrapolate: '%s'" % [config_string])
+		# calculate the starting value and increment
+		var start: int
+		var increment: int
+		if ints_split.size() < 1:
+			# if the index string is empty, we do not loop
 			break
+		elif ints_split.size() == 1:
+			# for a single value like '6...' we use an increment of 1
+			start = int(ints_split[0])
+			increment = 1
+		else:
+			# for a series like '6,8,10...' we calculate the difference of the last two values
+			var low := int(ints_split[ints_split.size() - 2])
+			var high := int(ints_split[ints_split.size() - 1])
+			if high <= low:
+				push_warning("nonsensical index string extrapolation: '%s'" % [config_string])
+				break
+			increment = high - low
+			start = high + increment
 		
-		var low := int(ints_split[ints_split.size() - 2])
-		var high := int(ints_split[ints_split.size() - 1])
-		if high <= low:
-			push_warning("nonsensical index string extrapolation: '%s'" % [config_string])
-			break
-		
-		var i := 2 * high - low
 		# extrapolate until we hit max_int
+		var i := start
 		while i <= max_int:
 			ints[i] = true
-			i += high - low
+			i += increment
 	
 	return ints
 

--- a/project/src/main/puzzle/level/level-trigger.gd
+++ b/project/src/main/puzzle/level/level-trigger.gd
@@ -9,10 +9,12 @@ class_name LevelTrigger
 enum LevelTriggerPhase {
 	AFTER_PIECE_WRITTEN, # after the piece is written, and all boxes are made, and all lines are cleared
 	BOX_BUILT, # when a snack/cake box is built
+	COMBO_ENDED, # when the player breaks their combo
 	INITIAL_ROTATED_CW, # when the piece is rotated clockwise using initial DAS
 	INITIAL_ROTATED_CCW, # when the piece is rotated counterclockwise using initial DAS
 	INITIAL_ROTATED_180, # when the piece is flipped using initial DAS
 	LINE_CLEARED, # after the line is erased for a line clear, but before the lines above are shifted
+	PICKUP_COLLECTED, # when a pickup is collected
 	PIECE_WRITTEN, # when the piece is written, but before any boxes are made or lines are cleared
 	ROTATED_CW, # when the piece is rotated clockwise
 	ROTATED_CCW, # when the piece is rotated counterclockwise
@@ -20,14 +22,23 @@ enum LevelTriggerPhase {
 	TIMER_0, # when timer 0 times out
 	TIMER_1, # when timer 1 times out
 	TIMER_2, # when timer 2 times out
+	TIMER_3, # when timer 3 times out
+	TIMER_4, # when timer 4 times out
+	TIMER_5, # when timer 5 times out
+	TIMER_6, # when timer 6 times out
+	TIMER_7, # when timer 7 times out
+	TIMER_8, # when timer 8 times out
+	TIMER_9, # when timer 9 times out
 }
 
 const AFTER_PIECE_WRITTEN := LevelTriggerPhase.AFTER_PIECE_WRITTEN
 const BOX_BUILT := LevelTriggerPhase.BOX_BUILT
+const COMBO_ENDED := LevelTriggerPhase.COMBO_ENDED
 const INITIAL_ROTATED_CW := LevelTriggerPhase.INITIAL_ROTATED_CW
 const INITIAL_ROTATED_CCW := LevelTriggerPhase.INITIAL_ROTATED_CCW
 const INITIAL_ROTATED_180 := LevelTriggerPhase.INITIAL_ROTATED_180
 const LINE_CLEARED := LevelTriggerPhase.LINE_CLEARED
+const PICKUP_COLLECTED := LevelTriggerPhase.PICKUP_COLLECTED
 const PIECE_WRITTEN := LevelTriggerPhase.PIECE_WRITTEN
 const ROTATED_CW := LevelTriggerPhase.ROTATED_CW
 const ROTATED_CCW := LevelTriggerPhase.ROTATED_CCW
@@ -35,6 +46,13 @@ const ROTATED_180 := LevelTriggerPhase.ROTATED_180
 const TIMER_0 := LevelTriggerPhase.TIMER_0
 const TIMER_1 := LevelTriggerPhase.TIMER_1
 const TIMER_2 := LevelTriggerPhase.TIMER_2
+const TIMER_3 := LevelTriggerPhase.TIMER_3
+const TIMER_4 := LevelTriggerPhase.TIMER_4
+const TIMER_5 := LevelTriggerPhase.TIMER_5
+const TIMER_6 := LevelTriggerPhase.TIMER_6
+const TIMER_7 := LevelTriggerPhase.TIMER_7
+const TIMER_8 := LevelTriggerPhase.TIMER_8
+const TIMER_9 := LevelTriggerPhase.TIMER_9
 
 ## key: (int) an enum from LevelTriggerPhase
 ## value: (Array, PhaseCondition) Conditions for whether the trigger should fire

--- a/project/src/main/puzzle/line-clearer.gd
+++ b/project/src/main/puzzle/line-clearer.gd
@@ -367,7 +367,7 @@ func _delete_lines(old_lines_being_cleared: Array, _old_lines_being_erased: Arra
 				# after lines are erased, but before they're shifted. Otherwise lines might be inserted in the wrong place,
 				# or the newly inserted lines could be deleted as a part of a big line clear.
 				_total_cleared_line_count += 1
-				var event_params := {"y": line_being_deleted, "n": _total_cleared_line_count}
+				var event_params := {"y": line_being_deleted, "n": _total_cleared_line_count, "combo": PuzzleState.combo - i}
 				CurrentLevel.settings.triggers.run_triggers(LevelTrigger.LINE_CLEARED, event_params)
 			
 			# reassign 'line_being_deleted' in case lines_being_deleted_during_trigger was modified during the

--- a/project/src/main/puzzle/pickups.gd
+++ b/project/src/main/puzzle/pickups.gd
@@ -290,6 +290,11 @@ func _on_PuzzleState_before_piece_written() -> void:
 		remaining_food_for_piece -= 1
 		emit_signal("food_spawned", pickup_cell, remaining_food_for_piece, pickup.food_type)
 	
+	# Run pickup_collected triggers
+	for pickup_cell in collected_pickup_cells:
+		var pickup: Pickup = _pickups_by_cell[pickup_cell]
+		CurrentLevel.settings.triggers.run_triggers(LevelTrigger.PICKUP_COLLECTED, {"type": pickup.food_type})
+	
 	# Remove collected pickups
 	for pickup_cell in collected_pickup_cells:
 		var pickup: Pickup = _pickups_by_cell[pickup_cell]

--- a/project/src/test/puzzle/level/test-config-string-utils.gd
+++ b/project/src/test/puzzle/level/test-config-string-utils.gd
@@ -8,6 +8,9 @@ func test_ints_from_config_string() -> void:
 	assert_eq(ConfigStringUtils.ints_from_config_string("1-2,4-5").keys(), [1, 2, 4, 5])
 	assert_eq(ConfigStringUtils.ints_from_config_string("0,4-6").keys(), [0, 4, 5, 6])
 	assert_eq(ConfigStringUtils.ints_from_config_string("6,2-4,13").keys(), [6, 2, 3, 4, 13])
+	assert_eq(ConfigStringUtils.ints_from_config_string("10,11,12...", 15).keys(), [10, 11, 12, 13, 14, 15])
+	assert_eq(ConfigStringUtils.ints_from_config_string("5,8...", 15).keys(), [5, 8, 11, 14])
+	assert_eq(ConfigStringUtils.ints_from_config_string("2...", 5).keys(), [2, 3, 4, 5])
 
 
 func test_config_string_from_ints() -> void:
@@ -18,8 +21,3 @@ func test_config_string_from_ints() -> void:
 	assert_eq("0-3", ConfigStringUtils.config_string_from_ints([0, 1, 2, 3]))
 	assert_eq("0,4-6", ConfigStringUtils.config_string_from_ints([0, 4, 5, 6]))
 	assert_eq("2-4,6,13", ConfigStringUtils.config_string_from_ints([4, 3, 6, 13, 2]))
-
-
-func test_ints_from_ints_from_config_string() -> void:
-	assert_eq(ConfigStringUtils.ints_from_config_string("10,11,12...", 15).keys(), [10, 11, 12, 13, 14, 15])
-	assert_eq(ConfigStringUtils.ints_from_config_string("5,8...", 15).keys(), [5, 8, 11, 14])

--- a/project/src/test/puzzle/level/test-phase-conditions.gd
+++ b/project/src/test/puzzle/level/test-phase-conditions.gd
@@ -21,6 +21,9 @@ func test_line_cleared_phase_config() -> void:
 	condition = PhaseConditions.LineClearedPhaseCondition.new({"n": "1,2,3..."})
 	assert_eq_shallow(condition.get_phase_config(), {"n": "1,2,3..."})
 	
+	condition = PhaseConditions.LineClearedPhaseCondition.new({"combo": "1,2,3..."})
+	assert_eq_shallow(condition.get_phase_config(), {"combo": "1,2,3..."})
+	
 	condition = PhaseConditions.LineClearedPhaseCondition.new({})
 	assert_eq_shallow(condition.get_phase_config(), {})
 
@@ -35,6 +38,27 @@ func test_box_built_phase_condition() -> void:
 	
 	condition = PhaseConditions.BoxBuiltPhaseCondition.new({"0": "any"})
 	assert_eq_shallow(condition.get_phase_config(), {})
+
+
+func test_combo_ended_phase_condition() -> void:
+	var condition: PhaseConditions.ComboEndedPhaseCondition
+	condition = PhaseConditions.ComboEndedPhaseCondition.new({})
+	assert_eq_shallow(condition.get_phase_config(), {})
+	
+	condition = PhaseConditions.ComboEndedPhaseCondition.new({"combo": "5-10"})
+	assert_eq_shallow(condition.get_phase_config(), {"combo": "5-10"})
+
+
+func test_pickup_collected() -> void:
+	var condition: PhaseConditions.PickupCollectedPhaseCondition
+	condition = PhaseConditions.PickupCollectedPhaseCondition.new({})
+	assert_eq_shallow(condition.get_phase_config(), {})
+	
+	condition = PhaseConditions.PickupCollectedPhaseCondition.new({"0": "snack"})
+	assert_eq_shallow(condition.get_phase_config(), {"0": "snack"})
+	
+	condition = PhaseConditions.PickupCollectedPhaseCondition.new({"0": "cake"})
+	assert_eq_shallow(condition.get_phase_config(), {"0": "cake"})
 
 
 func test_piece_written_phase_condition() -> void:


### PR DESCRIPTION
Added 'combo_ended' level trigger. This can trigger every time a combo ends, or specifically when a combo of a certain size ends.

Added 'pickup_collected' level trigger. This can trigger every time a pickup is collected, or specifically cake/snack pickups.

line_cleared level trigger now supports 'combo' condition.

Levels now support up to 10 timers, increased from 3.

piece_written and other config strings now accept "1..." as a shorthand for "1,2,3..."