### PR TITLE
Replace 'stool_path' property with proximity logic

### DIFF
--- a/project/src/demo/world/environment/marsh/MarshFreeRoamEnvironment.tscn
+++ b/project/src/demo/world/environment/marsh/MarshFreeRoamEnvironment.tscn
@@ -175,7 +175,6 @@ dna = {
 [node name="Jayton" parent="Obstacles" instance=ExtResource( 34 )]
 position = Vector2( 339.509, 1583.36 )
 offset = Vector2( 0, -100 )
-stool_path = NodePath("../ButtercupStool1")
 target_properties = {
 "creature_id": "jayton",
 "elevation": 80.0,

--- a/project/src/demo/world/environment/restaurant/TurboFatFreeRoamEnvironment.tscn
+++ b/project/src/demo/world/environment/restaurant/TurboFatFreeRoamEnvironment.tscn
@@ -642,7 +642,6 @@ target_properties = {
 [node name="Terpion" parent="Obstacles" instance=ExtResource( 2 )]
 position = Vector2( 349, 323 )
 offset = Vector2( 0, -140 )
-stool_path = NodePath("../Stool4")
 target_properties = {
 "creature_id": "terpion",
 "elevation": 150.0,
@@ -654,7 +653,6 @@ max_fatness = 4.0
 position = Vector2( 525, 323 )
 offset = Vector2( 0, -140 )
 flip_h = true
-stool_path = NodePath("../Stool3")
 target_properties = {
 "creature_id": "pandon",
 "elevation": 150.0,
@@ -665,7 +663,6 @@ max_fatness = 4.0
 [node name="Nictor" parent="Obstacles" instance=ExtResource( 2 )]
 position = Vector2( 1313.39, 220 )
 offset = Vector2( 0, -140 )
-stool_path = NodePath("../Stool10")
 target_properties = {
 "creature_id": "nictor",
 "elevation": 150.0,
@@ -677,7 +674,6 @@ max_fatness = 3.0
 position = Vector2( 768, 36 )
 offset = Vector2( 0, -140 )
 flip_h = true
-stool_path = NodePath("../Stool1")
 target_properties = {
 "creature_id": "beats",
 "elevation": 150.0,

--- a/project/src/main/world/creature-spawner.gd
+++ b/project/src/main/world/creature-spawner.gd
@@ -7,9 +7,6 @@ extends Node2D
 
 export (NodePath) var overworld_environment_path: NodePath = NodePath("../..")
 
-## (optional) path to a stool the spawned creature sits on
-export (NodePath) var stool_path: NodePath
-
 ## the properties of the spawned creature
 export (Dictionary) var target_properties: Dictionary
 
@@ -31,7 +28,6 @@ var _target_creature: Creature
 onready var _overworld_environment: OverworldEnvironment = get_node(overworld_environment_path)
 
 func _ready() -> void:
-	_stool = get_node(stool_path) if stool_path else null
 	_update_stool_occupied()
 	
 	if spawn_if and BoolExpressionEvaluator.evaluate(spawn_if):
@@ -45,14 +41,9 @@ func _ready() -> void:
 
 ## Updates the spawned creature's stool to be occupied or unoccupied.
 func _update_stool_occupied() -> void:
-	if not _stool:
-		return
-
 	var occupied := _target_creature != null
-	if _stool is ObstacleSpawner:
-		_stool.set_target_property("occupied", occupied)
-	else:
-		_stool.occupied = occupied
+	
+	Stool.update_stool_occupied(self, occupied)
 
 
 ## Spawns the creature and removes the spawner from the scene tree.

--- a/project/src/main/world/environment/lemon/BrotSpotStool.tscn
+++ b/project/src/main/world/environment/lemon/BrotSpotStool.tscn
@@ -13,7 +13,7 @@ shader_param/edge_fix_factor = 1.0
 [sub_resource type="RectangleShape2D" id=2]
 extents = Vector2( 38, 18 )
 
-[node name="Stool" type="KinematicBody2D"]
+[node name="Stool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 2 )
 __meta__ = {
 "shadow_scale": 0.5

--- a/project/src/main/world/environment/marsh/ButtercupStool.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupStool.tscn
@@ -13,7 +13,7 @@ shader_param/edge_fix_factor = 1.0
 [sub_resource type="RectangleShape2D" id=2]
 extents = Vector2( 38, 18 )
 
-[node name="Stool" type="KinematicBody2D"]
+[node name="Stool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 1 )
 __meta__ = {
 "shadow_scale": 0.5

--- a/project/src/main/world/environment/marsh/ButtercupStoolSpawnerG.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupStoolSpawnerG.tscn
@@ -5,7 +5,7 @@
 [ext_resource path="res://src/main/world/obstacle-spawner.gd" type="Script" id=4]
 [ext_resource path="res://assets/main/world/environment/marsh/buttercup-stool-green.png" type="Texture" id=5]
 
-[node name="ButtercupStool" type="Sprite"]
+[node name="ButtercupStool" type="Sprite" groups=["stools"]]
 scale = Vector2( 0.4, 0.4 )
 texture = ExtResource( 5 )
 centered = false

--- a/project/src/main/world/environment/marsh/ButtercupStoolSpawnerW.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupStoolSpawnerW.tscn
@@ -5,7 +5,7 @@
 [ext_resource path="res://assets/main/world/environment/marsh/buttercup-stool-white-occupied.png" type="Texture" id=3]
 [ext_resource path="res://src/main/world/obstacle-spawner.gd" type="Script" id=4]
 
-[node name="ButtercupStool" type="Sprite"]
+[node name="ButtercupStool" type="Sprite" groups=["stools"]]
 scale = Vector2( 0.4, 0.4 )
 texture = ExtResource( 2 )
 centered = false

--- a/project/src/main/world/environment/marsh/MarshEnvironment.tscn
+++ b/project/src/main/world/environment/marsh/MarshEnvironment.tscn
@@ -359,7 +359,6 @@ spawn_if = "not chat_finished chat/career/marsh/60_end"
 [node name="Jayton" parent="Obstacles" instance=ExtResource( 33 )]
 position = Vector2( 3910.69, 1327.71 )
 offset = Vector2( 0, -100 )
-stool_path = NodePath("../ButtercupStool5")
 target_properties = {
 "creature_id": "jayton",
 "elevation": 80.0,

--- a/project/src/main/world/environment/restaurant/BoxStool1.tscn
+++ b/project/src/main/world/environment/restaurant/BoxStool1.tscn
@@ -15,7 +15,7 @@ shader_param/edge_fix_factor = 1.0
 [sub_resource type="RectangleShape2D" id=2]
 extents = Vector2( 28, 14 )
 
-[node name="BoxStool" type="KinematicBody2D"]
+[node name="BoxStool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 4 )
 __meta__ = {
 "shadow_scale": 0.5

--- a/project/src/main/world/environment/restaurant/BoxStool2.tscn
+++ b/project/src/main/world/environment/restaurant/BoxStool2.tscn
@@ -15,7 +15,7 @@ shader_param/edge_fix_factor = 1.0
 [sub_resource type="RectangleShape2D" id=2]
 extents = Vector2( 28, 14 )
 
-[node name="BoxStool" type="KinematicBody2D"]
+[node name="BoxStool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 4 )
 __meta__ = {
 "shadow_scale": 0.5

--- a/project/src/main/world/environment/restaurant/BoxStool3.tscn
+++ b/project/src/main/world/environment/restaurant/BoxStool3.tscn
@@ -15,7 +15,7 @@ shader_param/edge_fix_factor = 1.0
 [sub_resource type="RectangleShape2D" id=2]
 extents = Vector2( 28, 14 )
 
-[node name="BoxStool" type="KinematicBody2D"]
+[node name="BoxStool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 4 )
 __meta__ = {
 "shadow_scale": 0.5

--- a/project/src/main/world/environment/restaurant/TurboFatEnvironment.tscn
+++ b/project/src/main/world/environment/restaurant/TurboFatEnvironment.tscn
@@ -154,7 +154,6 @@ position = Vector2( 1313, 220 )
 __meta__ = {
 "_editor_description_": ""
 }
-stool_path = NodePath("../../Obstacles/Stool10")
 id = "bar_stool"
 elevation = 140.0
 
@@ -165,25 +164,21 @@ id = "chef"
 
 [node name="Customer1" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 592, 35 )
-stool_path = NodePath("../../Obstacles/Stool2")
 id = "customer_1"
 elevation = 140.0
 
 [node name="Customer2" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 349, 322 )
-stool_path = NodePath("../../Obstacles/Stool4")
 id = "customer_2"
 elevation = 140.0
 
 [node name="Customer3" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 992, 35 )
-stool_path = NodePath("../../Obstacles/Stool8")
 id = "customer_3"
 elevation = 140.0
 
 [node name="Customer4" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 1313, 220 )
-stool_path = NodePath("../../Obstacles/Stool10")
 id = "customer_4"
 elevation = 140.0
 
@@ -238,7 +233,6 @@ id = "kitchen_11"
 
 [node name="TableSeatLeft" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 749.285, 321.719 )
-stool_path = NodePath("../../Obstacles/Stool6")
 id = "table_seat_left"
 elevation = 140.0
 
@@ -259,6 +253,5 @@ id = "table_10"
 [node name="TableSeatRight" parent="Spawns" instance=ExtResource( 38 )]
 position = Vector2( 925.285, 321.719 )
 orientation = 1
-stool_path = NodePath("../../Obstacles/Stool5")
 id = "table_seat_right"
 elevation = 140.0

--- a/project/src/main/world/environment/restaurant/TurboFatStool.tscn
+++ b/project/src/main/world/environment/restaurant/TurboFatStool.tscn
@@ -15,7 +15,7 @@ shader_param/edge_fix_factor = 1.0
 [sub_resource type="RectangleShape2D" id=2]
 extents = Vector2( 28, 14 )
 
-[node name="Stool" type="KinematicBody2D"]
+[node name="Stool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 2 )
 __meta__ = {
 "shadow_scale": 0.5

--- a/project/src/main/world/environment/restaurant/UndecoratedTurboFatEnvironment.tscn
+++ b/project/src/main/world/environment/restaurant/UndecoratedTurboFatEnvironment.tscn
@@ -146,7 +146,6 @@ position = Vector2( 1313, 220 )
 __meta__ = {
 "_editor_description_": ""
 }
-stool_path = NodePath("../../Obstacles/Stool10")
 id = "bar_stool"
 elevation = 140.0
 
@@ -157,25 +156,21 @@ id = "chef"
 
 [node name="Customer1" parent="Spawns" instance=ExtResource( 30 )]
 position = Vector2( 592, 35 )
-stool_path = NodePath("../../Obstacles/Stool2")
 id = "customer_1"
 elevation = 140.0
 
 [node name="Customer2" parent="Spawns" instance=ExtResource( 30 )]
 position = Vector2( 349, 322 )
-stool_path = NodePath("../../Obstacles/Stool4")
 id = "customer_2"
 elevation = 140.0
 
 [node name="Customer3" parent="Spawns" instance=ExtResource( 30 )]
 position = Vector2( 992, 35 )
-stool_path = NodePath("../../Obstacles/Stool8")
 id = "customer_3"
 elevation = 140.0
 
 [node name="Customer4" parent="Spawns" instance=ExtResource( 30 )]
 position = Vector2( 1313, 220 )
-stool_path = NodePath("../../Obstacles/Stool10")
 id = "customer_4"
 elevation = 140.0
 
@@ -230,7 +225,6 @@ id = "kitchen_11"
 
 [node name="TableSeatLeft" parent="Spawns" instance=ExtResource( 30 )]
 position = Vector2( 749.285, 321.719 )
-stool_path = NodePath("../../Obstacles/Stool6")
 id = "table_seat_left"
 elevation = 140.0
 
@@ -251,6 +245,5 @@ id = "table_10"
 [node name="TableSeatRight" parent="Spawns" instance=ExtResource( 30 )]
 position = Vector2( 925.285, 321.719 )
 orientation = 1
-stool_path = NodePath("../../Obstacles/Stool5")
 id = "table_seat_right"
 elevation = 140.0

--- a/project/src/main/world/environment/stool.gd
+++ b/project/src/main/world/environment/stool.gd
@@ -5,6 +5,9 @@ extends OverworldObstacle
 ##
 ## The stool can toggle to an 'occupied' state when it's sat upon. This affects its collisions and appearance.
 
+## maximum distance where a creature occupies a stool
+const MAX_STOOL_DISTANCE := 4
+
 ## the texture to use when the stool has a creature sitting on it
 export (Texture) var occupied_texture: Texture
 
@@ -44,3 +47,52 @@ func _refresh_occupied() -> void:
 func set_occupied(new_occupied: bool) -> void:
 	occupied = new_occupied
 	_refresh_occupied()
+
+
+## Finds a stool at the specified Node2D's location.
+##
+## The specified Node2D should correspond to a creature in some way -- either the Creature themselves, or an object
+## with the same location. This method returns a stool which is directly beneath the creature, if any.
+##
+## Parameters:
+## 	'nearby_node2d': A Node2D whose corresponding stool should be returned.
+##
+## Returns:
+## 	The stool which is directly beneath the creature, or 'null' if no stool is found.
+static func find_stool(nearby_node2d: Node2D) -> Node2D:
+	var result: Node2D
+	
+	for next_stool in nearby_node2d.get_tree().get_nodes_in_group("stools"):
+		if not "position" in next_stool:
+			push_warning("stool %s does not define a property 'position'" % [next_stool])
+			continue
+		
+		if nearby_node2d.position.distance_to(next_stool.position) < MAX_STOOL_DISTANCE:
+			result = next_stool
+			break
+	
+	return result
+
+
+## Updates any stool at the specified Node2D's location to be occupied or unoccupied.
+##
+## The specified Node2D should correspond to a creature in some way -- either the Creature themselves, or an object
+## with the same location. This method returns a stool which is directly beneath the creature, if any.
+##
+## Parameters:
+## 	'nearby_node2d': A Node2D whose corresponding stool should be updated.
+##
+## 	'new_occupied': 'true' if the stool has a creature sitting on it
+static func update_stool_occupied(nearby_node2d: Node2D, new_occupied: bool) -> void:
+	var stool := find_stool(nearby_node2d)
+	if not stool:
+		# stool not found
+		pass
+	elif "occupied" in stool:
+		# stool is a stool
+		stool.occupied = new_occupied
+	elif "target_properties" in stool:
+		# stool is an obstacle spawner which spawns a stool
+		stool.set_target_property("occupied", new_occupied)
+	else:
+		push_warning("stool %s does not define a property 'occupied' or 'target_properties'")

--- a/project/src/main/world/spawn.gd
+++ b/project/src/main/world/spawn.gd
@@ -5,20 +5,10 @@ extends Node2D
 ## the direction the creature will face
 export (Creatures.Orientation) var orientation := Creatures.SOUTHEAST
 
-## (optional) path to a stool the spawned creature sits on
-export (NodePath) var stool_path: NodePath
-
 ## a unique id for this spawn point
 export (String) var id: String
 
 export (float) var elevation: float
-
-## stool the creature sits on, if any
-var _stool: Stool
-
-func _ready() -> void:
-	_stool = get_node(stool_path) if stool_path else null
-
 
 ## Relocates the specified creature to this spawn point.
 func move_creature(creature: Creature) -> void:
@@ -26,5 +16,4 @@ func move_creature(creature: Creature) -> void:
 	creature.orientation = orientation
 	creature.elevation = elevation
 	
-	if _stool:
-		_stool.occupied = true
+	Stool.update_stool_occupied(self, true)


### PR DESCRIPTION
Instead of creatures and spawn points needing an explicit 'stool_path' assigned, a corresponding stool is now found by searching for the nearest stool. Stools within a very narrow radius (4 units) are considered 'matching' and will be returned.