### PR TITLE
Sfx bus fixes: master bus mistakes, voice/sfx

### DIFF
--- a/project/src/main/editor/creature/CreatureEditor.tscn
+++ b/project/src/main/editor/creature/CreatureEditor.tscn
@@ -1269,10 +1269,12 @@ script = ExtResource( 7 )
 [node name="HoverSound" type="AudioStreamPlayer" parent="Ui/CreatureSelector"]
 stream = ExtResource( 9 )
 volume_db = -8.0
+bus = "Sound Bus"
 
 [node name="ClickSound" type="AudioStreamPlayer" parent="Ui/CreatureSelector"]
 stream = ExtResource( 16 )
 volume_db = -4.0
+bus = "Sound Bus"
 
 [node name="Settings" type="Button" parent="Ui"]
 margin_left = 839.0

--- a/project/src/main/puzzle/Playfield.tscn
+++ b/project/src/main/puzzle/Playfield.tscn
@@ -160,26 +160,32 @@ anchor_bottom = 1.0
 [node name="PickupSfx0" type="AudioStreamPlayer" parent="TileMapClip/Pickups"]
 stream = ExtResource( 28 )
 pitch_scale = 0.5
+bus = "Sound Bus"
 
 [node name="PickupSfx1" type="AudioStreamPlayer" parent="TileMapClip/Pickups"]
 stream = ExtResource( 28 )
 pitch_scale = 0.54
+bus = "Sound Bus"
 
 [node name="PickupSfx2" type="AudioStreamPlayer" parent="TileMapClip/Pickups"]
 stream = ExtResource( 28 )
 pitch_scale = 0.58
+bus = "Sound Bus"
 
 [node name="PickupSfx3" type="AudioStreamPlayer" parent="TileMapClip/Pickups"]
 stream = ExtResource( 28 )
 pitch_scale = 0.62
+bus = "Sound Bus"
 
 [node name="PickupSfx4" type="AudioStreamPlayer" parent="TileMapClip/Pickups"]
 stream = ExtResource( 28 )
 pitch_scale = 0.66
+bus = "Sound Bus"
 
 [node name="PickupSfx5" type="AudioStreamPlayer" parent="TileMapClip/Pickups"]
 stream = ExtResource( 28 )
 pitch_scale = 0.7
+bus = "Sound Bus"
 
 [node name="CollectSfxTimer" type="Timer" parent="TileMapClip/Pickups"]
 wait_time = 0.04

--- a/project/src/main/puzzle/critter/Mole.tscn
+++ b/project/src/main/puzzle/critter/Mole.tscn
@@ -561,15 +561,19 @@ script = ExtResource( 12 )
 [node name="Poof" type="AudioStreamPlayer" parent="MoleSfx"]
 stream = ExtResource( 13 )
 volume_db = -4.0
+bus = "Sound Bus"
 
 [node name="Dig0" type="AudioStreamPlayer" parent="MoleSfx"]
 stream = ExtResource( 14 )
+bus = "Sound Bus"
 
 [node name="Dig1" type="AudioStreamPlayer" parent="MoleSfx"]
 stream = ExtResource( 14 )
+bus = "Sound Bus"
 
 [node name="Found" type="AudioStreamPlayer" parent="MoleSfx"]
 stream = ExtResource( 15 )
 volume_db = -4.0
+bus = "Sound Bus"
 
 [connection signal="animation_finished" from="Poof" to="." method="_on_Poof_animation_finished"]

--- a/project/src/main/puzzle/critter/Shark.tscn
+++ b/project/src/main/puzzle/critter/Shark.tscn
@@ -1372,25 +1372,31 @@ script = ExtResource( 2 )
 [node name="Bite" type="AudioStreamPlayer" parent="SharkSfx"]
 stream = ExtResource( 27 )
 volume_db = -4.0
+bus = "Sound Bus"
 
 [node name="Eat" type="AudioStreamPlayer" parent="SharkSfx"]
 stream = ExtResource( 25 )
 volume_db = -12.0
+bus = "Sound Bus"
 
 [node name="Poof" type="AudioStreamPlayer" parent="SharkSfx"]
 stream = ExtResource( 11 )
 volume_db = -4.0
+bus = "Sound Bus"
 
 [node name="Squish" type="AudioStreamPlayer" parent="SharkSfx"]
 stream = ExtResource( 24 )
+bus = "Sound Bus"
 
 [node name="VoiceFriendly" type="AudioStreamPlayer" parent="SharkSfx"]
 stream = ExtResource( 23 )
 volume_db = -4.0
+bus = "Sound Bus"
 
 [node name="VoiceShort" type="AudioStreamPlayer" parent="SharkSfx"]
 stream = ExtResource( 26 )
 volume_db = -4.0
+bus = "Sound Bus"
 
 [connection signal="finished_eating" from="ToothCloud" to="." method="_on_ToothCloud_finished_eating"]
 [connection signal="timeout" from="ToothCloud/CloudTimer" to="ToothCloud" method="_on_CloudTimer_timeout"]

--- a/project/src/main/puzzle/critter/SpearWide.tscn
+++ b/project/src/main/puzzle/critter/SpearWide.tscn
@@ -291,9 +291,11 @@ wide = true
 [node name="Poof" type="AudioStreamPlayer" parent="SpearSfx"]
 stream = ExtResource( 22 )
 volume_db = -8.0
+bus = "Sound Bus"
 
 [node name="Pop" type="AudioStreamPlayer" parent="SpearSfx"]
 stream = ExtResource( 8 )
+bus = "Sound Bus"
 
 [node name="VoiceWarn" type="AudioStreamPlayer" parent="SpearSfx"]
 stream = ExtResource( 28 )

--- a/project/src/main/puzzle/piece/PieceManager.tscn
+++ b/project/src/main/puzzle/piece/PieceManager.tscn
@@ -115,6 +115,7 @@ autostart = true
 [node name="PresquishSfx" type="AudioStreamPlayer" parent="SquishFx"]
 stream = ExtResource( 25 )
 script = ExtResource( 24 )
+bus = "Sound Bus"
 
 [node name="States" parent="." instance=ExtResource( 35 )]
 script = ExtResource( 19 )

--- a/project/src/main/utils/SceneTransition.tscn
+++ b/project/src/main/utils/SceneTransition.tscn
@@ -200,3 +200,4 @@ anims/fade-out = SubResource( 4 )
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 5 )
 volume_db = -80.0
+bus = "Sound Bus"

--- a/project/src/main/world/creature/Creature.tscn
+++ b/project/src/main/world/creature/Creature.tscn
@@ -355,7 +355,7 @@ volume_db = 6.0
 bus = "Voice Bus"
 
 [node name="MunchSound" type="AudioStreamPlayer" parent="CreatureSfx"]
-bus = "Voice Bus"
+bus = "Sound Bus"
 
 [node name="HopSound" type="AudioStreamPlayer2D" parent="CreatureSfx"]
 stream = ExtResource( 7 )

--- a/project/src/main/world/environment/restaurant/TurboFatRestaurant.tscn
+++ b/project/src/main/world/environment/restaurant/TurboFatRestaurant.tscn
@@ -51,3 +51,4 @@ shape = SubResource( 2 )
 [node name="PoofInSfx" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 7 )
 volume_db = -4.0
+bus = "Sound Bus"


### PR DESCRIPTION
Added missing sound bus settings for things like pickups, level editors, and creature 'poofs'. These were going directly to the master bus instead of the sfx bus.

Changed creature 'eat' sound from voice bus to sfx bus. I'm not sure whether anybody would just want to mute voice sounds -- but if they did, I think it would be because they don't like the silly voices. So I'm using the voice bus just for the silly voices, and sound effects go to the sfx bus -- even things like bite/chew noises, and voices for the little puzzle critters (which often have a gameplay effect.)