### PR TITLE
Fixed new LevelSelectButton focus bugs

### DIFF
--- a/project/src/main/ui/level-select/level-select-button.gd
+++ b/project/src/main/ui/level-select/level-select-button.gd
@@ -111,6 +111,20 @@ func refresh_style_color(color: Color) -> void:
 	_button_control.get("custom_styles/hover").bg_color = color
 
 
+## Returns true if this button is currently focused.
+##
+## For cosmetic reasons, this control itself doesn't have focus, but the child button control does.
+func has_focus() -> bool:
+	return _button_control.has_focus()
+
+
+## Steals the focus from another control and becomes the focused control.
+##
+## For cosmetic reasons, this control itself doesn't have focus, but the child button control does.
+func grab_focus() -> void:
+	_button_control.grab_focus()
+
+
 ## Updates the button's text, colors, size and icon based on the level and its status.
 func _refresh_appearance() -> void:
 	if not is_inside_tree():

--- a/project/src/main/ui/menu/paged-level-buttons.gd
+++ b/project/src/main/ui/menu/paged-level-buttons.gd
@@ -237,8 +237,9 @@ func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDete
 		_unlock_cheat_enabled = !_unlock_cheat_enabled
 		detector.play_cheat_sound(_unlock_cheat_enabled)
 		var button_index_to_focus := -1
-		if get_focus_owner() in _grid_container.get_children():
-			button_index_to_focus = get_focus_owner().get_index()
+		for child_index in range(_grid_container.get_children().size()):
+			if _grid_container.get_child(child_index).has_focus():
+				button_index_to_focus = child_index
 		_refresh()
 		if button_index_to_focus != -1:
 			yield(get_tree(), "idle_frame")


### PR DESCRIPTION
LevelSelectButton was modified in b21415d9 to include new visual effects, but this affected how it grabbed focus in different situations. It wouldn't grab initial focus, and the "UNLOCK" cheat caused it to lose focus as well.

Both of these bugs have been fixed, the LevelSelectButton should grab focus appropriately again.