### PR TITLE
Refactor: dictionary names include '_by_'

### DIFF
--- a/project/src/main/career/career-rewinder.gd
+++ b/project/src/main/career/career-rewinder.gd
@@ -38,7 +38,7 @@ func skip_to_region(region_index: int) -> bool:
 	PlayerData.career.best_distance_travelled = region.start
 
 	# remove chapter cutscene history
-	for key in PlayerData.chat_history.chat_history.duplicate():
+	for key in PlayerData.chat_history.history_index_by_chat_key.duplicate():
 		if region.cutscene_path and key.begins_with(region.cutscene_path + "/"):
 			PlayerData.chat_history.delete_history_item(key)
 	

--- a/project/src/main/chat/chat-history.gd
+++ b/project/src/main/chat/chat-history.gd
@@ -13,7 +13,7 @@ const CHAT_AGE_NEVER := 99999999
 ##
 ## key: (String) chat key
 ## value: (int) ordering of when the chat happened (smaller is older)
-var chat_history: Dictionary
+var history_index_by_chat_key: Dictionary
 
 ## Flags which can be stored/retreived from chatscript. Flags represent chat choices the player made, such as the
 ## answer to a yes or no question. They are persisted alongside the player's chat history.
@@ -32,7 +32,7 @@ var phrases: Dictionary
 var _chat_count := 0
 
 func reset() -> void:
-	chat_history.clear()
+	history_index_by_chat_key.clear()
 	flags.clear()
 	phrases.clear()
 	_chat_count = 0
@@ -40,7 +40,7 @@ func reset() -> void:
 
 func add_history_item(chat_key: String) -> void:
 	_chat_count += 1
-	chat_history[chat_key] = _chat_count
+	history_index_by_chat_key[chat_key] = _chat_count
 
 
 ## Deletes an item from the chat history.
@@ -48,7 +48,7 @@ func add_history_item(chat_key: String) -> void:
 ## Returns:
 ## 	'true' if the key was present in the chat history, 'false' otherwise.
 func delete_history_item(chat_key: String) -> bool:
-	return chat_history.erase(chat_key)
+	return history_index_by_chat_key.erase(chat_key)
 
 
 ## Returns how long ago the player had the specified chat.
@@ -56,13 +56,13 @@ func delete_history_item(chat_key: String) -> bool:
 ## Used to avoid repeating conversations too frequently.
 func chat_age(chat_key: String) -> int:
 	var result := CHAT_AGE_NEVER
-	if chat_history.has(chat_key):
-		result = _chat_count - chat_history.get(chat_key)
+	if history_index_by_chat_key.has(chat_key):
+		result = _chat_count - history_index_by_chat_key.get(chat_key)
 	return result
 
 
 func is_chat_finished(chat_key: String) -> bool:
-	return chat_history.has(chat_key)
+	return history_index_by_chat_key.has(chat_key)
 
 
 func set_flag(key: String, value: String = "true") -> void:
@@ -117,19 +117,19 @@ func is_flag(flag: String, value: String) -> bool:
 func to_json_dict() -> Dictionary:
 	return {
 		"flags": flags,
-		"history_items": chat_history,
+		"history_items": history_index_by_chat_key,
 		"phrases": phrases,
 	}
 
 
 func from_json_dict(json: Dictionary) -> void:
 	flags = json.get("flags", {})
-	chat_history = json.get("history_items", {})
+	history_index_by_chat_key = json.get("history_items", {})
 	phrases = json.get("phrases", {})
-	_convert_float_values_to_ints(chat_history)
+	_convert_float_values_to_ints(history_index_by_chat_key)
 	
 	# calculate _chat_count instead of storing it
-	for value in chat_history.values():
+	for value in history_index_by_chat_key.values():
 		_chat_count = int(max(value, _chat_count))
 
 

--- a/project/src/main/editor/creature/creature-editor-nametags.gd
+++ b/project/src/main/editor/creature/creature-editor-nametags.gd
@@ -9,8 +9,9 @@ const NAMETAG_LOWLIGHT := Color.darkgray
 
 export (PackedScene) var HookableNametagScene: PackedScene
 
-## mapping from Creatures to NametagPanels
-var _creature_to_nametag: Dictionary
+## key: (Creature) Creature shown in the creature editor
+## value: (Panel) Creature's nametag
+var _nametags_by_creature: Dictionary
 
 func _ready() -> void:
 	# create nametags for all creatures in the scene
@@ -21,7 +22,7 @@ func _ready() -> void:
 		add_child(hookable_nametag)
 		creature.get_node("NametagHook").remote_path = creature.get_node("NametagHook").get_path_to(hookable_nametag)
 		creature.connect("creature_name_changed", self, "_on_Creature_creature_name_changed", [creature, nametag])
-		_creature_to_nametag[creature] = nametag
+		_nametags_by_creature[creature] = nametag
 
 
 ## When a creature is renamed, the corresponding nametag changes its text and position.
@@ -39,11 +40,11 @@ func _on_Creature_creature_name_changed(creature: Creature, nametag: Panel) -> v
 func _on_CreatureSelector_hovered_creature_changed(value: Creature) -> void:
 	if value:
 		# creature is highlighted; their nametag is blue, others are gray
-		for nametag in _creature_to_nametag.values():
+		for nametag in _nametags_by_creature.values():
 			nametag.set_bg_color(NAMETAG_LOWLIGHT)
-		_creature_to_nametag[value].set_bg_color(NAMETAG_HIGHLIGHT)
+		_nametags_by_creature[value].set_bg_color(NAMETAG_HIGHLIGHT)
 	else:
 		# no creature is highlighted; main nametag is blue, others are gray
-		for creature in _creature_to_nametag:
-			var nametag: Panel = _creature_to_nametag[creature]
+		for creature in _nametags_by_creature:
+			var nametag: Panel = _nametags_by_creature[creature]
 			nametag.set_bg_color(NAMETAG_HIGHLIGHT if creature.has_meta("main_creature") else NAMETAG_LOWLIGHT)

--- a/project/src/main/utils/resource-cache.gd
+++ b/project/src/main/utils/resource-cache.gd
@@ -73,7 +73,7 @@ var _remaining_scene_paths := []
 ## singleton nodes, cached to preserve their appearance during scene transitions
 ## key: (String) singleton names
 ## value: (Node) singleton nodes
-var _singletons: Dictionary
+var _singletons_by_name: Dictionary
 
 ## System time when we initialized the resource load.
 var _start_load_begin_msec: float
@@ -128,7 +128,7 @@ func _process(_delta: float) -> void:
 
 
 func _exit_tree() -> void:
-	for singleton in _singletons.values():
+	for singleton in _singletons_by_name.values():
 		# singletons are not freed when their parent scene is removed from the tree, we have to free them manually
 		singleton.free()
 	if _load_threads:
@@ -143,23 +143,23 @@ func substitute_singletons() -> void:
 		var non_singleton: Node = non_singleton_obj
 		
 		var parent := non_singleton.get_parent()
-		if _singletons.has(non_singleton.name):
+		if _singletons_by_name.has(non_singleton.name):
 			# we have a singleton value to substitute; remove the non-singleton value
 			var wallpaper_index := parent.get_children().find(non_singleton)
 			non_singleton.queue_free()
 			parent.remove_child(non_singleton)
 			
 			# add the singleton value
-			parent.add_child(_singletons[non_singleton.name])
-			parent.move_child(_singletons[non_singleton.name], wallpaper_index)
+			parent.add_child(_singletons_by_name[non_singleton.name])
+			parent.move_child(_singletons_by_name[non_singleton.name], wallpaper_index)
 		else:
 			# we have no singleton value stored; store a new singleton value
-			_singletons[non_singleton.name] = non_singleton
+			_singletons_by_name[non_singleton.name] = non_singleton
 
 
 ## Removes singletons from their parent nodes to prevent them from being freed.
 func remove_singletons() -> void:
-	for singleton_obj in _singletons.values():
+	for singleton_obj in _singletons_by_name.values():
 		if singleton_obj.get_parent():
 			singleton_obj.get_parent().remove_child(singleton_obj)
 

--- a/project/src/test/career/test-career-rewinder.gd
+++ b/project/src/test/career/test-career-rewinder.gd
@@ -41,6 +41,6 @@ func test_skip_to_region_erases_chat_history() -> void:
 	
 	career_rewinder.skip_to_region(1)
 	
-	var chat_history_keys := PlayerData.chat_history.chat_history.keys()
+	var chat_history_keys := PlayerData.chat_history.history_index_by_chat_key.keys()
 	chat_history_keys.sort()
 	assert_eq(chat_history_keys, ["chat/career/diege_2/a", "chat/career/remis/a"])

--- a/project/src/test/data/test-player-save-upgrader.gd
+++ b/project/src/test/data/test-player-save-upgrader.gd
@@ -175,10 +175,10 @@ func test_3776_chat_history_purged() -> void:
 	load_player_data("turbofat-3776.json")
 	
 	# chat history
-	assert_eq(PlayerData.chat_history.chat_history.has("chat/career/marsh/010_b"), true)
-	assert_eq(PlayerData.chat_history.chat_history.has("chat/level_select"), false)
-	assert_eq(PlayerData.chat_history.chat_history.has("creature/bort/filler_000"), false)
-	assert_eq(PlayerData.chat_history.chat_history.has("level/marsh/pulling_for_everyone_100"), false)
+	assert_eq(PlayerData.chat_history.history_index_by_chat_key.has("chat/career/marsh/010_b"), true)
+	assert_eq(PlayerData.chat_history.history_index_by_chat_key.has("chat/level_select"), false)
+	assert_eq(PlayerData.chat_history.history_index_by_chat_key.has("creature/bort/filler_000"), false)
+	assert_eq(PlayerData.chat_history.history_index_by_chat_key.has("level/marsh/pulling_for_everyone_100"), false)
 
 
 func test_37b3_chat_history_migrated() -> void:


### PR DESCRIPTION
A few dictionaries had comments saying things like 'mapping from creatures to nametag panels' which is implied by our naming convention. A few dictionaries had comments like 'creature_to_nametag' which oppose our dictionary conventions. I've changed some of these places to be consistent.