### PR TITLE
Fixed 'print statement' delint script

### DIFF
--- a/delint.sh
+++ b/delint.sh
@@ -192,7 +192,12 @@ fi
 
 # print statements that got left in by mistake
 RESULT=$(git diff main | grep print\()
-RESULT=$(git diff main | grep print_debug\()
+RESULT=${RESULT}"Ê"$(git diff main | grep print_debug\()
+RESULT=$(echo "${RESULT}" |
+  sed 's/ÊÊÊ*/Ê/g' | # remove consecutive newline placeholders
+  sed 's/^Ê\(.*\)$/\1/g' | # remove trailing newline placeholders
+  sed 's/^\(.*\)Ê$/\1/g' | # remove following newline placeholders
+  sed 's/Ê/\n/g') # convert newline placeholders to newlines
 if [ -n "$RESULT" ]
 then
   echo ""


### PR DESCRIPTION
This was broken in b1853eeb when we added the check for 'print_debug'. The results were not concatenated, and the 'print' results were erased.