### PR TITLE
Shark animation fixes: '!', 'dance-end'

### DIFF
--- a/project/src/main/puzzle/critter/Shark.tscn
+++ b/project/src/main/puzzle/critter/Shark.tscn
@@ -185,7 +185,7 @@ tracks/0/keys = {
 "times": PoolRealArray( 0, 0.260892, 0.521784, 0.782677, 1.04357, 1.30446, 1.56535, 1.82625 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 20, 21, 20, 21, 22, 3, 22, 3 ]
+"values": [ 21, 20, 21, 20, 23, 22, 23, 22 ]
 }
 tracks/1/type = "value"
 tracks/1/path = NodePath("Shark:visible")
@@ -233,7 +233,7 @@ tracks/4/keys = {
 "times": PoolRealArray( 0, 0.260892, 0.521784, 0.782677, 1.04357, 1.30446, 1.56535, 1.82625 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 2, 0, 1, 3, 0, 2, 3, 1 ]
+"values": [ 6, 4, 5, 7, 4, 6, 7, 5 ]
 }
 tracks/5/type = "value"
 tracks/5/path = NodePath("ToothCloud:eating")
@@ -263,7 +263,7 @@ tracks/0/keys = {
 "times": PoolRealArray( 0, 0.260892, 0.521784, 0.782677, 1.04357, 1.30446, 1.56535, 1.82625 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 10, 11, 10, 11, 12, 13, 12, 13 ]
+"values": [ 11, 10, 11, 10, 13, 12, 13, 12 ]
 }
 tracks/1/type = "value"
 tracks/1/path = NodePath("Shark:visible")
@@ -311,7 +311,7 @@ tracks/4/keys = {
 "times": PoolRealArray( 0, 0.260892, 0.521784, 0.782677, 1.04357, 1.30446, 1.56535, 1.82625 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 2, 0, 1, 3, 0, 2, 3, 1 ]
+"values": [ 6, 4, 5, 7, 4, 6, 7, 5 ]
 }
 tracks/5/type = "value"
 tracks/5/path = NodePath("ToothCloud:eating")
@@ -341,7 +341,7 @@ tracks/0/keys = {
 "times": PoolRealArray( 0, 0.260892, 0.521784, 0.782677, 1.04357, 1.30446, 1.56535, 1.82625 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 0, 1, 0, 1, 2, 3, 2, 3 ]
+"values": [ 1, 0, 1, 0, 3, 2, 3, 2 ]
 }
 tracks/1/type = "value"
 tracks/1/path = NodePath("Shark:visible")
@@ -389,7 +389,7 @@ tracks/4/keys = {
 "times": PoolRealArray( 0, 0.260892, 0.521784, 0.782677, 1.04357, 1.30446, 1.56535, 1.82625 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 2, 0, 1, 3, 0, 2, 3, 1 ]
+"values": [ 6, 4, 5, 7, 4, 6, 7, 5 ]
 }
 tracks/5/type = "value"
 tracks/5/path = NodePath("ToothCloud:eating")

--- a/project/src/main/puzzle/critter/shark.gd
+++ b/project/src/main/puzzle/critter/shark.gd
@@ -264,7 +264,7 @@ func play_shark_anim(anim_prefix: String) -> void:
 	
 	# preserve old animation position when transitioning from 'dance' to 'dance-end' or vice-versa
 	if old_animation.begins_with("dance-") and animation_player.current_animation.begins_with("dance-"):
-		animation_player.seek(old_animation_position)
+		animation_player.seek(old_animation_position, true)
 
 
 ## Refreshes our appearance and behavior based on our current shark size.


### PR DESCRIPTION
The 'dance-end' state now shows a '!' bubble instead of a '...' bubble. This helps express the urgency of 'Hurry, you'll miss it!' better, plus we're already using the '...' bubble for a different purpose.

The 'dance-end' animations were using incorrect frames, resulting in a jerky transition from the 'dance' state. Actually, the large shark was using the wrong frames entirely causing it to briefly become a small shark.