### PR TITLE
bug: Line pieces could break cake tutorial.

### DIFF
--- a/project/src/main/puzzle/piece/piece-queue.gd
+++ b/project/src/main/puzzle/piece/piece-queue.gd
@@ -319,6 +319,10 @@ func _on_PuzzleState_game_prepared() -> void:
 ## This has the potential for some very silly gameplay where the player repeatedly toggles the cheat on and off to get
 ## every piece in a particular order.
 func _on_GameplaySettings_line_piece_changed(_value: bool) -> void:
+	if CurrentLevel.settings.other.tutorial:
+		# don't regenerate pieces for tutorials. it can make the tutorials impossible
+		return
+	
 	var old_popped_piece_count := _popped_piece_count
 	
 	clear()


### PR DESCRIPTION
Playing part way through the cake tutorial and toggling the line piece cheat could result in an impossible setup. Since the piece order is randomized, regenerating the piece queue could give you the same piece twice and omit other important pieces.

Tutorials no longer regenerate the piece queue if the player toggles the cheat.