### PR TITLE
Bug: Sharks could enter/exit the eating state at unusual times

### DIFF
--- a/project/src/demo/puzzle/PuzzleCritterDemo.tscn
+++ b/project/src/demo/puzzle/PuzzleCritterDemo.tscn
@@ -5,6 +5,6 @@
 
 [node name="PuzzleCritterDemo" type="Node"]
 script = ExtResource( 1 )
-level_path = "res://assets/demo/puzzle/levels/experiment.json"
+level_path = "res://assets/main/puzzle/levels/practice/marathon-normal.json"
 
 [node name="Puzzle" parent="." instance=ExtResource( 2 )]

--- a/project/src/demo/puzzle/puzzle-critter-demo.gd
+++ b/project/src/demo/puzzle/puzzle-critter-demo.gd
@@ -24,6 +24,7 @@ extends Node
 ## 	[S] -> [1]: Add a small shark
 ## 	[S] -> [2]: Add a medium shark
 ## 	[S] -> [3]: Add a large shark
+## 	[S] -> [4]: Toggle shark patience
 ## 	[S] -> ']': Advance sharks
 
 enum CritterType {
@@ -130,5 +131,7 @@ func _shark_input(event: InputEvent) -> void:
 		KEY_3:
 			_shark_config.size = SharkConfig.SharkSize.LARGE
 			$Puzzle/Fg/Critters/Sharks.add_sharks(_shark_config)
+		KEY_4:
+			_shark_config.patience = 0 if _shark_config.patience == 3 else 3
 		KEY_BRACKETRIGHT:
 			$Puzzle/Fg/Critters/Sharks.advance_sharks()

--- a/project/src/main/puzzle/critter/shark.gd
+++ b/project/src/main/puzzle/critter/shark.gd
@@ -155,13 +155,16 @@ func has_next_state() -> bool:
 ## If the shark is currently hidden, they remain invisible. But this still updates their hidden state and returns the
 ## dequeued state.
 ##
+## Parameters:
+## 	'force': If 'true', the shark will be updated again even if it was already updated this frame.
+##
 ## Returns:
 ## 	An enum from States for the shark's new state.
-func pop_next_state() -> int:
+func pop_next_state(force: bool = false) -> int:
 	if not _next_states:
 		return NONE
 	
-	if _already_popped_state:
+	if _already_popped_state and not force:
 		pass
 	else:
 		var next_state: int = _next_states.pop_front()
@@ -242,7 +245,16 @@ func sync_dance() -> void:
 ## They stay squished for two cycles and then poof away.
 func squish() -> void:
 	_next_states = [SQUISHED, SQUISHED, NONE]
-	pop_next_state()
+	pop_next_state(true)
+
+
+## Makes the shark eat.
+##
+## Details about the piece being eaten should be assigned with set_puzzle_tile_set_type(), set_eaten_cell(),
+## set_eaten_color() and set_duration().
+func eat() -> void:
+	_next_states = [EATING]
+	pop_next_state(true)
 
 
 ## Plays the specified 'shark animation', such as 'dance' which corresponds to a longer animation name like

--- a/project/src/main/puzzle/critter/sharks.gd
+++ b/project/src/main/puzzle/critter/sharks.gd
@@ -148,7 +148,7 @@ func _refresh_sharks_for_piece() -> void:
 			
 			# Change the shark, adding any eaten cells
 			var new_piece_cells := _playfield_piece_cells()
-			shark.set_state(Shark.EATING)
+			shark.eat()
 			_feed_shark_cells(shark_cell, old_piece_cells, new_piece_cells)
 
 


### PR DESCRIPTION
Sharks eating wouldn't purge their 'next_states' queue, meaning that after eating, they would go back to normal if the 'advance_sharks' trigger effect occurred. Sharks eating now purge their 'next_states' queue.

Sharks being squished wouldn't pop their next state if the 'advance_sharks' trigger effect had just triggered. Sharks being squished or eating now pop their next state no matter what.

Added a 'shark patience toggle' to the PuzzleCritterDemo to test patience related bugs.