### PR TITLE
Added 'unautotile' to tilers

### DIFF
--- a/project/src/main/world/environment/grass-overworld-tiler.gd
+++ b/project/src/main/world/environment/grass-overworld-tiler.gd
@@ -33,6 +33,9 @@ export (int) var grass_tile_index: int
 ## Editor toggle which adds grass to a random selection of goopy/goopless cake tiles
 export (bool) var _autotile: bool setget autotile
 
+## Editor toggle which undoes autotiling, removing all grass.
+export (bool) var _unautotile: bool setget unautotile
+
 ## Obstacle tilemap with grass tiles to place
 onready var _tile_map := get_parent()
 
@@ -59,6 +62,20 @@ func autotile(value: bool) -> void:
 	
 	_erase_all_grass()
 	_add_random_grass()
+
+
+## Removes all grass tiles.
+func unautotile(value: bool) -> void:
+	if not value:
+		# only unautotile in the editor when the 'unautotile' property is toggled
+		return
+	
+	if Engine.editor_hint:
+		if not _tile_map:
+			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
+			_initialize_onready_variables()
+	
+	_erase_all_grass()
 
 
 ## Preemptively initializes onready variables to avoid null references.

--- a/project/src/main/world/environment/invisible-obstacle-tiler.gd
+++ b/project/src/main/world/environment/invisible-obstacle-tiler.gd
@@ -19,6 +19,9 @@ export (int) var impassable_tile_index := -1
 ## (https://github.com/godotengine/godot/issues/11855)
 export (bool) var _autotile: bool setget autotile
 
+## Editor toggle which undoes autotiling, removing all invisible obstacles.
+export (bool) var _unautotile: bool setget unautotile
+
 ## tilemap containing data on which cells are walkable
 onready var _ground_map: TileMap = get_node(ground_map_path)
 
@@ -46,6 +49,20 @@ func autotile(value: bool) -> void:
 	
 	_erase_all_invisible_obstacles()
 	_add_invisible_obstacles()
+
+
+## Removes all invisible obstacles.
+func unautotile(value: bool) -> void:
+	if not value:
+		# only unautotile in the editor when the 'unautotile' property is toggled
+		return
+	
+	if Engine.editor_hint:
+		if not _tile_map:
+			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
+			_initialize_onready_variables()
+	
+	_erase_all_invisible_obstacles()
 
 
 func _erase_all_invisible_obstacles() -> void:

--- a/project/src/main/world/environment/pebble-overworld-tiler.gd
+++ b/project/src/main/world/environment/pebble-overworld-tiler.gd
@@ -21,6 +21,9 @@ export (int) var pebble_tile_index: int
 ## Editor toggle which adds pebbles to a random selection of goopy/goopless cake tiles
 export (bool) var _autotile: bool setget autotile
 
+## Editor toggle which undoes autotiling, removing all pebbles
+export (bool) var _unautotile: bool setget unautotile
+
 ## Terrain tilemap with pebble tiles to place
 onready var _tile_map := get_parent()
 
@@ -47,6 +50,20 @@ func autotile(value: bool) -> void:
 	
 	_erase_all_pebbles()
 	_add_random_pebbles()
+
+
+## Removes all pebble tiles.
+func unautotile(value: bool) -> void:
+	if not value:
+		# only unautotile in the editor when the 'unautotile' property is toggled
+		return
+	
+	if Engine.editor_hint:
+		if not _tile_map:
+			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
+			_initialize_onready_variables()
+	
+	_erase_all_pebbles()
 
 
 ## Preemptively initializes onready variables to avoid null references.

--- a/project/src/main/world/environment/poki/puddle-overworld-tiler.gd
+++ b/project/src/main/world/environment/poki/puddle-overworld-tiler.gd
@@ -18,6 +18,9 @@ export (int) var puddle_tile_index: int
 ## Editor toggle which adds puddles to a random selection of goopy/goopless cake tiles
 export (bool) var _autotile: bool setget autotile
 
+## Editor toggle which undoes autotiling, removing all puddles
+export (bool) var _unautotile: bool setget unautotile
+
 ## Terrain tilemap with puddle tiles to place
 onready var _tile_map := get_parent()
 
@@ -44,6 +47,20 @@ func autotile(value: bool) -> void:
 	
 	_erase_all_puddles()
 	_add_random_puddles()
+
+
+## Removes all puddle tiles.
+func unautotile(value: bool) -> void:
+	if not value:
+		# only unautotile in the editor when the 'unautotile' property is toggled
+		return
+	
+	if Engine.editor_hint:
+		if not _tile_map:
+			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
+			_initialize_onready_variables()
+	
+	_erase_all_puddles()
 
 
 ## Preemptively initializes onready variables to avoid null references.

--- a/project/src/main/world/environment/restaurant/carpet-tiler.gd
+++ b/project/src/main/world/environment/restaurant/carpet-tiler.gd
@@ -27,6 +27,9 @@ export (int) var carpet_tile_index: int = -1
 ## (https://github.com/godotengine/godot/issues/11855)
 export (bool) var _autotile: bool setget autotile
 
+## Editor toggle which undoes autotiling, removing all carpet imperfections.
+export (bool) var _unautotile: bool setget unautotile
+
 ## tilemap containing floors
 onready var _tile_map: TileMap = get_parent()
 
@@ -50,6 +53,21 @@ func autotile(value: bool) -> void:
 	
 	for cell in _tile_map.get_used_cells_by_id(carpet_tile_index):
 		_autotile_carpet(cell)
+
+
+## Removes all carpet imperfections.
+func unautotile(value: bool) -> void:
+	if not value:
+		# only unautotile in the editor when the 'unautotile' property is toggled
+		return
+	
+	if Engine.editor_hint:
+		if not _tile_map:
+			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
+			_initialize_onready_variables()
+	
+	for cell in _tile_map.get_used_cells_by_id(carpet_tile_index):
+		_set_cell_autotile_coord(cell, CARPET_FLAWLESS_CELL)
 
 
 ## Preemptively initializes onready variables to avoid null references.

--- a/project/src/main/world/environment/sand/chip-overworld-tiler.gd
+++ b/project/src/main/world/environment/sand/chip-overworld-tiler.gd
@@ -24,6 +24,9 @@ export (int) var chip_goop_tile_index: int
 ## Editor toggle which adds chips to a random selection of goopy/goopless cake tiles
 export (bool) var _autotile: bool setget autotile
 
+## Editor toggle which undoes autotiling, removing all chips
+export (bool) var _unautotile: bool setget unautotile
+
 ## Terrain tilemap with chip tiles to place
 onready var _tile_map := get_parent()
 
@@ -50,6 +53,20 @@ func autotile(value: bool) -> void:
 	
 	_erase_all_chips()
 	_add_random_chips()
+
+
+## Removes all chip tiles.
+func unautotile(value: bool) -> void:
+	if not value:
+		# only unautotile in the editor when the 'unautotile' property is toggled
+		return
+	
+	if Engine.editor_hint:
+		if not _tile_map:
+			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
+			_initialize_onready_variables()
+	
+	_erase_all_chips()
 
 
 ## Preemptively initializes onready variables to avoid null references.

--- a/project/src/main/world/environment/sand/sand-tiler.gd
+++ b/project/src/main/world/environment/sand/sand-tiler.gd
@@ -27,6 +27,9 @@ export (int) var sand_tile_index: int = -1
 ## (https://github.com/godotengine/godot/issues/11855)
 export (bool) var _autotile: bool setget autotile
 
+## Editor toggle which undoes autotiling, removing all hills
+export (bool) var _unautotile: bool setget unautotile
+
 ## tilemap containing floors
 onready var _tile_map: TileMap = get_parent()
 
@@ -50,6 +53,21 @@ func autotile(value: bool) -> void:
 	
 	for cell in _tile_map.get_used_cells_by_id(sand_tile_index):
 		_autotile_sand(cell)
+
+
+## Removes all hills.
+func unautotile(value: bool) -> void:
+	if not value:
+		# only unautotile in the editor when the 'unautotile' property is toggled
+		return
+	
+	if Engine.editor_hint:
+		if not _tile_map:
+			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
+			_initialize_onready_variables()
+	
+	for cell in _tile_map.get_used_cells_by_id(sand_tile_index):
+		_set_cell_autotile_coord(cell, SAND_FLAWLESS_CELL)
 
 
 ## Preemptively initializes onready variables to avoid null references.

--- a/project/src/main/world/environment/sand/water-overworld-tiler.gd
+++ b/project/src/main/world/environment/sand/water-overworld-tiler.gd
@@ -11,6 +11,9 @@ export (Array, int) var water_tile_indexes := []
 ## Editor toggle which manually applies autotiling
 export (bool) var _autotile: bool setget autotile
 
+## Editor toggle which undoes autotiling, making all water tiles the same
+export (bool) var _unautotile: bool setget unautotile
+
 ## Tilemap with water which we should autotile
 onready var _tile_map := get_parent()
 
@@ -33,6 +36,19 @@ func autotile(value: bool) -> void:
 	_shuffle_water_tiles()
 
 
+func unautotile(value: bool) -> void:
+	if not value:
+		# only unautotile in the editor when the 'unautotile' property is toggled
+		return
+	
+	if Engine.editor_hint:
+		if not _tile_map:
+			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
+			_initialize_onready_variables()
+	
+	_unshuffle_water_tiles()
+
+
 ## Preemptively initializes onready variables to avoid null references.
 func _initialize_onready_variables() -> void:
 	_tile_map = get_parent()
@@ -43,3 +59,10 @@ func _shuffle_water_tiles() -> void:
 	for cell in _tile_map.get_used_cells():
 		if _tile_map.get_cellv(cell) in water_tile_indexes:
 			_tile_map.set_cellv(cell, Utils.rand_value(water_tile_indexes), randf() < 0.5)
+
+
+## Applies the same water texture to each water cell.
+func _unshuffle_water_tiles() -> void:
+	for cell in _tile_map.get_used_cells():
+		if _tile_map.get_cellv(cell) in water_tile_indexes:
+			_tile_map.set_cellv(cell, water_tile_indexes[0])

--- a/project/src/main/world/environment/sand/water-ripple-overworld-tiler.gd
+++ b/project/src/main/world/environment/sand/water-ripple-overworld-tiler.gd
@@ -23,6 +23,9 @@ export (float, 0.0, 1.0) var ripple_density := 0.15
 ## Editor toggle which adds ripples to a random selection of water tiles
 export (bool) var _autotile: bool setget autotile
 
+## Editor toggle which undoes autotiling, removing all ripples
+export (bool) var _unautotile: bool setget unautotile
+
 ## Terrain tilemap with ripple tiles to place
 onready var _tile_map := get_parent()
 
@@ -50,6 +53,20 @@ func autotile(value: bool) -> void:
 	
 	_erase_all_ripples()
 	_add_random_ripples()
+
+
+## Removes all ripple tiles.
+func unautotile(value: bool) -> void:
+	if not value:
+		# only unautotile in the editor when the 'unautotile' property is toggled
+		return
+	
+	if Engine.editor_hint:
+		if not _tile_map:
+			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
+			_initialize_onready_variables()
+	
+	_erase_all_ripples()
 
 
 ## Preemptively initializes onready variables to avoid null references.


### PR DESCRIPTION
Autotilers often do things like randomize water tiles or randomly place chocolate chips which are difficult to reverse. Autotilers now include an 'unautotile' editor flag which can be flipped to reverse or remove all randomized tiles.