### PR TITLE
Fixed career map level select button focus_entered bug

### DIFF
--- a/project/src/main/career/ui/career-map-level-select.gd
+++ b/project/src/main/career/ui/career-map-level-select.gd
@@ -25,7 +25,12 @@ func _ready() -> void:
 ##
 ## For a boss level where only one level is available, this will return '0' if the level button is selected.
 func focused_level_button_index() -> int:
-	_prev_focused_level_button_index = _level_buttons_container.get_children().find(_control.get_focus_owner())
+	var focused_child_index := -1
+	for child_index in range(_level_buttons_container.get_child_count()):
+		if _level_buttons_container.get_child(child_index).has_focus():
+			focused_child_index = child_index
+			break
+	_prev_focused_level_button_index = focused_child_index
 	return _prev_focused_level_button_index
 
 

--- a/project/src/main/career/ui/progress-board-spots.gd
+++ b/project/src/main/career/ui/progress-board-spots.gd
@@ -91,12 +91,12 @@ func _refresh_spots() -> void:
 	
 	# calculate minimum distance between two adjacent spots
 	var min_dist := 999999.0
-	for child_index in range(1, get_children().size()):
+	for child_index in range(1, get_child_count()):
 		var dist: float = get_child(child_index - 1).rect_position.distance_to(get_child(child_index).rect_position)
 		min_dist = min(dist, min_dist)
 	
 	# assign frames; make each spot a circle, dot, or star
-	for child_index in range(get_children().size()):
+	for child_index in range(get_child_count()):
 		var child: ProgressBoardSpot = get_child(child_index)
 		var possible_frames := []
 		if child_index == get_child_count() - 1:

--- a/project/src/main/ui/level-select/level-select-button.gd
+++ b/project/src/main/ui/level-select/level-select-button.gd
@@ -176,6 +176,10 @@ func _on_ButtonControl_focus_entered() -> void:
 	_focus_just_entered = true
 	var font: DynamicFont = _label.get("custom_fonts/font")
 	font.outline_color = Color("007a99")
+	
+	# Propagate the focus_entered signal. This control cannot be focused, but other scenes such as the career map and
+	# level select screen need to react to our focus events
+	emit_signal("focus_entered")
 
 
 func _on_ButtonControl_focus_exited() -> void:

--- a/project/src/main/ui/menu/paged-level-buttons.gd
+++ b/project/src/main/ui/menu/paged-level-buttons.gd
@@ -237,7 +237,7 @@ func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDete
 		_unlock_cheat_enabled = !_unlock_cheat_enabled
 		detector.play_cheat_sound(_unlock_cheat_enabled)
 		var button_index_to_focus := -1
-		for child_index in range(_grid_container.get_children().size()):
+		for child_index in range(_grid_container.get_child_count()):
 			if _grid_container.get_child(child_index).has_focus():
 				button_index_to_focus = child_index
 				break


### PR DESCRIPTION
Converting the LevelSelectButton from a Button to Control to add the nice graphics in b21415d9 broke 'focus_entered' events from being propagated correctly. This meant the distance indicators in Career mode were broken.

Changed 'get_children().size()' calls to 'get_child_count()'