### PR TITLE
Removed ChatIconHook. NightModeToggler comments.

### DIFF
--- a/project/src/main/puzzle/night/night-mode-toggler.gd
+++ b/project/src/main/puzzle/night/night-mode-toggler.gd
@@ -24,7 +24,11 @@ const TWEEN_DURATION := 0.3
 
 var _night_mode := false
 
-## Set of Node instances which are being gradually modulated to transparent.
+## Nodes being tweened to transparent. After the tween completes, we set the 'visible' property on these nodes to
+## 'false'.
+##
+## key: (Node) node being modulated to transparent
+## kalue: (bool) true
 var _nodes_modulated_to_transparent := {}
 
 ## Adjusts node colors and visibility during day/night transitions.

--- a/project/src/main/world/environment/marsh/ButtercupSign.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupSign.tscn
@@ -30,6 +30,3 @@ offset = Vector2( -275, -240 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource( 2 )
-
-[node name="ChatIconHook" type="RemoteTransform2D" parent="."]
-position = Vector2( 80, 0 )

--- a/project/src/main/world/environment/marsh/ForLeaseSign.tscn
+++ b/project/src/main/world/environment/marsh/ForLeaseSign.tscn
@@ -26,7 +26,3 @@ offset = Vector2( 0, -75 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource( 2 )
-
-[node name="ChatIconHook" type="RemoteTransform2D" parent="."]
-position = Vector2( -20, 0 )
-scale = Vector2( -1, 1 )

--- a/project/src/main/world/environment/marsh/MarshCrystal.tscn
+++ b/project/src/main/world/environment/marsh/MarshCrystal.tscn
@@ -30,5 +30,3 @@ offset = Vector2( -70, -102 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource( 2 )
-
-[node name="ChatIconHook" type="RemoteTransform2D" parent="."]


### PR DESCRIPTION
Removed ChatIconHook for ButtercupSign, ForLeaseSign and MarshCrystal. These hooks are left over from earlier versions of Turbo Fat where you could freely run around and explore the world -- these hooks specified the position of the little chat indicators which showed an item could be interacted with.

Improved NightModeToggler comment to include key/value indicators.