### PR TITLE
Fixed shark crashes related to PieceWritten trigger, piece orientation

### DIFF
--- a/project/assets/demo/puzzle/levels/experiment.json
+++ b/project/assets/demo/puzzle/levels/experiment.json
@@ -1,20 +1,23 @@
 {
   "version": "4c5c",
-  "start_speed": "0",
   "name": "Experiment",
   "description": "Just goofing around",
   "finish_condition": {
     "type": "time_over",
-    "value": "900"
+    "value": 900
   },
-  "piece_types": [
-    "piece_c",
-    "piece_j",
-    "piece_k",
-    "piece_l",
-    "piece_p",
-    "piece_q",
-    "piece_t",
-    "piece_u"
+  "triggers": [
+    {
+      "phases": [
+        "piece_written"
+      ],
+      "effect": "add_sharks size=large patience=2"
+    },
+    {
+      "phases": [
+        "piece_written"
+      ],
+      "effect": "advance_sharks"
+    }
   ]
 }

--- a/project/src/demo/puzzle/PuzzleDemo.tscn
+++ b/project/src/demo/puzzle/PuzzleDemo.tscn
@@ -5,6 +5,6 @@
 
 [node name="PuzzleDemo" type="Node"]
 script = ExtResource( 2 )
-level_path = "res://assets/test/puzzle/levels/level-49db.json"
+level_path = "res://assets/demo/puzzle/levels/experiment.json"
 
 [node name="Puzzle" parent="." instance=ExtResource( 1 )]

--- a/project/src/main/puzzle/critter/critter-manager.gd
+++ b/project/src/main/puzzle/critter/critter-manager.gd
@@ -134,19 +134,22 @@ func vertically_relocate_critter(old_cell: Vector2) -> void:
 		remove_critter(old_cell)
 
 
-## Updates the piece manager with the specified piece type, possibly cycling to the next piece.
+## Updates the piece manager with the specified piece type.
 ##
-## If all blocks were removed from the specified piece, we cycle to the next piece.
+## check_for_empty_piece() should be called afterwards to cycle to the next piece if the new piece is empty. It is not
+## called here to avoid edge cases where we'd cycle prematurely or fire triggers at bad times.
 func update_piece_manager_piece(new_type: PieceType, new_pos: Vector2, new_orientation: int) -> void:
 	_piece_manager.piece.type = new_type
 	_piece_manager.piece.pos = new_pos
-	_piece_manager.piece.orientation = new_orientation
 	
-	# If all blocks were removed from a piece while being moved, we manually apply some steps which usually happen
-	# automatically such as pausing and running certain triggers. This occurs when sharks eat an entire piece.
+	# The null piece type only has one orientation. Illegal orientations can cause errors.
+	_piece_manager.piece.orientation = new_orientation % _piece_manager.piece.type.pos_arr.size()
+
+
+## If all blocks were removed from a piece while being moved, we manually apply some steps which usually happen
+## automatically such as pausing and running certain triggers. This occurs when sharks eat an entire piece.
+func check_for_empty_piece() -> void:
 	if _piece_manager.piece.type.empty() and _piece_manager.get_state() == _piece_manager.states.move_piece:
-		# null piece type only has one orientation
-		_piece_manager.piece.orientation = 0
 		_playfield.add_misc_delay_frames(PieceSpeeds.current_speed.lock_delay)
 		
 		# fire 'piece_written' triggers to ensure critters get advanced

--- a/project/src/main/puzzle/critter/spears.gd
+++ b/project/src/main/puzzle/critter/spears.gd
@@ -443,6 +443,7 @@ func _check_for_speared_piece(spear: Spear) -> void:
 		# The piece was speared. Update the piece manager with the new piece type, possibly cycling to the next piece.
 		spear.emit_crumbs(crumb_colors.keys(), 0)
 		_critter_manager.update_piece_manager_piece(new_type, new_pos, new_orientation)
+		_critter_manager.check_for_empty_piece()
 
 
 ## Removes veggie cells from the playfield for the specified spear.


### PR DESCRIPTION
The PieceWritten trigger fires when a shark eats a piece. This trigger can cause level effects like inserting lines, and moving sharks, which then was causing crashes (for sharks that could not be found) or graphical oddities (for sharks that moved)

The PieceWritten trigger now only fires after all sharks eat.

Eating a piece with a non-zero orientation was causing crashes in some cases. I've moved the check to 'UpdatePieceManagerPiece' so that a null piece will never have a non-zero orientation.