### PR TITLE
Avoid reporting 'All Clear!' between tutorial sections.

### DIFF
--- a/project/assets/demo/puzzle/levels/experiment.json
+++ b/project/assets/demo/puzzle/levels/experiment.json
@@ -1,44 +1,26 @@
 {
   "version": "39e5",
   "start_speed": "0",
-  "name": "No Smoking Section",
-  "description": "Carrot smoke is the healthiest kind of smoke! But, we still don't like it very much.",
+  "name": "Just Cream",
+  "description": "What are these pieces!? LOLOLOL",
   "finish_condition": {
     "type": "time_over",
-    "value": "90"
+    "value": "50"
   },
-  "timers": [
-    {
-      "initial_interval": 2.0,
-      "interval": 20
-    },
-    {
-      "initial_interval": 4.0,
-      "interval": 20
-    },
-    {
-      "initial_interval": 12.0,
-      "interval": 20
-    },
-    {
-      "initial_interval": 14.0,
-      "interval": 20
-    }
+  "rank": [
+    "box_factor 0.76",
+    "master_pickup_score_per_line 3.84",
+    "show_pickups_rank"
   ],
-  "triggers": [
-    {
-      "phases": [
-        "timer_0",
-        "timer_1"
-      ],
-      "effect": "add_carrots size=small smoke=large x=0-2"
-    },
-    {
-      "phases": [
-        "timer_2",
-        "timer_3"
-      ],
-      "effect": "add_carrots size=small smoke=large x=5-7"
-    }
+  "piece_types": [
+    "ordered_start",
+    "start_piece_v",
+    "start_piece_v",
+    "start_piece_v",
+    "start_piece_o",
+    "start_piece_o",
+    "start_piece_o",
+    "piece_o",
+    "piece_v"
   ]
 }

--- a/project/src/main/puzzle/line-clear-sfx.gd
+++ b/project/src/main/puzzle/line-clear-sfx.gd
@@ -106,5 +106,9 @@ func _on_Playfield_all_lines_cleared() -> void:
 	if MilestoneManager.is_met(CurrentLevel.settings.finish_condition):
 		# message is not shown at the end of a level
 		return
+		
+	if PuzzleState.tutorial_section_finished:
+		# message is not shown at the end of a tutorial section
+		return
 	
 	_all_clear_sound.play()

--- a/project/src/main/puzzle/puzzle-messages.gd
+++ b/project/src/main/puzzle/puzzle-messages.gd
@@ -201,6 +201,10 @@ func _on_Playfield_all_lines_cleared() -> void:
 		# avoid showing conflicting messages
 		return
 	
+	if PuzzleState.tutorial_section_finished:
+		# avoid showing conflicting messages
+		return
+	
 	# show an an all clear message
 	show_message(PuzzleMessage.GOOD, all_clear_message_text)
 	_hide_message_timer.start()

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -86,6 +86,9 @@ var fatness_score := 0
 ## 'true' if the player has started a game which is still running.
 var game_active: bool
 
+## 'true' if the player finished this tutorial section.
+var tutorial_section_finished: bool
+
 ## 'true' if the player survived until the end the level.
 var finish_triggered: bool
 
@@ -189,6 +192,7 @@ func change_level(level_id: String, delay_between_levels: float = DELAY_SHORT) -
 ## wasn't wasted, if they built a lot of boxes they didn't clear.
 func trigger_finish() -> void:
 	if CurrentLevel.settings.other.tutorial:
+		tutorial_section_finished = true
 		emit_signal("tutorial_section_finished")
 	else:
 		game_active = false
@@ -280,6 +284,7 @@ func reset() -> void:
 	level_performance = PuzzlePerformance.new()
 	game_active = false
 	finish_triggered = false
+	tutorial_section_finished = false
 	game_ended = false
 	speed_index = 0
 	no_more_customers = CurrentLevel.settings.other.tutorial
@@ -339,6 +344,7 @@ func after_piece_written() -> void:
 func _prepare_game() -> void:
 	game_active = false
 	finish_triggered = false
+	tutorial_section_finished = false
 	game_ended = false
 	
 	if CurrentLevel.settings.other.start_level:

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -293,4 +293,8 @@ func _on_Playfield_all_lines_cleared() -> void:
 		# avoid conflicting chef moods at the end of a level
 		return
 	
+	if PuzzleState.tutorial_section_finished:
+		# avoid reporting 'all clear' at the end of a tutorial section
+		return
+	
 	get_chef().play_mood(Creatures.Mood.LAUGH1)

--- a/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
@@ -192,6 +192,7 @@ func _advance_level() -> void:
 ## Each cake makes a unique kind of food. We clear the lines so that the player can see what they made.
 func _schedule_finish_line_clears() -> void:
 	hud.puzzle.get_playfield().line_clearer.schedule_finish_line_clears()
+	PuzzleState.tutorial_section_finished = true
 
 
 func _handle_build_cake_message() -> void:

--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -53,6 +53,7 @@ func prepare_tutorial_level() -> void:
 	# Reset the player's combo between puzzle sections. Each tutorial section should have a fresh start; We don't want
 	# them to receive a discouraging 'you broke your combo' fanfare at the start of a section.
 	PuzzleState.set_combo(0)
+	PuzzleState.tutorial_section_finished = false
 	
 	# Hide all completed skill tally items.
 	for skill_tally_item_obj in hud.skill_tally_items():


### PR DESCRIPTION
The 'make cakes' tutorial clears all cake lines at the end of a tutorial section. This would trigger the all clear message if the player hadn't placed their final piece.

I've added a 'tutorial_section_finished' flag which is assigned/unassigned during tutorials. If it's been set, the all clear message is suppressed.