### PR TITLE
Avoid duplicate code in LevelEditor ready, load

### DIFF
--- a/project/src/main/editor/puzzle/level-editor.gd
+++ b/project/src/main/editor/puzzle/level-editor.gd
@@ -19,12 +19,7 @@ func _ready() -> void:
 	var level_text := FileUtils.get_file_as_text(LevelSettings.path_from_level_key(DEFAULT_LEVEL_ID))
 	
 	# immediately parse and upgrade the level; LevelEditor will behave strangely with older level formats
-	var settings := LevelSettings.new()
-	settings.load_from_text(DEFAULT_LEVEL_ID, level_text)
-	_level_json.text = Utils.print_json(settings.to_json_dict())
-	
-	_level_json.reset_editors()
-	level_id_label.text = DEFAULT_LEVEL_ID
+	_parse_level(DEFAULT_LEVEL_ID, level_text)
 	Breadcrumb.connect("trail_popped", self, "_on_Breadcrumb_trail_popped")
 
 
@@ -34,15 +29,19 @@ func save_level(path: String) -> void:
 
 
 func load_level(path: String) -> void:
+	var level_id := LevelSettings.level_key_from_path(path)
 	var level_text := FileUtils.get_file_as_text(path)
-	
+	_parse_level(level_id, level_text)
+
+
+func _parse_level(level_id: String, level_text: String) -> void:
 	# immediately parse and upgrade the level; LevelEditor will behave strangely with older level formats
 	var settings := LevelSettings.new()
-	settings.load_from_text(LevelSettings.level_key_from_path(path), level_text)
+	settings.load_from_text(level_id, level_text)
 	_level_json.text = Utils.print_json(settings.to_json_dict())
 	
 	_level_json.reset_editors()
-	level_id_label.text = LevelSettings.level_key_from_path(path)
+	level_id_label.text = level_id
 
 
 func _start_test() -> void:


### PR DESCRIPTION
This duplicate code caused a bug when we made the level editor upgrade level files when loading them. The code is now the same in both places.