### PR TITLE
Shark refactorings; crumb colors, mole comments

### DIFF
--- a/project/src/main/puzzle/critter/mole.gd
+++ b/project/src/main/puzzle/critter/mole.gd
@@ -154,6 +154,8 @@ func pop_next_state() -> int:
 	return hidden_mole_state if hidden else state
 
 
+## Parameters:
+## 	'new_state': an enum from States for the mole's new animation state.
 func set_state(new_state: int) -> void:
 	state = new_state
 	_refresh_state()

--- a/project/src/main/puzzle/critter/moles.gd
+++ b/project/src/main/puzzle/critter/moles.gd
@@ -377,18 +377,11 @@ func _on_PieceManager_piece_disturbed(_piece: ActivePiece) -> void:
 
 
 func _on_PuzzleState_before_piece_written() -> void:
-	for mole_cell in _moles_by_cell.duplicate():
-		var mole: Mole = _moles_by_cell[mole_cell]
-		if mole.hidden:
-			if mole.state == Mole.WAITING or mole.hidden and mole.hidden_mole_state == Mole.WAITING:
-				# mole hasn't appeared yet; relocate the mole
-				_relocate_mole(mole_cell)
-			else:
-				# mole was squished; remove the mole
-				remove_mole(mole_cell)
-		
-		# immediately unhide the mole
-		mole.hidden = false
+	_refresh_moles_for_playfield()
+	
+	# restore any remaining moles which were hidden by the active piece
+	for mole_cell in _moles_by_cell:
+		_moles_by_cell[mole_cell].hidden = false
 
 
 func _on_Playfield_line_deleted(y: int) -> void:

--- a/project/src/main/puzzle/foods.gd
+++ b/project/src/main/puzzle/foods.gd
@@ -39,13 +39,21 @@ enum FoodType {
 	CAKE_QUV,
 }
 
-## Food colors for the food which gets hurled into the creature's mouth.
+## Food colors for food crumbs and goop.
 const COLOR_VEGETABLE := Color("335320")
 const COLOR_BROWN := Color("a4470b")
 const COLOR_PINK := Color("ff5d68")
 const COLOR_BREAD := Color("ffa357")
 const COLOR_WHITE := Color("fff6eb")
 const COLORS_ALL := [COLOR_BROWN, COLOR_PINK, COLOR_BREAD, COLOR_WHITE ]
+
+## Food colors for veggie crumbs and goop, for levels which use the 'veggie' tileset.
+const COLOR_VEG_GREEN := Color("839f43")
+const COLOR_VEG_RED := Color("a21d24")
+const COLOR_VEG_BREAD := Color("af884d")
+const COLOR_VEG_WHITE := Color("c1a57e")
+const COLORS_VEG_ALL := [COLOR_VEG_GREEN, COLOR_VEG_RED, COLOR_VEG_BREAD, COLOR_VEG_WHITE]
+
 
 ## key: (int) an enum from FoodType
 ## value: (int) an enum from BoxType for the corresponding box
@@ -103,6 +111,24 @@ const FOOD_TYPES_BY_BOX_TYPES := {
 	BoxType.CAKE_PUV: [FoodType.CAKE_PUV],
 	BoxType.CAKE_QUV: [FoodType.CAKE_QUV],
 }
+
+## key: (int) an enum from BoxType
+## value: (Array, int) array of enums from FoodType for the corresponding food items
+const COLORS_BY_BOX_TYPES := {
+	BoxType.BROWN: [COLOR_BROWN],
+	BoxType.PINK: [COLOR_PINK],
+	BoxType.BREAD: [COLOR_BREAD],
+	BoxType.WHITE: [COLOR_WHITE],
+	BoxType.CAKE_JJO: [COLOR_PINK, COLOR_PINK, COLOR_WHITE],
+	BoxType.CAKE_JLO: [COLOR_PINK, COLOR_BROWN, COLOR_WHITE],
+	BoxType.CAKE_JTT: [COLOR_PINK, COLOR_BREAD, COLOR_BREAD],
+	BoxType.CAKE_LLO: [COLOR_BROWN, COLOR_BROWN, COLOR_WHITE],
+	BoxType.CAKE_LTT: [COLOR_BROWN, COLOR_BREAD, COLOR_BREAD],
+	BoxType.CAKE_PQV: [COLOR_PINK, COLOR_BROWN, COLOR_WHITE],
+	BoxType.CAKE_PUV: [COLOR_PINK, COLOR_BREAD, COLOR_WHITE],
+	BoxType.CAKE_QUV: [COLOR_BROWN, COLOR_BREAD, COLOR_WHITE],
+}
+
 
 ## Returns 'true' if the specified box type corresponds to a snack box.
 ##

--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -109,6 +109,14 @@ func get_state() -> State:
 	return states.get_state()
 
 
+## Updates our piece state to a specific state from PieceStates.
+##
+## PieceManager typically updates its own state, but unusual level gimmicks may need to interrupt it with a custom
+## state.
+func set_state(new_state: State) -> void:
+	states.set_state(new_state)
+
+
 func is_playfield_ready_for_new_piece() -> bool:
 	return _playfield.ready_for_new_piece()
 

--- a/project/src/main/puzzle/puzzle-tile-map.gd
+++ b/project/src/main/puzzle/puzzle-tile-map.gd
@@ -283,6 +283,36 @@ func contents_as_string() -> String:
 	return result
 
 
+## Returns crumb colors for the specified cell.
+##
+## If the cell contains a normal piece, the resulting list will only have a single item. If the cell contains a cake
+## box, the resulting list will have a few items based on the cake ingredients.
+##
+## Parameters:
+## 	'cell_pos': An (x, y) position in the TileMap
+##
+## Returns:
+## 	An array of Color instances corresponding to crumb colors when the specified cell is destroyed.
+func crumb_colors_for_cell(cell_pos: Vector2) -> Array:
+	var result := []
+	var autotile_coord := get_cell_autotile_coord(cell_pos.x, cell_pos.y)
+	
+	var cellv := get_cellv(cell_pos)
+	match cellv:
+		TILE_PIECE, TILE_CORNER:
+			match puzzle_tile_set_type:
+				TileSetType.DEFAULT, TileSetType.DIAGRAM:
+					result = [Foods.COLORS_ALL[int(autotile_coord.y)]]
+				TileSetType.VEGGIE:
+					result = [Foods.COLORS_VEG_ALL[int(autotile_coord.y)]]
+		TILE_BOX:
+			result = Foods.COLORS_BY_BOX_TYPES[int(autotile_coord.y)]
+		TILE_VEG:
+			result = [Foods.COLOR_VEGETABLE]
+	
+	return result
+
+
 ## Disconnects a row from any empty neighbors.
 ##
 ## Disconnected boxes have their connections updated. Disconnected pieces are converted to vegetable blocks.


### PR DESCRIPTION
The 'Foods' class now not only includes colors for food crumbs, but also pieces and vegetables. These fields are referenced by a new PuzzleTileMap.crumb_colors_for_cell() method.

Refactored some unnecessary duplicate code in mole.gd. Documented an undocumented 'new_state' parameter.