### PR TITLE
Squish drops only emit signals if squishing is necessary.

### DIFF
--- a/project/src/main/puzzle/piece/piece-squisher.gd
+++ b/project/src/main/puzzle/piece/piece-squisher.gd
@@ -47,7 +47,13 @@ func attempt_squish(piece: ActivePiece) -> void:
 				squish_drop_target = prev_squish_drop_target
 				break
 		
-		if squish_drop_target != piece.pos:
+		var squish_move_is_unnecessary = true
+		for y in range(piece.pos.y, squish_drop_target.y):
+			if not piece.can_move_to(Vector2(piece.pos.x, y), piece.orientation):
+				squish_move_is_unnecessary = false
+				break
+		
+		if not squish_move_is_unnecessary and squish_drop_target != piece.pos:
 			# squish drop
 			_squish_to(piece, squish_drop_target)
 			emit_signal("hard_dropped", piece)


### PR DESCRIPTION
Fixed bug with squish drop signals. Before, if you performed squish drop inputs, it would count as a squish move even if no squish was necessary.  Now it only performs a squish drop if the piece could not reach its destination with a regular drop.