### PR TITLE
Rewrote FreeRoamTouchButtons to avoid overridding show/hide

### DIFF
--- a/project/src/demo/world/FreeRoamTouchButtons.tscn
+++ b/project/src/demo/world/FreeRoamTouchButtons.tscn
@@ -27,3 +27,5 @@ up_right_weight = 1.0
 up_left_weight = 1.0
 down_right_weight = 1.0
 down_left_weight = 1.0
+
+[connection signal="visibility_changed" from="." to="." method="_on_TouchButtons_visibility_changed"]

--- a/project/src/demo/world/free-roam-touch-buttons.gd
+++ b/project/src/demo/world/free-roam-touch-buttons.gd
@@ -4,32 +4,23 @@ extends Control
 func _ready() -> void:
 	if OS.has_touchscreen_ui_hint():
 		SystemData.touch_settings.connect("settings_changed", self, "_on_TouchSettings_settings_changed")
-		_refresh_button_positions()
 		show()
 	else:
 		hide()
 
 
-## Shows the touchscreen buttons and captures touch input.
-func show() -> void:
-	.show()
-	# stop ignoring touch input
-	$ButtonsSw.show()
-
-
-## Hides the touchscreen buttons and ignores touch input.
-func hide() -> void:
-	.hide()
-	# release any held buttons, and ignore touch input
-	$ButtonsSw.hide()
-
-
 ## Updates the buttons based on the player's settings.
 ##
-## This updates their location and size.
-func _refresh_button_positions() -> void:
-	$ButtonsSw.rect_scale = Vector2.ONE * SystemData.touch_settings.size
-	$ButtonsSw.rect_position.y = rect_size.y - 10 - $ButtonsSw.rect_size.y * $ButtonsSw.rect_scale.y
+## This updates their location, visibility and size.
+func _refresh_buttons() -> void:
+	if visible and OS.has_touchscreen_ui_hint():
+		# stop ignoring touch input
+		$ButtonsSw.show()
+		$ButtonsSw.rect_scale = Vector2.ONE * SystemData.touch_settings.size
+		$ButtonsSw.rect_position.y = rect_size.y - 10 - $ButtonsSw.rect_size.y * $ButtonsSw.rect_scale.y
+	else:
+		# release any held buttons, and ignore touch input
+		$ButtonsSw.hide()
 
 
 func _on_Menu_show() -> void:
@@ -42,4 +33,8 @@ func _on_Menu_hide() -> void:
 
 
 func _on_TouchSettings_settings_changed() -> void:
-	_refresh_button_positions()
+	_refresh_buttons()
+
+
+func _on_TouchButtons_visibility_changed():
+	_refresh_buttons()


### PR DESCRIPTION
Overriding native methods causes an error in Godot 4. Rather than overriding show/hide, we now react to shown/hidden signals.