### PR TITLE
Autowrap settings labels.

### DIFF
--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -215,6 +215,7 @@ size_flags_stretch_ratio = 0.74
 text = "Creature detail"
 align = 2
 valign = 1
+autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -251,6 +252,7 @@ size_flags_stretch_ratio = 0.74
 text = "Use Vsync"
 align = 2
 valign = 1
+autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -302,6 +304,7 @@ size_flags_stretch_ratio = 0.63
 text = "Ghost Piece"
 align = 2
 valign = 1
+autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -338,6 +341,7 @@ size_flags_stretch_ratio = 0.63
 text = "Soft Drop Lock Cancel"
 align = 2
 valign = 1
+autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -396,6 +400,7 @@ size_flags_stretch_ratio = 0.74
 text = "Speed"
 align = 2
 valign = 1
+autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -433,6 +438,7 @@ size_flags_stretch_ratio = 0.63
 text = "Line Piece"
 align = 2
 valign = 1
+autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -469,6 +475,7 @@ size_flags_stretch_ratio = 0.63
 text = "Hold Piece"
 align = 2
 valign = 1
+autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -802,6 +809,7 @@ size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.5
 text = "Size"
 align = 2
+autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -867,6 +875,7 @@ size_flags_stretch_ratio = 0.74
 text = "Scheme"
 align = 2
 valign = 1
+autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -903,6 +912,7 @@ size_flags_stretch_ratio = 0.74
 text = "Fat Finger"
 align = 2
 valign = 1
+autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -947,6 +957,7 @@ size_flags_stretch_ratio = 0.74
 text = "Language"
 align = 2
 valign = 1
+autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -992,6 +1003,7 @@ size_flags_stretch_ratio = 0.74
 text = "Save Slot"
 align = 2
 valign = 1
+autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -1102,6 +1114,7 @@ size_flags_vertical = 1
 size_flags_stretch_ratio = 0.74
 text = "Copied!"
 valign = 1
+autowrap = true
 
 [node name="CopiedTween" type="Tween" parent="Window/UiArea/TabContainer/Misc/CopySaveData/HBoxContainer"]
 

--- a/project/src/main/ui/settings/VolumeSetting.tscn
+++ b/project/src/main/ui/settings/VolumeSetting.tscn
@@ -36,6 +36,7 @@ size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.5
 text = "Music"
 align = 2
+autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/project/src/main/ui/settings/keybind/KeybindCustom.tscn
+++ b/project/src/main/ui/settings/keybind/KeybindCustom.tscn
@@ -26,6 +26,7 @@ size_flags_vertical = 7
 size_flags_stretch_ratio = 0.74
 align = 2
 valign = 1
+autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/project/src/main/ui/settings/keybind/KeybindPreset.tscn
+++ b/project/src/main/ui/settings/keybind/KeybindPreset.tscn
@@ -25,6 +25,7 @@ size_flags_vertical = 5
 size_flags_stretch_ratio = 0.9
 align = 2
 valign = 1
+autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }


### PR DESCRIPTION
These settings are all one line in English, but in Spanish or other languages they may overrun their boundaries. Settings labels will now wrap to multiple lines as necessary.

Closes #1840.