### PR TITLE
New level trigger phases: 'before_start', 'start'

### DIFF
--- a/project/src/main/puzzle/level/level-trigger.gd
+++ b/project/src/main/puzzle/level/level-trigger.gd
@@ -8,6 +8,7 @@ class_name LevelTrigger
 ## phases when a level trigger can fire
 enum LevelTriggerPhase {
 	AFTER_PIECE_WRITTEN, # after the piece is written, and all boxes are made, and all lines are cleared
+	BEFORE_START, # when the game will start soon, including when the puzzle is first shown
 	BOX_BUILT, # when a snack/cake box is built
 	COMBO_ENDED, # when the player breaks their combo
 	INITIAL_ROTATED_CW, # when the piece is rotated clockwise using initial DAS
@@ -19,6 +20,7 @@ enum LevelTriggerPhase {
 	ROTATED_CW, # when the piece is rotated clockwise
 	ROTATED_CCW, # when the piece is rotated counterclockwise
 	ROTATED_180, # when the piece is flipped
+	START, # after the initial countdown finishes, when the player can start playing.
 	TIMER_0, # when timer 0 times out
 	TIMER_1, # when timer 1 times out
 	TIMER_2, # when timer 2 times out
@@ -32,6 +34,7 @@ enum LevelTriggerPhase {
 }
 
 const AFTER_PIECE_WRITTEN := LevelTriggerPhase.AFTER_PIECE_WRITTEN
+const BEFORE_START := LevelTriggerPhase.BEFORE_START
 const BOX_BUILT := LevelTriggerPhase.BOX_BUILT
 const COMBO_ENDED := LevelTriggerPhase.COMBO_ENDED
 const INITIAL_ROTATED_CW := LevelTriggerPhase.INITIAL_ROTATED_CW
@@ -43,6 +46,7 @@ const PIECE_WRITTEN := LevelTriggerPhase.PIECE_WRITTEN
 const ROTATED_CW := LevelTriggerPhase.ROTATED_CW
 const ROTATED_CCW := LevelTriggerPhase.ROTATED_CCW
 const ROTATED_180 := LevelTriggerPhase.ROTATED_180
+const START := LevelTriggerPhase.START
 const TIMER_0 := LevelTriggerPhase.TIMER_0
 const TIMER_1 := LevelTriggerPhase.TIMER_1
 const TIMER_2 := LevelTriggerPhase.TIMER_2

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -435,6 +435,7 @@ func _prepare_game() -> void:
 	_timers.clear()
 	emit_signal("game_prepared")
 	emit_signal("after_game_prepared")
+	CurrentLevel.settings.triggers.run_triggers(LevelTrigger.BEFORE_START)
 
 
 func _start_game() -> void:
@@ -445,6 +446,7 @@ func _start_game() -> void:
 	# initialize input_frame to allow for recording/replaying inputs
 	input_frame = 0
 	emit_signal("game_started")
+	CurrentLevel.settings.triggers.run_triggers(LevelTrigger.START)
 
 
 func _add_score(delta: int) -> void:

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -13,6 +13,8 @@ func _ready() -> void:
 	PuzzleState.connect("game_started", self, "_on_PuzzleState_game_started")
 	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")
 	PuzzleState.connect("after_level_changed", self, "_on_PuzzleState_after_level_changed")
+	CurrentLevel.connect("settings_changed", self, "_on_Level_settings_changed")
+	
 	$Fg/Playfield/TileMapClip/TileMap/ShadowViewport/ShadowMap.piece_tile_map = $Fg/PieceManager/TileMap
 	$Fg/Playfield/TileMapClip/TileMap/GhostPieceViewport/ShadowMap.piece_tile_map = $Fg/PieceManager/TileMap
 	$Fg/Playfield.pickups.piece_manager_path = $Fg/Playfield.pickups.get_path_to($Fg/PieceManager)
@@ -36,6 +38,8 @@ func _ready() -> void:
 		$PuzzleMusicManager.start_puzzle_music()
 		yield(get_tree().create_timer(0.8), "timeout")
 		_start_puzzle()
+	else:
+		CurrentLevel.settings.triggers.run_triggers(LevelTrigger.BEFORE_START)
 
 
 func _exit_tree() -> void:
@@ -336,3 +340,9 @@ func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDete
 				PuzzleState.level_performance.seconds = finish_condition.adjusted_value()
 		
 		detector.play_cheat_sound(true)
+
+
+func _on_Level_settings_changed() -> void:
+	CurrentLevel.settings.triggers.run_triggers(LevelTrigger.BEFORE_START)
+	if PuzzleState.game_active:
+		CurrentLevel.settings.triggers.run_triggers(LevelTrigger.START)


### PR DESCRIPTION
The new onion levels want to start onions in the air, so they want to be able to add an onion immediately when the level starts -- or even when it first loads. These new phases allow for this.