### PR TITLE
CutsceneDemo now restores creatures to their default fatness.

### DIFF
--- a/project/src/demo/world/cutscene-demo.gd
+++ b/project/src/demo/world/cutscene-demo.gd
@@ -25,6 +25,8 @@ func _ready() -> void:
 	_load_demo_data()
 	
 	_assign_focus()
+	
+	PlayerData.creature_library.clear_all_fatness()
 
 
 func _assign_focus() -> void:

--- a/project/src/main/world/creature/creature-library.gd
+++ b/project/src/main/world/creature/creature-library.gd
@@ -146,6 +146,11 @@ func set_fatness(creature_id: String, fatness: float) -> void:
 	_fatnesses_by_creature_id[creature_id] = fatness
 
 
+## Reset all creatures to their default fatness.
+func clear_all_fatness() -> void:
+	_fatnesses_by_creature_id.clear()
+
+
 func to_json_dict() -> Dictionary:
 	return {
 		PLAYER_ID: get_player_def().to_json_dict(),


### PR DESCRIPTION
When viewing a cutscene for demo purposes, we already have options for making creatures very fat or very thin. But by default, it's good for them to have their default appearance.