### PR TITLE
Added kicks for O piece.

### DIFF
--- a/project/src/main/puzzle/piece/piece-types.gd
+++ b/project/src/main/puzzle/piece/piece-types.gd
@@ -185,7 +185,7 @@ var piece_o := PieceType.new("o",
 			[Vector2(10, 3), Vector2( 6, 3), Vector2( 9, 3), Vector2( 5, 3)],
 			[Vector2(10, 3), Vector2( 6, 3), Vector2( 9, 3), Vector2( 5, 3)],
 		],
-		KICKS_NONE
+		KICKS_JLSZ
 	)
 
 var piece_p := PieceType.new("p",


### PR DESCRIPTION
This is usually unnecessary, but sharks can whittle an O piece down where kicks are helpful. Currently, eaten pieces inherit kicks from the original piece, so eaten O pieces had no kicks at all. They now use the JLSZ kick table.