### PR TITLE
Mangled dominos now keep original piece names.

### DIFF
--- a/project/src/main/puzzle/critter/sharks.gd
+++ b/project/src/main/puzzle/critter/sharks.gd
@@ -285,6 +285,10 @@ func _to_domino(piece_type: PieceType) -> PieceType:
 	var result := PieceType.new()
 	result.copy_from(PieceTypes.piece_domino)
 	result.set_box_type(piece_type.get_box_type())
+	
+	# We update the piece string so that tech moves like 'T-spin' reflect the original piece.
+	result.string = piece_type.string
+	
 	return result
 
 


### PR DESCRIPTION
Before, mangling a T-piece with small sharks would still report a 'T-spin', but mangling a T-piece with a medium shark would report a 'D-spin' because it is now a domino. ...I've changed it so they will all report a 'T-Spin' for consistency.

Levels can still be created which have dominos, and those will report a 'D-spin'.