### PR TITLE
Avoid adding/removing critters during line clears.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -59,6 +59,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/puzzle/box-builder.gd"
 }, {
+"base": "Reference",
+"class": "CallQueue",
+"language": "GDScript",
+"path": "res://src/main/puzzle/critter/call-queue.gd"
+}, {
 "base": "Node",
 "class": "CareerData",
 "language": "GDScript",
@@ -1350,6 +1355,7 @@ _global_script_class_icons={
 "BoolExpressionEvaluator": "",
 "BoolExpressionParser": "",
 "BoxBuilder": "",
+"CallQueue": "",
 "CareerData": "",
 "CareerLevel": "",
 "CareerLevelSelect": "",

--- a/project/src/main/puzzle/critter/call-queue.gd
+++ b/project/src/main/puzzle/critter/call-queue.gd
@@ -1,0 +1,52 @@
+## A queue of deferred method calls, for scenarios where we need to call methods in the future.
+##
+## A typical use case scenario for this queue involves three steps:
+## 	1. Repeatedly deferring methods using defer(). This schedules calls to occur in the future.
+## 	2. Repeatedly popping deferred calls using pop_deferred().
+## 	3. Verifying the queue is empty using assert_empty().
+class_name CallQueue
+
+## List of Dictionary items defining method calls and arguments.
+## 	'target': (String) the object whose method should be called
+## 	'method': (String) the method to call
+## 	'args': (Array) arguments to pass into the method
+var _deferred_calls := []
+
+## Add a method call to the queue.
+##
+## Parameters:
+## 	'target': the object whose method should be called
+##
+## 	'method': the method to call
+##
+## 	'args': arguments to pass into the method
+func defer(target: Object, method: String, args: Array) -> void:
+	_deferred_calls.append({"target": target, "method": method, "args": args})
+
+
+## Pops method call from the queue, calling the appropriate target.
+##
+## Parameters:
+## 	'target': (Optional) the object whose calls should be dequeued. If unspecified, method calls will be dequeued
+## 		for all objects.
+##
+## 	'method': (Optional) the method name whose calls which should be dequeued. If unspecified, method calls will be
+## 		dequeued for all method names.
+func pop_deferred(target: Object = null, method: String = "") -> void:
+	var new_deferred_calls := []
+	
+	for call in _deferred_calls:
+		if (target and call.target != target) or (method and call.method != method):
+			new_deferred_calls.append(call)
+		else:
+			target.callv(method, call.args)
+	
+	_deferred_calls = new_deferred_calls
+
+
+## Pushes a warning message if the queue is not empty.
+##
+## This should be called after calling pop_deferred() to ensure all calls were dequeued.
+func assert_empty() -> void:
+	if not _deferred_calls.empty():
+		push_warning("CallQueue should be empty, but was: %s" % [_deferred_calls])


### PR DESCRIPTION
Critters being added/removed during line clears is messy for multiline clears. For example, critters might spawn as a result of a top line being cleared, be placed on the bottom line, which is then cleared as well. This might result in a level which is supposed to spawn 5 critters only spawning 3, because the other 2 spawned in strange places.

This scenario is now handled by a new "CallQueue". Critters spawning/advancing is now delayed until after all lines are cleared. Critters removing is still handled immediately -- this removal occurs in a specific cell, so if we didn't handle it immediately those coordinates wouldn't track to the critter's new location without a lot of work.

Fixed some shark/mole comments referencing the wrong critter.