### PR TITLE
Unused code: GoopMain, GoopGutter, new_customer_index

### DIFF
--- a/project/src/main/puzzle/piece/NextPieceDisplays.tscn
+++ b/project/src/main/puzzle/piece/NextPieceDisplays.tscn
@@ -16,20 +16,6 @@ anchor_bottom = 1.0
 texture = ExtResource( 3 )
 expand = true
 
-[node name="GoopMain" type="ColorRect" parent="."]
-visible = false
-modulate = Color( 1, 1, 1, 0.588235 )
-margin_right = 64.0
-margin_bottom = 484.0
-color = Color( 1, 0.364706, 0.407843, 1 )
-
-[node name="GoopGutter" type="ColorRect" parent="."]
-visible = false
-margin_top = 484.0
-margin_right = 64.0
-margin_bottom = 544.0
-color = Color( 1, 0.364706, 0.407843, 0.392157 )
-
 [node name="Shadow" type="ColorRect" parent="."]
 margin_right = 6.0
 margin_bottom = 544.0

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -176,14 +176,9 @@ func summon_customer(customer_index: int = -1) -> void:
 
 
 ## Scroll to a new customer and replace the old customer.
-##
-## Parameters:
-## 	'new_customer_index': (Optional) The index of the customer to scroll to. Defaults to a random creature index
-## 		different from the current creature index.
-func scroll_to_new_customer(new_customer_index: int = -1) -> void:
+func scroll_to_new_customer() -> void:
 	var old_customer_index: int = get_current_customer_index()
-	if new_customer_index == -1:
-		new_customer_index = next_customer_index()
+	var new_customer_index := next_customer_index()
 	set_current_customer_index(new_customer_index)
 	_restaurant_viewport_scene.get_customer().restart_idle_timer()
 	


### PR DESCRIPTION
Removed unused scroll_to_new_customer() parameter.

Removed unused 'GoopMain' and 'GoopGutter' nodes. These nodes were introduced in bf295952, but according to #186 I decided not to do it because it seemed unnecessary.