### PR TITLE
Refactor: Plural enums, dictionaries

### DIFF
--- a/project/src/main/career/career-data.gd
+++ b/project/src/main/career/career-data.gd
@@ -20,7 +20,7 @@ var invalid_time_of_day := tr("?:?? zm")
 
 ## key: (int) corresonding to the number of levels the player has played
 ## value: (String) human-readable time of day
-var time_of_day_by_hours := {
+var times_of_day_by_hour := {
 	0: tr("11:00 am"),
 	1: tr("12:10 pm"),
 	2: tr("1:20 pm"),

--- a/project/src/main/career/ui/career-time-label.gd
+++ b/project/src/main/career/ui/career-time-label.gd
@@ -14,11 +14,11 @@ func _ready() -> void:
 ## Update the label's text and icon.
 func _refresh() -> void:
 	# update the label's text
-	_label.text = PlayerData.career.time_of_day_by_hours.get(
+	_label.text = PlayerData.career.times_of_day_by_hour.get(
 			PlayerData.career.hours_passed, PlayerData.career.invalid_time_of_day)
 	
-	if not PlayerData.career.time_of_day_by_hours.has(PlayerData.career.hours_passed):
-		push_warning("_time_of_day_by_hours has no entry for %s" % [PlayerData.career.hours_passed])
+	if not PlayerData.career.times_of_day_by_hour.has(PlayerData.career.hours_passed):
+		push_warning("_times_of_day_by_hour has no entry for %s" % [PlayerData.career.hours_passed])
 	
 	# update the icon
 	_icon_sprite.frame = PlayerData.career.hours_passed

--- a/project/src/main/career/ui/progress-board-clock.gd
+++ b/project/src/main/career/ui/progress-board-clock.gd
@@ -10,7 +10,7 @@ const INVALID_HAND_POSITIONS := [11.0, 0.0]
 ##
 ## key: (int) corresonding to the number of levels the player has played
 ## value: (Array, float) Array with two entries for the position of the analog clock's hour and minute hands.
-const HAND_POSITIONS_BY_HOURS := {
+const HAND_POSITIONS_BY_HOUR := {
 	0: [11.0, 0.0], # 11:00 am
 	1: [12.0, 10.0], # 12:10 pm
 	2: [13.0, 20.0], # 1:20 pm
@@ -87,7 +87,7 @@ func set_hours_passed(new_hours_passed: int = 0) -> void:
 ## Parameters:
 ## 	'new_hours_passed': The number of hours passed in career mode.
 func _minute_hand_position(new_hours_passed: int) -> float:
-	var hand_positions: Array = HAND_POSITIONS_BY_HOURS.get(new_hours_passed, INVALID_HAND_POSITIONS)
+	var hand_positions: Array = HAND_POSITIONS_BY_HOUR.get(new_hours_passed, INVALID_HAND_POSITIONS)
 	return hand_positions[1]
 
 
@@ -100,7 +100,7 @@ func _minute_hand_position(new_hours_passed: int) -> float:
 ## 		two numbers on an analog clock. If false, the hour hand will ignore the minute hand, pointing directly to one
 ## 		of the twelve numbers on an analog clock.
 func _hour_hand_position(new_hours_passed: int, advance_for_minutes: bool = true) -> float:
-	var hand_positions: Array = HAND_POSITIONS_BY_HOURS.get(new_hours_passed, INVALID_HAND_POSITIONS)
+	var hand_positions: Array = HAND_POSITIONS_BY_HOUR.get(new_hours_passed, INVALID_HAND_POSITIONS)
 	var new_hours: float = hand_positions[0]
 	if advance_for_minutes:
 		new_hours += _minute_hand_position(new_hours_passed) / 60.0
@@ -125,7 +125,7 @@ func _filled_percent(new_hours_passed: int) -> float:
 
 ## Calculates the text of the digital clock, like '12:30 pm'
 func _clock_text(new_hours_passed: int) -> String:
-	return PlayerData.career.time_of_day_by_hours.get(new_hours_passed, PlayerData.career.invalid_time_of_day)
+	return PlayerData.career.times_of_day_by_hour.get(new_hours_passed, PlayerData.career.invalid_time_of_day)
 
 
 ## Updates the clock visuals based on the number of hours passed.

--- a/project/src/main/editor/puzzle/editor-pickups.gd
+++ b/project/src/main/editor/puzzle/editor-pickups.gd
@@ -39,7 +39,7 @@ func get_food_type(cell: Vector2) -> int:
 	var result := -1
 	if _pickups_by_cell.has(cell):
 		var food_type: int = _pickups_by_cell.get(cell, -1).food_type
-		result = Foods.BOX_TYPE_BY_FOOD_TYPE[food_type]
+		result = Foods.BOX_TYPES_BY_FOOD_TYPE[food_type]
 	return result
 
 
@@ -68,5 +68,5 @@ func get_used_cells() -> Array:
 ## The food type corresponds to the box type, although we alternate identical snack box pickups in a checkerboard
 ## pattern.
 func _food_type_for_cell(box_type: int, cell: Vector2) -> int:
-	var food_types: Array = Foods.FOOD_TYPES_BY_BOX_TYPES[box_type]
+	var food_types: Array = Foods.FOOD_TYPES_BY_BOX_TYPE[box_type]
 	return food_types[(int(cell.x + cell.y) % food_types.size())]

--- a/project/src/main/editor/puzzle/pickup-level-chunk-control.gd
+++ b/project/src/main/editor/puzzle/pickup-level-chunk-control.gd
@@ -23,7 +23,7 @@ func get_drag_data(_pos: Vector2) -> Object:
 
 
 func _refresh_pickup() -> void:
-	_pickup.food_type = Foods.FOOD_TYPES_BY_BOX_TYPES[box_type][0]
+	_pickup.food_type = Foods.FOOD_TYPES_BY_BOX_TYPE[box_type][0]
 
 
 func _on_ChangeButton_pressed() -> void:

--- a/project/src/main/puzzle/critter/mole.gd
+++ b/project/src/main/puzzle/critter/mole.gd
@@ -6,7 +6,7 @@ extends Node2D
 ## or if the player clears the row they are digging.
 
 ## States the mole goes through when digging up star seeds.
-enum States {
+enum State {
 	NONE,
 	WAITING,
 	DIGGING,
@@ -16,38 +16,38 @@ enum States {
 }
 
 ## The mole has not appeared yet, or has disappeared.
-const NONE := States.NONE
+const NONE := State.NONE
 
 ## The mole will appear soon. If the player crushes the mole with their piece when it is in this state, it relocates
 ## elsewhere in the playfield. This is so that players are not punished unfairly for crushing a mole which they did
 ## not see quickly enough.
-const WAITING := States.WAITING
+const WAITING := State.WAITING
 
 ## The mole is digging, searching for a star seed.
-const DIGGING := States.DIGGING
+const DIGGING := State.DIGGING
 
 ## The mole has found a star seed, and will finish digging it up very soon.
-const DIGGING_END := States.DIGGING_END
+const DIGGING_END := State.DIGGING_END
 
 ## The mole has found a seed pickup.
-const FOUND_SEED := States.FOUND_SEED
+const FOUND_SEED := State.FOUND_SEED
 
 ## The mole has found a star pickup.
-const FOUND_STAR := States.FOUND_STAR
+const FOUND_STAR := State.FOUND_STAR
 
-## Enum from States for the mole's current animation state.
+## Enum from State for the mole's current animation state.
 var state: int = NONE setget set_state
 
 ## 'true' if the mole is temporarily hidden by the piece.
 var hidden: bool setget set_hidden
 
-## Enum from States for the mole's previous animation state, if they are temporarily hidden by the player's piece.
+## Enum from State for the mole's previous animation state, if they are temporarily hidden by the player's piece.
 var hidden_mole_state: int = NONE
 
 ## 'true' if the Mole will be queued for deletion after the 'poof' animation completes.
 var _free_after_poof := false
 
-## Queue of enums from States for the mole's upcoming animation states.
+## Queue of enums from State for the mole's upcoming animation states.
 var _next_states := []
 
 ## 'true' if a state has already been popped from the _next_states queue this frame. We track this to avoid
@@ -70,7 +70,7 @@ onready var wait_high := $WaitHigh
 
 onready var sfx := $MoleSfx
 
-## key: (int) Enum from States
+## key: (int) Enum from State
 ## value: (Node) State node from the _states StateMachine
 onready var _state_nodes_by_enum := {
 	NONE: $States/None,
@@ -112,10 +112,10 @@ func set_hidden(new_hidden: bool) -> void:
 		hidden_mole_state = NONE
 
 
-## Enqueues an enums from States to the mole's upcoming animation states.
+## Enqueues an enums from State to the mole's upcoming animation states.
 ##
 ## Parameters:
-## 	'next_state': Enum from States
+## 	'next_state': Enum from State
 ##
 ## 	'count': (Optional) Number of instances of the state to enqueue.
 func append_next_state(next_state: int, count: int = 1) -> void:
@@ -136,7 +136,7 @@ func has_next_state() -> bool:
 ## dequeued state.
 ##
 ## Returns:
-## 	Enum from States for the mole's new state.
+## 	Enum from State for the mole's new state.
 func pop_next_state() -> int:
 	if _next_states.empty():
 		return NONE
@@ -155,7 +155,7 @@ func pop_next_state() -> int:
 
 
 ## Parameters:
-## 	'new_state': enum from States for the mole's new animation state.
+## 	'new_state': enum from State for the mole's new animation state.
 func set_state(new_state: int) -> void:
 	state = new_state
 	_refresh_state()

--- a/project/src/main/puzzle/critter/shark.gd
+++ b/project/src/main/puzzle/critter/shark.gd
@@ -6,7 +6,7 @@ extends Node2D
 ## from the piece, a big bite from the piece, or eat the entire piece.
 
 ## States the shark goes through when eating a piece.
-enum States {
+enum State {
 	NONE,
 	WAITING,
 	DANCING,
@@ -20,25 +20,25 @@ enum States {
 const DEFAULT_EAT_DURATION := 0.8
 
 ## The shark has not appeared yet, or has disappeared.
-const NONE := States.NONE
+const NONE := State.NONE
 
 ## The shark will appear soon.
-const WAITING := States.WAITING
+const WAITING := State.WAITING
 
 ## The shark is dancing, waiting to be fed.
-const DANCING := States.DANCING
+const DANCING := State.DANCING
 
 ## The shark is dancing, but will stop dancing very soon.
-const DANCING_END := States.DANCING_END
+const DANCING_END := State.DANCING_END
 
 ## The shark is eating a piece.
-const EATING := States.EATING
+const EATING := State.EATING
 
 ## The shark has been fed, and looks happy.
-const FED := States.FED
+const FED := State.FED
 
 ## The shark has been squished by a piece.
-const SQUISHED := States.SQUISHED
+const SQUISHED := State.SQUISHED
 
 ## Shorter sharks need the tooth cloud moved lower so it will line up with their mouth. This constant stores the tooth
 ## cloud height for different shark types.
@@ -65,13 +65,13 @@ var shark_size: int = SharkConfig.SharkSize.MEDIUM setget set_shark_size
 ## Duration in seconds the shark takes to eat.
 var eat_duration: float = DEFAULT_EAT_DURATION setget set_eat_duration
 
-## Enum from States for the shark's current animation state.
+## Enum from State for the shark's current animation state.
 var state: int = NONE setget set_state
 
 ## 'true' if the shark will be queued for deletion after the 'poof' animation completes.
 var _free_after_poof := false
 
-## Queue of enums from States for the shark's upcoming animation states.
+## Queue of enums from State for the shark's upcoming animation states.
 var _next_states := []
 
 ## 'true' if a state has already been popped from the _next_states queue this frame. We track this to avoid
@@ -97,7 +97,7 @@ onready var wait_high := $WaitHigh
 
 onready var sfx := $SharkSfx
 
-## key: (int) Enum from States
+## key: (int) Enum from State
 ## value: (Node) State node from the _states StateMachine
 onready var _state_nodes_by_enum := {
 	NONE: $States/None,
@@ -132,10 +132,10 @@ func set_shark_size(new_shark_size: int) -> void:
 	_refresh_shark_size()
 
 
-## Enqueues an enums from States to the shark's upcoming animation states.
+## Enqueues an enums from State to the shark's upcoming animation states.
 ##
 ## Parameters:
-## 	'next_state': Enum from States
+## 	'next_state': Enum from State
 ##
 ## 	'count': (Optional) Number of instances of the state to enqueue.
 func append_next_state(next_state: int, count: int = 1) -> void:
@@ -159,7 +159,7 @@ func has_next_state() -> bool:
 ## 	'force': If 'true', the shark will be updated again even if it was already updated this frame.
 ##
 ## Returns:
-## 	Enum from States for the shark's new state.
+## 	Enum from State for the shark's new state.
 func pop_next_state(force: bool = false) -> int:
 	if _next_states.empty():
 		return NONE
@@ -209,7 +209,7 @@ func set_puzzle_tile_set_type(new_puzzle_tile_set_type: int) -> void:
 
 
 ## Parameters:
-## 	'new_state': enum from States for the shark's new animation state.
+## 	'new_state': enum from State for the shark's new animation state.
 func set_state(new_state: int) -> void:
 	if state == new_state:
 		return

--- a/project/src/main/puzzle/foods.gd
+++ b/project/src/main/puzzle/foods.gd
@@ -57,7 +57,7 @@ const COLORS_VEG_ALL := [COLOR_VEG_GREEN, COLOR_VEG_RED, COLOR_VEG_BREAD, COLOR_
 
 ## key: (FoodType)
 ## value: (BoxType) corresponding box
-const BOX_TYPE_BY_FOOD_TYPE := {
+const BOX_TYPES_BY_FOOD_TYPE := {
 	FoodType.BROWN_0: BoxType.BROWN,
 	FoodType.BROWN_1: BoxType.BROWN,
 	FoodType.PINK_0: BoxType.PINK,
@@ -97,7 +97,7 @@ const COLORS_BY_FOOD_TYPE := {
 
 ## key: (BoxType)
 ## value: (Array, FoodType) FoodTypes for the corresponding food items
-const FOOD_TYPES_BY_BOX_TYPES := {
+const FOOD_TYPES_BY_BOX_TYPE := {
 	BoxType.BROWN: [FoodType.BROWN_0, FoodType.BROWN_1],
 	BoxType.PINK: [FoodType.PINK_0, FoodType.PINK_1],
 	BoxType.BREAD: [FoodType.BREAD_0, FoodType.BREAD_1],
@@ -114,7 +114,7 @@ const FOOD_TYPES_BY_BOX_TYPES := {
 
 ## key: (BoxType)
 ## value: (Array, Color) Food colors for the corresponding food items
-const COLORS_BY_BOX_TYPES := {
+const COLORS_BY_BOX_TYPE := {
 	BoxType.BROWN: [COLOR_BROWN],
 	BoxType.PINK: [COLOR_PINK],
 	BoxType.BREAD: [COLOR_BREAD],

--- a/project/src/main/puzzle/night/night-pickup.gd
+++ b/project/src/main/puzzle/night/night-pickup.gd
@@ -42,7 +42,7 @@ func _refresh_appearance() -> void:
 	if not is_inside_tree():
 		return
 	
-	var box_type: int = Foods.BOX_TYPE_BY_FOOD_TYPE[food_type]
+	var box_type: int = Foods.BOX_TYPES_BY_FOOD_TYPE[food_type]
 	
 	# refresh seed appearance
 	_seed.visible = not food_shown and Foods.is_snack_box(box_type)

--- a/project/src/main/puzzle/pickup.gd
+++ b/project/src/main/puzzle/pickup.gd
@@ -40,7 +40,7 @@ func set_food_type(new_food_type: int) -> void:
 
 ## Returns 'true' if this pickup will spawn a cake when collected.
 func is_cake() -> bool:
-	var box_type: int = Foods.BOX_TYPE_BY_FOOD_TYPE[food_type]
+	var box_type: int = Foods.BOX_TYPES_BY_FOOD_TYPE[food_type]
 	return Foods.is_cake_box(box_type)
 
 
@@ -49,7 +49,7 @@ func _refresh_appearance() -> void:
 	if not (is_inside_tree() and _food_item):
 		return
 	
-	var box_type: int = Foods.BOX_TYPE_BY_FOOD_TYPE[food_type]
+	var box_type: int = Foods.BOX_TYPES_BY_FOOD_TYPE[food_type]
 	
 	# refresh seed appearance
 	_seed.visible = not food_shown and Foods.is_snack_box(box_type)

--- a/project/src/main/puzzle/pickups.gd
+++ b/project/src/main/puzzle/pickups.gd
@@ -171,7 +171,7 @@ func _prepare_pickups_for_level() -> void:
 ## The food type corresponds to the box type, although we alternate identical snack box pickups in a checkerboard
 ## pattern.
 func _food_type_for_box_type(box_type: int, cell: Vector2) -> int:
-	var food_types: Array = Foods.FOOD_TYPES_BY_BOX_TYPES[box_type]
+	var food_types: Array = Foods.FOOD_TYPES_BY_BOX_TYPE[box_type]
 	return food_types[(int(cell.x + cell.y) % food_types.size())]
 
 

--- a/project/src/main/puzzle/puzzle-tile-map.gd
+++ b/project/src/main/puzzle/puzzle-tile-map.gd
@@ -306,7 +306,7 @@ func crumb_colors_for_cell(cell_pos: Vector2) -> Array:
 				TileSetType.VEGGIE:
 					result = [Foods.COLORS_VEG_ALL[int(autotile_coord.y)]]
 		TILE_BOX:
-			result = Foods.COLORS_BY_BOX_TYPES[int(autotile_coord.y)]
+			result = Foods.COLORS_BY_BOX_TYPE[int(autotile_coord.y)]
 		TILE_VEG:
 			result = [Foods.COLOR_VEGETABLE]
 	

--- a/project/src/main/puzzle/star-seed.gd
+++ b/project/src/main/puzzle/star-seed.gd
@@ -21,6 +21,6 @@ func _refresh_appearance() -> void:
 	if not is_inside_tree():
 		return
 	
-	var box_type: int = Foods.BOX_TYPE_BY_FOOD_TYPE[food_type]
+	var box_type: int = Foods.BOX_TYPES_BY_FOOD_TYPE[food_type]
 	_seed.visible = Foods.is_snack_box(box_type)
 	_star.visible = Foods.is_cake_box(box_type)

--- a/project/src/main/puzzle/star-seeds.gd
+++ b/project/src/main/puzzle/star-seeds.gd
@@ -225,7 +225,7 @@ func _spawn_star_seeds(rect: Rect2, box_type: int, star_seed_positions: Array) -
 			if cell.y < PuzzleTileMap.FIRST_VISIBLE_ROW:
 				star_seed.visible = false
 			
-			var food_types: Array = Foods.FOOD_TYPES_BY_BOX_TYPES[box_type]
+			var food_types: Array = Foods.FOOD_TYPES_BY_BOX_TYPE[box_type]
 			
 			# alternate snack foods in a horizontal stripe pattern
 			star_seed.food_type = food_types[int(cell.y) % food_types.size()]

--- a/project/src/main/world/environment/goop-overworld-tiler.gd
+++ b/project/src/main/world/environment/goop-overworld-tiler.gd
@@ -8,7 +8,7 @@ extends Node
 ##
 ## This class also assigns appropriate 'corner covers', tiles which cover the corners of an overworld tilemap.
 
-enum TileTypes {
+enum TileType {
 	NONE,
 	NO_GOOP,
 	SOME_GOOP,
@@ -49,143 +49,143 @@ const CAKE_CENTER := 1024
 ##
 ## key: (int) bitmask of surrounding tiles
 ## value: (Vector2) array of two elements which define a 'binding value':
-##  value[0]: (int) enum from TileTypes defining the new tile type, such as 'ALL_GOOP' or 'SOME_GOOP'
+##  value[0]: (int) enum from TileType defining the new tile type, such as 'ALL_GOOP' or 'SOME_GOOP'
 ##  value[1]: (Vector2) autotile coordinate of the new tile
 const NO_GOOP_AUTOTILE_COORDS_BY_BINDING := {
 	# goopless tiles
-	0: [TileTypes.NO_GOOP,
+	0: [TileType.NO_GOOP,
 			[Vector2(0, 0), Vector2(1, 0)]],
-	CAKE_TOP: [TileTypes.NO_GOOP,
+	CAKE_TOP: [TileType.NO_GOOP,
 			[Vector2(2, 0), Vector2(3, 0)]],
-	CAKE_BOTTOM: [TileTypes.NO_GOOP,
+	CAKE_BOTTOM: [TileType.NO_GOOP,
 			[Vector2(4, 0), Vector2(5, 0)]],
-	CAKE_BOTTOM | CAKE_TOP: [TileTypes.NO_GOOP,
+	CAKE_BOTTOM | CAKE_TOP: [TileType.NO_GOOP,
 			[Vector2(0, 1), Vector2(1, 1)]],
-	CAKE_LEFT: [TileTypes.NO_GOOP,
+	CAKE_LEFT: [TileType.NO_GOOP,
 			[Vector2(2, 1), Vector2(3, 1)]],
-	CAKE_LEFT | CAKE_TOP: [TileTypes.NO_GOOP,
+	CAKE_LEFT | CAKE_TOP: [TileType.NO_GOOP,
 			[Vector2(4, 1), Vector2(5, 1)]],
-	CAKE_LEFT | CAKE_BOTTOM: [TileTypes.NO_GOOP,
+	CAKE_LEFT | CAKE_BOTTOM: [TileType.NO_GOOP,
 			[Vector2(0, 2), Vector2(1, 2)]],
-	CAKE_LEFT | CAKE_BOTTOM | CAKE_TOP: [TileTypes.NO_GOOP,
+	CAKE_LEFT | CAKE_BOTTOM | CAKE_TOP: [TileType.NO_GOOP,
 			[Vector2(2, 2), Vector2(3, 2)]],
-	CAKE_RIGHT: [TileTypes.NO_GOOP,
+	CAKE_RIGHT: [TileType.NO_GOOP,
 			[Vector2(4, 2), Vector2(5, 2)]],
-	CAKE_RIGHT | CAKE_TOP: [TileTypes.NO_GOOP,
+	CAKE_RIGHT | CAKE_TOP: [TileType.NO_GOOP,
 			[Vector2(0, 3), Vector2(1, 3)]],
-	CAKE_RIGHT | CAKE_BOTTOM: [TileTypes.NO_GOOP,
+	CAKE_RIGHT | CAKE_BOTTOM: [TileType.NO_GOOP,
 			[Vector2(2, 3), Vector2(3, 3)]],
-	CAKE_RIGHT | CAKE_BOTTOM | CAKE_TOP: [TileTypes.NO_GOOP,
+	CAKE_RIGHT | CAKE_BOTTOM | CAKE_TOP: [TileType.NO_GOOP,
 			[Vector2(4, 3), Vector2(5, 3)]],
-	CAKE_RIGHT | CAKE_LEFT: [TileTypes.NO_GOOP,
+	CAKE_RIGHT | CAKE_LEFT: [TileType.NO_GOOP,
 			[Vector2(0, 4), Vector2(1, 4)]],
-	CAKE_RIGHT | CAKE_LEFT | CAKE_TOP: [TileTypes.NO_GOOP,
+	CAKE_RIGHT | CAKE_LEFT | CAKE_TOP: [TileType.NO_GOOP,
 			[Vector2(2, 4), Vector2(3, 4)]],
-	CAKE_RIGHT | CAKE_LEFT | CAKE_BOTTOM: [TileTypes.NO_GOOP,
+	CAKE_RIGHT | CAKE_LEFT | CAKE_BOTTOM: [TileType.NO_GOOP,
 			[Vector2(4, 4), Vector2(5, 4)]],
-	CAKE_RIGHT | CAKE_LEFT | CAKE_BOTTOM | CAKE_TOP: [TileTypes.NO_GOOP,
+	CAKE_RIGHT | CAKE_LEFT | CAKE_BOTTOM | CAKE_TOP: [TileType.NO_GOOP,
 			# This first 4-way goopless tile is blank. We repeat it to increase its likelihood of being selected.
 			[Vector2(0, 5), Vector2(0, 5), Vector2(0, 5), Vector2(0, 5), Vector2(0, 5),
 			Vector2(1, 5), Vector2(2, 5), Vector2(3, 5), Vector2(4, 5), Vector2(5, 5)]],
 	
 	# fully goopy tiles, where all adjacent cells are also goopy
 	GOOP_CENTER:
-			[TileTypes.ALL_GOOP, [Vector2(0, 0)]],
+			[TileType.ALL_GOOP, [Vector2(0, 0)]],
 	GOOP_CENTER | CAKE_TOP | GOOP_TOP:
-			[TileTypes.ALL_GOOP, [Vector2(1, 0)]],
+			[TileType.ALL_GOOP, [Vector2(1, 0)]],
 	GOOP_CENTER | CAKE_BOTTOM | GOOP_BOTTOM:
-			[TileTypes.ALL_GOOP, [Vector2(2, 0)]],
+			[TileType.ALL_GOOP, [Vector2(2, 0)]],
 	GOOP_CENTER | CAKE_BOTTOM | CAKE_TOP | GOOP_BOTTOM | GOOP_TOP:
-			[TileTypes.ALL_GOOP, [Vector2(3, 0)]],
+			[TileType.ALL_GOOP, [Vector2(3, 0)]],
 	GOOP_CENTER | CAKE_LEFT | GOOP_LEFT:
-			[TileTypes.ALL_GOOP, [Vector2(4, 0)]],
+			[TileType.ALL_GOOP, [Vector2(4, 0)]],
 	GOOP_CENTER | CAKE_LEFT | CAKE_TOP | GOOP_LEFT | GOOP_TOP:
-			[TileTypes.ALL_GOOP, [Vector2(5, 0)]],
+			[TileType.ALL_GOOP, [Vector2(5, 0)]],
 	GOOP_CENTER | CAKE_LEFT | CAKE_BOTTOM | GOOP_LEFT | GOOP_BOTTOM:
-			[TileTypes.ALL_GOOP, [Vector2(0, 1)]],
+			[TileType.ALL_GOOP, [Vector2(0, 1)]],
 	GOOP_CENTER | CAKE_LEFT | CAKE_BOTTOM | CAKE_TOP | GOOP_LEFT | GOOP_BOTTOM | GOOP_TOP:
-			[TileTypes.ALL_GOOP, [Vector2(1, 1)], Vector2(2, 1), Vector2(3, 1), Vector2(4, 1)],
+			[TileType.ALL_GOOP, [Vector2(1, 1)], Vector2(2, 1), Vector2(3, 1), Vector2(4, 1)],
 	GOOP_CENTER | CAKE_RIGHT | GOOP_RIGHT:
-			[TileTypes.ALL_GOOP, [Vector2(5, 1)]],
+			[TileType.ALL_GOOP, [Vector2(5, 1)]],
 	GOOP_CENTER | CAKE_RIGHT | CAKE_TOP | GOOP_RIGHT | GOOP_TOP:
-			[TileTypes.ALL_GOOP, [Vector2(0, 2)]],
+			[TileType.ALL_GOOP, [Vector2(0, 2)]],
 	GOOP_CENTER | CAKE_BOTTOM | CAKE_RIGHT | GOOP_BOTTOM | GOOP_RIGHT:
-			[TileTypes.ALL_GOOP, [Vector2(1, 2)]],
+			[TileType.ALL_GOOP, [Vector2(1, 2)]],
 	GOOP_CENTER | CAKE_RIGHT | CAKE_BOTTOM | CAKE_TOP | GOOP_RIGHT | GOOP_BOTTOM | GOOP_TOP:
-			[TileTypes.ALL_GOOP, [Vector2(2, 2)]],
+			[TileType.ALL_GOOP, [Vector2(2, 2)]],
 	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | GOOP_RIGHT | GOOP_LEFT:
-			[TileTypes.ALL_GOOP, [Vector2(3, 2)]],
+			[TileType.ALL_GOOP, [Vector2(3, 2)]],
 	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_TOP | GOOP_RIGHT | GOOP_LEFT | GOOP_TOP:
-			[TileTypes.ALL_GOOP, [Vector2(4, 2), Vector2(5, 2), Vector2(0, 3), Vector2(1, 3)]],
+			[TileType.ALL_GOOP, [Vector2(4, 2), Vector2(5, 2), Vector2(0, 3), Vector2(1, 3)]],
 	GOOP_CENTER | CAKE_BOTTOM | CAKE_RIGHT | CAKE_LEFT | GOOP_RIGHT | GOOP_LEFT | GOOP_BOTTOM:
-			[TileTypes.ALL_GOOP, [Vector2(2, 3)]],
+			[TileType.ALL_GOOP, [Vector2(2, 3)]],
 	GOOP_CENTER | CAKE_ALL | GOOP_RIGHT | GOOP_LEFT | GOOP_BOTTOM | GOOP_TOP:
-			[TileTypes.ALL_GOOP, [Vector2(3, 3)]],
+			[TileType.ALL_GOOP, [Vector2(3, 3)]],
 	
 	# partially goopy tiles, where some adjacent cells are goopless
 	GOOP_CENTER | CAKE_ALL:
-			[TileTypes.SOME_GOOP, [Vector2(0, 0)]],
-	GOOP_CENTER | CAKE_ALL | GOOP_TOP: [TileTypes.SOME_GOOP,
+			[TileType.SOME_GOOP, [Vector2(0, 0)]],
+	GOOP_CENTER | CAKE_ALL | GOOP_TOP: [TileType.SOME_GOOP,
 			[Vector2(1, 0)]],
-	GOOP_CENTER | CAKE_ALL | GOOP_BOTTOM: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_ALL | GOOP_BOTTOM: [TileType.SOME_GOOP,
 			[Vector2(2, 0)]],
-	GOOP_CENTER | CAKE_ALL | GOOP_BOTTOM | GOOP_TOP: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_ALL | GOOP_BOTTOM | GOOP_TOP: [TileType.SOME_GOOP,
 			[Vector2(3, 0), Vector2(4, 0)]],
-	GOOP_CENTER | CAKE_ALL | GOOP_LEFT: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_ALL | GOOP_LEFT: [TileType.SOME_GOOP,
 			[Vector2(5, 0)]],
-	GOOP_CENTER | CAKE_ALL | GOOP_LEFT | GOOP_TOP: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_ALL | GOOP_LEFT | GOOP_TOP: [TileType.SOME_GOOP,
 			[Vector2(6, 0), Vector2(7, 0)]],
-	GOOP_CENTER | CAKE_ALL | GOOP_LEFT | GOOP_BOTTOM: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_ALL | GOOP_LEFT | GOOP_BOTTOM: [TileType.SOME_GOOP,
 			[Vector2(0, 1), Vector2(1, 1)]],
-	GOOP_CENTER | CAKE_ALL | GOOP_LEFT | GOOP_BOTTOM | GOOP_TOP: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_ALL | GOOP_LEFT | GOOP_BOTTOM | GOOP_TOP: [TileType.SOME_GOOP,
 			[Vector2(2, 1), Vector2(3, 1)]],
-	GOOP_CENTER | CAKE_ALL | GOOP_RIGHT: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_ALL | GOOP_RIGHT: [TileType.SOME_GOOP,
 			[Vector2(4, 1)]],
-	GOOP_CENTER | CAKE_ALL | GOOP_RIGHT | GOOP_TOP: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_ALL | GOOP_RIGHT | GOOP_TOP: [TileType.SOME_GOOP,
 			[Vector2(5, 1), Vector2(6, 1)]],
-	GOOP_CENTER | CAKE_ALL | GOOP_RIGHT | GOOP_BOTTOM: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_ALL | GOOP_RIGHT | GOOP_BOTTOM: [TileType.SOME_GOOP,
 			[Vector2(7, 1), Vector2(0, 2)]],
-	GOOP_CENTER | CAKE_ALL | GOOP_RIGHT | GOOP_BOTTOM | GOOP_TOP: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_ALL | GOOP_RIGHT | GOOP_BOTTOM | GOOP_TOP: [TileType.SOME_GOOP,
 			[Vector2(1, 2), Vector2(2, 2)]],
-	GOOP_CENTER | CAKE_ALL | GOOP_RIGHT | GOOP_LEFT: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_ALL | GOOP_RIGHT | GOOP_LEFT: [TileType.SOME_GOOP,
 			[Vector2(3, 2), Vector2(4, 2)]],
-	GOOP_CENTER | CAKE_ALL | GOOP_RIGHT | GOOP_LEFT | GOOP_TOP: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_ALL | GOOP_RIGHT | GOOP_LEFT | GOOP_TOP: [TileType.SOME_GOOP,
 			[Vector2(5, 2), Vector2(6, 2)]],
-	GOOP_CENTER | CAKE_ALL | GOOP_RIGHT | GOOP_LEFT | GOOP_BOTTOM: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_ALL | GOOP_RIGHT | GOOP_LEFT | GOOP_BOTTOM: [TileType.SOME_GOOP,
 			[Vector2(7, 2), Vector2(0, 3)]],
 	
 	# partially goopy tiles on an edge
-	GOOP_CENTER | CAKE_LEFT | CAKE_BOTTOM | CAKE_TOP | GOOP_TOP: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_LEFT | CAKE_BOTTOM | CAKE_TOP | GOOP_TOP: [TileType.SOME_GOOP,
 			[Vector2(1, 3)]],
-	GOOP_CENTER | CAKE_LEFT | CAKE_BOTTOM | CAKE_TOP | GOOP_BOTTOM: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_LEFT | CAKE_BOTTOM | CAKE_TOP | GOOP_BOTTOM: [TileType.SOME_GOOP,
 			[Vector2(2, 3)]],
-	GOOP_CENTER | CAKE_LEFT | CAKE_BOTTOM | CAKE_TOP | GOOP_LEFT | GOOP_TOP: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_LEFT | CAKE_BOTTOM | CAKE_TOP | GOOP_LEFT | GOOP_TOP: [TileType.SOME_GOOP,
 			[Vector2(3, 3)]],
-	GOOP_CENTER | CAKE_LEFT | CAKE_BOTTOM | CAKE_TOP | GOOP_LEFT | GOOP_BOTTOM: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_LEFT | CAKE_BOTTOM | CAKE_TOP | GOOP_LEFT | GOOP_BOTTOM: [TileType.SOME_GOOP,
 			[Vector2(4, 3)]],
-	GOOP_CENTER | CAKE_RIGHT | CAKE_BOTTOM | CAKE_TOP | GOOP_TOP: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_RIGHT | CAKE_BOTTOM | CAKE_TOP | GOOP_TOP: [TileType.SOME_GOOP,
 			[Vector2(5, 3)]],
-	GOOP_CENTER | CAKE_RIGHT | CAKE_BOTTOM | CAKE_TOP | GOOP_BOTTOM: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_RIGHT | CAKE_BOTTOM | CAKE_TOP | GOOP_BOTTOM: [TileType.SOME_GOOP,
 			[Vector2(6, 3)]],
-	GOOP_CENTER | CAKE_RIGHT | CAKE_BOTTOM | CAKE_TOP | GOOP_RIGHT | GOOP_TOP: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_RIGHT | CAKE_BOTTOM | CAKE_TOP | GOOP_RIGHT | GOOP_TOP: [TileType.SOME_GOOP,
 			[Vector2(7, 3)]],
-	GOOP_CENTER | CAKE_RIGHT | CAKE_BOTTOM | CAKE_TOP | GOOP_RIGHT | GOOP_BOTTOM: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_RIGHT | CAKE_BOTTOM | CAKE_TOP | GOOP_RIGHT | GOOP_BOTTOM: [TileType.SOME_GOOP,
 			[Vector2(0, 4)]],
-	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_TOP | GOOP_LEFT: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_TOP | GOOP_LEFT: [TileType.SOME_GOOP,
 			[Vector2(1, 4)]],
-	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_TOP | GOOP_LEFT | GOOP_TOP: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_TOP | GOOP_LEFT | GOOP_TOP: [TileType.SOME_GOOP,
 			[Vector2(2, 4)]],
-	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_TOP | GOOP_RIGHT: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_TOP | GOOP_RIGHT: [TileType.SOME_GOOP,
 			[Vector2(3, 4)]],
-	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_TOP | GOOP_RIGHT | GOOP_TOP: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_TOP | GOOP_RIGHT | GOOP_TOP: [TileType.SOME_GOOP,
 			[Vector2(4, 4)]],
-	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_BOTTOM | GOOP_LEFT: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_BOTTOM | GOOP_LEFT: [TileType.SOME_GOOP,
 			[Vector2(5, 4)]],
-	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_BOTTOM | GOOP_LEFT | GOOP_BOTTOM: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_BOTTOM | GOOP_LEFT | GOOP_BOTTOM: [TileType.SOME_GOOP,
 			[Vector2(6, 4)]],
-	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_BOTTOM | GOOP_RIGHT: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_BOTTOM | GOOP_RIGHT: [TileType.SOME_GOOP,
 			[Vector2(7, 4)]],
-	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_BOTTOM | GOOP_RIGHT | GOOP_BOTTOM: [TileTypes.SOME_GOOP,
+	GOOP_CENTER | CAKE_RIGHT | CAKE_LEFT | CAKE_BOTTOM | GOOP_RIGHT | GOOP_BOTTOM: [TileType.SOME_GOOP,
 			[Vector2(0, 5)]],
 }
 
@@ -236,13 +236,13 @@ export (int) var corner_tile_index: int
 ## https://github.com/godotengine/godot/issues/11855
 export (bool) var _autotile: bool setget autotile
 
-## key: (TileTypes)
+## key: (TileType)
 ## value: (int) tile index from the parent tilemap for the specified enum, as defined by no_goop_tile_index,
 ## 	some_goop_tile_index and all_goop_tile_index
 var _tile_indexes_by_type := {}
 
 ## key: (int) tile index from the parent tilemap
-## value: (TileTypes) tile index, as defined by no_goop_tile_index, some_goop_tile_index and all_goop_tile_index
+## value: (TileType) tile index, as defined by no_goop_tile_index, some_goop_tile_index and all_goop_tile_index
 var _tile_types_by_index := {}
 
 ## indexes of cake tiles in the parent tilemap, both goopy and goopless
@@ -315,14 +315,14 @@ func _initialize_onready_variables() -> void:
 ## function initializes the internal helper fields when the tiler is initialized or when the export fields change.
 func _refresh_tile_indexes() -> void:
 	_tile_indexes_by_type = {
-		TileTypes.NO_GOOP: no_goop_tile_index,
-		TileTypes.SOME_GOOP: some_goop_tile_index,
-		TileTypes.ALL_GOOP: all_goop_tile_index,
+		TileType.NO_GOOP: no_goop_tile_index,
+		TileType.SOME_GOOP: some_goop_tile_index,
+		TileType.ALL_GOOP: all_goop_tile_index,
 	}
 	_tile_types_by_index = {
-		no_goop_tile_index: TileTypes.NO_GOOP,
-		some_goop_tile_index: TileTypes.SOME_GOOP,
-		all_goop_tile_index: TileTypes.ALL_GOOP,
+		no_goop_tile_index: TileType.NO_GOOP,
+		some_goop_tile_index: TileType.SOME_GOOP,
+		all_goop_tile_index: TileType.ALL_GOOP,
 	}
 	_cake_indexes = [no_goop_tile_index, some_goop_tile_index, all_goop_tile_index]
 	_goop_indexes = [some_goop_tile_index, all_goop_tile_index]
@@ -332,7 +332,7 @@ func _refresh_tile_indexes() -> void:
 func _autotile_ground_tiles() -> void:
 	for cell in _tile_map.get_used_cells():
 		match _tile_types_by_index.get(_tile_map.get_cellv(cell)):
-			TileTypes.NO_GOOP, TileTypes.SOME_GOOP, TileTypes.ALL_GOOP: _autotile_ground_tile(cell)
+			TileType.NO_GOOP, TileType.SOME_GOOP, TileType.ALL_GOOP: _autotile_ground_tile(cell)
 
 
 ## Autotiles the cake tile at the specified coordinates.
@@ -353,7 +353,7 @@ func _autotile_corner_tiles() -> void:
 	_corner_map.clear()
 	for cell in _tile_map.get_used_cells():
 		match _tile_types_by_index.get(_tile_map.get_cellv(cell)):
-			TileTypes.NO_GOOP, TileTypes.SOME_GOOP, TileTypes.ALL_GOOP: _autotile_corner_tile(cell)
+			TileType.NO_GOOP, TileType.SOME_GOOP, TileType.ALL_GOOP: _autotile_corner_tile(cell)
 
 
 ## Autotiles the corner cover at the specified coordinates.


### PR DESCRIPTION
Fixed dictionaries to be consistently named '_foos_by_bar', with the first noun plural and the second noun singular. There are a few exceptions where the dictionary's key is actually a hybrid key with several different parts, in which case it actually should be plural.

Fixed enums to be consistently singular with names like 'State' and 'TileType' instead of 'States' and 'TileTypes'