### PR TITLE
Career mode preserves lives lost.

### DIFF
--- a/project/assets/main/puzzle/levels/career/creeping-crevice-2.json
+++ b/project/assets/main/puzzle/levels/career/creeping-crevice-2.json
@@ -13,9 +13,6 @@
   "rank": [
     "box_factor 0.80"
   ],
-  "lose_condition": [
-    "top_out 2"
-  ],
   "triggers": [
     {
       "phases": [

--- a/project/src/main/career/career-calendar.gd
+++ b/project/src/main/career/career-calendar.gd
@@ -18,7 +18,9 @@ func _init(init_career_data: CareerData) -> void:
 ## 	'new_distance_earned': The maximum distance the player will travel.
 ##
 ## 	'success': 'True' if the player met the success criteria for the current level.
-func advance_clock(new_distance_earned: int, success: bool) -> void:
+##
+## 	'lost': 'True' if the player gave up or lost all their lives.
+func advance_clock(new_distance_earned: int, success: bool, lost: bool) -> void:
 	if career_data.remain_in_region:
 		# don't show progress; the player is not trying to beat the region
 		pass
@@ -29,7 +31,10 @@ func advance_clock(new_distance_earned: int, success: bool) -> void:
 	career_data.distance_earned = new_distance_earned
 	career_data.skipped_previous_level = false
 	
-	career_data.hours_passed += 1
+	if lost:
+		career_data.hours_passed = Careers.HOURS_PER_CAREER_DAY
+	else:
+		career_data.hours_passed += 1
 	
 	if career_data.is_boss_level():
 		var region: CareerRegion = career_data.current_region()
@@ -78,6 +83,7 @@ func advance_calendar() -> void:
 	career_data.daily_seconds_played = 0.0
 	career_data.daily_steps = 0
 	career_data.day = min(career_data.day + 1, Careers.MAX_DAY)
+	career_data.top_out_count = 0
 	
 	# Put the player at the start of their current region and trigger the 'distance_travelled_changed' signal
 	career_data.distance_travelled = career_data.current_region().start

--- a/project/src/main/career/career-data.gd
+++ b/project/src/main/career/career-data.gd
@@ -84,6 +84,9 @@ var skipped_previous_level := false
 ## Whether the career map should show the player's progress.
 var show_progress: int = Careers.ShowProgress.STATIC
 
+## Number of times the player has topped out in the current career session.
+var top_out_count := 0
+
 ## periodically increments the 'daily_seconds_played' value
 var _daily_seconds_played_timer: Timer
 
@@ -124,6 +127,7 @@ func reset() -> void:
 	best_distance_travelled = 0
 	remain_in_region = false
 	skipped_previous_level = false
+	top_out_count = 0
 	emit_signal("distance_travelled_changed")
 
 
@@ -143,6 +147,7 @@ func from_json_dict(json: Dictionary) -> void:
 	best_distance_travelled = int(json.get("best_distance_travelled", 0))
 	remain_in_region = bool(json.get("remain_in_region", false))
 	skipped_previous_level = bool(json.get("skipped_previous_level", false))
+	top_out_count = int(json.get("top_out_count", 0))
 	emit_signal("distance_travelled_changed")
 
 
@@ -163,6 +168,7 @@ func to_json_dict() -> Dictionary:
 	results["best_distance_travelled"] = best_distance_travelled
 	results["remain_in_region"] = remain_in_region
 	results["skipped_previous_level"] = skipped_previous_level
+	results["top_out_count"] = top_out_count
 	return results
 
 
@@ -315,8 +321,10 @@ func distance_penalties() -> Array:
 ## 	'new_distance_earned': The maximum distance the player will travel.
 ##
 ## 	'success': 'True' if the player met the success criteria for the current level.
-func advance_clock(new_distance_earned: int, success: bool) -> void:
-	_career_calendar.advance_clock(new_distance_earned, success)
+##
+## 	'lost': 'True' if the player gave up or lost all their lives.
+func advance_clock(new_distance_earned: int, success: bool, lost: bool) -> void:
+	_career_calendar.advance_clock(new_distance_earned, success, lost)
 
 
 ## Advances the calendar day and resets all daily variables.

--- a/project/src/main/career/career-flow.gd
+++ b/project/src/main/career/career-flow.gd
@@ -51,7 +51,7 @@ func process_puzzle_result() -> void:
 	if not PuzzleState.game_ended:
 		# player skipped a level
 		skip_remaining_cutscenes = true
-		career_data.advance_clock(0, false)
+		career_data.advance_clock(0, false, false)
 		career_data.skipped_previous_level = true
 	
 	if PlayerData.cutscene_queue.has_cutscene_flag("intro_level") \
@@ -85,27 +85,20 @@ func _preapply_failure_penalties() -> void:
 	
 	if PlayerSave.is_connected("after_save", self, "_on_PlayerSave_after_save"):
 		PlayerSave.disconnect("after_save", self, "_on_PlayerSave_after_save")
-	PlayerSave.connect("after_save", self, "_on_PlayerSave_after_save",
-			[career_data.distance_earned, career_data.distance_travelled, career_data.hours_passed])
+	PlayerSave.connect("after_save", self, "_on_PlayerSave_after_save", [career_data.hours_passed])
 	
 	PlayerSave.schedule_save()
 
 
 func _on_PlayerSave_before_save() -> void:
 	# Temporarily sabotage the player's career progress to punish them if they try to savescum when losing a puzzle.
-	career_data.advance_clock(0, false)
-	
-	# Set the 'skipped_previous_level' flag; this will be reset to false if the player finishes a puzzle.
-	career_data.skipped_previous_level = true
+	career_data.hours_passed = Careers.HOURS_PER_CAREER_DAY
 	
 	PlayerSave.disconnect("before_save", self, "_on_PlayerSave_before_save")
 
 
-func _on_PlayerSave_after_save(distance_earned: int, distance_travelled: int, hours_passed: int) -> void:
-	# Restore the player's distance earned, distance travelled and hours passed. The 'skipped_previous_level' flag is
-	# still set to true; this is reset to false after the player finishes a puzzle.
-	career_data.distance_earned = distance_earned
-	career_data.distance_travelled = distance_travelled
+func _on_PlayerSave_after_save(hours_passed: int) -> void:
+	# Restore the player's hours passed.
 	career_data.hours_passed = hours_passed
 	
 	PlayerSave.disconnect("after_save", self, "_on_PlayerSave_after_save")

--- a/project/src/main/puzzle/pan/puzzle-frying-pans-ui.gd
+++ b/project/src/main/puzzle/pan/puzzle-frying-pans-ui.gd
@@ -15,6 +15,13 @@ func _refresh_lives() -> void:
 		pans_remaining = 0
 	else:
 		pans_remaining = CurrentLevel.settings.lose_condition.top_out - PuzzleState.level_performance.top_out_count
+		
+		if PlayerData.career.is_career_mode() and CurrentLevel.attempt_count == 0:
+			pans_remaining = int(max(0, pans_remaining - PlayerData.career.top_out_count))
+			if pans_remaining == 0 and PuzzleState.level_performance.top_out_count == 0:
+				# the player always starts with at least one life in career mode, even if they've topped out a lot on
+				# previous levels
+				pans_remaining = 1
 	gold = CurrentLevel.settings.blocks_during.clear_on_top_out
 	refresh_tilemap()
 

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -186,7 +186,15 @@ func apply_top_out_score_penalty() -> void:
 ##
 ## If the player is not out of lives, the game will still continue.
 func top_out() -> void:
-	if level_performance.top_out_count + 1 >= CurrentLevel.settings.lose_condition.top_out:
+	var lost_last_life := false
+	if PlayerData.career.is_career_mode() and CurrentLevel.attempt_count == 0:
+		lost_last_life = level_performance.top_out_count + PlayerData.career.top_out_count + 1 \
+				>= CurrentLevel.settings.lose_condition.top_out
+	else:
+		lost_last_life = level_performance.top_out_count + 1 \
+				>= CurrentLevel.settings.lose_condition.top_out
+	
+	if lost_last_life:
 		PuzzleState.level_performance.top_out_count += 1
 		make_player_lose()
 	else:
@@ -212,6 +220,8 @@ func make_player_lose() -> void:
 		
 		# trigger the visual effects for topping out, such as making the player go swirly eyed
 		apply_top_out_score_penalty()
+		# use up all of the players lives; especially for career mode, we don't want to reward players who give up
+		PuzzleState.level_performance.top_out_count = CurrentLevel.settings.lose_condition.top_out
 		emit_signal("topped_out")
 		emit_signal("score_changed")
 	end_game()

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -68,6 +68,8 @@ func _input(event: InputEvent) -> void:
 				PuzzleState.game_active = false
 				PuzzleState.game_ended = true
 				PuzzleState.apply_top_out_score_penalty()
+				# use up all of the players lives; especially for career mode, we don't want to reward players who give up
+				PuzzleState.level_performance.top_out_count = CurrentLevel.settings.lose_condition.top_out
 			if PlayerData.career.is_career_mode() and CurrentLevel.attempt_count == 0:
 				PuzzleState.end_game()
 			var rank_result := RankCalculator.new().calculate_rank()
@@ -263,7 +265,8 @@ func _update_career_data(rank_result: RankResult) -> void:
 	var distance_to_advance: int = Careers.RANK_MILESTONES[milestone_index].distance
 	
 	PlayerData.career.daily_steps += distance_to_advance
-	PlayerData.career.advance_clock(distance_to_advance, rank_result.success)
+	PlayerData.career.top_out_count += PuzzleState.level_performance.top_out_count
+	PlayerData.career.advance_clock(distance_to_advance, rank_result.success, rank_result.lost)
 
 
 ## Stores the rank result for later.

--- a/project/src/test/world/test-career-data.gd
+++ b/project/src/test/world/test-career-data.gd
@@ -35,7 +35,7 @@ func test_prev_daily_earnings() -> void:
 
 func test_advance_clock_stops_at_boss_level_0() -> void:
 	_data.best_distance_travelled = 0
-	_data.advance_clock(50, false)
+	_data.advance_clock(50, false, false)
 	assert_eq(_data.distance_earned, 50)
 	assert_eq(_data.distance_travelled, 9)
 	assert_eq(_data.banked_steps, 41)
@@ -44,7 +44,7 @@ func test_advance_clock_stops_at_boss_level_0() -> void:
 func test_advance_clock_stops_at_boss_level_1() -> void:
 	_data.best_distance_travelled = 0
 	_data.distance_travelled = 8 # just before a boss level
-	_data.advance_clock(3, true)
+	_data.advance_clock(3, true, false)
 	assert_eq(_data.distance_earned, 3)
 	assert_eq(_data.distance_travelled, 9)
 	assert_eq(_data.banked_steps, 2)
@@ -53,7 +53,7 @@ func test_advance_clock_stops_at_boss_level_1() -> void:
 func test_advance_clock_clears_boss_level() -> void:
 	_data.best_distance_travelled = 0
 	_data.distance_travelled = 9 # boss level
-	_data.advance_clock(4, true)
+	_data.advance_clock(4, true, false)
 	assert_eq(_data.distance_earned, 4)
 	assert_eq(_data.distance_travelled, 10)
 	assert_eq(_data.banked_steps, 3)
@@ -62,7 +62,7 @@ func test_advance_clock_clears_boss_level() -> void:
 func test_advance_clock_fails_boss_level() -> void:
 	_data.best_distance_travelled = 0
 	_data.distance_travelled = 9 # boss level
-	_data.advance_clock(4, false)
+	_data.advance_clock(4, false, false)
 	assert_true(_data.distance_earned < 0,
 			"distance_earned should be less than 0 but was %s" % [_data.distance_earned])
 	assert_true(_data.distance_travelled < 9,
@@ -75,7 +75,7 @@ func test_advance_clock_stops_at_unbeaten_intro_level() -> void:
 	
 	PlayerData.level_history.delete_results("intro_311")
 	
-	_data.advance_clock(50, false)
+	_data.advance_clock(50, false, false)
 	assert_eq(_data.distance_earned, 50)
 	assert_eq(_data.distance_travelled, 10)
 	assert_eq(_data.banked_steps, 40)
@@ -88,7 +88,7 @@ func test_advance_clock_stops_at_beaten_intro_level() -> void:
 	var result := RankResult.new()
 	PlayerData.level_history.add_result("intro_311", result)
 	
-	_data.advance_clock(50, false)
+	_data.advance_clock(50, false, false)
 	assert_eq(_data.distance_earned, 50)
 	assert_eq(_data.distance_travelled, 10)
 	assert_eq(_data.banked_steps, 40)
@@ -99,7 +99,7 @@ func test_advance_clock_clears_intro_level() -> void:
 	_data.best_distance_travelled = 10
 	_data.banked_steps = 5
 	
-	_data.advance_clock(1, false)
+	_data.advance_clock(1, false, false)
 	assert_eq(_data.distance_earned, 6)
 	assert_eq(_data.distance_travelled, 16)
 	assert_eq(_data.banked_steps, 0)
@@ -110,7 +110,7 @@ func test_advance_clock_fails_intro_level() -> void:
 	_data.best_distance_travelled = 10
 	_data.banked_steps = 5
 	
-	_data.advance_clock(0, false)
+	_data.advance_clock(0, false, false)
 	assert_eq(_data.distance_earned, 0)
 	assert_eq(_data.distance_travelled, 10)
 	assert_eq(_data.banked_steps, 5)
@@ -120,7 +120,7 @@ func test_advance_clock_banked_steps_for_failed_boss_level() -> void:
 	_data.best_distance_travelled = 0
 	_data.banked_steps = 5
 	_data.distance_travelled = 9 # boss level
-	_data.advance_clock(4, false)
+	_data.advance_clock(4, false, false)
 	assert_true(_data.distance_earned < 0,
 			"distance_earned should be less than 0 but was %s" % [_data.distance_earned])
 	assert_eq(_data.banked_steps, 5)
@@ -128,15 +128,20 @@ func test_advance_clock_banked_steps_for_failed_boss_level() -> void:
 
 func test_advance_clock_banked_steps_for_failed_level() -> void:
 	_data.banked_steps = 5
-	_data.advance_clock(0, false)
+	_data.advance_clock(0, false, false)
 	assert_eq(_data.distance_earned, 0)
 	assert_eq(_data.distance_travelled, 0)
 	assert_eq(_data.banked_steps, 5)
 
 
+func test_advance_clock_lost_level() -> void:
+	_data.advance_clock(0, false, true)
+	assert_eq(_data.hours_passed, Careers.HOURS_PER_CAREER_DAY)
+
+
 func test_advance_clock_banked_steps_for_finished_level() -> void:
 	_data.banked_steps = 5
-	_data.advance_clock(1, false)
+	_data.advance_clock(1, false, false)
 	assert_eq(_data.distance_earned, 6)
 	assert_eq(_data.distance_travelled, 6)
 	assert_eq(_data.banked_steps, 0)


### PR DESCRIPTION
If the player tops out, they'll have one less life for the rest of the career session. If they lose all their lives, the session ends. They always start with at least one life, even if they've previously lost more lives than the current level allows.

The penalty for save scumming is now that the career day immediately ends, instead of skipping forward an hour.