### PR TITLE
Practice boss levels. Sharky cheese 2 pickups rank.

### DIFF
--- a/project/assets/main/puzzle/levels/career/dark/sharky-cheese-2.json
+++ b/project/assets/main/puzzle/levels/career/dark/sharky-cheese-2.json
@@ -23,7 +23,8 @@
   "rank": [
     "box_factor 0.85",
     "combo_factor 0.71",
-    "master_pickup_score_per_line 11.90"
+    "master_pickup_score_per_line 11.90",
+    "show_pickups_rank"
   ],
   "speed_ups": [
     {

--- a/project/src/main/ui/menu/paged-level-panel.gd
+++ b/project/src/main/ui/menu/paged-level-panel.gd
@@ -28,6 +28,10 @@ func populate(new_region: Object, default_level_id: String = "") -> void:
 	if _region is CareerRegion:
 		for career_level in _region.levels:
 			level_ids.append(career_level.level_id)
+		if _region.boss_level and not _region.boss_level.level_id in level_ids:
+			level_ids.append(_region.boss_level.level_id)
+		if _region.intro_level and not _region.intro_level.level_id in level_ids:
+			level_ids.append(_region.intro_level.level_id)
 	else:
 		level_ids.append_array(_region.level_ids)
 	


### PR DESCRIPTION
Boss levels and intro levels now show up in the practice menu.

Added missing 'show_pickups_rank' flag for Sharky Cheese 2.