### PR TITLE
Fixed bugs with onion, nighttime when restarting levels.

### DIFF
--- a/project/src/demo/puzzle/critter/onion-demo.gd
+++ b/project/src/demo/puzzle/critter/onion-demo.gd
@@ -7,6 +7,7 @@ extends Node
 ## [2]: Dance End
 ## [3]: Night
 ## [4]: Disappear
+## [N]: Skip to night mode
 
 onready var _onion := $Onion
 
@@ -17,3 +18,4 @@ func _input(event: InputEvent) -> void:
 		KEY_2: _onion.state = OnionConfig.OnionState.DAY_END
 		KEY_3: _onion.state = OnionConfig.OnionState.NIGHT
 		KEY_4: _onion.state = OnionConfig.OnionState.NONE
+		KEY_N: _onion.skip_to_night_mode()

--- a/project/src/demo/puzzle/puzzle-critter-demo.gd
+++ b/project/src/demo/puzzle/puzzle-critter-demo.gd
@@ -92,14 +92,19 @@ func _onion_input(event: InputEvent) -> void:
 		KEY_0:
 			$Puzzle/Fg/Critters/Onions.remove_onion()
 		KEY_1:
+			$Puzzle/Fg/Critters/Onions.remove_onion()
 			$Puzzle/Fg/Critters/Onions.add_onion(OnionConfig.new("denn."))
 		KEY_2:
 			$Puzzle/Fg/Critters/Onions.advance_onion()
 		KEY_3:
+			$Puzzle/Fg/Critters/Onions.remove_onion()
 			$Puzzle/Fg/Critters/Onions.add_onion(OnionConfig.new("dd"))
 		KEY_4:
+			$Puzzle/Fg/Critters/Onions.remove_onion()
 			$Puzzle/Fg/Critters/Onions.add_onion(OnionConfig.new("ee"))
 		KEY_5:
+			$Puzzle/Fg/Critters/Onions.remove_onion()
 			$Puzzle/Fg/Critters/Onions.add_onion(OnionConfig.new("nn"))
 		KEY_6:
+			$Puzzle/Fg/Critters/Onions.remove_onion()
 			$Puzzle/Fg/Critters/Onions.add_onion(OnionConfig.new(".."))

--- a/project/src/main/puzzle/critter/Onion.tscn
+++ b/project/src/main/puzzle/critter/Onion.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=49 format=2]
+[gd_scene load_steps=51 format=2]
 
 [ext_resource path="res://src/main/puzzle/critter/OnionStateMachine.tres" type="AnimationNodeStateMachine" id=1]
 [ext_resource path="res://src/main/puzzle/critter/onion.gd" type="Script" id=2]
@@ -580,18 +580,6 @@ tracks/4/keys = {
 "update": 1,
 "values": [ true ]
 }
-tracks/5/type = "value"
-tracks/5/path = NodePath("Sfx/Kaboom:playing")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
-"update": 1,
-"values": [ true ]
-}
 
 [sub_resource type="Animation" id=15]
 resource_name = "land"
@@ -891,6 +879,59 @@ tracks/4/keys = {
 "values": [ false ]
 }
 
+[sub_resource type="Animation" id=27]
+resource_name = "skip-to-float"
+length = 0.1
+step = 0.0333333
+tracks/0/type = "value"
+tracks/0/path = NodePath("Soil:visible")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("Onion:visible")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath(".:onion_location")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ 2 ]
+}
+tracks/3/type = "value"
+tracks/3/path = NodePath(".:float_animation_playing")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ true ]
+}
+
 [sub_resource type="Animation" id=12]
 resource_name = "soar"
 length = 0.4
@@ -955,6 +996,71 @@ tracks/4/keys = {
 "transitions": PoolRealArray( 1 ),
 "update": 1,
 "values": [ false ]
+}
+
+[sub_resource type="Animation" id=26]
+resource_name = "start-float"
+length = 0.1
+step = 0.0333333
+tracks/0/type = "value"
+tracks/0/path = NodePath("Soil:visible")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("Onion:visible")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath(".:onion_location")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ 2 ]
+}
+tracks/3/type = "value"
+tracks/3/path = NodePath(".:float_animation_playing")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ true ]
+}
+tracks/4/type = "value"
+tracks/4/path = NodePath("Sfx/Kaboom:playing")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ true ]
 }
 
 [sub_resource type="Animation" id=24]
@@ -1155,12 +1261,10 @@ tracks/8/keys = {
 script = ExtResource( 2 )
 
 [node name="Soil" type="Sprite" parent="."]
-visible = false
 position = Vector2( 0, -6.93842 )
 texture = ExtResource( 16 )
 
 [node name="Onion" type="Sprite" parent="."]
-visible = false
 position = Vector2( 0, -6.93842 )
 texture = ExtResource( 11 )
 offset = Vector2( -3, 0 )
@@ -1189,7 +1293,9 @@ anims/land = SubResource( 15 )
 anims/launch = SubResource( 11 )
 anims/none = SubResource( 23 )
 anims/plummet = SubResource( 13 )
+anims/skip-to-float = SubResource( 27 )
 anims/soar = SubResource( 12 )
+anims/start-float = SubResource( 26 )
 anims/start-plummet = SubResource( 24 )
 anims/stun = SubResource( 14 )
 

--- a/project/src/main/puzzle/critter/OnionStateMachine.tres
+++ b/project/src/main/puzzle/critter/OnionStateMachine.tres
@@ -1,4 +1,4 @@
-[gd_resource type="AnimationNodeStateMachine" load_steps=34 format=2]
+[gd_resource type="AnimationNodeStateMachine" load_steps=40 format=2]
 
 [sub_resource type="AnimationNodeAnimation" id=1]
 animation = "dance-end-start"
@@ -24,8 +24,14 @@ animation = "none"
 [sub_resource type="AnimationNodeAnimation" id=28]
 animation = "plummet"
 
+[sub_resource type="AnimationNodeAnimation" id=35]
+animation = "skip-to-float"
+
 [sub_resource type="AnimationNodeAnimation" id=8]
 animation = "soar"
+
+[sub_resource type="AnimationNodeAnimation" id=36]
+animation = "start-float"
 
 [sub_resource type="AnimationNodeAnimation" id=7]
 animation = "start-plummet"
@@ -106,6 +112,20 @@ advance_condition = "floating"
 [sub_resource type="AnimationNodeStateMachineTransition" id=34]
 advance_condition = "dancing"
 
+[sub_resource type="AnimationNodeStateMachineTransition" id=37]
+advance_condition = "location_sky"
+
+[sub_resource type="AnimationNodeStateMachineTransition" id=38]
+switch_mode = 2
+auto_advance = true
+
+[sub_resource type="AnimationNodeStateMachineTransition" id=39]
+switch_mode = 2
+auto_advance = true
+
+[sub_resource type="AnimationNodeStateMachineTransition" id=40]
+advance_condition = "not_floating"
+
 [resource]
 resource_name = "onion_location_sky"
 states/dance/node = SubResource( 2 )
@@ -115,7 +135,7 @@ states/dance-end/position = Vector2( 306, -70.011 )
 states/dance-end-start/node = SubResource( 1 )
 states/dance-end-start/position = Vector2( 14, -80.011 )
 states/float/node = SubResource( 3 )
-states/float/position = Vector2( 631, 55.989 )
+states/float/position = Vector2( 752, 96.989 )
 states/land/node = SubResource( 4 )
 states/land/position = Vector2( -207, 137.989 )
 states/launch/node = SubResource( 5 )
@@ -124,12 +144,16 @@ states/none/node = SubResource( 6 )
 states/none/position = Vector2( -207, -19.011 )
 states/plummet/node = SubResource( 28 )
 states/plummet/position = Vector2( 71, 233.989 )
+states/skip-to-float/node = SubResource( 35 )
+states/skip-to-float/position = Vector2( 933, 96.989 )
 states/soar/node = SubResource( 8 )
 states/soar/position = Vector2( 457, -28.011 )
+states/start-float/node = SubResource( 36 )
+states/start-float/position = Vector2( 616, -19.011 )
 states/start-plummet/node = SubResource( 7 )
 states/start-plummet/position = Vector2( 347, 203.989 )
 states/stun/node = SubResource( 9 )
-states/stun/position = Vector2( 586, 183.989 )
-transitions = [ "none", "dance", SubResource( 11 ), "land", "dance", SubResource( 12 ), "dance", "launch", SubResource( 13 ), "launch", "soar", SubResource( 14 ), "soar", "float", SubResource( 15 ), "float", "stun", SubResource( 16 ), "stun", "start-plummet", SubResource( 17 ), "start-plummet", "land", SubResource( 18 ), "dance", "dance-end-start", SubResource( 19 ), "dance-end-start", "launch", SubResource( 20 ), "none", "dance-end-start", SubResource( 21 ), "land", "dance-end-start", SubResource( 22 ), "soar", "start-plummet", SubResource( 23 ), "start-plummet", "soar", SubResource( 24 ), "land", "launch", SubResource( 25 ), "none", "launch", SubResource( 26 ), "dance-end-start", "dance", SubResource( 27 ), "start-plummet", "plummet", SubResource( 29 ), "plummet", "land", SubResource( 30 ), "dance-end-start", "dance-end", SubResource( 32 ), "dance-end", "launch", SubResource( 33 ), "dance-end", "dance", SubResource( 34 ) ]
+states/stun/position = Vector2( 616, 203.989 )
+transitions = [ "none", "dance", SubResource( 11 ), "land", "dance", SubResource( 12 ), "dance", "launch", SubResource( 13 ), "launch", "soar", SubResource( 14 ), "soar", "float", SubResource( 15 ), "float", "stun", SubResource( 16 ), "stun", "start-plummet", SubResource( 17 ), "start-plummet", "land", SubResource( 18 ), "dance", "dance-end-start", SubResource( 19 ), "dance-end-start", "launch", SubResource( 20 ), "none", "dance-end-start", SubResource( 21 ), "land", "dance-end-start", SubResource( 22 ), "soar", "start-plummet", SubResource( 23 ), "start-plummet", "soar", SubResource( 24 ), "land", "launch", SubResource( 25 ), "none", "launch", SubResource( 26 ), "dance-end-start", "dance", SubResource( 27 ), "start-plummet", "plummet", SubResource( 29 ), "plummet", "land", SubResource( 30 ), "dance-end-start", "dance-end", SubResource( 32 ), "dance-end", "launch", SubResource( 33 ), "dance-end", "dance", SubResource( 34 ), "soar", "start-float", SubResource( 37 ), "start-float", "float", SubResource( 38 ), "skip-to-float", "float", SubResource( 39 ), "start-float", "stun", SubResource( 40 ) ]
 start_node = "none"
-graph_offset = Vector2( -370, -147.011 )
+graph_offset = Vector2( -78, -131.011 )

--- a/project/src/main/puzzle/critter/onion.gd
+++ b/project/src/main/puzzle/critter/onion.gd
@@ -124,6 +124,23 @@ func emit_dirt_particles() -> void:
 	_dirt_particles.emitting = true
 
 
+## Immediately puts the onion in the sky without an animation.
+##
+## This is used when initially loading a night level, or when restarting a permanently dark level.
+func skip_to_night_mode() -> void:
+	# There is no path to the 'skip-to-float' node, so the animation tree always warps there instantly. 
+	_animation_tree["parameters/playback"].travel("skip-to-float")
+
+
+## Resets the onion to the first state in its day/night cycle.
+func reset_cycle() -> void:
+	if not _next_states:
+		set_state(OnionConfig.OnionState.NONE)
+	else:
+		_current_state_index = 0
+		set_state(_next_states[_current_state_index])
+
+
 ## Updates the state machine's state to match the value of the 'state' enum.
 func _refresh_state() -> void:
 	if not is_inside_tree():

--- a/project/src/main/puzzle/night-mode-toggler.gd
+++ b/project/src/main/puzzle/night-mode-toggler.gd
@@ -48,6 +48,10 @@ func set_night_mode(new_night_mode: bool, duration := TWEEN_DURATION) -> void:
 	_start_night_tween(duration)
 
 
+func is_night_mode() -> bool:
+	return _night_mode
+
+
 ## Tweens the modulate properties of all daytime/nighttime nodes in the scene tree.
 ##
 ## This finds all nodes in the 'night_mode_...' groups and adjusts their modulate property appropriately. This usually

--- a/project/src/main/puzzle/onion-playfield-tile-map.gd
+++ b/project/src/main/puzzle/onion-playfield-tile-map.gd
@@ -20,6 +20,14 @@ func _reset() -> void:
 	_silhouettes_by_cell.clear()
 
 
+## When assigned a tilemap, we immediately refresh our silhouettes.
+##
+## This allows the silhouettes to be visible when a puzzle is first loaded, so the player can't see any gaps.
+func set_source_tile_map(new_source_tile_map: PuzzleTileMap) -> void:
+	.set_source_tile_map(new_source_tile_map)
+	_refresh_silhouettes()
+
+
 ## Updates our tilemap based on the source tilemap, and based on our calculated silhouettes.
 func _refresh_tiles_from_source() -> void:
 	# copy data from the source tilemap

--- a/project/src/main/puzzle/onion-puzzle-tile-map.gd
+++ b/project/src/main/puzzle/onion-puzzle-tile-map.gd
@@ -8,7 +8,7 @@ extends TileMap
 const TILE_COLOR := Color("aed8d1")
 
 ## tilemap to synchronize with
-var source_tile_map: PuzzleTileMap
+var source_tile_map: PuzzleTileMap setget set_source_tile_map
 
 ## a number in the range [0, 1] which can be set to make the tilemap flash or blink.
 var whiteness := 0.0 setget set_whiteness
@@ -23,6 +23,10 @@ func _process(_delta: float) -> void:
 		_refresh_tiles_from_source()
 		scale = source_tile_map.scale
 		position = source_tile_map.position
+
+
+func set_source_tile_map(new_source_tile_map: PuzzleTileMap) -> void:
+	source_tile_map = new_source_tile_map
 
 
 # Refreshes the tilemap's cells to match the source tilemap 1:1.

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -145,6 +145,10 @@ func set_night_mode(night_mode: bool) -> void:
 	_night_mode_toggler.set_night_mode(night_mode)
 
 
+func is_night_mode() -> bool:
+	return _night_mode_toggler.is_night_mode()
+
+
 ## Starts or restarts the puzzle, loading new customers and preparing the level.
 func _start_puzzle() -> void:
 	PlayerData.customer_queue.reset_standard_customer_queue()
@@ -268,14 +272,9 @@ func _save_level_result(rank_result: RankResult) -> void:
 
 ## For nighttime levels, this initializes night mode immediately to avoid an unpleasant blink effect.
 func _initialize_night_mode() -> void:
-	var initial_add_onion_effect: LevelTriggerEffects.AddOnionEffect
-	for trigger_obj in CurrentLevel.settings.triggers.triggers.get(LevelTrigger.BEFORE_START, []):
-		var trigger: LevelTrigger = trigger_obj
-		if trigger.effect is LevelTriggerEffects.AddOnionEffect:
-			initial_add_onion_effect = trigger.effect
-	
-	if initial_add_onion_effect and initial_add_onion_effect.config.get_state(0) == OnionConfig.OnionState.NIGHT:
+	if get_onions().starts_in_night_mode():
 		_night_mode_toggler.set_night_mode(true, 0.0)
+		get_onions().skip_to_night_mode()
 
 
 func _on_Hud_start_button_pressed() -> void:


### PR DESCRIPTION
These bugs especially affected levels that begin at nighttime and toggle to daytime. When restarting in nighttime, sometimes the onion wouldn't launch, or it would launch even though it was already in the sky.

The onion now has the ability to skip to the 'floating in the air' mode which is used when restarting a nighttime level.