### PR TITLE
*_environment_name -> *_environment_id

### DIFF
--- a/project/src/main/career/career-level.gd
+++ b/project/src/main/career/career-level.gd
@@ -10,7 +10,7 @@ var level_id: String
 var chef_id: String
 var customer_ids: Array
 var observer_id: String
-var puzzle_environment_name: String
+var puzzle_environment_id: String
 
 ## Boolean condition which enables this level, such as 'chat_finished chat/career/marsh/030_c_end'
 var available_if: String
@@ -22,6 +22,6 @@ func from_json_dict(json: Dictionary) -> void:
 	for i in range(customer_ids.size()):
 		customer_ids[i] = StringUtils.hashwrap_constants(customer_ids[i])
 	observer_id = StringUtils.hashwrap_constants(json.get("observer_id", ""))
-	puzzle_environment_name = json.get("puzzle_environment", "")
+	puzzle_environment_id = json.get("puzzle_environment", "")
 	available_if = json.get("available_if", "")
  

--- a/project/src/main/career/career-region.gd
+++ b/project/src/main/career/career-region.gd
@@ -80,14 +80,14 @@ var levels := []
 var min_piece_speed := "0"
 var max_piece_speed := "0"
 
-## Human-readable environment name, such as 'lemon' or 'marsh' for the overworld environment
-var overworld_environment_name: String
+## Human-readable id such as 'lemon' or 'marsh' for the overworld environment
+var overworld_environment_id: String
 
-## Human-readable environment name, such as 'lemon' or 'marsh' for the puzzle environment
-var puzzle_environment_name: String
+## Human-readable id such as 'lemon' or 'marsh' for the puzzle environment
+var puzzle_environment_id: String
 
-## Human-readable name, such as 'lemon' or 'marsh' for the button on the region select screen
-var region_button_name: String
+## Human-readable id such as 'lemon' or 'marsh' for the button on the region select screen
+var region_button_id: String
 
 func from_json_dict(json: Dictionary) -> void:
 	id = json.get("id", "")
@@ -111,8 +111,8 @@ func from_json_dict(json: Dictionary) -> void:
 		var level: CareerLevel = CareerLevel.new()
 		level.from_json_dict(level_json)
 		levels.append(level)
-	overworld_environment_name = json.get("overworld_environment", "")
-	region_button_name = json.get("region_button", "")
+	overworld_environment_id = json.get("overworld_environment", "")
+	region_button_id = json.get("region_button", "")
 	var piece_speed_string: String = json.get("piece_speed", "0")
 	if "-" in piece_speed_string:
 		min_piece_speed = StringUtils.substring_before(piece_speed_string, "-")
@@ -120,7 +120,7 @@ func from_json_dict(json: Dictionary) -> void:
 	else:
 		min_piece_speed = piece_speed_string
 		max_piece_speed = piece_speed_string
-	puzzle_environment_name = json.get("puzzle_environment", "")
+	puzzle_environment_id = json.get("puzzle_environment", "")
 
 
 func get_prologue_chat_key() -> String:

--- a/project/src/main/career/ui/career-win-world.gd
+++ b/project/src/main/career/ui/career-win-world.gd
@@ -6,10 +6,10 @@ extends OverworldWorld
 ## environment, or regions which specify an invalid environment
 const DEFAULT_ENVIRONMENT_PATH := "res://src/main/world/environment/marsh/MarshWinEnvironment.tscn"
 
-## key: (String) an Environment name which appears in the json definitions
+## key: (String) an Environment id which appears in the json definitions
 ## value: (String) Path to the scene resource defining creatures and obstacles which appear on the victory screen
 ## 	in that environment
-const ENVIRONMENT_PATH_BY_NAME := {
+const ENVIRONMENT_PATH_BY_ID := {
 	"lemon": "res://src/main/world/environment/lemon/LemonWinEnvironment.tscn",
 	"marsh": "res://src/main/world/environment/marsh/MarshWinEnvironment.tscn",
 	"poki": "res://src/main/world/environment/poki/PokiWinEnvironment.tscn",
@@ -29,8 +29,8 @@ func _ready() -> void:
 
 
 func initial_environment_path() -> String:
-	var environment_name := PlayerData.career.current_region().overworld_environment_name
-	return ENVIRONMENT_PATH_BY_NAME.get(environment_name, DEFAULT_ENVIRONMENT_PATH)
+	var environment_id := PlayerData.career.current_region().overworld_environment_id
+	return ENVIRONMENT_PATH_BY_ID.get(environment_id, DEFAULT_ENVIRONMENT_PATH)
 
 
 ## Updates the creature moods based on the player's performance.

--- a/project/src/main/chat/chat-tree.gd
+++ b/project/src/main/chat/chat-tree.gd
@@ -83,7 +83,7 @@ var observer_id: String
 
 ## Puzzle environment applicable to this cutscene, if any. A cutscene might take place at another restaurant for
 ## example, in which case the puzzle should happen in that restaurant as well.
-var puzzle_environment_name: String
+var puzzle_environment_id: String
 
 ## Creatures in this cutscene.
 var creature_ids: Array
@@ -190,7 +190,7 @@ func reset() -> void:
 	chef_id = ""
 	customer_ids = []
 	observer_id = ""
-	puzzle_environment_name = ""
+	puzzle_environment_id = ""
 	creature_ids = []
 	_position.reset()
 	_did_prepare = false

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -40,8 +40,8 @@ var best_result: int = Levels.Result.NONE setget set_best_result
 ## How many times the player has tried the level in this session.
 var attempt_count := 0
 
-## Human-readable environment name, such as 'lemon' or 'marsh' for the puzzle environment
-var puzzle_environment_name: String
+## Human-readable id such as 'lemon' or 'marsh' for the puzzle environment
+var puzzle_environment_id: String
 
 func _ready() -> void:
 	Breadcrumb.connect("before_scene_changed", self, "_on_Breadcrumb_before_scene_changed")
@@ -59,7 +59,7 @@ func reset() -> void:
 	chef_id = ""
 	best_result = Levels.Result.NONE
 	attempt_count = 0
-	puzzle_environment_name = ""
+	puzzle_environment_id = ""
 
 
 ## Stores the launched level data, so the level can be played later.

--- a/project/src/main/puzzle/other-region.gd
+++ b/project/src/main/puzzle/other-region.gd
@@ -30,11 +30,11 @@ var flags: Dictionary = {}
 ## List of string level ids for levels in this region
 var level_ids := []
 
-## Human-readable environment name, such as 'lemon' or 'marsh' for the puzzle environment
-var puzzle_environment_name: String
+## Human-readable id such as 'lemon' or 'marsh' for the puzzle environment
+var puzzle_environment_id: String
 
-## Human-readable name, such as 'lemon' or 'marsh' for the button on the region select screen
-var region_button_name: String
+## Human-readable id such as 'lemon' or 'marsh' for the button on the region select screen
+var region_button_id: String
 
 func from_json_dict(json: Dictionary) -> void:
 	id = json.get("id", "")
@@ -44,8 +44,8 @@ func from_json_dict(json: Dictionary) -> void:
 	for flags_string in json.get("flags", []):
 		flags[flags_string] = true
 	level_ids = json.get("level_ids", "")
-	puzzle_environment_name = json.get("puzzle_environment", "")
-	region_button_name = json.get("region_button", "")
+	puzzle_environment_id = json.get("puzzle_environment", "")
+	region_button_id = json.get("region_button", "")
 
 
 ## Returns 'true' if this region has the specified flag.

--- a/project/src/main/puzzle/puzzle-bg-loader.gd
+++ b/project/src/main/puzzle/puzzle-bg-loader.gd
@@ -8,15 +8,15 @@ const DEFAULT_BG_PATH := "res://src/main/puzzle/WoodBg.tscn"
 ## Shadow color for levels which do not specify a color, or which specify an invalid color
 const DEFAULT_BG_COLOR := Color("582612")
 
-## key: (String) an Environment name which appears in the json definitions
+## key: (String) an Environment id which appears in the json definitions
 ## value: (String) Path to the scene resource defining a puzzle background for that environment
-const BG_PATH_BY_NAME := {
+const BG_PATH_BY_ID := {
 	"lemon": "res://src/main/puzzle/LemonBg.tscn",
 }
 
-## key: (String) an Environment name which appears in the json definitions
+## key: (String) an Environment id which appears in the json definitions
 ## value: (Color) Color for shadows in the puzzle scene
-const BG_SHADOW_COLOR_BY_NAME := {
+const BG_SHADOW_COLOR_BY_ID := {
 	"lemon": Color("3d291f"),
 }
 
@@ -39,7 +39,7 @@ func _remove_bg() -> void:
 
 
 func _add_bg() -> void:
-	var bg_scene_path: String = BG_PATH_BY_NAME.get(CurrentLevel.puzzle_environment_name, DEFAULT_BG_PATH)
+	var bg_scene_path: String = BG_PATH_BY_ID.get(CurrentLevel.puzzle_environment_id, DEFAULT_BG_PATH)
 	var bg_scene: PackedScene = load(bg_scene_path)
 	var bg := bg_scene.instance()
 	bg.name = "Bg"
@@ -47,7 +47,7 @@ func _add_bg() -> void:
 
 
 func _refresh_shadow_color() -> void:
-	var shadow_color: Color = BG_SHADOW_COLOR_BY_NAME.get(CurrentLevel.puzzle_environment_name, DEFAULT_BG_COLOR)
+	var shadow_color: Color = BG_SHADOW_COLOR_BY_ID.get(CurrentLevel.puzzle_environment_id, DEFAULT_BG_COLOR)
 	for shadow_path in shadow_paths:
 		var shadow_node: Node = get_node(shadow_path)
 		if "color" in shadow_node:

--- a/project/src/main/ui/menu/paged-region-buttons.gd
+++ b/project/src/main/ui/menu/paged-region-buttons.gd
@@ -160,7 +160,7 @@ func _region_select_button(button_index: int, region_obj: Object) -> RegionSelec
 	if region_obj is CareerRegion:
 		var region: CareerRegion = region_obj
 		region_button.region_name = PlayerData.career.obfuscated_region_name(region)
-		region_button.button_type = Utils.enum_from_snake_case(RegionSelectButton.Type, region.region_button_name)
+		region_button.button_type = Utils.enum_from_snake_case(RegionSelectButton.Type, region.region_button_id)
 		
 		var ranks := []
 		for career_level_obj in region.levels:
@@ -186,7 +186,7 @@ func _region_select_button(button_index: int, region_obj: Object) -> RegionSelec
 		region_button.ranks = ranks
 		region_button.completion_percent = level_completion / float(potential_completion)
 		region_button.region_name = region.name
-		region_button.button_type = Utils.enum_from_snake_case(RegionSelectButton.Type, region.region_button_name)
+		region_button.button_type = Utils.enum_from_snake_case(RegionSelectButton.Type, region.region_button_id)
 	
 	region_button.connect("focus_entered", self, "_on_RegionButton_focus_entered", [region_button, region_obj])
 	region_button.connect("region_chosen", self, "_on_RegionButton_region_chosen", [region_obj])

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -197,8 +197,8 @@ func _new_level_posse(level_index: int) -> LevelPosse:
 			level_posse.customer_ids = chat_tree.customer_ids.duplicate()
 		if chat_tree.observer_id:
 			level_posse.observer_id = chat_tree.observer_id
-		if chat_tree.puzzle_environment_name:
-			level_posse.puzzle_environment_name = chat_tree.puzzle_environment_name
+		if chat_tree.puzzle_environment_id:
+			level_posse.puzzle_environment_id = chat_tree.puzzle_environment_id
 	
 	# add customers/chefs from the level if the cutscene doesn't define any
 	if not level_posse.chef_id:
@@ -207,8 +207,8 @@ func _new_level_posse(level_index: int) -> LevelPosse:
 		level_posse.customer_ids = career_level.customer_ids.duplicate()
 	if not level_posse.observer_id:
 		level_posse.observer_id = career_level.observer_id
-	if not level_posse.puzzle_environment_name:
-		level_posse.puzzle_environment_name = career_level.puzzle_environment_name
+	if not level_posse.puzzle_environment_id:
+		level_posse.puzzle_environment_id = career_level.puzzle_environment_id
 	
 	# add customers/chefs from the region if the level doesn't define any
 	var region := PlayerData.career.current_region()
@@ -224,8 +224,8 @@ func _new_level_posse(level_index: int) -> LevelPosse:
 		var observer: Population.CreatureAppearance = region.population.random_observer()
 		if observer:
 			level_posse.observer_id = observer.id
-	if not level_posse.puzzle_environment_name:
-		level_posse.puzzle_environment_name = region.puzzle_environment_name
+	if not level_posse.puzzle_environment_id:
+		level_posse.puzzle_environment_id = region.puzzle_environment_id
 	
 	return level_posse
 
@@ -301,7 +301,7 @@ func _on_LevelSelectButton_level_chosen(level_index: int) -> void:
 	var level_posse: LevelPosse = _level_posses[level_index]
 	CurrentLevel.customers = level_posse.customer_ids
 	CurrentLevel.chef_id = level_posse.chef_id
-	CurrentLevel.puzzle_environment_name = level_posse.puzzle_environment_name
+	CurrentLevel.puzzle_environment_id = level_posse.puzzle_environment_id
 	
 	if _pickable_career_levels.size() == 1 or not CurrentLevel.customers:
 		# Append filler customers for the selected level.
@@ -333,7 +333,7 @@ func _on_LevelSelectButton_level_chosen(level_index: int) -> void:
 		"chef_id": CurrentLevel.chef_id,
 		"customers": CurrentLevel.customers,
 		"hardcore": CurrentLevel.hardcore,
-		"puzzle_environment_name": CurrentLevel.puzzle_environment_name,
+		"puzzle_environment_id": CurrentLevel.puzzle_environment_id,
 	})
 	
 	if postroll_key:

--- a/project/src/main/world/career-world.gd
+++ b/project/src/main/world/career-world.gd
@@ -20,10 +20,10 @@ const MOODS_RARE := [Creatures.Mood.AWKWARD1, Creatures.Mood.SIGH0, Creatures.Mo
 ## environment, or regions which specify an invalid environment
 const DEFAULT_ENVIRONMENT_PATH := "res://src/main/world/environment/marsh/MarshEnvironment.tscn"
 
-## key: (String) an Environment name which appears in the json definitions
+## key: (String) an Environment id which appears in the json definitions
 ## value: (String) Path to the scene resource defining creatures and obstacles which appear in
 ## 	that environment
-const ENVIRONMENT_PATH_BY_NAME := {
+const ENVIRONMENT_PATH_BY_ID := {
 	"lava": "res://src/main/world/environment/lava/LavaEnvironment.tscn",
 	"lemon": "res://src/main/world/environment/lemon/LemonEnvironment.tscn",
 	"lemon_2": "res://src/main/world/environment/lemon/Lemon2Environment.tscn",
@@ -159,8 +159,8 @@ func _remove_mile_markers() -> void:
 
 
 func _career_environment_path() -> String:
-	var environment_name := PlayerData.career.current_region().overworld_environment_name
-	return ENVIRONMENT_PATH_BY_NAME.get(environment_name, DEFAULT_ENVIRONMENT_PATH)
+	var environment_id := PlayerData.career.current_region().overworld_environment_id
+	return ENVIRONMENT_PATH_BY_ID.get(environment_id, DEFAULT_ENVIRONMENT_PATH)
 
 
 ## Updates the creature/chef IDs for a boss/intro level, where the player only has one choice.

--- a/project/src/main/world/cutscene-queue.gd
+++ b/project/src/main/world/cutscene-queue.gd
@@ -108,6 +108,6 @@ func _pop_level() -> void:
 		CurrentLevel.customers = level_properties["customers"]
 	if level_properties.has("hardcore"):
 		CurrentLevel.hardcore = level_properties["hardcore"]
-	if level_properties.has("puzzle_environment_name"):
-		CurrentLevel.puzzle_environment_name = level_properties["puzzle_environment_name"]
+	if level_properties.has("puzzle_environment_id"):
+		CurrentLevel.puzzle_environment_id = level_properties["puzzle_environment_id"]
 	PlayerData.customer_queue.pop_standard_customers(CurrentLevel.get_creature_ids())

--- a/project/src/main/world/level-posse.gd
+++ b/project/src/main/world/level-posse.gd
@@ -7,4 +7,4 @@ class_name LevelPosse
 var chef_id := ""
 var customer_ids := []
 var observer_id := ""
-var puzzle_environment_name: String
+var puzzle_environment_id: String

--- a/project/src/main/world/puzzle-world.gd
+++ b/project/src/main/world/puzzle-world.gd
@@ -9,10 +9,10 @@ const DECORATED_PUZZLE_ENVIRONMENT_PATH := "res://src/main/world/environment/res
 const UNDECORATED_PUZZLE_ENVIRONMENT_PATH \
 		:= "res://src/main/world/environment/restaurant/UndecoratedTurboFatEnvironment.tscn"
 
-## key: (String) an Environment name which appears in the json definitions
+## key: (String) an Environment id which appears in the json definitions
 ## value: (String) Path to the scene resource defining creatures and obstacles which appear in
 ## 	that environment
-const ENVIRONMENT_PATH_BY_NAME := {
+const ENVIRONMENT_PATH_BY_ID := {
 	"lemon": "res://src/main/world/environment/lemon/LemonRestaurantEnvironment.tscn",
 	"marsh": "res://src/main/world/environment/restaurant/TurboFatEnvironment.tscn",
 	"lava/zagma": "res://src/main/world/environment/lava/ZagmaEnvironment.tscn"
@@ -31,7 +31,7 @@ func _ready() -> void:
 
 
 func initial_environment_path() -> String:
-	var result: String = ENVIRONMENT_PATH_BY_NAME.get(CurrentLevel.puzzle_environment_name, \
+	var result: String = ENVIRONMENT_PATH_BY_ID.get(CurrentLevel.puzzle_environment_id, \
 			DECORATED_PUZZLE_ENVIRONMENT_PATH)
 	
 	# if the player hasn't gotten far enough in the story, they don't have a nice decorated restaurant


### PR DESCRIPTION
Fields like 'overworld_environment_name' are now called 'overworld_environment_id' instead. I think this makes more sense because these are unique identifiers like 'lava/zagma' and not names like 'Chocolava Canyon'.