### PR TITLE
Reorder: puzzle-demo, critters, CareerCutsceneLibrary

### DIFF
--- a/project/src/demo/puzzle/puzzle-demo.gd
+++ b/project/src/demo/puzzle/puzzle-demo.gd
@@ -2,16 +2,16 @@ extends Node
 ## Shows off the visual effects for the puzzle.
 ##
 ## Keys:
-## 	[Q,W,E]: Build a box at different locations in the playfield
-## 	[T,Y]: Insert a line at different locations in the playfield
 ## 	[A,S,D,F,G]: Change the box color to brown, pink, bread, white, cake
 ## 	[H]: Change the cake box variation used to make cake boxes
-## 	[U,I,O]: Clear a line at different locations in the playfield
-## 	[N]: Toggle night mode
-## 	[P]: Add pickups
 ## 	[J]: Generate a food item
 ## 	[K]: Cycle to the next food item
 ## 	[L]: Level up
+## 	[N]: Toggle night mode
+## 	[P]: Add pickups
+## 	[Q,W,E]: Build a box at different locations in the playfield
+## 	[T,Y]: Insert a line at different locations in the playfield
+## 	[U,I,O]: Clear a line at different locations in the playfield
 
 var _line_clear_count := 1
 var _box_type := 0

--- a/project/src/main/career/career-cutscene-library.gd
+++ b/project/src/main/career/career-cutscene-library.gd
@@ -174,63 +174,6 @@ func potential_chat_key_pairs(chat_key_roots: Array,
 	return trimmed_chat_key_pairs
 
 
-## Returns 'true' if the specified chat key pair does not have a quirky chef, customer or observer.
-func _chat_key_pair_is_nonquirky(chat_key_pair: ChatKeyPair) -> bool:
-	var quirky := false
-	var region: CareerRegion = PlayerData.career.current_region()
-	
-	for chat_key in chat_key_pair.chat_keys():
-		var chat_tree: ChatTree = ChatLibrary.chat_tree_for_key(chat_key)
-		
-		if not quirky and chat_tree.chef_id:
-			# If a cutscene specifies a quirky chef, it must be accompanied by a level with their quirks.
-			if region.population.has_quirky_chef(chat_tree.chef_id):
-				quirky = true
-		
-		if not quirky and chat_tree.customer_ids:
-			# If a cutscene specifies a quirky customer, it must be accompanied by a level with their quirks.
-			for customer_id in chat_tree.customer_ids:
-				if region.population.has_quirky_customer(customer_id):
-					quirky = true
-					break
-		
-		if not quirky and chat_tree.observer_id:
-			# If a cutscene defines a quirky observer, it must be accompanied by a level with their quirks.
-			if region.population.has_quirky_observer(chat_tree.observer_id):
-				quirky = true
-		
-		if quirky:
-			break
-	
-	return not quirky
-
-
-## Returns 'true' if the specified chat key pair features the specified chef, customer or observer.
-func _chat_key_pair_has_creatures(chat_key_pair: ChatKeyPair,
-		chef_id: String, customer_id: String, observer_id: String) -> bool:
-	var matches := false
-	
-	for chat_key in chat_key_pair.chat_keys():
-		var chat_tree: ChatTree = ChatLibrary.chat_tree_for_key(chat_key)
-		
-		if not matches and chef_id:
-			if chat_tree.chef_id == chef_id:
-				matches = true
-		
-		if not matches and customer_id:
-			if customer_id in chat_tree.customer_ids:
-				matches = true
-		
-		if not matches and observer_id:
-			if observer_id == chat_tree.observer_id:
-				matches = true
-		
-		if matches:
-			break
-	
-	return matches
-
-
 ## Assigns the list of interlude ChatKeyPairs, and regenerates all internal fields such as the preroll tree.
 func set_all_chat_key_pairs(new_all_chat_key_pairs: Array) -> void:
 	all_chat_key_pairs = new_all_chat_key_pairs
@@ -268,13 +211,6 @@ func set_all_chat_key_pairs(new_all_chat_key_pairs: Array) -> void:
 				_general_sensei_chat_keys.append(chat_key)
 			if chat_tree.inside_restaurant():
 				_general_restaurant_chat_keys.append(chat_key)
-
-
-## Splits a preroll key like 'foo/bar/10_d' into an array like ['foo/bar', '10', 'd'].
-func _split_key(preroll_key: String) -> Array:
-	var result := [StringUtils.substring_before_last(preroll_key, "/")]
-	result.append_array(StringUtils.substring_after_last(preroll_key, "/").split("_"))
-	return result
 
 
 ## Returns a collection of interlude preroll chat keys for cutscenes the player has already seen.
@@ -412,6 +348,70 @@ func find_chat_key_pairs(chat_key_roots: Array, search_flags: CutsceneSearchFlag
 ## Returns a list of all file paths in the career cutscene root path, performing a tree traversal.
 func find_career_cutscene_resource_paths() -> Array:
 	return _find_resource_paths(career_cutscene_root_path)
+
+
+## Returns 'true' if the specified chat key pair does not have a quirky chef, customer or observer.
+func _chat_key_pair_is_nonquirky(chat_key_pair: ChatKeyPair) -> bool:
+	var quirky := false
+	var region: CareerRegion = PlayerData.career.current_region()
+	
+	for chat_key in chat_key_pair.chat_keys():
+		var chat_tree: ChatTree = ChatLibrary.chat_tree_for_key(chat_key)
+		
+		if not quirky and chat_tree.chef_id:
+			# If a cutscene specifies a quirky chef, it must be accompanied by a level with their quirks.
+			if region.population.has_quirky_chef(chat_tree.chef_id):
+				quirky = true
+		
+		if not quirky and chat_tree.customer_ids:
+			# If a cutscene specifies a quirky customer, it must be accompanied by a level with their quirks.
+			for customer_id in chat_tree.customer_ids:
+				if region.population.has_quirky_customer(customer_id):
+					quirky = true
+					break
+		
+		if not quirky and chat_tree.observer_id:
+			# If a cutscene defines a quirky observer, it must be accompanied by a level with their quirks.
+			if region.population.has_quirky_observer(chat_tree.observer_id):
+				quirky = true
+		
+		if quirky:
+			break
+	
+	return not quirky
+
+
+## Returns 'true' if the specified chat key pair features the specified chef, customer or observer.
+func _chat_key_pair_has_creatures(chat_key_pair: ChatKeyPair,
+		chef_id: String, customer_id: String, observer_id: String) -> bool:
+	var matches := false
+	
+	for chat_key in chat_key_pair.chat_keys():
+		var chat_tree: ChatTree = ChatLibrary.chat_tree_for_key(chat_key)
+		
+		if not matches and chef_id:
+			if chat_tree.chef_id == chef_id:
+				matches = true
+		
+		if not matches and customer_id:
+			if customer_id in chat_tree.customer_ids:
+				matches = true
+		
+		if not matches and observer_id:
+			if observer_id == chat_tree.observer_id:
+				matches = true
+		
+		if matches:
+			break
+	
+	return matches
+
+
+## Splits a preroll key like 'foo/bar/10_d' into an array like ['foo/bar', '10', 'd'].
+func _split_key(preroll_key: String) -> Array:
+	var result := [StringUtils.substring_before_last(preroll_key, "/")]
+	result.append_array(StringUtils.substring_after_last(preroll_key, "/").split("_"))
+	return result
 
 
 ## Returns a child chat key by combining the specified chat key with a delimiter and suffix.

--- a/project/src/main/puzzle/critter/critters.gd
+++ b/project/src/main/puzzle/critter/critters.gd
@@ -4,14 +4,14 @@ extends Control
 export (NodePath) var playfield_path: NodePath setget set_playfield_path
 export (NodePath) var piece_manager_path: NodePath setget set_piece_manager_path
 
+# Draws carrots, puzzle critters which rocket up the screen, blocking the player's vision.
+onready var _carrots: Carrots = $Carrots
+
 ## Draws moles, puzzle critters which dig up star seeds for the player.
 onready var _moles: Moles = $Moles
 
 ## Draws onions, puzzle critters which darken things making it hard to see.
 onready var _onions: Onions = $Onions
-
-# Draws carrots, puzzle critters which rocket up the screen, blocking the player's vision.
-onready var _carrots: Carrots = $Carrots
 
 func _ready() -> void:
 	Pauser.connect("paused_changed", self, "_on_Pauser_paused_changed")

--- a/project/src/main/puzzle/level/level-trigger-effects.gd
+++ b/project/src/main/puzzle/level/level-trigger-effects.gd
@@ -355,11 +355,11 @@ class InsertLineEffect extends LevelTriggerEffect:
 
 
 var effects_by_string := {
+	"add_carrots": AddCarrotsEffect,
 	"add_moles": AddMolesEffect,
 	"add_onion": AddOnionEffect,
 	"advance_moles": AdvanceMolesEffect,
 	"advance_onion": AdvanceOnionEffect,
-	"add_carrots": AddCarrotsEffect,
 	"clear_filled_lines": ClearFilledLinesEffect,
 	"remove_carrots": RemoveCarrotsEffect,
 	"remove_onion": RemoveOnionEffect,

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -85,6 +85,11 @@ func get_piece_queue() -> PieceQueue:
 	return $PieceQueue as PieceQueue
 
 
+## Returns the node which handles carrots, puzzle critters which block the player's vision.
+func get_carrots() -> Carrots:
+	return $Fg/Critters/Carrots as Carrots
+
+
 ## Returns the node which handles moles, puzzle critters which dig up star seeds for the player.
 func get_moles() -> Moles:
 	return $Fg/Critters/Moles as Moles
@@ -93,11 +98,6 @@ func get_moles() -> Moles:
 ## Returns the node which handles onions, puzzle critters which darken things making it hard to see.
 func get_onions() -> Onions:
 	return $Fg/Critters/Onions as Onions
-
-
-## Returns the node which handles carrots, puzzle critters which block the player's vision.
-func get_carrots() -> Carrots:
-	return $Fg/Critters/Carrots as Carrots
 
 
 func hide_buttons() -> void:

--- a/project/src/test/puzzle/level/test-level-trigger-effects.gd
+++ b/project/src/test/puzzle/level/test-level-trigger-effects.gd
@@ -30,24 +30,34 @@ func test_insert_line_get_config() -> void:
 	assert_eq_shallow(effect.get_config(), {"y": "5"})
 
 
-func test_add_onion_set_config() -> void:
-	var effect: LevelTriggerEffects.AddOnionEffect
+func test_add_carrots_set_config() -> void:
+	var effect: LevelTriggerEffects.AddCarrotsEffect
 	
-	effect = LevelTriggerEffects.create("add_onion", {"0": "nnndddd"})
-	assert_eq_shallow(effect.get_config(), {"0": "nnndddd"})
+	effect = LevelTriggerEffects.create("add_carrots", {})
+	assert_eq(effect.config.columns, [])
+	assert_eq(effect.config.count, 1)
+	assert_eq(effect.config.duration, 8.0)
+	assert_eq(effect.config.size, CarrotConfig.CarrotSize.MEDIUM)
+	assert_eq(effect.config.smoke, CarrotConfig.Smoke.SMALL)
 	
-	effect = LevelTriggerEffects.create("add_onion", {})
-	assert_eq_shallow(effect.get_config(), {})
+	effect = LevelTriggerEffects.create("add_carrots", {"x": "0-2", "count": "2", "duration": "12.0", "size": "large",
+			"smoke": "none"})
+	assert_eq(effect.config.columns, [0, 1, 2])
+	assert_eq(effect.config.count, 2)
+	assert_eq(effect.config.duration, 12.0)
+	assert_eq(effect.config.size, CarrotConfig.CarrotSize.LARGE)
+	assert_eq(effect.config.smoke, CarrotConfig.Smoke.NONE)
 
 
-func test_add_onion_get_config() -> void:
-	var effect: LevelTriggerEffects.AddOnionEffect
+func test_add_carrots_get_config() -> void:
+	var effect: LevelTriggerEffects.AddCarrotsEffect
 	
-	effect = LevelTriggerEffects.create("add_onion", {"0": "nnndddd"})
-	assert_eq_shallow(effect.get_config(), {"0": "nnndddd"})
+	effect = LevelTriggerEffects.create("add_carrots", {})
+	assert_eq_shallow({}, effect.get_config())
 	
-	effect = LevelTriggerEffects.create("add_onion", {})
-	assert_eq_shallow(effect.get_config(), {})
+	effect = LevelTriggerEffects.create("add_carrots", {"x": "0-2", "count": "2", "duration": "12.0", "size": "large",
+			"smoke": "none"})
+	assert_eq_shallow({"count": "2", "duration": "12", "size": "large", "smoke": "none", "x": "0-2"}, effect.get_config())
 
 
 func test_add_moles_set_config() -> void:
@@ -90,34 +100,24 @@ func test_add_moles_get_config() -> void:
 	assert_eq_shallow({"y": "0,8"}, effect.get_config())
 
 
-func test_add_carrots_set_config() -> void:
-	var effect: LevelTriggerEffects.AddCarrotsEffect
+func test_add_onion_set_config() -> void:
+	var effect: LevelTriggerEffects.AddOnionEffect
 	
-	effect = LevelTriggerEffects.create("add_carrots", {})
-	assert_eq(effect.config.columns, [])
-	assert_eq(effect.config.count, 1)
-	assert_eq(effect.config.duration, 8.0)
-	assert_eq(effect.config.size, CarrotConfig.CarrotSize.MEDIUM)
-	assert_eq(effect.config.smoke, CarrotConfig.Smoke.SMALL)
+	effect = LevelTriggerEffects.create("add_onion", {"0": "nnndddd"})
+	assert_eq_shallow(effect.get_config(), {"0": "nnndddd"})
 	
-	effect = LevelTriggerEffects.create("add_carrots", {"x": "0-2", "count": "2", "duration": "12.0", "size": "large",
-			"smoke": "none"})
-	assert_eq(effect.config.columns, [0, 1, 2])
-	assert_eq(effect.config.count, 2)
-	assert_eq(effect.config.duration, 12.0)
-	assert_eq(effect.config.size, CarrotConfig.CarrotSize.LARGE)
-	assert_eq(effect.config.smoke, CarrotConfig.Smoke.NONE)
+	effect = LevelTriggerEffects.create("add_onion", {})
+	assert_eq_shallow(effect.get_config(), {})
 
 
-func test_add_carrots_get_config() -> void:
-	var effect: LevelTriggerEffects.AddCarrotsEffect
+func test_add_onion_get_config() -> void:
+	var effect: LevelTriggerEffects.AddOnionEffect
 	
-	effect = LevelTriggerEffects.create("add_carrots", {})
-	assert_eq_shallow({}, effect.get_config())
+	effect = LevelTriggerEffects.create("add_onion", {"0": "nnndddd"})
+	assert_eq_shallow(effect.get_config(), {"0": "nnndddd"})
 	
-	effect = LevelTriggerEffects.create("add_carrots", {"x": "0-2", "count": "2", "duration": "12.0", "size": "large",
-			"smoke": "none"})
-	assert_eq_shallow({"count": "2", "duration": "12", "size": "large", "smoke": "none", "x": "0-2"}, effect.get_config())
+	effect = LevelTriggerEffects.create("add_onion", {})
+	assert_eq_shallow(effect.get_config(), {})
 
 
 func test_remove_carrots_set_config() -> void:


### PR DESCRIPTION
Alphabetized PuzzleDemo's keys.

Reordered carrots/moles/onions in alphabetical order where it made sense. I did not reorder the nodes in the Critters.tscn because carrots should cover everything, it would look strange if they were not in front.

Reordered CareerCutsceneLibrary methods; public methods should precede private methods.