### PR TITLE
Fixed career savescum bug.

### DIFF
--- a/project/src/main/data/player-save.gd
+++ b/project/src/main/data/player-save.gd
@@ -3,6 +3,10 @@ extends Node
 ##
 ## This data includes how well they've done on each level and how much money they've earned.
 
+signal before_save
+
+signal after_save
+
 ## Current version for saved player data. Should be updated if and only if the player format changes.
 ## This version number follows a 'ymdh' hex date format which is documented in issue #234.
 const PLAYER_DATA_VERSION := "38c3"
@@ -66,6 +70,7 @@ func schedule_save() -> void:
 
 ## Writes the player's in-memory data to a save file.
 func save_player_data() -> void:
+	emit_signal("before_save")
 	var save_json := []
 	save_json.append(_save_item("version", PLAYER_DATA_VERSION).to_json_dict())
 	var player_info := {}
@@ -87,6 +92,7 @@ func save_player_data() -> void:
 			PlayerData.level_history.finished_levels).to_json_dict())
 	FileUtils.write_file(data_filename, Utils.print_json(save_json))
 	rolling_backups.rotate_backups()
+	emit_signal("after_save")
 
 
 ## Populates the player's in-memory data based on their save files.


### PR DESCRIPTION
The game had a savescum prevention feature which sabotaged the player's save data before starting a new puzzle. However, this was broken in c081854f632d4e26cc1f51c737ac5ab2c6ab7fe2 when the save data was replaced with an asynchronous system which didn't save right away.

I've expanded this code so that it is asynchronous as well, and the player's save data is temporarily sabotaged immediately before being written to disk, and then restored.