### PR TITLE
Replaced level timer 'initial_interval' with 'start/end'

### DIFF
--- a/project/src/main/puzzle/level/level-settings-upgrader.gd
+++ b/project/src/main/puzzle/level/level-settings-upgrader.gd
@@ -21,6 +21,7 @@ var _upgrade_methods := {}
 
 func _init() -> void:
 	current_version = Levels.LEVEL_DATA_VERSION
+	_add_upgrade_method("_upgrade_4373", "4373", "49db")
 	_add_upgrade_method("_upgrade_39e5", "39e5", "4373")
 	_add_upgrade_method("_upgrade_392b", "392b", "39e5")
 	_add_upgrade_method("_upgrade_2cb4", "2cb4", "392b")
@@ -92,6 +93,20 @@ func _add_upgrade_method(method: String, old_version: String, new_version: Strin
 	upgrade_method.old_version = old_version
 	upgrade_method.new_version = new_version
 	_upgrade_methods[old_version] = upgrade_method
+
+
+func _upgrade_4373(old_json: Dictionary, old_key: String, new_json: Dictionary) -> Dictionary:
+	match old_key:
+		"timers":
+			var new_value: Array = old_json[old_key].duplicate(true)
+			for timer in new_value:
+				if timer.has("initial_interval"):
+					timer["start"] = timer["initial_interval"]
+					timer.erase("initial_interval")
+			new_json[old_key] = new_value
+		_:
+			new_json[old_key] = old_json[old_key]
+	return new_json
 
 
 func _upgrade_39e5(old_json: Dictionary, old_key: String, new_json: Dictionary) -> Dictionary:

--- a/project/src/main/puzzle/level/level-timers.gd
+++ b/project/src/main/puzzle/level/level-timers.gd
@@ -12,13 +12,22 @@ func get_timer_interval(timer_index: int) -> float:
 
 
 ## Returns how long the timer should wait to fire the first time, measured in seconds.
-func get_timer_initial_interval(timer_index: int) -> float:
+func get_timer_start(timer_index: int) -> float:
 	var result: float
-	if timers[timer_index].has("initial_interval"):
-		result = timers[timer_index]["initial_interval"]
+	if timers[timer_index].has("start"):
+		result = timers[timer_index]["start"]
 	else:
 		result = timers[timer_index].get("interval", 1.0)
 	return result
+
+
+## Returns 'true' if the timer should eventually stop firing.
+func is_timer_end(timer_index: int) -> bool:
+	return timers[timer_index].has("end")
+
+
+func get_timer_end(timer_index: int) -> float:
+	return timers[timer_index].get("end", 0.0)
 
 
 ## Returns the number of timers used by this level.

--- a/project/src/main/puzzle/level/levels.gd
+++ b/project/src/main/puzzle/level/levels.gd
@@ -15,4 +15,4 @@ enum Result {
 
 ## Current version for saved level data. Should be updated if and only if the level format changes.
 ## This version number follows a 'ymdh' hex date format which is documented in issue #234.
-const LEVEL_DATA_VERSION := "4373"
+const LEVEL_DATA_VERSION := "49db"


### PR DESCRIPTION
Level timers used to have an optional 'initial_interval' property to define when the timer started, but there was no way to stop a level timer. I've replaced this 'initial_interval' property with a 'start' property, which is more intuitive and matches the naming conventions of Godot's timers. I've also added a new 'end' property.