### PR TITLE
Refactor: shadowed variables, redundant slice, key tests

### DIFF
--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -233,9 +233,9 @@ func _tweak_creature(creature: Creature, allele: String, color_mode: int) -> voi
 	creature.creature_def = center_creature.creature_def
 	
 	var dna := {}
-	for allele in DnaUtils.ALLELES:
-		if center_creature.dna.has(allele):
-			dna[allele] = center_creature.dna[allele]
+	for next_allele in DnaUtils.ALLELES:
+		if center_creature.dna.has(next_allele):
+			dna[next_allele] = center_creature.dna[next_allele]
 	
 	match allele:
 		"name":

--- a/project/src/main/puzzle/level/level-history.gd
+++ b/project/src/main/puzzle/level/level-history.gd
@@ -103,7 +103,7 @@ func best_results(level_id: String, daily: bool = false) -> Array:
 				results.sort_custom(self, "_compare_by_low_seconds")
 			_:
 				results.sort_custom(self, "_compare_by_high_score")
-	return results.slice(0, min(results.size() - 1, max_size - 1))
+	return results.slice(0, max_size - 1)
 
 
 ## Returns the most recent result for a specific level.

--- a/project/src/test/settings/test-keybind-manager.gd
+++ b/project/src/test/settings/test-keybind-manager.gd
@@ -19,5 +19,6 @@ func test_pretty_string_joypad_buttons() -> void:
 	assert_eq(KeybindManager.pretty_string({"type": "joypad_button", "device": 0, "button_index": 1}), "Face Right")
 	assert_eq(KeybindManager.pretty_string({"type": "joypad_button", "device": 0, "button_index": 5}), "R")
 	assert_eq(KeybindManager.pretty_string({"type": "joypad_button", "device": 0, "button_index": 14}), "DPAD Left")
+	assert_eq(KeybindManager.pretty_string({"type": "joypad_button", "device": 0, "button_index": 91}), "")
 	
 	TranslationServer.set_locale(original_locale)


### PR DESCRIPTION
Avoid shadowing 'allele' parameter. This is an error in Godot 4, but it is still bad in Godot 3.x.

Removed redundant slice check. Slice is already bound by the array size, so explicitly constraining it to the array size is redundant.

Added explicit test demonstrating keybindmanager's behavior for unrecognized joystick buttons. This behavior will change in Godot 4.