### PR TITLE
Refactor: FryingPansUi, TweakAlleleRow onready, ProgressBoard -/=

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -359,6 +359,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/demo/world/free-roam-world.gd"
 }, {
+"base": "Control",
+"class": "FryingPansUi",
+"language": "GDScript",
+"path": "res://src/main/puzzle/pan/frying-pans-ui.gd"
+}, {
 "base": "Reference",
 "class": "GameplayDifficultyAdjustments",
 "language": "GDScript",
@@ -1415,6 +1420,7 @@ _global_script_class_icons={
 "Foods": "",
 "FrameInput": "",
 "FreeRoamWorld": "",
+"FryingPansUi": "",
 "GameplayDifficultyAdjustments": "",
 "GameplaySettings": "",
 "GoopGlob": "",

--- a/project/src/demo/career/ui/progress-board-demo.gd
+++ b/project/src/demo/career/ui/progress-board-demo.gd
@@ -63,10 +63,12 @@ func _input(event: InputEvent) -> void:
 			PlayerData.career.hours_passed = Utils.key_num(event)
 			_progress_board.refresh()
 		KEY_EQUAL:
+			PlayerData.career.show_progress = Careers.ShowProgress.STATIC
 			PlayerData.career.distance_earned = 0
 			PlayerData.career.distance_travelled += 10 if Input.is_key_pressed(KEY_SHIFT) else 1
 			_progress_board.refresh()
 		KEY_MINUS:
+			PlayerData.career.show_progress = Careers.ShowProgress.STATIC
 			PlayerData.career.distance_earned = 0
 			PlayerData.career.distance_travelled -= 10 if Input.is_key_pressed(KEY_SHIFT) else 1
 			PlayerData.career.distance_travelled = int(max(PlayerData.career.distance_travelled, 0))

--- a/project/src/main/editor/creature/tweak-allele-row.gd
+++ b/project/src/main/editor/creature/tweak-allele-row.gd
@@ -13,9 +13,11 @@ export (NodePath) var creature_editor_path: NodePath
 var _allele_values: Array
 
 onready var _creature_editor: CreatureEditor = get_node(creature_editor_path)
+onready var _edit := $Edit
+onready var _label := $Label
 
 func _ready() -> void:
-	$Label.text = "%s:" % text
+	_label.text = "%s:" % text
 	_creature_editor.connect("center_creature_changed", self, "_on_CreatureEditor_center_creature_changed")
 
 
@@ -37,10 +39,10 @@ func _on_Edit_pressed() -> void:
 		else:
 			allele_index += 1
 	
-	$Edit.clear()
+	_edit.clear()
 	for value in _allele_values:
-		$Edit.add_item(DnaUtils.allele_name(allele, value))
-	$Edit.selected = _allele_values.find(_creature_editor.center_creature.dna[allele])
+		_edit.add_item(DnaUtils.allele_name(allele, value))
+	_edit.selected = _allele_values.find(_creature_editor.center_creature.dna[allele])
 
 
 func _on_Edit_item_selected(index: int) -> void:
@@ -58,6 +60,6 @@ func _on_Dna_pressed() -> void:
 ## Update the option button with the creature's allele value.
 func _on_CreatureEditor_center_creature_changed() -> void:
 	if _creature_editor.center_creature.dna[allele]:
-		$Edit.text = DnaUtils.allele_name(allele, _creature_editor.center_creature.dna[allele])
+		_edit.text = DnaUtils.allele_name(allele, _creature_editor.center_creature.dna[allele])
 	else:
-		$Edit.text = ""
+		_edit.text = ""

--- a/project/src/main/puzzle/pan/frying-pans-ui.gd
+++ b/project/src/main/puzzle/pan/frying-pans-ui.gd
@@ -1,3 +1,4 @@
+class_name FryingPansUi
 extends Control
 ## UI control which shows a list of frying pans corresponding to the player's lives.
 ##

--- a/project/src/main/puzzle/pan/puzzle-frying-pans-ui.gd
+++ b/project/src/main/puzzle/pan/puzzle-frying-pans-ui.gd
@@ -1,4 +1,4 @@
-extends "res://src/main/puzzle/pan/frying-pans-ui.gd"
+extends FryingPansUi
 ## Updates the FryingPansUi based on the level's settings and how the player is doing.
 
 func _ready() -> void:


### PR DESCRIPTION
PuzzleFryingPansUi now extends FryingPansUi instead of extending a script name.

Extracted onready fields for TweakAlleleRow.

Fixed bug where ProgressBoardDemo -/= keys would not work after advancing with Z/X/C