### PR TITLE
Retry refactorings: 0.0 timers, piece states

### DIFF
--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -84,8 +84,8 @@ func _ready() -> void:
 	piece = ActivePiece.new(PieceTypes.piece_null, funcref(tile_map, "is_cell_obstructed"))
 
 	PieceSpeeds.current_speed = PieceSpeeds.speed("0")
-	_states.set_state(_states.none)
 	_clear_piece()
+	_states.set_state(_states.none)
 	_prepare_tileset()
 
 
@@ -308,6 +308,7 @@ func _on_PuzzleState_game_prepared() -> void:
 	# enable physics_process if it was temporarily disabled
 	set_physics_process(true)
 	_clear_piece()
+	_states.set_state(_states.none)
 
 
 func _on_PuzzleState_game_started() -> void:

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -225,7 +225,11 @@ func end_game() -> void:
 			wait_time = 4.2
 		Levels.Result.NONE:
 			wait_time = 0.0
-	start_timer(wait_time).connect("timeout", self, "_on_Timer_timeout_emit_after_game_ended")
+	
+	if wait_time > 0.0:
+		start_timer(wait_time).connect("timeout", self, "_on_Timer_timeout_emit_after_game_ended")
+	else:
+		emit_signal("after_game_ended")
 
 
 ## Signals a level transition.
@@ -312,7 +316,7 @@ func end_combo() -> void:
 		# don't add $0 creatures. creatures don't pay if they owe $0
 		pass
 	elif CurrentLevel.settings.finish_condition.type == Milestone.CUSTOMERS \
-			and PuzzleState.customer_scores.size() >= CurrentLevel.settings.finish_condition.value:
+			and customer_scores.size() >= CurrentLevel.settings.finish_condition.value:
 		# some levels have a limited number of customers
 		no_more_customers = true
 	else:

--- a/project/src/main/puzzle/step-meter.gd
+++ b/project/src/main/puzzle/step-meter.gd
@@ -9,15 +9,17 @@ var _rank_calculator: RankCalculator = RankCalculator.new()
 onready var _recalculate_timer: Timer = $RecalculateTimer
 
 func _ready() -> void:
-	# only display the meter in career mode
 	if PlayerData.career.is_career_mode():
-		visible = true
-		_recalculate_timer.start()
 		PuzzleState.connect("after_game_prepared", self, "_on_PuzzleState_after_game_prepared")
 		PuzzleState.connect("score_changed", self, "_on_PuzzleState_score_changed")
 		PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")
+	
+	if PlayerData.career.is_career_mode():
+		visible = true
+		_recalculate_timer.start()
 	else:
 		visible = false
+		_recalculate_timer.stop()
 	
 	# initialize the meter as empty
 	_recalculate()
@@ -37,6 +39,11 @@ func _milestone_met_percent(milestone: Milestone) -> float:
 ##
 ## For career mode boss levels, the success condition acts as an additional prerequisite to progress. This method
 ## calculates how close the player is to progressing through career mode.
+##
+## For non-boss levels, this method always returns 1.0.
+##
+## Returns:
+## 	A number in the range [0.0, 1.0] for the player's progress toward the current level's success condition.
 func _boss_level_percent() -> float:
 	if CurrentLevel.settings.success_condition.type == Milestone.NONE:
 		return 1.0


### PR DESCRIPTION
Various small refactorings encountered while working on the 'retry' button.

PieceManager now updates its state to 'none' when preparing a level. This avoids edge cases if a level is restarted while the piece is in an unusual state.

Fixed a bug where PuzzleState would try to launch a 0.0 second timer when ending a level.

Removed an unnecessary reference from PuzzleState to itself (PuzzleState.customer_scores)

Extracted a Puzzle._save_level_result() function.

Minor refactoring of StepMeter and improved comments. This new code layout makes it easier to rearrange the code later if we decide we want the step meter to become visible/invisible during a puzzle.