### PR TITLE
Replaced 'row/col' with 'y/x' where appropriate

### DIFF
--- a/project/src/main/puzzle/critter/carrots.gd
+++ b/project/src/main/puzzle/critter/carrots.gd
@@ -70,22 +70,22 @@ func remove_carrots(count: int) -> void:
 ## Parameters:
 ## 	'config': rules for how many carrots to add, where to add them, and how fast they move.
 func add_carrots(config: CarrotConfig) -> void:
-	var potential_carrot_columns: Array
+	var potential_carrot_x_coords: Array
 	if config.columns:
-		potential_carrot_columns = config.columns.duplicate()
+		potential_carrot_x_coords = config.columns.duplicate()
 	else:
-		potential_carrot_columns = range(PuzzleTileMap.COL_COUNT)
+		potential_carrot_x_coords = range(PuzzleTileMap.COL_COUNT)
 	
 	# don't allow carrots to spawn too far to the right
 	var carrot_dimensions: Vector2 = CarrotConfig.DIMENSIONS_BY_CARROT_SIZE[config.size]
-	potential_carrot_columns = Utils.intersection(potential_carrot_columns, \
+	potential_carrot_x_coords = Utils.intersection(potential_carrot_x_coords, \
 			range(PuzzleTileMap.COL_COUNT - carrot_dimensions.x + 1))
-	potential_carrot_columns.shuffle()
+	potential_carrot_x_coords.shuffle()
 	
-	potential_carrot_columns = deconflict_carrots(potential_carrot_columns, carrot_dimensions)
+	potential_carrot_x_coords = deconflict_carrots(potential_carrot_x_coords, carrot_dimensions)
 	
-	for i in range(min(config.count, potential_carrot_columns.size())):
-		_add_carrot(Vector2(potential_carrot_columns[i], PuzzleTileMap.ROW_COUNT), config)
+	for i in range(min(config.count, potential_carrot_x_coords.size())):
+		_add_carrot(Vector2(potential_carrot_x_coords[i], PuzzleTileMap.ROW_COUNT), config)
 	SfxDeconflicter.play(_carrot_poof_sound)
 
 

--- a/project/src/main/puzzle/critter/moles.gd
+++ b/project/src/main/puzzle/critter/moles.gd
@@ -96,14 +96,14 @@ func _potential_mole_cells(config: MoleConfig) -> Array:
 	var potential_mole_cells := []
 	
 	# Columns which have a ceiling overhead, for moles with a home of 'surface' or 'hole'
-	var ceiling_cols := {}
+	var ceiling_x_coords := {}
 	
-	for row in range(PuzzleTileMap.FIRST_VISIBLE_ROW, PuzzleTileMap.ROW_COUNT):
-		for col in range(PuzzleTileMap.COL_COUNT):
-			var mole_cell := Vector2(col, row)
+	for y in range(PuzzleTileMap.FIRST_VISIBLE_ROW, PuzzleTileMap.ROW_COUNT):
+		for x in range(PuzzleTileMap.COL_COUNT):
+			var mole_cell := Vector2(x, y)
 			
 			if _playfield.tile_map.get_cellv(mole_cell) != TileMap.INVALID_CELL:
-				ceiling_cols[col] = true
+				ceiling_x_coords[x] = true
 			
 			# check if the mole is in an appropriate row
 			if config.lines:
@@ -134,10 +134,10 @@ func _potential_mole_cells(config: MoleConfig) -> Array:
 						if not _playfield.tile_map.is_cake_cell(mole_cell + Vector2.DOWN):
 							at_home = false
 					MoleConfig.Home.SURFACE:
-						if ceiling_cols.has(int(mole_cell.x)):
+						if ceiling_x_coords.has(int(mole_cell.x)):
 							at_home = false
 					MoleConfig.Home.HOLE:
-						if not ceiling_cols.has(int(mole_cell.x)):
+						if not ceiling_x_coords.has(int(mole_cell.x)):
 							at_home = false
 				if not at_home:
 					continue
@@ -346,14 +346,14 @@ func _erase_row(y: int) -> void:
 ## Shifts a group of moles up or down.
 ##
 ## Parameters:
-## 	'bottom_row': The lowest row to shift. All moles at or above this row will be shifted.
+## 	'bottom_y': The lowest row to shift. All moles at or above this row will be shifted.
 ##
 ## 	'direction': The direction to shift the moles, such as Vector2.UP or Vector2.DOWN.
-func _shift_rows(bottom_row: int, direction: Vector2) -> void:
+func _shift_rows(bottom_y: int, direction: Vector2) -> void:
 	# First, erase and store all the old moles which are shifting
 	var shifted := {}
 	for cell in _moles_by_cell.keys():
-		if cell.y > bottom_row:
+		if cell.y > bottom_y:
 			# moles below the specified bottom row are left alone
 			continue
 		# moles above the specified bottom row are shifted

--- a/project/src/main/puzzle/line-clearer.gd
+++ b/project/src/main/puzzle/line-clearer.gd
@@ -8,7 +8,7 @@ extends Node
 signal all_lines_cleared
 
 ## emitted shortly before a set of lines are cleared
-signal line_clears_scheduled(ys)
+signal line_clears_scheduled(y_coords)
 
 ## emitted before a 'line clear' where a line is erased and the player is rewarded
 signal before_line_cleared(y, total_lines, remaining_lines, box_ints)

--- a/project/src/main/puzzle/piece/puzzle-shadow-map.gd
+++ b/project/src/main/puzzle/piece/puzzle-shadow-map.gd
@@ -13,13 +13,13 @@ func _process(_delta: float) -> void:
 	clear()
 	
 	# draw shadows cast by the left wall
-	for row in range(PuzzleTileMap.ROW_COUNT):
-		set_cell(-1, row, 0, false, false, false, Vector2(15, 0))
+	for y in range(PuzzleTileMap.ROW_COUNT):
+		set_cell(-1, y, 0, false, false, false, Vector2(15, 0))
 	
 	# draw shadows cast by the bottom wall
 	set_cell(-1, PuzzleTileMap.ROW_COUNT, 0, false, false, false, Vector2(15, 0))
-	for col in range(PuzzleTileMap.COL_COUNT):
-		set_cell(col, PuzzleTileMap.ROW_COUNT, 0, false, false, false, Vector2(15, 0))
+	for x in range(PuzzleTileMap.COL_COUNT):
+		set_cell(x, PuzzleTileMap.ROW_COUNT, 0, false, false, false, Vector2(15, 0))
 	
 	# draw shadows cast by blocks in the playfield
 	for cell in _playfield_tile_map.get_used_cells():

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -10,7 +10,7 @@ signal all_lines_cleared
 signal box_built(rect, box_type)
 
 ## emitted shortly before a set of lines are cleared
-signal line_clears_scheduled(ys)
+signal line_clears_scheduled(y_coords)
 
 ## emitted before a 'line clear' where a line is erased and the player is rewarded
 signal before_line_cleared(y, total_lines, remaining_lines, box_ints)
@@ -181,8 +181,8 @@ func _on_BoxBuilder_after_boxes_built() -> void:
 		PuzzleState.after_piece_written()
 
 
-func _on_LineClearer_line_clears_scheduled(ys: Array) -> void:
-	emit_signal("line_clears_scheduled", ys)
+func _on_LineClearer_line_clears_scheduled(y_coords: Array) -> void:
+	emit_signal("line_clears_scheduled", y_coords)
 
 
 func _on_LineClearer_before_line_cleared(y: int, total_lines: int, remaining_lines: int, box_ints: Array) -> void:

--- a/project/src/main/puzzle/squish-map.gd
+++ b/project/src/main/puzzle/squish-map.gd
@@ -10,35 +10,35 @@ var _max_distance := 0
 var _color_y: int
 
 func _ready() -> void:
-	for row in range(ROW_COUNT):
+	for y in range(ROW_COUNT):
 		_stretch_pos.append([])
-		for _col in range(COL_COUNT):
-			_stretch_pos[row].append(0)
+		for _x in range(COL_COUNT):
+			_stretch_pos[y].append(0)
 	set_process(false)
 
 
 func _process(delta: float) -> void:
-	for row in range(ROW_COUNT):
-		for col in range(COL_COUNT):
-			if _stretch_pos[row][col] > _max_distance \
+	for y in range(ROW_COUNT):
+		for x in range(COL_COUNT):
+			if _stretch_pos[y][x] > _max_distance \
 					* (squish_seconds_total - squish_seconds_remaining) / squish_seconds_total:
-				set_block(Vector2(col, row), 0, Vector2(0, _color_y))
+				set_block(Vector2(x, y), 0, Vector2(0, _color_y))
 			else:
-				set_block(Vector2(col, row), -1)
+				set_block(Vector2(x, y), -1)
 	
-	for row in range(ROW_COUNT):
-		for col in range(COL_COUNT):
-			var cell_pos := Vector2(col, row)
+	for y in range(ROW_COUNT):
+		for x in range(COL_COUNT):
+			var cell_pos := Vector2(x, y)
 			if is_cell_empty(cell_pos):
 				continue
 			var color_x := 0
-			if row > 0 and is_cell_obstructed(cell_pos + Vector2.UP):
+			if y > 0 and is_cell_obstructed(cell_pos + Vector2.UP):
 				color_x = PuzzleConnect.set_u(color_x)
-			if row < ROW_COUNT - 1 and is_cell_obstructed(cell_pos + Vector2.DOWN):
+			if y < ROW_COUNT - 1 and is_cell_obstructed(cell_pos + Vector2.DOWN):
 				color_x = PuzzleConnect.set_d(color_x)
-			if col > 0 and is_cell_obstructed(cell_pos + Vector2.LEFT):
+			if x > 0 and is_cell_obstructed(cell_pos + Vector2.LEFT):
 				color_x = PuzzleConnect.set_l(color_x)
-			if col < COL_COUNT - 1 and is_cell_obstructed(cell_pos + Vector2.RIGHT):
+			if x < COL_COUNT - 1 and is_cell_obstructed(cell_pos + Vector2.RIGHT):
 				color_x = PuzzleConnect.set_r(color_x)
 			set_block(cell_pos, 0, Vector2(color_x, _color_y))
 	
@@ -68,9 +68,9 @@ func start_squish(post_squish_frames: int, new_color_y: int) -> void:
 	
 	clear()
 	corner_map.dirty = true
-	for row in range(ROW_COUNT):
-		for col in range(COL_COUNT):
-			_stretch_pos[row][col] = 0
+	for y in range(ROW_COUNT):
+		for x in range(COL_COUNT):
+			_stretch_pos[y][x] = 0
 
 
 ## Returns 'true' if the piece is already stretched to the specified position.


### PR DESCRIPTION
For plural cases, I replaced them with 'x_coords' and 'y_coords' because I think is more intuitive than 'xs' or 'ys'. A variable named 'ceiling_xs' seems like it could be referencing 'excess' or 'extra small' whereas 'ceiling_x_coords' is unambiguous.