### PR TITLE
SceneTransition duration bug fixes

### DIFF
--- a/project/src/main/music/music-transition.gd
+++ b/project/src/main/music/music-transition.gd
@@ -16,7 +16,7 @@ func _on_SceneTransition_fade_in_started() -> void:
 	if _faded_bgm:
 		# If we faded the music out, we fade it back in
 		MusicPlayer.play_bgm(_faded_bgm, _faded_bgm.get_playback_position())
-		MusicPlayer.fade_in(SceneTransition.SCREEN_FADE_IN_DURATION * 1.5)
+		MusicPlayer.fade_in(SceneTransition.DEFAULT_FADE_IN_DURATION * 1.5)
 		
 		# reset _faded_bgm to avoid fading the same song in twice
 		_faded_bgm = null

--- a/project/src/main/ui/scene-transition-cover.gd
+++ b/project/src/main/ui/scene-transition-cover.gd
@@ -27,10 +27,10 @@ func fade_out() -> void:
 ## Launches the 'fade in' visual transition.
 func fade_in() -> void:
 	_mask.modulate = SceneTransition.fade_color
-	_animation_player.play("fade-in", -1, 1.0 / SceneTransition.SCREEN_FADE_IN_DURATION)
+	_animation_player.play("fade-in", -1, 1.0 / SceneTransition.next_fade_in_duration)
 	
 	# play a random part of the scene transition sound effect so it's not as repetitive
-	var max_audio_start := max(0.0, _audio_stream_player.stream.get_length() - SceneTransition.SCREEN_FADE_IN_DURATION)
+	var max_audio_start := max(0.0, _audio_stream_player.stream.get_length() - SceneTransition.next_fade_in_duration)
 	_audio_stream_player.play(rand_range(0.0, max_audio_start))
 
 

--- a/project/src/main/utils/scene-transition.gd
+++ b/project/src/main/utils/scene-transition.gd
@@ -1,8 +1,8 @@
 extends Node
 ## Emits scene transition signals and keeps track of the currently active scene transition.
 
-const SCREEN_FADE_OUT_DURATION := 1.2
-const SCREEN_FADE_IN_DURATION := 0.6
+const DEFAULT_FADE_OUT_DURATION := 1.2
+const DEFAULT_FADE_IN_DURATION := 0.6
 
 ## A scene transition emits these two signals in order as the screen fades out and fades back in
 signal fade_out_started
@@ -20,8 +20,8 @@ var breadcrumb_arg_array: Array
 
 ## The duration of the next fade duration (or the current one, if already fading). These can be assigned for a slower
 ## or faster fadeout, but they will reset to their default values after the next fade.
-var next_fade_in_duration := SCREEN_FADE_IN_DURATION
-var next_fade_out_duration := SCREEN_FADE_OUT_DURATION
+var next_fade_in_duration := DEFAULT_FADE_IN_DURATION
+var next_fade_out_duration := DEFAULT_FADE_OUT_DURATION
 
 ## Navigates forward one level, appending the new path to the breadcrumb trail after a scene transition.
 ##
@@ -94,7 +94,7 @@ func change_scene(skip_transition: bool = false) -> void:
 
 ## Called when the 'fade out' visual transition ends, triggering a scene transition.
 func end_fade_out() -> void:
-	next_fade_out_duration = SCREEN_FADE_OUT_DURATION
+	next_fade_out_duration = DEFAULT_FADE_OUT_DURATION
 	if breadcrumb_method:
 		breadcrumb_method.call_funcv(breadcrumb_arg_array)
 
@@ -109,7 +109,7 @@ func fade_in() -> void:
 
 ## Called when the 'fade in' visual transition ends, toggling a state variable.
 func end_fade_in() -> void:
-	next_fade_out_duration = SCREEN_FADE_IN_DURATION
+	next_fade_out_duration = DEFAULT_FADE_OUT_DURATION
 	fading = false
 
 


### PR DESCRIPTION
A few places confused fade_in_duration with fade_out_duration, or relied exclusively on the SCREEN_FADE_IN_DURATION constants instead of the customizable 'next_fade_in_duration' fields.

Renamed 'SCREEN_FADE_IN_DURATION' to 'DEFAULT_FADE_IN_DURATION'