### PR TITLE
'puzzle_environment' flag; Zagma puzzle environment

### DIFF
--- a/project/assets/main/puzzle/career-regions.json
+++ b/project/assets/main/puzzle/career-regions.json
@@ -459,10 +459,12 @@
       "piece_speed": "6-9",
       "cutscene_path": "chat/career/lava",
       "boss_level": {
-        "id": "career/boss_1k"
+        "id": "career/boss_1k",
+        "puzzle_environment": "lava/zagma"
       },
       "intro_level": {
-        "id": "career/nice_and_cheesy"
+        "id": "career/nice_and_cheesy",
+        "puzzle_environment": "lava/zagma"
       },
       "levels": [
         {

--- a/project/src/main/career/career-level.gd
+++ b/project/src/main/career/career-level.gd
@@ -6,10 +6,11 @@ const NONQUIRKY_CUSTOMER := "#nonquirky_customer#"
 
 var level_id: String
 
-## Some levels involve specific chefs, customers or observers.
+## Some levels involve specific chefs, customers, observers or puzzle environments.
 var chef_id: String
 var customer_ids: Array
 var observer_id: String
+var puzzle_environment_name: String
 
 ## Boolean condition which enables this level, such as 'chat_finished chat/career/marsh/030_c_end'
 var available_if: String
@@ -21,4 +22,6 @@ func from_json_dict(json: Dictionary) -> void:
 	for i in range(customer_ids.size()):
 		customer_ids[i] = StringUtils.hashwrap_constants(customer_ids[i])
 	observer_id = StringUtils.hashwrap_constants(json.get("observer_id", ""))
+	puzzle_environment_name = json.get("puzzle_environment", "")
 	available_if = json.get("available_if", "")
+ 

--- a/project/src/main/chat/chat-tree.gd
+++ b/project/src/main/chat/chat-tree.gd
@@ -81,6 +81,10 @@ var customer_ids: Array
 ## cutscenes.
 var observer_id: String
 
+## Puzzle environment applicable to this cutscene, if any. A cutscene might take place at another restaurant for
+## example, in which case the puzzle should happen in that restaurant as well.
+var puzzle_environment_name: String
+
 ## Creatures in this cutscene.
 var creature_ids: Array
 
@@ -186,6 +190,7 @@ func reset() -> void:
 	chef_id = ""
 	customer_ids = []
 	observer_id = ""
+	puzzle_environment_name = ""
 	creature_ids = []
 	_position.reset()
 	_did_prepare = false

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -190,6 +190,8 @@ func _new_level_posse(level_index: int) -> LevelPosse:
 			level_posse.customer_ids = chat_tree.customer_ids.duplicate()
 		if chat_tree.observer_id:
 			level_posse.observer_id = chat_tree.observer_id
+		if chat_tree.puzzle_environment_name:
+			level_posse.puzzle_environment_name = chat_tree.puzzle_environment_name
 	
 	# add customers/chefs from the level if the cutscene doesn't define any
 	if not level_posse.chef_id:
@@ -198,6 +200,8 @@ func _new_level_posse(level_index: int) -> LevelPosse:
 		level_posse.customer_ids = career_level.customer_ids.duplicate()
 	if not level_posse.observer_id:
 		level_posse.observer_id = career_level.observer_id
+	if not level_posse.puzzle_environment_name:
+		level_posse.puzzle_environment_name = career_level.puzzle_environment_name
 	
 	# add customers/chefs from the region if the level doesn't define any
 	var region := PlayerData.career.current_region()
@@ -213,6 +217,8 @@ func _new_level_posse(level_index: int) -> LevelPosse:
 		var observer: Population.CreatureAppearance = region.population.random_observer()
 		if observer:
 			level_posse.observer_id = observer.id
+	if not level_posse.puzzle_environment_name:
+		level_posse.puzzle_environment_name = region.puzzle_environment_name
 	
 	return level_posse
 
@@ -282,12 +288,12 @@ func _on_LevelSelectButton_level_chosen(level_index: int) -> void:
 	
 	PlayerData.career.daily_level_ids.append(level_settings.id)
 	CurrentLevel.set_launched_level(level_settings.id)
-	CurrentLevel.puzzle_environment_name = PlayerData.career.current_region().puzzle_environment_name
 	CurrentLevel.piece_speed = _piece_speed
 	
 	var level_posse: LevelPosse = _level_posses[level_index]
 	CurrentLevel.customers = level_posse.customer_ids
 	CurrentLevel.chef_id = level_posse.chef_id
+	CurrentLevel.puzzle_environment_name = level_posse.puzzle_environment_name
 	
 	if _pickable_career_levels.size() == 1 or not CurrentLevel.customers:
 		# Append filler customers for the selected level.

--- a/project/src/main/world/environment/restaurant/RestaurantPuzzleScene.tscn
+++ b/project/src/main/world/environment/restaurant/RestaurantPuzzleScene.tscn
@@ -1,10 +1,12 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://src/main/world/OverworldBg.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/puzzle-world.gd" type="Script" id=2]
 [ext_resource path="res://src/main/world/environment/restaurant/restaurant-puzzle-scene.gd" type="Script" id=3]
 [ext_resource path="res://src/main/world/environment/EmptyEnvironment.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/world/environment/restaurant/door-chime.gd" type="Script" id=5]
+[ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=6]
+[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=7]
 
 [node name="RestaurantPuzzleScene" type="Node"]
 script = ExtResource( 3 )
@@ -14,7 +16,11 @@ script = ExtResource( 3 )
 [node name="World" type="Node" parent="."]
 script = ExtResource( 2 )
 
-[node name="Environment" parent="World" instance=ExtResource( 4 )]
+[node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 4 )]
+script = ExtResource( 6 )
+environment_shadows_path = NodePath("Ground/Shadows")
+obstacles_path = NodePath("Obstacles")
+CreatureScene = ExtResource( 7 )
 
 [node name="DoorChime" type="AudioStreamPlayer2D" parent="."]
 position = Vector2( 130, 314 )

--- a/project/src/main/world/level-posse.gd
+++ b/project/src/main/world/level-posse.gd
@@ -7,3 +7,4 @@ class_name LevelPosse
 var chef_id := ""
 var customer_ids := []
 var observer_id := ""
+var puzzle_environment_name: String

--- a/project/src/main/world/puzzle-world.gd
+++ b/project/src/main/world/puzzle-world.gd
@@ -15,6 +15,7 @@ const UNDECORATED_PUZZLE_ENVIRONMENT_PATH \
 const ENVIRONMENT_PATH_BY_NAME := {
 	"lemon": "res://src/main/world/environment/lemon/LemonRestaurantEnvironment.tscn",
 	"marsh": "res://src/main/world/environment/restaurant/TurboFatEnvironment.tscn",
+	"lava/zagma": "res://src/main/world/environment/lava/ZagmaEnvironment.tscn"
 }
 
 var customers := []


### PR DESCRIPTION
Zagma levels now take place in the appropriate puzzle environment. This is controlled by a new 'puzzle_environment' json flag, which works just like the customer flags. It can be set on cutscenes, levels or regions. We currently only set it on levels.

Closes #2264 .