### PR TITLE
Fixed bug where credits orb could skip some pieces.

### DIFF
--- a/project/src/main/credits/credits-director.gd
+++ b/project/src/main/credits/credits-director.gd
@@ -107,7 +107,7 @@ func _ready() -> void:
 	_credits_scroll.set_target_header_letter_for_piece(353, 6)
 	
 	# initialize total_time to a particular value, so the letters which hit the header are 'T', 'u', 'r'...
-	_credits_scroll.orb.total_time = 2.92682
+	_credits_scroll.orb.initialize_time(2.92682)
 
 
 ## Returns the number of seconds the music is ahead of the animation.


### PR DESCRIPTION
These skipped pieces resulted in the 'pieces spelling turbo fat' being out of sync -- the title would spell out turbo fat, and then 20 seconds later the pieces would fly up there. It was very jarring.

These skipped pieces occur when fast-forwarding the demo and loading a cutscene. But I think it could also happen on a lower-end machine watching the credits normally.