### PR TITLE
Removed scene cruft from FreeRoam, ViewportCreatureOutline

### DIFF
--- a/project/src/demo/world/FreeRoam.tscn
+++ b/project/src/demo/world/FreeRoam.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://src/demo/world/free-roam.gd" type="Script" id=1]
 [ext_resource path="res://src/demo/world/free-roam-world.gd" type="Script" id=2]
@@ -6,8 +6,6 @@
 [ext_resource path="res://src/main/world/OverworldBg.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/world/ChatLetters.tscn" type="PackedScene" id=5]
 [ext_resource path="res://src/demo/world/FreeRoamUi.tscn" type="PackedScene" id=6]
-[ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=7]
-[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=8]
 [ext_resource path="res://src/demo/world/environment/poki/PokiFreeRoamEnvironment.tscn" type="PackedScene" id=9]
 
 [node name="FreeRoam" type="Node"]
@@ -19,9 +17,7 @@ script = ExtResource( 1 )
 script = ExtResource( 2 )
 EnvironmentScene = ExtResource( 9 )
 
-[node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 9 )]
-script = ExtResource( 7 )
-CreatureScene = ExtResource( 8 )
+[node name="Environment" parent="World" instance=ExtResource( 9 )]
 
 [node name="ChatLetters" parent="World" instance=ExtResource( 5 )]
 

--- a/project/src/main/world/creature/ViewportCreatureOutline.tscn
+++ b/project/src/main/world/creature/ViewportCreatureOutline.tscn
@@ -1,12 +1,6 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://src/main/world/creature/CreatureVisuals.tscn" type="PackedScene" id=9]
-[ext_resource path="res://assets/main/world/creature/1/leg-z0-packed.png" type="Texture" id=10]
-[ext_resource path="res://assets/main/world/creature/1/sprint-z0-packed.png" type="Texture" id=13]
-[ext_resource path="res://assets/main/world/creature/1/chin-packed.png" type="Texture" id=17]
-[ext_resource path="res://assets/main/world/creature/1/leg-z1-packed.png" type="Texture" id=19]
-[ext_resource path="res://assets/main/world/creature/1/arm-z0-packed.png" type="Texture" id=20]
-[ext_resource path="res://assets/main/world/creature/1/arm-z1-packed.png" type="Texture" id=21]
 [ext_resource path="res://src/main/utils/outline.shader" type="Shader" id=23]
 [ext_resource path="res://src/main/world/creature/viewport-creature-outline.gd" type="Script" id=24]
 
@@ -34,64 +28,6 @@ audio_listener_enable_2d = true
 
 [node name="Visuals" parent="Viewport" instance=ExtResource( 9 )]
 position = Vector2( 512, 912 )
-dna = {
-"property:Body:belly_color": Color( 0, 0, 0, 1 ),
-"property:Body:body_color": Color( 0, 0, 0, 1 ),
-"property:Body:line_color": Color( 0, 0, 0, 1 ),
-"property:Body:shadow_color": Color( 0, 0, 0, 0.25 ),
-"property:FarArm:frame_data": "res://assets/main/world/creature/1/arm-z0-packed.json",
-"property:FarArm:texture": ExtResource( 20 ),
-"property:FarLeg:frame_data": "res://assets/main/world/creature/1/leg-z0-packed.json",
-"property:FarLeg:texture": ExtResource( 10 ),
-"property:NearArm:frame_data": "res://assets/main/world/creature/1/arm-z1-packed.json",
-"property:NearArm:texture": ExtResource( 21 ),
-"property:NearLeg:frame_data": "res://assets/main/world/creature/1/leg-z1-packed.json",
-"property:NearLeg:texture": ExtResource( 19 ),
-"property:Neck0/HeadBobber/Chin:frame_data": "res://assets/main/world/creature/1/chin-packed.json",
-"property:Neck0/HeadBobber/Chin:texture": ExtResource( 17 ),
-"property:Sprint:frame_data": "res://assets/main/world/creature/1/sprint-z0-packed.json",
-"property:Sprint:texture": ExtResource( 13 ),
-"shader:Bellybutton:black": Color( 0, 0, 0, 1 ),
-"shader:Collar:black": Color( 0, 0, 0, 1 ),
-"shader:EmoteBody:black": Color( 0, 0, 0, 1 ),
-"shader:FarArm:black": Color( 0, 0, 0, 1 ),
-"shader:FarLeg:black": Color( 0, 0, 0, 1 ),
-"shader:NearArm:black": Color( 0, 0, 0, 1 ),
-"shader:NearLeg:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/AccessoryZ0:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/AccessoryZ0:blue": Color( 1, 1, 1, 1 ),
-"shader:Neck0/HeadBobber/AccessoryZ1:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/AccessoryZ1:blue": Color( 1, 1, 1, 1 ),
-"shader:Neck0/HeadBobber/AccessoryZ2:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/AccessoryZ2:blue": Color( 1, 1, 1, 1 ),
-"shader:Neck0/HeadBobber/CheekZ0:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/CheekZ1:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/CheekZ2:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/Chin:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/EarZ0:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/EarZ1:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/EarZ2:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/EmoteArmZ0:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/EmoteArmZ1:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/EmoteBrain:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/EmoteEyeZ0:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/EmoteEyeZ0:red": Color( 1, 1, 1, 1 ),
-"shader:Neck0/HeadBobber/EmoteEyeZ1:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/EmoteEyeZ1:red": Color( 1, 1, 1, 1 ),
-"shader:Neck0/HeadBobber/EyeZ0:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/EyeZ1:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/HairZ0:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/HairZ1:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/HairZ2:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/Head:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/HornZ0:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/HornZ1:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/Mouth:black": Color( 0, 0, 0, 1 ),
-"shader:Neck0/HeadBobber/Mouth:green": Color( 0.952941, 0.572549, 0.454902, 1 ),
-"shader:Neck0/HeadBobber/Nose:black": Color( 0, 0, 0, 1 ),
-"shader:TailZ0:black": Color( 0, 0, 0, 1 ),
-"shader:TailZ1:black": Color( 0, 0, 0, 1 )
-}
 
 [node name="TextureRect" type="TextureRect" parent="."]
 light_mask = 2


### PR DESCRIPTION
These properties were automatically unassigned when the scenes were opened in the Godot editor; presumably they are redundant or unnecessary