### PR TITLE
Disabled 'size_override_stretch' flag

### DIFF
--- a/project/src/main/credits/Pinup.tscn
+++ b/project/src/main/credits/Pinup.tscn
@@ -117,7 +117,6 @@ script = ExtResource( 17 )
 
 [node name="Viewport" type="Viewport" parent="Customer/View"]
 size = Vector2( 50, 43 )
-size_override_stretch = true
 handle_input_locally = false
 hdr = false
 usage = 0

--- a/project/src/main/world/creature/ViewportCreatureOutline.tscn
+++ b/project/src/main/world/creature/ViewportCreatureOutline.tscn
@@ -17,7 +17,6 @@ script = ExtResource( 24 )
 [node name="Viewport" type="Viewport" parent="."]
 size = Vector2( 1200, 1200 )
 transparent_bg = true
-size_override_stretch = true
 handle_input_locally = false
 hdr = false
 usage = 0

--- a/project/src/main/world/environment/restaurant/RestaurantView.tscn
+++ b/project/src/main/world/environment/restaurant/RestaurantView.tscn
@@ -165,7 +165,6 @@ script = ExtResource( 4 )
 
 [node name="RestaurantViewport" type="Viewport" parent="."]
 size = Vector2( 1, 1 )
-size_override_stretch = true
 handle_input_locally = false
 hdr = false
 usage = 0
@@ -201,7 +200,6 @@ world_viewport_path = NodePath("../../RestaurantViewport")
 
 [node name="Viewport" type="Viewport" parent="Customer/View"]
 size = Vector2( 72, 67 )
-size_override_stretch = true
 handle_input_locally = false
 hdr = false
 usage = 0
@@ -275,7 +273,6 @@ world_viewport_path = NodePath("../../RestaurantViewport")
 
 [node name="Viewport" type="Viewport" parent="Chef/View"]
 size = Vector2( 37, 35 )
-size_override_stretch = true
 handle_input_locally = false
 hdr = false
 usage = 0


### PR DESCRIPTION
I don't know why we set this originally, or if it had an effect in older versions of godot, or older versions of our viewport logic. It doesn't do anything now.