### PR TITLE
Path traversal logic now ignores .gitkeep

### DIFF
--- a/project/src/main/career/career-cutscene-library.gd
+++ b/project/src/main/career/career-cutscene-library.gd
@@ -501,7 +501,10 @@ static func _find_resource_paths(path: String) -> Array:
 	var dir: Directory
 	var file: String
 	while true:
-		if file:
+		if file and file.begins_with("."):
+			# ignore .gitkeep
+			pass
+		elif file:
 			var resource_path := "%s/%s" % [dir.get_current_dir(), file.get_file()]
 			if dir.current_is_dir():
 				dir_queue.append(resource_path)

--- a/project/src/main/utils/resource-cache.gd
+++ b/project/src/main/utils/resource-cache.gd
@@ -282,7 +282,10 @@ func _find_resource_paths() -> Array:
 	var dir: Directory
 	var file: String
 	while true:
-		if file:
+		if file and file.begins_with("."):
+			# ignore .gitkeep
+			pass
+		elif file:
 			var resource_path: String
 			if file.ends_with(".import"):
 				resource_path = "%s/%s" % [dir.get_current_dir(), file.get_basename()]


### PR DESCRIPTION
I'd like to write some test scenarios which have empty folders, but this is impossible because of limitations of Git. I'm modifying our path traversal logic to ignore gitkeep files, so that our test scenarios will work even if they have a '.gitkeep' folder and won't do something silly like look for a '.gitkeep cutscene'