### PR TITLE
PuzzleTileMap uses preload() instead of load()

### DIFF
--- a/project/src/main/puzzle/puzzle-tile-map.gd
+++ b/project/src/main/puzzle/puzzle-tile-map.gd
@@ -40,9 +40,9 @@ onready var _ghost_piece_shadow_map: TileMap = $GhostPieceViewport/ShadowMap
 onready var _ghost_piece_corner_map: TileMap = $GhostPieceViewport/ShadowMap/CornerMap
 
 var _puzzle_tile_sets_by_enum := {
-	TileSetType.DEFAULT: load("res://src/main/puzzle/puzzle-tile-set.tres"),
-	TileSetType.VEGGIE: load("res://src/main/puzzle/puzzle-tile-set-veggies.tres"),
-	TileSetType.DIAGRAM: load("res://src/main/puzzle/puzzle-tile-set-diagram.tres"),
+	TileSetType.DEFAULT: preload("res://src/main/puzzle/puzzle-tile-set.tres"),
+	TileSetType.VEGGIE: preload("res://src/main/puzzle/puzzle-tile-set-veggies.tres"),
+	TileSetType.DIAGRAM: preload("res://src/main/puzzle/puzzle-tile-set-diagram.tres"),
 }
 
 


### PR DESCRIPTION
This doesn't have any noticable gameplay effect, but it's consistent with other similar code.