### PR TITLE
Added test for KeybindManager

### DIFF
--- a/project/src/test/settings/test-keybind-manager.gd
+++ b/project/src/test/settings/test-keybind-manager.gd
@@ -1,0 +1,23 @@
+extends GutTest
+
+func test_pretty_string_keys() -> void:
+	var original_locale := TranslationServer.get_locale()
+	TranslationServer.set_locale("en")
+	
+	assert_eq(KeybindManager.pretty_string({"type": "key", "scancode": 0}), "")
+	assert_eq(KeybindManager.pretty_string({"type": "key", "scancode": 82}), "R")
+	assert_eq(KeybindManager.pretty_string({"type": "key", "scancode": 16777231}), "Left")
+	
+	TranslationServer.set_locale(original_locale)
+
+
+func test_pretty_string_joypad_buttons() -> void:
+	var original_locale := TranslationServer.get_locale()
+	TranslationServer.set_locale("en")
+	
+	assert_eq(KeybindManager.pretty_string({"type": "joypad_button", "device": 0, "button_index": 0}), "Face Bottom")
+	assert_eq(KeybindManager.pretty_string({"type": "joypad_button", "device": 0, "button_index": 1}), "Face Right")
+	assert_eq(KeybindManager.pretty_string({"type": "joypad_button", "device": 0, "button_index": 5}), "R")
+	assert_eq(KeybindManager.pretty_string({"type": "joypad_button", "device": 0, "button_index": 14}), "DPAD Left")
+	
+	TranslationServer.set_locale(original_locale)


### PR DESCRIPTION
Input.get_joy_button_string() has been removed from Godot 4, and there is seemingly no replacement. We'll need to write our own version of this, so it's good to have it all tested beforehand.