### PR TITLE
Moving no longer interrupts mood. Disabled north-facing emotes.

### DIFF
--- a/project/src/demo/chat/ui/mood-demo.gd
+++ b/project/src/demo/chat/ui/mood-demo.gd
@@ -19,6 +19,7 @@ extends Node
 ## 	[space bar]: Feed
 ## 	[brace keys]: Change the creature's appearance
 ## 	[Shift + /]: Print DNA
+## 	[right]: Toggle creature movement
 ##
 ## 	[Shift + Q, W]: Look over shoulder
 ## 	[Shift + E, R]: Yawn
@@ -39,6 +40,12 @@ onready var _creature_animations: CreatureAnimations = $Creature.creature_visual
 func _ready() -> void:
 	if creature_path:
 		_creature.creature_def = CreatureDef.new().from_json_path(creature_path)
+
+
+func _physics_process(_delta: float) -> void:
+	if _creature.non_iso_walk_direction:
+		# The creature movement toggle actually moves the creature. Reset the creature to a central position
+		_creature.position = Vector2(512, 420)
 
 
 func _input(event: InputEvent) -> void:
@@ -96,6 +103,11 @@ func _input(event: InputEvent) -> void:
 			KEY_PERIOD: _creature.play_mood(Creatures.Mood.YES1)
 			KEY_SPACE: _creature.feed(Foods.FoodType.BROWN_0)
 			KEY_EQUAL: _creature.set_fatness(3)
+			KEY_RIGHT:
+				if _creature.non_iso_walk_direction == Vector2.ZERO:
+					_creature.non_iso_walk_direction = Vector2(1.0, 1.0)
+				else:
+					_creature.non_iso_walk_direction = Vector2.ZERO
 
 
 func _change_demographic(demographic_type: int) -> void:

--- a/project/src/main/world/creature/creature-animations.gd
+++ b/project/src/main/world/creature/creature-animations.gd
@@ -127,8 +127,9 @@ func play_movement_animation(animation_name: String) -> void:
 		# prevent emotes from conflicting with movement animations
 		if not _emote_player.current_animation.begins_with("ambient") \
 				and not animation_name.begins_with("idle"):
-			# don't unemote during sitting-still animations; only when changing movement stances
-			_emote_player.unemote_immediate()
+			
+			# if the creature starts moving, they can't emote with their arms
+			set_emote_arm_frame(0)
 		
 		# play the animation
 		if _movement_player.current_animation.begins_with(animation_prefix):

--- a/project/src/main/world/creature/creature-visuals.gd
+++ b/project/src/main/world/creature/creature-visuals.gd
@@ -369,7 +369,10 @@ func set_movement_mode(new_mode: int) -> void:
 ## Parameters:
 ## 	'mood': The creature's new mood from Creatures.Mood
 func play_mood(mood: int) -> void:
-	_animations.play_mood(mood)
+	if oriented_south():
+		# Only play moods for south-facing creatures. Creatures do not have north-facing emotes, and playing them
+		# causes glitches (eyes on the back of the head, etc)
+		_animations.play_mood(mood)
 
 
 func restart_idle_timer() -> void:


### PR DESCRIPTION
Instead of interrupting the movement animations, moving just resets the creature's "emote arm frame". This is the same mechanism that happens when you launch an emote while the creature is running.

Creatures will no longer emote when facing north. This was resulting in some buggy behavior like eyes on the back of their head.

Closes #1905.

Added movement options to MoodDemo.