### PR TITLE
DynamicViewportContainer null case. MoodDemo line.

### DIFF
--- a/project/src/demo/chat/ui/mood-demo.gd
+++ b/project/src/demo/chat/ui/mood-demo.gd
@@ -68,7 +68,6 @@ func _input(event: InputEvent) -> void:
 	else:
 		match Utils.key_scancode(event):
 			KEY_BRACKETLEFT, KEY_BRACKETRIGHT:
-				_creature.dna = DnaUtils.random_dna(_creature_type)
 				_randomize_creature()
 			
 			KEY_1: _creature.play_mood(Creatures.Mood.DEFAULT)

--- a/project/src/main/utils/dynamic-viewport-container.gd
+++ b/project/src/main/utils/dynamic-viewport-container.gd
@@ -8,7 +8,8 @@ onready var _viewport := $Viewport
 func _ready() -> void:
 	connect("item_rect_changed", self, "_on_item_rect_changed")
 	
-	_viewport.world_2d = get_node(restaurant_viewport_path).world_2d if restaurant_viewport_path else null
+	if restaurant_viewport_path:
+		_viewport.world_2d = get_node(restaurant_viewport_path).world_2d
 	_refresh_viewport_size()
 
 


### PR DESCRIPTION
Changed DynamicViewportContainer to leave the world2d intact instead of overwriting it with null. Null is not a valid value for the world2d, and causes errors.

Removed an unnecessary line from MoodDemo which assigned the creature's dna redundantly.