### PR TITLE
Added line piece cheat.

### DIFF
--- a/project/src/demo/puzzle/PuzzleDemo.tscn
+++ b/project/src/demo/puzzle/PuzzleDemo.tscn
@@ -5,6 +5,6 @@
 
 [node name="PuzzleDemo" type="Node"]
 script = ExtResource( 2 )
-level_path = "res://assets/main/puzzle/levels/practice/marathon-normal.json"
+level_path = "res://assets/main/puzzle/levels/career/veggie-patty.json"
 
 [node name="Puzzle" parent="." instance=ExtResource( 1 )]

--- a/project/src/main/settings/gameplay-settings.gd
+++ b/project/src/main/settings/gameplay-settings.gd
@@ -5,6 +5,8 @@ signal ghost_piece_changed(value)
 
 signal speed_changed(value)
 
+signal line_piece_changed(value)
+
 enum Speed {
 	DEFAULT,
 	SLOW,
@@ -35,6 +37,9 @@ const GRAVITY_FACTOR_BY_ENUM := {
 ## 'true' if a ghost piece should be shown during the puzzle sections.
 var ghost_piece := true setget set_ghost_piece
 
+## 'true' if line pieces should appear on all levels
+var line_piece := false setget set_line_piece
+
 ## 'true' if pressing soft drop should perform a lock cancel
 var soft_drop_lock_cancel := true
 
@@ -56,6 +61,13 @@ func set_speed(new_speed: int) -> void:
 	emit_signal("speed_changed", new_speed)
 
 
+func set_line_piece(new_line_piece: bool) -> void:
+	if line_piece == new_line_piece:
+		return
+	line_piece = new_line_piece
+	emit_signal("line_piece_changed", new_line_piece)
+
+
 ## Resets the gameplay settings to their default values.
 func reset() -> void:
 	from_json_dict({})
@@ -64,6 +76,7 @@ func reset() -> void:
 func to_json_dict() -> Dictionary:
 	return {
 		"ghost_piece": ghost_piece,
+		"line_piece": line_piece,
 		"soft_drop_lock_cancel": soft_drop_lock_cancel,
 		"speed": Utils.enum_to_snake_case(Speed, speed),
 	}
@@ -71,8 +84,9 @@ func to_json_dict() -> Dictionary:
 
 func from_json_dict(json: Dictionary) -> void:
 	set_ghost_piece(json.get("ghost_piece", true))
+	set_line_piece(json.get("line_piece", false))
 	soft_drop_lock_cancel = json.get("soft_drop_lock_cancel", true)
-	speed = Utils.enum_from_snake_case(Speed, json.get("speed", ""))
+	set_speed(Utils.enum_from_snake_case(Speed, json.get("speed", "")))
 
 
 ## Returns a number in the range [0.0, ∞) for how piece gravity should be modified.

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=34 format=2]
+[gd_scene load_steps=35 format=2]
 
 [ext_resource path="res://src/main/ui/theme/h4.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=2]
@@ -30,6 +30,7 @@
 [ext_resource path="res://src/main/ui/settings/settings-lock-cancel.gd" type="Script" id=28]
 [ext_resource path="res://src/main/ui/settings/settings-menu-bottom.gd" type="Script" id=29]
 [ext_resource path="res://src/main/ui/settings/settings-gameplay-speed.gd" type="Script" id=30]
+[ext_resource path="res://src/main/ui/settings/settings-line-piece.gd" type="Script" id=31]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 5.0
@@ -280,7 +281,7 @@ custom_constants/separation = 20
 script = ExtResource( 12 )
 
 [node name="Label" type="Label" parent="Window/UiArea/TabContainer/Gameplay/GhostPiece"]
-margin_right = 196.0
+margin_right = 216.0
 margin_bottom = 28.0
 rect_min_size = Vector2( 120, 28 )
 size_flags_horizontal = 3
@@ -294,13 +295,13 @@ __meta__ = {
 }
 
 [node name="CheckBox" type="CheckBox" parent="Window/UiArea/TabContainer/Gameplay/GhostPiece"]
-margin_left = 216.0
+margin_left = 236.0
 margin_right = 560.0
 margin_bottom = 28.0
 rect_min_size = Vector2( 160, 26 )
 size_flags_horizontal = 3
 size_flags_vertical = 4
-size_flags_stretch_ratio = 1.1
+size_flags_stretch_ratio = 0.94
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -316,7 +317,7 @@ custom_constants/separation = 20
 script = ExtResource( 28 )
 
 [node name="Label" type="Label" parent="Window/UiArea/TabContainer/Gameplay/LockCancel"]
-margin_right = 196.0
+margin_right = 216.0
 margin_bottom = 28.0
 rect_min_size = Vector2( 120, 28 )
 size_flags_horizontal = 3
@@ -330,13 +331,13 @@ __meta__ = {
 }
 
 [node name="CheckBox" type="CheckBox" parent="Window/UiArea/TabContainer/Gameplay/LockCancel"]
-margin_left = 216.0
+margin_left = 236.0
 margin_right = 560.0
 margin_bottom = 28.0
 rect_min_size = Vector2( 160, 26 )
 size_flags_horizontal = 3
 size_flags_vertical = 4
-size_flags_stretch_ratio = 1.1
+size_flags_stretch_ratio = 0.94
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -349,7 +350,7 @@ rect_min_size = Vector2( 0, 20 )
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.1
 
-[node name="Label" type="Label" parent="Window/UiArea/TabContainer/Gameplay"]
+[node name="Cheats" type="Label" parent="Window/UiArea/TabContainer/Gameplay"]
 margin_top = 88.0
 margin_right = 560.0
 margin_bottom = 108.0
@@ -373,7 +374,7 @@ theme = ExtResource( 1 )
 custom_constants/separation = 20
 script = ExtResource( 30 )
 
-[node name="Label" type="Label" parent="Window/UiArea/TabContainer/Gameplay/Speed"]
+[node name="Speed" type="Label" parent="Window/UiArea/TabContainer/Gameplay/Speed"]
 margin_right = 217.0
 margin_bottom = 26.0
 rect_min_size = Vector2( 120, 0 )
@@ -395,6 +396,43 @@ rect_min_size = Vector2( 160, 0 )
 size_flags_horizontal = 2
 size_flags_vertical = 4
 size_flags_stretch_ratio = 1.1
+__meta__ = {
+"_edit_use_anchors_": false,
+"_editor_description_": ""
+}
+
+[node name="LinePiece" type="HBoxContainer" parent="Window/UiArea/TabContainer/Gameplay"]
+margin_top = 142.0
+margin_right = 560.0
+margin_bottom = 170.0
+rect_min_size = Vector2( 400, 26 )
+size_flags_horizontal = 3
+theme = ExtResource( 1 )
+custom_constants/separation = 20
+script = ExtResource( 31 )
+
+[node name="Label" type="Label" parent="Window/UiArea/TabContainer/Gameplay/LinePiece"]
+margin_right = 216.0
+margin_bottom = 28.0
+rect_min_size = Vector2( 120, 28 )
+size_flags_horizontal = 3
+size_flags_vertical = 5
+size_flags_stretch_ratio = 0.63
+text = "Line Piece"
+align = 2
+valign = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="CheckBox" type="CheckBox" parent="Window/UiArea/TabContainer/Gameplay/LinePiece"]
+margin_left = 236.0
+margin_right = 560.0
+margin_bottom = 28.0
+rect_min_size = Vector2( 160, 26 )
+size_flags_horizontal = 3
+size_flags_vertical = 4
+size_flags_stretch_ratio = 0.94
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -1238,6 +1276,7 @@ __meta__ = {
 [connection signal="pressed" from="Window/UiArea/Bottom/HBoxContainer/VBoxContainer1/Holder2/Quit2" to="Window/UiArea/Bottom" method="_on_Quit_pressed"]
 [connection signal="pressed" from="Window/UiArea/Bottom/HBoxContainer/VBoxContainer2/Holder/Ok" to="Window/UiArea/Bottom" method="_on_Ok_pressed"]
 [connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/GhostPiece/CheckBox" to="Window/UiArea/TabContainer/Gameplay/GhostPiece" method="_on_OptionButton_toggled"]
+[connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/LinePiece/CheckBox" to="Window/UiArea/TabContainer/Gameplay/LinePiece" method="_on_OptionButton_toggled"]
 [connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/LockCancel/CheckBox" to="Window/UiArea/TabContainer/Gameplay/LockCancel" method="_on_OptionButton_toggled"]
 [connection signal="item_selected" from="Window/UiArea/TabContainer/Gameplay/Speed/OptionButton" to="Window/UiArea/TabContainer/Gameplay/Speed" method="_on_OptionButton_item_selected"]
 [connection signal="pressed" from="Window/UiArea/TabContainer/Misc/CopySaveData/HBoxContainer/Button" to="Window/UiArea/TabContainer/Misc/CopySaveData" method="_on_Button_pressed"]

--- a/project/src/main/ui/settings/settings-line-piece.gd
+++ b/project/src/main/ui/settings/settings-line-piece.gd
@@ -1,0 +1,11 @@
+extends Control
+## UI control for enabling line pieces to all levels
+
+onready var _check_box := $CheckBox
+
+func _ready() -> void:
+	_check_box.pressed = SystemData.gameplay_settings.line_piece
+
+
+func _on_OptionButton_toggled(_button_pressed: bool) -> void:
+	SystemData.gameplay_settings.line_piece = _check_box.pressed

--- a/project/src/test/data/test-system-save-upgrader.gd
+++ b/project/src/test/data/test-system-save-upgrader.gd
@@ -48,3 +48,4 @@ func test_27bb() -> void:
 	assert_eq(SystemData.keybind_settings.custom_keybinds.has("walk_up"), false)
 	
 	assert_eq(SystemData.gameplay_settings.speed, GameplaySettings.Speed.DEFAULT)
+	assert_eq(SystemData.gameplay_settings.line_piece, false)


### PR DESCRIPTION
Player can now toggle line pieces to appear in all levels.

Line pieces are added with their own weird 'nine bag' system. Adding line pieces to the existing piece bag would result in them appearing insanely frequently on levels which use a 2-piece bag. This nine bag system makes them appear as frequently as the eight turbo fat pieces on normal levels, and makes them appear with the same frequency on unusual levels.

This cheat can be toggled before or even during a level, which regenerates the piece queue with line pieces inserted throughout. Because this regenerates the piece queue from scratch, the player can toggle the cheat to reorder their pieces or get duplicates of pieces they already had in their current bag. This is an unintended consequence but I don't think it's worth worrying about.

Minor tweaks to SettingsMenu cheat layout.

Closes #1754.