### PR TITLE
Vector2 reuse, NameGenerator tweaks

### DIFF
--- a/project/src/main/data/player-save-upgrader.gd
+++ b/project/src/main/data/player-save-upgrader.gd
@@ -225,8 +225,8 @@ const CHAT_PRUNE_LIST_3776 := {
 }
 
 ## chat history prefixes to replace when upgrading from version 2743
-## key: (string) old string prefix to be replaced
-## value: (string) new string prefix
+## key: (String) old string prefix to be replaced
+## value: (String) new string prefix
 const PREFIX_REPLACEMENTS_2743 := {
 	"chat/bones": "creature/bones",
 	"chat/skins": "creature/skins",

--- a/project/src/main/puzzle/box-builder.gd
+++ b/project/src/main/puzzle/box-builder.gd
@@ -16,7 +16,7 @@ signal box_built(rect, box_type)
 ## with pink and white pieces, where 'l123' is a 5x3 box with pink, bread and white pieces. 's0' is a 3x3 box with
 ## brown pieces.
 ##
-## key: (string) Ingredient string describing the box's size and color
+## key: (String) Ingredient string describing the box's size and color
 ## value: (int) Enum from Foods.BoxType for the resulting snack/cake
 const BOX_TYPES_BY_INGREDIENTS := {
 	# 3x3

--- a/project/src/main/world/creature/name-generator.gd
+++ b/project/src/main/world/creature/name-generator.gd
@@ -8,11 +8,11 @@ var min_length: int setget set_min_length
 var max_length: int setget set_max_length
 var order: float setget set_order
 
-## key: (string) Word from the source material
+## key: (String) Word from the source material
 ## value: (bool) true
 var _seed_words := {}
 
-## cached list of generated names; we generate many names at once at cache them
+## cached list of generated names; we generate many names at once and cache them
 var _generated_names := []
 
 ## resource paths containing input names (one word per line)
@@ -80,9 +80,7 @@ func _mix_seed_lists() -> Array:
 	for word_list in _seed_word_lists:
 		word_count = min(word_count, word_list.size())
 	for word_list in _seed_word_lists:
-		var new_words := []
-		for word in word_list:
-			new_words.append(word)
+		var new_words: Array = word_list.duplicate()
 		new_words.shuffle()
 		words += new_words.slice(0, word_count - 1)
 	return words

--- a/project/src/main/world/environment/invisible-obstacle-tiler.gd
+++ b/project/src/main/world/environment/invisible-obstacle-tiler.gd
@@ -59,11 +59,12 @@ func autotile(value: bool) -> void:
 		
 		for neighbor_x in range(cell.x - 1, cell.x + 2):
 			for neighbor_y in range(cell.y - 1, cell.y + 2):
-				if unwalkable_cells.has(Vector2(neighbor_x, neighbor_y)):
+				var neighbor_cell := Vector2(neighbor_x, neighbor_y)
+				if unwalkable_cells.has(neighbor_cell):
 					# already added an entry to the map
 					continue
 				
-				if _is_walkable(Vector2(neighbor_x, neighbor_y)):
+				if _is_walkable(neighbor_cell):
 					# walkable; the ground map has terrain at that cell
 					continue
 				
@@ -71,7 +72,7 @@ func autotile(value: bool) -> void:
 					# the obstacle map already has an obstacle at that cell; don't overwrite it
 					continue
 				
-				unwalkable_cells[Vector2(neighbor_x, neighbor_y)] = true
+				unwalkable_cells[neighbor_cell] = true
 	
 	# place an invisible obstacle on each unwalkable cell
 	for unwalkable_cell_obj in unwalkable_cells:


### PR DESCRIPTION
Updated InvisibleObstacleTiler to reuse its 'neighbor_cell' Vector2 to avoid repetition

Changed 'string' to 'String' in a few code comments. This type is capitalized in GDScript.

Updated NameGenerator to use 'Array.duplicate()' instead of looping through the source array to add items one at a time.