### PR TITLE
Fix cheeky LineClearer slice call.

### DIFF
--- a/project/src/main/puzzle/line-clearer.gd
+++ b/project/src/main/puzzle/line-clearer.gd
@@ -184,7 +184,7 @@ func calculate_lines_to_clear(filled_lines: Array, force: bool = false) -> Array
 				lines_to_clear.sort()
 	
 	# apply 'filled_line_clear_max' setting
-	if lines_to_clear and not force:
+	if lines_to_clear and CurrentLevel.settings.blocks_during.filled_line_clear_max >= 1 and not force:
 		lines_to_clear = lines_to_clear.slice(0, CurrentLevel.settings.blocks_during.filled_line_clear_max - 1)
 	
 	return lines_to_clear


### PR DESCRIPTION
LineClearer had a slice call which, for most levels, resulted in Array.slice(0, -1) which actually has no effect. In Godot 4.x, the slice function is exclusive instead of inclusive, meaning the code translates to Array.slice(0, 0) which empties the array, introducing a bug.

It's better just to preempt this bug by avoiding this cheeky code.