### PR TITLE
Improved keybinds. 'Numpad 2' -> 'Kp 2'

### DIFF
--- a/project/assets/main/keybind/guideline.json
+++ b/project/assets/main/keybind/guideline.json
@@ -6,15 +6,15 @@
     },
     {
       "type": "key",
-      "scancode": 16777237
-    },
-    {
-      "type": "key",
       "scancode": 32
     },
     {
       "type": "key",
       "scancode": 16777358
+    },
+    {
+      "type": "key",
+      "scancode": 16777237
     },
     {
       "type": "joypad_button",
@@ -25,6 +25,16 @@
       "type": "joypad_button",
       "device": 0,
       "button_index": 3
+    },
+    {
+      "type": "joypad_button",
+      "device": 0,
+      "button_index": 4
+    },
+    {
+      "type": "joypad_button",
+      "device": 0,
+      "button_index": 5
     }
   ],
   "interact": [

--- a/project/assets/main/keybind/wasd.json
+++ b/project/assets/main/keybind/wasd.json
@@ -2,19 +2,15 @@
   "hard_drop": [
     {
       "type": "key",
-      "scancode": 16777232
-    },
-    {
-      "type": "key",
-      "scancode": 32
-    },
-    {
-      "type": "key",
       "scancode": 87
     },
     {
       "type": "key",
       "scancode": 16777355
+    },
+    {
+      "type": "key",
+      "scancode": 16777222
     },
     {
       "type": "joypad_button",
@@ -25,6 +21,16 @@
       "type": "joypad_button",
       "device": 0,
       "button_index": 3
+    },
+    {
+      "type": "joypad_button",
+      "device": 0,
+      "button_index": 4
+    },
+    {
+      "type": "joypad_button",
+      "device": 0,
+      "button_index": 5
     }
   ],
   "move_piece_left": [
@@ -110,10 +116,6 @@
     }
   ],
   "soft_drop": [
-    {
-      "type": "key",
-      "scancode": 16777234
-    },
     {
       "type": "key",
       "scancode": 83

--- a/project/src/main/ui/settings/keybind/settings-keybinds-control.gd
+++ b/project/src/main/ui/settings/keybind/settings-keybinds-control.gd
@@ -31,16 +31,16 @@ func _refresh_keybind_labels() -> void:
 	match preset:
 		KeybindSettings.GUIDELINE:
 			$PresetScrollContainer.visible = true
-			$PresetScrollContainer/VBoxContainer/MovePiece.keybind_value = tr("Left, Right, Numpad4/6")
-			$PresetScrollContainer/VBoxContainer/SoftDrop.keybind_value = tr("Down, Numpad2")
-			$PresetScrollContainer/VBoxContainer/HardDrop.keybind_value = tr("Space, Up, Shift, Numpad8")
-			$PresetScrollContainer/VBoxContainer/RotatePiece.keybind_value = tr("Z, X, Numpad7/9")
+			$PresetScrollContainer/VBoxContainer/MovePiece.keybind_value = tr("Left, Right, Kp 4, Kp 6")
+			$PresetScrollContainer/VBoxContainer/SoftDrop.keybind_value = tr("Down, Kp 2")
+			$PresetScrollContainer/VBoxContainer/HardDrop.keybind_value = tr("Space, Up, Kp 8, Shift")
+			$PresetScrollContainer/VBoxContainer/RotatePiece.keybind_value = tr("Z, X, Kp 7, Kp 9")
 		KeybindSettings.WASD:
 			$PresetScrollContainer.visible = true
-			$PresetScrollContainer/VBoxContainer/MovePiece.keybind_value = tr("A, D, Numpad4/6")
-			$PresetScrollContainer/VBoxContainer/SoftDrop.keybind_value = tr("Down, S, Numpad8")
-			$PresetScrollContainer/VBoxContainer/HardDrop.keybind_value = tr("Up, Space, W, Numpad5")
-			$PresetScrollContainer/VBoxContainer/RotatePiece.keybind_value = tr("Left, Right, Numpad7/9")
+			$PresetScrollContainer/VBoxContainer/MovePiece.keybind_value = tr("A, D, Kp 4, Kp 6")
+			$PresetScrollContainer/VBoxContainer/SoftDrop.keybind_value = tr("S, Kp 8")
+			$PresetScrollContainer/VBoxContainer/HardDrop.keybind_value = tr("W, Kp 5, Kp Enter")
+			$PresetScrollContainer/VBoxContainer/RotatePiece.keybind_value = tr("Left, Right, Kp 7, Kp 9")
 		KeybindSettings.CUSTOM:
 			$CustomScrollContainer.visible = true
 


### PR DESCRIPTION
Keybinds now map joypad's L1/R1 buttons to hard drop. This is analogous to how we remap shift to hard drop as well, and makes sense for the same reasons -- Turbo Fat encourages chord-based play involving holding 2-3 buttons at once, and it is hard to hold multiple face buttons.

Reordered guideline keybinds; Space, Kp 8, Shift with 'Shift' going last. Shift is last because it corresponds to the hold key, so I like the idea of it being removed from the end of the list instead of deleted from the middle.

Improved WASD keybinds. Up and Space no longer hard drop with the WASD preset, but I've added KP Enter. Down no longer soft drops. This seems more consistent with traditional WASD controls for similar games, while enabling pinky hard drop which I find useful for high speed play.

Renamed 'Numpad 2' to 'Kp 2'. This is a little shorter and more confusing, but it's consistent with what appears when customizing your controls. If we want to change this to 'Numpad 2' that's fine but the two places should be consistent.