### PR TITLE
Replace 'if foo' with 'if not foo.empty()'

### DIFF
--- a/project/src/main/chat/chat-event.gd
+++ b/project/src/main/chat/chat-event.gd
@@ -55,14 +55,14 @@ func enabled_link_indexes() -> Array:
 				link_condition = meta_item.trim_prefix("link_if ")
 				break
 		
-		if not link_condition or BoolExpressionEvaluator.evaluate(link_condition):
+		if link_condition.empty() or BoolExpressionEvaluator.evaluate(link_condition):
 			enabled_link_indexes.append(i)
 	return enabled_link_indexes
 
 
 ## Returns 'true' if this chat event represents something the player is thinking.
 func is_thought() -> bool:
-	return text.begins_with("(") and text.ends_with(")") and not who
+	return text.begins_with("(") and text.ends_with(")") and who.empty()
 
 
 func _to_string() -> String:

--- a/project/src/main/data/player-save.gd
+++ b/project/src/main/data/player-save.gd
@@ -151,7 +151,7 @@ func _save_item(type: String, value, key: String = "") -> SaveItem:
 ## Returns 'true' if the data is loaded successfully.
 func _load_player_data_from_file(filename: String) -> bool:
 	var json_save_items := _save_items_from_file(filename)
-	if not json_save_items:
+	if json_save_items.empty():
 		return false
 	
 	for json_save_item_obj in json_save_items:

--- a/project/src/main/editor/puzzle/playfield-editor-control.gd
+++ b/project/src/main/editor/puzzle/playfield-editor-control.gd
@@ -73,7 +73,7 @@ func _on_PlayfieldNav_add_tiles_key_pressed() -> void:
 			new_key = potential_new_key
 			break
 	
-	if not new_key:
+	if new_key.empty():
 		push_error("Couldn't add tiles key: Too many conflicts")
 		return
 	

--- a/project/src/main/puzzle/critter/mole.gd
+++ b/project/src/main/puzzle/critter/mole.gd
@@ -138,7 +138,7 @@ func has_next_state() -> bool:
 ## Returns:
 ## 	An enum from States for the mole's new state.
 func pop_next_state() -> int:
-	if not _next_states:
+	if _next_states.empty():
 		return NONE
 	
 	if _already_popped_state:

--- a/project/src/main/puzzle/critter/onion-config.gd
+++ b/project/src/main/puzzle/critter/onion-config.gd
@@ -44,7 +44,7 @@ func _init(init_day_string: String = "") -> void:
 ## Returns:
 ## 	An enum from OnionState for the state the onion should be in
 func get_state(advance_count: int) -> int:
-	if not day_string:
+	if day_string.empty():
 		return OnionState.NONE
 	
 	return onion_state_by_day_char.get(day_string[advance_count % day_string.length()], OnionState.NONE)

--- a/project/src/main/puzzle/critter/onion.gd
+++ b/project/src/main/puzzle/critter/onion.gd
@@ -100,7 +100,7 @@ func append_next_state(next_state: int) -> void:
 func advance_state() -> int:
 	if _already_popped_state:
 		pass
-	elif not _next_states:
+	elif _next_states.empty():
 		set_state(OnionConfig.OnionState.NONE)
 	else:
 		_current_state_index = (_current_state_index + 1) % _next_states.size()
@@ -134,7 +134,7 @@ func skip_to_night_mode() -> void:
 
 ## Resets the onion to the first state in its day/night cycle.
 func reset_cycle() -> void:
-	if not _next_states:
+	if _next_states.empty():
 		set_state(OnionConfig.OnionState.NONE)
 	else:
 		_current_state_index = 0

--- a/project/src/main/puzzle/critter/shark.gd
+++ b/project/src/main/puzzle/critter/shark.gd
@@ -161,7 +161,7 @@ func has_next_state() -> bool:
 ## Returns:
 ## 	An enum from States for the shark's new state.
 func pop_next_state(force: bool = false) -> int:
-	if not _next_states:
+	if _next_states.empty():
 		return NONE
 	
 	if _already_popped_state and not force:

--- a/project/src/main/puzzle/line-filler.gd
+++ b/project/src/main/puzzle/line-filler.gd
@@ -94,7 +94,7 @@ func _schedule_playfield_refill() -> void:
 ## 	'filled_line_count': The number of lines at the top of the playfield to fill. Empty lines are filled, non-empty
 ## 		lines are skipped.
 func _fill_empty_lines(filled_line_count: int) -> void:
-	if not _fill_lines_tiles_key():
+	if _fill_lines_tiles_key().empty():
 		return
 	
 	# fill the empty rows from bottom to top
@@ -170,7 +170,7 @@ func _tiles_src_y(tiles_key: String) -> int:
 		
 		# obtain the row bag
 		var row_bag: Array = _row_bag_by_tiles_key.get(tiles_key, [])
-		if not row_bag:
+		if row_bag.empty():
 			# refill the row bag
 			for i in range(_row_count_by_tiles_key[tiles_key]):
 				row_bag.append(i)

--- a/project/src/main/puzzle/line-inserter.gd
+++ b/project/src/main/puzzle/line-inserter.gd
@@ -97,7 +97,7 @@ func _determine_tiles_key(tiles_keys: Array) -> String:
 	var prev_tiles_key: String = _prev_tiles_key_by_tiles_keys.get(tiles_keys_string, "")
 	var prev_tiles_key_insert_count: int = _prev_tiles_key_insert_count_by_tiles_keys.get(tiles_keys_string, 0)
 	
-	if not tiles_keys:
+	if tiles_keys.empty():
 		result = ""
 	elif prev_tiles_key and prev_tiles_key_insert_count < _row_count_by_tiles_key[prev_tiles_key]:
 		# the previously used tiles key isn't exhausted, continue using it
@@ -106,7 +106,7 @@ func _determine_tiles_key(tiles_keys: Array) -> String:
 	else:
 		# the previously used tiles key is exhausted, pick a new tiles key.
 		var possible_tiles_keys := tiles_keys.duplicate()
-		if possible_tiles_keys.size() > 1 and prev_tiles_key:
+		if possible_tiles_keys.size() > 1 and not prev_tiles_key.empty():
 			# avoid picking the same key twice
 			possible_tiles_keys.remove(possible_tiles_keys.find(prev_tiles_key))
 		result = Utils.rand_value(possible_tiles_keys)
@@ -132,7 +132,7 @@ func _tiles_src_y(tiles_key: String) -> int:
 		BlocksDuringRules.ShuffleLinesType.BAG:
 			# obtain the row bag
 			var row_bag: Array = _row_bag_by_tiles_key.get(tiles_key, [])
-			if not row_bag:
+			if row_bag.empty():
 				# refill the row bag
 				for i in range(_row_count_by_tiles_key[tiles_key]):
 					row_bag.append(i)

--- a/project/src/main/puzzle/piece/active-piece.gd
+++ b/project/src/main/puzzle/piece/active-piece.gd
@@ -61,7 +61,7 @@ func _init(init_type: PieceType, init_cell_obstructed_func: FuncRef) -> void:
 ## This calculates the center of the smallest rectangle encompassing the piece. It does not care if the piece has more
 ## cells on one side. If the piece's dimensions are even, this will return a fractional result.
 func center() -> Vector2:
-	if not get_pos_arr():
+	if get_pos_arr().empty():
 		return Vector2.ZERO
 	var cell_bounds: Rect2 = Rect2(get_pos_arr()[0], Vector2.ZERO)
 	for cell_pos in get_pos_arr():

--- a/project/src/main/puzzle/piece/piece-queue.gd
+++ b/project/src/main/puzzle/piece/piece-queue.gd
@@ -171,7 +171,7 @@ func _reset_cheat_bag() -> void:
 
 func _shuffled_piece_types() -> Array:
 	var result: Array = CurrentLevel.settings.piece_types.types
-	if not result:
+	if result.empty():
 		result = _default_piece_types
 	result = result.duplicate()
 	result.shuffle()

--- a/project/src/main/puzzle/puzzle-tile-map.gd
+++ b/project/src/main/puzzle/puzzle-tile-map.gd
@@ -214,7 +214,7 @@ func set_whiteness(new_whiteness: float) -> void:
 ## 	'cell_offset': (Optional) Grid-based coordinates of the random offset to apply. If unspecified, the coordinate
 ## 		will be randomly offset by a value in the range [(0, 0), (1, 1)]
 func somewhere_near_cell(cell_pos: Vector2, cell_offset: Vector2 = Vector2.ZERO) -> Vector2:
-	if not cell_offset:
+	if cell_offset == Vector2.ZERO:
 		cell_offset = Vector2(randf(), randf())
 	return (cell_pos + cell_offset) * cell_size * scale
 

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -282,7 +282,7 @@ func _on_PuzzleState_added_line_score(combo_score: int, box_score: int) -> void:
 
 ## When collecting pickups, the chef smiles if they're scoring a lot of bonus points.
 func _on_PuzzleState_added_pickup_score(pickup_score: int) -> void:
-	if not _recent_bonuses:
+	if _recent_bonuses.empty():
 		_recent_bonuses.append(0)
 	_recent_bonuses[_recent_bonuses.size() - 1] += pickup_score
 	_react_to_total_bonus()

--- a/project/src/main/settings/keybind-settings.gd
+++ b/project/src/main/settings/keybind-settings.gd
@@ -114,7 +114,7 @@ func to_json_dict() -> Dictionary:
 func from_json_dict(json: Dictionary) -> void:
 	preset = int(json.get("preset", GUIDELINE))
 	custom_keybinds = json.get("custom_keybinds", {})
-	if not custom_keybinds:
+	if custom_keybinds.empty():
 		restore_default_custom_keybinds()
 	emit_signal("settings_changed")
 

--- a/project/src/main/ui/wallpaper/sticker-row.gd
+++ b/project/src/main/ui/wallpaper/sticker-row.gd
@@ -20,7 +20,7 @@ var _blank_texture_countdown := randi() % 7
 var _back_sticker: Sprite
 
 func _physics_process(delta: float) -> void:
-	if not velocity:
+	if velocity == Vector2.ZERO:
 		# nothing to do if velocity is 0
 		return
 	

--- a/project/src/main/utils/packed-sprite.gd
+++ b/project/src/main/utils/packed-sprite.gd
@@ -45,7 +45,7 @@ func set_frame_data(new_frame_data: String) -> void:
 		_frame_src_rects = ResourceCache.get_frame_src_rects(frame_data)
 		_frame_dest_rects = ResourceCache.get_frame_dest_rects(frame_data)
 
-		if not _frame_src_rects:
+		if _frame_src_rects.empty():
 			# if the ResourceCache is unavailable (possibly during demos) we load things the slow way
 			_load_rects_from_json()
 	update()
@@ -85,7 +85,7 @@ func set_offset(new_offset: Vector2) -> void:
 
 
 func _draw() -> void:
-	if not _frame_dest_rects:
+	if _frame_dest_rects.empty():
 		# frame data not loaded
 		return
 	

--- a/project/src/main/utils/utils.gd
+++ b/project/src/main/utils/utils.gd
@@ -49,7 +49,7 @@ static func to_transparent(color: Color, alpha := 0.0) -> Color:
 ##
 ## Returns a default value of 0.0 if the array is empty.
 static func mean(values: Array, default := 0.0) -> float:
-	if not values:
+	if values.empty():
 		return default
 	
 	var sum := 0.0
@@ -62,7 +62,7 @@ static func mean(values: Array, default := 0.0) -> float:
 ##
 ## Returns a default value of 0.0 if the array is empty.
 static func max_value(values: Array, default := 0.0) -> float:
-	if not values:
+	if values.empty():
 		return default
 	
 	var max_value: float = values[0]
@@ -108,7 +108,7 @@ static func weighted_rand_value(weights_map: Dictionary):
 ## find_closest([1.0, 2.0, 4.0, 8.0], 100) = 3
 ## find_closest([], 100)                   = -1
 static func find_closest(values: Array, target: float) -> int:
-	if not values:
+	if values.empty():
 		return -1
 	
 	var result := 0

--- a/project/src/main/world/chat-key-pair.gd
+++ b/project/src/main/world/chat-key-pair.gd
@@ -24,7 +24,7 @@ var type: int = NONE
 
 ## Returns 'true' if this ChatKeyPair does not define any cutscenes.
 func empty() -> bool:
-	return not preroll and not postroll
+	return preroll.empty() and postroll.empty()
 
 
 ## Returns an ordered list of all cutscenes defined by this ChatKeyPair.

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -290,7 +290,7 @@ func get_orientation() -> int:
 ## 	'stored_fatness': The fatness to save in the creature library. This can be higher than the creature's current
 ## 		fatness if they're still eating.
 func save_fatness(stored_fatness: float) -> void:
-	if not creature_id:
+	if creature_id.empty():
 		# randomly-generated creatures have no creature id; their fatness isn't stored
 		return
 	

--- a/project/src/main/world/creature/walking-buddy.gd
+++ b/project/src/main/world/creature/walking-buddy.gd
@@ -107,17 +107,17 @@ func _walk() -> void:
 			_walk_state = WalkState.SITTING
 			_sit_and_reorient()
 			new_non_iso_walk_direction = Vector2.ZERO
-		elif non_iso_walk_direction and buddy_relative_pos.length() > TOO_FAR_THRESHOLD:
+		elif non_iso_walk_direction != Vector2.ZERO and buddy_relative_pos.length() > TOO_FAR_THRESHOLD:
 			# we're too far from our buddy, and they're following us. stop moving
 			new_non_iso_walk_direction = Vector2.ZERO
-		elif not non_iso_walk_direction and buddy_relative_pos.length() < lerp(TOO_CLOSE_THRESHOLD, TOO_FAR_THRESHOLD, 0.2):
+		elif non_iso_walk_direction == Vector2.ZERO and buddy_relative_pos.length() < lerp(TOO_CLOSE_THRESHOLD, TOO_FAR_THRESHOLD, 0.2):
 			# we're too close to our buddy, and they're following us. start moving
 			new_non_iso_walk_direction = _desired_walk_direction
 	elif leader_or_follower == LeaderOrFollower.FOLLOWER:
-		if not non_iso_walk_direction and buddy_relative_pos.length() > lerp(TOO_CLOSE_THRESHOLD, TOO_FAR_THRESHOLD, 0.8):
+		if non_iso_walk_direction == Vector2.ZERO and buddy_relative_pos.length() > lerp(TOO_CLOSE_THRESHOLD, TOO_FAR_THRESHOLD, 0.8):
 			# we're too far from our buddy, and they're leading us. start moving
 			new_non_iso_walk_direction = _desired_walk_direction
-		elif non_iso_walk_direction and buddy_relative_pos.length() < TOO_CLOSE_THRESHOLD:
+		elif non_iso_walk_direction != Vector2.ZERO and buddy_relative_pos.length() < TOO_CLOSE_THRESHOLD:
 			# we're too close to our buddy, and they're leading us. stop moving
 			new_non_iso_walk_direction = Vector2.ZERO
 	

--- a/project/src/main/world/overworld-ui.gd
+++ b/project/src/main/world/overworld-ui.gd
@@ -124,7 +124,7 @@ func _find_creatures_in_chat_tree(chat_tree: ChatTree) -> Array:
 ## Updates the different UI components to be visible/invisible based on the UI's current state.
 func _update_visible() -> void:
 	$ChatUi.visible = true if chatters else false
-	$Labels/SoutheastLabels/VersionLabel.visible = _show_version and not chatters
+	$Labels/SoutheastLabels/VersionLabel.visible = _show_version and chatters.empty()
 
 
 ## Applies the specified ChatEvent metadata to the scene.


### PR DESCRIPTION
Godot 3.x let us treat integers/arrays/dictionaries as boolean values, but Godot 4.x doesn't let us do that anymore. In preparation for the Godot 4 upgrade, I'm replacing these boolean evaluations.