### PR TITLE
Simplified int vector rotation logic. Indentation.

### DIFF
--- a/project/src/main/chat/chatscript-parser.gd
+++ b/project/src/main/chat/chatscript-parser.gd
@@ -61,7 +61,7 @@ class DefaultState extends AbstractState:
 class LocationState extends AbstractState:
 	
 	func _init(init_chat_tree: ChatTree).(init_chat_tree) -> void:
-			pass
+		pass
 	
 	
 	## Syntax:

--- a/project/src/main/world/environment/ripple-wave.gd
+++ b/project/src/main/world/environment/ripple-wave.gd
@@ -106,7 +106,7 @@ func _add_ripple_sprite(cell_pos: Vector2) -> void:
 ## Refreshes all ripple's states and appearance based on the tilemap.
 func _refresh_ripple_sprites() -> void:
 	var cell_forward_vector: Vector2 = Ripples.TILEMAP_VECTOR_BY_RIPPLE_DIRECTION[_direction]
-	var cell_right_vector: Vector2 = _round_vector2(cell_forward_vector.rotated(PI / 2))
+	var cell_right_vector: Vector2 = _rotate_right(cell_forward_vector)
 	
 	for ripple_sprite in get_children():
 		if not ripple_sprite is RippleSprite:
@@ -155,8 +155,8 @@ func _is_rippleable(tile_position: Vector2) -> bool:
 	return result
 
 
-## Rounds floating point vectors to avoid bugs when interacting with the TileMap class.
+## Rotates floating point vectors using integers to avoid bugs when interacting with the TileMap class.
 ##
 ## Workaround for Godot #18324 (https://github.com/godotengine/godot/issues/18324).
-static func _round_vector2(v: Vector2) -> Vector2:
-	return Vector2(round(v.x), round(v.y))
+static func _rotate_right(v: Vector2) -> Vector2:
+	return Vector2(-v.y, v.x)


### PR DESCRIPTION
Replaced 'round rotate PI/2' logic with int logic. Godot 4 replaces Vector2 with Vector2i which breaks this rounding logic.

Fixed incorrect indentation; this results in an error in Godot 4.