### PR TITLE
Refactor: 'tile map', Vector2.UP, PieceDropper signals

### DIFF
--- a/project/src/main/editor/puzzle/editor-playfield.gd
+++ b/project/src/main/editor/puzzle/editor-playfield.gd
@@ -104,14 +104,14 @@ func get_drag_data(_pos: Vector2) -> Object:
 	return _prev_dropped_data
 
 
-## Adds a dragged chunk of blocks to a tile map.
+## Adds a dragged chunk of blocks to a tilemap.
 ##
 ## Parameters:
-## 	'target_tile_map': The tile map to modify
+## 	'target_tile_map': The tilemap to modify
 ##
 ## 	'pos': An x/y control coordinate like '58, 132'
 ##
-## 	'data': The data to apply to the tile map
+## 	'data': The data to apply to the tilemap
 func _store_block_level_chunk(target_tile_map: PuzzleTileMap, pos: Vector2, data: BlockLevelChunk) -> void:
 	for cell in data.used_cells:
 		var target_pos: Vector2 = _cell_pos(pos) + cell

--- a/project/src/main/puzzle/critter/shark-clouds.gd
+++ b/project/src/main/puzzle/critter/shark-clouds.gd
@@ -7,7 +7,7 @@ const CLOUD_VARIANT_COUNT := 3
 
 export (PackedScene) var CloudPartScene: PackedScene
 
-## Tile map for the pieces the shark is eating.
+## Tilemap for the pieces the shark is eating.
 var tile_map: PuzzleTileMap setget set_tile_map
 
 func set_tile_map(new_tile_map: PuzzleTileMap) -> void:

--- a/project/src/main/puzzle/critter/shark-crumbs.gd
+++ b/project/src/main/puzzle/critter/shark-crumbs.gd
@@ -1,7 +1,7 @@
 extends Particles2D
 ## Emits crumb particles as a piece is eaten.
 
-## Tile map for the pieces the shark is eating.
+## Tilemap for the pieces the shark is eating.
 var tile_map: PuzzleTileMap setget set_tile_map
 
 func set_tile_map(new_tile_map: PuzzleTileMap) -> void:

--- a/project/src/main/puzzle/critter/shark-tooth-cloud.gd
+++ b/project/src/main/puzzle/critter/shark-tooth-cloud.gd
@@ -164,7 +164,7 @@ func _check_for_tilemap() -> void:
 	if not _tile_map:
 		_borrow_tilemap()
 		_tile_map.position = TILE_MAP_START_POSITION
-		_tile_map.scale = Vector2(1.0, 1.0)
+		_tile_map.scale = Vector2.ONE
 		_tile_map.z_index = 0
 
 

--- a/project/src/main/puzzle/critter/sharks.gd
+++ b/project/src/main/puzzle/critter/sharks.gd
@@ -280,7 +280,7 @@ func _replace_active_piece_with_domino() -> void:
 			if pos_arr.has(pos_arr_item + Vector2.RIGHT):
 				new_type = _to_domino(old_type)
 				new_orientation = 0
-				new_pos = old_pos + pos_arr_item + Vector2(0, -1)
+				new_pos = old_pos + pos_arr_item + Vector2.UP
 				break
 			
 			# next, try orienting our domino vertically

--- a/project/src/main/puzzle/night/night-playfield-tile-map.gd
+++ b/project/src/main/puzzle/night/night-playfield-tile-map.gd
@@ -1,6 +1,6 @@
 class_name NightPlayfieldTileMap
 extends NightPuzzleTileMap
-## Displays the playfield tile map during night mode.
+## Displays the playfield tilemap during night mode.
 ##
 ## Many other night mode tilemaps such as the active piece, next piece and hold piece use similar logic. The playfield
 ## tilemap is distinct because its pieces cast an opaque vertical shadow, making gameplay more difficult.

--- a/project/src/main/puzzle/piece/piece-dropper.gd
+++ b/project/src/main/puzzle/piece/piece-dropper.gd
@@ -4,9 +4,9 @@ extends Node
 ## Emitted when the hard drop destination for the current piece changes. Used for drawing the ghost piece.
 signal hard_drop_target_pos_changed(piece, hard_drop_target_pos)
 
-signal soft_dropped # emitted when the player presses the soft drop key
-signal hard_dropped # emitted when the player presses the hard drop key
-signal dropped # emitted when the piece falls as a result of a soft drop, hard drop, or gravity
+signal soft_dropped(dropped_piece) # emitted when the player presses the soft drop key
+signal hard_dropped(dropped_piece) # emitted when the player presses the hard drop key
+signal dropped(dropped_piece) # emitted when the piece falls as a result of a soft drop, hard drop, or gravity
 
 export (NodePath) var input_path: NodePath
 export (NodePath) var piece_mover_path: NodePath
@@ -27,7 +27,7 @@ func _physics_process(_delta: float) -> void:
 ## Recalculates the hard drop destination for the current piece.
 func calculate_hard_drop_target(piece: ActivePiece) -> void:
 	piece.reset_target()
-	while piece.can_move_to(piece.target_pos + Vector2(0, 1), piece.orientation):
+	while piece.can_move_to(piece.target_pos + Vector2.DOWN, piece.orientation):
 		piece.target_pos.y += 1
 	hard_drop_target_pos = piece.target_pos
 	emit_signal("hard_drop_target_pos_changed", piece, hard_drop_target_pos)

--- a/project/src/main/puzzle/playfield-fx.gd
+++ b/project/src/main/puzzle/playfield-fx.gd
@@ -73,8 +73,9 @@ var _glow_duration := 0.0
 ## current background light color
 var _color := Color.transparent
 
-## tile indexes by food/vegetable color
-var _color_tile_indexes: Dictionary
+## key: (Color) Food/vegetable color
+## value: (int) Index of a tile in light_map or glow_map
+var _tile_index_by_color: Dictionary
 
 ## lights which turn on and off
 onready var light_map: TileMap = $LightMap
@@ -96,7 +97,7 @@ func _ready() -> void:
 	PuzzleState.connect("combo_changed", self, "_on_PuzzleState_combo_changed")
 	PuzzleState.connect("added_pickup_score", self, "_on_PuzzleState_added_pickup_score")
 	_init_tile_set()
-	_init_color_tile_indexes()
+	_init_tile_index_by_color()
 	reset()
 
 
@@ -131,13 +132,13 @@ func _init_tile_set() -> void:
 
 
 ## Initializes the mapping of tile indexes by food/vegetable color.
-func _init_color_tile_indexes() -> void:
-	if _color_tile_indexes:
+func _init_tile_index_by_color() -> void:
+	if _tile_index_by_color:
 		return
 	
 	for tile_index in light_map.tile_set.get_tiles_ids():
 		var color: Color = light_map.tile_set.tile_get_modulate(tile_index)
-		_color_tile_indexes[color] = tile_index
+		_tile_index_by_color[color] = tile_index
 
 
 func _init_tile(color: Color) -> void:
@@ -205,7 +206,7 @@ func _calculate_brightness(combo: int) -> void:
 	modulate.a = _brightness
 
 
-## Calculates the new light pattern and refreshes the tile maps.
+## Calculates the new light pattern and refreshes the tilemaps.
 func _refresh_tile_maps() -> void:
 	bg_strobe.color = Utils.to_transparent(_color)
 	
@@ -229,8 +230,8 @@ func _refresh_tile_maps() -> void:
 				if s[x] == '#':
 					if _color == RAINBOW_LIGHT_COLOR:
 						tile = 6 + ((x + _pattern_y) % RAINBOW_COLOR_COUNT)
-					elif _color_tile_indexes.has(_color):
-						tile = _color_tile_indexes[_color]
+					elif _tile_index_by_color.has(_color):
+						tile = _tile_index_by_color[_color]
 				light_map.set_cell(x, y, tile)
 				glow_map.set_cell(x, y, tile)
 

--- a/project/src/main/puzzle/squish-map.gd
+++ b/project/src/main/puzzle/squish-map.gd
@@ -5,7 +5,7 @@ extends PuzzleTileMap
 var squish_seconds_remaining := 0.0
 var squish_seconds_total := 0.0
 
-## key: (Vector2) tile map cell
+## key: (Vector2) tilemap cell
 ## value: (int) Number proportional to how long this cell should contain a stretched block. Higher numbered cells are
 ## 	drawn for more frames, lower numbered cells are drawn for fewer frames. Cells with a value of zero are never drawn.
 var _stretch_pos := {}

--- a/project/src/main/settings/graphics-settings.gd
+++ b/project/src/main/settings/graphics-settings.gd
@@ -16,7 +16,7 @@ enum FeedingAnimation {
 ## enum from CreatureDetail describing how detailed the creatures should look
 var creature_detail: int = _default_creature_detail() setget set_creature_detail
 
-var feeding_animation: int = _default_feeding_animation() setget set_feeding_animation
+var feeding_animation: int = _default_feeding_animation()
 
 var use_vsync: bool = _default_use_vsync() setget set_use_vsync
 
@@ -30,10 +30,6 @@ func set_creature_detail(new_creature_detail: int) -> void:
 func set_use_vsync(new_use_vsync: bool) -> void:
 	use_vsync = new_use_vsync
 	OS.set_use_vsync(new_use_vsync)
-
-
-func set_feeding_animation(new_feeding_animation: int) -> void:
-	feeding_animation = new_feeding_animation
 
 
 ## Resets the gameplay settings to their default values.
@@ -52,7 +48,7 @@ func to_json_dict() -> Dictionary:
 func from_json_dict(json: Dictionary) -> void:
 	set_creature_detail(json.get("creature_detail", _default_creature_detail()))
 	set_use_vsync(json.get("use_vsync", _default_use_vsync()))
-	set_feeding_animation(json.get("feeding_animation", _default_feeding_animation()))
+	feeding_animation = json.get("feeding_animation", _default_feeding_animation())
 
 
 ## Returns the default creature detail setting value. Web and mobile targets use lower detail.


### PR DESCRIPTION
Changed 'tile map' to 'tilemap' in code comments. The godot documentation is inconsistent, but it usually refers to it as 'tilemap' or 'TileMap' and rarely as 'tile map'.

Changed some code to use Vector2 constants instead of hardcoding 'Vector2(0, -1)'

Added parameters to PieceDropper signals.

Removed unnecessary set_feeding_animation method.

Changed PlayfieldFx._color_tile_indexes field to conform to our conventions for dictionaries.