### PR TITLE
ProgressBoard progress for Starberry Mountain

### DIFF
--- a/project/src/demo/career/ui/progress-board-demo.gd
+++ b/project/src/demo/career/ui/progress-board-demo.gd
@@ -74,6 +74,7 @@ func _input(event: InputEvent) -> void:
 
 
 func _animate_progress(distance_earned: int) -> void:
+	PlayerData.career.distance_earned = distance_earned
 	if PlayerData.career.current_region().length == Careers.MAX_DISTANCE_TRAVELLED:
 		PlayerData.career.distance_travelled = int(min(PlayerData.career.distance_travelled,
 				PlayerData.career.current_region().start + 5))

--- a/project/src/main/career/ui/progress-board.gd
+++ b/project/src/main/career/ui/progress-board.gd
@@ -148,10 +148,12 @@ func _spots_travelled_start() -> int:
 func _spots_travelled_finish() -> int:
 	var region := PlayerData.career.current_region()
 	var spots_travelled := PlayerData.career.distance_travelled - region.start
-	spots_travelled = int(clamp(spots_travelled, 0, _trail.spot_count))
 	if not region.has_end():
-		spots_travelled = int(min(spots_travelled, 30))
-	spots_travelled = int(min(spots_travelled, _trail.spot_count - 1))
+		var start_spots_travelled := PlayerData.career.progress_board_start_distance_travelled - region.start
+		start_spots_travelled = int(min(start_spots_travelled, 5))
+		
+		spots_travelled = int(min(start_spots_travelled + PlayerData.career.distance_earned, 30))
+	spots_travelled = int(clamp(spots_travelled, 0, _trail.spot_count))
 	return spots_travelled
 
 


### PR DESCRIPTION
Fixed bug where ProgressBoard would make it look like the player was progressing through Starberry Mountain even if the player quit.

The player's progress was still updated appropriately, but visually it would show them hopping along the path. Now it only advances then the number of steps they advance according to the 'distance_earned' variable.