### PR TITLE
Refactor: Level editor chunk control parent references

### DIFF
--- a/project/src/main/editor/puzzle/BlockLevelChunkControl.tscn
+++ b/project/src/main/editor/puzzle/BlockLevelChunkControl.tscn
@@ -9,7 +9,7 @@ resource_local_to_scene = true
 shader = ExtResource( 1 )
 shader_param/mix_color = Color( 1, 1, 1, 0 )
 
-[node name="BlockLevelChunkControl" type="Control"]
+[node name="BlockLevelChunkControl" type="Control" groups=["chunk_controls"]]
 rect_min_size = Vector2( 72, 64 )
 script = ExtResource( 3 )
 

--- a/project/src/main/editor/puzzle/PlayfieldEditor.tscn
+++ b/project/src/main/editor/puzzle/PlayfieldEditor.tscn
@@ -226,7 +226,7 @@ script = ExtResource( 11 )
 box_type = 0
 box_size = Vector2( 3, 5 )
 
-[node name="Pickup" type="Control" parent="Palette/VBoxContainer/LevelChunks"]
+[node name="Pickup" type="Control" parent="Palette/VBoxContainer/LevelChunks" groups=["chunk_controls"]]
 margin_left = 152.0
 margin_top = 272.0
 margin_right = 224.0

--- a/project/src/main/editor/puzzle/box-level-chunk-control.gd
+++ b/project/src/main/editor/puzzle/box-level-chunk-control.gd
@@ -5,11 +5,6 @@ export (Foods.BoxType) var box_type: int setget set_box_type
 
 export (Vector2) var box_size: Vector2 = Vector2(3, 3) setget set_box_size
 
-func _ready() -> void:
-	$"../../Buttons/RotateButton".connect("pressed", self, "_on_RotateButton_pressed")
-	$"../../Buttons/ChangeButton".connect("pressed", self, "_on_ChangeButton_pressed")
-
-
 func set_box_type(new_box_type: int) -> void:
 	box_type = new_box_type
 	_refresh_tile_map()

--- a/project/src/main/editor/puzzle/pickup-level-chunk-control.gd
+++ b/project/src/main/editor/puzzle/pickup-level-chunk-control.gd
@@ -8,7 +8,6 @@ onready var _pickup := $Pickup
 
 func _ready() -> void:
 	_pickup.position = rect_size * 0.5
-	$"../../Buttons/ChangeButton".connect("pressed", self, "_on_ChangeButton_pressed")
 
 
 func set_box_type(new_box_type: int) -> void:

--- a/project/src/main/editor/puzzle/piece-level-chunk-control.gd
+++ b/project/src/main/editor/puzzle/piece-level-chunk-control.gd
@@ -21,10 +21,6 @@ var _editor_pieces := {
 var _orientation := 0
 var _type: PieceType = PieceTypes.piece_j
 
-func _ready() -> void:
-	$"../../Buttons/RotateButton".connect("pressed", self, "_on_RotateButton_pressed")
-
-
 func set_editor_piece(new_editor_piece: int) -> void:
 	editor_piece = new_editor_piece
 	_type = _editor_pieces[editor_piece]

--- a/project/src/main/editor/puzzle/playfield-editor-control.gd
+++ b/project/src/main/editor/puzzle/playfield-editor-control.gd
@@ -18,6 +18,12 @@ var tiles_keys := ["start"] setget set_tiles_keys
 var tiles_key := "start" setget set_tiles_key
 
 onready var _playfield_nav := $PlayfieldNav
+onready var _rotate_button := $Palette/VBoxContainer/Buttons/RotateButton
+onready var _change_button := $Palette/VBoxContainer/Buttons/ChangeButton
+
+func _ready() -> void:
+	_connect_chunk_control_listeners()
+
 
 ## Updates the list of selectable tiles keys.
 ##
@@ -45,6 +51,14 @@ func get_tile_map() -> TileMap:
 
 func get_pickups() -> EditorPickups:
 	return $CenterPanel/Playfield.get_pickups()
+
+
+func _connect_chunk_control_listeners() -> void:
+	for chunk_control in get_tree().get_nodes_in_group("chunk_controls"):
+		if chunk_control.has_method("_on_RotateButton_pressed"):
+			_rotate_button.connect("pressed", chunk_control, "_on_RotateButton_pressed")
+		if chunk_control.has_method("_on_ChangeButton_pressed"):
+			_change_button.connect("pressed", chunk_control, "_on_ChangeButton_pressed")
 
 
 ## Ensure the tiles keys are sorted, and that they always include a 'start' key.

--- a/project/src/main/editor/puzzle/veg-level-chunk-control.gd
+++ b/project/src/main/editor/puzzle/veg-level-chunk-control.gd
@@ -4,11 +4,6 @@ extends BlockLevelChunkControl
 ## Increasing this size allows you to draw vegetable blocks as a cluster, instead of one at a time.
 export (Vector2) var veg_size: Vector2 = Vector2.ONE setget set_veg_size
 
-func _ready() -> void:
-	$"../../Buttons/RotateButton".connect("pressed", self, "_on_RotateButton_pressed")
-	$"../../Buttons/ChangeButton".connect("pressed", self, "_on_ChangeButton_pressed")
-
-
 func set_veg_size(new_veg_size: Vector2) -> void:
 	veg_size = new_veg_size
 	_refresh_tile_map()


### PR DESCRIPTION
Before, level editor chunk controls included ugly parent references like '../../Button/RotateButton'. These were bad because they were dependent on hard-coded path names, they were used in several sections of code, and if the level editor chunk controls changed their location in the scene tree everything would break.

PlayfieldEditorControl now connects its child listeners. Chunk controls are all in a node group so that PlayfieldEditorControl can easily find them all.