### PR TITLE
Carrot sfx fixes; silence, quieter poof sounds

### DIFF
--- a/project/src/main/puzzle/critter/Critters.tscn
+++ b/project/src/main/puzzle/critter/Critters.tscn
@@ -27,13 +27,14 @@ CarrotScene = ExtResource( 5 )
 
 [node name="CarrotPoofSound" type="AudioStreamPlayer" parent="Carrots"]
 stream = ExtResource( 7 )
+volume_db = -4.0
 bus = "Sound Bus"
 
 [node name="CarrotMoveSound" type="AudioStreamPlayer" parent="Carrots"]
 stream = ExtResource( 6 )
-volume_db = -4.0
+volume_db = -2.0
 bus = "Sound Bus"
 
-[node name="Tween" type="Tween" parent="Carrots"]
+[node name="SfxTween" type="Tween" parent="Carrots"]
 
-[connection signal="tween_completed" from="Carrots/Tween" to="Carrots" method="_on_Tween_tween_completed"]
+[connection signal="tween_completed" from="Carrots/SfxTween" to="Carrots" method="_on_Tween_tween_completed"]


### PR DESCRIPTION
Decreased poof sound volume. I thought I fixed this with 3d7f9dbf but I had adjusted the move sound volume instead.

Increased move sound volume. I inadvertently lowered this to -4 in 3d7f9dbf but after restoring it to full volume, I think it sounds better at -2 instead.

Fixed bug where carrots could be silenced if carrots appeared/disappeared simultaneously. This edge case is now avoided with a 'move_sfx_state' field.