### PR TITLE
Refactor: restaurant_viewport_path, customer-view

### DIFF
--- a/project/src/demo/world/environment/lava/CrowdSurfCutsceneDemo.tscn
+++ b/project/src/demo/world/environment/lava/CrowdSurfCutsceneDemo.tscn
@@ -14,7 +14,7 @@ anchor_bottom = 1.0
 stretch = true
 stretch_shrink = 4
 script = ExtResource( 3 )
-restaurant_viewport_path = NodePath("Viewport")
+world_viewport_path = NodePath("Viewport")
 
 [node name="Viewport" type="Viewport" parent="ViewportContainer"]
 size = Vector2( 256, 150 )

--- a/project/src/demo/world/environment/lava/CrowdWalkCutsceneDemo.tscn
+++ b/project/src/demo/world/environment/lava/CrowdWalkCutsceneDemo.tscn
@@ -14,7 +14,7 @@ anchor_bottom = 1.0
 stretch = true
 stretch_shrink = 4
 script = ExtResource( 4 )
-restaurant_viewport_path = NodePath("Viewport")
+world_viewport_path = NodePath("Viewport")
 
 [node name="Viewport" type="Viewport" parent="ViewportContainer"]
 size = Vector2( 256, 150 )

--- a/project/src/main/credits/CreditsScroll.tscn
+++ b/project/src/main/credits/CreditsScroll.tscn
@@ -212,7 +212,7 @@ margin_bottom = 547.5
 stretch = true
 stretch_shrink = 4
 script = ExtResource( 17 )
-restaurant_viewport_path = NodePath("Viewport")
+world_viewport_path = NodePath("Viewport")
 
 [node name="Viewport" type="Viewport" parent="Movie/ViewportContainer"]
 size = Vector2( 101, 123 )

--- a/project/src/main/puzzle/customer-view.gd
+++ b/project/src/main/puzzle/customer-view.gd
@@ -1,7 +1,0 @@
-extends ViewportContainer
-## Shows the active customer in the restaurant scene.
-
-export (NodePath) var restaurant_viewport_path: NodePath
-
-func _ready() -> void:
-	$Viewport.world_2d = get_node(restaurant_viewport_path).world_2d if restaurant_viewport_path else null

--- a/project/src/main/utils/dynamic-viewport-container.gd
+++ b/project/src/main/utils/dynamic-viewport-container.gd
@@ -1,15 +1,15 @@
 extends ViewportContainer
 ## Container which resizes its child viewport based on the container size.
 
-export (NodePath) var restaurant_viewport_path: NodePath
+export (NodePath) var world_viewport_path: NodePath
 
 onready var _viewport := $Viewport
 
 func _ready() -> void:
 	connect("item_rect_changed", self, "_on_item_rect_changed")
 	
-	if restaurant_viewport_path:
-		_viewport.world_2d = get_node(restaurant_viewport_path).world_2d
+	if world_viewport_path:
+		_viewport.world_2d = get_node(world_viewport_path).world_2d
 	_refresh_viewport_size()
 
 

--- a/project/src/main/world/environment/restaurant/RestaurantView.tscn
+++ b/project/src/main/world/environment/restaurant/RestaurantView.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=22 format=2]
+[gd_scene load_steps=21 format=2]
 
 [ext_resource path="res://src/main/world/environment/restaurant/chef-camera-mover.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/environment/restaurant/RestaurantPuzzleScene.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/utils/dynamic-viewport-container.gd" type="Script" id=3]
 [ext_resource path="res://src/main/puzzle/restaurant-view.gd" type="Script" id=4]
-[ext_resource path="res://src/main/puzzle/customer-view.gd" type="Script" id=5]
 [ext_resource path="res://assets/main/puzzle/chef-view-outline.png" type="Texture" id=6]
 [ext_resource path="res://assets/main/puzzle/customer-view-mask.png" type="Texture" id=7]
 [ext_resource path="res://assets/main/puzzle/customer-view-outline.png" type="Texture" id=8]
@@ -197,8 +196,8 @@ margin_right = 290.0
 margin_bottom = 270.0
 stretch = true
 stretch_shrink = 4
-script = ExtResource( 5 )
-restaurant_viewport_path = NodePath("../../RestaurantViewport")
+script = ExtResource( 3 )
+world_viewport_path = NodePath("../../RestaurantViewport")
 
 [node name="Viewport" type="Viewport" parent="Customer/View"]
 size = Vector2( 72, 67 )
@@ -272,7 +271,7 @@ margin_bottom = 140.0
 stretch = true
 stretch_shrink = 4
 script = ExtResource( 3 )
-restaurant_viewport_path = NodePath("../../RestaurantViewport")
+world_viewport_path = NodePath("../../RestaurantViewport")
 
 [node name="Viewport" type="Viewport" parent="Chef/View"]
 size = Vector2( 37, 35 )


### PR DESCRIPTION
Renamed DynamicViewportContainer's restaurant_viewport_path to world_viewport_path. This is now being reused and does not always point to a restaurant.

Replaced customer-view.gd with dynamic-viewport-container.gd. This script seemed redundant and did not do anything to justify being unique.