### PR TITLE
Fixed bugs when interrupting/restarting tutorials.

### DIFF
--- a/project/src/demo/puzzle/PuzzleDemo.tscn
+++ b/project/src/demo/puzzle/PuzzleDemo.tscn
@@ -5,6 +5,6 @@
 
 [node name="PuzzleDemo" type="Node"]
 script = ExtResource( 2 )
-level_path = "res://assets/demo/puzzle/levels/experiment.json"
+level_path = "res://assets/main/puzzle/levels/tutorial/combo-0.json"
 
 [node name="Puzzle" parent="." instance=ExtResource( 1 )]

--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -305,6 +305,8 @@ func _on_States_entered_state(prev_state: State, state: State) -> void:
 
 
 func _on_PuzzleState_game_prepared() -> void:
+	# enable physics_process if it was temporarily disabled
+	set_physics_process(true)
 	_clear_piece()
 
 

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -53,7 +53,7 @@ signal combo_ended
 ## emitted when the current piece can't be placed in the playfield
 signal topped_out
 
-const DELAY_NONE := 0.00
+const DELAY_NONE := 0.01
 const DELAY_SHORT := 2.05
 const DELAY_LONG := 3.30
 
@@ -171,12 +171,8 @@ func end_game() -> void:
 	emit_signal("after_game_ended")
 
 
-func change_level(level_id: String, delay_between_levels: float = DELAY_SHORT) -> void:
+func change_level(level_id: String) -> void:
 	emit_signal("before_level_changed", level_id)
-	
-	if delay_between_levels:
-		yield(get_tree().create_timer(delay_between_levels), "timeout")
-	
 	var settings := LevelSettings.new()
 	settings.load_from_resource(level_id)
 	CurrentLevel.switch_level(settings)

--- a/project/src/main/puzzle/tutorial/TutorialBasicsModule.tscn
+++ b/project/src/main/puzzle/tutorial/TutorialBasicsModule.tscn
@@ -162,3 +162,5 @@ custom_styles/fg = SubResource( 1 )
 custom_styles/bg = SubResource( 2 )
 max_value = 2.0
 label_text = "Snack Stack"
+
+[node name="Timers" type="Node" parent="."]

--- a/project/src/main/puzzle/tutorial/TutorialCakesModule.tscn
+++ b/project/src/main/puzzle/tutorial/TutorialCakesModule.tscn
@@ -54,3 +54,5 @@ custom_styles/fg = SubResource( 1 )
 custom_styles/bg = SubResource( 2 )
 max_value = 8.0
 label_text = "Cake Box"
+
+[node name="Timers" type="Node" parent="."]

--- a/project/src/main/puzzle/tutorial/TutorialComboModule.tscn
+++ b/project/src/main/puzzle/tutorial/TutorialComboModule.tscn
@@ -16,3 +16,5 @@ label_text = "Combo"
 visible = false
 max_value = 2.0
 label_text = "Cake Box"
+
+[node name="Timers" type="Node" parent="."]

--- a/project/src/main/puzzle/tutorial/TutorialModule.tscn
+++ b/project/src/main/puzzle/tutorial/TutorialModule.tscn
@@ -6,3 +6,5 @@
 script = ExtResource( 1 )
 
 [node name="SkillTallyItems" type="Node" parent="."]
+
+[node name="Timers" type="Node" parent="."]

--- a/project/src/main/puzzle/tutorial/TutorialSpinsModule.tscn
+++ b/project/src/main/puzzle/tutorial/TutorialSpinsModule.tscn
@@ -43,3 +43,5 @@ custom_styles/bg = SubResource( 2 )
 max_value = 1.0
 label_text = "Make Box"
 signal_names = [ "box_built" ]
+
+[node name="Timers" type="Node" parent="."]

--- a/project/src/main/puzzle/tutorial/TutorialSquishModule.tscn
+++ b/project/src/main/puzzle/tutorial/TutorialSquishModule.tscn
@@ -67,3 +67,5 @@ custom_styles/bg = SubResource( 2 )
 max_value = 3.0
 label_text = "Line Clear"
 signal_names = [ "line_cleared" ]
+
+[node name="Timers" type="Node" parent="."]

--- a/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
@@ -63,7 +63,7 @@ func _advance_level() -> void:
 		# the player did something crazy; skip the tutorial entirely
 		
 		# change the level immediately; don't wait for dialog to finish
-		PuzzleState.change_level("tutorial/oh_my", false)
+		PuzzleState.change_level("tutorial/oh_my")
 		
 		hud.set_big_message(ChatLibrary.add_mega_lull_characters(tr("OH, MY!!!")))
 		hud.enqueue_pop_out()

--- a/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
@@ -19,7 +19,6 @@ var _cakes_diagram_1 := preload("res://assets/main/puzzle/tutorial/cakes-diagram
 func _ready() -> void:
 	PuzzleState.connect("after_game_prepared", self, "_on_PuzzleState_after_game_prepared")
 	PuzzleState.connect("after_piece_written", self, "_on_PuzzleState_after_piece_written")
-	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")
 	playfield.connect("box_built", self, "_on_Playfield_box_built")
 	piece_manager.connect("piece_spawned", self, "_on_PieceManager_piece_spawned")
 	
@@ -243,6 +242,8 @@ func _on_PuzzleState_after_game_prepared() -> void:
 
 
 func _on_PuzzleState_game_ended() -> void:
+	._on_PuzzleState_game_ended()
+	
 	if not PuzzleState.level_performance.lost and CurrentLevel.settings.id == "tutorial/cakes_9":
 		# show end-of-tutorial message
 		if _cakes_built == 0:

--- a/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
@@ -187,20 +187,17 @@ func _on_PuzzleState_after_piece_written() -> void:
 				_advance_level()
 		"tutorial/combo_3":
 			if PuzzleState.level_performance.pieces == 2:
-				if not hud.messages.is_all_messages_visible():
-					yield(hud.messages, "all_messages_shown")
-				yield(get_tree().create_timer(3.0), "timeout")
-				hud.set_message(tr("Oops! I can still make the cake box, but my combo already broke."))
+				var message := tr("Oops! I can still make the cake box, but my combo already broke.")
+				start_timer_after_all_messages_shown(3.0) \
+						.connect("timeout", self, "_on_Timer_timeout_set_message", [message])
 			if PuzzleState.level_performance.pieces >= 3:
-				yield(get_tree().create_timer(3.0), "timeout")
-				_advance_level()
+				start_timer(3.0) \
+						.connect("timeout", self, "_on_Timer_timeout_advance_level")
 		"tutorial/combo_4":
 			if PuzzleState.level_performance.pieces >= 4:
 				hud.set_message(tr("There, I did it!\n\nThat was tricky."))
-				if not hud.messages.is_all_messages_visible():
-					yield(hud.messages, "all_messages_shown")
-				yield(get_tree().create_timer(3.0), "timeout")
-				_advance_level()
+				start_timer_after_all_messages_shown(3.0) \
+						.connect("timeout", self, "_on_Timer_timeout_advance_level")
 		"tutorial/combo_5":
 			if hud.skill_tally_item("CakeBox").is_complete():
 				_advance_level()
@@ -246,6 +243,14 @@ func _on_PuzzleState_after_game_prepared() -> void:
 	_show_diagram_count = 0
 	
 	prepare_tutorial_level()
+
+
+func _on_Timer_timeout_set_message(message: String) -> void:
+	hud.set_message(message)
+
+
+func _on_Timer_timeout_advance_level() -> void:
+	_advance_level()
 
 
 func _on_TutorialDiagram_ok_chosen() -> void:

--- a/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
@@ -194,16 +194,15 @@ func _on_PuzzleState_after_piece_written() -> void:
 		"tutorial/squish_5":
 			if PuzzleState.level_performance.pieces == 1:
 				CurrentLevel.settings.input_replay.clear()
-				if not hud.messages.is_all_messages_visible():
-					yield(hud.messages, "all_messages_shown")
-				yield(get_tree().create_timer(1.5), "timeout")
+				var messages: Array
 				if _level_attempt_count.get(CurrentLevel.settings.id, 0) >= 2:
-					hud.set_message(tr("Not again! ...Can you clean this up using squish moves?"
-								+ "\n\nTry to clear three lines."))
+					messages = [tr("Not again! ...Can you clean this up using squish moves?"
+								+ "\n\nTry to clear three lines.")]
 				else:
-					hud.set_message(tr("Oops! Look at the mess you made."
-								+ " ...Can you clean this up using squish moves?"
-								+ "\n\nTry to clear three lines."))
+					messages = [tr("Oops! Look at the mess you made. ...Can you clean this up using squish moves?"
+								+ "\n\nTry to clear three lines.")]
+				start_timer_after_all_messages_shown(1.5)\
+						.connect("timeout", self, "_on_Timer_timeout_set_messages", [messages])
 			
 			if PuzzleState.level_performance.pieces >= CurrentLevel.settings.finish_condition.value \
 					or PuzzleState.level_performance.lines >= 3:
@@ -211,15 +210,15 @@ func _on_PuzzleState_after_piece_written() -> void:
 		"tutorial/squish_6":
 			if PuzzleState.level_performance.pieces == 1:
 				CurrentLevel.settings.input_replay.clear()
-				if not hud.messages.is_all_messages_visible():
-					yield(hud.messages, "all_messages_shown")
-				yield(get_tree().create_timer(1.5), "timeout")
+				var messages: Array
 				if _level_attempt_count.get(CurrentLevel.settings.id, 0) >= 2:
-					hud.set_message(tr("Oh no, it keeps happening! Well, try to clear three lines."
-							+ "\n\nRemember your squish moves!"))
+					messages = [tr("Oh no, it keeps happening! Well, try to clear three lines."
+							+ "\n\nRemember your squish moves!")]
 				else:
-					hud.set_messages([tr("Oh no! Now you've done it.\n\nLook at how clumsy you are!"),
-						tr("That's okay.\n\nI'm sure you'll think of a clever way to clean this up, too.")])
+					messages = [tr("Oh no! Now you've done it.\n\nLook at how clumsy you are!"),
+						tr("That's okay.\n\nI'm sure you'll think of a clever way to clean this up, too.")]
+				start_timer_after_all_messages_shown(1.5)\
+						.connect("timeout", self, "_on_Timer_timeout_set_messages", [messages])
 			
 			if PuzzleState.level_performance.pieces >= CurrentLevel.settings.finish_condition.value \
 					or PuzzleState.level_performance.lines >= 3:
@@ -238,6 +237,10 @@ func _on_PuzzleState_after_game_prepared() -> void:
 	_show_diagram_count = 0
 	
 	prepare_tutorial_level()
+
+
+func _on_Timer_timeout_set_messages(messages: Array) -> void:
+	hud.set_messages(messages)
 
 
 func _on_TutorialDiagram_ok_chosen() -> void:


### PR DESCRIPTION
When restarting tutorials after the 'Good!' message showed up, the piece would never appear, softlocking the tutorial. This is because PieceManager set physics_process to false during the level transition but did not set it back to true. It now sets physics_process to true at the start of a new game.

Tutorials would demonstrate weird behavior when interrupted, because 'yield' statements would continue from the previously run tutorial. These 'yield' statements have been replaced with timers and listeners which are cleaned up when a new tutorial is started.

The choices which appear when the player is watching tutorial diagrams were lingering even if the player gave up on the tutorial. This let them do strange things like choose tutorial options when they weren't playing anymore. The choices are now hidden when the tutorial ends.

The TutorialModule framework now includes utility methods to make it easier for tutorials to do something after a delay, or do something after all messages are shown to the player.

Closes #1180.