### PR TITLE
Removed redundant tween from values.

### DIFF
--- a/project/src/main/career/ui/progress-board-clock.gd
+++ b/project/src/main/career/ui/progress-board-clock.gd
@@ -67,9 +67,9 @@ func play(new_hours_passed: int, duration: float) -> void:
 	
 	_tween.interpolate_property(_visuals, "minutes", old_minute_hand_position, new_minute_hand_position,
 			duration, Tween.TRANS_SINE, Tween.EASE_OUT)
-	_tween.interpolate_property(_visuals, "hours", _visuals.hours, _hour_hand_position(new_hours_passed),
+	_tween.interpolate_property(_visuals, "hours", null, _hour_hand_position(new_hours_passed),
 			duration, Tween.TRANS_SINE, Tween.EASE_OUT)
-	_tween.interpolate_property(_visuals, "filled_percent", _visuals.filled_percent, _filled_percent(new_hours_passed),
+	_tween.interpolate_property(_visuals, "filled_percent", null, _filled_percent(new_hours_passed),
 			duration, Tween.TRANS_SINE, Tween.EASE_OUT)
 	
 	_clock_advance_sound.play()

--- a/project/src/main/career/ui/progress-board-player.gd
+++ b/project/src/main/career/ui/progress-board-player.gd
@@ -73,7 +73,7 @@ func play(new_spots_travelled: int, duration: float) -> void:
 	
 	# launch the movement tween, causing the player sprite to move along the path
 	_tween.remove_all()
-	_tween.interpolate_property(self, "visual_spots_travelled", visual_spots_travelled, new_spots_travelled,
+	_tween.interpolate_property(self, "visual_spots_travelled", null, new_spots_travelled,
 			duration)
 	_tween.start()
 	

--- a/project/src/main/chat/ui/chat-choice-tween.gd
+++ b/project/src/main/chat/ui/chat-choice-tween.gd
@@ -37,11 +37,11 @@ func _interpolate_pop(popping_in: bool) -> void:
 	var chat_choice_modulate := Color.white if popping_in else Color.transparent
 	var chat_choice_scale := Vector2.ONE if popping_in else POP_OUT_SCALE
 	
-	interpolate_property(_chat_choice, "modulate", _chat_choice.modulate,
+	interpolate_property(_chat_choice, "modulate", null,
 			chat_choice_modulate, 0.1, Tween.TRANS_LINEAR)
-	interpolate_property(_chat_choice, "rect_scale:x", _chat_choice.rect_scale.x,
+	interpolate_property(_chat_choice, "rect_scale:x", null,
 			chat_choice_scale.x, 0.4, Tween.TRANS_ELASTIC, Tween.EASE_OUT)
-	interpolate_property(_chat_choice, "rect_scale:y", _chat_choice.rect_scale.y,
+	interpolate_property(_chat_choice, "rect_scale:y", null,
 			chat_choice_scale.y, 0.2, Tween.TRANS_ELASTIC, Tween.EASE_OUT)
 	start()
 

--- a/project/src/main/chat/ui/chat-pop-tween.gd
+++ b/project/src/main/chat/ui/chat-pop-tween.gd
@@ -44,11 +44,11 @@ func _interpolate_pop(popping_in: bool) -> void:
 	var chat_frame_modulate := Color.white if popping_in else Color.transparent
 	var chat_frame_scale := Vector2.ONE if popping_in else POP_OUT_SCALE
 	
-	interpolate_property(_chat_frame, "modulate", _chat_frame.modulate,
+	interpolate_property(_chat_frame, "modulate", null,
 			chat_frame_modulate, 0.2, Tween.TRANS_LINEAR)
-	interpolate_property(_chat_frame, "rect_scale:x", _chat_frame.rect_scale.x,
+	interpolate_property(_chat_frame, "rect_scale:x", null,
 			chat_frame_scale.x, 0.8, Tween.TRANS_ELASTIC, Tween.EASE_OUT)
-	interpolate_property(_chat_frame, "rect_scale:y", _chat_frame.rect_scale.y,
+	interpolate_property(_chat_frame, "rect_scale:y", null,
 			chat_frame_scale.y, 0.4, Tween.TRANS_ELASTIC, Tween.EASE_OUT)
 	start()
 

--- a/project/src/main/chat/ui/chat-squish-tween.gd
+++ b/project/src/main/chat/ui/chat-squish-tween.gd
@@ -18,5 +18,5 @@ func unsquish() -> void:
 ## Squishes/unsquishes the chat window when prompting the player.
 func _interpolate_squish(squished: bool) -> void:
 	remove(_chat_frame, "rect_position:x")
-	interpolate_property(_chat_frame, "rect_position:x", _chat_frame.rect_position.x,
+	interpolate_property(_chat_frame, "rect_position:x", null,
 			-100 if squished else 0, 0.2, Tween.TRANS_CIRC, Tween.EASE_OUT)

--- a/project/src/main/music/music-tween.gd
+++ b/project/src/main/music/music-tween.gd
@@ -23,7 +23,7 @@ func fade_out(player: AudioStreamPlayer, min_volume: float, duration: float = FA
 	fading_state = FADING_OUT
 	stop(player, "volume_db")
 	remove(player, "volume_db")
-	interpolate_property(player, "volume_db", player.volume_db, min_volume, duration)
+	interpolate_property(player, "volume_db", null, min_volume, duration)
 	start()
 
 
@@ -32,7 +32,7 @@ func fade_in(player: AudioStreamPlayer, max_volume: float, duration: float = FAD
 	fading_state = FADING_IN
 	stop(player, "volume_db")
 	remove(player, "volume_db")
-	interpolate_property(player, "volume_db", player.volume_db, max_volume, duration)
+	interpolate_property(player, "volume_db", null, max_volume, duration)
 	start()
 
 

--- a/project/src/main/puzzle/critter/carrot.gd
+++ b/project/src/main/puzzle/critter/carrot.gd
@@ -98,11 +98,11 @@ func show() -> void:
 	_visuals.scale = HIDE_SCALE
 	
 	_show_tween.remove_all()
-	_show_tween.interpolate_property(_visuals, "modulate", _visuals.modulate, Color.white,
+	_show_tween.interpolate_property(_visuals, "modulate", null, Color.white,
 			SHOW_DURATION)
-	_show_tween.interpolate_property(self, "_mix_color", _mix_color, Color.transparent,
+	_show_tween.interpolate_property(self, "_mix_color", null, Color.transparent,
 			SHOW_DURATION * 3.0, Tween.TRANS_QUAD, Tween.EASE_IN)
-	_show_tween.interpolate_property(_visuals, "scale", _visuals.scale, Vector2.ONE,
+	_show_tween.interpolate_property(_visuals, "scale", null, Vector2.ONE,
 			SHOW_DURATION)
 	_show_tween.start()
 
@@ -116,11 +116,9 @@ func hide() -> void:
 	emit_signal("started_hiding")
 	
 	_show_tween.remove(_visuals, "modulate")
-	_show_tween.interpolate_property(_visuals, "modulate", _visuals.modulate, Color.transparent,
-			HIDE_DURATION)
+	_show_tween.interpolate_property(_visuals, "modulate", null, Color.transparent, HIDE_DURATION)
 	_show_tween.remove(_visuals, "scale")
-	_show_tween.interpolate_property(_visuals, "scale", _visuals.scale, HIDE_SCALE,
-			HIDE_DURATION)
+	_show_tween.interpolate_property(_visuals, "scale", null, HIDE_SCALE, HIDE_DURATION)
 	_show_tween.start()
 
 
@@ -132,8 +130,7 @@ func hide() -> void:
 ## 	'duration': The duration in seconds to travel toward the destination.
 func launch(destination: Vector2, duration: float) -> void:
 	_move_tween.remove_all()
-	_move_tween.interpolate_property(self, "position", position, destination,
-			duration)
+	_move_tween.interpolate_property(self, "position", null, destination, duration)
 	_move_tween.start()
 
 

--- a/project/src/main/puzzle/critter/carrots.gd
+++ b/project/src/main/puzzle/critter/carrots.gd
@@ -185,7 +185,7 @@ func _refresh_carrot_move_sound() -> void:
 	elif not active_carrots and _move_sfx_state in [MoveSfxState.PLAYING, MoveSfxState.STARTING]:
 		_move_sfx_state = MoveSfxState.STOPPING
 		_tween.remove(_carrot_move_sound, "volume_db")
-		_tween.interpolate_property(_carrot_move_sound, "volume_db", _carrot_move_sound.volume_db, MIN_VOLUME,
+		_tween.interpolate_property(_carrot_move_sound, "volume_db", null, MIN_VOLUME,
 				0.4, Tween.TRANS_SINE, Tween.EASE_IN)
 		_tween.start()
 

--- a/project/src/main/puzzle/goop-glob.gd
+++ b/project/src/main/puzzle/goop-glob.gd
@@ -108,7 +108,7 @@ func fall() -> void:
 	smear_time = min(rand_range(0.0, FALL_DURATION * 0.7), rand_range(0.0, FALL_DURATION * 1.2))
 	
 	_tween.remove_all()
-	_tween.interpolate_property(self, "modulate", modulate, Utils.to_transparent(modulate), \
+	_tween.interpolate_property(self, "modulate", null, Utils.to_transparent(modulate), \
 			FALL_DURATION * rand_range(0.8, 1.2), Tween.TRANS_CIRC, Tween.EASE_IN)
 	_tween.start()
 
@@ -122,7 +122,7 @@ func fade() -> void:
 	
 	# No Tween.start() call; Tween is started once timer finishes
 	_tween.remove_all()
-	_tween.interpolate_property(self, "modulate", modulate, Utils.to_transparent(modulate), \
+	_tween.interpolate_property(self, "modulate", null, Utils.to_transparent(modulate), \
 			FADE_DURATION * rand_range(0.8, 1.2), Tween.TRANS_LINEAR, Tween.EASE_IN)
 
 

--- a/project/src/main/puzzle/hud-flash.gd
+++ b/project/src/main/puzzle/hud-flash.gd
@@ -6,5 +6,5 @@ extends ColorRect
 func flash() -> void:
 	modulate.a = 0.25
 	$Tween.remove_all()
-	$Tween.interpolate_property(self, "modulate:a", modulate.a, 0.0, 1.0)
+	$Tween.interpolate_property(self, "modulate:a", null, 0.0, 1.0)
 	$Tween.start()

--- a/project/src/main/puzzle/leaf-poof.gd
+++ b/project/src/main/puzzle/leaf-poof.gd
@@ -49,7 +49,7 @@ func _update_tween_and_animation() -> void:
 	
 	_animation_player.advance(randf() * 10)
 	_tween.remove_all()
-	_tween.interpolate_property(self, "modulate", modulate, Utils.to_transparent(modulate),
+	_tween.interpolate_property(self, "modulate", null, Utils.to_transparent(modulate),
 			LIFETIME, Tween.TRANS_QUAD, Tween.EASE_IN)
 	_tween.start()
 

--- a/project/src/main/puzzle/pickup.gd
+++ b/project/src/main/puzzle/pickup.gd
@@ -82,7 +82,7 @@ func _launch_star_color_tween(var initial_launch := false) -> void:
 	var duration_min := STAR_COLOR_CHANGE_DURATION * (0.0 if initial_launch else 0.8)
 	var duration_max := STAR_COLOR_CHANGE_DURATION * 1.2
 	_star_color_tween.interpolate_property(_star, "modulate", \
-			_star.modulate, _star_colors[new_star_color_index], rand_range(duration_min, duration_max),
+			null, _star_colors[new_star_color_index], rand_range(duration_min, duration_max),
 			Tween.TRANS_SINE)
 	_star_color_tween.start()
 	_star_color_index = new_star_color_index

--- a/project/src/main/puzzle/puzzle-money-hud.gd
+++ b/project/src/main/puzzle/puzzle-money-hud.gd
@@ -24,16 +24,14 @@ func _ready() -> void:
 func _show_money(rank_result: RankResult) -> void:
 	_money_label.set_shown_money(PlayerData.money - rank_result.score)
 	_money_label_tween.remove_all()
-	_money_label_tween.interpolate_property(_money_label, "rect_position:y",
-			_money_label.rect_position.y, 0, TWEEN_DURATION)
+	_money_label_tween.interpolate_property(_money_label, "rect_position:y", null, 0, TWEEN_DURATION)
 	_money_label_tween.start()
 
 
 ## Hides the money label.
 func _hide_money() -> void:
 	_money_label_tween.remove_all()
-	_money_label_tween.interpolate_property(_money_label, "rect_position:y",
-			_money_label.rect_position.y, -32.0, TWEEN_DURATION)
+	_money_label_tween.interpolate_property(_money_label, "rect_position:y", null, -32.0, TWEEN_DURATION)
 	_money_label_tween.start()
 
 

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -218,9 +218,9 @@ func _swoop_bubble(bubble: Control, onscreen: bool) -> void:
 		target_pos = _customer_onscreen_rect_position if onscreen else _customer_offscreen_rect_position
 	var target_opacity := Color.white if onscreen else Color.transparent
 	
-	_swoop_tween.interpolate_property(bubble, "modulate", bubble.modulate, target_opacity,
+	_swoop_tween.interpolate_property(bubble, "modulate", null, target_opacity,
 			SWOOP_DURATION)
-	_swoop_tween.interpolate_property(bubble, "rect_position", bubble.rect_position, target_pos,
+	_swoop_tween.interpolate_property(bubble, "rect_position", null, target_pos,
 			SWOOP_DURATION, Tween.TRANS_CIRC, Tween.EASE_OUT)
 	_swoop_tween.start()
 

--- a/project/src/main/puzzle/tutorial/skill-tally-item.gd
+++ b/project/src/main/puzzle/tutorial/skill-tally-item.gd
@@ -115,14 +115,14 @@ func _blink(bright: bool = false) -> void:
 	if bright:
 		_bright_tween_active = true
 		_blink_panel.modulate = Color.white
-		_tween.interpolate_property(_blink_panel, "rect_scale", _blink_panel.rect_scale, Vector2(2.0, 2.0), 1.2)
-		_tween.interpolate_property(_blink_panel, "modulate", _blink_panel.modulate, Color(0.111, 0.888, 0.111, 0.0),
+		_tween.interpolate_property(_blink_panel, "rect_scale", null, Vector2(2.0, 2.0), 1.2)
+		_tween.interpolate_property(_blink_panel, "modulate", null, Color(0.111, 0.888, 0.111, 0.0),
 				1.2, Tween.TRANS_CIRC, Tween.EASE_IN_OUT)
 		_task_complete_sound.play()
 	else:
 		_blink_panel.modulate = Color(0.111, 0.888, 0.111, 0.5)
-		_tween.interpolate_property(_blink_panel, "rect_scale", _blink_panel.rect_scale, Vector2(1.5, 1.5), 0.6)
-		_tween.interpolate_property(_blink_panel, "modulate:a", _blink_panel.modulate.a, 0.0,
+		_tween.interpolate_property(_blink_panel, "rect_scale", null, Vector2(1.5, 1.5), 0.6)
+		_tween.interpolate_property(_blink_panel, "modulate:a", null, 0.0,
 				0.6, Tween.TRANS_CIRC, Tween.EASE_IN_OUT)
 	_tween.start()
 

--- a/project/src/main/ui/music-popup-tween.gd
+++ b/project/src/main/ui/music-popup-tween.gd
@@ -58,7 +58,7 @@ func _pop_in() -> void:
 	if tween_duration:
 		_popup_state = PopupState.POPPING_IN
 		remove_all()
-		interpolate_property(_music_panel, "rect_position:y", _music_panel.rect_position.y, POP_IN_Y, tween_duration)
+		interpolate_property(_music_panel, "rect_position:y", null, POP_IN_Y, tween_duration)
 		start()
 	else:
 		$PopOutTimer.start(POPUP_DURATION)
@@ -74,7 +74,7 @@ func _pop_out() -> void:
 	if tween_duration:
 		_popup_state = PopupState.POPPING_OUT
 		remove_all()
-		interpolate_property(_music_panel, "rect_position:y", _music_panel.rect_position.y, POP_OUT_Y, tween_duration)
+		interpolate_property(_music_panel, "rect_position:y", null, POP_OUT_Y, tween_duration)
 		start()
 	else:
 		_popup_state = PopupState.POPPED_OUT

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -441,7 +441,7 @@ func get_eating_delay() -> float:
 ## Starts a tween which changes this creature's opacity.
 func _launch_fade_tween(new_alpha: float, duration: float) -> void:
 	_fade_tween.remove_all()
-	_fade_tween.interpolate_property(self, "modulate", modulate, Utils.to_transparent(modulate, new_alpha), duration)
+	_fade_tween.interpolate_property(self, "modulate", null, Utils.to_transparent(modulate, new_alpha), duration)
 	_fade_tween.start()
 
 

--- a/project/src/main/world/creature/emote-player.gd
+++ b/project/src/main/world/creature/emote-player.gd
@@ -348,17 +348,14 @@ func unemote(anim_name: String = "") -> void:
 		play("ambient-sweat")
 	
 	_reset_tween.remove_all()
-	_reset_tween.interpolate_property(_head_bobber, "rotation_degrees",
-			_head_bobber.rotation_degrees, 0, UNEMOTE_DURATION)
+	_reset_tween.interpolate_property(_head_bobber, "rotation_degrees", null, 0, UNEMOTE_DURATION)
 	for emote_sprite in _emote_sprites:
-		_reset_tween.interpolate_property(emote_sprite, "rotation_degrees", emote_sprite.rotation_degrees, 0,
-				UNEMOTE_DURATION)
-		_reset_tween.interpolate_property(emote_sprite, "modulate", emote_sprite.modulate,
+		_reset_tween.interpolate_property(emote_sprite, "rotation_degrees", null, 0, UNEMOTE_DURATION)
+		_reset_tween.interpolate_property(emote_sprite, "modulate", null,
 				Utils.to_transparent(emote_sprite.modulate), UNEMOTE_DURATION)
 	for eye_sprite in [_emote_eye_z0, _emote_eye_z1]:
 		# some animations like the 'love' animation change the emote eye scale
-		_reset_tween.interpolate_property(eye_sprite, "scale", eye_sprite.scale, Vector2(2.0, 2.0),
-				UNEMOTE_DURATION)
+		_reset_tween.interpolate_property(eye_sprite, "scale", null, Vector2(2.0, 2.0), UNEMOTE_DURATION)
 	
 	_head_bobber.reset_head_bob()
 	_reset_tween.start()
@@ -368,7 +365,7 @@ func unemote(anim_name: String = "") -> void:
 ## Adjusts the volume for all mood-related sound effects for this creature.
 func _tween_sfx_volume(new_value: float) -> void:
 	_volume_db_tween.remove_all()
-	_volume_db_tween.interpolate_property(_emote_sfx, "volume_db", _emote_sfx.volume_db, new_value, FADE_SFX_DURATION)
+	_volume_db_tween.interpolate_property(_emote_sfx, "volume_db", null, new_value, FADE_SFX_DURATION)
 	_volume_db_tween.start()
 
 
@@ -528,16 +525,14 @@ func _transition_rage1_rage0() -> void:
 func _transition_sigh1_sigh0() -> void:
 	_creature_visuals.get_node("Neck0").scale = Vector2.ONE
 	_reset_tween.remove_all()
-	_reset_tween.interpolate_property(_head_bobber, "rotation_degrees",
-			_head_bobber.rotation_degrees, 0.0, UNEMOTE_DURATION)
+	_reset_tween.interpolate_property(_head_bobber, "rotation_degrees", null, 0.0, UNEMOTE_DURATION)
 	_reset_tween.start()
 
 
 ## Transitions from 'sly0' to 'sly1', resetting the head's rotation
 func _transition_sly0_sly1() -> void:
 	_reset_tween.remove_all()
-	_reset_tween.interpolate_property(_head_bobber, "rotation_degrees",
-			_head_bobber.rotation_degrees, 0.0, UNEMOTE_DURATION)
+	_reset_tween.interpolate_property(_head_bobber, "rotation_degrees", null, 0.0, UNEMOTE_DURATION)
 	_reset_tween.start()
 
 
@@ -550,8 +545,7 @@ func _transition_sly1_sly0() -> void:
 func _transition_smile1_any() -> void:
 	_reset_tween.remove_all()
 	_tween_nodes_to_transparent(["Neck0/HeadBobber/EmoteBrain", "Neck0/HeadBobber/EmoteGlow"])
-	_reset_tween.interpolate_property(_head_bobber, "rotation_degrees",
-			_head_bobber.rotation_degrees, 0.0, UNEMOTE_DURATION)
+	_reset_tween.interpolate_property(_head_bobber, "rotation_degrees", null, 0.0, UNEMOTE_DURATION)
 	_reset_tween.start()
 
 
@@ -567,7 +561,7 @@ func _transition_sweat1_sweat0() -> void:
 func _tween_nodes_to_transparent(paths: Array) -> void:
 	for path in paths:
 		var node: Node2D = _creature_visuals.get_node(path)
-		_reset_tween.interpolate_property(node, "modulate", node.modulate, Color.transparent, UNEMOTE_DURATION)
+		_reset_tween.interpolate_property(node, "modulate", null, Color.transparent, UNEMOTE_DURATION)
 
 
 ## This function manually assigns fields which Godot would ideally assign automatically by calling _ready. It is a

--- a/project/src/main/world/environment/ripple-sprite.gd
+++ b/project/src/main/world/environment/ripple-sprite.gd
@@ -34,7 +34,7 @@ func _refresh_ripple_state() -> void:
 	# fade the sprite in or out
 	var new_modulate := Color.transparent if ripple_state == Ripples.RippleState.OFF else Color.white
 	if modulate != new_modulate:
-		_fade_tween.interpolate_property(self, "modulate", modulate, new_modulate, FADE_DURATION)
+		_fade_tween.interpolate_property(self, "modulate", null, new_modulate, FADE_DURATION)
 		_fade_tween.start()
 	
 	# determine the animation to play. we change the animation if the sprite is flipped


### PR DESCRIPTION
Tween's interpolate_property function's 'from' parameter defaults to the current value. Explicitly specifying the from parameter is redundant.