### PR TITLE
Minor tweak to line piece code, to resolve square curse crash

### DIFF
--- a/project/src/main/puzzle/piece/piece-queue.gd
+++ b/project/src/main/puzzle/piece/piece-queue.gd
@@ -218,6 +218,9 @@ func _maybe_insert_cheat_pieces(min_line_piece_index: int) -> void:
 			# insert a line piece
 			_cheat_bag_line_pieces_remaining -= 1
 			pieces.insert(piece_index, _new_next_piece(PieceTypes.piece_i))
+			
+			# increment piece_index past the inserted line piece
+			piece_index += 1
 		
 		_cheat_bag_pieces_remaining -= 1
 		piece_index += 1


### PR DESCRIPTION
Hish of the Turbo Fat discord still says Square Curse crashes on their machine with the line piece cheat enabled. I can't duplicate this or find any obvious reasin it would crash, but I noticed this section of code could, if it had a second bug I'm not seeing, increment piece_index and pieces.size() by one repeatedly causing an infinite loop. I've revised the code so it increments piece_index by 2 in this case which should avoid any potential infinite loop I'm not seeing.