### PR TITLE
Shark scoring bugfix, increases: 20,20,20 -> 10,20,50

### DIFF
--- a/project/src/main/puzzle/critter/sharks.gd
+++ b/project/src/main/puzzle/critter/sharks.gd
@@ -124,11 +124,11 @@ func _refresh_sharks_for_piece() -> void:
 		if shark.state in [Shark.DANCING, Shark.DANCING_END] and piece_overlaps_shark:
 			match shark.shark_size:
 				SharkConfig.SharkSize.SMALL:
-					PuzzleState.add_unusual_cell_score(shark_cell + Vector2.UP, 5)
-				SharkConfig.SharkSize.MEDIUM:
 					PuzzleState.add_unusual_cell_score(shark_cell + Vector2.UP, 10)
-				SharkConfig.SharkSize.LARGE:
+				SharkConfig.SharkSize.MEDIUM:
 					PuzzleState.add_unusual_cell_score(shark_cell + Vector2.UP, 20)
+				SharkConfig.SharkSize.LARGE:
+					PuzzleState.add_unusual_cell_score(shark_cell + Vector2.UP, 50)
 			
 			# Assign the color before the piece is eaten. Otherwise if the entire piece is eaten, we won't know which
 			# color it was.

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -322,7 +322,7 @@ func add_pickup_score(pickup_score: int) -> void:
 ## This occurs during very specific levels with gimmicks like sharks. It mostly gets treated the same way as pickups,
 ## but also triggers a money UI popup.
 func add_unusual_cell_score(cell: Vector2, cell_score: int) -> void:
-	PuzzleState.add_pickup_score(20)
+	PuzzleState.add_pickup_score(cell_score)
 	emit_signal("added_unusual_cell_score", cell, cell_score)
 
 


### PR DESCRIPTION
Fixed a bug in PuzzleState which caused all sharks to give $20 when eating a piece, instead of giving the displayed reward.

Increased shark payouts; even when the medium sharks were bugged to give out $20, it wasn't enough to compensate for the clumsiness/slowness of playing with this gimmick. Honestly, we could probably double it again.