### PR TITLE
Added new 'cells_consumed' functionality.

### DIFF
--- a/project/src/main/puzzle/line-clear-sfx.gd
+++ b/project/src/main/puzzle/line-clear-sfx.gd
@@ -86,7 +86,8 @@ func _play_box_sound(_y: int, _total_lines: int, _remaining_lines: int, box_ints
 		sound = _clear_cake_piece_sound
 	elif not box_ints.empty():
 		sound = _clear_snack_piece_sound
-	if sound: sound.play()
+	if sound:
+		sound.play()
 
 
 ## Clearing a line results in three overlapping sounds:
@@ -112,3 +113,8 @@ func _on_Playfield_all_lines_cleared() -> void:
 		return
 	
 	_all_clear_sound.play()
+
+
+func _on_Playfield_cells_consumed(_cells: Array, box_ints: Array) -> void:
+	_play_thump_sound(0, 1, 0, box_ints)
+	_play_box_sound(0, 0, 0, box_ints)

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -9,6 +9,10 @@ signal all_lines_cleared
 ## emitted when a new box is built
 signal box_built(rect, box_type)
 
+# warning-ignore:unused_signal
+## emitted when blocks are erased by playfield hazards such as spears
+signal cells_consumed(cells, box_ints)
+
 ## emitted shortly before a set of lines are cleared
 signal line_clears_scheduled(y_coords)
 


### PR DESCRIPTION
Some critters destroy boxes, but we still want to award the player points. This 'cells_consumed' event gives StarSeeds a hook where it can emit food and play sound effects when a cake is destroyed by a critter.