### PR TITLE
Fixed redundant tutorial chimes.

### DIFF
--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -17,6 +17,7 @@ signal game_started
 
 ## emitted during tutorials, when changing from one tutorial section to the next
 signal before_level_changed(new_level_id)
+
 signal after_level_changed
 
 ## emitted when the player survives until the end the level.
@@ -171,8 +172,14 @@ func end_game() -> void:
 	emit_signal("after_game_ended")
 
 
-func change_level(level_id: String) -> void:
+## Signals a level transition.
+##
+## During tutorials, this notifies the player that this section is over. It also pauses time-sensitive puzzle logic.
+func prepare_level_change(level_id: String) -> void:
 	emit_signal("before_level_changed", level_id)
+
+
+func change_level(level_id: String) -> void:
 	var settings := LevelSettings.new()
 	settings.load_from_resource(level_id)
 	CurrentLevel.switch_level(settings)

--- a/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
@@ -63,7 +63,9 @@ func _advance_level() -> void:
 		# the player did something crazy; skip the tutorial entirely
 		
 		# change the level immediately; don't wait for dialog to finish
-		PuzzleState.change_level("tutorial/oh_my")
+		var level_id := "tutorial/oh_my"
+		PuzzleState.prepare_level_change(level_id)
+		PuzzleState.change_level(level_id)
 		
 		hud.set_big_message(ChatLibrary.add_mega_lull_characters(tr("OH, MY!!!")))
 		hud.enqueue_pop_out()

--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -84,8 +84,7 @@ func prepare_tutorial_level() -> void:
 ##
 ## Copy/pasted from PuzzleState.change_level with an extra yield statement added.
 func change_level(level_id: String, delay_between_levels: float = PuzzleState.DELAY_SHORT) -> void:
-	PuzzleState.emit_signal("before_level_changed", level_id)
-	
+	PuzzleState.prepare_level_change(level_id)
 	start_timer_after_all_messages_shown(delay_between_levels) \
 			.connect("timeout", self, "_on_Timer_timeout_change_level", [level_id])
 


### PR DESCRIPTION
Tutorial chimes were playing at the start and end of each section, because the 'before_level_changed' signal was being emitted too frequently. This bug was introduced in 52c1784 when fixing bugs related to interrupting/restarting tutorials.

Closes #1782.