### PR TITLE
Added 'maximum piece speed' setting.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -345,6 +345,11 @@ _global_script_classes=[ {
 "path": "res://src/demo/world/free-roam-world.gd"
 }, {
 "base": "Reference",
+"class": "GameplayPieceSpeeds",
+"language": "GDScript",
+"path": "res://src/main/puzzle/level/gameplay-piece-speeds.gd"
+}, {
+"base": "Reference",
 "class": "GameplaySettings",
 "language": "GDScript",
 "path": "res://src/main/settings/gameplay-settings.gd"
@@ -1232,6 +1237,7 @@ _global_script_class_icons={
 "Foods": "",
 "FrameInput": "",
 "FreeRoamWorld": "",
+"GameplayPieceSpeeds": "",
 "GameplaySettings": "",
 "GoopGlob": "",
 "GoopViewports": "",

--- a/project/src/main/puzzle/level/gameplay-piece-speeds.gd
+++ b/project/src/main/puzzle/level/gameplay-piece-speeds.gd
@@ -1,0 +1,418 @@
+class_name GameplayPieceSpeeds
+## Adjusts piece speeds based on the player's gameplay speed settings.
+##
+## This is specifically used for cheats where the player can make the pieces fall slower or faster. To speed up and
+## slow down pieces, we adjust all drop speeds by a fixed percent. This doesn't have a significant effect on instant
+## gravity levels however (50% of 20G is still 10G which is way too fast for a novice) so this script defines mappings
+## to adjust piece speeds based on the player's gameplay speed settings.
+
+## key: (int) enum from GameplaySettings.Speed
+## value: (Dictionary) mapping from piece speed strings to adjusted piece speed strings
+const PIECE_SPEED_MAPPING_BY_GAMEPLAY_SPEED := {
+	# pieces are literally always at the fastest 20G speed
+	GameplaySettings.Speed.FASTESTEST: {
+		"T": "FFF",
+
+		"0": "FFF",
+		"1": "FFF",
+		"2": "FFF",
+		"3": "FFF",
+		"4": "FFF",
+		"5": "FFF",
+		"6": "FFF",
+		"7": "FFF",
+		"8": "FFF",
+		"9": "FFF",
+
+		"A0": "FFF",
+		"A1": "FFF",
+		"A2": "FFF",
+		"A3": "FFF",
+		"A4": "FFF",
+		"A5": "FFF",
+		"A6": "FFF",
+		"A7": "FFF",
+		"A8": "FFF",
+		"A9": "FFF",
+
+		"AA": "FFF",
+		"AB": "FFF",
+		"AC": "FFF",
+		"AD": "FFF",
+		"AE": "FFF",
+		"AF": "FFF",
+
+		"F0": "FFF",
+		"F1": "FFF",
+		"FA": "FFF",
+		"FB": "FFF",
+		"FC": "FFF",
+		"FD": "FFF",
+		"FE": "FFF",
+		"FF": "FFF",
+		"FFF": "FFF",
+	},
+	
+	# pieces fall much much faster (the slowest speed is F1)
+	GameplaySettings.Speed.FASTEST: {
+		"T": "T",
+
+		"0": "F0",
+		"1": "F1",
+		"2": "F1",
+		"3": "F1",
+		"4": "F1",
+		"5": "F1",
+		"6": "F1",
+		"7": "F1",
+		"8": "F1",
+		"9": "F1",
+
+		"A0": "F0",
+		"A1": "FA",
+		"A2": "FA",
+		"A3": "FA",
+		"A4": "FB",
+		"A5": "FB",
+		"A6": "FB",
+		"A7": "FC",
+		"A8": "FC",
+		"A9": "FC",
+
+		"AA": "FD",
+		"AB": "FD",
+		"AC": "FE",
+		"AD": "FE",
+		"AE": "FF",
+		"AF": "FF",
+
+		"F0": "F0",
+		"F1": "FFF",
+		"FA": "FFF",
+		"FB": "FFF",
+		"FC": "FFF",
+		"FD": "FFF",
+		"FE": "FFF",
+		"FF": "FFF",
+		"FFF": "FFF",
+	},
+	
+	# pieces fall much faster (the slowest speed is A1)
+	GameplaySettings.Speed.FASTER: {
+		"T": "T",
+
+		"0": "A0",
+		"1": "A1",
+		"2": "A1",
+		"3": "A1",
+		"4": "A2",
+		"5": "A2",
+		"6": "A3",
+		"7": "A3",
+		"8": "A4",
+		"9": "A4",
+
+		"A0": "A0",
+		"A1": "A5",
+		"A2": "A5",
+		"A3": "A6",
+		"A4": "A6",
+		"A5": "A7",
+		"A6": "A7",
+		"A7": "A8",
+		"A8": "A8",
+		"A9": "A9",
+
+		"AA": "AA",
+		"AB": "AB",
+		"AC": "AC",
+		"AD": "AD",
+		"AE": "AE",
+		"AF": "AF",
+
+		"F0": "F0",
+		"F1": "F1",
+		"FA": "FA",
+		"FB": "FB",
+		"FC": "FC",
+		"FD": "FD",
+		"FE": "FE",
+		"FF": "FF",
+		"FFF": "FFF",
+	},
+	
+	# pieces fall faster (the slowest speed is 5)
+	GameplaySettings.Speed.FAST: {
+		"T": "T",
+
+		"0": "5",
+		"1": "5",
+		"2": "6",
+		"3": "6",
+		"4": "7",
+		"5": "7",
+		"6": "8",
+		"7": "8",
+		"8": "9",
+		"9": "9",
+
+		"A0": "A0",
+		"A1": "A1",
+		"A2": "A2",
+		"A3": "A3",
+		"A4": "A4",
+		"A5": "A5",
+		"A6": "A6",
+		"A7": "A7",
+		"A8": "A8",
+		"A9": "A9",
+
+		"AA": "AA",
+		"AB": "AB",
+		"AC": "AC",
+		"AD": "AD",
+		"AE": "AE",
+		"AF": "AF",
+
+		"F0": "F0",
+		"F1": "F1",
+		"FA": "FA",
+		"FB": "FB",
+		"FC": "FC",
+		"FD": "FD",
+		"FE": "FE",
+		"FF": "FF",
+		"FFF": "FFF",
+	},
+	
+	GameplaySettings.Speed.DEFAULT: {
+		"T": "T",
+
+		"0": "0",
+		"1": "1",
+		"2": "2",
+		"3": "3",
+		"4": "4",
+		"5": "5",
+		"6": "6",
+		"7": "7",
+		"8": "8",
+		"9": "9",
+
+		"A0": "A0",
+		"A1": "A1",
+		"A2": "A2",
+		"A3": "A3",
+		"A4": "A4",
+		"A5": "A5",
+		"A6": "A6",
+		"A7": "A7",
+		"A8": "A8",
+		"A9": "A9",
+
+		"AA": "AA",
+		"AB": "AB",
+		"AC": "AC",
+		"AD": "AD",
+		"AE": "AE",
+		"AF": "AF",
+
+		"F0": "F0",
+		"F1": "F1",
+		"FA": "FA",
+		"FB": "FB",
+		"FC": "FC",
+		"FD": "FD",
+		"FE": "FE",
+		"FF": "FF",
+		"FFF": "FFF",
+	},
+	
+	# pieces fall slower (the fastest speed is AA)
+	GameplaySettings.Speed.SLOW: {
+		"T": "T",
+
+		"0": "0",
+		"1": "1",
+		"2": "2",
+		"3": "3",
+		"4": "4",
+		"5": "5",
+		"6": "6",
+		"7": "7",
+		"8": "8",
+		"9": "9",
+
+		"A0": "A0",
+		"A1": "A1",
+		"A2": "A2",
+		"A3": "A3",
+		"A4": "A4",
+		"A5": "A5",
+		"A6": "A6",
+		"A7": "A6",
+		"A8": "A7",
+		"A9": "A7",
+
+		"AA": "A8",
+		"AB": "A8",
+		"AC": "A9",
+		"AD": "A9",
+		"AE": "AA",
+		"AF": "AA",
+
+		"F0": "A0",
+		"F1": "AA",
+		"FA": "AA",
+		"FB": "AA",
+		"FC": "AA",
+		"FD": "AA",
+		"FE": "AA",
+		"FF": "AA",
+		"FFF": "AA",
+	},
+	
+	# pieces fall much slower (the fastest speed is 9)
+	GameplaySettings.Speed.SLOWER: {
+		"T": "T",
+
+		"0": "0",
+		"1": "1",
+		"2": "2",
+		"3": "3",
+		"4": "4",
+		"5": "5",
+		"6": "6",
+		"7": "7",
+		"8": "8",
+		"9": "9",
+
+		"A0": "0",
+		"A1": "9",
+		"A2": "9",
+		"A3": "9",
+		"A4": "9",
+		"A5": "9",
+		"A6": "9",
+		"A7": "9",
+		"A8": "9",
+		"A9": "9",
+
+		"AA": "9",
+		"AB": "9",
+		"AC": "9",
+		"AD": "9",
+		"AE": "9",
+		"AF": "9",
+
+		"F0": "0",
+		"F1": "9",
+		"FA": "9",
+		"FB": "9",
+		"FC": "9",
+		"FD": "9",
+		"FE": "9",
+		"FF": "9",
+		"FFF": "9",
+	},
+	
+	# pieces fall much much slower (the fastest speed is 7)
+	GameplaySettings.Speed.SLOWEST: {
+		"T": "T",
+
+		"0": "0",
+		"1": "0",
+		"2": "1",
+		"3": "1",
+		"4": "2",
+		"5": "3",
+		"6": "4",
+		"7": "5",
+		"8": "6",
+		"9": "7",
+
+		"A0": "0",
+		"A1": "7",
+		"A2": "7",
+		"A3": "7",
+		"A4": "7",
+		"A5": "7",
+		"A6": "7",
+		"A7": "7",
+		"A8": "7",
+		"A9": "7",
+
+		"AA": "7",
+		"AB": "7",
+		"AC": "7",
+		"AD": "7",
+		"AE": "7",
+		"AF": "7",
+
+		"F0": "0",
+		"F1": "7",
+		"FA": "7",
+		"FB": "7",
+		"FC": "7",
+		"FD": "7",
+		"FE": "7",
+		"FF": "7",
+		"FFF": "7",
+	},
+	
+	# pieces literally don't fall
+	GameplaySettings.Speed.SLOWESTEST: {
+		"T": "T",
+
+		"0": "T",
+		"1": "T",
+		"2": "T",
+		"3": "T",
+		"4": "T",
+		"5": "T",
+		"6": "T",
+		"7": "T",
+		"8": "T",
+		"9": "T",
+
+		"A0": "T",
+		"A1": "T",
+		"A2": "T",
+		"A3": "T",
+		"A4": "T",
+		"A5": "T",
+		"A6": "T",
+		"A7": "T",
+		"A8": "T",
+		"A9": "T",
+
+		"AA": "T",
+		"AB": "T",
+		"AC": "T",
+		"AD": "T",
+		"AE": "T",
+		"AF": "T",
+
+		"F0": "T",
+		"F1": "T",
+		"FA": "T",
+		"FB": "T",
+		"FC": "T",
+		"FD": "T",
+		"FE": "T",
+		"FF": "T",
+		"FFF": "T",
+	},
+}
+
+## Adjusts a piece speed based on the player's gameplay speed settings.
+##
+## Parameters:
+## 	'piece_speed_string': An unmodified piece speed string such as '0' or 'A9'
+##
+## Returns:
+## 	A modified piece speed string such as '0' or 'A9'
+static func get_adjusted_piece_speed(piece_speed_string: String) -> String:
+	var adjusted_speed_by_piece_speed: Dictionary = \
+			PIECE_SPEED_MAPPING_BY_GAMEPLAY_SPEED.get(SystemData.gameplay_settings.speed, {})
+	return adjusted_speed_by_piece_speed.get(piece_speed_string, piece_speed_string)

--- a/project/src/main/puzzle/piece/piece-speeds.gd
+++ b/project/src/main/puzzle/piece/piece-speeds.gd
@@ -88,6 +88,8 @@ func _ready() -> void:
 	current_speed = PieceSpeeds.speed("0")
 	PuzzleState.connect("speed_index_changed", self, "_on_PuzzleState_speed_index_changed")
 	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
+	
+	SystemData.gameplay_settings.connect("speed_changed", self, "_on_GameplaySettings_speed_changed")
 
 
 func speed(string: String) -> PieceSpeed:
@@ -105,7 +107,10 @@ func _add_speed(speed: PieceSpeed) -> void:
 
 
 func _update_current_speed() -> void:
-	PieceSpeeds.current_speed = PieceSpeeds.speed(MilestoneManager.prev_milestone().get_meta("speed"))
+	var piece_speed_string: String = MilestoneManager.prev_milestone().get_meta("speed")
+	if not CurrentLevel.settings.other.tutorial:
+		piece_speed_string = GameplayPieceSpeeds.get_adjusted_piece_speed(piece_speed_string)
+	PieceSpeeds.current_speed = PieceSpeeds.speed(piece_speed_string)
 
 
 func _on_PuzzleState_speed_index_changed(_value: int) -> void:
@@ -113,4 +118,8 @@ func _on_PuzzleState_speed_index_changed(_value: int) -> void:
 
 
 func _on_PuzzleState_game_prepared() -> void:
+	_update_current_speed()
+
+
+func _on_GameplaySettings_speed_changed(_value: int) -> void:
 	_update_current_speed()

--- a/project/src/main/settings/gameplay-settings.gd
+++ b/project/src/main/settings/gameplay-settings.gd
@@ -3,6 +3,8 @@ class_name GameplaySettings
 
 signal ghost_piece_changed(value)
 
+signal speed_changed(value)
+
 enum Speed {
 	DEFAULT,
 	SLOW,
@@ -38,13 +40,20 @@ var soft_drop_lock_cancel := true
 
 ## The current gameplay speed. The player can reduce this to make the game easier. They can also increase it to make
 ## the game harder, or to cheat on levels which otherwise require slow and thoughtful play.
-var speed: int = Speed.DEFAULT
+var speed: int = Speed.DEFAULT setget set_speed
 
 func set_ghost_piece(new_ghost_piece: bool) -> void:
 	if ghost_piece == new_ghost_piece:
 		return
 	ghost_piece = new_ghost_piece
 	emit_signal("ghost_piece_changed", new_ghost_piece)
+
+
+func set_speed(new_speed: int) -> void:
+	if speed == new_speed:
+		return
+	speed = new_speed
+	emit_signal("speed_changed", new_speed)
 
 
 ## Resets the gameplay settings to their default values.


### PR DESCRIPTION
Adjusting the gameplay speed setting now enforces a minimum/maximum piece speed. This eliminates instant gravity speeds for players who enable a cheat code.

Closes #1752.