### PR TITLE
Simplified OverworldExit. Removed unused spawns.

### DIFF
--- a/project/src/demo/world/environment/lemon/Lemon2FreeRoamEnvironment.tscn
+++ b/project/src/demo/world/environment/lemon/Lemon2FreeRoamEnvironment.tscn
@@ -1,10 +1,10 @@
 [gd_scene load_steps=29 format=2]
 
 [ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=1]
-[ext_resource path="res://src/main/world/Spawn.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/world/environment/InvisibleObstacleTiler.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/world/OverworldExit.tscn" type="PackedScene" id=5]
+[ext_resource path="res://assets/main/world/environment/exit-ne-sheet.png" type="Texture" id=6]
 [ext_resource path="res://src/main/world/environment/pebble-overworld-tiler.gd" type="Script" id=8]
 [ext_resource path="res://assets/main/world/environment/lemon/brot-spot-stool-orange-occupied.png" type="Texture" id=9]
 [ext_resource path="res://assets/main/world/environment/lemon/brot-spot-stool-orange.png" type="Texture" id=10]
@@ -70,47 +70,37 @@ pebble_tile_index = 1
 
 [node name="Exit1" parent="Ground/Exits" instance=ExtResource( 5 )]
 position = Vector2( 392.52, 2352.6 )
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit2" parent="Ground/Exits" instance=ExtResource( 5 )]
 position = Vector2( 2225.2, 3093.34 )
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit3" parent="Ground/Exits" instance=ExtResource( 5 )]
 position = Vector2( 3104.93, 3153.04 )
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit4" parent="Ground/Exits" instance=ExtResource( 5 )]
 position = Vector2( 4687, 2528.28 )
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit5" parent="Ground/Exits" instance=ExtResource( 5 )]
 position = Vector2( 5611.91, 2310.53 )
+texture = ExtResource( 6 )
 exit_direction = 1
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit6" parent="Ground/Exits" instance=ExtResource( 5 )]
 position = Vector2( 1431.91, 3666.53 )
+scale = Vector2( -0.539476, -0.539476 )
+texture = ExtResource( 6 )
 exit_direction = 5
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit7" parent="Ground/Exits" instance=ExtResource( 5 )]
 position = Vector2( 35.9053, 2346.53 )
+scale = Vector2( -0.539476, 0.539476 )
+texture = ExtResource( 6 )
 exit_direction = 7
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit8" parent="Ground/Exits" instance=ExtResource( 5 )]
 position = Vector2( 3579.91, 1030.53 )
+texture = ExtResource( 6 )
 exit_direction = 1
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Shadows" parent="Ground" instance=ExtResource( 26 )]
 obstacle_map_path = NodePath("../../Obstacles/ObstacleMap")
@@ -516,23 +506,3 @@ frame = 3
 position = Vector2( 1632.74, 1188.63 )
 frame = 3
 flip_h = true
-
-[node name="Spawns" type="Node2D" parent="."]
-
-[node name="Restaurant11" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 4574.49, 2526.68 )
-id = "restaurant_11"
-
-[node name="Restaurant8" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 4513.88, 2585.05 )
-id = "restaurant_8"
-
-[node name="Restaurant4" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 4852.86, 2596.27 )
-orientation = 1
-id = "restaurant_4"
-
-[node name="Restaurant1" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 4787.76, 2535.66 )
-orientation = 1
-id = "restaurant_1"

--- a/project/src/demo/world/environment/lemon/LemonFreeRoamEnvironment.tscn
+++ b/project/src/demo/world/environment/lemon/LemonFreeRoamEnvironment.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=31 format=2]
+[gd_scene load_steps=32 format=2]
 
 [ext_resource path="res://src/main/world/environment/lemon/lemon-obstacle-library.tres" type="TileSet" id=1]
 [ext_resource path="res://src/main/world/environment/lemon/lemon-terrain-library.tres" type="TileSet" id=2]
@@ -28,6 +28,7 @@
 [ext_resource path="res://src/main/world/environment/lemon/LemonCookieLarge.tscn" type="PackedScene" id=26]
 [ext_resource path="res://src/main/world/environment/lemon/LemonLemon.tscn" type="PackedScene" id=27]
 [ext_resource path="res://src/main/world/environment/lemon/LemonCookieSmall.tscn" type="PackedScene" id=28]
+[ext_resource path="res://assets/main/world/environment/exit-ne-sheet.png" type="Texture" id=29]
 [ext_resource path="res://src/main/world/OverworldExit.tscn" type="PackedScene" id=31]
 
 [sub_resource type="Curve2D" id=4]
@@ -76,14 +77,19 @@ pebble_tile_index = 1
 
 [node name="Exit0" parent="Ground/Exits" instance=ExtResource( 31 )]
 position = Vector2( 244.964, 1525.82 )
+scale = Vector2( -0.539476, 0.539476 )
+texture = ExtResource( 29 )
 exit_direction = 7
 
 [node name="Exit1" parent="Ground/Exits" instance=ExtResource( 31 )]
 position = Vector2( 5061.51, 3607.66 )
+scale = Vector2( 0.539476, -0.539476 )
+texture = ExtResource( 29 )
 exit_direction = 3
 
 [node name="Exit2" parent="Ground/Exits" instance=ExtResource( 31 )]
 position = Vector2( 3563.94, 1266.17 )
+texture = ExtResource( 29 )
 exit_direction = 1
 
 [node name="Exit3" parent="Ground/Exits" instance=ExtResource( 31 )]
@@ -452,8 +458,6 @@ rotation = 3.14159
 position = Vector2( 3260.33, 1646.82 )
 rotation = 3.14159
 frame = 3
-
-[node name="Spawns" type="Node2D" parent="."]
 
 [node name="PlayerPath" type="Path2D" parent="."]
 position = Vector2( 475.371, 923.074 )

--- a/project/src/demo/world/environment/marsh/MarshFreeRoamEnvironment.tscn
+++ b/project/src/demo/world/environment/marsh/MarshFreeRoamEnvironment.tscn
@@ -5,10 +5,10 @@
 [ext_resource path="res://src/main/world/environment/GoopOverworldTiler.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/world/environment/OutdoorShadows.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/world/environment/marsh/marsh-terrain-library.tres" type="TileSet" id=5]
+[ext_resource path="res://assets/main/world/environment/exit-ne-sheet.png" type="Texture" id=6]
 [ext_resource path="res://src/main/world/environment/marsh/marsh-obstacle-library.tres" type="TileSet" id=23]
 [ext_resource path="res://src/main/world/creature/sensei.gd" type="Script" id=25]
 [ext_resource path="res://src/main/world/environment/marsh/ButtercupSign.tscn" type="PackedScene" id=28]
-[ext_resource path="res://src/main/world/Spawn.tscn" type="PackedScene" id=29]
 [ext_resource path="res://src/main/world/environment/marsh/ButtercupStoolSpawnerW.tscn" type="PackedScene" id=31]
 [ext_resource path="res://src/main/world/environment/marsh/MarshHouse.tscn" type="PackedScene" id=32]
 [ext_resource path="res://src/main/world/environment/marsh/MarshGroundMap.tscn" type="PackedScene" id=33]
@@ -63,15 +63,15 @@ position = Vector2( 1409.4, 1003.45 )
 
 [node name="NwExit" parent="Ground/Exits" instance=ExtResource( 44 )]
 position = Vector2( 759.881, 359.956 )
+scale = Vector2( -0.539476, 0.539476 )
+texture = ExtResource( 6 )
 exit_direction = 7
-player_spawn_id = "se_player"
-sensei_spawn_id = "se_sensei"
 
 [node name="SeExit" parent="Ground/Exits" instance=ExtResource( 44 )]
 position = Vector2( 1919.48, 1759.62 )
+scale = Vector2( 0.539476, -0.539476 )
+texture = ExtResource( 6 )
 exit_direction = 3
-player_spawn_id = "nw_player"
-sensei_spawn_id = "nw_sensei"
 
 [node name="Shadows" parent="Ground" instance=ExtResource( 4 )]
 obstacle_map_path = NodePath("../../Obstacles/ObstacleMap")
@@ -298,91 +298,3 @@ position = Vector2( 1499.38, 1292.35 )
 
 [node name="TurboFatCrystal8" parent="Obstacles" instance=ExtResource( 48 )]
 position = Vector2( 1238.62, 921.227 )
-
-[node name="Spawns" type="Node2D" parent="."]
-
-[node name="Restaurant1" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 1665.79, 1022.31 )
-orientation = 1
-id = "restaurant_1"
-
-[node name="Restaurant4" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 1715.18, 1110.98 )
-orientation = 1
-id = "restaurant_4"
-
-[node name="Restaurant8" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 1488.44, 1124.45 )
-id = "restaurant_8"
-
-[node name="Restaurant11" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 1524.36, 1023.43 )
-id = "restaurant_11"
-
-[node name="RestaurantPlayer" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 1396.4, 1014.45 )
-orientation = 1
-id = "restaurant_player"
-
-[node name="RestaurantSensei" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 1569.4, 1042.45 )
-id = "restaurant_sensei"
-
-[node name="Buttercup1" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 710.294, 1360.37 )
-orientation = 1
-id = "buttercup_1"
-
-[node name="Buttercup3" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 779.594, 1434.7 )
-orientation = 1
-id = "buttercup_3"
-
-[node name="Buttercup6" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 635.089, 1495.06 )
-orientation = 1
-id = "buttercup_6"
-
-[node name="Buttercup7" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 526.21, 1473.74 )
-id = "buttercup_7"
-
-[node name="Buttercup9" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 455.069, 1418.4 )
-id = "buttercup_9"
-
-[node name="Buttercup11" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 532.99, 1349.44 )
-id = "buttercup_11"
-
-[node name="ButtercupSeat" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 339.509, 1583.36 )
-id = "buttercup_seat"
-elevation = 80.0
-
-[node name="ButtercupFence3" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 1114.3, 1323.42 )
-orientation = 1
-id = "buttercup_fence_3"
-
-[node name="ButtercupFence12" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 987.723, 1271.8 )
-id = "buttercup_fence_12"
-
-[node name="SePlayer" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 1764.82, 1680.06 )
-orientation = 2
-id = "se_player"
-
-[node name="SeSensei" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 1916.18, 1737.24 )
-orientation = 2
-id = "se_sensei"
-
-[node name="NwPlayer" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 932.693, 435.451 )
-id = "nw_player"
-
-[node name="NwPlayer2" parent="Spawns" instance=ExtResource( 29 )]
-position = Vector2( 826.74, 356.406 )
-id = "nw_sensei"

--- a/project/src/demo/world/environment/poki/PokiFreeRoamEnvironment.tscn
+++ b/project/src/demo/world/environment/poki/PokiFreeRoamEnvironment.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=23 format=2]
+[gd_scene load_steps=24 format=2]
 
 [ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/environment/poki/PokiGroundMap.tscn" type="PackedScene" id=2]
@@ -19,6 +19,7 @@
 [ext_resource path="res://src/main/world/environment/poki/PokiCactusPlaque.tscn" type="PackedScene" id=17]
 [ext_resource path="res://src/main/world/environment/poki/WeAccept.tscn" type="PackedScene" id=18]
 [ext_resource path="res://src/main/world/environment/poki/Tent.tscn" type="PackedScene" id=19]
+[ext_resource path="res://assets/main/world/environment/exit-ne-sheet.png" type="Texture" id=20]
 [ext_resource path="res://src/main/world/environment/OutdoorShadows.tscn" type="PackedScene" id=24]
 [ext_resource path="res://src/main/world/creature/player.gd" type="Script" id=28]
 
@@ -67,10 +68,14 @@ puddle_tile_index = 1
 
 [node name="OverworldExit" parent="Ground/Exits" instance=ExtResource( 4 )]
 position = Vector2( 309.859, 1727.8 )
+scale = Vector2( -0.539476, -0.539476 )
+texture = ExtResource( 20 )
 exit_direction = 5
 
 [node name="OverworldExit2" parent="Ground/Exits" instance=ExtResource( 4 )]
 position = Vector2( 3874.24, 2254.34 )
+scale = Vector2( 0.539476, -0.539476 )
+texture = ExtResource( 20 )
 exit_direction = 3
 
 [node name="OverworldExit3" parent="Ground/Exits" instance=ExtResource( 4 )]
@@ -190,8 +195,6 @@ flip_h = true
 
 [node name="CactusSmall" parent="Obstacles" instance=ExtResource( 5 )]
 position = Vector2( 1738.11, 1243.44 )
-
-[node name="Spawns" type="Node2D" parent="."]
 
 [node name="PlayerPath" type="Path2D" parent="."]
 position = Vector2( 475.371, 923.074 )

--- a/project/src/demo/world/environment/restaurant/TurboFatFreeRoamEnvironment.tscn
+++ b/project/src/demo/world/environment/restaurant/TurboFatFreeRoamEnvironment.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=39 format=2]
+[gd_scene load_steps=38 format=2]
 
 [ext_resource path="res://src/main/world/OverworldExit.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/CreatureSpawner.tscn" type="PackedScene" id=2]
@@ -8,7 +8,6 @@
 [ext_resource path="res://src/main/world/environment/restaurant/WoodPillar.tscn" type="PackedScene" id=6]
 [ext_resource path="res://src/main/world/environment/restaurant/TurboFatStool.tscn" type="PackedScene" id=7]
 [ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=8]
-[ext_resource path="res://src/main/world/Spawn.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/world/creature/player.gd" type="Script" id=10]
 [ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=11]
 [ext_resource path="res://src/main/world/environment/restaurant/kitchen-obstacle-tiler.gd" type="Script" id=12]
@@ -69,9 +68,8 @@ kitchen_tile_index = 54907
 
 [node name="FreeRoamExit" parent="Ground/Exits" instance=ExtResource( 1 )]
 position = Vector2( 130.547, 315.908 )
+scale = Vector2( 0.539476, -0.539476 )
 exit_direction = 4
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Shadows" parent="Ground" instance=ExtResource( 3 )]
 obstacle_map_path = NodePath("../../Obstacles/ObstacleMap")
@@ -740,101 +738,3 @@ position = Vector2( 1313.39, 219 )
 
 [node name="Stool11" parent="Obstacles" instance=ExtResource( 7 )]
 position = Vector2( 1383.76, 123.852 )
-
-[node name="Spawns" type="Node2D" parent="."]
-
-[node name="Chef" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 1512, 255 )
-orientation = 1
-id = "chef"
-
-[node name="Customer1" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 592, 35 )
-stool_path = NodePath("../../Obstacles/Stool2")
-id = "customer_1"
-elevation = 140.0
-
-[node name="Customer2" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 349, 322 )
-stool_path = NodePath("../../Obstacles/Stool4")
-id = "customer_2"
-elevation = 140.0
-
-[node name="Customer3" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 992, 35 )
-stool_path = NodePath("../../Obstacles/Stool8")
-id = "customer_3"
-elevation = 140.0
-
-[node name="Customer4" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 1313, 220 )
-stool_path = NodePath("../../Obstacles/Stool10")
-id = "customer_4"
-elevation = 140.0
-
-[node name="Entrance2" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 342.245, 52.3916 )
-orientation = 1
-id = "entrance_2"
-
-[node name="Entrance5" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 394.38, 152.458 )
-orientation = 1
-id = "entrance_5"
-
-[node name="Entrance7" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 126.975, 170.117 )
-id = "entrance_7"
-
-[node name="Entrance10" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 179.111, 52.3916 )
-id = "entrance_10"
-
-[node name="Kitchen1" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 1863.6, 75.8002 )
-orientation = 1
-id = "kitchen_1"
-
-[node name="Kitchen3" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 1910.61, 182.605 )
-orientation = 1
-id = "kitchen_3"
-
-[node name="Kitchen5" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 1955.82, 282.207 )
-orientation = 1
-id = "kitchen_5"
-
-[node name="Kitchen7" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 1596.46, 279.091 )
-id = "kitchen_7"
-
-[node name="Kitchen9" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 1667.9, 173.54 )
-id = "kitchen_9"
-
-[node name="Kitchen11" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 1740.68, 77.2144 )
-id = "kitchen_11"
-
-[node name="TableSeatLeft" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 749.285, 321.719 )
-stool_path = NodePath("../../Obstacles/Stool6")
-id = "table_seat_left"
-elevation = 140.0
-
-[node name="Table2" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 689.515, 237.165 )
-id = "table_2"
-
-[node name="Table10" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 995.141, 231.219 )
-orientation = 1
-id = "table_10"
-
-[node name="TableSeatRight" parent="Spawns" instance=ExtResource( 9 )]
-position = Vector2( 925.285, 321.719 )
-orientation = 1
-stool_path = NodePath("../../Obstacles/Stool5")
-id = "table_seat_right"
-elevation = 140.0

--- a/project/src/demo/world/environment/restaurant/UndecoratedTurboFatFreeRoamEnvironment.tscn
+++ b/project/src/demo/world/environment/restaurant/UndecoratedTurboFatFreeRoamEnvironment.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=39 format=2]
+[gd_scene load_steps=38 format=2]
 
 [ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=1]
-[ext_resource path="res://src/main/world/Spawn.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/world/environment/InvisibleObstacleTiler.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/world/OverworldExit.tscn" type="PackedScene" id=5]
@@ -70,9 +69,8 @@ undecorated_tile_index = 82456
 
 [node name="FreeRoamExit" parent="Ground/Exits" instance=ExtResource( 5 )]
 position = Vector2( 130.547, 315.908 )
+scale = Vector2( 0.539476, -0.539476 )
 exit_direction = 4
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Shadows" parent="Ground" instance=ExtResource( 33 )]
 obstacle_map_path = NodePath("../../Obstacles/ObstacleMap")
@@ -504,101 +502,3 @@ position = Vector2( 1313.39, 219 )
 
 [node name="Stool11" parent="Obstacles" instance=ExtResource( 32 )]
 position = Vector2( 1383.76, 123.852 )
-
-[node name="Spawns" type="Node2D" parent="."]
-
-[node name="Chef" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 1512, 255 )
-orientation = 1
-id = "chef"
-
-[node name="Customer1" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 592, 35 )
-stool_path = NodePath("../../Obstacles/Stool2")
-id = "customer_1"
-elevation = 140.0
-
-[node name="Customer2" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 349, 321 )
-stool_path = NodePath("../../Obstacles/Stool4")
-id = "customer_2"
-elevation = 140.0
-
-[node name="Customer3" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 992, 35 )
-stool_path = NodePath("../../Obstacles/Stool8")
-id = "customer_3"
-elevation = 140.0
-
-[node name="Customer4" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 1313, 220 )
-stool_path = NodePath("../../Obstacles/Stool10")
-id = "customer_4"
-elevation = 140.0
-
-[node name="Entrance2" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 342.245, 52.3916 )
-orientation = 1
-id = "entrance_2"
-
-[node name="Entrance5" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 394.38, 152.458 )
-orientation = 1
-id = "entrance_5"
-
-[node name="Entrance7" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 126.975, 170.117 )
-id = "entrance_7"
-
-[node name="Entrance10" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 179.111, 52.3916 )
-id = "entrance_10"
-
-[node name="Kitchen1" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 1863.6, 75.8002 )
-orientation = 1
-id = "kitchen_1"
-
-[node name="Kitchen3" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 1910.61, 182.605 )
-orientation = 1
-id = "kitchen_3"
-
-[node name="Kitchen5" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 1955.82, 282.207 )
-orientation = 1
-id = "kitchen_5"
-
-[node name="Kitchen7" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 1596.46, 279.091 )
-id = "kitchen_7"
-
-[node name="Kitchen9" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 1667.9, 173.54 )
-id = "kitchen_9"
-
-[node name="Kitchen11" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 1740.68, 77.2144 )
-id = "kitchen_11"
-
-[node name="TableSeatLeft" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 749.285, 321.719 )
-stool_path = NodePath("../../Obstacles/Stool6")
-id = "table_seat_left"
-elevation = 140.0
-
-[node name="Table2" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 689.515, 237.165 )
-id = "table_2"
-
-[node name="Table10" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 995.141, 231.219 )
-orientation = 1
-id = "table_10"
-
-[node name="TableSeatRight" parent="Spawns" instance=ExtResource( 2 )]
-position = Vector2( 925.285, 321.719 )
-orientation = 1
-stool_path = NodePath("../../Obstacles/Stool5")
-id = "table_seat_right"
-elevation = 140.0

--- a/project/src/main/world/OverworldExit.tscn
+++ b/project/src/main/world/OverworldExit.tscn
@@ -1,11 +1,10 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://src/main/utils/outline.shader" type="Shader" id=1]
 [ext_resource path="res://src/main/world/overworld-exit.gd" type="Script" id=2]
 [ext_resource path="res://assets/main/world/environment/exit-n-sheet.png" type="Texture" id=3]
 
 [sub_resource type="ShaderMaterial" id=1]
-resource_local_to_scene = true
 shader = ExtResource( 1 )
 shader_param/width = 1.5
 shader_param/black = Color( 0.423529, 0.262745, 0.192157, 1 )
@@ -44,16 +43,7 @@ tracks/0/keys = {
 "values": [ 4, 5, 6, 7, 0, 1, 2, 3, 4 ]
 }
 
-[sub_resource type="RectangleShape2D" id=3]
-extents = Vector2( 20, 20 )
-
-[node name="OverworldExit" type="Area2D"]
-script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
-
-[node name="Sprite" type="Sprite" parent="."]
+[node name="Sprite" type="Sprite"]
 modulate = Color( 1, 1, 1, 0.752941 )
 material = SubResource( 1 )
 scale = Vector2( 0.539476, 0.539476 )
@@ -61,12 +51,9 @@ texture = ExtResource( 3 )
 hframes = 3
 vframes = 3
 frame = 4
+script = ExtResource( 2 )
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 autoplay = "default"
 anims/RESET = SubResource( 4 )
 anims/default = SubResource( 2 )
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2( 0, -20 )
-shape = SubResource( 3 )

--- a/project/src/main/world/environment/lemon/Lemon2Environment.tscn
+++ b/project/src/main/world/environment/lemon/Lemon2Environment.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=28 format=2]
+[gd_scene load_steps=29 format=2]
 
 [ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/environment/pebble-overworld-tiler.gd" type="Script" id=2]
@@ -20,6 +20,7 @@
 [ext_resource path="res://src/main/world/environment/GoopOverworldTiler.tscn" type="PackedScene" id=18]
 [ext_resource path="res://src/main/world/environment/lemon/LemonGroundMap.tscn" type="PackedScene" id=19]
 [ext_resource path="res://src/main/world/environment/lemon/BrotSpotTable.tscn" type="PackedScene" id=20]
+[ext_resource path="res://assets/main/world/environment/exit-ne-sheet.png" type="Texture" id=21]
 [ext_resource path="res://src/main/world/OverworldExit.tscn" type="PackedScene" id=22]
 [ext_resource path="res://src/main/world/environment/lemon/LemonTree.tscn" type="PackedScene" id=23]
 [ext_resource path="res://assets/main/world/environment/lemon/brot-spot-stool-orange.png" type="Texture" id=24]
@@ -73,47 +74,37 @@ pebble_tile_index = 1
 
 [node name="Exit1" parent="Ground/Exits" instance=ExtResource( 22 )]
 position = Vector2( 392.52, 2352.6 )
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit2" parent="Ground/Exits" instance=ExtResource( 22 )]
 position = Vector2( 2225.2, 3093.34 )
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit3" parent="Ground/Exits" instance=ExtResource( 22 )]
 position = Vector2( 3104.93, 3153.04 )
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit4" parent="Ground/Exits" instance=ExtResource( 22 )]
 position = Vector2( 4687, 2528.28 )
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit5" parent="Ground/Exits" instance=ExtResource( 22 )]
 position = Vector2( 5611.91, 2310.53 )
+texture = ExtResource( 21 )
 exit_direction = 1
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit6" parent="Ground/Exits" instance=ExtResource( 22 )]
 position = Vector2( 1431.91, 3666.53 )
+scale = Vector2( -0.539476, -0.539476 )
+texture = ExtResource( 21 )
 exit_direction = 5
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit7" parent="Ground/Exits" instance=ExtResource( 22 )]
 position = Vector2( 35.9053, 2346.53 )
+scale = Vector2( -0.539476, 0.539476 )
+texture = ExtResource( 21 )
 exit_direction = 7
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit8" parent="Ground/Exits" instance=ExtResource( 22 )]
 position = Vector2( 3579.91, 1030.53 )
+texture = ExtResource( 21 )
 exit_direction = 1
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Shadows" parent="Ground" instance=ExtResource( 14 )]
 obstacle_map_path = NodePath("../../Obstacles/ObstacleMap")

--- a/project/src/main/world/environment/lemon/LemonEnvironment.tscn
+++ b/project/src/main/world/environment/lemon/LemonEnvironment.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=30 format=2]
+[gd_scene load_steps=31 format=2]
 
 [ext_resource path="res://src/main/world/environment/lemon/lemon-obstacle-library.tres" type="TileSet" id=1]
 [ext_resource path="res://src/main/world/environment/GoopOverworldTiler.tscn" type="PackedScene" id=2]
@@ -25,6 +25,7 @@
 [ext_resource path="res://src/main/world/environment/lemon/GravesiteGrave.tscn" type="PackedScene" id=23]
 [ext_resource path="res://src/main/world/environment/lemon/GravesiteCup.tscn" type="PackedScene" id=24]
 [ext_resource path="res://src/main/world/Spawn.tscn" type="PackedScene" id=25]
+[ext_resource path="res://assets/main/world/environment/exit-ne-sheet.png" type="Texture" id=26]
 [ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=29]
 [ext_resource path="res://src/main/world/environment/lemon/LemonRippleWaves.tscn" type="PackedScene" id=30]
 [ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=31]
@@ -75,36 +76,29 @@ pebble_tile_index = 1
 
 [node name="Exit0" parent="Ground/Exits" instance=ExtResource( 11 )]
 position = Vector2( 244.964, 1525.82 )
+scale = Vector2( -0.539476, 0.539476 )
+texture = ExtResource( 26 )
 exit_direction = 7
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit1" parent="Ground/Exits" instance=ExtResource( 11 )]
 position = Vector2( 5061.51, 3607.66 )
+scale = Vector2( 0.539476, -0.539476 )
+texture = ExtResource( 26 )
 exit_direction = 3
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit2" parent="Ground/Exits" instance=ExtResource( 11 )]
 position = Vector2( 3563.94, 1266.17 )
+texture = ExtResource( 26 )
 exit_direction = 1
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit3" parent="Ground/Exits" instance=ExtResource( 11 )]
 position = Vector2( 485.181, 1437.24 )
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit4" parent="Ground/Exits" instance=ExtResource( 11 )]
 position = Vector2( 1364.91, 1496.94 )
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit5" parent="Ground/Exits" instance=ExtResource( 11 )]
 position = Vector2( 4468.65, 2463.38 )
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Shadows" parent="Ground" instance=ExtResource( 8 )]
 obstacle_map_path = NodePath("../../Obstacles/ObstacleMap")

--- a/project/src/main/world/environment/marsh/MarshEnvironment.tscn
+++ b/project/src/main/world/environment/marsh/MarshEnvironment.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=28 format=2]
+[gd_scene load_steps=30 format=2]
 
 [ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/environment/marsh/marsh-obstacle-library.tres" type="TileSet" id=2]
@@ -7,6 +7,8 @@
 [ext_resource path="res://src/main/world/environment/marsh/marsh-terrain-library.tres" type="TileSet" id=5]
 [ext_resource path="res://src/main/world/environment/InvisibleObstacleTiler.tscn" type="PackedScene" id=6]
 [ext_resource path="res://src/main/world/environment/GoopOverworldTiler.tscn" type="PackedScene" id=7]
+[ext_resource path="res://assets/main/world/environment/exit-e-sheet.png" type="Texture" id=8]
+[ext_resource path="res://assets/main/world/environment/exit-ne-sheet.png" type="Texture" id=9]
 [ext_resource path="res://src/main/world/OverworldExit.tscn" type="PackedScene" id=10]
 [ext_resource path="res://src/main/world/environment/marsh/MarshCrystal.tscn" type="PackedScene" id=20]
 [ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=23]
@@ -66,30 +68,23 @@ tile_data = PoolIntArray( -1769413, 0, 327681, -1769412, 0, 131072, -1703878, 0,
 
 [node name="Exit0" parent="Ground/Exits" instance=ExtResource( 10 )]
 position = Vector2( 31.4402, 1073.84 )
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit1" parent="Ground/Exits" instance=ExtResource( 10 )]
 position = Vector2( 1891.49, 1132.19 )
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit2" parent="Ground/Exits" instance=ExtResource( 10 )]
 position = Vector2( 5553.59, 1072.96 )
+texture = ExtResource( 8 )
 exit_direction = 2
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit3" parent="Ground/Exits" instance=ExtResource( 10 )]
 position = Vector2( -997.007, 1179.2 )
+scale = Vector2( -0.539476, 0.539476 )
+texture = ExtResource( 9 )
 exit_direction = 7
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Exit4" parent="Ground/Exits" instance=ExtResource( 10 )]
 position = Vector2( 4042.15, 1078.19 )
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Shadows" parent="Ground" instance=ExtResource( 4 )]
 obstacle_map_path = NodePath("../../Obstacles/ObstacleMap")

--- a/project/src/main/world/environment/overworld-environment.gd
+++ b/project/src/main/world/environment/overworld-environment.gd
@@ -1,3 +1,4 @@
+
 class_name OverworldEnvironment
 extends Node
 ## Maintains creatures and obstacles for an overworld scene

--- a/project/src/main/world/environment/poki/PokiEnvironment.tscn
+++ b/project/src/main/world/environment/poki/PokiEnvironment.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=26 format=2]
+[gd_scene load_steps=27 format=2]
 
 [ext_resource path="res://src/main/world/environment/poki/poki-terrain-library.tres" type="TileSet" id=1]
 [ext_resource path="res://src/main/world/environment/poki/PokiCrowdSpawner.tscn" type="PackedScene" id=2]
@@ -24,6 +24,7 @@
 [ext_resource path="res://src/main/world/ObstacleSpawner.tscn" type="PackedScene" id=22]
 [ext_resource path="res://assets/main/world/environment/poki/we-accept.png" type="Texture" id=23]
 [ext_resource path="res://assets/main/world/environment/poki/poki-cactus-plaque.png" type="Texture" id=24]
+[ext_resource path="res://assets/main/world/environment/exit-ne-sheet.png" type="Texture" id=25]
 
 [sub_resource type="Curve2D" id=1]
 _data = {
@@ -73,18 +74,21 @@ script = ExtResource( 11 )
 position = Vector2( -2, 1 )
 
 [node name="OverworldExit" parent="Ground/Exits" instance=ExtResource( 12 )]
-position = Vector2( -1.26801, 1894.68 )
+position = Vector2( 0.73199, 1893.68 )
+scale = Vector2( -0.539476, -0.539476 )
+texture = ExtResource( 25 )
 exit_direction = 5
 
 [node name="OverworldExit2" parent="Ground/Exits" instance=ExtResource( 12 )]
-position = Vector2( 5514.73, 1753.71 )
+position = Vector2( 5516.73, 1752.71 )
+texture = ExtResource( 25 )
 exit_direction = 1
 
 [node name="OverworldExit3" parent="Ground/Exits" groups=["turbo_fat_entrances"] instance=ExtResource( 12 )]
-position = Vector2( 381.77, 1387.85 )
+position = Vector2( 383.77, 1386.85 )
 
 [node name="OverworldExit4" parent="Ground/Exits" instance=ExtResource( 12 )]
-position = Vector2( 1139.4, 1351.17 )
+position = Vector2( 1141.4, 1350.17 )
 
 [node name="Shadows" parent="Ground" instance=ExtResource( 19 )]
 obstacle_map_path = NodePath("../../Obstacles/ObstacleMap")

--- a/project/src/main/world/environment/restaurant/TurboFatEnvironment.tscn
+++ b/project/src/main/world/environment/restaurant/TurboFatEnvironment.tscn
@@ -45,9 +45,8 @@ kitchen_tile_index = 54907
 
 [node name="FreeRoamExit" parent="Ground/Exits" instance=ExtResource( 35 )]
 position = Vector2( 130.547, 315.908 )
+scale = Vector2( 0.539476, -0.539476 )
 exit_direction = 4
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Shadows" parent="Ground" instance=ExtResource( 42 )]
 obstacle_map_path = NodePath("../../Obstacles/ObstacleMap")

--- a/project/src/main/world/environment/restaurant/UndecoratedTurboFatEnvironment.tscn
+++ b/project/src/main/world/environment/restaurant/UndecoratedTurboFatEnvironment.tscn
@@ -47,9 +47,8 @@ undecorated_tile_index = 82456
 
 [node name="FreeRoamExit" parent="Ground/Exits" instance=ExtResource( 35 )]
 position = Vector2( 130.547, 315.908 )
+scale = Vector2( 0.539476, -0.539476 )
 exit_direction = 4
-player_spawn_id = "restaurant_player"
-sensei_spawn_id = "restaurant_sensei"
 
 [node name="Shadows" parent="Ground" instance=ExtResource( 34 )]
 obstacle_map_path = NodePath("../../Obstacles/ObstacleMap")

--- a/project/src/main/world/overworld-exit.gd
+++ b/project/src/main/world/overworld-exit.gd
@@ -1,5 +1,5 @@
 tool
-extends Area2D
+extends Sprite
 ## An exit on the floor which the player can step on to go somewhere else.
 ##
 ## Stepping on this exit results transitions to a new scene.
@@ -25,27 +25,8 @@ const SOUTHWEST := ExitDirection.SOUTHWEST
 const WEST := ExitDirection.WEST
 const NORTHWEST := ExitDirection.NORTHWEST
 
-## key: (int) an enum from ExitDirection
-## value: (Vector2) a non-isometric unit vector in the direction the exit is facing
-const VECTOR_BY_EXIT_DIRECTION := {
-	NORTH: Vector2.UP,
-	NORTHEAST: Vector2(sqrt(2), -sqrt(2)),
-	EAST: Vector2.RIGHT,
-	SOUTHEAST: Vector2(sqrt(2), sqrt(2)),
-	SOUTH: Vector2.DOWN,
-	SOUTHWEST: Vector2(-sqrt(2), sqrt(2)),
-	WEST: Vector2.LEFT,
-	NORTHWEST: Vector2(-sqrt(2), -sqrt(2))
-}
-
 ## the direction the exit is facing. Also the direction the player needs to move to use the exit
 export (ExitDirection) var exit_direction := ExitDirection.NORTH setget set_exit_direction
-
-## the id of the spawn where the player will appear on the overworld after using the exit
-export (String) var player_spawn_id: String
-
-## the id of the spawn where the sensei will appear on the overworld after using the exit
-export (String) var sensei_spawn_id: String
 
 ## sprite sheet for when the exit faces east or west
 var _exit_e_sheet := preload("res://assets/main/world/environment/exit-e-sheet.png")
@@ -56,56 +37,26 @@ var _exit_n_sheet := preload("res://assets/main/world/environment/exit-n-sheet.p
 ## sprite sheet for when the exit faces northeast, southeast, southwest or northwest
 var _exit_ne_sheet := preload("res://assets/main/world/environment/exit-ne-sheet.png")
 
-## 'true' if the player is currently overlapping the exit. this might not make them exit if they're sitting still or
-## moving the wrong way
-var _player_overlapping := false
-
-## 'true' if the player stepped on this exit arrow and is exiting
-var _player_exiting := false
-
 ## We embed the get_overworld_ui() call in a conditional to avoid errors in the editor
 onready var _overworld_ui: OverworldUi = null if Engine.editor_hint else Global.get_overworld_ui()
 
-onready var _collision_shape_2d := $CollisionShape2D
-onready var _sprite := $Sprite
-
 func _ready() -> void:
-	connect("body_entered", self, "_on_body_entered")
-	connect("body_exited", self, "_on_body_exited")
-	
 	_refresh_exit_direction()
-
-
-## Preemptively initializes onready variables to avoid null references.
-func _enter_tree() -> void:
-	_collision_shape_2d = $CollisionShape2D
-	_sprite = $Sprite
 
 
 func set_exit_direction(new_exit_direction: int) -> void:
 	exit_direction = new_exit_direction
+	
 	if is_inside_tree():
 		_refresh_exit_direction()
 
 
 ## Updates the appearance and collision shape based on the new exit direction.
 func _refresh_exit_direction() -> void:
-	_collision_shape_2d.position = VECTOR_BY_EXIT_DIRECTION.get(exit_direction) * 20
-	
-	_sprite.scale.x = abs(_sprite.scale.x) * (-1 if exit_direction in [SOUTHWEST, WEST, NORTHWEST] else 1)
-	_sprite.scale.y = abs(_sprite.scale.y) * (-1 if exit_direction in [SOUTHWEST, SOUTH, SOUTHEAST] else 1)
+	scale.x = abs(scale.x) * (-1 if exit_direction in [SOUTHWEST, WEST, NORTHWEST] else 1)
+	scale.y = abs(scale.y) * (-1 if exit_direction in [SOUTHWEST, SOUTH, SOUTHEAST] else 1)
 	
 	match exit_direction:
-		NORTH, SOUTH: _sprite.texture = _exit_n_sheet
-		NORTHEAST, SOUTHEAST, NORTHWEST, SOUTHWEST: _sprite.texture = _exit_ne_sheet
-		EAST, WEST: _sprite.texture = _exit_e_sheet
-
-
-func _on_body_entered(body: Node) -> void:
-	if body == CreatureManager.player:
-		_player_overlapping = true
-
-
-func _on_body_exited(body: Node) -> void:
-	if body == CreatureManager.player:
-		_player_overlapping = false
+		NORTH, SOUTH: texture = _exit_n_sheet
+		NORTHEAST, SOUTHEAST, NORTHWEST, SOUTHWEST: texture = _exit_ne_sheet
+		EAST, WEST: texture = _exit_e_sheet


### PR DESCRIPTION
OverworldExit is now a sprite. I've removed its hit detection logic and its CollisionShape2D. None of this is necessary since there is no longer the functionality of stepping on the exit to transition to a new area.

Removed spawns from FreeRoam environments. These were originally used because cinematics took place in these environments, but they are now just used for demos and don't need spawns.