### PR TITLE
Increment attempt count at start; not end

### DIFF
--- a/project/src/main/puzzle/puzzle-messages.gd
+++ b/project/src/main/puzzle/puzzle-messages.gd
@@ -29,6 +29,8 @@ func _ready() -> void:
 		# they can't go back in career mode
 		_back_button.text = tr("Skip")
 	
+	_refresh_start_button(0)
+	
 	# grab focus so the player can start a new game or navigate with the keyboard
 	_start_button.grab_focus()
 
@@ -61,14 +63,14 @@ func hide_buttons() -> void:
 
 
 ## Updates the start button's text after the player finishes the level.
-func _refresh_start_button() -> void:
+func _refresh_start_button(new_attempt_count: int) -> void:
 	if PlayerData.career.is_career_mode():
-		match CurrentLevel.attempt_count:
+		match new_attempt_count:
 			0: _start_button.text = tr("Start")
 			1: _start_button.text = tr("Practice")
 			_: _start_button.text = tr("Retry")
 	else:
-		match CurrentLevel.attempt_count:
+		match new_attempt_count:
 			0: _start_button.text = tr("Start")
 			_: _start_button.text = tr("Retry")
 
@@ -162,7 +164,7 @@ func _on_PuzzleState_after_game_ended() -> void:
 	if PlayerData.career.is_career_mode():
 		# in career mode, the back (continue) button is the default. but after retrying in career mode, the default
 		# is to retry
-		if CurrentLevel.attempt_count >= 2:
+		if CurrentLevel.attempt_count >= 1:
 			buttons_to_focus.push_front(_start_button)
 	elif CurrentLevel.keep_retrying:
 		buttons_to_focus.push_front(_start_button)
@@ -170,7 +172,7 @@ func _on_PuzzleState_after_game_ended() -> void:
 		buttons_to_focus.push_front(_start_button)
 	
 	# update the start button's text after the player finishes the level
-	_refresh_start_button()
+	_refresh_start_button(CurrentLevel.attempt_count + 1)
 	
 	# grab focus so the player can retry or navigate with the keyboard
 	for button_to_focus_obj in buttons_to_focus:

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -6,6 +6,9 @@ onready var _restaurant_view: RestaurantView = $Fg/RestaurantView
 onready var _settings_menu: SettingsMenu = $SettingsMenu
 onready var _night_mode_toggler: NightModeToggler = $NightModeToggler
 
+## Number of time the player has started the puzzle.
+var _start_puzzle_count := 0
+
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
 	MusicPlayer.play_chill_bgm()
@@ -156,6 +159,10 @@ func is_night_mode() -> bool:
 
 ## Starts or restarts the puzzle, loading new customers and preparing the level.
 func _start_puzzle() -> void:
+	# increment the attempt count
+	_start_puzzle_count += 1
+	CurrentLevel.attempt_count = _start_puzzle_count - 1
+	
 	PlayerData.customer_queue.reset_standard_customer_queue()
 	var current_customer_ids := []
 	_restaurant_view.reset()
@@ -270,7 +277,6 @@ func _save_level_result(rank_result: RankResult) -> void:
 	if PlayerData.career.is_career_mode() and CurrentLevel.attempt_count == 0:
 		_update_career_data(rank_result)
 	CurrentLevel.best_result = max(CurrentLevel.best_result, PuzzleState.end_result())
-	CurrentLevel.attempt_count += 1
 	
 	PlayerSave.schedule_save()
 


### PR DESCRIPTION
CurrentLevel.attempt_count is now incremented at the start of a puzzle, not at the end. Before, attempt_count was '1' after finishing a puzzle which made it more difficult to code in the 'persistent lives' logic.