### PR TITLE
Extracted, improved convert_floats_to_ints json utils.

### DIFF
--- a/project/src/main/chat/chat-history.gd
+++ b/project/src/main/chat/chat-history.gd
@@ -126,18 +126,8 @@ func from_json_dict(json: Dictionary) -> void:
 	flags = json.get("flags", {})
 	history_index_by_chat_key = json.get("history_items", {})
 	phrases = json.get("phrases", {})
-	_convert_float_values_to_ints(history_index_by_chat_key)
+	history_index_by_chat_key = Utils.convert_floats_to_ints_in_dict(history_index_by_chat_key)
 	
 	# calculate _chat_count instead of storing it
 	for value in history_index_by_chat_key.values():
 		_chat_count = int(max(value, _chat_count))
-
-
-## Converts the float values in a Dictionary to int values.
-##
-## Godot's JSON parser converts all ints into floats, so we need to change them back. See Godot #9499
-## (https://github.com/godotengine/godot/issues/9499)
-func _convert_float_values_to_ints(dict: Dictionary) -> void:
-	for key in dict:
-		if dict[key] is float:
-			dict[key] = int(dict[key])

--- a/project/src/main/utils/utils.gd
+++ b/project/src/main/utils/utils.gd
@@ -43,6 +43,30 @@ static func brightness(color: Color) -> float:
 	return clamp(color.r * 0.2990 + color.g * 0.5871 + color.b * 0.1140, 0.0, 1.0)
 
 
+## Converts the float values in an array to int values.
+##
+## Godot's JSON parser converts all ints into floats, so we need to change them back. See Godot #9499
+## (https://github.com/godotengine/godot/issues/9499)
+static func convert_floats_to_ints_in_array(a: Array) -> Array:
+	var result := []
+	for i in range(a.size()):
+		result.append(int(a[i]) if a[i] is float else a[i])
+	return result
+
+
+## Converts the float keys and values in a Dictionary to int values.
+##
+## Godot's JSON parser converts all ints into floats, so we need to change them back. See Godot #9499
+## (https://github.com/godotengine/godot/issues/9499)
+static func convert_floats_to_ints_in_dict(dict: Dictionary) -> Dictionary:
+	var result := {}
+	for in_key in dict:
+		var out_key := int(in_key) if in_key is float else in_key
+		var out_value := int(dict[in_key]) if dict[in_key] is float else dict[in_key]
+		result[out_key] = out_value
+	return result
+
+
 ## Returns a new array containing the disjunction of the given arrays.
 ##
 ## This is equivalent to union(subtract(a, b), subtract(b, a)).

--- a/project/src/test/utils/test-utils.gd
+++ b/project/src/test/utils/test-utils.gd
@@ -18,6 +18,41 @@ func test_brightness() -> void:
 	assert_almost_eq(Utils.brightness(Color("000080")), 0.05, 0.1)
 
 
+func test_convert_floats_to_ints_in_array() -> void:
+	var input := ["a", 2, 3.0]
+	var result := Utils.convert_floats_to_ints_in_array(input)
+	assert_eq_shallow(result, ["a", 2, 3])
+
+
+func test_convert_floats_to_ints_in_array_input_unmodified() -> void:
+	var input := ["a", 2, 3.0]
+	Utils.convert_floats_to_ints_in_array(input)
+	assert_eq_shallow(input, ["a", 2, 3.0])
+
+
+func test_convert_floats_to_ints_in_dict_keys() -> void:
+	var input := {"a": "b", 2: "c", 3.0: "d"}
+	var result := Utils.convert_floats_to_ints_in_dict(input)
+	assert_eq_shallow(result, {"a": "b", 2: "c", 3: "d"})
+
+
+func test_convert_floats_to_ints_in_dict_values() -> void:
+	var input := {"b": "a", "c": 2, "d": 3.0}
+	var result := Utils.convert_floats_to_ints_in_dict(input)
+	assert_eq_shallow(result, {"b": "a", "c": 2, "d": 3})
+
+
+func test_convert_floats_to_ints_in_dict_keys_and_values() -> void:
+	var input := {62: 94, 48.0: 54, 44: 90.0, 38.0: 73.0}
+	var result := Utils.convert_floats_to_ints_in_dict(input)
+	assert_eq_shallow(result, {62: 94, 48: 54, 44: 90, 38: 73})
+
+
+func test_convert_floats_to_ints_in_dict_input_unmodified() -> void:
+	var input := {62: 94, 48.0: 54, 44: 90.0, 38.0: 73.0}
+	Utils.convert_floats_to_ints_in_dict(input)
+	assert_eq_shallow(input, {62: 94, 48.0: 54, 44: 90.0, 38.0: 73.0})
+
 
 func test_disjunction() -> void:
 	assert_eq(Utils.disjunction([1, 2, 3], [2, 3, 4]), [1, 4])


### PR DESCRIPTION
These utilities are useful for other JSON saving/loading code, so they shouldn't be private to ChatHistory.

convert_floats_to_ints_in_dict has been improved. It no longer modifies the source dictionary, and is able to convert both keys and values. I've also added unit tests.