### PR TITLE
Fixed .tres resource names, malformed critter comments.

### DIFF
--- a/project/src/main/puzzle/critter/moles.gd
+++ b/project/src/main/puzzle/critter/moles.gd
@@ -44,20 +44,18 @@ func set_piece_manager_path(new_piece_manager_path: NodePath) -> void:
 ## 	'config': rules for how many moles to add, where to add them, how long they stay and what they dig.
 func add_moles(config: MoleConfig) -> void:
 	if _playfield.is_clearing_lines():
-		# We don't add moles during line clear events -- the playfield
+		# If moles are being added as a part of line clears, we wait to add moles until all lines are deleted.
 		_call_queue.defer(self, "_inner_add_moles", [config])
 	else:
-		# If moles are being added as a part of line clears, we wait to add moles until all lines are deleted.
 		_inner_add_moles(config)
 
 
 ## Advances all moles by one state.
 func advance_moles() -> void:
 	if _playfield.is_clearing_lines():
-		# We don't add moles during line clear events -- the playfield
+		# If moles are being advanced as a part of line clears, we wait to advance moles until all lines are deleted.
 		_call_queue.defer(self, "_inner_advance_moles", [])
 	else:
-		# If moles are being added as a part of line clears, we wait to add moles until all lines are deleted.
 		_inner_advance_moles()
 
 

--- a/project/src/main/puzzle/critter/sharks.gd
+++ b/project/src/main/puzzle/critter/sharks.gd
@@ -52,10 +52,9 @@ func set_piece_manager_path(new_piece_manager_path: NodePath) -> void:
 ## 	'config': rules for how many sharks to add, where to add them, how long they stay and how much they eat.
 func add_sharks(config: SharkConfig) -> void:
 	if _playfield.is_clearing_lines():
-		# We don't add sharks during line clear events -- the playfield
+		# If sharks are being added as a part of line clears, we wait to add sharks until all lines are deleted.
 		_call_queue.defer(self, "_inner_add_sharks", [config])
 	else:
-		# If sharks are being added as a part of line clears, we wait to add sharks until all lines are deleted.
 		_inner_add_sharks(config)
 
 
@@ -72,9 +71,9 @@ func remove_shark(cell: Vector2) -> void:
 ## Advances all sharks by one state.
 func advance_sharks() -> void:
 	if _playfield.is_clearing_lines():
+		# If sharks are being advanced as a part of line clears, we wait to advance sharks until all lines are deleted.
 		_call_queue.defer(self, "_inner_advance_sharks", [])
 	else:
-		# If sharks are being advanced as a part of line clears, we wait to advance sharks until all lines are deleted.
 		_inner_advance_sharks()
 
 

--- a/project/src/main/puzzle/critter/spears.gd
+++ b/project/src/main/puzzle/critter/spears.gd
@@ -50,7 +50,7 @@ func set_playfield_path(new_playfield_path: NodePath) -> void:
 ## Adds spears in response to a level event.
 func add_spears(config: SpearConfig) -> void:
 	if _playfield.is_clearing_lines():
-		# We don't add spears during line clear events -- the playfield
+		# If spears are being added as a part of line clears, we wait to add spears until all lines are deleted.
 		_call_queue.defer(self, "_inner_add_spears", [config])
 	else:
 		_inner_add_spears(config)
@@ -92,7 +92,7 @@ func set_piece_manager_path(new_piece_manager_path: NodePath) -> void:
 ## Advances all spears by one state.
 func advance_spears() -> void:
 	if _playfield.is_clearing_lines():
-		# We don't advance spears during line clear events -- the playfield
+		# If spears are being advanced as a part of line clears, we wait to advance spears until all lines are deleted.
 		_call_queue.defer(self, "_inner_advance_spears", [])
 	else:
 		_inner_advance_spears()

--- a/project/src/main/puzzle/puzzle-tile-set-onion.tres
+++ b/project/src/main/puzzle/puzzle-tile-set-onion.tres
@@ -6,7 +6,7 @@
 [ext_resource path="res://assets/main/puzzle/blocks/blocks-corners-onion.png" type="Texture" id=4]
 
 [resource]
-0/name = "blocks.png"
+0/name = "blocks-onion.png"
 0/texture = ExtResource( 3 )
 0/tex_offset = Vector2( 0, 0 )
 0/modulate = Color( 1, 1, 1, 1 )
@@ -27,7 +27,7 @@
 0/shape_one_way_margin = 0.0
 0/shapes = [  ]
 0/z_index = 0
-1/name = "blocks-boxes.png"
+1/name = "blocks-boxes-onion.png"
 1/texture = ExtResource( 2 )
 1/tex_offset = Vector2( 0, 0 )
 1/modulate = Color( 1, 1, 1, 1 )
@@ -48,7 +48,7 @@
 1/shape_one_way_margin = 0.0
 1/shapes = [  ]
 1/z_index = 0
-2/name = "blocks-veggie-cubes.png"
+2/name = "blocks-veggie-cubes-onion.png"
 2/texture = ExtResource( 1 )
 2/tex_offset = Vector2( 0, 0 )
 2/modulate = Color( 1, 1, 1, 1 )
@@ -69,7 +69,7 @@
 2/shape_one_way_margin = 0.0
 2/shapes = [  ]
 2/z_index = 0
-3/name = "blocks-corners.png 2"
+3/name = "blocks-corners-onion.png 2"
 3/texture = ExtResource( 4 )
 3/tex_offset = Vector2( 0, 0 )
 3/modulate = Color( 1, 1, 1, 1 )

--- a/project/src/main/puzzle/puzzle-tile-set-veggies.tres
+++ b/project/src/main/puzzle/puzzle-tile-set-veggies.tres
@@ -6,7 +6,7 @@
 [ext_resource path="res://assets/main/puzzle/blocks/blocks-veggie-corners.png" type="Texture" id=4]
 
 [resource]
-0/name = "blocks.png"
+0/name = "blocks-veggies.png"
 0/texture = ExtResource( 3 )
 0/tex_offset = Vector2( 0, 0 )
 0/modulate = Color( 1, 1, 1, 1 )

--- a/project/src/main/world/environment/sand/banana-hq-floor-library.tres
+++ b/project/src/main/world/environment/sand/banana-hq-floor-library.tres
@@ -3,7 +3,7 @@
 [ext_resource path="res://assets/main/world/environment/sand/banana-hq-floor-sheet.png" type="Texture" id=2]
 
 [resource]
-82455/name = "floor-carpet-sheet.png 2"
+82455/name = "banana-hq-floor-sheet.png 2"
 82455/texture = ExtResource( 2 )
 82455/tex_offset = Vector2( 39, 0 )
 82455/modulate = Color( 1, 1, 1, 1 )


### PR DESCRIPTION
A few scripts had names like 'blocks.png' for resources like 'blocks-veggies.png'.

A few critter scripts had nonsensical comments like 'We don't add moles during line clear events -- the playfield'