### PR TITLE
Fixed sidger dialog crash. These are reported by the release toolkit.

### DIFF
--- a/project/assets/main/chat/career/lemon-2/030-a.chat
+++ b/project/assets/main/chat/career/lemon-2/030-a.chat
@@ -21,7 +21,7 @@ s1: Hmm, I see. #player#, try to focus more. These careless mistakes of yours ar
 
 [conniving]
 p1: >__< Sidger, you conniving little... munch!
- (p faces left)
+ (p1 faces left)
 p1: If you're gonna lie, at least lie about something that matters! Not just, overcooking this one stupid-
 [dont_blame]
 


### PR DESCRIPTION
Fixed a bug where Sidger's 'conniving little munch' dialog crashed the game. Errors like this are now reported by the ReleaseToolkit.

I considered patching the game so that these crashes wouldn't happen, or would result in a warning -- but I think it is better for now that these errors surface to where I can fix them. Players would not report a warning, and they wouldn't know if a cutscene had some unintended weirdness like a character facing the wrong direction. If it crashes, they will tell me.