### PR TITLE
Bug: sharky cheese sharks were disappearing

### DIFF
--- a/project/src/main/puzzle/critter/Critters.tscn
+++ b/project/src/main/puzzle/critter/Critters.tscn
@@ -60,3 +60,6 @@ bus = "Sound Bus"
 
 [node name="CellCritterManager" type="Node" parent="."]
 script = ExtResource( 14 )
+
+[connection signal="line_inserted" from="CellCritterManager" to="Moles" method="_on_CritterManager_line_inserted"]
+[connection signal="line_inserted" from="CellCritterManager" to="Sharks" method="_on_CritterManager_line_inserted"]

--- a/project/src/main/puzzle/critter/critter-manager.gd
+++ b/project/src/main/puzzle/critter/critter-manager.gd
@@ -2,6 +2,11 @@ class_name CellCritterManager
 extends Node
 ## Common logic for puzzle critters like moles and sharks who sit on blocks in the playfield.
 
+# Some critters like moles and sharks need to react to the playfield moving after the critter manager. This signal is a
+# 1:1 replacement for the Playfield's 'line_inserted' signal which is always emitted after the critter manager shifts
+# critters around.
+signal line_inserted(y, tiles_key, src_y)
+
 var piece_manager_path: NodePath setget set_piece_manager_path
 var playfield_path: NodePath setget set_playfield_path
 
@@ -206,9 +211,13 @@ func _on_Playfield_blocks_prepared() -> void:
 	_clear_critters()
 
 
-func _on_Playfield_line_inserted(y: int, _tiles_key: String, _src_y: int) -> void:
+func _on_Playfield_line_inserted(y: int, tiles_key: String, src_y: int) -> void:
 	# raise all critters at or above the specified row
 	_shift_rows(y, Vector2.UP)
+	
+	# Some critters like moles and sharks need to react to the playfield moving after the critter manager. Emit the
+	# corresponding 'line_inserted' signal to ensure they react after us.
+	emit_signal("line_inserted", y, tiles_key, src_y)
 
 
 func _on_Playfield_line_deleted(y: int) -> void:

--- a/project/src/main/puzzle/critter/moles.gd
+++ b/project/src/main/puzzle/critter/moles.gd
@@ -300,7 +300,7 @@ func _on_Playfield_line_erased(_y: int, _total_lines: int, _remaining_lines: int
 		_refresh_moles_for_playfield()
 
 
-func _on_Playfield_line_inserted(_y: int, _tiles_key: String, _src_y: int) -> void:
+func _on_CritterManager_line_inserted(_y: int, _tiles_key: String, _src_y: int) -> void:
 	if _playfield.is_clearing_lines():
 		# If lines are being erased as a part of line clears, we wait to relocate moles until all lines are deleted.
 		pass

--- a/project/src/main/puzzle/critter/sharks.gd
+++ b/project/src/main/puzzle/critter/sharks.gd
@@ -376,7 +376,6 @@ func _refresh_playfield_path() -> void:
 	
 	if _playfield:
 		_playfield.disconnect("line_erased", self, "_on_Playfield_line_erased")
-		_playfield.disconnect("line_inserted", self, "_on_Playfield_line_inserted")
 		_playfield.disconnect("line_filled", self, "_on_Playfield_line_filled")
 		_playfield.disconnect("after_lines_deleted", self, "_on_Playfield_after_lines_deleted")
 	
@@ -384,7 +383,6 @@ func _refresh_playfield_path() -> void:
 	
 	if _playfield:
 		_playfield.connect("line_erased", self, "_on_Playfield_line_erased")
-		_playfield.connect("line_inserted", self, "_on_Playfield_line_inserted")
 		_playfield.connect("line_filled", self, "_on_Playfield_line_filled")
 		_playfield.connect("after_lines_deleted", self, "_on_Playfield_after_lines_deleted")
 
@@ -521,7 +519,7 @@ func _on_Playfield_line_erased(_y: int, _total_lines: int, _remaining_lines: int
 		_refresh_sharks_for_playfield()
 
 
-func _on_Playfield_line_inserted(_y: int, _tiles_key: String, _src_y: int) -> void:
+func _on_CritterManager_line_inserted(_y: int, _tiles_key: String, _src_y: int) -> void:
 	if _playfield.is_clearing_lines():
 		# If lines are being erased as a part of line clears, we wait to relocate sharks until all lines are deleted.
 		pass


### PR DESCRIPTION
This bug was introduced by the CritterManager refactoring in 2a7c921d. Before, sharks would be shifted and then their positions would be evaluated. But after, sharks would be evaluated before being shifted because the signal methods were called in the wrong order.

I've added a CritterManager.line_inserted signal to ensure these calls are ordered appropriately.