### PR TITLE
Viewport: size_override_stretch=true, hdr=false

### DIFF
--- a/project/src/main/credits/CreditsScroll.tscn
+++ b/project/src/main/credits/CreditsScroll.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=2]
+[gd_scene load_steps=20 format=2]
 
 [ext_resource path="res://src/main/credits/CreditsHeader.tscn" type="PackedScene" id=1]
 [ext_resource path="res://assets/main/ui/menu/loading-orb-sheet.png" type="Texture" id=2]
@@ -116,7 +116,9 @@ stretch = true
 
 [node name="Viewport" type="Viewport" parent="Movie/ViewportContainer"]
 size = Vector2( 407, 495 )
+size_override_stretch = true
 handle_input_locally = false
+hdr = false
 usage = 0
 render_target_update_mode = 3
 __meta__ = {

--- a/project/src/main/world/creature/ViewportCreatureOutline.tscn
+++ b/project/src/main/world/creature/ViewportCreatureOutline.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://src/main/world/creature/CreatureVisuals.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/utils/outline.shader" type="Shader" id=23]
@@ -17,7 +17,9 @@ script = ExtResource( 24 )
 [node name="Viewport" type="Viewport" parent="."]
 size = Vector2( 1200, 1200 )
 transparent_bg = true
+size_override_stretch = true
 handle_input_locally = false
+hdr = false
 usage = 0
 render_target_update_mode = 3
 audio_listener_enable_2d = true

--- a/project/src/main/world/environment/restaurant/RestaurantView.tscn
+++ b/project/src/main/world/environment/restaurant/RestaurantView.tscn
@@ -166,7 +166,9 @@ script = ExtResource( 4 )
 
 [node name="RestaurantViewport" type="Viewport" parent="."]
 size = Vector2( 1, 1 )
+size_override_stretch = true
 handle_input_locally = false
+hdr = false
 usage = 0
 render_target_update_mode = 3
 
@@ -202,6 +204,7 @@ restaurant_viewport_path = NodePath("../../RestaurantViewport")
 size = Vector2( 72, 67 )
 size_override_stretch = true
 handle_input_locally = false
+hdr = false
 usage = 0
 render_target_update_mode = 3
 audio_listener_enable_2d = true
@@ -275,6 +278,7 @@ restaurant_viewport_path = NodePath("../../RestaurantViewport")
 size = Vector2( 37, 35 )
 size_override_stretch = true
 handle_input_locally = false
+hdr = false
 usage = 0
 render_target_update_mode = 3
 


### PR DESCRIPTION
Some of our viewports use subtly different settings, so I'm making them more consistent. I also notice a few use different sound settings, but I'm leaving this alone for now. I think they do it to avoid having sound effects play in the left or right channel in weird ways.