### PR TITLE
Fixed bug where line clear triggers happened on finish

### DIFF
--- a/project/src/main/puzzle/line-clearer.gd
+++ b/project/src/main/puzzle/line-clearer.gd
@@ -367,6 +367,9 @@ func _delete_lines(old_lines_being_cleared: Array, _old_lines_being_erased: Arra
 			if lines_being_cleared_during_trigger.empty():
 				# If lines are being deleted because of a top out, we don't fire triggers.
 				pass
+			elif PuzzleState.finish_triggered:
+				# If lines are being deleted at the level end, we don't fire triggers.
+				pass
 			else:
 				# Some levels insert lines in response to lines being deleted. It is important that line clear
 				# triggers run after lines are erased, but before they're shifted. Otherwise lines might be inserted


### PR DESCRIPTION
These line clear triggers were tweaked on 940c3d4e2 but they inadvertently started firing during level finishes. This results in weird things happening like the player finishing a level, and 15 carrots launching or 10 sharks appearing.