### PR TITLE
Fixed orphaned critters when shifting rows.

### DIFF
--- a/project/src/main/puzzle/critter/moles.gd
+++ b/project/src/main/puzzle/critter/moles.gd
@@ -377,6 +377,8 @@ func _shift_rows(bottom_y: int, direction: Vector2) -> void:
 	
 	# Next, write the old moles in their new locations
 	for cell in shifted.keys():
+		if _moles_by_cell.has(cell):
+			remove_mole(cell)
 		_moles_by_cell[cell] = shifted[cell]
 
 

--- a/project/src/main/puzzle/critter/sharks.gd
+++ b/project/src/main/puzzle/critter/sharks.gd
@@ -624,6 +624,8 @@ func _shift_rows(bottom_y: int, direction: Vector2) -> void:
 	
 	# Next, write the old sharks in their new locations
 	for cell in shifted.keys():
+		if _sharks_by_cell.has(cell):
+			remove_shark(cell)
 		_sharks_by_cell[cell] = shifted[cell]
 
 


### PR DESCRIPTION
Shifting rows could result an _moles_by_cell entry being overwritten. The result was that a critter would remain on the playfield, but would be inaccessible and never advance or be affected by pieces.

Shifting rows now remove conflicting critters. This shouldn't happen often, and only in weird scenarios where multiple critters are spawning in the same column multiple times during a line clear. But it should now work properly.