### PR TITLE
randi_range(). Vector.ONE.

### DIFF
--- a/project/src/demo/world/free-roam-touch-buttons.gd
+++ b/project/src/demo/world/free-roam-touch-buttons.gd
@@ -28,7 +28,7 @@ func hide() -> void:
 ##
 ## This updates their location and size.
 func _refresh_button_positions() -> void:
-	$ButtonsSw.rect_scale = Vector2(1.0, 1.0) * SystemData.touch_settings.size
+	$ButtonsSw.rect_scale = Vector2.ONE * SystemData.touch_settings.size
 	$ButtonsSw.rect_position.y = rect_size.y - 10 - $ButtonsSw.rect_size.y * $ButtonsSw.rect_scale.y
 
 

--- a/project/src/main/chat/ui/chat-choice-tween.gd
+++ b/project/src/main/chat/ui/chat-choice-tween.gd
@@ -35,7 +35,7 @@ func _interpolate_pop(popping_in: bool) -> void:
 	remove(_chat_choice, "rect_scale:y")
 	
 	var chat_choice_modulate := Color.white if popping_in else Color.transparent
-	var chat_choice_scale := Vector2(1.0, 1.0) if popping_in else POP_OUT_SCALE
+	var chat_choice_scale := Vector2.ONE if popping_in else POP_OUT_SCALE
 	
 	interpolate_property(_chat_choice, "modulate", _chat_choice.modulate,
 			chat_choice_modulate, 0.1, Tween.TRANS_LINEAR)

--- a/project/src/main/chat/ui/chat-pop-tween.gd
+++ b/project/src/main/chat/ui/chat-pop-tween.gd
@@ -42,7 +42,7 @@ func _interpolate_pop(popping_in: bool) -> void:
 	remove(_chat_frame, "rect_scale:y")
 	
 	var chat_frame_modulate := Color.white if popping_in else Color.transparent
-	var chat_frame_scale := Vector2(1.0, 1.0) if popping_in else POP_OUT_SCALE
+	var chat_frame_scale := Vector2.ONE if popping_in else POP_OUT_SCALE
 	
 	interpolate_property(_chat_frame, "modulate", _chat_frame.modulate,
 			chat_frame_modulate, 0.2, Tween.TRANS_LINEAR)

--- a/project/src/main/editor/puzzle/veg-level-chunk-control.gd
+++ b/project/src/main/editor/puzzle/veg-level-chunk-control.gd
@@ -2,7 +2,7 @@ extends BlockLevelChunkControl
 ## A level editor chunk which contains a vegetable block.
 
 ## Increasing this size allows you to draw vegetable blocks as a cluster, instead of one at a time.
-export (Vector2) var veg_size: Vector2 = Vector2(1, 1) setget set_veg_size
+export (Vector2) var veg_size: Vector2 = Vector2.ONE setget set_veg_size
 
 func _ready() -> void:
 	$"../../Buttons/RotateButton".connect("pressed", self, "_on_RotateButton_pressed")

--- a/project/src/main/puzzle/burst-accent.gd
+++ b/project/src/main/puzzle/burst-accent.gd
@@ -3,10 +3,10 @@ extends PackedSprite
 ## A colored accent sprite which appears behind a combo/spin/squish indicator.
 
 ## The unmodified scale/rotation before pulsing
-export (Vector2) var base_scale: Vector2 = Vector2(1.0, 1.0) setget set_base_scale
+export (Vector2) var base_scale: Vector2 = Vector2.ONE setget set_base_scale
 
 ## Scale modifiers applied by an animation
-export (Vector2) var scale_modifier: Vector2 = Vector2(1.0, 1.0) setget set_scale_modifier
+export (Vector2) var scale_modifier: Vector2 = Vector2.ONE setget set_scale_modifier
 
 func set_base_scale(new_base_scale: Vector2) -> void:
 	base_scale = new_base_scale

--- a/project/src/main/puzzle/combo-score-value-label.gd
+++ b/project/src/main/puzzle/combo-score-value-label.gd
@@ -46,7 +46,7 @@ func _on_PuzzleState_score_changed() -> void:
 func _on_PuzzleState_topped_out() -> void:
 	modulate = Color("80ff5555")
 	text = StringUtils.format_money(-1 * PuzzleState.TOP_OUT_PENALTY)
-	rect_size = Vector2(0, 0)
+	rect_size = Vector2.ZERO
 	_penalty_timer.start()
 
 

--- a/project/src/main/puzzle/food-item.gd
+++ b/project/src/main/puzzle/food-item.gd
@@ -8,11 +8,11 @@ extends PackedSprite
 signal ready_to_fly
 
 ## Scale/rotation modifiers applied by our animation
-export (Vector2) var scale_modifier := Vector2(1.0, 1.0)
+export (Vector2) var scale_modifier := Vector2.ONE
 export (float) var rotation_modifier := 0.0
 
 ## The unmodified scale/rotation before pulsing/spinning
-var base_scale := Vector2(1.0, 1.0) setget set_base_scale
+var base_scale := Vector2.ONE setget set_base_scale
 var base_rotation := 0.0 setget set_base_rotation
 
 ## The velocity applied to the food when in the 'floating' state

--- a/project/src/main/puzzle/goop-glob.gd
+++ b/project/src/main/puzzle/goop-glob.gd
@@ -84,7 +84,7 @@ func initialize(new_box_type: int, new_position: Vector2) -> void:
 		modulate = Foods.COLORS_ALL[new_box_type]
 	
 	position = new_position
-	scale = Vector2(1, 1)
+	scale = Vector2.ONE
 	rotation = 0
 	velocity = Vector2.ZERO
 	# add x velocity twice so that its distribution is more of a bell curve

--- a/project/src/main/puzzle/leaf-poofs.gd
+++ b/project/src/main/puzzle/leaf-poofs.gd
@@ -27,7 +27,7 @@ func _spawn_poofs(y: int, veg_columns: Array, poof_count: int) -> void:
 	
 	# we split the line 3/6 or 4/5 between the two leaf varieties. 'cutoff' decides where the line is split.
 	# 'cutoff_direction' decides which leaf variety is on which side
-	var cutoff := int(rand_range(3, 6))
+	var cutoff := Utils.randi_range(3, 5)
 	var cutoff_direction := randf() < 0.5
 	
 	veg_columns.shuffle()

--- a/project/src/main/puzzle/pan/frying-pans-ui.gd
+++ b/project/src/main/puzzle/pan/frying-pans-ui.gd
@@ -126,7 +126,7 @@ func _add_pans_to_tilemap(pan_cells: Array) -> void:
 ## The tilemap is rescaled so that its contents will fit into its parent control horizontally.
 func _update_tilemap_scale() -> void:
 	var total_width := max(10, _tile_map.get_used_rect().size.x + 1) * _tile_map.cell_size.x
-	_tile_map.scale = Vector2(1, 1) * (rect_size.x / total_width)
+	_tile_map.scale = Vector2.ONE * (rect_size.x / total_width)
 
 
 ## Animates a pan disappearing when the player loses a life.

--- a/project/src/main/puzzle/piece-display.gd
+++ b/project/src/main/puzzle/piece-display.gd
@@ -21,7 +21,7 @@ func refresh_tile_map(next_piece: NextPiece) -> void:
 	_tile_map.clear()
 	if next_piece.type != PieceTypes.piece_null:
 		var bounding_box := Rect2( \
-				next_piece.type.get_cell_position(next_piece.orientation, 0), Vector2(1.0, 1.0))
+				next_piece.type.get_cell_position(next_piece.orientation, 0), Vector2.ONE)
 		# update the tilemap with the new piece type
 		for i in range(next_piece.type.pos_arr[0].size()):
 			var block_pos := next_piece.type.get_cell_position(next_piece.orientation, i)
@@ -30,7 +30,7 @@ func refresh_tile_map(next_piece: NextPiece) -> void:
 			bounding_box = bounding_box.expand( \
 					next_piece.type.get_cell_position(next_piece.orientation, i))
 			bounding_box = bounding_box.expand( \
-					next_piece.type.get_cell_position(next_piece.orientation, i) + Vector2(1, 1))
+					next_piece.type.get_cell_position(next_piece.orientation, i) + Vector2.ONE)
 		
 		# grow to accommodate bigger pieces
 		var bounding_box_longest_dimension := max(bounding_box.size.x, bounding_box.size.y)

--- a/project/src/main/puzzle/piece/piece-queue.gd
+++ b/project/src/main/puzzle/piece/piece-queue.gd
@@ -304,7 +304,7 @@ func _move_duplicate_piece(from_index: int, min_to_index: int) -> int:
 ## 	'max_pieces_to_right': The maximum number of pieces to the right of the new piece. '0' guarantees the new piece
 ## 		will be appended to the end of the queue, '8' means it will be mixed in with the last eight pieces.
 func _insert_annoying_piece(max_pieces_to_right: int) -> void:
-	var new_piece_index := int(rand_range(pieces.size() - max_pieces_to_right + 1, pieces.size() + 1))
+	var new_piece_index := Utils.randi_range(pieces.size() - max_pieces_to_right + 1, pieces.size())
 	var extra_piece_types: Array = _shuffled_piece_types()
 	if CurrentLevel.settings.piece_types.suppress_repeat_piece and extra_piece_types.size() >= 3:
 		# check the neighboring pieces, and remove those from the pieces we're picking from

--- a/project/src/main/puzzle/puzzle-touch-buttons.gd
+++ b/project/src/main/puzzle/puzzle-touch-buttons.gd
@@ -95,10 +95,10 @@ func _refresh_emit_actions() -> void:
 ##
 ## This updates their location and size.
 func _refresh_button_positions() -> void:
-	$ButtonsSw.rect_scale = Vector2(1.0, 1.0) * SystemData.touch_settings.size
+	$ButtonsSw.rect_scale = Vector2.ONE * SystemData.touch_settings.size
 	$ButtonsSw.rect_position.y = rect_size.y - 10 - $ButtonsSw.rect_size.y * $ButtonsSw.rect_scale.y
 	
-	$ButtonsSe.rect_scale = Vector2(1.0, 1.0) * SystemData.touch_settings.size
+	$ButtonsSe.rect_scale = Vector2.ONE * SystemData.touch_settings.size
 	$ButtonsSe.rect_position.x = rect_size.x - 10 - $ButtonsSw.rect_size.x * $ButtonsSw.rect_scale.x
 	$ButtonsSe.rect_position.y = rect_size.y - 10 - $ButtonsSw.rect_size.y * $ButtonsSw.rect_scale.y
 	

--- a/project/src/main/puzzle/score-value-label.gd
+++ b/project/src/main/puzzle/score-value-label.gd
@@ -10,7 +10,7 @@ func _ready() -> void:
 	
 	# Workaround for Godot #40357 to force the label to shrink to its minimum size. Otherwise, the ScoreParticles
 	# will be positioned incorrectly if the text ever shrinks.
-	rect_size = Vector2(0, 0)
+	rect_size = Vector2.ZERO
 
 
 func _on_resized() -> void:
@@ -30,7 +30,7 @@ func _on_PuzzleState_score_changed() -> void:
 	
 	# Workaround for Godot #40357 to force the label to shrink to its minimum size. Otherwise, the ScoreParticles
 	# will be positioned incorrectly if the text ever shrinks.
-	rect_size = Vector2(0, 0)
+	rect_size = Vector2.ZERO
 
 
 func _on_PuzzleState_topped_out() -> void:

--- a/project/src/main/puzzle/tutorial/skill-tally-item.gd
+++ b/project/src/main/puzzle/tutorial/skill-tally-item.gd
@@ -111,7 +111,7 @@ func _blink(bright: bool = false) -> void:
 		return
 	
 	_tween.remove_all()
-	_blink_panel.rect_scale = Vector2(1, 1)
+	_blink_panel.rect_scale = Vector2.ONE
 	if bright:
 		_bright_tween_active = true
 		_blink_panel.modulate = Color.white

--- a/project/src/main/ui/wallpaper/sticker-row.gd
+++ b/project/src/main/ui/wallpaper/sticker-row.gd
@@ -84,7 +84,7 @@ func _add_sticker() -> void:
 	var new_sticker: Sticker = StickerScene.instance()
 	
 	if _blank_texture_countdown == 0:
-		_blank_texture_countdown = int(rand_range(2, 7))
+		_blank_texture_countdown = Utils.randi_range(2, 6)
 	else:
 		_blank_texture_countdown -= 1
 		new_sticker.texture = _textures[_texture_index]

--- a/project/src/main/ui/wallpaper/sticker.gd
+++ b/project/src/main/ui/wallpaper/sticker.gd
@@ -3,7 +3,7 @@ extends Sprite
 ## An image which scrolls by on the wallpaper.
 
 ## The unmodified scale/rotation before pulsing/spinning
-var base_scale := Vector2(1.0, 1.0) setget set_base_scale
+var base_scale := Vector2.ONE setget set_base_scale
 var base_rotation := 0.0 setget set_base_rotation
 
 ## Stickers pulse and rotate. This field is used to calculate the pulse/rotation amount

--- a/project/src/main/utils/utils.gd
+++ b/project/src/main/utils/utils.gd
@@ -76,6 +76,11 @@ static func rand_value(values: Array):
 	return values[randi() % values.size()]
 
 
+## Generates a pseudo-random 32-bit signed integer between from and to (inclusive).
+static func randi_range(from: int, to: int) -> int:
+	return randi() % (to + 1 - from) + from
+
+
 ## Returns a random key from the specified dictionary.
 ##
 ## The values in the dictionary are numeric weights for each key.
@@ -256,7 +261,7 @@ static func to_bool(s: String) -> bool:
 ## For now, the nuance and complexity required in correctly implementing this trivial functionality warrants a utility
 ## function.
 static func map_to_world_centered(tile_map: TileMap, cell: Vector2) -> Vector2:
-	return (tile_map.map_to_world(cell) + tile_map.map_to_world(cell + Vector2(1, 1))) * 0.5
+	return (tile_map.map_to_world(cell) + tile_map.map_to_world(cell + Vector2.ONE)) * 0.5
 
 
 ## Shuffles the entries of the given array in a predictable manner, using the Fisher-Yates algorithm.

--- a/project/src/main/world/career-camera.gd
+++ b/project/src/main/world/career-camera.gd
@@ -11,7 +11,7 @@ const MANUAL_CAMERA_SPEED := 3000
 var _total_time := rand_range(0.0, 10.0)
 
 ## base zoom value before drift is applied
-var _base_zoom := Vector2(1.0, 1.0)
+var _base_zoom := Vector2.ONE
 
 ## period for offset/zoom drift, in seconds
 var offset_h_drift_period := 6.450 * rand_range(0.666, 1.333)

--- a/project/src/main/world/creature/creature-shadow.gd
+++ b/project/src/main/world/creature/creature-shadow.gd
@@ -6,7 +6,7 @@ extends Node2D
 export (Vector2) var shadow_offset: Vector2
 
 export (NodePath) var creature_path: NodePath setget set_creature_path
-export (Vector2) var shadow_scale := Vector2(1.0, 1.0)
+export (Vector2) var shadow_scale := Vector2.ONE
 
 ## The Creature this shadow is for
 var _creature: Creature

--- a/project/src/main/world/creature/emote-player.gd
+++ b/project/src/main/world/creature/emote-player.gd
@@ -455,7 +455,7 @@ func _post_unemote() -> void:
 	_creature_visuals.get_node("Neck0/HeadBobber/EmoteBrain").material.set_shader_param("red", Color.white)
 	_creature_visuals.get_node("EmoteBody").scale = Vector2(0.836, 0.836)
 	_creature_visuals.get_node("Neck0/HeadBobber/EmoteHead").position = Vector2( 0, 256 )
-	_creature_visuals.get_node("Neck0").scale = Vector2(1.0, 1.0)
+	_creature_visuals.get_node("Neck0").scale = Vector2.ONE
 
 
 ## Transition function for moods which don't need a transition.
@@ -465,7 +465,7 @@ func _transition_noop() -> void:
 
 ## Transitions from 'awkward1' to 'awkward0', hiding the white sweat circles.
 func _transition_awkward1_awkward0() -> void:
-	_creature_visuals.get_node("Neck0").scale = Vector2(1.0, 1.0)
+	_creature_visuals.get_node("Neck0").scale = Vector2.ONE
 	_reset_tween.remove_all()
 	_tween_nodes_to_transparent(["Neck0/HeadBobber/EmoteHead"])
 	_reset_tween.start()
@@ -526,7 +526,7 @@ func _transition_rage1_rage0() -> void:
 
 ## Transitions from 'sigh1' to 'sigh0', turning the head forward again
 func _transition_sigh1_sigh0() -> void:
-	_creature_visuals.get_node("Neck0").scale = Vector2(1.0, 1.0)
+	_creature_visuals.get_node("Neck0").scale = Vector2.ONE
 	_reset_tween.remove_all()
 	_reset_tween.interpolate_property(_head_bobber, "rotation_degrees",
 			_head_bobber.rotation_degrees, 0.0, UNEMOTE_DURATION)

--- a/project/src/main/world/cutscene-camera.gd
+++ b/project/src/main/world/cutscene-camera.gd
@@ -10,7 +10,7 @@ const LERP_WEIGHT := 0.05
 
 ## zoom amount when zoomed in or out
 const ZOOM_AMOUNT_NEAR := Vector2(0.5, 0.5)
-const ZOOM_AMOUNT_FAR := Vector2(1.0, 1.0)
+const ZOOM_AMOUNT_FAR := Vector2.ONE
 
 ## fixed zoom amount for cutscenes which should not zoom in and out
 var fixed_zoom := 0.0

--- a/project/src/main/world/environment/frame-overworld-obstacle.gd
+++ b/project/src/main/world/environment/frame-overworld-obstacle.gd
@@ -28,6 +28,6 @@ func set_shuffle(value: bool) -> void:
 	
 	set_frame(randi() % ($Sprite.hframes * $Sprite.vframes))
 	set_flip_h(randf() > 0.5)
-	scale = Vector2(1.0, 1.0)
+	scale = Vector2.ONE
 	
 	property_list_changed_notify()

--- a/project/src/main/world/environment/restaurant/undecorated-floor-tiler.gd
+++ b/project/src/main/world/environment/restaurant/undecorated-floor-tiler.gd
@@ -71,7 +71,7 @@ func _autotile_undecorated_floor(cell: Vector2) -> void:
 		_set_cell_autotile_coord(cell, tile_alternatives[0])
 	else:
 		# replace the cell with a blemished undecorated floor tile
-		_set_cell_autotile_coord(cell, tile_alternatives[int(rand_range(1, tile_alternatives.size()))])
+		_set_cell_autotile_coord(cell, tile_alternatives[Utils.randi_range(1, tile_alternatives.size() - 1)])
 
 
 ## Updates the autotile coordinate for a TileMap cell.


### PR DESCRIPTION
Replaced int(rand_range()) calls with randi_range() calls. According to Godot's documentation, int(rand_rage(3, 6)) has a theoretical (albeit infinitesimally small) chance to return 6. A replacement of randi_range(3, 5) is better. Godot has a built-in
RandomNumberGenerator.randi_range() method, but this is difficult to invoke from a static instance so I've written my own.

Replaced Vector(1, 1) calls with Vector.ONE, and Vector2(0, 0) calls with Vector.ZERO.