### PR TITLE
Crowd walk tweaks: initial positions, naming, sit still

### DIFF
--- a/project/src/demo/world/environment/lava/crowd-walk-cutscene-demo.gd
+++ b/project/src/demo/world/environment/lava/crowd-walk-cutscene-demo.gd
@@ -18,13 +18,13 @@ func _input(event: InputEvent) -> void:
 		KEY_MINUS:
 			_director.bouncing_crowd_percent = clamp(_director.bouncing_crowd_percent - 0.1, 0.0, 1.0)
 		KEY_Q:
-			_director.prepare_launch_timer(10)
+			restart_cutscene(10)
 		KEY_W:
-			_director.prepare_launch_timer(5)
+			restart_cutscene(5)
 		KEY_E:
-			_director.prepare_launch_timer(3)
+			restart_cutscene(3)
 		KEY_R:
-			_director.prepare_launch_timer(1)
+			restart_cutscene(1)
 
 
 func _process(delta: float) -> void:
@@ -32,3 +32,8 @@ func _process(delta: float) -> void:
 	# warning-ignore:integer_division
 	_time_label.text = "%01d:%02d.%02d" % [
 			int(_total_time) / 60, int(_total_time) % 60, 100*(_total_time - int(_total_time))]
+
+
+func restart_cutscene(time_until_launch: float) -> void:
+	_total_time = 0.0
+	_director.play(time_until_launch)

--- a/project/src/main/world/environment/lava/crowd-walk-cutscene.gd
+++ b/project/src/main/world/environment/lava/crowd-walk-cutscene.gd
@@ -3,5 +3,5 @@ extends Node
 
 onready var _crowd_walk_director: CrowdWalkDirector = $Environment/CrowdWalkDirector
 
-func prepare_launch_timer(time_until_launch: float) -> void:
-	_crowd_walk_director.prepare_launch_timer(time_until_launch)
+func play(time_until_launch: float) -> void:
+	_crowd_walk_director.play(time_until_launch)

--- a/project/src/main/world/environment/lava/crowd-walking-buddy.gd
+++ b/project/src/main/world/environment/lava/crowd-walking-buddy.gd
@@ -2,6 +2,11 @@ extends WalkingBuddy
 ## Creature who walks in a straight line alongside another creature, for a unique cutscene where the player and Fat
 ## Sensei walk through a cheering crowd.
 
+## Keep the creatures stationary until the cutscene starts.
+func _ready() -> void:
+	stop_walking()
+
+
 func play_mood_think0() -> void:
 	stop_walking()
 	play_mood(Creatures.Mood.THINK0)


### PR DESCRIPTION
Crowd walk cutscene creature initial positions are now cached. Before, we'd just move the player, and move all creatures the same amount. This caused some bugs which we worked around by just having the creature always move in a perfectly straight line, but it's better to just store the creature's initial positions and always reset them to where they started.

Player and Fat Sensei remain stationary until the cutscene starts.

Changed 'prepare launch timer' method to 'play'. This is less descriptive, but all of our credits cutscenes can use the method name 'play' which will give them a more intuitive API.