### PR TITLE
LevelTriggerEffect improvements: priority, y=1,3...

### DIFF
--- a/project/src/main/puzzle/level/level-trigger-effect.gd
+++ b/project/src/main/puzzle/level/level-trigger-effect.gd
@@ -3,6 +3,9 @@ class_name LevelTriggerEffect
 ##
 ## A LevelTriggerEffect might subtract points from the player's score, rotate a piece or turn the playfield invisible.
 
+## Priority field for triggers which occur in the same phase. Lower triggers occur first.
+var priority: int = 100
+
 ## Executes this level trigger effect.
 func run() -> void:
 	pass

--- a/project/src/main/puzzle/level/level-trigger-effects.gd
+++ b/project/src/main/puzzle/level/level-trigger-effects.gd
@@ -61,7 +61,7 @@ class AddCarrotsEffect extends LevelTriggerEffect:
 		if new_config.has("smoke"):
 			config.smoke = Utils.enum_from_snake_case(CarrotConfig.Smoke, new_config["smoke"])
 		if new_config.has("x"):
-			config.columns = ConfigStringUtils.ints_from_config_string(new_config["x"]).keys()
+			config.columns = ConfigStringUtils.ints_from_config_string(new_config["x"], 8).keys()
 	
 	
 	## Adds one or more carrots to the playfield.
@@ -144,10 +144,10 @@ class AddMolesEffect extends LevelTriggerEffect:
 		if new_config.has("home"):
 			config.home = Utils.enum_from_snake_case(MoleConfig.Home, new_config["home"])
 		if new_config.has("y"):
-			var inverted_lines := ConfigStringUtils.ints_from_config_string(new_config["y"])
+			var inverted_lines := ConfigStringUtils.ints_from_config_string(new_config["y"], 16)
 			config.lines = ConfigStringUtils.invert_puzzle_row_indexes(inverted_lines.keys())
 		if new_config.has("x"):
-			config.columns = ConfigStringUtils.ints_from_config_string(new_config["x"]).keys()
+			config.columns = ConfigStringUtils.ints_from_config_string(new_config["x"], 8).keys()
 		if new_config.has("dig_duration"):
 			config.dig_duration = new_config["dig_duration"].to_int()
 		if new_config.has("reward"):
@@ -203,10 +203,10 @@ class AddSharksEffect extends LevelTriggerEffect:
 		if new_config.has("home"):
 			config.home = Utils.enum_from_snake_case(SharkConfig.Home, new_config["home"])
 		if new_config.has("y"):
-			var inverted_lines := ConfigStringUtils.ints_from_config_string(new_config["y"])
+			var inverted_lines := ConfigStringUtils.ints_from_config_string(new_config["y"], 16)
 			config.lines = ConfigStringUtils.invert_puzzle_row_indexes(inverted_lines.keys())
 		if new_config.has("x"):
-			config.columns = ConfigStringUtils.ints_from_config_string(new_config["x"]).keys()
+			config.columns = ConfigStringUtils.ints_from_config_string(new_config["x"], 8).keys()
 		if new_config.has("patience"):
 			config.patience = new_config["patience"].to_int()
 		if new_config.has("size"):
@@ -265,7 +265,7 @@ class AddSpearsEffect extends LevelTriggerEffect:
 		if new_config.has("wait"):
 			config.wait = new_config["wait"].to_int()
 		if new_config.has("y"):
-			var inverted_lines := ConfigStringUtils.ints_from_config_string(new_config["y"])
+			var inverted_lines := ConfigStringUtils.ints_from_config_string(new_config["y"], 16)
 			config.lines = ConfigStringUtils.invert_puzzle_row_indexes(inverted_lines.keys())
 	
 	
@@ -294,6 +294,8 @@ class AddSpearsEffect extends LevelTriggerEffect:
 
 ## Advances the day/night cycle of any onions on the playfield.
 class AdvanceOnionEffect extends LevelTriggerEffect:
+	func _init() -> void:
+		priority = 86
 	
 	## Advances the day/night cycle of any onions on the playfield.
 	func run() -> void:
@@ -302,6 +304,8 @@ class AdvanceOnionEffect extends LevelTriggerEffect:
 
 ## Advances all moles on the playfield, allowing them to dig up pickups.
 class AdvanceMolesEffect extends LevelTriggerEffect:
+	func _init() -> void:
+		priority = 86
 	
 	## Advances all moles on the playfield, allowing them to dig up pickups.
 	func run() -> void:
@@ -310,6 +314,8 @@ class AdvanceMolesEffect extends LevelTriggerEffect:
 
 ## Advances all sharks on the playfield, making them appear/disappear.
 class AdvanceSharksEffect extends LevelTriggerEffect:
+	func _init() -> void:
+		priority = 86
 	
 	## Advances all sharks on the playfield, making them appear/disappear
 	func run() -> void:
@@ -318,6 +324,8 @@ class AdvanceSharksEffect extends LevelTriggerEffect:
 
 ## Advances all spears on the playfield, making them appear/disappear.
 class AdvanceSpearsEffect extends LevelTriggerEffect:
+	func _init() -> void:
+		priority = 86
 	
 	## Advances all spears on the playfield, making them appear/disappear.
 	func run() -> void:
@@ -327,6 +335,9 @@ class AdvanceSpearsEffect extends LevelTriggerEffect:
 ## Removes one or more carrots from the playfield.
 class RemoveCarrotsEffect extends LevelTriggerEffect:
 	var count := 1
+	
+	func _init() -> void:
+		priority = 53
 	
 	## Updates the effect's configuration.
 	##
@@ -356,6 +367,9 @@ class RemoveCarrotsEffect extends LevelTriggerEffect:
 
 ## Removes the onion from the playfield.
 class RemoveOnionEffect extends LevelTriggerEffect:
+	func _init():
+		priority = 53
+	
 	func run() -> void:
 		CurrentLevel.puzzle.get_onions().remove_onion()
 
@@ -363,6 +377,9 @@ class RemoveOnionEffect extends LevelTriggerEffect:
 ## Removes one or more carrots from the playfield.
 class RemoveSpearsEffect extends LevelTriggerEffect:
 	var count := 1
+	
+	func _init() -> void:
+		priority = 53
 	
 	## Updates the effect's configuration.
 	##
@@ -372,6 +389,7 @@ class RemoveSpearsEffect extends LevelTriggerEffect:
 	##
 	## Example: ["remove_spears 2"]
 	func set_config(new_config: Dictionary = {}) -> void:
+		priority = 53
 		if new_config.has("0"):
 			count = new_config["0"].to_int()
 	

--- a/project/src/main/puzzle/level/level-triggers.gd
+++ b/project/src/main/puzzle/level/level-triggers.gd
@@ -19,7 +19,10 @@ func run_triggers(phase: int, event_params: Dictionary = {}) -> void:
 	if not triggers.has(phase):
 		return
 	
-	for trigger in triggers.get(phase, []):
+	var phase_triggers: Array = triggers.get(phase, []).duplicate()
+	phase_triggers.sort_custom(self, "_compare_by_priority")
+	
+	for trigger in phase_triggers:
 		if trigger.should_run(phase, event_params):
 			trigger.run()
 
@@ -73,3 +76,7 @@ func _add_trigger(trigger: LevelTrigger) -> void:
 	for phase in trigger.phases:
 		Utils.put_if_absent(triggers, phase, [])
 		triggers[phase].append(trigger)
+
+
+func _compare_by_priority(a: LevelTrigger, b: LevelTrigger) -> bool:
+	return a.effect.priority < b.effect.priority

--- a/project/src/test/puzzle/level/test-level-trigger-effects.gd
+++ b/project/src/test/puzzle/level/test-level-trigger-effects.gd
@@ -151,11 +151,16 @@ func test_add_spears_set_config() -> void:
 	assert_eq(effect.config.lines, [])
 	assert_eq(effect.config.sizes, ["x4"])
 	
-	effect = LevelTriggerEffects.create("add_spears", {"count": "5", "duration": "2", "y": "3-5", "sizes": "x2,x4,x6"})
+	effect = LevelTriggerEffects.create("add_spears", {"count": "5", "duration": "2", "y": "3-5", "sizes": "x2,x4,x6",
+			"wait": "3"})
 	assert_eq(effect.config.count, 5)
 	assert_eq(effect.config.duration, 2)
 	assert_eq(effect.config.lines, [16, 15, 14])
 	assert_eq(effect.config.sizes, ["x2", "x4", "x6"])
+	assert_eq(effect.config.wait, 3)
+	
+	effect = LevelTriggerEffects.create("add_spears", {"y": "2,4..."})
+	assert_eq(effect.config.lines, [17, 15, 13, 11, 9, 7, 5, 3])
 
 
 func test_add_spears_get_config() -> void:
@@ -164,8 +169,9 @@ func test_add_spears_get_config() -> void:
 	effect = LevelTriggerEffects.create("add_spears", {})
 	assert_eq_shallow({}, effect.get_config())
 	
-	effect = LevelTriggerEffects.create("add_spears", {"count": "5", "duration": "2", "y": "3-5", "sizes": "x2,x4,x6"})
-	assert_eq_shallow({"count": "5", "duration": "2", "y": "3-5", "sizes": "x2,x4,x6"}, effect.get_config())
+	effect = LevelTriggerEffects.create("add_spears", {"count": "5", "duration": "2", "y": "3-5", "sizes": "x2,x4,x6",
+			"wait": "3"})
+	assert_eq_shallow({"count": "5", "duration": "2", "y": "3-5", "sizes": "x2,x4,x6", "wait": "3"}, effect.get_config())
 
 
 func test_remove_carrots_set_config() -> void:


### PR DESCRIPTION
Added 'priority' field to LevelTriggerEffect. The default priority is
100. Effects with a lower priority happen first. This replaces the old ordering behavior, where effects were fired in the order they were declared in the level file.

Without this priority behavior, some bugs were happening because levels would add a shark before advancing, or vice versa. Now we can define globally, 'remove should happen first, followed by advance, followed by add' regardless of how individual level files are written.

Level critters now support syntax like 'x=1,3...' to only appear in odd numbered columns.

Added missing 'spear.wait' tests