### PR TITLE
Localize chat messages with symbols, 'Hello #player#'

### DIFF
--- a/project/src/main/chat/chat-tree.gd
+++ b/project/src/main/chat/chat-tree.gd
@@ -246,7 +246,12 @@ func _assign_flags_and_phrases() -> void:
 				"unset_flag": _process_unset_flag_statement(args)
 
 
-
+## Processes a default_phrase statement like 'default_phrase dog_breed Labrador Retriever'
+##
+## Assigns the specified value to the specified chat history phrase if the phrase is currently unset.
+##
+## Parameters:
+## 	'args': The statement's arguments, such as ['dog_breed', 'Labrador' 'Retriever']
 func _process_default_phrase_statement(args: Array) -> void:
 	if args.size() < 2:
 		push_warning("Invalid argument count for default_phrase call. Expected at least 2 but was %s"
@@ -258,6 +263,13 @@ func _process_default_phrase_statement(args: Array) -> void:
 				args[0], PoolStringArray(args.slice(1, args.size())).join(" "))
 
 
+## Processes a set_flag statement like 'set_flag foo' or 'set_flag foo bar'
+##
+## Assigns the specified value to the specified chat history flag. If no value is specified, it is set to the word
+## 'true'.
+##
+## Parameters:
+## 	'args': The statement's arguments, such as ['foo'] or ['foo', 'bar']
 func _process_set_flag_statement(args: Array) -> void:
 	match args.size():
 		1:
@@ -269,6 +281,12 @@ func _process_set_flag_statement(args: Array) -> void:
 					% [args.size()])
 
 
+## Processes a set_phrase statement like 'set_phrase dog_breed Labrador Retriever'
+##
+## Assigns the specified value to the specified chat history phrase.
+##
+## Parameters:
+## 	'args': The statement's arguments, such as ['dog_breed', 'Labrador', 'Retriever]
 func _process_set_phrase_statement(args: Array) -> void:
 	if args.size() < 2:
 		push_warning("Invalid argument count for set_phrase call. Expected at least 2 but was %s"
@@ -279,6 +297,12 @@ func _process_set_phrase_statement(args: Array) -> void:
 			args[0], PoolStringArray(args.slice(1, args.size())).join(" "))
 
 
+## Processes an unset_flag statement like 'unset_flag foo'
+##
+## Unassigns the specified chat history flag.
+##
+## Parameters:
+## 	'args': The statement's arguments, such as ['foo'].
 func _process_unset_flag_statement(args: Array) -> void:
 	if args.size() != 1:
 		push_warning("Invalid argument count for unset_flag call. Expected 1 but was %s"

--- a/project/src/main/chat/ui/chat-frame.gd
+++ b/project/src/main/chat/ui/chat-frame.gd
@@ -59,11 +59,13 @@ func play_chat_event(chat_event: ChatEvent, squished: bool) -> void:
 			$SquishTween.unsquish()
 		_squished = squished
 	
-	# add lull characters
-	var text_with_lulls := ChatLibrary.add_lull_characters(chat_event.text)
+	# substitute variables and add lull characters
+	var text_to_show := chat_event.text
+	text_to_show = PlayerData.creature_library.substitute_variables(text_to_show)
+	text_to_show = ChatLibrary.add_lull_characters(text_to_show)
 	
 	# set the text and calculate how big of a frame we need
-	var chat_line_size: int = $ChatLineLabel.show_message(text_with_lulls, 0.5)
+	var chat_line_size: int = $ChatLineLabel.show_message(text_to_show, 0.5)
 	var creature_name := ""
 	if chat_event.who:
 		var creature_def := PlayerData.creature_library.get_creature_def(chat_event.who)

--- a/project/src/main/chat/ui/label-typer.gd
+++ b/project/src/main/chat/ui/label-typer.gd
@@ -55,8 +55,6 @@ func _process(delta: float) -> void:
 ## This function also calculates the duration to pause for each character. All visible characters cause a short pause.
 ## Newlines cause a long pause. Slashes cause a medium pause and are hidden from the player.
 func show_message(text_with_lulls: String, initial_pause: float = 0.0) -> void:
-	text_with_lulls = PlayerData.creature_library.substitute_variables(text_with_lulls)
-	
 	# clear any pauses and data related to the old message
 	hide_message()
 	

--- a/project/src/main/chat/ui/narration-frame.gd
+++ b/project/src/main/chat/ui/narration-frame.gd
@@ -36,11 +36,13 @@ func play_chat_event(chat_event: ChatEvent) -> void:
 		# Ensure the chat window is showing before we start changing its text and playing sounds
 		pop_in()
 	
-	# add lull characters
-	var text_with_lulls := ChatLibrary.add_lull_characters(chat_event.text)
+	# substitute variables and add lull characters
+	var text_to_show := chat_event.text
+	text_to_show = PlayerData.creature_library.substitute_variables(text_to_show)
+	text_to_show = ChatLibrary.add_lull_characters(text_to_show)
 	
 	# set the text
-	$NarrationPanel.show_message(text_with_lulls, 0.5)
+	$NarrationPanel.show_message(text_to_show, 0.5)
 
 
 func is_narration_window_showing() -> bool:

--- a/project/src/main/world/creature/creature-library.gd
+++ b/project/src/main/world/creature/creature-library.gd
@@ -187,6 +187,7 @@ func substitute_variables(string: String) -> String:
 		rules[phrase] = tr(PlayerData.chat_history.phrases[phrase])
 	var grammar := Tracery.Grammar.new(rules)
 	grammar.add_modifiers(Tracery.Modifiers.get_modifiers())
+	grammar.add_translation_exempt_symbol("#player#")
 	return grammar.flatten(string)
 
 


### PR DESCRIPTION
Before, messages like 'I'm #mood#' would fail
to be translated for two reasons.

Firstly, the translation happened when the message was displayed to the user, after all entities were replaced. So even if we had a translation for 'I'm #mood#', the translation engine would instead search for 'I'm angry' which was undefined.

Secondly, the translation engine did not translate replaceable entities like 'angry'.

Both these issues are now fixed.