### PR TITLE
Added 'gameplay speed' cheat to settings.

### DIFF
--- a/project/src/main/puzzle/piece/piece-dropper.gd
+++ b/project/src/main/puzzle/piece/piece-dropper.gd
@@ -56,11 +56,14 @@ func apply_gravity(piece: ActivePiece) -> void:
 		piece.remaining_post_squish_frames -= 1
 		piece_mover.attempt_mid_drop_movement(piece)
 	else:
+		var current_gravity := PieceSpeeds.current_speed.gravity
+		if not CurrentLevel.settings.other.tutorial:
+			current_gravity *= SystemData.gameplay_settings.get_gravity_factor()
 		if input.is_soft_drop_pressed():
 			# soft drop
-			piece.gravity += int(max(PieceSpeeds.DROP_G, PieceSpeeds.current_speed.gravity))
+			piece.gravity += int(max(PieceSpeeds.DROP_G, current_gravity))
 		else:
-			piece.gravity += PieceSpeeds.current_speed.gravity
+			piece.gravity += current_gravity
 		
 		var pos_changed := false
 		while piece.gravity >= PieceSpeeds.G:

--- a/project/src/main/settings/gameplay-settings.gd
+++ b/project/src/main/settings/gameplay-settings.gd
@@ -3,11 +3,42 @@ class_name GameplaySettings
 
 signal ghost_piece_changed(value)
 
+enum Speed {
+	DEFAULT,
+	SLOW,
+	SLOWER,
+	SLOWEST,
+	SLOWESTEST,
+	FAST,
+	FASTER,
+	FASTEST,
+	FASTESTEST,
+}
+
+## Returns a number in the range [0.0, ∞) for how piece gravity should be modified for each gameplay speed setting.
+##
+## A value like 2.0 means pieces should fall faster, and a value like 0.5 means they should fall slower.
+const GRAVITY_FACTOR_BY_ENUM := {
+	Speed.DEFAULT: 1.0,
+	Speed.SLOW: 0.707,
+	Speed.SLOWER: 0.500,
+	Speed.SLOWEST: 0.333,
+	Speed.SLOWESTEST: 0.0,
+	Speed.FAST: 1.414,
+	Speed.FASTER: 1.5,
+	Speed.FASTEST: 2.0,
+	Speed.FASTESTEST: 100.0,
+}
+
 ## 'true' if a ghost piece should be shown during the puzzle sections.
 var ghost_piece := true setget set_ghost_piece
 
 ## 'true' if pressing soft drop should perform a lock cancel
 var soft_drop_lock_cancel := true
+
+## The current gameplay speed. The player can reduce this to make the game easier. They can also increase it to make
+## the game harder, or to cheat on levels which otherwise require slow and thoughtful play.
+var speed: int = Speed.DEFAULT
 
 func set_ghost_piece(new_ghost_piece: bool) -> void:
 	if ghost_piece == new_ghost_piece:
@@ -25,9 +56,18 @@ func to_json_dict() -> Dictionary:
 	return {
 		"ghost_piece": ghost_piece,
 		"soft_drop_lock_cancel": soft_drop_lock_cancel,
+		"speed": Utils.enum_to_snake_case(Speed, speed),
 	}
 
 
 func from_json_dict(json: Dictionary) -> void:
 	set_ghost_piece(json.get("ghost_piece", true))
 	soft_drop_lock_cancel = json.get("soft_drop_lock_cancel", true)
+	speed = Utils.enum_from_snake_case(Speed, json.get("speed", ""))
+
+
+## Returns a number in the range [0.0, ∞) for how piece gravity should be modified.
+##
+## A value like 2.0 means pieces should fall faster, and a value like 0.5 means they should fall slower.
+func get_gravity_factor() -> float:
+	return GRAVITY_FACTOR_BY_ENUM.get(speed, 1.0)

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=33 format=2]
+[gd_scene load_steps=34 format=2]
 
 [ext_resource path="res://src/main/ui/theme/h4.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=2]
@@ -29,6 +29,7 @@
 [ext_resource path="res://src/main/ui/settings/settings-copy-save-data.gd" type="Script" id=27]
 [ext_resource path="res://src/main/ui/settings/settings-lock-cancel.gd" type="Script" id=28]
 [ext_resource path="res://src/main/ui/settings/settings-menu-bottom.gd" type="Script" id=29]
+[ext_resource path="res://src/main/ui/settings/settings-gameplay-speed.gd" type="Script" id=30]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 5.0
@@ -334,6 +335,64 @@ margin_right = 560.0
 margin_bottom = 28.0
 rect_min_size = Vector2( 160, 26 )
 size_flags_horizontal = 3
+size_flags_vertical = 4
+size_flags_stretch_ratio = 1.1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Spacer1" type="Control" parent="Window/UiArea/TabContainer/Gameplay"]
+margin_top = 64.0
+margin_right = 560.0
+margin_bottom = 84.0
+rect_min_size = Vector2( 0, 20 )
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.1
+
+[node name="Label" type="Label" parent="Window/UiArea/TabContainer/Gameplay"]
+margin_top = 88.0
+margin_right = 560.0
+margin_bottom = 108.0
+rect_min_size = Vector2( 120, 0 )
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.5
+theme = ExtResource( 1 )
+text = "Cheats"
+align = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Scheme" type="HBoxContainer" parent="Window/UiArea/TabContainer/Gameplay"]
+margin_top = 112.0
+margin_right = 560.0
+margin_bottom = 138.0
+rect_min_size = Vector2( 400, 26 )
+size_flags_horizontal = 3
+theme = ExtResource( 1 )
+custom_constants/separation = 20
+script = ExtResource( 30 )
+
+[node name="Label" type="Label" parent="Window/UiArea/TabContainer/Gameplay/Scheme"]
+margin_right = 217.0
+margin_bottom = 26.0
+rect_min_size = Vector2( 120, 0 )
+size_flags_horizontal = 3
+size_flags_vertical = 5
+size_flags_stretch_ratio = 0.74
+text = "Scheme"
+align = 2
+valign = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="OptionButton" type="OptionButton" parent="Window/UiArea/TabContainer/Gameplay/Scheme"]
+margin_left = 237.0
+margin_right = 397.0
+margin_bottom = 26.0
+rect_min_size = Vector2( 160, 0 )
+size_flags_horizontal = 2
 size_flags_vertical = 4
 size_flags_stretch_ratio = 1.1
 __meta__ = {
@@ -1180,6 +1239,7 @@ __meta__ = {
 [connection signal="pressed" from="Window/UiArea/Bottom/HBoxContainer/VBoxContainer2/Holder/Ok" to="Window/UiArea/Bottom" method="_on_Ok_pressed"]
 [connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/GhostPiece/CheckBox" to="Window/UiArea/TabContainer/Gameplay/GhostPiece" method="_on_OptionButton_toggled"]
 [connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/LockCancel/CheckBox" to="Window/UiArea/TabContainer/Gameplay/LockCancel" method="_on_OptionButton_toggled"]
+[connection signal="item_selected" from="Window/UiArea/TabContainer/Gameplay/Scheme/OptionButton" to="Window/UiArea/TabContainer/Gameplay/Scheme" method="_on_OptionButton_item_selected"]
 [connection signal="pressed" from="Window/UiArea/TabContainer/Misc/CopySaveData/HBoxContainer/Button" to="Window/UiArea/TabContainer/Misc/CopySaveData" method="_on_Button_pressed"]
 [connection signal="item_selected" from="Window/UiArea/TabContainer/Misc/Language/OptionButton" to="Window/UiArea/TabContainer/Misc/Language" method="_on_OptionButton_item_selected"]
 [connection signal="pressed" from="Window/UiArea/TabContainer/Misc/Open User Folder/Button" to="Window/UiArea/TabContainer/Misc/Open User Folder" method="_on_Button_pressed"]

--- a/project/src/main/ui/settings/settings-gameplay-speed.gd
+++ b/project/src/main/ui/settings/settings-gameplay-speed.gd
@@ -1,0 +1,23 @@
+extends Control
+## UI control for adjusting the gameplay speed.
+##
+## The gameplay speed affects how fast pieces fall in puzzle mode.
+
+onready var _option_button: OptionButton = $OptionButton
+
+func _ready() -> void:
+	_option_button.add_item(tr("Slowestest"), GameplaySettings.Speed.SLOWESTEST)
+	_option_button.add_item(tr("Slowest"), GameplaySettings.Speed.SLOWEST)
+	_option_button.add_item(tr("Slower"), GameplaySettings.Speed.SLOWER)
+	_option_button.add_item(tr("Slow"), GameplaySettings.Speed.SLOW)
+	_option_button.add_item(tr("Default"), GameplaySettings.Speed.DEFAULT)
+	_option_button.add_item(tr("Fast"), GameplaySettings.Speed.FAST)
+	_option_button.add_item(tr("Faster"), GameplaySettings.Speed.FASTER)
+	_option_button.add_item(tr("Fastest"), GameplaySettings.Speed.FASTEST)
+	_option_button.add_item(tr("Fastestest"), GameplaySettings.Speed.FASTESTEST)
+	_option_button.selected = SystemData.touch_settings.scheme
+
+
+func _on_OptionButton_item_selected(index: int) -> void:
+	var item_id := _option_button.get_item_id(index)
+	SystemData.gameplay_settings.speed = item_id

--- a/project/src/test/data/test-system-save-upgrader.gd
+++ b/project/src/test/data/test-system-save-upgrader.gd
@@ -46,3 +46,5 @@ func test_27bb() -> void:
 	assert_eq(SystemData.keybind_settings.custom_keybinds.has("walk_left"), false)
 	assert_eq(SystemData.keybind_settings.custom_keybinds.has("walk_right"), false)
 	assert_eq(SystemData.keybind_settings.custom_keybinds.has("walk_up"), false)
+	
+	assert_eq(SystemData.gameplay_settings.speed, GameplaySettings.Speed.DEFAULT)

--- a/project/src/test/data/test-system-save.gd
+++ b/project/src/test/data/test-system-save.gd
@@ -32,6 +32,7 @@ func test_save_and_load() -> void:
 	SystemData.volume_settings.set_bus_volume_linear(VolumeSettings.MUSIC, 0.695)
 	SystemData.volume_settings.set_bus_volume_linear(VolumeSettings.SOUND, 0.279)
 	SystemData.volume_settings.set_bus_volume_linear(VolumeSettings.VOICE, 0.405)
+	SystemData.gameplay_settings.speed = GameplaySettings.Speed.FASTEST
 	SystemSave.save_system_data()
 	SystemData.reset()
 	SystemSave.load_system_data()
@@ -39,3 +40,4 @@ func test_save_and_load() -> void:
 	assert_almost_eq(SystemData.volume_settings.get_bus_volume_linear(VolumeSettings.MUSIC), 0.695, 0.001)
 	assert_almost_eq(SystemData.volume_settings.get_bus_volume_linear(VolumeSettings.SOUND), 0.279, 0.001)
 	assert_almost_eq(SystemData.volume_settings.get_bus_volume_linear(VolumeSettings.VOICE), 0.405, 0.001)
+	assert_eq(SystemData.gameplay_settings.speed, GameplaySettings.Speed.FASTEST)


### PR DESCRIPTION
Player can adjust gameplay speed to make pieces fall faster or slower.

This only scales piece speeds by a constant factor, and does not have a meaningful effect on levels with instant gravity speeds. These will be addressed by #1752.

Closes #1751.