### PR TITLE
Fixed progress bar bug, caused by adjustable difficulty

### DIFF
--- a/project/src/main/puzzle/level/gameplay-difficulty-adjustments.gd
+++ b/project/src/main/puzzle/level/gameplay-difficulty-adjustments.gd
@@ -451,7 +451,7 @@ static func adjust_piece_speed(piece_speed_string: String) -> String:
 static func adjust_score_milestone(score: int) -> int:
 	var score_milestone_factor: float = \
 			SCORE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(SystemData.gameplay_settings.speed, 1.0)
-	return int(max(score * score_milestone_factor, 1.0))
+	return int(ceil(score * score_milestone_factor))
 
 
 ## Adjusts a line milestone value based on the player's gameplay speed settings.
@@ -460,7 +460,7 @@ static func adjust_score_milestone(score: int) -> int:
 static func adjust_line_milestone(lines: int) -> int:
 	var line_milestone_factor: float = \
 			LINE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(SystemData.gameplay_settings.speed, 1.0)
-	return int(max(lines * line_milestone_factor, 1.0))
+	return int(ceil(lines * line_milestone_factor))
 
 
 ## Adjusts a piece milestone value based on the player's gameplay speed settings.
@@ -469,7 +469,7 @@ static func adjust_line_milestone(lines: int) -> int:
 static func adjust_piece_milestone(pieces: int) -> int:
 	var piece_milestone_factor: float = \
 			LINE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(SystemData.gameplay_settings.speed, 1.0)
-	return int(max(pieces * piece_milestone_factor, 1.0))
+	return int(ceil(pieces * piece_milestone_factor))
 
 
 ## Adjusts a duration milestone value based on the player's gameplay speed settings.
@@ -478,4 +478,4 @@ static func adjust_piece_milestone(pieces: int) -> int:
 static func adjust_time_over_milestone(time_over: int) -> int:
 	var time_over_milestone_factor: float = \
 			TIME_OVER_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(SystemData.gameplay_settings.speed, 1.0)
-	return int(max(time_over * time_over_milestone_factor, 1.0))
+	return int(ceil(time_over * time_over_milestone_factor))

--- a/project/src/test/puzzle/level/test-gameplay-difficulty-adjustments.gd
+++ b/project/src/test/puzzle/level/test-gameplay-difficulty-adjustments.gd
@@ -14,7 +14,7 @@ func test_adjust_line_milestone() -> void:
 	
 	# slowing down gameplay speed decreases lines required
 	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOW
-	assert_eq(GameplayDifficultyAdjustments.adjust_line_milestone(50), 42)
+	assert_eq(GameplayDifficultyAdjustments.adjust_line_milestone(50), 43)
 	
 	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOWER
 	assert_eq(GameplayDifficultyAdjustments.adjust_line_milestone(50), 35)
@@ -34,7 +34,7 @@ func test_adjust_piece_milestone() -> void:
 	
 	# slowing down gameplay speed decreases pieces required
 	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOW
-	assert_eq(GameplayDifficultyAdjustments.adjust_piece_milestone(50), 42)
+	assert_eq(GameplayDifficultyAdjustments.adjust_piece_milestone(50), 43)
 	
 	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOWER
 	assert_eq(GameplayDifficultyAdjustments.adjust_piece_milestone(50), 35)
@@ -81,11 +81,11 @@ func test_adjust_time_over_milestone() -> void:
 	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(180), 162)
 	
 	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOWEST
-	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(180), 125)
+	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(180), 126)
 	
 	# level duration won't decrease below a certain threshold (0:01)
 	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOWESTEST
-	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(3), 1)
+	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(3), 2)
 	
 	# increasing gameplay speed does not affect milestones
 	SystemData.gameplay_settings.speed = GameplaySettings.Speed.FASTER


### PR DESCRIPTION
Fixed a bug where the progress bar would remain empty even after dropping the first piece or clearing the first line. This is because the initial piece speed is handled as a milestone with value 0, but with the new adjustable difficulty changes this value was increased to 1.

The adjustable difficulty algorithm now uses the ceil() function instead of artificially capping the value at 1.