### PR TITLE
Refactor: Creature editor errors, mouth z_index

### DIFF
--- a/delint.sh
+++ b/delint.sh
@@ -180,6 +180,16 @@ then
   fi
 fi
 
+# ViewportTexture is assigned; this causes an error because of Godot #27790
+# (https://github.com/godotengine/godot/issues/27790)
+RESULT=$(grep "texture = SubResource" project/src/main/world/creature/ViewportCreatureOutline.tscn)
+if [ -n "$RESULT" ]
+then
+  echo ""
+  echo "ViewportTexture is assigned:"
+  echo "$RESULT"
+fi
+
 # print statements that got left in by mistake
 RESULT=$(git diff main | grep print\()
 RESULT=$(git diff main | grep print_debug\()

--- a/project/src/main/utils/packed-sprite.gd
+++ b/project/src/main/utils/packed-sprite.gd
@@ -85,10 +85,10 @@ func set_offset(new_offset: Vector2) -> void:
 
 
 func _draw() -> void:
-	if _frame_dest_rects.empty():
-		# frame data not loaded
+	if _frame_dest_rects.empty() or texture == null:
+		# nothing to draw
 		return
-	
+
 	var rect: Rect2 = _frame_dest_rects[min(frame, _frame_dest_rects.size() - 1)]
 	rect.position += offset
 	if centered:

--- a/project/src/main/world/creature/CreatureVisuals.tscn
+++ b/project/src/main/world/creature/CreatureVisuals.tscn
@@ -513,7 +513,6 @@ show_behind_parent = true
 light_mask = 2
 material = SubResource( 17 )
 scale = Vector2( 2, 2 )
-z_index = 1
 script = ExtResource( 2 )
 rect_size = Vector2( 512, 512 )
 frame = 1
@@ -754,7 +753,6 @@ creature_visuals_path = NodePath("../..")
 wait_time = 2.5
 one_shot = true
 
-[connection signal="dna_loaded" from="." to="Animations/IdleTimer" method="_on_CreatureVisuals_dna_loaded"]
 [connection signal="movement_mode_changed" from="." to="FarArm" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="FarLeg" method="_on_CreatureVisuals_movement_mode_changed"]
 [connection signal="movement_mode_changed" from="." to="Sprint" method="_on_CreatureVisuals_movement_mode_changed"]

--- a/project/src/main/world/creature/ViewportCreatureOutline.tscn
+++ b/project/src/main/world/creature/ViewportCreatureOutline.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://src/main/world/creature/CreatureVisuals.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/utils/outline.shader" type="Shader" id=23]
@@ -10,10 +10,6 @@ shader = ExtResource( 23 )
 shader_param/width = 2.5
 shader_param/black = Color( 0.254902, 0.156863, 0.117647, 1 )
 shader_param/edge_fix_factor = 0.001
-
-[sub_resource type="ViewportTexture" id=2]
-flags = 5
-viewport_path = NodePath("Viewport")
 
 [node name="CreatureOutline" type="Node2D"]
 script = ExtResource( 24 )
@@ -38,5 +34,4 @@ margin_right = 1000.0
 margin_bottom = 834.0
 rect_scale = Vector2( 0.4, 0.4 )
 mouse_filter = 2
-texture = SubResource( 2 )
 flip_v = true

--- a/project/src/main/world/creature/creature-visuals.gd
+++ b/project/src/main/world/creature/creature-visuals.gd
@@ -92,6 +92,11 @@ onready var _animations: Node = $Animations
 func _ready() -> void:
 	# Update creature's appearance based on their behavior and orientation
 	set_orientation(orientation)
+	
+	if not Engine.editor_hint:
+		# Don't connect IdleTimer signal in the editor; it is not a tool script and produces an error
+		connect("dna_loaded", $Animations/IdleTimer, "_on_CreatureVisuals_dna_loaded")
+	
 	$DnaLoader.connect("dna_loaded", self, "_on_DnaLoader_dna_loaded")
 	$TalkTimer.connect("timeout", self, "_on_TalkTimer_timeout")
 	_refresh_creature_sfx()

--- a/project/src/main/world/creature/dna-loader.gd
+++ b/project/src/main/world/creature/dna-loader.gd
@@ -88,6 +88,7 @@ func unload_dna() -> void:
 				node.material.set_shader_param("blue", Color.black)
 				node.material.set_shader_param("black", Color.black)
 	
+	_creature_visuals.get_node("Neck0/HeadBobber/Mouth").z_index = 0
 	_creature_visuals.get_node("Neck0/HeadBobber").position = Vector2(0, -100)
 	_creature_visuals.rescale(1.00)
 	

--- a/project/src/main/world/creature/viewport-creature-outline.gd
+++ b/project/src/main/world/creature/viewport-creature-outline.gd
@@ -12,6 +12,10 @@ func _ready() -> void:
 	_texture_rect.rect_scale = Vector2(Global.CREATURE_SCALE, Global.CREATURE_SCALE)
 	creature_visuals.connect("dna_changed", self, "_on_CreatureVisuals_dna_changed")
 	connect("elevation_changed", self, "_on_elevation_changed")
+	
+	# Workaround for Godot #27790 (https://github.com/godotengine/godot/issues/27790)
+	$TextureRect.texture = $Viewport.get_texture()
+	$TextureRect.texture.flags = Texture.FLAG_MIPMAPS | Texture.FLAG_FILTER
 
 
 func _on_elevation_changed(_new_elevation: float) -> void:


### PR DESCRIPTION
Added Godot #27790 workaround. Assigning a ViewportTexture results in an editor error, '(Node not found: "Viewport" (relative to "/root/EditorNode/@@596/@@597/@@605/@@607/@@611/@@615/@@616/@@617/@@633/@@634/@@643/@@644/@@6618/@@6450/@@6451/@@6452/@@6453/@@6454/@@6455/Creature").)' Leaving this texture null and assigning it in the _ready() function eliminates the error.

Added PackedSprite null texture check. Without this check, PackedSprite was throwing an error 'godot condition p_texture.is_null() is true'

DnaLoader.reset() unsets mouth z_index. This property is set by some animations, which caused the property to flip back and forth when saving CreatureVisuals.tscn even when resetting.