### PR TITLE
Opaque indoor/outdoor shadows.

### DIFF
--- a/project/src/main/world/environment/IndoorShadows.tscn
+++ b/project/src/main/world/environment/IndoorShadows.tscn
@@ -24,7 +24,6 @@
 0/z_index = 0
 
 [node name="Shadows" type="Node2D"]
-modulate = Color( 1, 1, 1, 0.627451 )
 script = ExtResource( 5 )
 __meta__ = {
 "_editor_description_": ""

--- a/project/src/main/world/environment/OutdoorShadows.tscn
+++ b/project/src/main/world/environment/OutdoorShadows.tscn
@@ -24,7 +24,6 @@
 0/z_index = 0
 
 [node name="Shadows" type="Node2D"]
-modulate = Color( 1, 1, 1, 0.627451 )
 script = ExtResource( 5 )
 
 [node name="ObstacleMapShadows" type="TileMap" parent="."]


### PR DESCRIPTION
Godot 3.x has no way to render translucent groups of nodes. We originally thought it would be feasible to upgrade to Godot 4.x and leverage Godot 4.x CanvasGroups, but we cannot migrate to Godot 4 due to critical missing features. More information is available on the godot-4-transition page in the wiki.

Closes #2060.