### PR TITLE
FrameOverworldObstacle improvements: shuffle_frames, initialize

### DIFF
--- a/project/src/main/world/environment/frame-overworld-obstacle.gd
+++ b/project/src/main/world/environment/frame-overworld-obstacle.gd
@@ -11,6 +11,9 @@ export (bool) var flip_h: bool setget set_flip_h
 ## Editor toggle which randomizes the obstacle's appearance
 export (bool) var shuffle: bool setget set_shuffle
 
+## List of frames to allow when shuffling. If omitted, all frames will be used.
+export (Array, int) var shuffle_frames: Array
+
 onready var _sprite := $Sprite
 
 func _ready() -> void:
@@ -19,7 +22,7 @@ func _ready() -> void:
 
 ## Preemptively initializes onready variables to avoid null references.
 func _enter_tree() -> void:
-	_sprite = $Sprite
+	_initialize_onready_variables()
 
 
 func set_frame(new_frame: int) -> void:
@@ -37,16 +40,29 @@ func set_shuffle(value: bool) -> void:
 	if not value:
 		return
 	
-	set_frame(randi() % (_sprite.hframes * _sprite.vframes))
+	var new_frame
+	if shuffle_frames:
+		new_frame = Utils.rand_value(shuffle_frames)
+	else:
+		new_frame = randi() % (_sprite.hframes * _sprite.vframes)
+	
+	set_frame(new_frame)
 	set_flip_h(randf() < 0.5)
 	scale = Vector2.ONE
 	
 	property_list_changed_notify()
 
 
+func _initialize_onready_variables() -> void:
+	_sprite = $Sprite
+
+
 func _refresh() -> void:
 	if not is_inside_tree():
 		return
+	
+	if Engine.editor_hint and not _sprite:
+		_initialize_onready_variables()
 	
 	_sprite.frame = frame
 	_sprite.flip_h = flip_h


### PR DESCRIPTION
Some upcoming obstacles have animations and static images in the same sprite sheet, so we might only want to allow an arbitray set of frames when shuffling.

FrameOverworldObstacle now initializes its onready variables if it detects its sprite is null in the editor. This happens sometimes when editing a tool script.