### PR TITLE
Added 'filming' chat location. Fixed nametag NPE.

### DIFF
--- a/project/src/main/chat/chat-tree.gd
+++ b/project/src/main/chat/chat-tree.gd
@@ -43,6 +43,7 @@ const ENVIRONMENT_SCENE_PATHS_BY_ID := {
 	"sand": "res://src/main/world/environment/sand/SandEnvironment.tscn",
 	"banana_hq": "res://src/main/world/environment/sand/BananaHqEnvironment.tscn",
 	"sand/walk": "res://src/main/world/environment/sand/SandWalkEnvironment.tscn",
+	"filming": "res://src/main/world/environment/sand/FilmingEnvironment.tscn",
 }
 
 ## unique key to identify this conversation in the chat history

--- a/project/src/main/chat/ui/chat-frame.gd
+++ b/project/src/main/chat/ui/chat-frame.gd
@@ -84,8 +84,10 @@ func play_chat_event(chat_event: ChatEvent, squished: bool) -> void:
 	if not nametag_text and chat_event.who:
 		var creature_def := PlayerData.creature_library.get_creature_def(chat_event.who)
 		if not creature_def:
+			nametag_text = ""
 			push_error("creature_def not found with id '%s'" % [chat_event.who])
-		nametag_text = creature_def.creature_name
+		else:
+			nametag_text = creature_def.creature_name
 	_nametag_panel.set_nametag_text(nametag_text)
 	
 	# update the UI's appearance


### PR DESCRIPTION
If a chatscript file specified an invalid name like 'p' instead of 'p1' the game would crash with an NPE, because creature_def.creature_name could not resolve with a null CreatureDef. I've added a null check which assigns the nametag_text to null.

Added missing 'filming' chat location.