### PR TITLE
Added multiple bar_stool spawns for cutscenes

### DIFF
--- a/project/assets/main/chat/career/poki/010-b-end.chat
+++ b/project/assets/main/chat/career/poki/010-b-end.chat
@@ -6,7 +6,7 @@ inside_turbo_fat
 [characters]
 player, p1, bar_10
 sensei, s1, bar_11
-(customer) raymon, r, bar_stool
+(customer) raymon, r, barstool_middle
 
 r: ^__^ Heck yeah, those were some seriously choice chocolate puffs! Sorry for bugging you about the whole nut thing.
  (r faces left)

--- a/project/assets/main/chat/career/poki/010-b.chat
+++ b/project/assets/main/chat/career/poki/010-b.chat
@@ -6,7 +6,7 @@ inside_turbo_fat
 [characters]
 player, p1, bar_10
 sensei, s1, bar_11
-(customer) raymon, r, bar_stool
+(customer) raymon, r, barstool_middle
 
 r: /._. Hey so these chocolate puffs... They don't have nuts do they? 'Cause I'm allergic to nuts.
  (r faces left)

--- a/project/assets/main/chat/career/poki/120.chat
+++ b/project/assets/main/chat/career/poki/120.chat
@@ -6,7 +6,7 @@ inside_turbo_fat
 [characters]
 sensei, s1, bar_10
 player, p1, bar_11
-(customer) lisk, l, bar_stool
+(customer) lisk, l, barstool_middle
 
 p1: ^__^/ Oh hey Lisk! What's going on, Desert Q's just seven days right? Didn't it end a few days ago?
 l: ^_^ Oh you know how it is. Seven days became eight days, and a few of us missed our flights home.

--- a/project/src/main/world/environment/restaurant/RestaurantSpawns.tscn
+++ b/project/src/main/world/environment/restaurant/RestaurantSpawns.tscn
@@ -12,9 +12,14 @@ id = "bar_10"
 position = Vector2( 1212.97, 121.172 )
 id = "bar_11"
 
-[node name="BarStool" parent="." instance=ExtResource( 2 )]
+[node name="BarstoolMiddle" parent="." instance=ExtResource( 2 )]
 position = Vector2( 1313, 220 )
-id = "bar_stool"
+id = "barstool_middle"
+elevation = 140.0
+
+[node name="BarstoolDown" parent="." instance=ExtResource( 2 )]
+position = Vector2( 1240, 322 )
+id = "barstool_down"
 elevation = 140.0
 
 [node name="Chef" parent="." instance=ExtResource( 2 )]


### PR DESCRIPTION
Some scenes want creatures to sit on other barstools, so I've replaced 'bar_stool' with 'barstool_middle' and 'barstool_down'. These names mirror 'table_seat_left' which use directions