### PR TITLE
Removed top_out_penalty.

### DIFF
--- a/project/assets/main/puzzle/levels/practice/sandbox-expert.json
+++ b/project/assets/main/puzzle/levels/practice/sandbox-expert.json
@@ -10,8 +10,7 @@
     "finish_on_lose"
   ],
   "rank": [
-    "unranked",
-    "top_out_penalty 0"
+    "unranked"
   ],
   "start_speed": "A5",
   "success_condition": {

--- a/project/assets/main/puzzle/levels/practice/sandbox-master.json
+++ b/project/assets/main/puzzle/levels/practice/sandbox-master.json
@@ -10,8 +10,7 @@
     "finish_on_lose"
   ],
   "rank": [
-    "unranked",
-    "top_out_penalty 0"
+    "unranked"
   ],
   "start_speed": "FA",
   "success_condition": {

--- a/project/assets/main/puzzle/levels/practice/sandbox-normal.json
+++ b/project/assets/main/puzzle/levels/practice/sandbox-normal.json
@@ -10,8 +10,7 @@
     "finish_on_lose"
   ],
   "rank": [
-    "unranked",
-    "top_out_penalty 0"
+    "unranked"
   ],
   "start_speed": "0",
   "success_condition": {

--- a/project/src/main/puzzle/level/rank-rules.gd
+++ b/project/src/main/puzzle/level/rank-rules.gd
@@ -77,9 +77,6 @@ var skip_results := false
 ## gives the player a little bump in rank so achieving the target score will always result in a higher grade.
 var success_bonus := 0.0
 
-## rank penalty applied each time the player tops out
-var top_out_penalty := 4.0
-
 ## If 'true' the player is not given a rank for this level.
 var unranked := false
 
@@ -103,7 +100,6 @@ func _init() -> void:
 	_rule_parser.add(ShowRankPropertyParser.new(self, "show_speed_rank"))
 	_rule_parser.add_bool("skip_results")
 	_rule_parser.add_float("success_bonus")
-	_rule_parser.add_float("top_out_penalty").default(4.0)
 	_rule_parser.add_bool("unranked")
 
 

--- a/project/src/test/puzzle/level/test-rank-rules.gd
+++ b/project/src/test/puzzle/level/test-rank-rules.gd
@@ -32,7 +32,6 @@ func test_convert_to_json_and_back() -> void:
 	rules.show_speed_rank = RankRules.ShowRank.HIDE
 	rules.skip_results = true
 	rules.success_bonus = 9.0
-	rules.top_out_penalty = 10.0
 	rules.unranked = true
 	_convert_to_json_and_back()
 	
@@ -51,7 +50,6 @@ func test_convert_to_json_and_back() -> void:
 	assert_eq(rules.show_speed_rank, RankRules.ShowRank.HIDE)
 	assert_eq(rules.skip_results, true)
 	assert_eq(rules.success_bonus, 9.0)
-	assert_eq(rules.top_out_penalty, 10.0)
 	assert_eq(rules.unranked, true)
 
 


### PR DESCRIPTION
The rank algorithm used to decrease the player's rank if they topped out. The decrease amount was configurable with a 'top_out_penalty' property. This is no longer the case, the player's score is now just decreased by ¥100 each time. Sometimes this affects their rank but sometimes it does not.