### PR TITLE
Chatscript fixes: suppress_warnings, creature_ids, reset

### DIFF
--- a/project/src/demo/toolkit/fix-chats-button.gd
+++ b/project/src/demo/toolkit/fix-chats-button.gd
@@ -56,7 +56,7 @@ func _report_invalid_meta_creature_ids(chat_tree: ChatTree) -> void:
 						meta_creature_ids.append(meta_split[1])
 				
 				for meta_creature_id in meta_creature_ids:
-					var chat_tree_has_creature := chat_tree.spawn_locations.has(meta_creature_id)
+					var chat_tree_has_creature := chat_tree.creature_ids.has(meta_creature_id)
 					
 					if not chat_tree_has_creature:
 						chat_tree.warn("The chat key '%s' has an invalid creature id %s"

--- a/project/src/demo/toolkit/fix-creatures-button.gd
+++ b/project/src/demo/toolkit/fix-creatures-button.gd
@@ -118,14 +118,9 @@ func _career_creature_ids() -> Array:
 	# get a list of 'story creature ids' from the cutscenes
 	for path in CareerCutsceneLibrary.find_career_cutscene_resource_paths():
 		var chat_tree := ChatLibrary.chat_tree_from_file(path)
-		for creature_id in _creature_ids_from_chat_tree(chat_tree):
+		for creature_id in chat_tree.creature_ids:
 			result[creature_id] = true
 	return result.keys()
-
-
-## Returns a list of creature ids in a chat tree.
-func _creature_ids_from_chat_tree(chat_tree: ChatTree) -> Array:
-	return chat_tree.spawn_locations.keys()
 
 
 ## Returns a list of creature ids in all creature files in a directory.

--- a/project/src/main/chat/chat-tree.gd
+++ b/project/src/main/chat/chat-tree.gd
@@ -75,6 +75,9 @@ var customer_ids: Array
 ## cutscenes.
 var observer_id: String
 
+## Creatures in this cutscene.
+var creature_ids: Array
+
 ## current position in this chat tree
 var _position := Position.new()
 
@@ -157,7 +160,7 @@ func chat_environment_path() -> String:
 	var result: String
 	
 	if not ENVIRONMENT_SCENE_PATHS_BY_ID.has(location_id):
-		push_warning("Invalid location_id: %s" % [location_id])
+		warn("Invalid location_id: %s" % [location_id])
 	
 	result = ENVIRONMENT_SCENE_PATHS_BY_ID.get(location_id, DEFAULT_ENVIRONMENT)
 	
@@ -175,7 +178,12 @@ func reset() -> void:
 	events = {}
 	location_id = ""
 	spawn_locations = {}
+	chef_id = ""
+	customer_ids = []
+	observer_id = ""
+	creature_ids = []
 	_position.reset()
+	_did_prepare = false
 
 
 ## Returns 'true' if this cutscene is set inside the restaurant.
@@ -189,7 +197,7 @@ func inside_restaurant() -> bool:
 ##
 ## This signifies that this cutscene should not be played if Fat Sensei is not following the player.
 func has_sensei() -> bool:
-	return spawn_locations.has(CreatureLibrary.SENSEI_ID)
+	return creature_ids.has(CreatureLibrary.SENSEI_ID)
 
 
 ## Suppresses warnings from showing up on the console.
@@ -207,7 +215,7 @@ func warn(warning: String) -> void:
 		meta["warnings"] = []
 	meta["warnings"].append(warning)
 	
-	if meta.get("suppress_warnings", false):
+	if not meta.get("suppress_warnings", false):
 		push_warning(warning)
 
 
@@ -233,7 +241,7 @@ func _apply_start_if_conditions() -> void:
 	
 	if start_keys.size() >= 2:
 		# if two or more 'start_if' conditions are met, report a warning
-		push_warning("Multiple start_if conditions were met: %s" % [[start_keys]])
+		warn("Multiple start_if conditions were met: %s" % [[start_keys]])
 
 
 ## Skip any dialog lines whose 'say_if' conditions are unmet.
@@ -275,7 +283,7 @@ func _assign_flags_and_phrases() -> void:
 ## 	'args': The statement's arguments, such as ['dog_breed', 'Labrador' 'Retriever']
 func _process_default_phrase_statement(args: Array) -> void:
 	if args.size() < 2:
-		push_warning("Invalid argument count for default_phrase call. Expected at least 2 but was %s"
+		warn("Invalid argument count for default_phrase call. Expected at least 2 but was %s"
 				% [args.size()])
 		return
 	
@@ -298,7 +306,7 @@ func _process_set_flag_statement(args: Array) -> void:
 		2:
 			PlayerData.chat_history.set_flag(args[0], args[1])
 		_:
-			push_warning("Invalid argument count for set_flag call. Expected 1 or 2 but was %s"
+			warn("Invalid argument count for set_flag call. Expected 1 or 2 but was %s"
 					% [args.size()])
 
 
@@ -310,7 +318,7 @@ func _process_set_flag_statement(args: Array) -> void:
 ## 	'args': The statement's arguments, such as ['dog_breed', 'Labrador', 'Retriever]
 func _process_set_phrase_statement(args: Array) -> void:
 	if args.size() < 2:
-		push_warning("Invalid argument count for set_phrase call. Expected at least 2 but was %s"
+		warn("Invalid argument count for set_phrase call. Expected at least 2 but was %s"
 				% [args.size()])
 		return
 	
@@ -326,7 +334,7 @@ func _process_set_phrase_statement(args: Array) -> void:
 ## 	'args': The statement's arguments, such as ['foo'].
 func _process_unset_flag_statement(args: Array) -> void:
 	if args.size() != 1:
-		push_warning("Invalid argument count for unset_flag call. Expected 1 but was %s"
+		warn("Invalid argument count for unset_flag call. Expected 1 but was %s"
 				% [args.size()])
 	
 	PlayerData.chat_history.unset_flag(args[0])

--- a/project/src/main/chat/chatscript-parser.gd
+++ b/project/src/main/chat/chatscript-parser.gd
@@ -120,6 +120,7 @@ class CharactersState extends AbstractState:
 		
 		# parse character name
 		character_name = StringUtils.hashwrap_constants(character_name)
+		chat_tree.creature_ids.append(character_name)
 		
 		# parse (chef) prefix
 		if character_prefix == "(chef)":

--- a/project/src/test/chat/test-chat-tree.gd
+++ b/project/src/test/chat/test-chat-tree.gd
@@ -15,8 +15,8 @@ func test_inside_restaurant() -> void:
 func test_has_sensei() -> void:
 	assert_eq(chat_tree.has_sensei(), false)
 	
-	chat_tree.spawn_locations[CreatureLibrary.PLAYER_ID] = "kitchen_7"
+	chat_tree.creature_ids.append(CreatureLibrary.PLAYER_ID)
 	assert_eq(chat_tree.has_sensei(), false)
 	
-	chat_tree.spawn_locations[CreatureLibrary.SENSEI_ID] = "kitchen_5"
+	chat_tree.creature_ids.append(CreatureLibrary.SENSEI_ID)
 	assert_eq(chat_tree.has_sensei(), true)

--- a/project/src/test/chat/test-chatscript-parser.gd
+++ b/project/src/test/chat/test-chatscript-parser.gd
@@ -48,6 +48,16 @@ func test_overall_meta() -> void:
 	assert_eq(chat_tree.meta.get("fixed_zoom"), 1.0)
 
 
+func test_cutscene_creature_ids() -> void:
+	var chat_tree := _chat_tree_from_file(CUTSCENE_FULL)
+	
+	assert_has(chat_tree.creature_ids, "#player#")
+	assert_has(chat_tree.creature_ids, "#sensei#")
+	assert_has(chat_tree.creature_ids, "richie")
+	assert_has(chat_tree.creature_ids, "skins")
+	assert_has(chat_tree.creature_ids, "bones")
+
+
 func test_cutscene_spawn_locations() -> void:
 	var chat_tree := _chat_tree_from_file(CUTSCENE_FULL)
 	


### PR DESCRIPTION
Fixed Chatscript suppress_warnings metadata. This was doing the exact opposite of what it was supposed to do, and only reporting warnings if suppress_warnings was true. I've also fixed many push_warning calls in ChatTree which seemed like they were accidentally sidestepping this mechanism.

Added ChatTree.creature_ids field. In most cases this is redundant with spawn_locations, but the walking cutscenes don't define spawn locations even though they have 2-3 characters (player, sensei, narrator). These walking cutscenes were reporting that they had 0 characters which caused false positive ReleaseToolkit warnings.

Fixed ChatTree.reset() method, which was skipping several newly introduced fields.