### PR TITLE
Added support for 'chef_if' flag.

### DIFF
--- a/project/src/main/career/population.gd
+++ b/project/src/main/career/population.gd
@@ -140,7 +140,18 @@ func random_creature_type() -> int:
 ##
 ## Returns null if this region does not define any nonquirky chefs.
 func random_chef() -> CreatureAppearance:
-	return _random_creature(chefs)
+	var result := _random_creature(chefs)
+	
+	if result:
+		# Omit creatures if their 'chef_if' flag hasn't been met yet.
+		#
+		# Cannot statically type as 'CreatureDef' because of cyclic reference.
+		var creature_def = PlayerData.creature_library.get_creature_def(result.id)
+		
+		if not creature_def.is_chef():
+			result = null
+	
+	return result
 
 
 ## Returns a random nonquirky customer from this region's list of customers.

--- a/project/src/main/editor/creature/dialogs.gd
+++ b/project/src/main/editor/creature/dialogs.gd
@@ -57,6 +57,7 @@ func _on_ExportButton_pressed() -> void:
 func _on_ExportDialog_file_selected(path: String) -> void:
 	var exported_creature: Creature = _creature_editor.center_creature
 	var exported_creature_def := exported_creature.creature_def
+	exported_creature_def.chef_if = "true"
 	exported_creature_def.customer_if = "true"
 	var exported_json := exported_creature_def.to_json_dict()
 	FileUtils.write_file(path, Utils.print_json(exported_json))
@@ -70,6 +71,7 @@ func _on_SaveButton_pressed() -> void:
 ## Updates the player character and writes it to their save file.
 func _on_SaveConfirmation_confirmed() -> void:
 	var saved_creature_def := _creature_editor.center_creature.creature_def
+	saved_creature_def.chef_if = "true"
 	saved_creature_def.customer_if = "false"
 	PlayerData.creature_library.player_def = saved_creature_def
 	PlayerSave.schedule_save()

--- a/project/src/main/world/creature/creature-def.gd
+++ b/project/src/main/world/creature/creature-def.gd
@@ -63,6 +63,12 @@ var chat_selectors: Array
 ## 'false' if they should never be a customer.
 var customer_if := "true"
 
+## Boolean condition which enables this creature to appear as a random chef, such as
+## 'chat_finished chat/career/marsh/30_c_end'
+##
+## 'false' if they should never be a chef.
+var chef_if := "true"
+
 ## how fat the creature's body is; 5.0 = 5x normal size
 var min_fatness := 1.0
 
@@ -104,6 +110,7 @@ func from_json_dict(json: Dictionary) -> void:
 	dna = json.get("dna", {})
 	chat_theme.from_json_dict(json.get("chat_theme", DEFAULT_CHAT_THEME_JSON))
 	chat_selectors = json.get("chat_selectors", [])
+	chef_if = json.get("chef_if", "true")
 	customer_if = json.get("customer_if", "true")
 	min_fatness = json.get("fatness", 1.0)
 	weight_gain_scale = json.get("weight_gain_scale", 1.0)
@@ -124,6 +131,7 @@ func to_json_dict() -> Dictionary:
 	var chat_theme_json := chat_theme.to_json_dict()
 	if chat_theme_json: result["chat_theme"] = chat_theme_json
 	if chat_selectors: result["chat_selectors"] = chat_selectors
+	if not chef_if in ["True", "TRUE", "true", "1"]: result["chef_if"] = chef_if
 	if not customer_if in ["True", "TRUE", "true", "1"]: result["customer_if"] = customer_if
 	if min_fatness != 1.0: result["fatness"] = min_fatness
 	if weight_gain_scale != 1.0: result["weight_gain_scale"] = weight_gain_scale
@@ -161,3 +169,8 @@ func rename(new_creature_name: String) -> void:
 ## Returns true if this creature can show up as a random customer.
 func is_customer() -> bool:
 	return BoolExpressionEvaluator.evaluate(customer_if)
+
+
+## Returns true if this creature can show up as a random customer.
+func is_chef() -> bool:
+	return BoolExpressionEvaluator.evaluate(chef_if)


### PR DESCRIPTION
The 'chef_if' flag is similar to the 'customer_if' flag and prevents a creature from appearing as a random chef until a condition is met. It's used for the upcoming Cannoli Sandbar cutscenes.