### PR TITLE
Bug: Gameplay speed settings menu.

### DIFF
--- a/project/src/main/puzzle/critter/mole.gd
+++ b/project/src/main/puzzle/critter/mole.gd
@@ -54,8 +54,8 @@ var _next_states := []
 ## accidentally popping two states from the queue when the mole first spawns.
 var _already_popped_state := false
 
-## key: An enum from States
-## value: A State node from the _states StateMachine
+## key: (int) An enum from States
+## value: (Node) A State node from the _states StateMachine
 onready var _state_nodes_by_enum := {
 	NONE: $States/None,
 	WAITING: $States/Waiting,

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -363,7 +363,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Scheme" type="HBoxContainer" parent="Window/UiArea/TabContainer/Gameplay"]
+[node name="Speed" type="HBoxContainer" parent="Window/UiArea/TabContainer/Gameplay"]
 margin_top = 112.0
 margin_right = 560.0
 margin_bottom = 138.0
@@ -373,21 +373,21 @@ theme = ExtResource( 1 )
 custom_constants/separation = 20
 script = ExtResource( 30 )
 
-[node name="Label" type="Label" parent="Window/UiArea/TabContainer/Gameplay/Scheme"]
+[node name="Label" type="Label" parent="Window/UiArea/TabContainer/Gameplay/Speed"]
 margin_right = 217.0
 margin_bottom = 26.0
 rect_min_size = Vector2( 120, 0 )
 size_flags_horizontal = 3
 size_flags_vertical = 5
 size_flags_stretch_ratio = 0.74
-text = "Scheme"
+text = "Speed"
 align = 2
 valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="OptionButton" type="OptionButton" parent="Window/UiArea/TabContainer/Gameplay/Scheme"]
+[node name="OptionButton" type="OptionButton" parent="Window/UiArea/TabContainer/Gameplay/Speed"]
 margin_left = 237.0
 margin_right = 397.0
 margin_bottom = 26.0
@@ -1239,7 +1239,7 @@ __meta__ = {
 [connection signal="pressed" from="Window/UiArea/Bottom/HBoxContainer/VBoxContainer2/Holder/Ok" to="Window/UiArea/Bottom" method="_on_Ok_pressed"]
 [connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/GhostPiece/CheckBox" to="Window/UiArea/TabContainer/Gameplay/GhostPiece" method="_on_OptionButton_toggled"]
 [connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/LockCancel/CheckBox" to="Window/UiArea/TabContainer/Gameplay/LockCancel" method="_on_OptionButton_toggled"]
-[connection signal="item_selected" from="Window/UiArea/TabContainer/Gameplay/Scheme/OptionButton" to="Window/UiArea/TabContainer/Gameplay/Scheme" method="_on_OptionButton_item_selected"]
+[connection signal="item_selected" from="Window/UiArea/TabContainer/Gameplay/Speed/OptionButton" to="Window/UiArea/TabContainer/Gameplay/Speed" method="_on_OptionButton_item_selected"]
 [connection signal="pressed" from="Window/UiArea/TabContainer/Misc/CopySaveData/HBoxContainer/Button" to="Window/UiArea/TabContainer/Misc/CopySaveData" method="_on_Button_pressed"]
 [connection signal="item_selected" from="Window/UiArea/TabContainer/Misc/Language/OptionButton" to="Window/UiArea/TabContainer/Misc/Language" method="_on_OptionButton_item_selected"]
 [connection signal="pressed" from="Window/UiArea/TabContainer/Misc/Open User Folder/Button" to="Window/UiArea/TabContainer/Misc/Open User Folder" method="_on_Button_pressed"]

--- a/project/src/main/ui/settings/settings-gameplay-speed.gd
+++ b/project/src/main/ui/settings/settings-gameplay-speed.gd
@@ -15,7 +15,8 @@ func _ready() -> void:
 	_option_button.add_item(tr("Faster"), GameplaySettings.Speed.FASTER)
 	_option_button.add_item(tr("Fastest"), GameplaySettings.Speed.FASTEST)
 	_option_button.add_item(tr("Fastestest"), GameplaySettings.Speed.FASTESTEST)
-	_option_button.selected = SystemData.touch_settings.scheme
+	
+	_option_button.selected = _option_button.get_item_index(SystemData.gameplay_settings.speed)
 
 
 func _on_OptionButton_item_selected(index: int) -> void:


### PR DESCRIPTION
Fixed bug where Gameplay Speed setting in settings menu was populated incorrectly. It was populated with the touch settings value instead of the speed settings value.

Fixed bug where Gameplay Speed setting was incorrectly given the label of 'Scheme' instead of 'Speed'.