### PR TITLE
Spear improvements: 'wait', 'x3x5', already_popped_state

### DIFF
--- a/project/src/main/puzzle/critter/spear-config.gd
+++ b/project/src/main/puzzle/critter/spear-config.gd
@@ -10,6 +10,9 @@ var count: int = 1
 ## how many turns/seconds/cycles the spears emerge for, or '-1' if they should emerge indefinitely
 var duration: int = -1
 
+# how many turns/seconds/cycles the spears wait for, or '0' if they should emerge immediately
+var wait: int = 2
+
 ## which rows the spears appear on
 var lines: Array = []
 

--- a/project/src/main/puzzle/critter/spear-sfx.gd
+++ b/project/src/main/puzzle/critter/spear-sfx.gd
@@ -15,7 +15,7 @@ func play_poof_sound() -> void:
 	SfxDeconflicter.play(_poof)
 
 
-func play_pop_sound(pop_anim_duration: float) -> void:
+func play_pop_sound() -> void:
 	_pop.pitch_scale = rand_range(0.95, 1.05)
 	SfxDeconflicter.play(_pop)
 

--- a/project/src/main/puzzle/critter/spear.gd
+++ b/project/src/main/puzzle/critter/spear.gd
@@ -86,6 +86,9 @@ func _ready() -> void:
 	_states.set_state(_state_nodes_by_enum[NONE])
 	spear_sprite.position.x = -450
 	
+	# avoid a case where we initialize a spear and it's immediately advanced
+	_already_popped_state = true
+	
 	_refresh_side()
 	_refresh_state()
 
@@ -156,6 +159,10 @@ func pop_in_immediately() -> void:
 ## 	'new_state': enum from State for the spear's new animation state.
 func set_state(new_state: int) -> void:
 	state = new_state
+	
+	# avoid a case where we set a spear's state, and it's immediately advanced
+	_already_popped_state = true
+	
 	_refresh_state()
 
 
@@ -171,7 +178,7 @@ func poof_and_free() -> void:
 
 # Tweens the spear into view, or out of view.
 func tween_and_pop(target_x: float, squint_duration: float) -> void:
-	sfx.play_pop_sound(pop_anim_duration)
+	sfx.play_pop_sound()
 	
 	_dirt_particles_burst.restart()
 	_dirt_particles_burst.emitting = true

--- a/project/src/main/puzzle/level/level-trigger-effects.gd
+++ b/project/src/main/puzzle/level/level-trigger-effects.gd
@@ -262,6 +262,8 @@ class AddSpearsEffect extends LevelTriggerEffect:
 			config.count = new_config["count"].to_int()
 		if new_config.has("duration"):
 			config.duration = new_config["duration"].to_int()
+		if new_config.has("wait"):
+			config.wait = new_config["wait"].to_int()
 		if new_config.has("y"):
 			var inverted_lines := ConfigStringUtils.ints_from_config_string(new_config["y"])
 			config.lines = ConfigStringUtils.invert_puzzle_row_indexes(inverted_lines.keys())
@@ -281,6 +283,8 @@ class AddSpearsEffect extends LevelTriggerEffect:
 			result["count"] = str(config.count)
 		if config.duration != -1:
 			result["duration"] = str(config.duration)
+		if config.wait != 2:
+			result["wait"] = str(config.wait)
 		if config.lines:
 			var inverted_lines: Array = ConfigStringUtils.invert_puzzle_row_indexes(config.lines)
 			result["y"] = ConfigStringUtils.config_string_from_ints(inverted_lines)

--- a/project/src/test/puzzle/critter/test-spears.gd
+++ b/project/src/test/puzzle/critter/test-spears.gd
@@ -1,0 +1,16 @@
+extends GutTest
+
+func test_resolve_spear_size_x() -> void:
+	assert_eq(Spears.resolve_spear_size_x("l1", 0), "l1")
+	assert_eq(Spears.resolve_spear_size_x("l2r3", 1), "l2r3")
+	
+	assert_eq(Spears.resolve_spear_size_x("x1", 0), "l1")
+	assert_eq(Spears.resolve_spear_size_x("x2", 1), "r2")
+	
+	assert_eq(Spears.resolve_spear_size_x("x1x2", 0), "l1r2")
+	assert_eq(Spears.resolve_spear_size_x("x3x4", 1), "r3l4")
+	
+	assert_eq(Spears.resolve_spear_size_x("X1X2", 0), "L1R2")
+	assert_eq(Spears.resolve_spear_size_x("X3X4", 1), "R3L4")
+	assert_eq(Spears.resolve_spear_size_x("X1x2", 0), "L1r2")
+	assert_eq(Spears.resolve_spear_size_x("x3X4", 1), "r3L4")


### PR DESCRIPTION
Added 'spear.wait' parameter to define how many cycles the spear should wait before popping out.

Spear supports spear size strings with two xs, like 'x3x5'.

Removed unused 'pop_anim_duration' parameter from
SpearSfx.play_pop_sound.

Fixed bug where spear would sometimes suddenly appear, instead of popping out.