### PR TITLE
Enable 'edit_group' for environment obstacles.

### DIFF
--- a/project/src/main/world/CreatureSpawner.tscn
+++ b/project/src/main/world/CreatureSpawner.tscn
@@ -8,6 +8,9 @@
 scale = Vector2( 0.6, 0.6 )
 texture = ExtResource( 2 )
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_group_": true
+}
 target_properties = {
 "creature_id": "",
 "elevation": 0.0,

--- a/project/src/main/world/ObstacleSpawner.tscn
+++ b/project/src/main/world/ObstacleSpawner.tscn
@@ -4,3 +4,6 @@
 
 [node name="ObstacleSpawner" type="Sprite"]
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}

--- a/project/src/main/world/environment/lemon/BrotSpotStool.tscn
+++ b/project/src/main/world/environment/lemon/BrotSpotStool.tscn
@@ -16,6 +16,7 @@ extents = Vector2( 38, 18 )
 [node name="Stool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 2 )
 __meta__ = {
+"_edit_group_": true,
 "shadow_scale": 0.5
 }
 shadow_scale = 0.5

--- a/project/src/main/world/environment/lemon/BrotSpotTable.tscn
+++ b/project/src/main/world/environment/lemon/BrotSpotTable.tscn
@@ -16,6 +16,9 @@ extents = Vector2( 80, 26 )
 
 [node name="BrotSpotTable" type="KinematicBody2D"]
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.9
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lemon/LemonCookieLarge.tscn
+++ b/project/src/main/world/environment/lemon/LemonCookieLarge.tscn
@@ -16,6 +16,9 @@ extents = Vector2( 64, 32 )
 
 [node name="LemonCookieLarge" type="KinematicBody2D"]
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.9
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lemon/LemonCookieSmall.tscn
+++ b/project/src/main/world/environment/lemon/LemonCookieSmall.tscn
@@ -16,6 +16,9 @@ extents = Vector2( 36, 18 )
 
 [node name="LemonCookieSmall" type="KinematicBody2D"]
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.7
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lemon/LemonLemon.tscn
+++ b/project/src/main/world/environment/lemon/LemonLemon.tscn
@@ -16,6 +16,9 @@ extents = Vector2( 36, 18 )
 
 [node name="LemonLemon" type="KinematicBody2D"]
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lemon/LemonTree.tscn
+++ b/project/src/main/world/environment/lemon/LemonTree.tscn
@@ -316,7 +316,6 @@ vframes = 3
 [node name="Lemons" type="Sprite" parent="."]
 position = Vector2( 0, -80 )
 texture = ExtResource( 5 )
-flip_h = true
 hframes = 5
 vframes = 3
 

--- a/project/src/main/world/environment/marsh/ButtercupSign.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupSign.tscn
@@ -16,6 +16,9 @@ extents = Vector2( 105, 10 )
 
 [node name="ButtercupSign" type="KinematicBody2D"]
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 1.5
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/marsh/ButtercupStool.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupStool.tscn
@@ -16,6 +16,7 @@ extents = Vector2( 38, 18 )
 [node name="Stool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 1 )
 __meta__ = {
+"_edit_group_": true,
 "shadow_scale": 0.5
 }
 shadow_scale = 0.5

--- a/project/src/main/world/environment/marsh/ButtercupStoolSpawnerG.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupStoolSpawnerG.tscn
@@ -11,6 +11,9 @@ texture = ExtResource( 5 )
 centered = false
 offset = Vector2( -76, -110 )
 script = ExtResource( 4 )
+__meta__ = {
+"_edit_group_": true
+}
 TargetScene = ExtResource( 1 )
 target_properties = {
 "occupied_texture": ExtResource( 2 ),

--- a/project/src/main/world/environment/marsh/ButtercupStoolSpawnerW.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupStoolSpawnerW.tscn
@@ -11,6 +11,9 @@ texture = ExtResource( 2 )
 centered = false
 offset = Vector2( -76, -110 )
 script = ExtResource( 4 )
+__meta__ = {
+"_edit_group_": true
+}
 TargetScene = ExtResource( 1 )
 target_properties = {
 "occupied_texture": ExtResource( 3 ),

--- a/project/src/main/world/environment/marsh/ButtercupTable.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupTable.tscn
@@ -17,6 +17,9 @@ extents = Vector2( 80, 26 )
 [node name="ButtercupTable" type="KinematicBody2D"]
 position = Vector2( -209.971, 976.928 )
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.9
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/marsh/ButtercupTableSpawner.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupTableSpawner.tscn
@@ -10,4 +10,7 @@ texture = ExtResource( 1 )
 centered = false
 offset = Vector2( -125, -200 )
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
 TargetScene = ExtResource( 3 )

--- a/project/src/main/world/environment/marsh/MarshCrystal.tscn
+++ b/project/src/main/world/environment/marsh/MarshCrystal.tscn
@@ -16,6 +16,9 @@ extents = Vector2( 24, 12 )
 
 [node name="MarshCrystal" type="KinematicBody2D"]
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/marsh/MarshCrystalSpawner.tscn
+++ b/project/src/main/world/environment/marsh/MarshCrystalSpawner.tscn
@@ -10,4 +10,7 @@ texture = ExtResource( 3 )
 centered = false
 offset = Vector2( -70, -102 )
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_group_": true
+}
 TargetScene = ExtResource( 2 )

--- a/project/src/main/world/environment/poki/PokiCactusHuge.tscn
+++ b/project/src/main/world/environment/poki/PokiCactusHuge.tscn
@@ -9,6 +9,9 @@ extents = Vector2( 28, 14 )
 [node name="CactusHuge" type="KinematicBody2D"]
 position = Vector2( 566.612, 247.67 )
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.8
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/poki/PokiCactusLarge.tscn
+++ b/project/src/main/world/environment/poki/PokiCactusLarge.tscn
@@ -10,6 +10,9 @@ extents = Vector2( 50, 14 )
 [node name="CactusLarge" type="KinematicBody2D"]
 position = Vector2( 486.489, 339.411 )
 script = ExtResource( 3 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.7
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/poki/PokiCactusPlaque.tscn
+++ b/project/src/main/world/environment/poki/PokiCactusPlaque.tscn
@@ -9,6 +9,9 @@ extents = Vector2( 58, 25 )
 [node name="CactusPlaque" type="KinematicBody2D"]
 position = Vector2( 566.612, 247.67 )
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/poki/PokiCactusSmall.tscn
+++ b/project/src/main/world/environment/poki/PokiCactusSmall.tscn
@@ -10,6 +10,9 @@ extents = Vector2( 28, 14 )
 [node name="CactusSmall" type="KinematicBody2D"]
 position = Vector2( 480.957, 462.977 )
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/poki/PokiCrowd.tscn
+++ b/project/src/main/world/environment/poki/PokiCrowd.tscn
@@ -9,6 +9,9 @@ extents = Vector2( 28, 14 )
 [node name="Crowd" type="KinematicBody2D"]
 position = Vector2( 561.443, 360.624 )
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/poki/PokiCrowdSpawner.tscn
+++ b/project/src/main/world/environment/poki/PokiCrowdSpawner.tscn
@@ -10,6 +10,9 @@ texture = ExtResource( 1 )
 centered = false
 offset = Vector2( -195, -375 )
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
 TargetScene = ExtResource( 3 )
 target_properties = {
 "crowd_color_index": 0,

--- a/project/src/main/world/environment/poki/PokiMarshmallow.tscn
+++ b/project/src/main/world/environment/poki/PokiMarshmallow.tscn
@@ -10,6 +10,9 @@ extents = Vector2( 50, 14 )
 [node name="Marshmallow" type="KinematicBody2D"]
 position = Vector2( 536.121, 330.356 )
 script = ExtResource( 3 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.6
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/poki/Tent.tscn
+++ b/project/src/main/world/environment/poki/Tent.tscn
@@ -10,6 +10,9 @@ extents = Vector2( 120, 14 )
 [node name="Tent" type="KinematicBody2D"]
 position = Vector2( 486.489, 339.411 )
 script = ExtResource( 3 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 1.2
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/poki/TentSpawner.tscn
+++ b/project/src/main/world/environment/poki/TentSpawner.tscn
@@ -9,5 +9,8 @@ scale = Vector2( 0.539, 0.539 )
 texture = ExtResource( 2 )
 offset = Vector2( 0, -100 )
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_group_": true
+}
 TargetScene = ExtResource( 3 )
 spawn_if = "false"

--- a/project/src/main/world/environment/restaurant/BananaStool.tscn
+++ b/project/src/main/world/environment/restaurant/BananaStool.tscn
@@ -18,6 +18,7 @@ extents = Vector2( 28, 14 )
 [node name="BananaStool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 3 )
 __meta__ = {
+"_edit_group_": true,
 "shadow_scale": 0.5
 }
 shadow_scale = 0.5

--- a/project/src/main/world/environment/restaurant/BananaStoolBig.tscn
+++ b/project/src/main/world/environment/restaurant/BananaStoolBig.tscn
@@ -18,6 +18,7 @@ extents = Vector2( 28, 14 )
 [node name="BananaStoolBig" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 3 )
 __meta__ = {
+"_edit_group_": true,
 "shadow_scale": 0.5
 }
 shadow_scale = 0.5

--- a/project/src/main/world/environment/restaurant/BoxStool1.tscn
+++ b/project/src/main/world/environment/restaurant/BoxStool1.tscn
@@ -18,6 +18,7 @@ extents = Vector2( 28, 14 )
 [node name="BoxStool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 4 )
 __meta__ = {
+"_edit_group_": true,
 "shadow_scale": 0.5
 }
 shadow_scale = 0.5

--- a/project/src/main/world/environment/restaurant/BoxStool2.tscn
+++ b/project/src/main/world/environment/restaurant/BoxStool2.tscn
@@ -18,6 +18,7 @@ extents = Vector2( 28, 14 )
 [node name="BoxStool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 4 )
 __meta__ = {
+"_edit_group_": true,
 "shadow_scale": 0.5
 }
 shadow_scale = 0.5

--- a/project/src/main/world/environment/restaurant/BoxStool3.tscn
+++ b/project/src/main/world/environment/restaurant/BoxStool3.tscn
@@ -18,6 +18,7 @@ extents = Vector2( 28, 14 )
 [node name="BoxStool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 4 )
 __meta__ = {
+"_edit_group_": true,
 "shadow_scale": 0.5
 }
 shadow_scale = 0.5

--- a/project/src/main/world/environment/restaurant/CrateTable.tscn
+++ b/project/src/main/world/environment/restaurant/CrateTable.tscn
@@ -17,6 +17,9 @@ extents = Vector2( 60, 20 )
 [node name="CrateTable" type="KinematicBody2D"]
 position = Vector2( 380, 405 )
 script = ExtResource( 3 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.9
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/restaurant/TurboFatStool.tscn
+++ b/project/src/main/world/environment/restaurant/TurboFatStool.tscn
@@ -18,6 +18,7 @@ extents = Vector2( 28, 14 )
 [node name="Stool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 2 )
 __meta__ = {
+"_edit_group_": true,
 "shadow_scale": 0.5
 }
 shadow_scale = 0.5

--- a/project/src/main/world/environment/restaurant/WoodPillar.tscn
+++ b/project/src/main/world/environment/restaurant/WoodPillar.tscn
@@ -17,6 +17,9 @@ extents = Vector2( 28, 14 )
 [node name="WoodPillar" type="KinematicBody2D"]
 position = Vector2( 531.162, 105 )
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/restaurant/WoodTable.tscn
+++ b/project/src/main/world/environment/restaurant/WoodTable.tscn
@@ -17,6 +17,9 @@ extents = Vector2( 60, 20 )
 [node name="WoodTable" type="KinematicBody2D"]
 position = Vector2( 380, 405 )
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.9
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/sand/BananaTentacleBack.tscn
+++ b/project/src/main/world/environment/sand/BananaTentacleBack.tscn
@@ -17,6 +17,9 @@ extents = Vector2( 86, 24 )
 [node name="BananaTentacleBack" type="KinematicBody2D"]
 position = Vector2( 171.378, 140.204 )
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
 
 [node name="Sprite" type="Sprite" parent="."]
 material = SubResource( 1 )

--- a/project/src/main/world/environment/sand/BananaTentacleFront.tscn
+++ b/project/src/main/world/environment/sand/BananaTentacleFront.tscn
@@ -17,6 +17,9 @@ extents = Vector2( 118, 24 )
 [node name="BananaTentacleFront" type="KinematicBody2D"]
 position = Vector2( 171.378, 140.204 )
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
 
 [node name="Sprite" type="Sprite" parent="."]
 material = SubResource( 1 )

--- a/project/src/main/world/environment/sand/Bottle.tscn
+++ b/project/src/main/world/environment/sand/Bottle.tscn
@@ -14,3 +14,6 @@ shader_param/edge_fix_factor = 1.0
 material = SubResource( 1 )
 scale = Vector2( 0.539, 0.539 )
 texture = ExtResource( 3 )
+__meta__ = {
+"_edit_group_": true
+}

--- a/project/src/main/world/environment/sand/BottleMat.tscn
+++ b/project/src/main/world/environment/sand/BottleMat.tscn
@@ -15,3 +15,6 @@ material = SubResource( 1 )
 position = Vector2( 177.429, 159.77 )
 scale = Vector2( 0.539, 0.539 )
 texture = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}

--- a/project/src/main/world/environment/sand/Mic1.tscn
+++ b/project/src/main/world/environment/sand/Mic1.tscn
@@ -16,6 +16,9 @@ extents = Vector2( 24, 12 )
 
 [node name="Mic1" type="KinematicBody2D"]
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/sand/Mic2.tscn
+++ b/project/src/main/world/environment/sand/Mic2.tscn
@@ -16,6 +16,9 @@ extents = Vector2( 24, 12 )
 
 [node name="Mic2" type="KinematicBody2D"]
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/sand/RobotDog.tscn
+++ b/project/src/main/world/environment/sand/RobotDog.tscn
@@ -360,6 +360,9 @@ tracks/4/keys = {
 
 [node name="RobotDog" type="KinematicBody2D"]
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.5
 
 [node name="Tail" type="Sprite" parent="."]

--- a/project/src/main/world/environment/sand/SandBanana.tscn
+++ b/project/src/main/world/environment/sand/SandBanana.tscn
@@ -17,6 +17,9 @@ extents = Vector2( 64.4, 25.2 )
 [node name="Banana" type="KinematicBody2D"]
 position = Vector2( 84.9487, 113.265 )
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.7
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/sand/SandCream.tscn
+++ b/project/src/main/world/environment/sand/SandCream.tscn
@@ -17,6 +17,9 @@ extents = Vector2( 56, 28 )
 [node name="Cream" type="KinematicBody2D"]
 position = Vector2( 84.9487, 113.265 )
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_group_": true
+}
 shadow_scale = 0.7
 frame = 4
 flip_h = true

--- a/project/src/main/world/environment/sand/SandGrass.tscn
+++ b/project/src/main/world/environment/sand/SandGrass.tscn
@@ -63,6 +63,9 @@ offset = Vector2( 0, -50 )
 hframes = 3
 vframes = 2
 script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 anims/RESET = SubResource( 3 )


### PR DESCRIPTION
This flag was enabled for most of them, but not all of them. I've enabled the flag for the obstacles which did not have it.

This flag prevents people using the Godot editor to accidentally move a sprite without moving its shadow, or things like that.