### PR TITLE
Scenes calling get_node() handle nulls better

### DIFF
--- a/project/src/demo/world/creature/palette-editor-tab.gd
+++ b/project/src/demo/world/creature/palette-editor-tab.gd
@@ -10,15 +10,14 @@ var _creature_editor: CreatureEditor
 var _creature_palettes := []
 
 func _ready() -> void:
-	if creature_editor_path:
-		_creature_editor = get_node(creature_editor_path)
+	_refresh_creature_editor_path()
 	for palette in DnaUtils.CREATURE_PALETTES:
 		_add_palette(palette)
 
 
 func set_creature_editor_path(new_creature_editor_path: NodePath) -> void:
+	_refresh_creature_editor_path()
 	creature_editor_path = new_creature_editor_path
-	_creature_editor = get_node(creature_editor_path)
 
 
 func get_center_creature() -> Creature:
@@ -48,6 +47,11 @@ func _print_palette(palette: Dictionary) -> void:
 	result += "\"glass_rgb\": \"%s\", " % palette["glass_rgb"]
 	result += "\"plastic_rgb\": \"%s\"}, # ??????" % palette["plastic_rgb"]
 	print(result)
+
+
+func _refresh_creature_editor_path() -> void:
+	if creature_editor_path:
+		_creature_editor = get_node(creature_editor_path) if creature_editor_path else null
 
 
 ## Updates the creature's colors with the clicked palette.

--- a/project/src/main/career/ui/progress-board-trail.gd
+++ b/project/src/main/career/ui/progress-board-trail.gd
@@ -59,10 +59,7 @@ func _refresh_path2d_path() -> void:
 	if not is_inside_tree():
 		return
 	
-	if path2d_path:
-		path2d = get_node(path2d_path)
-	else:
-		path2d = null
+	path2d = get_node(path2d_path) if path2d_path else null
 	
 	_lines.path2d = path2d
 	_spots.path2d = path2d

--- a/project/src/main/puzzle/chef-view.gd
+++ b/project/src/main/puzzle/chef-view.gd
@@ -4,5 +4,5 @@ extends ViewportContainer
 export (NodePath) var restaurant_viewport_path: NodePath
 
 func _ready() -> void:
-	$Viewport.world_2d = get_node(restaurant_viewport_path).world_2d
+	$Viewport.world_2d = get_node(restaurant_viewport_path).world_2d if restaurant_viewport_path else null
 	$Viewport.size = rect_size * 4

--- a/project/src/main/puzzle/critter/carrots.gd
+++ b/project/src/main/puzzle/critter/carrots.gd
@@ -96,9 +96,10 @@ func _refresh_playfield_path() -> void:
 	if _playfield:
 		_playfield.disconnect("blocks_prepared", self, "_on_Playfield_blocks_prepared")
 	
-	_playfield = get_node(playfield_path)
+	_playfield = get_node(playfield_path) if playfield_path else null
 	
-	_playfield.connect("blocks_prepared", self, "_on_Playfield_blocks_prepared")
+	if _playfield:
+		_playfield.connect("blocks_prepared", self, "_on_Playfield_blocks_prepared")
 
 
 ## Adds a carrot to the specified cell.

--- a/project/src/main/puzzle/critter/moles.gd
+++ b/project/src/main/puzzle/critter/moles.gd
@@ -46,14 +46,15 @@ func _refresh_playfield_path() -> void:
 		_playfield.disconnect("line_filled", self, "_on_Playfield_line_filled")
 		_playfield.disconnect("after_lines_deleted", self, "_on_Playfield_after_lines_deleted")
 	
-	_playfield = get_node(playfield_path)
+	_playfield = get_node(playfield_path) if playfield_path else null
 	
-	_playfield.connect("blocks_prepared", self, "_on_Playfield_blocks_prepared")
-	_playfield.connect("line_deleted", self, "_on_Playfield_line_deleted")
-	_playfield.connect("line_erased", self, "_on_Playfield_line_erased")
-	_playfield.connect("line_inserted", self, "_on_Playfield_line_inserted")
-	_playfield.connect("line_filled", self, "_on_Playfield_line_filled")
-	_playfield.connect("after_lines_deleted", self, "_on_Playfield_after_lines_deleted")
+	if _playfield:
+		_playfield.connect("blocks_prepared", self, "_on_Playfield_blocks_prepared")
+		_playfield.connect("line_deleted", self, "_on_Playfield_line_deleted")
+		_playfield.connect("line_erased", self, "_on_Playfield_line_erased")
+		_playfield.connect("line_inserted", self, "_on_Playfield_line_inserted")
+		_playfield.connect("line_filled", self, "_on_Playfield_line_filled")
+		_playfield.connect("after_lines_deleted", self, "_on_Playfield_after_lines_deleted")
 
 
 ## Connects piece manager listeners.
@@ -64,9 +65,10 @@ func _refresh_piece_manager_path() -> void:
 	if _piece_manager:
 		_piece_manager.disconnect("piece_disturbed", self, "_on_PieceManager_piece_disturbed")
 	
-	_piece_manager = get_node(piece_manager_path)
+	_piece_manager = get_node(piece_manager_path) if piece_manager_path else null
 	
-	_piece_manager.connect("piece_disturbed", self, "_on_PieceManager_piece_disturbed")
+	if _piece_manager:
+		_piece_manager.connect("piece_disturbed", self, "_on_PieceManager_piece_disturbed")
 
 
 ## Adds moles to the playfield.

--- a/project/src/main/puzzle/customer-view.gd
+++ b/project/src/main/puzzle/customer-view.gd
@@ -4,4 +4,4 @@ extends ViewportContainer
 export (NodePath) var restaurant_viewport_path: NodePath
 
 func _ready() -> void:
-	$Viewport.world_2d = get_node(restaurant_viewport_path).world_2d
+	$Viewport.world_2d = get_node(restaurant_viewport_path).world_2d if restaurant_viewport_path else null

--- a/project/src/main/puzzle/goop-globs.gd
+++ b/project/src/main/puzzle/goop-globs.gd
@@ -24,8 +24,8 @@ onready var _puzzle_tile_map_position: Vector2 = _puzzle_tile_map.get_global_tra
 
 func _ready() -> void:
 	_puzzle_areas = PuzzleAreas.new()
-	_puzzle_areas.playfield_area = get_node(playfield_path).get_rect()
-	_puzzle_areas.next_pieces_area = get_node(next_piece_displays_path).get_rect()
+	_puzzle_areas.playfield_area = get_node(playfield_path).get_rect() if playfield_path else null
+	_puzzle_areas.next_pieces_area = get_node(next_piece_displays_path).get_rect() if next_piece_displays_path else null
 	_puzzle_areas.walled_area = _puzzle_areas.playfield_area.merge(_puzzle_areas.next_pieces_area)
 
 

--- a/project/src/main/puzzle/puzzle-bg-loader.gd
+++ b/project/src/main/puzzle/puzzle-bg-loader.gd
@@ -24,13 +24,15 @@ const BG_SHADOW_COLOR_BY_NAME := {
 export (Array, NodePath) var shadow_paths: Array
 
 func _ready() -> void:
-	if has_node("Bg"):
-		_remove_bg()
+	_remove_bg()
 	_add_bg()
 	_refresh_shadow_color()
 
 
 func _remove_bg() -> void:
+	if not has_node("Bg"):
+		return
+	
 	var bg := get_node("Bg")
 	bg.queue_free()
 	remove_child(bg)

--- a/project/src/main/world/creature-spawner.gd
+++ b/project/src/main/world/creature-spawner.gd
@@ -31,9 +31,8 @@ var _target_creature: Creature
 onready var _overworld_environment: OverworldEnvironment = get_node(overworld_environment_path)
 
 func _ready() -> void:
-	if stool_path:
-		_stool = get_node(stool_path)
-		_update_stool_occupied()
+	_stool = get_node(stool_path) if stool_path else null
+	_update_stool_occupied()
 	
 	if spawn_if and BoolExpressionEvaluator.evaluate(spawn_if):
 		# Spawn the creature and remove the spawner from the scene tree.
@@ -46,6 +45,9 @@ func _ready() -> void:
 
 ## Updates the spawned creature's stool to be occupied or unoccupied.
 func _update_stool_occupied() -> void:
+	if not _stool:
+		return
+
 	var occupied := _target_creature != null
 	if _stool is ObstacleSpawner:
 		_stool.set_target_property("occupied", occupied)
@@ -76,9 +78,8 @@ func _spawn_target() -> void:
 		_target_creature.set_visual_fatness(max_fatness)
 		_target_creature.save_fatness(max_fatness)
 	
-	if _stool:
-		# mark the creature's stool as occupied
-		_update_stool_occupied()
+	# mark the creature's stool as occupied
+	_update_stool_occupied()
 	
 	# remove the spawner from the scene tree
 	queue_free()

--- a/project/src/main/world/creature/body.gd
+++ b/project/src/main/world/creature/body.gd
@@ -105,8 +105,9 @@ func _refresh_creature_visuals_path() -> void:
 	
 	if _creature_visuals:
 		_creature_visuals.disconnect("movement_mode_changed", self, "_on_CreatureVisuals_movement_mode_changed")
-	_creature_visuals = get_node(creature_visuals_path)
-	_creature_visuals.connect("movement_mode_changed", self, "_on_CreatureVisuals_movement_mode_changed")
+	_creature_visuals = get_node(creature_visuals_path) if creature_visuals_path else null
+	if _creature_visuals:
+		_creature_visuals.connect("movement_mode_changed", self, "_on_CreatureVisuals_movement_mode_changed")
 
 
 func _refresh_editing() -> void:

--- a/project/src/main/world/creature/head-sweat-squirts.gd
+++ b/project/src/main/world/creature/head-sweat-squirts.gd
@@ -25,8 +25,9 @@ func _refresh_creature_visuals_path() -> void:
 	
 	_creature_visuals = get_node(creature_visuals_path)
 	
-	_creature_visuals.connect("comfort_changed", self, "_on_CreatureVisuals_comfort_changed")
-	_creature_visuals.connect("dna_loaded", self, "_on_CreatureVisuals_dna_loaded")
+	if _creature_visuals:
+		_creature_visuals.connect("comfort_changed", self, "_on_CreatureVisuals_comfort_changed")
+		_creature_visuals.connect("dna_loaded", self, "_on_CreatureVisuals_dna_loaded")
 
 
 func _on_CreatureVisuals_comfort_changed() -> void:

--- a/project/src/main/world/creature/mouth-player.gd
+++ b/project/src/main/world/creature/mouth-player.gd
@@ -78,18 +78,20 @@ func _refresh_creature_visuals_path() -> void:
 	
 	root_node = creature_visuals_path
 	_creature_visuals = get_node(creature_visuals_path)
-	_creature_visuals.connect("orientation_changed", self, "_on_CreatureVisuals_orientation_changed")
-	_creature_visuals.connect("talking_changed", self, "_on_CreatureVisuals_talking_changed")
 	
-	_emote_player = _creature_visuals.get_node("Animations/EmotePlayer")
-	_emote_player.connect("animation_started", self, "_on_EmotePlayer_animation_started")
-	
-	idle_timer = _creature_visuals.get_node("Animations/IdleTimer")
-	idle_timer.connect("idle_animation_started", self, "_on_IdleTimer_idle_animation_started")
-	idle_timer.connect("idle_animation_stopped", self, "_on_IdleTimer_idle_animation_stopped")
-	
-	_mouth = _creature_visuals.get_node("Neck0/HeadBobber/Mouth")
-	_emote_glow = _creature_visuals.get_node("Neck0/HeadBobber/EmoteGlow")
+	if _creature_visuals:
+		_creature_visuals.connect("orientation_changed", self, "_on_CreatureVisuals_orientation_changed")
+		_creature_visuals.connect("talking_changed", self, "_on_CreatureVisuals_talking_changed")
+		
+		_emote_player = _creature_visuals.get_node("Animations/EmotePlayer")
+		_emote_player.connect("animation_started", self, "_on_EmotePlayer_animation_started")
+		
+		idle_timer = _creature_visuals.get_node("Animations/IdleTimer")
+		idle_timer.connect("idle_animation_started", self, "_on_IdleTimer_idle_animation_started")
+		idle_timer.connect("idle_animation_stopped", self, "_on_IdleTimer_idle_animation_stopped")
+		
+		_mouth = _creature_visuals.get_node("Neck0/HeadBobber/Mouth")
+		_emote_glow = _creature_visuals.get_node("Neck0/HeadBobber/EmoteGlow")
 
 
 ## Plays an appropriate mouth ambient animation for the creature's orientation and mood.

--- a/project/src/main/world/environment/grass-overworld-tiler.gd
+++ b/project/src/main/world/environment/grass-overworld-tiler.gd
@@ -64,7 +64,7 @@ func autotile(value: bool) -> void:
 ## Preemptively initializes onready variables to avoid null references.
 func _initialize_onready_variables() -> void:
 	_tile_map = get_parent()
-	_ground_map = get_node(ground_map_path)
+	_ground_map = get_node(ground_map_path) if ground_map_path else null
 
 
 func _erase_all_grass() -> void:

--- a/project/src/main/world/environment/invisible-obstacle-tiler.gd
+++ b/project/src/main/world/environment/invisible-obstacle-tiler.gd
@@ -75,4 +75,4 @@ func autotile(value: bool) -> void:
 ## Preemptively initializes onready variables to avoid null references.
 func _initialize_onready_variables() -> void:
 	_tile_map = get_parent()
-	_ground_map = get_node(ground_map_path)
+	_ground_map = get_node(ground_map_path) if ground_map_path else null

--- a/project/src/main/world/environment/obstacle-map-shadows.gd
+++ b/project/src/main/world/environment/obstacle-map-shadows.gd
@@ -30,8 +30,7 @@ func set_cell_shadow_mapping(new_cell_shadow_mapping: Dictionary) -> void:
 
 
 func _refresh_obstacle_map_path() -> void:
-	if obstacle_map_path:
-		_obstacle_map = get_node(obstacle_map_path)
+	_obstacle_map = get_node(obstacle_map_path) if obstacle_map_path else null
 
 
 func _refresh_shadows() -> void:

--- a/project/src/main/world/environment/pebble-overworld-tiler.gd
+++ b/project/src/main/world/environment/pebble-overworld-tiler.gd
@@ -52,7 +52,7 @@ func autotile(value: bool) -> void:
 ## Preemptively initializes onready variables to avoid null references.
 func _initialize_onready_variables() -> void:
 	_tile_map = get_parent()
-	_ground_map = get_node(ground_map_path)
+	_ground_map = get_node(ground_map_path) if ground_map_path else null
 
 
 func _erase_all_pebbles() -> void:

--- a/project/src/main/world/spawn.gd
+++ b/project/src/main/world/spawn.gd
@@ -17,8 +17,7 @@ export (float) var elevation: float
 var _stool: Stool
 
 func _ready() -> void:
-	if stool_path:
-		_stool = get_node(stool_path)
+	_stool = get_node(stool_path) if stool_path else null
 
 
 ## Relocates the specified creature to this spawn point.


### PR DESCRIPTION
I modified most of these places to assign the resulting field to 'null' if the node path is null. There were a few areas (especially relating to CreatureVisuals) which already had null handling logic which behaved differently, preserving the field's states if the node path is null. I kept these the way it is, because that code is especially brittle if the underlying CreatureVisuals is null anyways. Assigning a null CreatureVisuals would never do anything helpful.