### PR TITLE
ChatUi functions without OverworldUi.

### DIFF
--- a/project/src/demo/chat/ui/ChatUiDemo.tscn
+++ b/project/src/demo/chat/ui/ChatUiDemo.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=3 format=2]
 
-[ext_resource path="res://src/main/world/CutsceneUi.tscn" type="PackedScene" id=1]
+[ext_resource path="res://src/main/chat/ui/ChatUi.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/demo/chat/ui/chat-ui-demo.gd" type="Script" id=2]
 
 [node name="ChatUiDemo" type="Node"]
 script = ExtResource( 2 )
 
-[node name="Ui" parent="." instance=ExtResource( 1 )]
+[node name="ChatUi" parent="." instance=ExtResource( 1 )]

--- a/project/src/demo/chat/ui/chat-ui-demo.gd
+++ b/project/src/demo/chat/ui/chat-ui-demo.gd
@@ -90,5 +90,5 @@ func _play_chat_tree(filename: String = "") -> void:
 	if _choice_override:
 		for i in range(chat_tree.get_event().link_texts.size()):
 			chat_tree.get_event().link_texts[i] = _choice_override
-	$Ui/ChatUi.visible = true
-	$Ui/ChatUi.play_chat_tree(chat_tree)
+	$ChatUi.visible = true
+	$ChatUi.play_chat_tree(chat_tree)

--- a/project/src/main/chat/ui/chat-ui.gd
+++ b/project/src/main/chat/ui/chat-ui.gd
@@ -32,7 +32,8 @@ var _chat_tree: ChatTree
 var _chat_finished := false
 
 func _ready() -> void:
-	Global.get_overworld_ui().connect("visible_chatters_changed", self, "_on_OverworldUi_visible_chatters_changed")
+	if Global.get_overworld_ui():
+		Global.get_overworld_ui().connect("visible_chatters_changed", self, "_on_OverworldUi_visible_chatters_changed")
 
 
 func _process(delta: float) -> void:
@@ -162,6 +163,9 @@ func _enabled_link_texts(var chat_event: ChatEvent) -> Array:
 ## This information is stored back into the chat tree so that it can be utilized by the chat ui.
 func _assign_nametag_sides() -> void:
 	if not _chat_tree:
+		return
+	
+	if not Global.get_overworld_ui():
 		return
 	
 	var chatter_bounding_box := Global.get_overworld_ui().get_chatter_bounding_box([], [])


### PR DESCRIPTION
The only functionality which ChatUi needs OverworldUi for is assigning nametag sides. If no OverworldUi is present, it just doesn't move the nametags.