### PR TITLE
Muffle music during nighttime.

### DIFF
--- a/project/src/main/music/MusicPlayer.tscn
+++ b/project/src/main/music/MusicPlayer.tscn
@@ -147,4 +147,7 @@ song_color = Color( 0.913725, 0.905882, 0.47451, 1 )
 [node name="MusicTween" type="Tween" parent="."]
 script = ExtResource( 4 )
 
+[node name="FilterTween" type="Tween" parent="."]
+
+[connection signal="tween_completed" from="FilterTween" to="." method="_on_FilterTween_tween_completed"]
 [connection signal="tween_completed" from="MusicTween" to="MusicTween" method="_on_tween_completed"]

--- a/project/src/main/puzzle/night-mode-toggler.gd
+++ b/project/src/main/puzzle/night-mode-toggler.gd
@@ -27,6 +27,11 @@ var _night_mode := false
 ## Adjusts node colors and visibility during day/night transitions.
 onready var _tween := $Tween
 
+func _exit_tree() -> void:
+	# unset night filter if it was enabled
+	MusicPlayer.night_filter = false
+
+
 ## Transition the puzzle to day/night mode, with an accompanying visual effect.
 ##
 ## Parameters:
@@ -39,6 +44,7 @@ func set_night_mode(new_night_mode: bool, duration := TWEEN_DURATION) -> void:
 		return
 	_night_mode = new_night_mode
 	
+	MusicPlayer.night_filter = _night_mode
 	_start_night_tween(duration)
 
 

--- a/project/src/main/settings/default-bus-layout.tres
+++ b/project/src/main/settings/default-bus-layout.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AudioBusLayout" load_steps=2 format=2]
+[gd_resource type="AudioBusLayout" load_steps=3 format=2]
 
 [sub_resource type="AudioEffectReverb" id=1]
 resource_name = "Reverb"
@@ -8,6 +8,12 @@ damping = 0.05
 spread = 0.2
 hipass = 0.5
 wet = 0.15
+
+[sub_resource type="AudioEffectLowPassFilter" id=2]
+resource_name = "LowPassFilter"
+cutoff_hz = 500.0
+resonance = 0.4
+db = 2
 
 [resource]
 bus/1/name = "Sound Bus"
@@ -30,3 +36,5 @@ bus/3/mute = false
 bus/3/bypass_fx = false
 bus/3/volume_db = -6.0
 bus/3/send = "Master"
+bus/3/effect/0/effect = SubResource( 2 )
+bus/3/effect/0/enabled = false


### PR DESCRIPTION
This adds a low-pass filter to the music bus. The filter is disabled by default, and disabled again when the 'NightModeToggler' exits the scene tree which should prevent any possibility of the low-pass music filter being left on inadvertently.