### PR TITLE
Fixed spear timing bug when obliterating a piece.

### DIFF
--- a/project/src/main/puzzle/critter/critter-manager.gd
+++ b/project/src/main/puzzle/critter/critter-manager.gd
@@ -136,18 +136,20 @@ func vertically_relocate_critter(old_cell: Vector2) -> void:
 
 ## Updates the piece manager with the specified piece type, possibly cycling to the next piece.
 ##
-## If all blocks were removed from the specified piece, we cycle to the next piece after a brief pause.
+## If all blocks were removed from the specified piece, we cycle to the next piece.
 func update_piece_manager_piece(new_type: PieceType, new_pos: Vector2, new_orientation: int) -> void:
 	_piece_manager.piece.type = new_type
 	_piece_manager.piece.pos = new_pos
 	_piece_manager.piece.orientation = new_orientation
 	
-	if _piece_manager.piece.type.empty():
+	# If all blocks were removed from a piece while being moved, we manually apply some steps which usually happen
+	# automatically such as pausing and running certain triggers. This occurs when sharks eat an entire piece.
+	if _piece_manager.piece.type.empty() and _piece_manager.get_state() == _piece_manager.states.move_piece:
 		# null piece type only has one orientation
 		_piece_manager.piece.orientation = 0
 		_playfield.add_misc_delay_frames(PieceSpeeds.current_speed.lock_delay)
 		
-		# fire 'piece_written' triggers to ensure sharks get advanced
+		# fire 'piece_written' triggers to ensure critters get advanced
 		CurrentLevel.settings.triggers.run_triggers(LevelTrigger.PIECE_WRITTEN)
 		_piece_manager.set_state(_piece_manager.states.wait_for_playfield)
 


### PR DESCRIPTION
If spears eliminated a player's piece when clearing a line, there was an unnecessarily long piece because this 'add misc_delay_frames' logic was caused, even though there were already delay frames caused by the line clear.

These 'add misc delay frames' and other steps now only occur if the piece is obliterated while still moving.