### PR TITLE
Fixed visual bug with line pieces in next queue

### DIFF
--- a/project/src/main/puzzle/piece-display.gd
+++ b/project/src/main/puzzle/piece-display.gd
@@ -35,9 +35,9 @@ func refresh_tile_map(next_piece: NextPiece) -> void:
 		# grow to accommodate bigger pieces
 		var bounding_box_longest_dimension := max(bounding_box.size.x, bounding_box.size.y)
 		_tile_map.scale = Vector2(1.5, 1.5) / max(bounding_box_longest_dimension, 3)
-		
-		_tile_map.position = _tile_map.cell_size \
-				* (Vector2(1.5, 1.5) - (bounding_box.position + bounding_box.size * _tile_map.scale)) / 2.0
+		_tile_map.position = _tile_map.cell_size * Vector2(0.75, 0.75) \
+				- _tile_map.cell_size * _tile_map.scale * (bounding_box.position + bounding_box.size / 2.0)
+	
 	_tile_map.corner_map.dirty = true
 	_displayed_type = next_piece.type
 	_displayed_orientation = next_piece.orientation


### PR DESCRIPTION
Line pieces in the next piece queue were being offset slightly because of a math error.