### PR TITLE
Improved comments: customer_index, apache commons

### DIFF
--- a/project/src/demo/world/environment/restaurant/restaurant-puzzle-scene-demo.gd
+++ b/project/src/demo/world/environment/restaurant/restaurant-puzzle-scene-demo.gd
@@ -4,7 +4,7 @@ extends Node
 ## Keys:
 ## 	[F]: Feed the customer
 ## 	[1-9,0]: Change the customer's size from 10% to 100%
-## 	[Q,W,E,R]: Switch to the 1st, 2nd or 3rd customer.
+## 	[Q,W,E,R]: Switch to the 1st, 2nd, 3rd or 4th customer.
 ## 	brace keys: Change the customer's appearance
 
 const FATNESS_KEYS := [10.0, 1.0, 1.5, 2.0, 3.0, 5.0, 6.0, 7.0, 8.0, 9.0]

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -124,12 +124,7 @@ func get_customer() -> Creature:
 	return _restaurant_view.get_customer()
 
 
-## Triggers the eating animation and makes the customer fatter. Accepts a 'fatness_pct' parameter which defines how
-## much fatter the customer should get. We can calculate how fat they should be, and a value of 0.4 means the customer
-## should increase by 40% of the amount needed to reach that target.
-##
-## This 'fatness_pct' parameter is needed for the level where the player eliminates three lines at once. We don't
-## want the customer to suddenly grow full size. We want it to take 3 bites.
+## Triggers the eating animation and makes the customer fatter.
 ##
 ## Parameters:
 ## 	'customer': The customer to feed

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -115,6 +115,10 @@ func get_current_customer_index() -> int:
 	return _restaurant_viewport_scene.current_customer_index
 
 
+## Returns the specified customer.
+##
+## Parameters:
+## 	'customer_index' (Optional) The index of the customer to return. Defaults to the current creature.
 func get_customer(customer_index: int = -1) -> Creature:
 	return _restaurant_viewport_scene.get_customer(customer_index)
 
@@ -172,6 +176,10 @@ func summon_customer(customer_index: int = -1) -> void:
 
 
 ## Scroll to a new customer and replace the old customer.
+##
+## Parameters:
+## 	'new_customer_index': (Optional) The index of the customer to scroll to. Defaults to a random creature index
+## 		different from the current creature index.
 func scroll_to_new_customer(new_customer_index: int = -1) -> void:
 	var old_customer_index: int = get_current_customer_index()
 	if new_customer_index == -1:

--- a/project/src/main/utils/utils.gd
+++ b/project/src/main/utils/utils.gd
@@ -135,8 +135,6 @@ static func remove_all(values: Array, value) -> Array:
 
 
 ## Returns a new array containing a - b.
-##
-## The input arrays are not modified. This code is adapted from Apache Common Collections.
 static func subtract(a: Array, b: Array) -> Array:
 	var result := []
 	var bag := {}
@@ -155,8 +153,6 @@ static func subtract(a: Array, b: Array) -> Array:
 
 
 ## Returns a new array containing the intersection of the given arrays.
-##
-## The input arrays are not modified. This code is adapted from Apache Common Collections.
 static func intersection(a: Array, b: Array) -> Array:
 	var result := []
 	var bag := {}

--- a/project/src/main/world/creature/creature-visuals.gd
+++ b/project/src/main/world/creature/creature-visuals.gd
@@ -164,9 +164,6 @@ func set_visual_fatness(new_visual_fatness: float) -> void:
 
 ## Returns the creature's fatness, a float which determines how fat the creature
 ## should be; 5.0 = 5x normal size
-##
-## Parameters:
-## 	'creature_index': (Optional) The creature to ask about. Defaults to the current creature.
 func get_fatness() -> float:
 	return fatness
 
@@ -175,9 +172,7 @@ func get_fatness() -> float:
 ## the creature should be; 5.0 = 5x normal size
 ##
 ## Parameters:
-## 	'fatness_percent': Controls how fat the creature should be; 5.0 = 5x normal size
-##
-## 	'creature_index': (Optional) The creature to be altered. Defaults to the current creature.
+## 	'new_fatness': Controls how fat the creature should be; 5.0 = 5x normal size
 func set_fatness(new_fatness: float) -> void:
 	fatness = new_fatness
 	emit_signal("fatness_changed")
@@ -298,8 +293,7 @@ func feed(food_type: int) -> void:
 		mouth_player.eat()
 
 
-## Recolors the creature according to the specified creature definition. This involves updating shaders and sprite
-## properties.
+## Updates the creature's appearance according to the specified creature definition.
 func set_dna(new_dna: Dictionary) -> void:
 	dna = new_dna
 	if not is_inside_tree():

--- a/project/src/main/world/environment/restaurant/restaurant-puzzle-scene.gd
+++ b/project/src/main/world/environment/restaurant/restaurant-puzzle-scene.gd
@@ -25,11 +25,12 @@ func set_current_customer_index(new_index: int) -> void:
 	emit_signal("current_customer_index_changed", new_index)
 
 
-## Recolors the customer according to the specified creature definition. This involves updating shaders and sprite
-## properties.
+## Updates the creature's appearance according to the specified creature definition.
 ##
 ## Parameters:
 ## 	'creature_def': defines the customer's attributes such as name and appearance.
+##
+## 	'customer_index': (Optional) The index of the customer to update. Defaults to the current creature.
 func summon_customer(creature_def: CreatureDef, customer_index: int = -1) -> void:
 	var customer := get_customer(customer_index)
 	customer.set_creature_def(creature_def)
@@ -44,6 +45,10 @@ func get_customers() -> Array:
 	return _world.customers
 
 
+## Returns the specified customer.
+##
+## Parameters:
+## 	'customer_index': (Optional) The index of the customer to return. Defaults to the current creature.
 func get_customer(customer_index: int = -1) -> Creature:
 	return _world.customers[current_customer_index] if customer_index == -1 else _world.customers[customer_index]
 

--- a/project/src/main/world/obstacle-spawner.gd
+++ b/project/src/main/world/obstacle-spawner.gd
@@ -47,7 +47,7 @@ func set_target_property(property: String, value) -> void:
 		spawned_object.set(property, value)
 
 
-## Spawns the obstacle and remove the spawner from the scene tree.
+## Spawns the obstacle and removes the spawner from the scene tree.
 func spawn_target() -> void:
 	# change the spawner's name to avoid conflicting with the spawned object
 	var old_name := name


### PR DESCRIPTION
A lot of puzzle code allows a customer_index of -1, where -1 either means the current customer or a random customer. This behavior was undocumented and unintuitive. It's now documented.

Removed unnecessarily verbose 'The input arrays are not modified; this code is adapted from Apache Commons' comments. The input arrays not being modified seems implicit, and I'd expect a warning if they WERE modified. The code being adapted from an old version of Apache Commons is also not helpful information -- the code doesn't really resemble Apache Commons anymore, and I had to adapt the algorithms anyways.

Fixed some minor comment typos.