### PR TITLE
Fixed invisible shark behavior: permanent invisible bug, sfx

### DIFF
--- a/project/src/main/puzzle/critter/shark-state-dancing-end.gd
+++ b/project/src/main/puzzle/critter/shark-state-dancing-end.gd
@@ -4,7 +4,8 @@ extends State
 func enter(shark: Shark, prev_state_name: String) -> void:
 	if prev_state_name in ["None", "Waiting"]:
 		shark.poof.play_poof_animation()
-		shark.sfx.play_poof_sound()
+		if shark.visible:
+			shark.sfx.play_poof_sound()
 	shark.play_shark_anim("dance-end")
 	
 	shark.sync_dance()

--- a/project/src/main/puzzle/critter/shark-state-dancing.gd
+++ b/project/src/main/puzzle/critter/shark-state-dancing.gd
@@ -4,7 +4,8 @@ extends State
 func enter(shark: Shark, prev_state_name: String) -> void:
 	if prev_state_name in ["None", "Waiting"]:
 		shark.poof.play_poof_animation()
-		shark.sfx.play_poof_sound()
+		if shark.visible:
+			shark.sfx.play_poof_sound()
 	shark.play_shark_anim("dance")
 	
 	shark.sync_dance()

--- a/project/src/main/puzzle/critter/shark-state-eating.gd
+++ b/project/src/main/puzzle/critter/shark-state-eating.gd
@@ -7,7 +7,8 @@ const BITE_SFX_THRESHOLD := 0.30
 func enter(shark: Shark, prev_state_name: String) -> void:
 	if prev_state_name in ["None", "Waiting"]:
 		shark.poof.play_poof_animation()
-		shark.sfx.play_poof_sound()
+		if shark.visible:
+			shark.sfx.play_poof_sound()
 	shark.play_shark_anim("eat")
 	if shark.eat_duration < BITE_SFX_THRESHOLD:
 		shark.sfx.play_bite_sound()

--- a/project/src/main/puzzle/critter/shark-state-fed.gd
+++ b/project/src/main/puzzle/critter/shark-state-fed.gd
@@ -4,6 +4,7 @@ extends State
 func enter(shark: Shark, prev_state_name: String) -> void:
 	if prev_state_name in ["None", "Waiting"]:
 		shark.poof.play_poof_animation()
-		shark.sfx.play_poof_sound()
+		if shark.visible:
+			shark.sfx.play_poof_sound()
 	shark.play_shark_anim("fed")
 	shark.sfx.play_voice_friendly_sound()

--- a/project/src/main/puzzle/critter/shark-state-none.gd
+++ b/project/src/main/puzzle/critter/shark-state-none.gd
@@ -8,6 +8,7 @@ func enter(shark: Shark, prev_state_name: String) -> void:
 	
 	if not prev_state_name in ["", "None", "Waiting"]:
 		shark.poof.play_poof_animation()
-		shark.sfx.play_poof_sound()
+		if shark.visible:
+			shark.sfx.play_poof_sound()
 	shark.animation_player.stop()
 	shark.tooth_cloud.eating = false

--- a/project/src/main/puzzle/critter/shark-state-squished.gd
+++ b/project/src/main/puzzle/critter/shark-state-squished.gd
@@ -4,7 +4,8 @@ extends State
 func enter(shark: Shark, prev_state_name: String) -> void:
 	if prev_state_name in ["None", "Waiting"]:
 		shark.poof.play_poof_animation()
-		shark.sfx.play_poof_sound()
+		if shark.visible:
+			shark.sfx.play_poof_sound()
 	shark.play_shark_anim("squished")
 	shark.sfx.play_squish_sound()
 	get_tree().create_timer(0.20).connect("timeout", self, "_play_voice", [shark])

--- a/project/src/main/puzzle/critter/shark-state-waiting.gd
+++ b/project/src/main/puzzle/critter/shark-state-waiting.gd
@@ -4,5 +4,6 @@ extends State
 func enter(shark: Shark, prev_state_name: String) -> void:
 	if not prev_state_name in ["", "None", "Waiting"]:
 		shark.poof.play_poof_animation()
-		shark.sfx.play_poof_sound()
+		if shark.visible:
+			shark.sfx.play_poof_sound()
 	shark.animation_player.play("wait")

--- a/project/src/main/puzzle/critter/sharks.gd
+++ b/project/src/main/puzzle/critter/sharks.gd
@@ -114,6 +114,8 @@ func _refresh_sharks_for_piece() -> void:
 		
 		if shark.state == Shark.WAITING:
 			shark.visible = not piece_overlaps_shark
+		else:
+			shark.visible = true
 		
 		if _did_hard_drop and piece_overlaps_shark \
 				and shark.state in [Shark.DANCING, Shark.DANCING_END, Shark.EATING, Shark.FED]:
@@ -290,6 +292,8 @@ func _refresh_sharks_for_playfield(include_waiting_sharks: bool = true) -> void:
 		if _shark_cell_has_floor(shark_cell) \
 				and not _shark_cell_has_block(shark_cell):
 			continue
+		
+		shark.visible = true
 		
 		if shark.state == Shark.WAITING:
 			# shark hasn't appeared yet; relocate the shark


### PR DESCRIPTION
When a shark is in the waiting '...' state, they turn invisible if touched by a piece. Before, they'd only turn back visible in certain circumstances. They now turn visible when entering any other state, or when the piece is placed.

Sharks no longer play sound effects when invisible. Before, you'd sometimes hear 'poof sounds' when they entered/exited the none state from the waiting state.