### PR TITLE
Disable stool 'occupied' flag

### DIFF
--- a/project/src/demo/world/environment/restaurant/TurboFatFreeRoamEnvironment.tscn
+++ b/project/src/demo/world/environment/restaurant/TurboFatFreeRoamEnvironment.tscn
@@ -688,9 +688,6 @@ position = Vector2( 680, 35 )
 
 [node name="Stool2" parent="Obstacles" instance=ExtResource( 7 )]
 position = Vector2( 592, 35 )
-collision_layer = 0
-collision_mask = 0
-occupied = true
 
 [node name="Stool7" parent="Obstacles" instance=ExtResource( 7 )]
 position = Vector2( 1168, 35 )

--- a/project/src/demo/world/environment/sand/FilmingFreeRoamEnvironment.tscn
+++ b/project/src/demo/world/environment/sand/FilmingFreeRoamEnvironment.tscn
@@ -127,9 +127,6 @@ position = Vector2( 680, 35 )
 
 [node name="Stool2" parent="Obstacles" instance=ExtResource( 8 )]
 position = Vector2( 592, 35 )
-collision_layer = 0
-collision_mask = 0
-occupied = true
 
 [node name="Stool7" parent="Obstacles" instance=ExtResource( 8 )]
 position = Vector2( 1168, 35 )

--- a/project/src/main/world/environment/restaurant/TurboFatEnvironment.tscn
+++ b/project/src/main/world/environment/restaurant/TurboFatEnvironment.tscn
@@ -92,9 +92,6 @@ position = Vector2( 680, 35 )
 
 [node name="Stool2" parent="Obstacles" instance=ExtResource( 33 )]
 position = Vector2( 592, 35 )
-collision_layer = 0
-collision_mask = 0
-occupied = true
 
 [node name="Stool7" parent="Obstacles" instance=ExtResource( 33 )]
 position = Vector2( 1168, 35 )

--- a/project/src/main/world/environment/sand/FilmingEnvironment.tscn
+++ b/project/src/main/world/environment/sand/FilmingEnvironment.tscn
@@ -104,9 +104,6 @@ position = Vector2( 680, 35 )
 
 [node name="Stool2" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 592, 35 )
-collision_layer = 0
-collision_mask = 0
-occupied = true
 
 [node name="Stool7" parent="Obstacles" instance=ExtResource( 10 )]
 position = Vector2( 1168, 35 )


### PR DESCRIPTION
This flag was set by accident in several environment scenes. This probably wouldn't affect anything, but it could affect hit detection in the debug 'freeroam' scenes (which aren't accessible in the released game)