### PR TITLE
Remove 'daily' from career fields.

### DIFF
--- a/project/assets/test/data/turbofat-512b.json
+++ b/project/assets/test/data/turbofat-512b.json
@@ -1,0 +1,42 @@
+[
+  {
+    "type": "version",
+    "value": "4ceb"
+  },
+  {
+    "type": "career",
+    "value": {
+      "banked_steps": 9,
+      "distance_travelled": 98,
+      "distance_earned": 5,
+      "hours_passed": 2,
+      "daily_customers": 13,
+      "daily_earnings": 1210,
+      "daily_level_ids": [
+        "career/dark/a_little_extra",
+        "career/dark/muffin_impossible_2",
+        "career/dark/boxing_day"
+      ],
+      "daily_seconds_played": 525,
+      "daily_steps": 25,
+      "day": 67,
+      "extra_life_count": 2,
+      "forced_hardcore_level_hours": [
+        1,
+        4
+      ],
+      "prev_daily_earnings": [
+        4156,
+        2268
+      ],
+      "prev_distance_travelled": [
+        134,
+        114
+      ],
+      "best_distance_travelled": 134,
+      "remain_in_region": false,
+      "skipped_previous_level": false,
+      "top_out_count": 1
+    }
+  }
+]

--- a/project/src/main/career/career-calendar.gd
+++ b/project/src/main/career/career-calendar.gd
@@ -65,9 +65,9 @@ func advance_clock(new_distance_earned: int, success: bool, lost: bool) -> void:
 
 ## Advances the calendar day and resets all daily variables.
 func advance_calendar() -> void:
-	career_data.prev_daily_earnings.push_front(career_data.daily_earnings)
-	if career_data.prev_daily_earnings.size() > Careers.MAX_DAILY_HISTORY:
-		career_data.prev_daily_earnings = career_data.prev_daily_earnings.slice(0, Careers.MAX_DAILY_HISTORY - 1)
+	career_data.prev_money.push_front(career_data.money)
+	if career_data.prev_money.size() > Careers.MAX_DAILY_HISTORY:
+		career_data.prev_money = career_data.prev_money.slice(0, Careers.MAX_DAILY_HISTORY - 1)
 	
 	career_data.best_distance_travelled = max(career_data.best_distance_travelled, career_data.distance_travelled)
 	career_data.prev_distance_travelled.push_front(career_data.distance_travelled)
@@ -75,15 +75,15 @@ func advance_calendar() -> void:
 		career_data.prev_distance_travelled = career_data.prev_distance_travelled.slice(0, Careers.MAX_DAILY_HISTORY - 1)
 	
 	career_data.banked_steps = 0
-	career_data.distance_earned = 0
-	career_data.hours_passed = 0
-	career_data.daily_customers = 0
-	career_data.daily_earnings = 0
-	career_data.daily_level_ids.clear()
-	career_data.daily_seconds_played = 0.0
-	career_data.daily_steps = 0
+	career_data.customers = 0
 	career_data.day = min(career_data.day + 1, Careers.MAX_DAY)
+	career_data.distance_earned = 0
 	career_data.extra_life_count = 0
+	career_data.hours_passed = 0
+	career_data.level_ids.clear()
+	career_data.money = 0
+	career_data.seconds_played = 0.0
+	career_data.steps = 0
 	career_data.top_out_count = 0
 	career_data.randomize_forced_hardcore_level_hours()
 	

--- a/project/src/main/career/ui/career-map-ui.gd
+++ b/project/src/main/career/ui/career-map-ui.gd
@@ -176,7 +176,7 @@ func _force_epilogue_level() -> bool:
 ##
 ## This works by adjusting the daily earnings which affects the random seed.
 func _cycle_levels() -> void:
-	PlayerData.career.daily_earnings += 1
+	PlayerData.career.money += 1
 	SceneTransition.change_scene()
 
 

--- a/project/src/main/career/ui/career-win-world.gd
+++ b/project/src/main/career/ui/career-win-world.gd
@@ -37,11 +37,11 @@ func initial_environment_path() -> String:
 func _refresh_mood() -> void:
 	var player := CreatureManager.get_player()
 	var sensei := CreatureManager.get_sensei()
-	if PlayerData.career.daily_steps >= Careers.DAILY_STEPS_GOOD:
+	if PlayerData.career.steps >= Careers.DAILY_STEPS_GOOD:
 		player.play_mood(Creatures.Mood.LAUGH0)
 		if sensei:
 			sensei.play_mood(Creatures.Mood.LAUGH0)
-	elif PlayerData.career.daily_steps >= Careers.DAILY_STEPS_OK:
+	elif PlayerData.career.steps >= Careers.DAILY_STEPS_OK:
 		player.play_mood(Creatures.Mood.SMILE0)
 		if sensei:
 			sensei.play_mood(Creatures.Mood.SMILE0)

--- a/project/src/main/career/ui/career-win.gd
+++ b/project/src/main/career/ui/career-win.gd
@@ -25,7 +25,7 @@ func _exit_tree() -> void:
 
 ## Plays an applause sound if the player did well.
 func _refresh_mood() -> void:
-	if PlayerData.career.daily_steps >= Careers.DAILY_STEPS_GOOD:
+	if PlayerData.career.steps >= Careers.DAILY_STEPS_GOOD:
 		_applause_sound.play()
 
 

--- a/project/src/main/career/ui/chalkboard-earned.gd
+++ b/project/src/main/career/ui/chalkboard-earned.gd
@@ -4,4 +4,4 @@ extends MarginContainer
 onready var _value_label := $HBoxContainer/Label3
 
 func _ready() -> void:
-	_value_label.text = StringUtils.format_money(min(PlayerData.career.daily_earnings, 999999))
+	_value_label.text = StringUtils.format_money(min(PlayerData.career.money, 999999))

--- a/project/src/main/career/ui/chalkboard-served.gd
+++ b/project/src/main/career/ui/chalkboard-served.gd
@@ -16,4 +16,4 @@ func _ready() -> void:
 	var customer_icon_resource: Texture = Utils.rand_value(_customer_icon_resources)
 	_customer_icon.texture = customer_icon_resource
 	
-	_value_label.text = StringUtils.comma_sep(min(PlayerData.career.daily_customers, 99999))
+	_value_label.text = StringUtils.comma_sep(min(PlayerData.career.customers, 99999))

--- a/project/src/main/career/ui/chalkboard-steps.gd
+++ b/project/src/main/career/ui/chalkboard-steps.gd
@@ -4,4 +4,4 @@ extends MarginContainer
 onready var _value_label := $HBoxContainer/Label3
 
 func _ready() -> void:
-	_value_label.text = StringUtils.comma_sep(min(PlayerData.career.daily_steps, 99999))
+	_value_label.text = StringUtils.comma_sep(min(PlayerData.career.steps, 99999))

--- a/project/src/main/career/ui/chalkboard-time.gd
+++ b/project/src/main/career/ui/chalkboard-time.gd
@@ -4,4 +4,4 @@ extends MarginContainer
 onready var _value_label := $HBoxContainer/Label3
 
 func _ready() -> void:
-	_value_label.text = StringUtils.format_duration(min(PlayerData.career.daily_seconds_played, 5999)) # 99:59
+	_value_label.text = StringUtils.format_duration(min(PlayerData.career.seconds_played, 5999)) # 99:59

--- a/project/src/main/career/ui/chalkboard-title.gd
+++ b/project/src/main/career/ui/chalkboard-title.gd
@@ -60,9 +60,9 @@ onready var _left_title_icon := $Control1/TextureRect
 onready var _right_title_icon := $Control2/TextureRect
 
 func _ready() -> void:
-	if PlayerData.career.daily_steps >= 25:
+	if PlayerData.career.steps >= 25:
 		_title.text = Utils.rand_value(_great_titles)
-	elif PlayerData.career.daily_steps >= 8:
+	elif PlayerData.career.steps >= 8:
 		_title.text = Utils.rand_value(_good_titles)
 	else:
 		_title.text = Utils.rand_value(_bad_titles)

--- a/project/src/main/data/player-save-upgrader.gd
+++ b/project/src/main/data/player-save-upgrader.gd
@@ -277,7 +277,8 @@ var _third_zero_regex: RegEx
 ## Creates and configures a SaveItemUpgrader capable of upgrading older player save formats.
 func new_save_item_upgrader() -> SaveItemUpgrader:
 	var upgrader := SaveItemUpgrader.new()
-	upgrader.current_version = "4ceb"
+	upgrader.current_version = "512b"
+	upgrader.add_upgrade_method(self, "_upgrade_4ceb", "4ceb", "512b")
 	upgrader.add_upgrade_method(self, "_upgrade_49eb", "49eb", "4ceb")
 	upgrader.add_upgrade_method(self, "_upgrade_38c3", "38c3", "49eb")
 	upgrader.add_upgrade_method(self, "_upgrade_37b3", "37b3", "38c3")
@@ -298,6 +299,29 @@ func new_save_item_upgrader() -> SaveItemUpgrader:
 	upgrader.add_upgrade_method(self, "_upgrade_163e", "163e", "1682")
 	upgrader.add_upgrade_method(self, "_upgrade_15d2", "15d2", "163e")
 	return upgrader
+
+
+func _upgrade_4ceb(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
+	var career_properties := [
+		["daily_customers", "customers"],
+		["daily_level_ids", "level_ids"],
+		["daily_earnings", "money"],
+		["prev_daily_earnings", "prev_money"],
+		["daily_seconds_played", "seconds_played"],
+		["daily_steps", "steps"],
+	]
+	
+	match save_item.type:
+		"career":
+			for career_property_item in career_properties:
+				var old_property: String = career_property_item[0]
+				var new_property: String = career_property_item[1]
+				
+				if save_item.value.has(old_property):
+					save_item.value[new_property] = save_item.value[old_property]
+					save_item.value.erase(old_property)
+	
+	return save_item
 
 
 func _upgrade_49eb(_old_save_items: Array, save_item: SaveItem) -> SaveItem:

--- a/project/src/main/data/player-save.gd
+++ b/project/src/main/data/player-save.gd
@@ -9,7 +9,7 @@ signal after_save
 
 ## Current version for saved player data. Should be updated if and only if the player format changes.
 ## This version number follows a 'ymdh' hex date format which is documented in issue #234.
-const PLAYER_DATA_VERSION := "4ceb"
+const PLAYER_DATA_VERSION := "512b"
 
 var rolling_backups := RollingBackups.new()
 

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -248,7 +248,7 @@ func _overall_rank(rank_result: RankResult) -> float:
 
 ## Records the player's performance for career mode.
 func _update_career_data(rank_result: RankResult) -> void:
-	PlayerData.career.daily_earnings = min(PlayerData.career.daily_earnings + rank_result.score,
+	PlayerData.career.money = min(PlayerData.career.money + rank_result.score,
 			PlayerData.MAX_MONEY)
 	
 	for customer_score in PuzzleState.customer_scores:
@@ -256,7 +256,7 @@ func _update_career_data(rank_result: RankResult) -> void:
 			# If the player tops out without serving a customer, the customer is not included
 			pass
 		else:
-			PlayerData.career.daily_customers += 1
+			PlayerData.career.customers += 1
 	
 	# Calculate the player's distance to travel based on their overall rank
 	var overall_rank := _overall_rank(rank_result)
@@ -264,7 +264,7 @@ func _update_career_data(rank_result: RankResult) -> void:
 	var milestone_index := CareerData.rank_milestone_index(overall_rank)
 	var distance_to_advance: int = Careers.RANK_MILESTONES[milestone_index].distance
 	
-	PlayerData.career.daily_steps += distance_to_advance
+	PlayerData.career.steps += distance_to_advance
 	PlayerData.career.top_out_count += PuzzleState.level_performance.top_out_count
 	PlayerData.career.advance_clock(distance_to_advance, rank_result.success, rank_result.lost)
 

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -133,10 +133,10 @@ func _random_levels() -> Array:
 	# We use a seeded shuffle which always gives the player the same random levels. Otherwise they can relaunch career
 	# mode over and over until they get the exact levels they want to play.
 	var seed_int := 0
-	seed_int += PlayerData.career.daily_earnings
+	seed_int += PlayerData.career.money
 	seed_int += PlayerData.career.hours_passed
-	if PlayerData.career.prev_daily_earnings:
-		seed_int += PlayerData.career.prev_daily_earnings[0]
+	if PlayerData.career.prev_money:
+		seed_int += PlayerData.career.prev_money[0]
 	Utils.seeded_shuffle(levels, seed_int)
 	
 	# filter the levels based on which ones the player's unlocked
@@ -160,7 +160,7 @@ func _random_levels() -> Array:
 	# calculate a list of levels the player hasn't played in this career session
 	var unplayed_levels := []
 	for i in range(levels.size()):
-		if not levels[i].level_id in PlayerData.career.daily_level_ids:
+		if not levels[i].level_id in PlayerData.career.level_ids:
 			unplayed_levels.append(levels[i])
 	
 	# calculate a random set of levels for the player, and replace any the player's played if possible
@@ -170,7 +170,7 @@ func _random_levels() -> Array:
 		if unplayed_levels.empty():
 			break
 		
-		if random_levels[random_level_index].level_id in PlayerData.career.daily_level_ids:
+		if random_levels[random_level_index].level_id in PlayerData.career.level_ids:
 			random_levels[0] = unplayed_levels.pop_front()
 	
 	return random_levels
@@ -286,14 +286,14 @@ func _on_LevelSelectButton_level_chosen(level_index: int) -> void:
 	# apply a distance penalty if they select an earlier level
 	var distance_penalty: int = PlayerData.career.distance_penalties()[level_index]
 	PlayerData.career.distance_travelled -= distance_penalty
-	PlayerData.career.daily_steps -= distance_penalty
+	PlayerData.career.steps -= distance_penalty
 	PlayerData.career.progress_board_start_distance_travelled = PlayerData.career.distance_travelled
 	_distance_label.suppress_distance_penalty()
 	
 	var level_settings: LevelSettings = _pickable_level_settings[level_index]
 	var chat_key_pair: ChatKeyPair = _pickable_chat_key_pairs[level_index]
 	
-	PlayerData.career.daily_level_ids.append(level_settings.id)
+	PlayerData.career.level_ids.append(level_settings.id)
 	CurrentLevel.set_launched_level(level_settings.id)
 	CurrentLevel.piece_speed = _piece_speed
 	CurrentLevel.hardcore = level_settings.lose_condition.top_out == 1

--- a/project/src/test/data/test-player-save-upgrader.gd
+++ b/project/src/test/data/test-player-save-upgrader.gd
@@ -195,7 +195,20 @@ func test_37b3_chat_history_migrated() -> void:
 	assert_eq(PlayerData.chat_history.chat_age("chat/career/marsh/010_c_end"), 7)
 	assert_eq(PlayerData.chat_history.chat_age("chat/career/marsh/060_end"), 1)
 	assert_eq(PlayerData.chat_history.chat_age("chat/career/marsh/epilogue"), 0)
-	
+
+
+func test_prepend_third_zero() -> void:
+	var upgrader: PlayerSaveUpgrader = PlayerSaveUpgrader.new()
+	assert_eq(upgrader.prepend_third_zero("ilesa/sin/00_ibo_suture"), "ilesa/sin/000_ibo_suture")
+	assert_eq(upgrader.prepend_third_zero("ilesa_40"), "ilesa_040")
+	assert_eq(upgrader.prepend_third_zero("ilesa_21_sin"), "ilesa_021_sin")
+	assert_eq(upgrader.prepend_third_zero("93_ilesa"), "093_ilesa")
+	assert_eq(upgrader.prepend_third_zero("36_ilesa_72"), "036_ilesa_072")
+	assert_eq(upgrader.prepend_third_zero("ilesa"), "ilesa")
+	assert_eq(upgrader.prepend_third_zero("ilesa_443_sin"), "ilesa_443_sin")
+	assert_eq(upgrader.prepend_third_zero("ilesa_8_sin"), "ilesa_8_sin")
+
+
 func test_49eb_level_history_purged() -> void:
 	load_player_data("turbofat-49eb.json")
 	
@@ -216,13 +229,25 @@ func test_49eb_level_history_purged() -> void:
 	assert_eq(rank_results.has("career/boss_6k"), false)
 
 
-func test_prepend_third_zero() -> void:
-	var upgrader: PlayerSaveUpgrader = PlayerSaveUpgrader.new()
-	assert_eq(upgrader.prepend_third_zero("ilesa/sin/00_ibo_suture"), "ilesa/sin/000_ibo_suture")
-	assert_eq(upgrader.prepend_third_zero("ilesa_40"), "ilesa_040")
-	assert_eq(upgrader.prepend_third_zero("ilesa_21_sin"), "ilesa_021_sin")
-	assert_eq(upgrader.prepend_third_zero("93_ilesa"), "093_ilesa")
-	assert_eq(upgrader.prepend_third_zero("36_ilesa_72"), "036_ilesa_072")
-	assert_eq(upgrader.prepend_third_zero("ilesa"), "ilesa")
-	assert_eq(upgrader.prepend_third_zero("ilesa_443_sin"), "ilesa_443_sin")
-	assert_eq(upgrader.prepend_third_zero("ilesa_8_sin"), "ilesa_8_sin")
+func test_512b_career_data() -> void:
+	load_player_data("turbofat-512b.json")
+	
+	assert_eq(PlayerData.career.banked_steps, 9)
+	assert_eq(PlayerData.career.best_distance_travelled, 134)
+	assert_eq(PlayerData.career.customers, 13)
+	assert_eq(PlayerData.career.day, 67)
+	assert_eq(PlayerData.career.distance_earned, 5)
+	assert_eq(PlayerData.career.distance_travelled, 98)
+	assert_eq(PlayerData.career.money, 1210)
+	assert_eq(PlayerData.career.extra_life_count, 2)
+	assert_eq(PlayerData.career.forced_hardcore_level_hours, [1, 4])
+	assert_eq(PlayerData.career.hours_passed, 2)
+	assert_eq(PlayerData.career.level_ids,
+			["career/dark/a_little_extra", "career/dark/muffin_impossible_2", "career/dark/boxing_day"])
+	assert_eq(PlayerData.career.prev_distance_travelled, [134, 114])
+	assert_eq(PlayerData.career.prev_money, [4156, 2268])
+	assert_eq(PlayerData.career.remain_in_region, false)
+	assert_eq(PlayerData.career.seconds_played, 525)
+	assert_eq(PlayerData.career.skipped_previous_level, false)
+	assert_eq(PlayerData.career.steps, 25)
+	assert_eq(PlayerData.career.top_out_count, 1)

--- a/project/src/test/world/test-career-data.gd
+++ b/project/src/test/world/test-career-data.gd
@@ -23,14 +23,14 @@ func after_each() -> void:
 	_data.free()
 
 
-func test_prev_daily_earnings() -> void:
+func test_prev_money() -> void:
 	for i in range(10, 100):
-		_data.daily_earnings = i
+		_data.money = i
 		_data.advance_calendar()
 	
-	assert_eq(_data.prev_daily_earnings.size(), Careers.MAX_DAILY_HISTORY)
-	assert_eq(99, _data.prev_daily_earnings[0])
-	assert_eq(60, _data.prev_daily_earnings[Careers.MAX_DAILY_HISTORY - 1])
+	assert_eq(_data.prev_money.size(), Careers.MAX_DAILY_HISTORY)
+	assert_eq(99, _data.prev_money[0])
+	assert_eq(60, _data.prev_money[Careers.MAX_DAILY_HISTORY - 1])
 
 
 func test_advance_clock_stops_at_boss_level_0() -> void:


### PR DESCRIPTION
This was haphazardly applied. Some fields like 'distance_travelled' were not called 'daily_distance_travelled' even though they were properties of the current career day. Other fields like 'daily_steps' had the word 'daily'.

I've removed the word 'daily' from all career fields, and updated our backwards compatibility logic to remove it from the player's saves as well.