### PR TITLE
Moved tutorial delay constants. TestLevelTriggerEffects.

### DIFF
--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -54,10 +54,6 @@ signal combo_ended
 ## emitted when the current piece can't be placed in the playfield
 signal topped_out
 
-const DELAY_NONE := 0.01
-const DELAY_SHORT := 2.05
-const DELAY_LONG := 3.30
-
 const READY_DURATION := 1.4
 
 ## Number of points deducted from the player's score if they top out.

--- a/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
@@ -106,7 +106,7 @@ func _advance_level() -> void:
 	PuzzleState.level_performance.lost = false
 	_level_finished = true
 	
-	var delay_between_levels := PuzzleState.DELAY_SHORT
+	var delay_between_levels := TutorialModule.DELAY_SHORT
 	match CurrentLevel.settings.id:
 		"tutorial/cakes_0":
 			if _cakes_built == 0:
@@ -117,7 +117,7 @@ func _advance_level() -> void:
 				hud.set_message(tr("Ahha ha ha!\n\nYou're just trying to impress me."))
 		"tutorial/cakes_1":
 			# wait for the player to finish reading the diagram
-			delay_between_levels = PuzzleState.DELAY_LONG
+			delay_between_levels = TutorialModule.DELAY_LONG
 		"tutorial/cakes_2":
 			if _cakes_built >= 1:
 				_schedule_finish_line_clears()
@@ -144,7 +144,7 @@ func _advance_level() -> void:
 				PuzzleState.level_performance.lost = true
 		"tutorial/cakes_5":
 			# wait for the player to finish reading the diagram
-			delay_between_levels = PuzzleState.DELAY_LONG
+			delay_between_levels = TutorialModule.DELAY_LONG
 		"tutorial/cakes_6":
 			if _cakes_built >= 1:
 				_schedule_finish_line_clears()

--- a/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
@@ -109,28 +109,28 @@ func _set_combo_state(start: int, goal: int = 0) -> void:
 ## Advance to the next level in the tutorial.
 func _advance_level() -> void:
 	PuzzleState.level_performance.lost = false
-	var delay_between_levels := PuzzleState.DELAY_SHORT
+	var delay_between_levels := TutorialModule.DELAY_SHORT
 	match CurrentLevel.settings.id:
 		"tutorial/combo_0", "tutorial/combo_2":
 			if hud.skill_tally_item("Combo").is_complete():
 				hud.set_message(tr("Good job!"))
 			else:
 				hud.set_message(tr("Oops! ...You needed to clear a line with that last piece."))
-				delay_between_levels = PuzzleState.DELAY_LONG
+				delay_between_levels = TutorialModule.DELAY_LONG
 				PuzzleState.level_performance.lost = true
 		"tutorial/combo_1":
 			# no delay for the non-interactive segment where we show the player a diagram
-			delay_between_levels = PuzzleState.DELAY_NONE
+			delay_between_levels = TutorialModule.DELAY_NONE
 		"tutorial/combo_3", "tutorial/combo_4":
 			# no delay for the non-interactive segment where we demo for the player
-			delay_between_levels = PuzzleState.DELAY_NONE
+			delay_between_levels = TutorialModule.DELAY_NONE
 		"tutorial/combo_5":
 			if hud.skill_tally_item("CakeBox").is_complete():
 				hud.set_message(tr("Impressive!\n\nHmm... Was there anything else?"))
 				start_customer_countdown()
 			else:
 				hud.set_message(tr("Oh! ...You needed to clear a line that time."))
-				delay_between_levels = PuzzleState.DELAY_LONG
+				delay_between_levels = TutorialModule.DELAY_LONG
 				PuzzleState.level_performance.lost = true
 	
 	var level_ids := [

--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -4,6 +4,10 @@ extends Node
 ##
 ## Subclasses can show messages and advances the player through the tutorial as they complete tasks.
 
+const DELAY_NONE := 0.01
+const DELAY_SHORT := 2.05 # delay when the player should read something or dwell on a success
+const DELAY_LONG := 3.30 # delay when the player must read something important or dwell on a failure
+
 ## if 'true', the next level change will be accompanied by a 'Ready? Go!' countdown
 var _start_customer_countdown := false
 
@@ -75,7 +79,7 @@ func prepare_tutorial_level() -> void:
 ## Changes a level after all tutorial messages are shown.
 ##
 ## Copy/pasted from PuzzleState.change_level with an extra yield statement added.
-func change_level(level_id: String, delay_between_levels: float = PuzzleState.DELAY_SHORT) -> void:
+func change_level(level_id: String, delay_between_levels: float = TutorialModule.DELAY_SHORT) -> void:
 	PuzzleState.prepare_level_change(level_id)
 	start_timer_after_all_messages_shown(delay_between_levels) \
 			.connect("timeout", self, "_on_Timer_timeout_change_level", [level_id])

--- a/project/src/main/puzzle/tutorial/tutorial-spins-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-spins-module.gd
@@ -182,7 +182,7 @@ func _prepare_box_tally_item() -> void:
 ## Advance to the next level in the tutorial.
 func _advance_level() -> void:
 	PuzzleState.level_performance.lost = false
-	var delay_between_levels := PuzzleState.DELAY_SHORT
+	var delay_between_levels := TutorialModule.DELAY_SHORT
 	var new_level_id: String
 	
 	match CurrentLevel.settings.id:

--- a/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
@@ -87,11 +87,11 @@ func prepare_tutorial_level() -> void:
 ## Advance to the next level in the tutorial.
 func _advance_level() -> void:
 	PuzzleState.level_performance.lost = false
-	var delay_between_levels := PuzzleState.DELAY_SHORT
+	var delay_between_levels := TutorialModule.DELAY_SHORT
 	match CurrentLevel.settings.id:
 		"tutorial/squish_1":
 			# no delay for the non-interactive segment where we show the player a diagram
-			delay_between_levels = PuzzleState.DELAY_NONE
+			delay_between_levels = TutorialModule.DELAY_NONE
 		"tutorial/squish_2":
 			hud.set_message(tr("Yes, that's right."))
 		"tutorial/squish_3":

--- a/project/src/test/puzzle/level/test-level-trigger-effects.gd
+++ b/project/src/test/puzzle/level/test-level-trigger-effects.gd
@@ -2,109 +2,86 @@ extends GutTest
 
 func test_rotate_next_pieces_get_config() -> void:
 	var effect: LevelTriggerEffects.RotateNextPiecesEffect
-	effect = LevelTriggerEffects.RotateNextPiecesEffect.new()
+	effect = LevelTriggerEffects.create("rotate_next_pieces", {})
 	assert_eq_shallow(effect.get_config(), {"0": "none"})
 	
-	effect = LevelTriggerEffects.RotateNextPiecesEffect.new()
-	effect.set_config({"0": "cw", "1": "0", "2": "0"})
+	effect = LevelTriggerEffects.create("rotate_next_pieces", {"0": "cw", "1": "0", "2": "0"})
 	assert_eq_shallow(effect.get_config(), {"0": "cw", "1": "0", "2": "0"})
 
-	effect = LevelTriggerEffects.RotateNextPiecesEffect.new()
-	effect.set_config({"0": "180"})
+	effect = LevelTriggerEffects.create("rotate_next_pieces", {"0": "180"})
 	assert_eq_shallow(effect.get_config(), {"0": "180"})
 
 
 func test_insert_line_get_config() -> void:
 	var effect: LevelTriggerEffects.InsertLineEffect
-	effect = LevelTriggerEffects.InsertLineEffect.new()
+	effect = LevelTriggerEffects.create("insert_line", {})
 	assert_eq_shallow(effect.get_config(), {})
 	
-	effect = LevelTriggerEffects.InsertLineEffect.new()
-	effect.set_config({"count": "5"})
+	effect = LevelTriggerEffects.create("insert_line", {"count": "5"})
 	assert_eq_shallow(effect.get_config(), {"count": "5"})
 	
-	effect = LevelTriggerEffects.InsertLineEffect.new()
-	effect.set_config({"tiles_key": "0"})
+	effect = LevelTriggerEffects.create("insert_line", {"tiles_key": "0"})
 	assert_eq_shallow(effect.get_config(), {"tiles_key": "0"})
 	
-	effect = LevelTriggerEffects.InsertLineEffect.new()
-	effect.set_config({"tiles_keys": "0,1"})
+	effect = LevelTriggerEffects.create("insert_line", {"tiles_keys": "0,1"})
 	assert_eq_shallow(effect.get_config(), {"tiles_keys": "0,1"})
 	
-	effect = LevelTriggerEffects.InsertLineEffect.new()
-	effect.set_config({"y": "5"})
+	effect = LevelTriggerEffects.create("insert_line", {"y": "5"})
 	assert_eq_shallow(effect.get_config(), {"y": "5"})
 
 
 func test_add_moles_set_config() -> void:
 	var effect: LevelTriggerEffects.AddMolesEffect
 	
-	effect = LevelTriggerEffects.AddMolesEffect.new()
-	effect.set_config({})
+	effect = LevelTriggerEffects.create("add_moles", {})
 	assert_eq(effect.config.count, 1)
 	assert_eq(effect.config.home, MoleConfig.Home.ANY)
 	assert_eq(effect.config.dig_duration, 3)
 	assert_eq(effect.config.reward, MoleConfig.Reward.STAR)
 	
-	effect = LevelTriggerEffects.AddMolesEffect.new()
-	effect.set_config({"count": "2", "home": "veg", "dig_duration": "4", "reward": "star"})
+	effect = LevelTriggerEffects.create("add_moles", {"count": "2", "home": "veg", "dig_duration": "4",
+			"reward": "star"})
 	assert_eq(effect.config.count, 2)
 	assert_eq(effect.config.home, MoleConfig.Home.VEG)
 	assert_eq(effect.config.dig_duration, 4)
 	assert_eq(effect.config.reward, MoleConfig.Reward.STAR)
 	
-	effect = LevelTriggerEffects.AddMolesEffect.new()
-	effect.set_config({"x": "3-5"})
+	effect = LevelTriggerEffects.create("add_moles", {"x": "3-5"})
 	assert_eq(effect.config.columns, [3, 4, 5])
 	
-	effect = LevelTriggerEffects.AddMolesEffect.new()
-	effect.set_config({"y": "0,8"})
+	effect = LevelTriggerEffects.create("add_moles", {"y": "0,8"})
 	assert_eq(effect.config.lines, [19, 11])
 
 
 func test_add_moles_get_config() -> void:
 	var effect: LevelTriggerEffects.AddMolesEffect
 	
-	effect = LevelTriggerEffects.AddMolesEffect.new()
-	effect.set_config({})
-	assert_eq_shallow({}, effect.get_config())
-	
-	effect = LevelTriggerEffects.AddMolesEffect.new()
-	effect.set_config({"count": "2", "home": "veg", "dig_duration": "4", "reward": "seed"})
-	assert_eq_shallow({"count": "2", "home": "veg", "dig_duration": "4", "reward": "seed"}, effect.get_config())
-	
-	effect = LevelTriggerEffects.AddMolesEffect.new()
-	effect.set_config({"x": "3-5"})
-	assert_eq_shallow({"x": "3-5"}, effect.get_config())
-	
-	effect = LevelTriggerEffects.AddMolesEffect.new()
-	effect.set_config({"y": "0,8"})
-	assert_eq_shallow({"y": "0,8"}, effect.get_config())
-
-
-func test_add_moles_to_json() -> void:
-	var effect: LevelTriggerEffects.AddMolesEffect
-	
 	effect = LevelTriggerEffects.create("add_moles", {})
 	assert_eq_shallow({}, effect.get_config())
 	
-	effect = LevelTriggerEffects.create("add_moles", {"count": "2", "home": "veg", "dig_duration": "4", "reward": "seed"})
+	effect = LevelTriggerEffects.create("add_moles", {"count": "2", "home": "veg", "dig_duration": "4",
+			"reward": "seed"})
 	assert_eq_shallow({"count": "2", "home": "veg", "dig_duration": "4", "reward": "seed"}, effect.get_config())
+	
+	effect = LevelTriggerEffects.create("add_moles", {"x": "3-5"})
+	assert_eq_shallow({"x": "3-5"}, effect.get_config())
+	
+	effect = LevelTriggerEffects.create("add_moles", {"y": "0,8"})
+	assert_eq_shallow({"y": "0,8"}, effect.get_config())
 
 
 func test_add_carrots_set_config() -> void:
 	var effect: LevelTriggerEffects.AddCarrotsEffect
 	
-	effect = LevelTriggerEffects.AddCarrotsEffect.new()
-	effect.set_config({})
+	effect = LevelTriggerEffects.create("add_carrots", {})
 	assert_eq(effect.config.columns, [])
 	assert_eq(effect.config.count, 1)
 	assert_eq(effect.config.duration, 8.0)
 	assert_eq(effect.config.size, CarrotConfig.CarrotSize.MEDIUM)
 	assert_eq(effect.config.smoke, CarrotConfig.Smoke.SMALL)
 	
-	effect = LevelTriggerEffects.AddCarrotsEffect.new()
-	effect.set_config({"x": "0-2", "count": "2", "duration": "12.0", "size": "large", "smoke": "none"})
+	effect = LevelTriggerEffects.create("add_carrots", {"x": "0-2", "count": "2", "duration": "12.0", "size": "large",
+			"smoke": "none"})
 	assert_eq(effect.config.columns, [0, 1, 2])
 	assert_eq(effect.config.count, 2)
 	assert_eq(effect.config.duration, 12.0)
@@ -115,40 +92,34 @@ func test_add_carrots_set_config() -> void:
 func test_add_carrots_get_config() -> void:
 	var effect: LevelTriggerEffects.AddCarrotsEffect
 	
-	effect = LevelTriggerEffects.AddCarrotsEffect.new()
-	effect.set_config({})
+	effect = LevelTriggerEffects.create("add_carrots", {})
 	assert_eq_shallow({}, effect.get_config())
 	
-	effect = LevelTriggerEffects.AddCarrotsEffect.new()
-	effect.set_config({"count": "2", "duration": "12.0", "size": "large", "smoke": "none", "x": "0-2"})
+	effect = LevelTriggerEffects.create("add_carrots", {"count": "2", "duration": "12.0", "size": "large", "smoke": "none", "x": "0-2"})
 	assert_eq_shallow({"count": "2", "duration": "12", "size": "large", "smoke": "none", "x": "0-2"}, effect.get_config())
 
 
 func test_remove_carrots_set_config() -> void:
 	var effect: LevelTriggerEffects.RemoveCarrotsEffect
 	
-	effect = LevelTriggerEffects.RemoveCarrotsEffect.new()
-	effect.set_config({})
+	effect = LevelTriggerEffects.create("remove_carrots", {})
 	assert_eq(effect.count, 1)
 	
-	effect = LevelTriggerEffects.RemoveCarrotsEffect.new()
-	effect.set_config({"0": "2"})
+	effect = LevelTriggerEffects.create("remove_carrots", {"0": "2"})
 	assert_eq(effect.count, 2)
 
 
 func test_remove_carrots_get_config() -> void:
 	var effect: LevelTriggerEffects.RemoveCarrotsEffect
 	
-	effect = LevelTriggerEffects.RemoveCarrotsEffect.new()
-	effect.set_config({})
+	effect = LevelTriggerEffects.create("remove_carrots", {})
 	assert_eq_shallow({}, effect.get_config())
 	
-	effect = LevelTriggerEffects.RemoveCarrotsEffect.new()
-	effect.set_config({"0": "2"})
+	effect = LevelTriggerEffects.create("remove_carrots", {"0": "2"})
 	assert_eq_shallow({"0": "2"}, effect.get_config())
 
 
-func test_clear_filled_lines_to_json() -> void:
+func test_clear_filled_lines_get_config() -> void:
 	var effect: LevelTriggerEffects.ClearFilledLinesEffect
 	
 	effect = LevelTriggerEffects.create("clear_filled_lines", {})


### PR DESCRIPTION
Moved tutorial delay constants from PuzzleState into TutorialModule.

TestLevelTriggerEffects improvements. Renamed 'to_json' tests to 'get_config' tests. Removed redundant tests. Made tests consistently go through LevelTriggerEffects.create() instead of directly calling constructors.