### PR TITLE
Priority customers served consecutively. Missing customer tags.

### DIFF
--- a/project/assets/main/chat/career/lemon-2/boss-level.chat
+++ b/project/assets/main/chat/career/lemon-2/boss-level.chat
@@ -6,7 +6,7 @@ lemon_2
 [characters]
 player, p1, restaurant_11
 sensei, s1, !restaurant_8
-tunathy, t, restaurant_1
+(observer) tunathy, t, restaurant_1
 (customer) sandrew, s, !restaurant_4
 
 p1: .__.; Wait... Turbo Fat?

--- a/project/assets/main/chat/career/lemon/010-a.chat
+++ b/project/assets/main/chat/career/lemon/010-a.chat
@@ -6,7 +6,7 @@ lemon
 [characters]
 player, p1, forest_9
 (customer) namory, n, forest_3
-rice, r, forest_2
+(customer) rice, r, forest_2
 
 p1: Oh hello! Have you seen someone around here, short and purple? Goes by Turbo?
 n: ^_^/ Uhh yeah, they were headed back that way! Just keep walking, you can't miss them.

--- a/project/assets/main/chat/career/lemon/020-b.chat
+++ b/project/assets/main/chat/career/lemon/020-b.chat
@@ -5,8 +5,8 @@ lemon
 
 [characters]
 player, p1, grave_3
-mcgoat, m, !grave_9
 (customer) toat, t, grave_8
+(customer) mcgoat, m, !grave_9
 
 p1: ^_^/ Wow. That is one fat squirrel!
  (toat faces left)

--- a/project/assets/main/chat/career/lemon/030-c.chat
+++ b/project/assets/main/chat/career/lemon/030-c.chat
@@ -6,7 +6,7 @@ lemon
 [characters]
 player, p1, grave_8
 (customer) mcgoat, m, !grave_1
-toat, t, !grave_3
+(customer) toat, t, !grave_3
 
 p1: Oh it's that gravesite again. But there are no squirrels here...
 p1: /._. Hmm, this cup has an inscription! I didn't notice this before. 'We won't forget -- Turbo Fat'.

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -104,10 +104,10 @@ func push_level_trail() -> void:
 		if customer_obj is String:
 			var customer_id: String = customer_obj
 			var creature_def: CreatureDef = PlayerData.creature_library.get_creature_def(customer_id)
-			PlayerData.customer_queue.priority_queue.push_front(creature_def)
+			PlayerData.customer_queue.priority_queue.append(creature_def)
 		elif customer_obj is CreatureDef:
 			var creature_def: CreatureDef = customer_obj
-			PlayerData.customer_queue.priority_queue.push_front(creature_def)
+			PlayerData.customer_queue.priority_queue.append(creature_def)
 		else:
 			push_warning("Unrecognized customer: %s" % [customer_obj])
 	SceneTransition.push_trail(Global.SCENE_PUZZLE)

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -133,6 +133,7 @@ func feed_creature(customer: Creature, food_type: int) -> void:
 func _start_puzzle() -> void:
 	PlayerData.customer_queue.reset_standard_customer_queue()
 	var current_customer_ids := []
+	_restaurant_view.reset()
 	for customer in _restaurant_view.get_customers():
 		current_customer_ids.append(customer.creature_id)
 	PlayerData.customer_queue.pop_standard_customers(current_customer_ids)


### PR DESCRIPTION
Before, the first customer would be served, and the other customers would be seated randomly. They might be served second and third, or they might never be served at all.

Added missing customer tags to some cutscenes with multiple customers.

Closes #1479.