### PR TITLE
Unify autotile syntax: 'not value', initialize_onready

### DIFF
--- a/project/src/main/world/environment/goop-overworld-tiler.gd
+++ b/project/src/main/world/environment/goop-overworld-tiler.gd
@@ -276,7 +276,7 @@ func _enter_tree() -> void:
 ## dictionary constants defined in this script.
 func autotile(value: bool) -> void:
 	if not value:
-		# only autotile in the editor when the 'Autotile' property is toggled
+		# only autotile in the editor when the 'autotile' property is toggled
 		return
 	
 	if Engine.editor_hint:

--- a/project/src/main/world/environment/grass-overworld-tiler.gd
+++ b/project/src/main/world/environment/grass-overworld-tiler.gd
@@ -49,7 +49,7 @@ func _enter_tree() -> void:
 ## Grass tiles are added to a random selection of goopy/goopless cake tiles.
 func autotile(value: bool) -> void:
 	if not value:
-		# only autotile in the editor when the 'Autotile' property is toggled
+		# only autotile in the editor when the 'autotile' property is toggled
 		return
 	
 	if Engine.editor_hint:

--- a/project/src/main/world/environment/invisible-obstacle-tiler.gd
+++ b/project/src/main/world/environment/invisible-obstacle-tiler.gd
@@ -36,7 +36,7 @@ func _enter_tree() -> void:
 ## like a patch of ground.
 func autotile(value: bool) -> void:
 	if not value:
-		# only autotile in the editor when the 'Autotile' property is toggled
+		# only autotile in the editor when the 'autotile' property is toggled
 		return
 	
 	if Engine.editor_hint:
@@ -44,11 +44,18 @@ func autotile(value: bool) -> void:
 			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
 			_initialize_onready_variables()
 	
+	_erase_all_invisible_obstacles()
+	_add_invisible_obstacles()
+
+
+func _erase_all_invisible_obstacles() -> void:
 	# remove all invisible obstacles
 	for cell_obj in _tile_map.get_used_cells_by_id(impassable_tile_index):
 		var cell: Vector2 = cell_obj
 		_tile_map.set_cellv(cell, TileMap.INVALID_CELL)
-	
+
+
+func _add_invisible_obstacles() -> void:
 	# calculate empty unwalkable cells which are adjacent to walkable cells
 	var unwalkable_cells := {}
 	for cell_obj in _ground_map.get_used_cells():

--- a/project/src/main/world/environment/pebble-overworld-tiler.gd
+++ b/project/src/main/world/environment/pebble-overworld-tiler.gd
@@ -37,7 +37,7 @@ func _enter_tree() -> void:
 ## Pebble tiles are added to a random selection of goopy/goopless cake tiles.
 func autotile(value: bool) -> void:
 	if not value:
-		# only autotile in the editor when the 'Autotile' property is toggled
+		# only autotile in the editor when the 'autotile' property is toggled
 		return
 	
 	if Engine.editor_hint:

--- a/project/src/main/world/environment/poki/puddle-overworld-tiler.gd
+++ b/project/src/main/world/environment/poki/puddle-overworld-tiler.gd
@@ -34,7 +34,7 @@ func _enter_tree() -> void:
 ## Pebble tiles are added to a random selection of goopy/goopless cake tiles.
 func autotile(value: bool) -> void:
 	if not value:
-		# only autotile in the editor when the 'Autotile' property is toggled
+		# only autotile in the editor when the 'autotile' property is toggled
 		return
 	
 	if Engine.editor_hint:

--- a/project/src/main/world/environment/restaurant/carpet-tiler.gd
+++ b/project/src/main/world/environment/restaurant/carpet-tiler.gd
@@ -38,7 +38,16 @@ func _enter_tree() -> void:
 ## Autotiles floors, applying imperfections.
 ##
 ## The floor autotiling logic applies probabilities and cannot be handled by Godot's built-in autotiling.
-func autotile(_value: bool) -> void:
+func autotile(value: bool) -> void:
+	if not value:
+		# only autotile in the editor when the 'autotile' property is toggled
+		return
+	
+	if Engine.editor_hint:
+		if not _tile_map:
+			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
+			_initialize_onready_variables()
+	
 	for cell in _tile_map.get_used_cells_by_id(carpet_tile_index):
 		_autotile_carpet(cell)
 

--- a/project/src/main/world/environment/restaurant/kitchen-floor-tiler.gd
+++ b/project/src/main/world/environment/restaurant/kitchen-floor-tiler.gd
@@ -40,7 +40,16 @@ func _enter_tree() -> void:
 ## Autotiles floors, applying imperfections.
 ##
 ## The floor autotiling logic applies probabilities and cannot be handled by Godot's built-in autotiling.
-func autotile(_value: bool) -> void:
+func autotile(value: bool) -> void:
+	if not value:
+		# only autotile in the editor when the 'autotile' property is toggled
+		return
+	
+	if Engine.editor_hint:
+		if not _tile_map:
+			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
+			_initialize_onready_variables()
+	
 	for cell in _tile_map.get_used_cells_by_id(kitchen_tile_index):
 		_autotile_kitchen_floor(cell)
 

--- a/project/src/main/world/environment/restaurant/kitchen-obstacle-tiler.gd
+++ b/project/src/main/world/environment/restaurant/kitchen-obstacle-tiler.gd
@@ -196,7 +196,7 @@ func _enter_tree() -> void:
 ## dictionary constants defined in this script.
 func autotile(value: bool) -> void:
 	if not value:
-		# only autotile in the editor when the 'Autotile' property is toggled
+		# only autotile in the editor when the 'autotile' property is toggled
 		return
 	
 	if Engine.editor_hint:

--- a/project/src/main/world/environment/restaurant/undecorated-floor-tiler.gd
+++ b/project/src/main/world/environment/restaurant/undecorated-floor-tiler.gd
@@ -39,7 +39,16 @@ func _enter_tree() -> void:
 ## Autotiles floors, applying imperfections.
 ##
 ## The floor autotiling logic applies probabilities and cannot be handled by Godot's built-in autotiling.
-func autotile(_value: bool) -> void:
+func autotile(value: bool) -> void:
+	if not value:
+		# only autotile in the editor when the 'unautotile' property is toggled
+		return
+	
+	if Engine.editor_hint:
+		if not _tile_map:
+			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
+			_initialize_onready_variables()
+	
 	for cell in _tile_map.get_used_cells_by_id(undecorated_tile_index):
 		_autotile_undecorated_floor(cell)
 

--- a/project/src/main/world/environment/sand/chip-overworld-tiler.gd
+++ b/project/src/main/world/environment/sand/chip-overworld-tiler.gd
@@ -37,10 +37,10 @@ func _enter_tree() -> void:
 
 ## Refreshes the position of chip tiles.
 ##
-## Pebble tiles are added to a random selection of goopy/goopless cake tiles.
+## Chip tiles are added to a random selection of goopy/goopless cake tiles.
 func autotile(value: bool) -> void:
 	if not value:
-		# only autotile in the editor when the 'Autotile' property is toggled
+		# only autotile in the editor when the 'autotile' property is toggled
 		return
 	
 	if Engine.editor_hint:

--- a/project/src/main/world/environment/sand/sand-tiler.gd
+++ b/project/src/main/world/environment/sand/sand-tiler.gd
@@ -38,7 +38,16 @@ func _enter_tree() -> void:
 ## Autotiles floors, applying hills.
 ##
 ## The floor autotiling logic applies probabilities and cannot be handled by Godot's built-in autotiling.
-func autotile(_value: bool) -> void:
+func autotile(value: bool) -> void:
+	if not value:
+		# only autotile in the editor when the 'autotile' property is toggled
+		return
+	
+	if Engine.editor_hint:
+		if not _tile_map:
+			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
+			_initialize_onready_variables()
+	
 	for cell in _tile_map.get_used_cells_by_id(sand_tile_index):
 		_autotile_sand(cell)
 

--- a/project/src/main/world/environment/sand/water-overworld-tiler.gd
+++ b/project/src/main/world/environment/sand/water-overworld-tiler.gd
@@ -22,7 +22,7 @@ func _enter_tree() -> void:
 ## Autotiles water, applying a random water texture to each water cell.
 func autotile(value: bool) -> void:
 	if not value:
-		# only autotile in the editor when the 'Autotile' property is toggled
+		# only autotile in the editor when the 'autotile' property is toggled
 		return
 	
 	if Engine.editor_hint:

--- a/project/src/main/world/environment/sand/water-ripple-overworld-tiler.gd
+++ b/project/src/main/world/environment/sand/water-ripple-overworld-tiler.gd
@@ -40,7 +40,7 @@ func _enter_tree() -> void:
 ## other water tiles, as water tiles can overlay neighboring non-water ground tiles in an ugly way.
 func autotile(value: bool) -> void:
 	if not value:
-		# only autotile in the editor when the 'Autotile' property is toggled
+		# only autotile in the editor when the 'autotile' property is toggled
 		return
 	
 	if Engine.editor_hint:


### PR DESCRIPTION
Some autotiler scripts such as 'carpet-tiler.gd' and 'kitchen-floor-tiler.gd' did not check the value of the 'value' property, and did not initialize onready variables in the autotile function. This can result in unnecessary autotiling, unnecessary .tscn file changes, and nil reference errors.

Changed 'Autotile' property to 'autotile' property in comments (lower case)