### PR TITLE
LevelTimerManager now processes in the physics step; not the idle step

### DIFF
--- a/project/src/main/puzzle/level-timer-manager.gd
+++ b/project/src/main/puzzle/level-timer-manager.gd
@@ -29,6 +29,7 @@ func _ready() -> void:
 	# create placeholder timers. different levels might start some, all or none of these timers
 	for i in range(MAX_TIMER_COUNT):
 		var timer := Timer.new()
+		timer.process_mode = Timer.TIMER_PROCESS_PHYSICS
 		timer.connect("timeout", self, "_on_Timer_timeout", [i])
 		add_child(timer)
 


### PR DESCRIPTION
Before, timers were sometimes behaving unexpectedly. For example, two timers with intervals of 2s and 4s should fire simultaneously half the time, but they were falling out of sync.