### PR TITLE
Poki fixes: Tent shadows, crowd editor animations

### DIFF
--- a/project/src/main/world/environment/poki/PokiCrowd.tscn
+++ b/project/src/main/world/environment/poki/PokiCrowd.tscn
@@ -10,7 +10,6 @@ extents = Vector2( 28, 14 )
 position = Vector2( 561.443, 360.624 )
 script = ExtResource( 2 )
 shadow_scale = 0.4
-frame = 5
 
 [node name="Sprite" type="Sprite" parent="."]
 modulate = Color( 0.239216, 0.160784, 0.121569, 1 )
@@ -20,13 +19,11 @@ centered = false
 offset = Vector2( -195, -375 )
 hframes = 4
 vframes = 5
-frame = 5
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource( 1 )
 
 [node name="WiggleTimer" type="Timer" parent="."]
 wait_time = 7.0
-autostart = true
 
 [connection signal="timeout" from="WiggleTimer" to="." method="_on_WiggleTimer_timeout"]

--- a/project/src/main/world/environment/poki/Tent.tscn
+++ b/project/src/main/world/environment/poki/Tent.tscn
@@ -10,7 +10,7 @@ extents = Vector2( 120, 14 )
 [node name="Tent" type="KinematicBody2D"]
 position = Vector2( 486.489, 339.411 )
 script = ExtResource( 3 )
-shadow_scale = 0.7
+shadow_scale = 1.2
 
 [node name="Sprite" type="Sprite" parent="."]
 material = ExtResource( 2 )

--- a/project/src/main/world/environment/poki/poki-crowd.gd
+++ b/project/src/main/world/environment/poki/poki-crowd.gd
@@ -38,7 +38,12 @@ onready var _sprite := $Sprite
 onready var _wiggle_timer := $WiggleTimer
 
 func _ready() -> void:
-	_wiggle_timer.start(rand_range(0.0, 7.0))
+	if Engine.editor_hint:
+		# don't animate the crowd member in the editor, otherwise it randomizes the 'frame' and 'wait_time' fields
+		# polluting version control
+		pass
+	else:
+		_wiggle_timer.start(rand_range(0.0, 7.0))
 	
 	_refresh()
 


### PR DESCRIPTION
Increased size of Poki Desert tents.

Poki desert's crowds no longer animate in the editor. This was polluting .tscn files with unnecessary changes.