### PR TITLE
Extracted 'Tutorials' script with constants

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -1175,6 +1175,11 @@ _global_script_classes=[ {
 "path": "res://src/main/puzzle/tutorial/tutorial-module.gd"
 }, {
 "base": "Reference",
+"class": "Tutorials",
+"language": "GDScript",
+"path": "res://src/main/puzzle/tutorial/tutorials.gd"
+}, {
+"base": "Reference",
 "class": "Utils",
 "language": "GDScript",
 "path": "res://src/main/utils/utils.gd"
@@ -1433,6 +1438,7 @@ _global_script_class_icons={
 "TutorialHud": "",
 "TutorialMessages": "",
 "TutorialModule": "",
+"Tutorials": "",
 "Utils": "",
 "VolumeSettings": "",
 "WalkingBuddy": "",

--- a/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
@@ -106,7 +106,7 @@ func _advance_level() -> void:
 	PuzzleState.level_performance.lost = false
 	_level_finished = true
 	
-	var delay_between_levels := TutorialModule.DELAY_SHORT
+	var delay_between_levels := Tutorials.DELAY_SHORT
 	match CurrentLevel.settings.id:
 		"tutorial/cakes_0":
 			if _cakes_built == 0:
@@ -117,7 +117,7 @@ func _advance_level() -> void:
 				hud.set_message(tr("Ahha ha ha!\n\nYou're just trying to impress me."))
 		"tutorial/cakes_1":
 			# wait for the player to finish reading the diagram
-			delay_between_levels = TutorialModule.DELAY_LONG
+			delay_between_levels = Tutorials.DELAY_LONG
 		"tutorial/cakes_2":
 			if _cakes_built >= 1:
 				_schedule_finish_line_clears()
@@ -144,7 +144,7 @@ func _advance_level() -> void:
 				PuzzleState.level_performance.lost = true
 		"tutorial/cakes_5":
 			# wait for the player to finish reading the diagram
-			delay_between_levels = TutorialModule.DELAY_LONG
+			delay_between_levels = Tutorials.DELAY_LONG
 		"tutorial/cakes_6":
 			if _cakes_built >= 1:
 				_schedule_finish_line_clears()

--- a/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
@@ -109,28 +109,28 @@ func _set_combo_state(start: int, goal: int = 0) -> void:
 ## Advance to the next level in the tutorial.
 func _advance_level() -> void:
 	PuzzleState.level_performance.lost = false
-	var delay_between_levels := TutorialModule.DELAY_SHORT
+	var delay_between_levels := Tutorials.DELAY_SHORT
 	match CurrentLevel.settings.id:
 		"tutorial/combo_0", "tutorial/combo_2":
 			if hud.skill_tally_item("Combo").is_complete():
 				hud.set_message(tr("Good job!"))
 			else:
 				hud.set_message(tr("Oops! ...You needed to clear a line with that last piece."))
-				delay_between_levels = TutorialModule.DELAY_LONG
+				delay_between_levels = Tutorials.DELAY_LONG
 				PuzzleState.level_performance.lost = true
 		"tutorial/combo_1":
 			# no delay for the non-interactive segment where we show the player a diagram
-			delay_between_levels = TutorialModule.DELAY_NONE
+			delay_between_levels = Tutorials.DELAY_NONE
 		"tutorial/combo_3", "tutorial/combo_4":
 			# no delay for the non-interactive segment where we demo for the player
-			delay_between_levels = TutorialModule.DELAY_NONE
+			delay_between_levels = Tutorials.DELAY_NONE
 		"tutorial/combo_5":
 			if hud.skill_tally_item("CakeBox").is_complete():
 				hud.set_message(tr("Impressive!\n\nHmm... Was there anything else?"))
 				start_customer_countdown()
 			else:
 				hud.set_message(tr("Oh! ...You needed to clear a line that time."))
-				delay_between_levels = TutorialModule.DELAY_LONG
+				delay_between_levels = Tutorials.DELAY_LONG
 				PuzzleState.level_performance.lost = true
 	
 	var level_ids := [

--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -4,10 +4,6 @@ extends Node
 ##
 ## Subclasses can show messages and advances the player through the tutorial as they complete tasks.
 
-const DELAY_NONE := 0.01
-const DELAY_SHORT := 2.05 # delay when the player should read something or dwell on a success
-const DELAY_LONG := 3.30 # delay when the player must read something important or dwell on a failure
-
 ## if 'true', the next level change will be accompanied by a 'Ready? Go!' countdown
 var _start_customer_countdown := false
 
@@ -79,7 +75,7 @@ func prepare_tutorial_level() -> void:
 ## Changes a level after all tutorial messages are shown.
 ##
 ## Copy/pasted from PuzzleState.change_level with an extra yield statement added.
-func change_level(level_id: String, delay_between_levels: float = TutorialModule.DELAY_SHORT) -> void:
+func change_level(level_id: String, delay_between_levels: float = Tutorials.DELAY_SHORT) -> void:
 	PuzzleState.prepare_level_change(level_id)
 	start_timer_after_all_messages_shown(delay_between_levels) \
 			.connect("timeout", self, "_on_Timer_timeout_change_level", [level_id])

--- a/project/src/main/puzzle/tutorial/tutorial-spins-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-spins-module.gd
@@ -182,7 +182,7 @@ func _prepare_box_tally_item() -> void:
 ## Advance to the next level in the tutorial.
 func _advance_level() -> void:
 	PuzzleState.level_performance.lost = false
-	var delay_between_levels := TutorialModule.DELAY_SHORT
+	var delay_between_levels := Tutorials.DELAY_SHORT
 	var new_level_id: String
 	
 	match CurrentLevel.settings.id:

--- a/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
@@ -87,11 +87,11 @@ func prepare_tutorial_level() -> void:
 ## Advance to the next level in the tutorial.
 func _advance_level() -> void:
 	PuzzleState.level_performance.lost = false
-	var delay_between_levels := TutorialModule.DELAY_SHORT
+	var delay_between_levels := Tutorials.DELAY_SHORT
 	match CurrentLevel.settings.id:
 		"tutorial/squish_1":
 			# no delay for the non-interactive segment where we show the player a diagram
-			delay_between_levels = TutorialModule.DELAY_NONE
+			delay_between_levels = Tutorials.DELAY_NONE
 		"tutorial/squish_2":
 			hud.set_message(tr("Yes, that's right."))
 		"tutorial/squish_3":

--- a/project/src/main/puzzle/tutorial/tutorials.gd
+++ b/project/src/main/puzzle/tutorial/tutorials.gd
@@ -1,0 +1,6 @@
+class_name Tutorials
+## Enums, constants and utilities for tutorials
+
+const DELAY_NONE: float = 0.01
+const DELAY_SHORT: float = 2.05 # delay when the player should read something or dwell on a success
+const DELAY_LONG: float = 3.30 # delay when the player must read something important or dwell on a failure


### PR DESCRIPTION
This fixes a compile error where TutorialModule was referencing itself. But the compile error is sort of a code smell that maybe these constants were not where they were supposed to be. Now they're in a separate class.