### PR TITLE
Workaround for Stack Overflow in _on_resized()

### DIFF
--- a/project/src/main/puzzle/combo-score-value-label.gd
+++ b/project/src/main/puzzle/combo-score-value-label.gd
@@ -29,7 +29,10 @@ func _refresh_score() -> void:
 
 
 func _on_resized() -> void:
+	# Avoid a Stack Overflow where changing our margins triggers another _on_resized() event, see #1810
+	disconnect("resized", self, "_on_resized")
 	margin_left = -rect_size.x
+	connect("resized", self, "_on_resized")
 
 
 func _on_PuzzleState_score_changed() -> void:

--- a/project/src/main/puzzle/score-value-label.gd
+++ b/project/src/main/puzzle/score-value-label.gd
@@ -17,7 +17,11 @@ func _on_resized() -> void:
 	if not _top_out_particles:
 		return
 	
+	# Avoid a Stack Overflow where changing our margins triggers another _on_resized() event, see #1810
+	disconnect("resized", self, "_on_resized")
 	margin_left = -rect_size.x
+	connect("resized", self, "_on_resized")
+	
 	_top_out_particles.rect_position = rect_size * 0.5
 
 


### PR DESCRIPTION
combo-score-value-label.gd and score-value-label.gd could occasionally cause a Stack Overflow error, where assigning their margins would repeatedly change their rect size over and over, to a larger and larger negative value. This usually stabilized, but sometimes it would just go further and further negative forever. I noticed this mostly in Tutorials when I was using the debugger.

These labels now disconnect their listener so they cannot react to their own signals.

Closes #1810.