### PR TITLE
Enable object pooling for Shark PuzzleTileMaps

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -1164,6 +1164,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/puzzle/critter/shark-sfx.gd"
 }, {
+"base": "Node",
+"class": "SharkTileMapPool",
+"language": "GDScript",
+"path": "res://src/main/puzzle/critter/shark-tile-map-pool.gd"
+}, {
 "base": "Node2D",
 "class": "Sharks",
 "language": "GDScript",
@@ -1566,6 +1571,7 @@ _global_script_class_icons={
 "SharkClouds": "",
 "SharkConfig": "",
 "SharkSfx": "",
+"SharkTileMapPool": "",
 "Sharks": "",
 "SkillTallyItem": "",
 "SkillTallyPanel": "",

--- a/project/src/main/puzzle/critter/Critters.tscn
+++ b/project/src/main/puzzle/critter/Critters.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://src/main/puzzle/critter/moles.gd" type="Script" id=1]
 [ext_resource path="res://src/main/puzzle/critter/critters.gd" type="Script" id=2]
@@ -11,6 +11,8 @@
 [ext_resource path="res://src/main/puzzle/critter/Onion.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/puzzle/critter/sharks.gd" type="Script" id=10]
 [ext_resource path="res://src/main/puzzle/critter/Shark.tscn" type="PackedScene" id=11]
+[ext_resource path="res://src/main/puzzle/critter/shark-tile-map-pool.gd" type="Script" id=12]
+[ext_resource path="res://src/main/puzzle/PuzzleTileMap.tscn" type="PackedScene" id=13]
 
 [node name="Critters" type="Control"]
 margin_left = 364.0
@@ -30,6 +32,12 @@ OnionScene = ExtResource( 9 )
 [node name="Sharks" type="Node2D" parent="." groups=["night_mode_light"]]
 script = ExtResource( 10 )
 SharkScene = ExtResource( 11 )
+
+[node name="SharkHolder" type="Node2D" parent="Sharks"]
+
+[node name="SharkTileMapPool" type="Node" parent="Sharks" groups=["shark_tilemap_pools"]]
+script = ExtResource( 12 )
+PuzzleTileMapScene = ExtResource( 13 )
 
 [node name="Carrots" type="Node2D" parent="." groups=["night_mode_light"]]
 script = ExtResource( 4 )

--- a/project/src/main/puzzle/critter/Shark.tscn
+++ b/project/src/main/puzzle/critter/Shark.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=52 format=2]
+[gd_scene load_steps=50 format=2]
 
 [ext_resource path="res://assets/main/puzzle/critter/shark-sheet.png" type="Texture" id=1]
 [ext_resource path="res://src/main/puzzle/critter/shark-sfx.gd" type="Script" id=2]
@@ -17,8 +17,7 @@
 [ext_resource path="res://src/main/puzzle/critter/shark-clouds.gd" type="Script" id=15]
 [ext_resource path="res://assets/main/puzzle/critter/shark-tooth-sheet.png" type="Texture" id=16]
 [ext_resource path="res://src/main/puzzle/critter/shark-tooth-cloud.gd" type="Script" id=17]
-[ext_resource path="res://src/main/puzzle/flat-mix.shader" type="Shader" id=18]
-[ext_resource path="res://src/main/puzzle/PuzzleTileMap.tscn" type="PackedScene" id=19]
+[ext_resource path="res://src/main/puzzle/PuzzleTileMap.tscn" type="PackedScene" id=18]
 [ext_resource path="res://src/main/puzzle/critter/SharkCloudPart.tscn" type="PackedScene" id=20]
 [ext_resource path="res://assets/main/puzzle/crumbs.png" type="Texture" id=21]
 [ext_resource path="res://src/main/puzzle/critter/shark-crumbs.gd" type="Script" id=22]
@@ -27,11 +26,6 @@
 [ext_resource path="res://assets/main/puzzle/critter/shark-eat.wav" type="AudioStream" id=25]
 [ext_resource path="res://assets/main/puzzle/critter/shark-voice-short-0.wav" type="AudioStream" id=26]
 [ext_resource path="res://assets/main/puzzle/critter/shark-bite.wav" type="AudioStream" id=27]
-
-[sub_resource type="ShaderMaterial" id=9]
-resource_local_to_scene = true
-shader = ExtResource( 18 )
-shader_param/mix_color = Color( 1, 1, 1, 0 )
 
 [sub_resource type="CanvasItemMaterial" id=10]
 particles_animation = true
@@ -1273,6 +1267,7 @@ visible = false
 position = Vector2( 0, -30 )
 script = ExtResource( 17 )
 crumbs_path = NodePath("../Crumbs")
+PuzzleTileMapScene = ExtResource( 18 )
 
 [node name="TileMapHolder" type="Control" parent="ToothCloud"]
 margin_left = -180.0
@@ -1281,18 +1276,10 @@ margin_right = 180.0
 rect_pivot_offset = Vector2( 180, 360 )
 rect_clip_content = true
 
-[node name="TileMap" parent="ToothCloud/TileMapHolder" instance=ExtResource( 19 )]
-material = SubResource( 9 )
-position = Vector2( 144, 296 )
-scale = Vector2( 1, 1 )
-z_index = 0
-tile_data = PoolIntArray( 0, 1, 0 )
-
 [node name="Clouds" type="Node2D" parent="ToothCloud"]
 position = Vector2( 0, -18 )
 script = ExtResource( 15 )
 CloudPartScene = ExtResource( 20 )
-tile_map_path = NodePath("../TileMapHolder/TileMap")
 
 [node name="Tooth" type="Sprite" parent="ToothCloud"]
 position = Vector2( 0, -18 )
@@ -1320,7 +1307,6 @@ local_coords = false
 process_material = SubResource( 13 )
 texture = ExtResource( 21 )
 script = ExtResource( 22 )
-tile_map_path = NodePath("../ToothCloud/TileMapHolder/TileMap")
 
 [node name="WaitHigh" type="Sprite" parent="."]
 visible = false

--- a/project/src/main/puzzle/critter/shark-clouds.gd
+++ b/project/src/main/puzzle/critter/shark-clouds.gd
@@ -7,11 +7,14 @@ const CLOUD_VARIANT_COUNT := 3
 
 export (PackedScene) var CloudPartScene: PackedScene
 
-## The path to the tile map for the pieces the shark is eating.
-export (NodePath) var tile_map_path: NodePath
-
 ## The tile map for the pieces the shark is eating.
-onready var _tile_map: PuzzleTileMap = get_node(tile_map_path)
+var tile_map: PuzzleTileMap setget set_tile_map
+
+func set_tile_map(new_tile_map: PuzzleTileMap) -> void:
+	tile_map = new_tile_map
+	
+	refresh()
+
 
 ## Randomizes the cloud's appearance.
 ##
@@ -49,11 +52,14 @@ func shuffle() -> void:
 ##
 ## Depending on the shape of the eaten pieces, the dust cloud might be narrow, wide, or lopsided.
 func refresh() -> void:
+	if not tile_map:
+		return
+	
 	for child in get_children():
 		child.queue_free()
 		remove_child(child)
 	
-	var used_rect := _tile_map.get_used_rect()
+	var used_rect := tile_map.get_used_rect()
 	
 	if not used_rect:
 		# have a small cloud, even if nothing is being eaten
@@ -64,7 +70,7 @@ func refresh() -> void:
 	
 	for cell_x in range(start_cell_x, end_cell_x):
 		var new_cloud_part: Sprite = CloudPartScene.instance()
-		new_cloud_part.position.x = _tile_map.cell_size.x * cell_x
+		new_cloud_part.position.x = tile_map.cell_size.x * cell_x
 		add_child(new_cloud_part)
 	
 	shuffle()

--- a/project/src/main/puzzle/critter/shark-crumbs.gd
+++ b/project/src/main/puzzle/critter/shark-crumbs.gd
@@ -1,28 +1,31 @@
 extends Particles2D
 ## Emits crumb particles as a piece is eaten.
 
-## The path to the tile map for the pieces the shark is eating.
-export (NodePath) var tile_map_path: NodePath
-
 ## The tile map for the pieces the shark is eating.
-onready var _tile_map: PuzzleTileMap = get_node(tile_map_path)
+var tile_map: PuzzleTileMap setget set_tile_map
+
+func set_tile_map(new_tile_map: PuzzleTileMap) -> void:
+	tile_map = new_tile_map
+	
+	refresh()
+
 
 ## Updates our particle properties based on the pieces the shark is eating.
 ##
 ## If the shark is eating an especially wide chunk of food, we will emit more particles over a wider area.
 func refresh() -> void:
-	if not _tile_map.get_used_cells():
+	if not tile_map or not tile_map.get_used_cells():
 		amount = 2
 		return
 	
 	# assign color
-	var used_cell: Vector2 = _tile_map.get_used_cells()[0]
-	modulate = Utils.rand_value(_tile_map.crumb_colors_for_cell(used_cell))
+	var used_cell: Vector2 = tile_map.get_used_cells()[0]
+	modulate = Utils.rand_value(tile_map.crumb_colors_for_cell(used_cell))
 	
 	# assign width, position, scale
-	process_material.emission_box_extents.x = max(1.0, _tile_map.get_used_rect().size.x) * _tile_map.cell_size.x * 0.5
-	position.x = _tile_map.get_used_rect().get_center().x
-	process_material.scale = _tile_map.global_scale.x
+	process_material.emission_box_extents.x = max(1.0, tile_map.get_used_rect().size.x) * tile_map.cell_size.x * 0.5
+	position.x = tile_map.get_used_rect().get_center().x
+	process_material.scale = tile_map.global_scale.x
 	
 	# assign particle count (6 * cell width)
-	amount = 6 * max(1.0, _tile_map.get_used_rect().size.x)
+	amount = 6 * max(1.0, tile_map.get_used_rect().size.x)

--- a/project/src/main/puzzle/critter/shark-tile-map-pool.gd
+++ b/project/src/main/puzzle/critter/shark-tile-map-pool.gd
@@ -1,0 +1,76 @@
+class_name SharkTileMapPool
+extends Node
+## An object pool for Shark PuzzleTileMaps.
+##
+## Sharks use PuzzleTileMaps to render the eaten pieces. PuzzleTileMaps take about 40 ms to instance, so we instance
+## them in a thread before the puzzle starts.
+
+## Initial number of PuzzleTileMaps stored in the pool.
+##
+## At most, we need one shark tilemap for every shark that could be eating simultaneously. Five sharks could each be
+## eating different parts of a pentomino.
+const POOL_SIZE := 5
+
+export (PackedScene) var PuzzleTileMapScene: PackedScene
+
+## Pooled PuzzleTileMap instances which are available to borrow
+var _tilemaps := []
+
+## Thread which fills the pool
+var _load_thread: Thread
+
+func _ready() -> void:
+	CurrentLevel.connect("settings_changed", self, "_on_Level_settings_changed")
+
+
+func _exit_tree() -> void:
+	# empty the PuzzleTileMap pool
+	for tilemap in _tilemaps:
+		tilemap.free()
+	
+	# invoke 'wait_for_finish()' to avoid a console warning
+	if _load_thread:
+		_load_thread.wait_to_finish()
+
+
+## Obtains a PuzzleTileMap from the pool, or instances one if the pool is empty.
+func borrow_tilemap() -> PuzzleTileMap:
+	var tilemap: PuzzleTileMap
+	if _tilemaps:
+		tilemap = _tilemaps.pop_front()
+	else:
+		tilemap = PuzzleTileMapScene.instance()
+	tilemap.clear()
+	return tilemap
+
+
+## Returns a PuzzleTileMap to the pool, or frees it if the pool is full.
+func return_tilemap(tilemap: PuzzleTileMap) -> void:
+	if _tilemaps.size() < POOL_SIZE:
+		_tilemaps.append(tilemap)
+	else:
+		tilemap.queue_free()
+
+
+## Instances many PuzzleTileMaps until the pool is full.
+##
+## Instancing objects is expensive, so this should not be called from the main thread, and should not be called during
+## gameplay.
+func _fill_pool() -> void:
+	while _tilemaps.size() < POOL_SIZE:
+		var new_tile_map: PuzzleTileMap = PuzzleTileMapScene.instance()
+		_tilemaps.append(new_tile_map)
+
+
+## Fills the pool if the new level includes an 'add sharks' effect.
+func _on_Level_settings_changed() -> void:
+	if not CurrentLevel.settings.triggers.has_effect(LevelTriggerEffects.AddSharksEffect):
+		# there is no 'add sharks' effect, don't fill the pool
+		return
+	
+	if OS.has_feature("web"):
+		# Godot issue #12699; threads not supported for HTML5
+		_fill_pool()
+	else:
+		_load_thread = Thread.new()
+		_load_thread.start(self, "_fill_pool")

--- a/project/src/main/puzzle/level/level-triggers.gd
+++ b/project/src/main/puzzle/level/level-triggers.gd
@@ -49,6 +49,26 @@ func is_default() -> bool:
 	return triggers.empty()
 
 
+## Returns 'true' if this level contains a trigger with the specified effect.
+##
+## Parameters:
+## 	'effect_type': A LevelTriggerEffect class such as 'InsertLineEffect.LevelTriggerEffects'
+func has_effect(effect_type) -> bool:
+	var result := false
+	
+	for phase in triggers:
+		for trigger_obj in triggers[phase]:
+			var trigger: LevelTrigger = trigger_obj
+			if trigger.effect is effect_type:
+				result = true
+				break
+		
+		if result:
+			break
+	
+	return result
+
+
 func _add_trigger(trigger: LevelTrigger) -> void:
 	for phase in trigger.phases:
 		if not triggers.has(phase):

--- a/project/src/test/puzzle/level/test-level-triggers.gd
+++ b/project/src/test/puzzle/level/test-level-triggers.gd
@@ -13,6 +13,14 @@ func test_is_default() -> void:
 	assert_eq(triggers.is_default(), false)
 
 
+func test_has_effect() -> void:
+	assert_eq(triggers.has_effect(LevelTriggerEffects.InsertLineEffect), false)
+	triggers.from_json_array(
+			[{"phases": ["line_cleared y=0-5"], "effect": "insert_line tiles_key=0"}])
+	assert_eq(triggers.has_effect(LevelTriggerEffects.InsertLineEffect), true)
+	assert_eq(triggers.has_effect(LevelTriggerEffects.ClearFilledLinesEffect), false)
+
+
 func test_to_json_empty() -> void:
 	assert_eq(triggers.to_json_array(), [])
 


### PR DESCRIPTION
Sharks were taking about 40 ms to instance. This meant levels which spawned many sharks at once could have a half second of lag while all of the sharks were created. This stemmed from the fact that PuzzleTileMaps are expensive to create.

Shark PuzzleTileMap instances are now pooled in SharkTileMapPool. This lets us instance them at the start of the level and reduce lag. They're only instanced for levels with sharks. They're also instanced in a thread which reduces lag even further.