### PR TITLE
'Welcome To Turbofat' boss level advances player to the next region.

### DIFF
--- a/project/assets/main/chat/career/lemon-2/boss-level-end-2.chat
+++ b/project/assets/main/chat/career/lemon-2/boss-level-end-2.chat
@@ -1,4 +1,4 @@
-{"version": "2476"}
+{"version": "2476", "advance_region": true}
 
 [location]
 lemon/walk


### PR DESCRIPTION
This is redundant, but consistent with the 'Lemony Thickets' boss level.