### PR TITLE
Removed goop_texture_offset shader parameter.

### DIFF
--- a/project/src/demo/puzzle/puzzle-demo.gd
+++ b/project/src/demo/puzzle/puzzle-demo.gd
@@ -79,7 +79,7 @@ func _input(event: InputEvent) -> void:
 
 
 func _build_box(y: int) -> void:
-	$Puzzle/Fg/Playfield/BoxBuilder.build_box(Rect2(6, y, 3, 3), _box_type)
+	$Puzzle/Fg/Playfield/BoxBuilder.build_box(Rect2(0, y, 3, 3), _box_type)
 
 
 func _insert_line(tiles_key: String, y: int) -> void:

--- a/project/src/main/puzzle/OnionHoldPieceDisplays.tscn
+++ b/project/src/main/puzzle/OnionHoldPieceDisplays.tscn
@@ -26,7 +26,6 @@ viewport_path = NodePath("Fg/WallGlobViewports/RainbowViewport")
 [sub_resource type="ShaderMaterial" id=13]
 resource_local_to_scene = true
 shader = ExtResource( 1 )
-shader_param/goop_texture_offset = Vector2( 356, -10 )
 shader_param/goop_alpha = 0.6
 shader_param/noise = SubResource( 28 )
 shader_param/goop_texture = SubResource( 9 )

--- a/project/src/main/puzzle/Playfield.tscn
+++ b/project/src/main/puzzle/Playfield.tscn
@@ -56,7 +56,6 @@ viewport_path = NodePath("BgGlobViewports/RainbowViewport")
 [sub_resource type="ShaderMaterial" id=5]
 resource_local_to_scene = true
 shader = ExtResource( 18 )
-shader_param/goop_texture_offset = Vector2( 0, 0 )
 shader_param/goop_alpha = 0.6
 shader_param/noise = SubResource( 3 )
 shader_param/goop_texture = SubResource( 1 )

--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -178,7 +178,6 @@ viewport_path = NodePath("Fg/WallGlobViewports/RainbowViewport")
 [sub_resource type="ShaderMaterial" id=13]
 resource_local_to_scene = true
 shader = ExtResource( 15 )
-shader_param/goop_texture_offset = Vector2( 356, -10 )
 shader_param/goop_alpha = 0.6
 shader_param/noise = SubResource( 11 )
 shader_param/goop_texture = SubResource( 9 )

--- a/project/src/main/puzzle/texture-metaball.shader
+++ b/project/src/main/puzzle/texture-metaball.shader
@@ -26,9 +26,6 @@ uniform sampler2D goop_texture : hint_albedo;
 // texture for rainbow metaballs
 uniform sampler2D rainbow_texture : hint_albedo;
 
-// an offset which is applied to both textures
-uniform vec2 goop_texture_offset;
-
 // the maximum goop opacity
 uniform float goop_alpha = 0.6;
 


### PR DESCRIPTION
This shader parameter dates back to when the shader was authored in June 2020, but the parameter has never done anything.