### PR TITLE
Carrot improvements: sfx, deconflicting

### DIFF
--- a/license/asset-license.txt
+++ b/license/asset-license.txt
@@ -5,6 +5,7 @@ $ = MAY credit in your credits (you sort of used their stuff, i guess. Or their 
 Sounds: 
 $$ "2000 Game SFX Collection" by GameBurp (Soniss license, https://sonniss.com/sound-effects-licensing/)
 $$ "Call Bell.WAV" by Pablobd at FreeSound.org (CC0 1.0 Universal (CC0 1.0) Public Domain Dedication, https://creativecommons.org/publicdomain/zero/1.0/)
+$$ "Cartoon Plane Loop" from tsymbal at pond5.com (Pond5 Content License Agreement https://www.pond5.com/legal/license)
 $$ "Cartoon Voices" by Dawid Moroz, Soundholder Studio (Soniss license, https://sonniss.com/sound-effects-licensing/)
 $$ "Clog Boxes" by Alan Vista at alanvista.com (Advertised as 'Free VST', no license provided)
 $$ "Cooking Game" by Epic Stock Media (Coniss license, https://sonniss.com/sound-effects-licensing/)
@@ -48,6 +49,7 @@ project/assets/main/puzzle/applause.wav "GameBurp - 2000 Game Sound FX Collectio
 project/assets/main/puzzle/clear-cake-box.wav "Cooking_Game_16bit\Ingredient_Pickup\Cooking_Game_Ingredient_Pickup_Goop_A_01.wav" 
 project/assets/main/puzzle/clear-snack-box.wav "Cooking_Game_16bit\Ingredient_Pickup\Cooking_Game_Ingredient_Pickup_Goop_A_01.wav"
 project/assets/main/puzzle/combo-*.wav Adapted from an SNES sound effect
+project/assets/main/puzzle/critter/carrot-move.wav "Cartoon Plane Loop" from tsymbal
 project/assets/main/puzzle/critter/critter-poof.wav "GameBurp - 2000 Game Sound FX Collection (WAV)\SWIPES - SLASHES - WHOOSHES - (58)\SWIPE Whoosh 07.wav"
 project/assets/main/puzzle/critter/mole-dig.wav "Cooking_Game_16bit\Cooking_Actions\Organic_Actions\Cooking_Game_Actions_Slice_Bread_Thick_03.wav"
 project/assets/main/puzzle/critter/mole-found.wav "GameBurp - 2000 Game Sound FX Collection (WAV)\VOCAL CUTE - CHARACTERS - (113)\VOCAL CUTE Call Happy 05.wav"

--- a/project/src/main/puzzle/critter/Carrot.tscn
+++ b/project/src/main/puzzle/critter/Carrot.tscn
@@ -21,6 +21,7 @@ colors = PoolColorArray( 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 )
 gradient = SubResource( 6 )
 
 [sub_resource type="ParticlesMaterial" id=5]
+resource_local_to_scene = true
 emission_shape = 2
 emission_box_extents = Vector3( 10, 4, 1 )
 flag_disable_z = true

--- a/project/src/main/puzzle/critter/Critters.tscn
+++ b/project/src/main/puzzle/critter/Critters.tscn
@@ -1,10 +1,12 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://src/main/puzzle/critter/moles.gd" type="Script" id=1]
 [ext_resource path="res://src/main/puzzle/critter/critters.gd" type="Script" id=2]
 [ext_resource path="res://src/main/puzzle/critter/Mole.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/puzzle/critter/carrots.gd" type="Script" id=4]
 [ext_resource path="res://src/main/puzzle/critter/Carrot.tscn" type="PackedScene" id=5]
+[ext_resource path="res://assets/main/puzzle/critter/carrot-move.wav" type="AudioStream" id=6]
+[ext_resource path="res://assets/main/puzzle/critter/critter-poof.wav" type="AudioStream" id=7]
 
 [node name="Critters" type="Control"]
 margin_left = 364.0
@@ -20,3 +22,17 @@ MoleScene = ExtResource( 3 )
 [node name="Carrots" type="Node2D" parent="."]
 script = ExtResource( 4 )
 CarrotScene = ExtResource( 5 )
+
+[node name="CarrotHolder" type="Node2D" parent="Carrots"]
+
+[node name="CarrotPoofSound" type="AudioStreamPlayer" parent="Carrots"]
+stream = ExtResource( 7 )
+bus = "Sound Bus"
+
+[node name="CarrotMoveSound" type="AudioStreamPlayer" parent="Carrots"]
+stream = ExtResource( 6 )
+bus = "Sound Bus"
+
+[node name="Tween" type="Tween" parent="Carrots"]
+
+[connection signal="tween_completed" from="Carrots/Tween" to="Carrots" method="_on_Tween_tween_completed"]

--- a/project/src/main/puzzle/critter/carrot.gd
+++ b/project/src/main/puzzle/critter/carrot.gd
@@ -5,6 +5,9 @@ extends Node2D
 ## Carrots remain onscreen for several seconds. They have many different sizes, and can also leave behind a smokescreen
 ## which blocks the player's vision for even longer.
 
+## Emitted when the carrot starts its 'hide' animation, indicating it will soon be freed.
+signal started_hiding
+
 ## Duration in seconds it takes for the carrot's show animation.
 const SHOW_DURATION := 0.20
 
@@ -110,6 +113,7 @@ func show() -> void:
 ## frees itself from memory.
 func hide() -> void:
 	hiding = true
+	emit_signal("started_hiding")
 	
 	_show_tween.remove(_visuals, "modulate")
 	_show_tween.interpolate_property(_visuals, "modulate", _visuals.modulate, Color.transparent,

--- a/project/src/test/puzzle/critter/test-carrots.gd
+++ b/project/src/test/puzzle/critter/test-carrots.gd
@@ -1,0 +1,15 @@
+extends "res://addons/gut/test.gd"
+
+func test_deconflict_carrots_width_1() -> void:
+	assert_eq(Carrots.deconflict_carrots([3, 4, 5, 1, 2, 0, 6], Vector2(1, 4)), [3, 4, 5, 1, 2, 3, 6])
+	assert_eq(Carrots.deconflict_carrots([6, 0, 1, 5, 4, 2, 3], Vector2(1, 4)), [6, 0, 1, 5, 4, 2, 3])
+
+
+func test_deconflict_carrots_width_2() -> void:
+	assert_eq(Carrots.deconflict_carrots([3, 4, 5, 1, 2, 0, 6], Vector2(2, 3)), [3, 5, 1, 4, 2, 0, 6])
+	assert_eq(Carrots.deconflict_carrots([6, 0, 1, 5, 4, 2, 3], Vector2(2, 3)), [6, 0, 4, 2, 1, 5, 3])
+
+
+func test_deconflict_carrots_width_3() -> void:
+	assert_eq(Carrots.deconflict_carrots([3, 4, 5, 1, 2, 0, 6], Vector2(3, 4)), [3, 0, 6, 4, 5, 1, 2])
+	assert_eq(Carrots.deconflict_carrots([6, 0, 1, 5, 4, 2, 3], Vector2(3, 4)), [6, 0, 3, 1, 5, 4, 2])


### PR DESCRIPTION
Added carrot sfx. They make a 'whoosh' sound when they poof in and out, and a cartoon plane sound when they fly by.

Fixed carrot deconflicting algorithm. This algorithm used to swap carrots which were too close together, but this often just moved other carrots which were also too close. The new algorithm is more consistent, as demonstrated with a unit test.

Fixed remove_carrots() performance degradation. When calling it with a large number like 999,999, it would still loop 999,999 times even if it only had to remove 3 carrots. It now terminates the loop prematurely once the last carrot is removed.