### PR TITLE
PieceManager refactoring: initialize_piece, prespawn top out

### DIFF
--- a/project/src/main/puzzle/piece/states/prespawn.gd
+++ b/project/src/main/puzzle/piece/states/prespawn.gd
@@ -5,8 +5,6 @@ func update(piece_manager: PieceManager) -> String:
 	var new_state_name := ""
 	if frames >= piece_manager.piece.spawn_delay:
 		piece_manager.pop_buffered_inputs()
-		if piece_manager.spawn_piece():
-			new_state_name = "MovePiece"
-		else:
-			new_state_name = "TopOut"
+		piece_manager.spawn_piece()
+		new_state_name = "MovePiece"
 	return new_state_name

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -545,11 +545,6 @@ margin_bottom = 80.0
 description = "Rotate Piece"
 keybind_value = "Z, X"
 
-[node name="SwapHoldPiece" parent="Window/UiArea/TabContainer/Controls/PresetScrollContainer/VBoxContainer" instance=ExtResource( 14 )]
-margin_top = 60.0
-margin_bottom = 80.0
-description = "Swap Hold Piece"
-
 [node name="Retry" parent="Window/UiArea/TabContainer/Controls/PresetScrollContainer/VBoxContainer" instance=ExtResource( 14 )]
 margin_top = 80.0
 margin_bottom = 100.0
@@ -632,12 +627,6 @@ margin_top = 78.0
 margin_bottom = 102.0
 description = "Hard Drop"
 action_name = "hard_drop"
-
-[node name="SwapHoldPiece" parent="Window/UiArea/TabContainer/Controls/CustomScrollContainer/VBoxContainer" instance=ExtResource( 16 )]
-margin_top = 78.0
-margin_bottom = 102.0
-description = "Swap Hold Piece"
-action_name = "swap_hold_piece"
 
 [node name="RotateCcw" parent="Window/UiArea/TabContainer/Controls/CustomScrollContainer/VBoxContainer" instance=ExtResource( 16 )]
 margin_top = 104.0


### PR DESCRIPTION
Extracted PieceManager._initialize_piece() utility method. This avoids bugs from duplicated code; some of these pieces were incorrectly initialized with the piece's tilemap which could cause complications down the road.

Prespawn state no longer explicitly changes to top out state. This simplifies the contract of PieceManager.spawn_piece(). We transition to the top out state anyways, so this logic was redundant.