### PR TITLE
Refactor: min_volume check, post_unemote

### DIFF
--- a/project/src/main/music/music-tween-manager.gd
+++ b/project/src/main/music/music-tween-manager.gd
@@ -47,5 +47,5 @@ func _fade(player: AudioStreamPlayer, new_volume_db: float, duration: float) -> 
 ## When a music track is faded out, we stop it from playing.
 func _on_Tween_completed(player: AudioStreamPlayer) -> void:
 	fading_state = FADING_NONE
-	if player.volume_db == MusicPlayer.MIN_VOLUME:
+	if is_equal_approx(player.volume_db, MusicPlayer.MIN_VOLUME):
 		player.stop()

--- a/project/src/main/puzzle/critter/carrots.gd
+++ b/project/src/main/puzzle/critter/carrots.gd
@@ -202,7 +202,7 @@ func _on_Carrot_started_hiding() -> void:
 
 
 func _on_Tween_completed() -> void:
-	if abs(_carrot_move_sound.volume_db - MIN_VOLUME) < 0.01:
+	if is_equal_approx(_carrot_move_sound.volume_db, MIN_VOLUME):
 		_carrot_move_sound.stop()
 		_move_sfx_state = MoveSfxState.STOPPED
 	else:


### PR DESCRIPTION
Made min_volume check consistent; instead of checking if two flats are equal or if their difference is within a threshold, we now use Godot's built-in 'is_equal_approx'

EmotePlayer no longer uses 'yield' to wait for a tween to finish. It now uses tween's tween_callback functionality. This avoids an error if the scene is disposed while yielding.