### PR TITLE
Bug: Polygon error with unusual fatness values

### DIFF
--- a/project/src/main/world/creature/creature-visuals.gd
+++ b/project/src/main/world/creature/creature-visuals.gd
@@ -138,6 +138,8 @@ func update_fattening_animation(delta: float) -> void:
 			_fattening_inertia = -_fattening_inertia
 		# dampening (reduces jiggle)
 		visual_fatness = lerp(visual_fatness, fatness, 0.04)
+		# behavior for values outside the range [1.0, 10.0] is undefined and results in visual errors
+		visual_fatness = clamp(visual_fatness, 1.0, 10.0)
 		set_visual_fatness(visual_fatness)
 		# squash n' stretch
 		var squash_amount: float = 1.0


### PR DESCRIPTION
When using pinup-demo.gd and changing the creature size from 10 to 1 abruptly, an error is logged.

    E 0:00:05.836   canvas_item_add_polygon: Invalid polygon data, triangulation failed.
      <C++ Error>   Condition "indices.empty()" is true.
      <C++ Source>  servers/visual/visual_server_canvas.cpp:768 @ canvas_item_add_polygon()

This specific error was because CreatureCurve lerps its polygon geometry based on the VisualFatness value. When it goes outside a specific range, it continues extrapolating in that direction but this eventually results in self-intersecting polygons.

We could fix CreatureCurve to avoid this use case, but even so -- values higher than 10.0 will result in oddities because the heads and arms are not lerped in the same way curves are, so they will stay constrained while the body grows bigger and bigger. We should just avoid setting these kinds of values.

Closes #2361.