### PR TITLE
PhaseCondition cleanup; LineClearedPhaseCondition

### DIFF
--- a/project/src/test/puzzle/level/test-level-triggers.gd
+++ b/project/src/test/puzzle/level/test-level-triggers.gd
@@ -28,7 +28,7 @@ func test_convert_to_json_and_back_complex() -> void:
 	assert_eq(trigger.phases.size(), 1)
 	assert_eq(trigger.phases[LevelTrigger.LINE_CLEARED].size(), 1)
 	assert_is(trigger.phases[LevelTrigger.LINE_CLEARED][0], PhaseConditions.LineClearedPhaseCondition)
-	assert_eq(trigger.phases[LevelTrigger.LINE_CLEARED][0].which_lines.keys(), [19, 18, 17, 16, 15, 14])
+	assert_eq(trigger.phases[LevelTrigger.LINE_CLEARED][0].rows.keys(), [19, 18, 17, 16, 15, 14])
 	assert_is(trigger.effect, LevelTriggerEffects.InsertLineEffect)
 	assert_eq(trigger.effect.tiles_keys, ["0"])
 


### PR DESCRIPTION
Exposed PhaseCondition fields to match LevelTriggerEffect. Some of these effects have fields corresponding to their behavior. Exposing these fields enables unit testing, otherwise we'd have to execute the effect and monitor its behavior which is cumbersome for configuration tests.

Renamed LineClearedPhaseCondition. Some names like 'which_lines' were ambiguous and differed from terms used in PieceWrittenPhaseCondition. They now consistently use less ambiguous terms like 'row' for the Y index, and 'index' for the sequential order.

Removed some unnecessary conditionals in LineClearedPhaseCondition's init method.