### PR TITLE
Smaller settings fonts for spanish. Locale signal.

### DIFF
--- a/project/src/main/ui/FontFitButton.tscn
+++ b/project/src/main/ui/FontFitButton.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/main/ui/font-fit-button.gd" type="Script" id=1]
+
+[node name="Button" type="Button"]
+margin_right = 12.0
+margin_bottom = 20.0
+clip_text = true
+script = ExtResource( 1 )
+__meta__ = {
+"_editor_description_": ""
+}

--- a/project/src/main/ui/font-fit-button.gd
+++ b/project/src/main/ui/font-fit-button.gd
@@ -1,0 +1,42 @@
+extends Button
+## This button changes its font dynamically based on the amount of text it needs to display. It chooses the largest
+## font which will not overrun its boundaries.
+
+## extra space needed on the left and right of the button's text
+const PADDING := 6
+
+## Different fonts to try. Should be ordered from largest to smallest.
+export(Array, Font) var fonts := [] setget set_fonts
+
+func _ready() -> void:
+	SystemData.misc_settings.connect("locale_changed", self, "_on_MiscSettings_locale_changed")
+	pick_largest_font()
+
+
+func set_fonts(new_fonts: Array) -> void:
+	fonts = new_fonts
+	pick_largest_font()
+
+
+## Sets the button's font to the largest font which will accommodate its text.
+##
+## If the button's text is modified this should be called manually. This class cannot respond to text changes or
+## override set_text because of Godot #29390 (https://github.com/godotengine/godot/issues/29390)
+func pick_largest_font() -> void:
+	# our shown text is translated; the translated text needs to fit in the button
+	var shown_text := tr(text)
+	
+	var chosen_font: Font
+	for i in range(fonts.size()):
+		# start with the largest font, and try smaller and smaller fonts
+		chosen_font = fonts[i]
+		var string_width := chosen_font.get_string_size(shown_text).x
+		if string_width < rect_size.x - 2 * PADDING:
+			# this font is small enough to accommodate all of the text
+			break
+	
+	set("custom_fonts/font", chosen_font)
+
+
+func _on_MiscSettings_locale_changed(_value: String) -> void:
+	pick_largest_font()

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -33,6 +33,11 @@
 [ext_resource path="res://src/main/ui/settings/settings-line-piece.gd" type="Script" id=31]
 [ext_resource path="res://src/main/ui/settings/settings-hold-piece.gd" type="Script" id=32]
 [ext_resource path="res://src/main/ui/settings/reset-gameplay-button.gd" type="Script" id=33]
+[ext_resource path="res://src/main/ui/theme/h5-font.tres" type="DynamicFont" id=35]
+[ext_resource path="res://src/main/ui/theme/h6-font.tres" type="DynamicFont" id=36]
+[ext_resource path="res://src/main/ui/theme/h7-font.tres" type="DynamicFont" id=37]
+[ext_resource path="res://src/main/ui/theme/h8-font.tres" type="DynamicFont" id=38]
+[ext_resource path="res://src/main/ui/FontFitButton.tscn" type="PackedScene" id=39]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 5.0
@@ -1089,15 +1094,16 @@ size_flags_horizontal = 3
 size_flags_vertical = 5
 size_flags_stretch_ratio = 0.74
 
-[node name="Button" type="Button" parent="Window/UiArea/TabContainer/Misc/VBoxContainer/Open User Folder"]
+[node name="Button" parent="Window/UiArea/TabContainer/Misc/VBoxContainer/Open User Folder" instance=ExtResource( 39 )]
 margin_left = 224.0
 margin_right = 384.0
 margin_bottom = 26.0
-rect_min_size = Vector2( 160, 0 )
+rect_min_size = Vector2( 160, 26 )
 size_flags_horizontal = 2
 size_flags_vertical = 4
 size_flags_stretch_ratio = 1.1
 text = "Open User Folder"
+fonts = [ ExtResource( 35 ), ExtResource( 36 ), ExtResource( 37 ), ExtResource( 38 ) ]
 
 [node name="CopySaveData" type="HBoxContainer" parent="Window/UiArea/TabContainer/Misc/VBoxContainer"]
 margin_top = 114.0
@@ -1126,14 +1132,15 @@ size_flags_horizontal = 2
 size_flags_vertical = 4
 size_flags_stretch_ratio = 1.1
 
-[node name="Button" type="Button" parent="Window/UiArea/TabContainer/Misc/VBoxContainer/CopySaveData/HBoxContainer"]
+[node name="Button" parent="Window/UiArea/TabContainer/Misc/VBoxContainer/CopySaveData/HBoxContainer" instance=ExtResource( 39 )]
 margin_right = 160.0
 margin_bottom = 26.0
-rect_min_size = Vector2( 160, 0 )
+rect_min_size = Vector2( 160, 26 )
 size_flags_horizontal = 2
 size_flags_vertical = 4
 size_flags_stretch_ratio = 1.1
 text = "Copy to Clipboard"
+fonts = [ ExtResource( 35 ), ExtResource( 36 ), ExtResource( 37 ), ExtResource( 38 ) ]
 
 [node name="Copied" type="Label" parent="Window/UiArea/TabContainer/Misc/VBoxContainer/CopySaveData/HBoxContainer"]
 margin_left = 164.0

--- a/project/src/main/ui/settings/settings-language.gd
+++ b/project/src/main/ui/settings/settings-language.gd
@@ -51,4 +51,4 @@ func _current_loaded_locale() -> String:
 
 func _on_OptionButton_item_selected(_index: int) -> void:
 	# update the locale to the selected locale
-	TranslationServer.set_locale(TranslationServer.get_loaded_locales()[_index])
+	SystemData.misc_settings.set_locale(TranslationServer.get_loaded_locales()[_index])

--- a/project/src/main/ui/theme/h6-font.tres
+++ b/project/src/main/ui/theme/h6-font.tres
@@ -1,0 +1,7 @@
+[gd_resource type="DynamicFont" load_steps=2 format=2]
+
+[ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=1]
+
+[resource]
+size = 12
+font_data = ExtResource( 1 )

--- a/project/src/main/ui/theme/h7-font.tres
+++ b/project/src/main/ui/theme/h7-font.tres
@@ -1,0 +1,7 @@
+[gd_resource type="DynamicFont" load_steps=2 format=2]
+
+[ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=1]
+
+[resource]
+size = 10
+font_data = ExtResource( 1 )

--- a/project/src/main/ui/theme/h8-font.tres
+++ b/project/src/main/ui/theme/h8-font.tres
@@ -1,0 +1,7 @@
+[gd_resource type="DynamicFont" load_steps=2 format=2]
+
+[ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=1]
+
+[resource]
+size = 8
+font_data = ExtResource( 1 )


### PR DESCRIPTION
The 'Open User Folder' and 'Copy To Clipboard' buttons now change their font size depending on the current locale. This lets them use a smaller font for languages like Spanish where the button needs more text on it.

Added a locale_changed signal to MiscSettings. All locale changes now go through MiscSettings instead of TranslationServer.

Closes #1841.