### PR TITLE
Added InputMapDemo.

### DIFF
--- a/project/src/demo/InputMapDemo.tscn
+++ b/project/src/demo/InputMapDemo.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/demo/input-map-demo.gd" type="Script" id=1]
+
+[node name="Demo" type="Node"]
+script = ExtResource( 1 )
+
+[node name="Label" type="Label" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -250.0
+margin_top = -250.0
+margin_right = 250.0
+margin_bottom = 250.0
+rect_min_size = Vector2( 500, 500 )

--- a/project/src/demo/input-map-demo.gd
+++ b/project/src/demo/input-map-demo.gd
@@ -1,0 +1,21 @@
+extends Node
+## Demonstrates the project's input map.
+##
+## Any keys, mouse actions or joystick inputs will be printed to the screen.
+
+onready var _label := $Label
+
+func _process(_delta: float) -> void:
+	var action_string := ""
+	for action in InputMap.get_actions():
+		if Input.is_action_just_pressed(action):
+			action_string += " +%s" % [action]
+		if Input.is_action_just_released(action):
+			action_string += " -%s" % [action]
+	if not action_string.empty():
+		if not _label.text.empty():
+			_label.text += "\n"
+		_label.text += action_string
+		
+		while _label.get_line_count() > _label.get_visible_line_count():
+			_label.text = StringUtils.substring_after(_label.text, "\n")


### PR DESCRIPTION
This demo was useful on the godot-4 branch for diagnosing bugs introduced by keybind-manager.gd. These bugs were caused by mismatches between the scancodes in our code and Godot 4's scancodes, but there could be similar bugs in the input map in the future if Godot updates.