### PR TITLE
Added unset_phrase chatscript metadata

### DIFF
--- a/project/assets/test/chat/chat-unset-phrase.chat
+++ b/project/assets/test/chat/chat-unset-phrase.chat
@@ -1,0 +1,9 @@
+{"version": "2476"}
+
+player: Hello!
+boatricia: Hello, nice to meet you!
+ (unset_phrase tall_cluttered Frequent Straw)
+  
+[alternate_start]
+boatricia: I remember you!
+ (start_if has_phrase tall_cluttered)

--- a/project/src/main/chat/chat-tree.gd
+++ b/project/src/main/chat/chat-tree.gd
@@ -41,6 +41,7 @@ const ENVIRONMENT_SCENE_PATHS_BY_ID := {
 	"poki": "res://src/main/world/environment/poki/PokiEnvironment.tscn",
 	"poki/walk": "res://src/main/world/environment/poki/PokiWalkEnvironment.tscn",
 	"sand": "res://src/main/world/environment/sand/SandEnvironment.tscn",
+	"banana_hq": "res://src/main/world/environment/sand/BananaHqEnvironment.tscn",
 	"sand/walk": "res://src/main/world/environment/sand/SandWalkEnvironment.tscn",
 }
 
@@ -273,6 +274,7 @@ func _assign_flags_and_phrases() -> void:
 				"set_flag": _process_set_flag_statement(args)
 				"set_phrase": _process_set_phrase_statement(args)
 				"unset_flag": _process_unset_flag_statement(args)
+				"unset_phrase": _process_unset_phrase_statement(args)
 
 
 ## Processes a default_phrase statement like 'default_phrase dog_breed Labrador Retriever'
@@ -324,6 +326,21 @@ func _process_set_phrase_statement(args: Array) -> void:
 	
 	PlayerData.chat_history.set_phrase(
 			args[0], PoolStringArray(args.slice(1, args.size())).join(" "))
+
+
+## Processes an unset_phrase statement like 'unset_phrase dog_breed'
+##
+## Unassigns the specified value from the specified chat history phrase.
+##
+## Parameters:
+## 	'args': The statement's arguments, such as ['dog_breed']
+func _process_unset_phrase_statement(args: Array) -> void:
+	if args.size() != 1:
+		warn("Invalid argument count for unset_phrase call. Expected 1 but was %s"
+				% [args.size()])
+		return
+	
+	PlayerData.chat_history.set_phrase(args[0], "")
 
 
 ## Processes an unset_flag statement like 'unset_flag foo'

--- a/project/src/test/chat/test-chatscript-parser.gd
+++ b/project/src/test/chat/test-chatscript-parser.gd
@@ -9,6 +9,7 @@ const CHAT_FULL := "res://assets/test/chat/chat-full.chat"
 const CHAT_LINK_MOOD := "res://assets/test/chat/chat-link-mood.chat"
 const CHAT_NEWLINES := "res://assets/test/chat/chat-newlines.chat"
 const CHAT_SET_PHRASE := "res://assets/test/chat/chat-set-phrase.chat"
+const CHAT_UNSET_PHRASE := "res://assets/test/chat/chat-unset-phrase.chat"
 const CHAT_SET_FLAG_STRING := "res://assets/test/chat/chat-set-flag-string.chat"
 const CHAT_SET_FLAG_BOOL := "res://assets/test/chat/chat-set-flag-bool.chat"
 const CHAT_THOUGHT := "res://assets/test/chat/chat-thought.chat"
@@ -277,6 +278,14 @@ func test_set_phrase() -> void:
 	
 	chat_tree.advance()
 	assert_eq(PlayerData.chat_history.get_phrase("tall_cluttered"), "Frequent Straw")
+
+
+func test_unset_phrase() -> void:
+	var chat_tree := _chat_tree_from_file(CHAT_UNSET_PHRASE)
+	PlayerData.chat_history.set_phrase("tall_cluttered", "Frequent Straw")
+	
+	chat_tree.advance()
+	assert_eq(PlayerData.chat_history.get_phrase("tall_cluttered"), "")
 
 
 func test_has_phrase() -> void:


### PR DESCRIPTION
This is used by the new Cannoli Sandbar script to avoid side effects when replaying the cutscene.