### PR TITLE
Fixed bug where 'give up' button doesn't work

### DIFF
--- a/project/src/main/career/career-flow.gd
+++ b/project/src/main/career/career-flow.gd
@@ -32,6 +32,12 @@ func push_career_trail() -> void:
 		CurrentCutscene.push_cutscene_trail()
 		redirected = true
 	
+	if not redirected and career_data.is_day_over() and career_data.show_progress == CareerData.ShowProgress.NONE:
+		# If the day is over, they're redirected to the career map to view the progress board. But if they don't need
+		# to view the progress board, we can redirect them directly to the career win screen.
+		SceneTransition.replace_trail(Global.SCENE_CAREER_WIN)
+		redirected = true
+	
 	if not redirected:
 		# After a puzzle (or any other scene), we go back to the career map.
 		SceneTransition.change_scene()

--- a/project/src/main/career/ui/career-map-ui.gd
+++ b/project/src/main/career/ui/career-map-ui.gd
@@ -180,7 +180,11 @@ func _on_SettingsMenu_quit_pressed() -> void:
 
 
 func _on_SettingsMenu_other_quit_pressed() -> void:
+	# If the day is over, they're redirected to the career map to view the progress board. But they don't need to view
+	# the progress board if they're already on the career map screen, so we set 'show_progress' to 'none' to redirect
+	# them directly to the career win screen.
 	PlayerData.career.hours_passed = CareerData.HOURS_PER_CAREER_DAY
+	PlayerData.career.show_progress = CareerData.ShowProgress.NONE
 	PlayerData.career.push_career_trail()
 
 

--- a/project/src/main/utils/global.gd
+++ b/project/src/main/utils/global.gd
@@ -13,6 +13,9 @@ const SCENE_CUTSCENE := "res://src/main/world/Cutscene.tscn"
 ## scene for career mode which shows the player's progress between levels
 const SCENE_CAREER_MAP := "res://src/main/world/CareerMap.tscn"
 
+## scene for career mode which is shown at the end of a day
+const SCENE_CAREER_WIN := "res://src/main/career/ui/CareerWin.tscn"
+
 ## scene for career mode's region select menu (chapter select menu)
 const SCENE_CAREER_REGION_SELECT_MENU := "res://src/main/ui/menu/CareerRegionSelectMenu.tscn"
 

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -40,11 +40,6 @@ func _ready() -> void:
 	
 	var redirected := false
 	
-	# if they've played eight levels, redirect them to the 'you win' screen
-	if not redirected and PlayerData.career.is_day_over():
-		PlayerData.career.push_career_trail()
-		redirected = true
-	
 	# if they haven't seen this region's prologue, redirect them to the prologue cutscene
 	if not redirected and PlayerData.career.should_play_prologue():
 		PlayerData.career.push_career_trail()
@@ -55,7 +50,7 @@ func _ready() -> void:
 		if PlayerData.career.show_progress == CareerData.ShowProgress.NONE:
 			# Ordinarily, we focus the level button after the progress board vanishes. But if the progress board is not
 			# being shown, we focus the button right away.
-			_level_select_control.focus_button()
+			_after_progress_board()
 
 
 func _exit_tree() -> void:
@@ -355,6 +350,18 @@ func _should_play_epilogue(chat_key_pair: ChatKeyPair) -> bool:
 	return result
 
 
+## After the progress board is shown, the player is either redirected to the career win screen, or we focus one of the
+## level buttons.
+##
+## If the progress board is not being shown, this happens at the start of the level.
+func _after_progress_board() -> void:
+	if PlayerData.career.is_day_over():
+		# After the final level, we show a 'you win' screen.
+		SceneTransition.replace_trail(Global.SCENE_CAREER_WIN)
+	else:
+		_level_select_control.focus_button()
+
+
 ## When the player clicks a level button twice, we launch the selected level
 func _on_LevelSelectButton_level_chosen(level_index: int) -> void:
 	if PlayerData.career.is_connected("distance_travelled_changed", self, "_on_CareerData_distance_travelled_changed"):
@@ -428,8 +435,4 @@ func _on_CareerData_distance_travelled_changed() -> void:
 
 
 func _on_ProgressBoardHolder_progress_board_hidden() -> void:
-	if PlayerData.career.is_day_over():
-		# After the final level, we show a 'you win' screen.
-		SceneTransition.replace_trail("res://src/main/career/ui/CareerWin.tscn")
-	else:
-		_level_select_control.focus_button()
+	_after_progress_board()


### PR DESCRIPTION
Career mode's 'end of day' logic was rewritten to redirect to the career map, but in some cases it needs to redirect to the career win screen. I've added some edge cases to cover this.