### PR TITLE
Refactoring: Remove 'randf() >' calls

### DIFF
--- a/project/src/demo/chat/ui/chat-frame-demo.gd
+++ b/project/src/demo/chat/ui/chat-frame-demo.gd
@@ -103,9 +103,9 @@ func _input(event: InputEvent) -> void:
 			_scale_index = randi() % SCALES.size()
 			_chat_theme.accent_scale = SCALES[_scale_index]
 			
-			_chat_theme.accent_swapped = randf() > 0.5
+			_chat_theme.accent_swapped = randf() <= 0.5
 			_chat_theme.accent_texture_index = randi() % ChatLinePanel.CHAT_TEXTURE_COUNT
-			_chat_theme.dark = randf() > 0.5
+			_chat_theme.dark = randf() <= 0.5
 			_play_chat_event()
 		KEY_S:
 			_chat_theme.accent_swapped = not _chat_theme.accent_swapped

--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -173,7 +173,7 @@ func _palette(color_mode: int = THEME_COLORS) -> Dictionary:
 		
 		# blend the belly color with the body color
 		belly = lerp(belly, body, rand_range(0.0, 1.0))
-		if randf() > 0.5:
+		if randf() <= 0.5:
 			# light belly
 			belly.s -= _rng.randfn(0.3, 0.15)
 			belly.v += _rng.randfn(0.3, 0.15)
@@ -309,7 +309,7 @@ func _alleles_to_mutate() -> Array:
 		var allele: String = allele_obj
 		if allele.ends_with("_rgb"):
 			some_rgb_locked = true
-	if not some_rgb_locked and randf() > 0.5:
+	if not some_rgb_locked and randf() <= 0.5:
 		var new_flexible_alleles := ["all_rgb"]
 		for allele in flexible_alleles:
 			if not allele.ends_with("_rgb"):
@@ -324,7 +324,7 @@ func _alleles_to_mutate() -> Array:
 	# determine how many alleles to mutate based on the 'mutagen' value
 	var extra_mutations_float: float = lerp(0, flexible_alleles.size(), _reroll_ui.mutagen)
 	var extra_mutations := int(extra_mutations_float)
-	if randf() < (extra_mutations_float - extra_mutations):
+	if randf() <= (extra_mutations_float - extra_mutations):
 		# numbers like 2.35 are rounded down 35% of the time, and rounded up 65% of the time
 		extra_mutations += 1
 	

--- a/project/src/main/puzzle/bursts.gd
+++ b/project/src/main/puzzle/bursts.gd
@@ -100,7 +100,7 @@ func _combo_burst_cell(y: int) -> Vector2:
 			target_cell.x = floor(target_cell.x) if _previous_cell_x == ceil(target_cell.x) else ceil(target_cell.x)
 		else:
 			# decide randomly between the two blocks
-			target_cell.x = floor(target_cell.x) if randf() > 0.5 else ceil(target_cell.x)
+			target_cell.x = floor(target_cell.x) if randf() <= 0.5 else ceil(target_cell.x)
 	elif target_cell.x == _previous_cell_x:
 		# if a combo burst vertically aligns with the previous counter, we move it horizontally
 		if target_cell.x == 0:
@@ -118,8 +118,8 @@ func _combo_burst_cell(y: int) -> Vector2:
 ## Tech move bursts appear in the middle of the current piece.
 func _tech_move_cell(piece: ActivePiece) -> Vector2:
 	var center := piece.center()
-	center.x = floor(center.x) if randf() < 0.5 else ceil(center.x)
-	center.y = floor(center.y) if randf() < 0.5 else ceil(center.y)
+	center.x = floor(center.x) if randf() <= 0.5 else ceil(center.x)
+	center.y = floor(center.y) if randf() <= 0.5 else ceil(center.y)
 	return center
 
 

--- a/project/src/main/puzzle/critter/carrot.gd
+++ b/project/src/main/puzzle/critter/carrot.gd
@@ -191,7 +191,7 @@ func _refresh_carrot_size() -> void:
 ##
 ## This face animation is played when the carrot appears and loops forever. It decides the carrot's facial expression.
 func _randomize_face() -> void:
-	if randf() > 0.5:
+	if randf() <= 0.5:
 		_face.flip_h = true
 	
 	# Choose a random face animation, weighting towards the earlier animations. The later animations are wacky and

--- a/project/src/main/puzzle/critter/shark-clouds.gd
+++ b/project/src/main/puzzle/critter/shark-clouds.gd
@@ -25,7 +25,7 @@ func shuffle() -> void:
 	
 	var old_frame: int = get_child(0).frame % CLOUD_VARIANT_COUNT
 	var new_frame: int = (old_frame + Utils.randi_range(1, CLOUD_VARIANT_COUNT - 1)) % CLOUD_VARIANT_COUNT
-	var new_flip_h: bool = randf() > 0.5
+	var new_flip_h: bool = randf() <= 0.5
 	
 	for i in range(get_child_count()):
 		var cloud_part := get_child(i)

--- a/project/src/main/puzzle/critter/shark-tooth-cloud.gd
+++ b/project/src/main/puzzle/critter/shark-tooth-cloud.gd
@@ -152,7 +152,7 @@ func _start_eat_tween() -> void:
 ##
 ## Cycles to a randomly selected animation frame and randomly flips it horizontally.
 func _shuffle_tooth() -> void:
-	_tooth.flip_h = randf() > 0.5
+	_tooth.flip_h = randf() <= 0.5
 	_tooth.frame = (_tooth.frame + Utils.randi_range(1, TOOTH_VARIANT_COUNT - 1)) % TOOTH_VARIANT_COUNT
 
 

--- a/project/src/main/puzzle/goop-glob.gd
+++ b/project/src/main/puzzle/goop-glob.gd
@@ -94,9 +94,9 @@ func initialize(new_box_type: int, new_position: Vector2) -> void:
 	
 	scale = Vector2(0.25, 0.25)
 	# randomly flip the sprite vertically/horizontally for variance
-	if randf() > 0.5:
+	if randf() <= 0.5:
 		scale *= Vector2(-1.0, 1.0)
-	if randf() > 0.5:
+	if randf() <= 0.5:
 		scale *= Vector2(1.0, -1.0)
 
 

--- a/project/src/main/puzzle/leaf-poofs.gd
+++ b/project/src/main/puzzle/leaf-poofs.gd
@@ -31,7 +31,7 @@ func _spawn_poofs(y: int) -> void:
 	# we split the line 3/6 or 4/5 between the two leaf varieties. 'cutoff' decides where the line is split.
 	# 'cutoff_direction' decides which leaf variety is on which side
 	var cutoff := Utils.randi_range(3, 5)
-	var cutoff_direction := randf() < 0.5
+	var cutoff_direction := randf() <= 0.5
 	
 	## Spawn leaf poofs
 	for x in poof_columns:

--- a/project/src/main/puzzle/night/night-sky.gd
+++ b/project/src/main/puzzle/night/night-sky.gd
@@ -23,8 +23,8 @@ func _ready() -> void:
 func _randomize_sky_sprites() -> void:
 	for sprite in _sky_sprites:
 		sprite.frame = (sprite.frame + Utils.randi_range(1, 2)) % 3
-		sprite.flip_h = randf() > 0.5
-		sprite.flip_v = randf() > 0.5
+		sprite.flip_h = randf() <= 0.5
+		sprite.flip_v = randf() <= 0.5
 		sprite.offset = Vector2(rand_range(-2, 2), rand_range(-2, 2))
 
 

--- a/project/src/main/ui/menu/loading-orb.gd
+++ b/project/src/main/ui/menu/loading-orb.gd
@@ -24,14 +24,14 @@ func _ready() -> void:
 	# initialize total_time so the wobble/position isn't always the same
 	_total_time = rand_range(0, 100)
 	
-	if randf() < 0.5:
+	if randf() <= 0.5:
 		# 50% of the time, the pieces are oriented to spell out 'T' 'u' 'r' 'b' 'o'...
 		_orientation = 0.0
 	else:
 		# 50% of the time, their orientation is randomized
 		_orientation = Utils.rand_value([0.0 * PI, 0.5 * PI, 1.0 * PI, 1.5 * PI])
 	
-	if randf() < 0.5:
+	if randf() <= 0.5:
 		# 50% of the time, the pieces are ordered with the 'T' piece first.
 		frame = 0
 	else:

--- a/project/src/main/ui/wallpaper/sticker-row.gd
+++ b/project/src/main/ui/wallpaper/sticker-row.gd
@@ -102,7 +102,7 @@ func _add_sticker() -> void:
 	new_sticker.position.y = rect_size.y * 0.5
 	new_sticker.position.x += rand_range(-0.2, 0.2) * rect_size.y
 	
-	new_sticker.flip_h = randf() > 0.5
+	new_sticker.flip_h = randf() <= 0.5
 	new_sticker.modulate = color
 	add_child(new_sticker)
 	_texture_index = (_texture_index + 1) % _textures.size()

--- a/project/src/main/utils/markov-model.gd
+++ b/project/src/main/utils/markov-model.gd
@@ -79,7 +79,7 @@ func generate_word() -> String:
 func _get_cluster(cluster_in: String, may_end: bool) -> String:
 	# calculate the total number of connections
 	var total := 0
-	var int_order := floor(order) if randf() > fmod(order, 1.0) else ceil(order)
+	var int_order := ceil(order) if randf() <= fmod(order, 1.0) else floor(order)
 	var prefix := cluster_in.substr(max(cluster_in.length() - int_order, 0))
 	for cluster in connections.get(prefix):
 		if cluster.ends_with("\n") and not may_end:

--- a/project/src/main/world/career-world.gd
+++ b/project/src/main/world/career-world.gd
@@ -258,9 +258,9 @@ func _add_level_creature() -> void:
 	_level_creatures.append(creature)
 	
 	var mood: int
-	if randf() < 0.8:
+	if randf() <= 0.8:
 		mood = Utils.rand_value(MOODS_COMMON)
-	elif randf() < 0.8:
+	elif randf() <= 0.8:
 		mood = Utils.rand_value(MOODS_UNCOMMON)
 	else:
 		mood = Utils.rand_value(MOODS_RARE)

--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -88,7 +88,7 @@ func random_customer_def(include_predefined_customers: bool = false,
 	var result: CreatureDef
 	if include_predefined_customers \
 			and PlayerData.customer_queue.has_standard_customer() \
-			and randf() < 0.2:
+			and randf() <= 0.2:
 		
 		# We check the next 8 creatures for one which matches the specified type. If we check too few creatures, we
 		# won't find one. If we check too many, we'll aggressively advance the creature queue. 8 feels about right.
@@ -125,10 +125,10 @@ func chat_theme(dna: Dictionary) -> ChatTheme:
 			4.00, 4.60, 5.33, 6.00, 7.00,
 			8.00
 	])
-	new_theme.accent_swapped = randf() > 0.5
+	new_theme.accent_swapped = randf() <= 0.5
 	new_theme.accent_texture_index = randi() % ChatLinePanel.CHAT_TEXTURE_COUNT
 	new_theme.color = dna.body_rgb
-	new_theme.dark = randf() > 0.5
+	new_theme.dark = randf() <= 0.5
 	return new_theme
 
 

--- a/project/src/main/world/environment/frame-overworld-obstacle.gd
+++ b/project/src/main/world/environment/frame-overworld-obstacle.gd
@@ -46,7 +46,7 @@ func set_shuffle(value: bool) -> void:
 		return
 	
 	set_frame(randi() % (_sprite.hframes * _sprite.vframes))
-	set_flip_h(randf() > 0.5)
+	set_flip_h(randf() <= 0.5)
 	scale = Vector2.ONE
 	
 	property_list_changed_notify()

--- a/project/src/main/world/environment/grass-overworld-tiler.gd
+++ b/project/src/main/world/environment/grass-overworld-tiler.gd
@@ -81,7 +81,7 @@ func _add_random_grass() -> void:
 			continue
 		if _tile_map.get_cellv(cell) != TileMap.INVALID_CELL:
 			continue
-		if randf() >= grass_density:
+		if not randf() <= grass_density:
 			# only add grass to a random selection of tiles
 			continue
 		var autotile_coord: Vector2

--- a/project/src/main/world/environment/lemon/lemon-tree.gd
+++ b/project/src/main/world/environment/lemon/lemon-tree.gd
@@ -36,7 +36,7 @@ func _ready() -> void:
 		_play_randomly_from_middle(_mouth_player, _mouth_animation_name())
 		
 		_play_randomly_from_middle(_lemon_player, Utils.rand_value(LEMON_ANIMATION_NAMES))
-		_lemons.scale.x = 1 if randf() > 0.5 else -1
+		_lemons.scale.x = 1 if randf() <= 0.5 else -1
 
 
 ## Preemptively initializes onready variables to avoid null references
@@ -92,7 +92,7 @@ func _refresh_tree_in_editor() -> void:
 	# update the lemon appearance (only affects the editor)
 	_lemon_player.play(Utils.rand_value(LEMON_ANIMATION_NAMES))
 	_lemon_player.advance(0)
-	_lemons.flip_h = randf() > 0.5
+	_lemons.flip_h = randf() <= 0.5
 	_lemon_player.stop()
 
 
@@ -136,4 +136,4 @@ func _play_randomly_from_middle(player: AnimationPlayer, anim_name: String) -> v
 func _on_LemonChangeTimer_timeout() -> void:
 	var possible_animations := Utils.subtract(LEMON_ANIMATION_NAMES, [_lemon_player.current_animation])
 	_play_randomly_from_middle(_lemon_player, Utils.rand_value(possible_animations))
-	_lemons.flip_h = randf() > 0.5
+	_lemons.flip_h = randf() <= 0.5

--- a/project/src/main/world/environment/mile-marker.gd
+++ b/project/src/main/world/environment/mile-marker.gd
@@ -41,7 +41,7 @@ func set_mile_number(new_mile_number: int) -> void:
 func _randomize_sprite() -> void:
 	# randomize the sprite's appearance
 	_sprite.frame = randi() % 4
-	_sprite.flip_h = randf() > 0.5
+	_sprite.flip_h = randf() <= 0.5
 	
 	# align the text based on the sprite's appearance
 	_text.position = TEXT_POSITION_BY_FRAME[_sprite.frame]

--- a/project/src/main/world/environment/pebble-overworld-tiler.gd
+++ b/project/src/main/world/environment/pebble-overworld-tiler.gd
@@ -69,7 +69,7 @@ func _add_random_pebbles() -> void:
 			continue
 		if _tile_map.get_cellv(cell) != TileMap.INVALID_CELL:
 			continue
-		if randf() >= pebble_density:
+		if not randf() <= pebble_density:
 			# only add pebbles to a random selection of tiles
 			continue
 		var autotile_coord := Vector2(randi() % 4, randi() % 3)

--- a/project/src/main/world/environment/poki/poki-crowd.gd
+++ b/project/src/main/world/environment/poki/poki-crowd.gd
@@ -74,7 +74,7 @@ func set_shuffle(value: bool) -> void:
 		return
 	
 	set_frame(randi() % (_sprite.hframes * _sprite.vframes))
-	set_flip_h(randf() < 0.5)
+	set_flip_h(randf() <= 0.5)
 	set_crowd_color_index(Utils.randi_range(0, CROWD_COLORS.size() - 1))
 	scale = Vector2.ONE
 	

--- a/project/src/main/world/environment/poki/puddle-overworld-tiler.gd
+++ b/project/src/main/world/environment/poki/puddle-overworld-tiler.gd
@@ -66,7 +66,7 @@ func _add_random_puddles() -> void:
 			continue
 		if _tile_map.get_cellv(cell) != TileMap.INVALID_CELL:
 			continue
-		if randf() >= puddle_density:
+		if not randf() <= puddle_density:
 			# only add puddles to a random selection of tiles
 			continue
 		var autotile_coord := Vector2(randi() % 4, randi() % 3)

--- a/project/src/main/world/environment/poki/tent-spawner.gd
+++ b/project/src/main/world/environment/poki/tent-spawner.gd
@@ -13,6 +13,6 @@ func set_shuffle(value: bool) -> void:
 		return
 	
 	target_properties["frame"] = randi() % 6
-	target_properties["flip_h"] = randf() > 0.5
+	target_properties["flip_h"] = randf() <= 0.5
 	
 	property_list_changed_notify()

--- a/project/src/main/world/environment/restaurant/carpet-tiler.gd
+++ b/project/src/main/world/environment/restaurant/carpet-tiler.gd
@@ -53,7 +53,7 @@ func _initialize_onready_variables() -> void:
 ## Parameters:
 ## 	'cell': The TileMap coordinates of the cell to be autotiled.
 func _autotile_carpet(cell: Vector2) -> void:
-	if randf() < CARPET_QUALITY:
+	if randf() <= CARPET_QUALITY:
 		# replace the cell with a perfect carpet tile
 		_set_cell_autotile_coord(cell, CARPET_FLAWLESS_CELL)
 	else:

--- a/project/src/main/world/environment/restaurant/hello-timer.gd
+++ b/project/src/main/world/environment/restaurant/hello-timer.gd
@@ -26,7 +26,7 @@ func _process(delta: float) -> void:
 ## frequently because those sounds are associated with negative reinforcement (broken combos).
 func _should_chat() -> bool:
 	var result := true
-	if greetiness + randf() > 1.0:
+	if randf() <= greetiness:
 		greetiness -= 1.0 / GREETINGS_PER_MINUTE
 	else:
 		result = false

--- a/project/src/main/world/environment/restaurant/kitchen-floor-tiler.gd
+++ b/project/src/main/world/environment/restaurant/kitchen-floor-tiler.gd
@@ -60,7 +60,7 @@ func _autotile_kitchen_floor(cell: Vector2) -> void:
 	if _tile_map.get_cell_autotile_coord(cell.x, cell.y) == KITCHEN_DRAIN_CELL:
 		# cell contains a drain; leave it alone
 		pass
-	elif randf() < KITCHEN_QUALITY:
+	elif randf() <= KITCHEN_QUALITY:
 		# replace the cell with a perfect kitchen floor tile
 		_set_cell_autotile_coord(cell, KITCHEN_FLAWLESS_CELL)
 	else:

--- a/project/src/main/world/environment/restaurant/undecorated-floor-tiler.gd
+++ b/project/src/main/world/environment/restaurant/undecorated-floor-tiler.gd
@@ -66,7 +66,7 @@ func _autotile_undecorated_floor(cell: Vector2) -> void:
 		# we have only one (or zero!) candidates for this cell. this is unusual so we push a warning
 		push_warning("Insufficient candidates for cell at %s (autotile_coord=%s)" % [cell, autotile_coord])
 		return
-	elif randf() < UNDECORATED_QUALITY:
+	elif randf() <= UNDECORATED_QUALITY:
 		# replace the cell with a perfect undecorated floor tile
 		_set_cell_autotile_coord(cell, tile_alternatives[0])
 	else:


### PR DESCRIPTION
At a glance, stuff like 'randf() > 0.35' looks like a 35% chance and 'randf() < 1.0' looks like a 100% chance. It takes a little more thought and mental arithmetic to figure out what it's actually doing. 'randf() <= 0.65' is easier to read.