### PR TITLE
Bug: cheat sfx were playing twice in practice menu

### DIFF
--- a/project/src/main/ui/cheat-code-detector.gd
+++ b/project/src/main/ui/cheat-code-detector.gd
@@ -33,12 +33,17 @@ const CODE_KEYS := {
 ## cheat code will take precedence.
 export (Array, String) var codes := []
 
+export (bool) var cheat_sounds_enabled := true
+
 ## Buffer of key strings which were previously pressed.
 var _previous_keypresses := ""
 
 
 ## Plays the sound effect for enabling/disabling a cheat.
 func play_cheat_sound(enabled: bool) -> void:
+	if not cheat_sounds_enabled:
+		return
+	
 	var cheat_sound := $CheatEnableSound if enabled else $CheatDisableSound
 	cheat_sound.play()
 

--- a/project/src/main/ui/menu/level-submenu.gd
+++ b/project/src/main/ui/menu/level-submenu.gd
@@ -29,6 +29,10 @@ func popup(new_region: Object, default_level_id: String = "") -> void:
 	show()
 
 
+func disable_cheat_sfx() -> void:
+	_paged_level_panel.disable_cheat_sfx()
+
+
 func _on_Panel_level_chosen(settings: LevelSettings) -> void:
 	emit_signal("level_chosen", _region, settings)
 

--- a/project/src/main/ui/menu/paged-level-panel.gd
+++ b/project/src/main/ui/menu/paged-level-panel.gd
@@ -11,6 +11,7 @@ signal level_chosen(settings)
 var _region: Object
 
 onready var _level_buttons: PagedLevelButtons = $VBoxContainer/Top/LevelButtons
+onready var _cheat_code_detector: CheatCodeDetector = $CheatCodeDetector
 
 ## Populates this submenu with levels in to show it to the player.
 ##
@@ -34,6 +35,10 @@ func populate(new_region: Object, default_level_id: String = "") -> void:
 	_level_buttons.level_ids = level_ids
 	if default_level_id:
 		_level_buttons.focus_level(default_level_id)
+
+
+func disable_cheat_sfx() -> void:
+	_cheat_code_detector.cheat_sounds_enabled = false
 
 
 func _on_LevelButtons_level_chosen(settings: LevelSettings) -> void:

--- a/project/src/main/ui/menu/practice-menu.gd
+++ b/project/src/main/ui/menu/practice-menu.gd
@@ -43,6 +43,9 @@ func _ready() -> void:
 	if PlayerData.practice.piece_speed:
 		_speed_selector.set_selected_speed(PlayerData.practice.piece_speed)
 	
+	# Disable cheat sfx to avoid duplicate sound for 'unlock' cheat. The 'unlock' cheat affects both the region and
+	# level panels.
+	_level_submenu.disable_cheat_sfx()
 	_start_button.grab_focus()
 
 


### PR DESCRIPTION
The 'unlock' cheat affects both the region and level panel, and was playing a doubled sound effect. The level panel now disables its cheat sound.