### PR TITLE
Avoid deprecated OS time calls

### DIFF
--- a/project/src/demo/packed-sprite-stress-test.gd
+++ b/project/src/demo/packed-sprite-stress-test.gd
@@ -18,9 +18,9 @@ onready var _count := $Ui/Control/Count
 var _target_sprite_count := 10
 
 func _physics_process(_delta: float) -> void:
-	var start_msec := OS.get_ticks_msec()
+	var start_msec := Time.get_ticks_msec()
 	while _sprite_container.get_child_count() != _target_sprite_count \
-			and OS.get_ticks_msec() < start_msec + 1000 * CHUNK_SECONDS:
+			and Time.get_ticks_msec() < start_msec + 1000 * CHUNK_SECONDS:
 		if _sprite_container.get_child_count() < _target_sprite_count:
 			_add_sprite()
 		elif _sprite_container.get_child_count() > _target_sprite_count:

--- a/project/src/main/puzzle/goop-glob.gd
+++ b/project/src/main/puzzle/goop-glob.gd
@@ -63,7 +63,7 @@ func copy_from(glob: Node) -> void:
 
 ## Returns the time in seconds since this glob was initialized.
 func get_age() -> float:
-	return (OS.get_ticks_msec() - _creation_time) / 1000
+	return (Time.get_ticks_msec() - _creation_time) / 1000
 
 
 func is_rainbow() -> bool:
@@ -72,7 +72,7 @@ func is_rainbow() -> bool:
 
 ## Resets this goop glob's state, including its color and position.
 func initialize(new_box_type: int, new_position: Vector2) -> void:
-	_creation_time = OS.get_ticks_msec()
+	_creation_time = Time.get_ticks_msec()
 	box_type = new_box_type
 	falling = true
 	set_process(true)

--- a/project/src/main/ui/creature-stress-test.gd
+++ b/project/src/main/ui/creature-stress-test.gd
@@ -28,9 +28,9 @@ func _ready() -> void:
 
 
 func _physics_process(_delta: float) -> void:
-	var start_msec := OS.get_ticks_msec()
+	var start_msec := Time.get_ticks_msec()
 	while _creature_container.get_child_count() != _target_creature_count \
-			and OS.get_ticks_msec() < start_msec + 1000 * CHUNK_SECONDS:
+			and Time.get_ticks_msec() < start_msec + 1000 * CHUNK_SECONDS:
 		if _creature_container.get_child_count() < _target_creature_count:
 			_add_creature()
 		elif _creature_container.get_child_count() > _target_creature_count:

--- a/project/src/main/utils/global.gd
+++ b/project/src/main/utils/global.gd
@@ -63,7 +63,7 @@ static func from_iso(vector: Vector2) -> Vector2:
 ## Sets the start time for a benchmark. Calling 'benchmark_start(foo)' and 'benchmark_finish(foo)' will display a
 ## message like 'foo took 123 milliseconds'.
 func benchmark_start(key: String = "") -> void:
-	_benchmark_start_times[key] = OS.get_ticks_usec()
+	_benchmark_start_times[key] = Time.get_ticks_usec()
 
 
 ## Prints the amount of time which has passed since a benchmark was started. Calling 'benchmark_start(foo)' and
@@ -72,7 +72,7 @@ func benchmark_end(key: String = "") -> void:
 	if not _benchmark_start_times.has(key):
 		print("Invalid benchmark: %s" % key)
 		return
-	print("benchmark %s: %.3f msec" % [key, (OS.get_ticks_usec() - _benchmark_start_times[key]) / 1000.0])
+	print("benchmark %s: %.3f msec" % [key, (Time.get_ticks_usec() - _benchmark_start_times[key]) / 1000.0])
 
 
 func get_overworld_ui() -> OverworldUi:

--- a/project/src/main/utils/resource-cache.gd
+++ b/project/src/main/utils/resource-cache.gd
@@ -90,7 +90,7 @@ func start_load() -> void:
 		threaded = true
 		load_seconds = 0
 	
-	_start_load_begin_msec = OS.get_ticks_msec()
+	_start_load_begin_msec = Time.get_ticks_msec()
 	set_process(true)
 	_find_resource_paths()
 	if threaded:
@@ -110,17 +110,17 @@ func _process(_delta: float) -> void:
 			# wait for background threads to finish
 			pass
 		else:
-			var start_msec := OS.get_ticks_msec()
+			var start_msec := Time.get_ticks_msec()
 			# Web targets do not support background threads, so we load a few resources every frame
-			while _remaining_resource_paths and OS.get_ticks_msec() < start_msec + 1000 * CHUNK_SECONDS:
+			while _remaining_resource_paths and Time.get_ticks_msec() < start_msec + 1000 * CHUNK_SECONDS:
 				_preload_next_resource()
 	elif _remaining_scene_paths:
-		var start_msec := OS.get_ticks_msec()
+		var start_msec := Time.get_ticks_msec()
 		# Loading scenes in threads causes 'another resource is loaded' errors, so we don't thread this
-		while _remaining_scene_paths and OS.get_ticks_msec() < start_msec + 1000 * CHUNK_SECONDS \
+		while _remaining_scene_paths and Time.get_ticks_msec() < start_msec + 1000 * CHUNK_SECONDS \
 				and not _overworked():
 			_preload_next_scene()
-	elif OS.get_ticks_msec() < _start_load_begin_msec + 1000 * load_seconds:
+	elif Time.get_ticks_msec() < _start_load_begin_msec + 1000 * load_seconds:
 		pass
 	else:
 		set_process(false)
@@ -172,7 +172,7 @@ func get_progress() -> float:
 
 
 func is_done() -> bool:
-	return _work_done >= _work_total and OS.get_ticks_msec() >= _start_load_begin_msec + 1000 * load_seconds
+	return _work_done >= _work_total and Time.get_ticks_msec() >= _start_load_begin_msec + 1000 * load_seconds
 
 
 func has_cached_resource(path: String) -> bool:
@@ -217,7 +217,7 @@ func _work_progress() -> float:
 func _wait_progress() -> float:
 	var wait_progress := 1.0
 	if load_seconds > 0:
-		wait_progress = clamp((OS.get_ticks_msec() - _start_load_begin_msec) / (1000 * load_seconds), 0.0, 1.0)
+		wait_progress = clamp((Time.get_ticks_msec() - _start_load_begin_msec) / (1000 * load_seconds), 0.0, 1.0)
 	return wait_progress
 
 
@@ -378,9 +378,9 @@ func _load_resource(resource_path: String) -> void:
 			# resource doesn't exist; cache so we don't try again
 			result = "_"
 		else:
-			var start := OS.get_ticks_msec()
+			var start := Time.get_ticks_msec()
 			result = load(resource_path)
-			var duration := OS.get_ticks_msec() - start
+			var duration := Time.get_ticks_msec() - start
 			if verbose: print("resource loaded: %4d, %s" % [duration, resource_path])
 		
 		_cache_mutex.lock()

--- a/project/src/main/utils/sfx-deconflicter.gd
+++ b/project/src/main/utils/sfx-deconflicter.gd
@@ -58,10 +58,10 @@ func should_play(player: Node) -> bool:
 	var result := true
 	var resource_path: String = player.stream.resource_path
 	var last_played_msec: int = last_played_msec_by_resource_path.get(resource_path, 0)
-	if last_played_msec + SUPPRESS_SFX_MSEC >= OS.get_ticks_msec():
+	if last_played_msec + SUPPRESS_SFX_MSEC >= Time.get_ticks_msec():
 		# suppress sound effect; sound was played too recently
 		result = false
 	else:
 		# update 'last_played'; sound is about to be played
-		last_played_msec_by_resource_path[resource_path] = OS.get_ticks_msec()
+		last_played_msec_by_resource_path[resource_path] = Time.get_ticks_msec()
 	return result

--- a/project/src/main/world/creature/dna-loader.gd
+++ b/project/src/main/world/creature/dna-loader.gd
@@ -22,8 +22,8 @@ func _process(_delta: float) -> void:
 	if _pending_shader_keys:
 		# if there are any pending shader keys, we load a few each frame. Setting shader params is slow and setting
 		# too many at once causes frame drops
-		var start_ticks_usec := OS.get_ticks_usec()
-		while OS.get_ticks_usec() - start_ticks_usec < MAX_SHADER_USEC_PER_FRAME and _pending_shader_keys:
+		var start_ticks_usec := Time.get_ticks_usec()
+		while Time.get_ticks_usec() - start_ticks_usec < MAX_SHADER_USEC_PER_FRAME and _pending_shader_keys:
 			var key: String = _pending_shader_keys.pop_front()
 			var node_path: String = key.split(":")[1]
 			var shader_param: String = key.split(":")[2]


### PR DESCRIPTION
Replaced deprecated OS time calls like 'OS.get_ticks_msec()' with equivalent calls on the singleton Time instance