### PR TITLE
Fixed bug with sharks deleting during multiline inserts

### DIFF
--- a/project/src/main/puzzle/box-builder.gd
+++ b/project/src/main/puzzle/box-builder.gd
@@ -73,8 +73,11 @@ func _physics_process(_delta: float) -> void:
 	remaining_box_build_frames -= 1
 	if remaining_box_build_frames <= 0:
 		# stop processing if we're done building boxes
-		set_physics_process(false)
 		emit_signal("after_boxes_built")
+		
+		# setting physics_process to 'false' causes 'Playfield.is_building_boxes()' to return false, so we make sure to
+		# assign this after all signals are fired.
+		set_physics_process(false)
 
 
 ## Builds a box with the specified location and size.

--- a/project/src/main/puzzle/critter/moles.gd
+++ b/project/src/main/puzzle/critter/moles.gd
@@ -419,11 +419,20 @@ func _on_Playfield_line_erased(_y: int, _total_lines: int, _remaining_lines: int
 func _on_Playfield_line_inserted(y: int, _tiles_key: String, _src_y: int) -> void:
 	# raise all moles at or above the specified row
 	_shift_rows(y, Vector2.UP)
-	_refresh_moles_for_playfield()
+	
+	if _playfield.is_clearing_lines():
+		# If lines are being erased as a part of line clears, we wait to relocate moles until all lines are deleted.
+		pass
+	else:
+		_refresh_moles_for_playfield()
 
 
 func _on_Playfield_line_filled(_y: int, _tiles_key: String, _src_y: int) -> void:
-	_refresh_moles_for_playfield()
+	if _playfield.is_clearing_lines():
+		# If lines are being erased as a part of line clears, we wait to relocate moles until all lines are deleted.
+		pass
+	else:
+		_refresh_moles_for_playfield()
 
 
 func _on_Playfield_after_lines_deleted(_lines: Array) -> void:

--- a/project/src/main/puzzle/critter/sharks.gd
+++ b/project/src/main/puzzle/critter/sharks.gd
@@ -639,11 +639,20 @@ func _on_Playfield_line_erased(_y: int, _total_lines: int, _remaining_lines: int
 func _on_Playfield_line_inserted(y: int, _tiles_key: String, _src_y: int) -> void:
 	# raise all sharks at or above the specified row
 	_shift_rows(y, Vector2.UP)
-	_refresh_sharks_for_playfield()
+	
+	if _playfield.is_clearing_lines():
+		# If lines are being erased as a part of line clears, we wait to relocate sharks until all lines are deleted.
+		pass
+	else:
+		_refresh_sharks_for_playfield()
 
 
 func _on_Playfield_line_filled(_y: int, _tiles_key: String, _src_y: int) -> void:
-	_refresh_sharks_for_playfield()
+	if _playfield.is_clearing_lines():
+		# If lines are being erased as a part of line clears, we wait to relocate sharks until all lines are deleted.
+		pass
+	else:
+		_refresh_sharks_for_playfield()
 
 
 func _on_Playfield_after_lines_deleted(_lines: Array) -> void:

--- a/project/src/main/puzzle/line-clearer.gd
+++ b/project/src/main/puzzle/line-clearer.gd
@@ -108,13 +108,15 @@ func _physics_process(_delta: float) -> void:
 		var old_lines_being_erased := lines_being_erased
 		var old_lines_being_deleted := lines_being_deleted
 		
-		set_physics_process(false)
-		
 		lines_being_cleared = []
 		lines_being_erased = []
 		lines_being_deleted = []
 		
 		_delete_lines(old_lines_being_cleared, old_lines_being_erased, old_lines_being_deleted)
+		
+		# setting physics_process to 'false' causes 'Playfield.is_building_boxes()' to return false, so we make sure to
+		# assign this after all signals are fired.
+		set_physics_process(false)
 
 
 ## Clears a full line in the playfield as a reward.
@@ -308,7 +310,6 @@ func reset() -> void:
 	
 	for line_dict in _line_dicts():
 		line_dict.clear()
-
 
 
 func _per_line_frame_delay() -> float:

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -78,7 +78,7 @@ func _physics_process(delta: float) -> void:
 
 
 func is_clearing_lines() -> bool:
-	return line_clearer.remaining_line_erase_frames > 0
+	return line_clearer.is_physics_processing()
 
 
 ## Returns the y coordinate of lines currently being cleared.
@@ -87,7 +87,7 @@ func get_lines_being_cleared() -> Array:
 
 
 func is_building_boxes() -> bool:
-	return _box_builder.remaining_box_build_frames > 0
+	return _box_builder.is_physics_processing()
 
 
 func add_misc_delay_frames(frames: int) -> void:


### PR DESCRIPTION
'sharks for playfield' are now refreshed once after all lines are deleted/inserted, rather than refreshing them for every inserted lines.

Playfield.is_clearing_lines() now returns true throughout LineClearer._delete_lines() method. Before, is_clearing_lines() returned false while triggers were firing, meaning bugs related to inserted/deleted lines were really difficult to work around.