### PR TITLE
Playfield fx/pickup refactoring for night mode.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -859,6 +859,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/editor/puzzle/playfield-editor-control.gd"
 }, {
+"base": "Node2D",
+"class": "PlayfieldFx",
+"language": "GDScript",
+"path": "res://src/main/puzzle/playfield-fx.gd"
+}, {
 "base": "VBoxContainer",
 "class": "PlayfieldNav",
 "language": "GDScript",
@@ -1089,6 +1094,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/puzzle/level/speed-rules.gd"
 }, {
+"base": "Control",
+"class": "SquishFx",
+"language": "GDScript",
+"path": "res://src/main/puzzle/piece/squish-fx.gd"
+}, {
 "base": "PuzzleTileMap",
 "class": "SquishMap",
 "language": "GDScript",
@@ -1098,6 +1108,11 @@ _global_script_classes=[ {
 "class": "StarSeed",
 "language": "GDScript",
 "path": "res://src/main/puzzle/star-seed.gd"
+}, {
+"base": "Control",
+"class": "StarSeeds",
+"language": "GDScript",
+"path": "res://src/main/puzzle/star-seeds.gd"
 }, {
 "base": "Node",
 "class": "State",
@@ -1385,6 +1400,7 @@ _global_script_class_icons={
 "PlayerSaveUpgrader": "",
 "Playfield": "",
 "PlayfieldEditorControl": "",
+"PlayfieldFx": "",
 "PlayfieldNav": "",
 "PokiCrowd": "",
 "Population": "",
@@ -1431,8 +1447,10 @@ _global_script_class_icons={
 "SmoothPath": "",
 "Spawn": "",
 "SpeedRules": "",
+"SquishFx": "",
 "SquishMap": "",
 "StarSeed": "",
+"StarSeeds": "",
 "State": "",
 "StateMachine": "",
 "Sticker": "",

--- a/project/src/main/puzzle/critter/moles.gd
+++ b/project/src/main/puzzle/critter/moles.gd
@@ -159,7 +159,7 @@ func _mole_cell_has_block(mole_cell: Vector2) -> bool:
 
 ## Returns 'true' if the specified cell has a pickup.
 func _mole_cell_has_pickup(mole_cell: Vector2) -> bool:
-	return _playfield.pickups.get_pickup(mole_cell) != TileMap.INVALID_CELL
+	return _playfield.pickups.get_pickup_food_type(mole_cell) != TileMap.INVALID_CELL
 
 
 ## Returns 'true' if the specified cell has a mole.

--- a/project/src/main/puzzle/pickups.gd
+++ b/project/src/main/puzzle/pickups.gd
@@ -52,13 +52,22 @@ func _ready() -> void:
 	_prepare_pickups_for_level()
 
 
-## Returns the pickup at the specified playfield cell.
+func get_cells_with_pickups() -> Array:
+	return _pickups_by_cell.keys()
+
+
+## Returns the pickup food type at the specified playfield cell.
 ##
 ## Returns TileMap.INVALID_CELL if the specified cell has no pickup.
-func get_pickup(cell: Vector2) -> int:
+func get_pickup_food_type(cell: Vector2) -> int:
 	if not _pickups_by_cell.has(cell):
 		return TileMap.INVALID_CELL
 	return _pickups_by_cell[cell].food_type
+
+
+## Returns the pickup at the specified playfield cell.
+func get_pickup(cell: Vector2) -> Pickup:
+	return _pickups_by_cell.get(cell)
 
 
 ## Adds or replaces a pickup in a playfield cell.
@@ -106,7 +115,7 @@ func set_piece_manager_path(new_piece_manager_path: NodePath) -> void:
 func row_is_empty(y: int) -> bool:
 	var row_is_empty := true
 	for x in range(PuzzleTileMap.COL_COUNT):
-		if not get_pickup(Vector2(x, y)) == TileMap.INVALID_CELL:
+		if not get_pickup_food_type(Vector2(x, y)) == TileMap.INVALID_CELL:
 			row_is_empty = false
 			break
 	return row_is_empty

--- a/project/src/main/puzzle/piece/next-piece-displays.gd
+++ b/project/src/main/puzzle/piece/next-piece-displays.gd
@@ -19,6 +19,10 @@ func _ready() -> void:
 		_add_display(i, 5, 5 + i * (486.0 / (DISPLAY_COUNT - 1)), 0.5)
 
 
+func get_display(piece_index: int) -> NextPieceDisplay:
+	return _next_piece_displays[piece_index]
+
+
 ## Adds a new next piece display.
 func _add_display(piece_index: int, x: float, y: float, scale: float) -> void:
 	var new_display: NextPieceDisplay = NextPieceDisplayScene.instance()

--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -252,6 +252,10 @@ func finish_squish_move(squish_piece: ActivePiece, lines_cleared: int) -> void:
 	emit_signal("finished_squish_move", squish_piece, lines_cleared)
 
 
+func get_squish_fx() -> SquishFx:
+	return $SquishFx as SquishFx
+
+
 func _prepare_tileset() -> void:
 	tile_map.puzzle_tile_set_type = CurrentLevel.settings.other.tile_set
 

--- a/project/src/main/puzzle/playfield-fx.gd
+++ b/project/src/main/puzzle/playfield-fx.gd
@@ -1,3 +1,4 @@
+class_name PlayfieldFx
 extends Node2D
 ## Generates visual lighting effects for the playfield.
 ##
@@ -78,13 +79,13 @@ var _color_tile_indexes: Dictionary
 onready var _combo_tracker: ComboTracker = get_node(combo_tracker_path)
 
 ## lights which turn on and off
-onready var _light_map: TileMap = $LightMap
+onready var light_map: TileMap = $LightMap
 
 ## glowy effect around the lights
-onready var _glow_map: TileMap = $GlowMap
+onready var glow_map: TileMap = $GlowMap
 
 ## bright flash when the player clears a line
-onready var _bg_strobe: ColorRect = $BgStrobe
+onready var bg_strobe: ColorRect = $BgStrobe
 
 ## gradually dims the glowiness
 onready var _glow_tween: Tween = $GlowTween
@@ -107,15 +108,15 @@ func _process(delta: float) -> void:
 func reset() -> void:
 	_pattern = OFF_PATTERN
 	_color = RAINBOW_LIGHT_COLOR
-	_light_map.modulate = Color.transparent
-	_glow_map.modulate = Color.transparent
+	light_map.modulate = Color.transparent
+	glow_map.modulate = Color.transparent
 	_calculate_brightness(0)
 	_refresh_tile_maps()
 
 
 ## Initializes the different colored tiles in LightMap/GlowMap.
 func _init_tile_set() -> void:
-	if len(_light_map.tile_set.get_tiles_ids()) > 1:
+	if len(light_map.tile_set.get_tiles_ids()) > 1:
 		return
 	
 	for food_light_color in FOOD_LIGHT_COLORS:
@@ -134,13 +135,13 @@ func _init_color_tile_indexes() -> void:
 	if _color_tile_indexes:
 		return
 	
-	for tile_index in _light_map.tile_set.get_tiles_ids():
-		var color: Color = _light_map.tile_set.tile_get_modulate(tile_index)
+	for tile_index in light_map.tile_set.get_tiles_ids():
+		var color: Color = light_map.tile_set.tile_get_modulate(tile_index)
 		_color_tile_indexes[color] = tile_index
 
 
 func _init_tile(color: Color) -> void:
-	for tile_set in [_light_map.tile_set, _glow_map.tile_set]:
+	for tile_set in [light_map.tile_set, glow_map.tile_set]:
 		var tile_index := len(tile_set.get_tiles_ids())
 		tile_set.create_tile(tile_index)
 		tile_set.tile_set_texture(tile_index, tile_set.tile_get_texture(0))
@@ -153,11 +154,11 @@ func _init_tile(color: Color) -> void:
 func _start_glow_tween() -> void:
 	if _brightness > 0 and _glow_duration > 0.0:
 		_glow_tween.remove_all()
-		_glow_tween.interpolate_property(_light_map, "modulate:a", 1.00, 0.50,
+		_glow_tween.interpolate_property(light_map, "modulate:a", 1.00, 0.50,
 			_glow_duration, Tween.TRANS_CIRC, Tween.EASE_OUT)
-		_glow_tween.interpolate_property(_glow_map, "modulate:a", 0.75, 0.125,
+		_glow_tween.interpolate_property(glow_map, "modulate:a", 0.75, 0.125,
 			_glow_duration, Tween.TRANS_CIRC, Tween.EASE_OUT)
-		_glow_tween.interpolate_property(_bg_strobe, "color:a", 0.33, 0.00,
+		_glow_tween.interpolate_property(bg_strobe, "color:a", 0.33, 0.00,
 			_glow_duration, Tween.TRANS_CIRC, Tween.EASE_OUT)
 		_glow_tween.start()
 
@@ -206,7 +207,7 @@ func _calculate_brightness(combo: int) -> void:
 
 ## Calculates the new light pattern and refreshes the tile maps.
 func _refresh_tile_maps() -> void:
-	_bg_strobe.color = Utils.to_transparent(_color)
+	bg_strobe.color = Utils.to_transparent(_color)
 	
 	var old_pattern := _pattern
 	var new_pattern: Array = OFF_PATTERN
@@ -230,8 +231,8 @@ func _refresh_tile_maps() -> void:
 						tile = 6 + ((x + _pattern_y) % RAINBOW_COLOR_COUNT)
 					elif _color_tile_indexes.has(_color):
 						tile = _color_tile_indexes[_color]
-				_light_map.set_cell(x, y, tile)
-				_glow_map.set_cell(x, y, tile)
+				light_map.set_cell(x, y, tile)
+				glow_map.set_cell(x, y, tile)
 
 
 func _on_Playfield_before_line_cleared(_y: int, _total_lines: int, _remaining_lines: int, box_ints: Array) -> void:

--- a/project/src/main/puzzle/star-seeds.gd
+++ b/project/src/main/puzzle/star-seeds.gd
@@ -1,3 +1,4 @@
+class_name StarSeeds
 extends Control
 ## Draws shadowy stars and seeds inside snack boxes and cake boxes.
 ##
@@ -87,6 +88,14 @@ onready var _puzzle_tile_map: PuzzleTileMap = get_node(puzzle_tile_map_path)
 
 func _ready() -> void:
 	Pauser.connect("paused_changed", self, "_on_Pauser_paused_changed")
+
+
+func get_cells_with_star_seeds() -> Array:
+	return _star_seeds_by_cell.keys()
+
+
+func get_star_seed(cell: Vector2) -> StarSeed:
+	return _star_seeds_by_cell.get(cell)
 
 
 ## Detects boxes in the playfield, and places star seeds in them.


### PR DESCRIPTION
Expanded Pickups.get_pickup() method name to
get_pickup_food_type(). Other scripts want access to the actual pickup nodes so that they can figure out the pickup's state and position.

Exposed SquishFx fields. The upcoming nighttime SquishFx needs access to these fields to copy its state.

New utility methods: Pickups.get_cells_with_pickups(), PieceManager.get_squish_fx(), NextPieceDisplays.get_display()