### PR TITLE
Refactor: get_fatness() -> fatness

### DIFF
--- a/project/src/demo/chat/ui/mood-demo.gd
+++ b/project/src/demo/chat/ui/mood-demo.gd
@@ -101,7 +101,7 @@ func _input(event: InputEvent) -> void:
 			KEY_COMMA: _creature.play_mood(Creatures.Mood.YES0)
 			KEY_PERIOD: _creature.play_mood(Creatures.Mood.YES1)
 			KEY_SPACE: _creature.feed(Foods.FoodType.BROWN_0)
-			KEY_EQUAL: _creature.set_fatness(3)
+			KEY_EQUAL: _creature.fatness = 3
 			KEY_RIGHT:
 				if _creature.non_iso_walk_direction == Vector2.ZERO:
 					_creature.non_iso_walk_direction = Vector2(1.0, 1.0)
@@ -116,4 +116,4 @@ func _change_demographic(demographic_type: int) -> void:
 
 func _randomize_creature() -> void:
 	_creature.dna = DnaUtils.random_dna(_creature_type)
-	_creature.set_fatness(Utils.rand_value(Global.FATNESSES))
+	_creature.fatness = Utils.rand_value(Global.FATNESSES)

--- a/project/src/demo/credits/pinup-demo.gd
+++ b/project/src/demo/credits/pinup-demo.gd
@@ -60,5 +60,5 @@ func _randomize_creature() -> void:
 	_pinup.creature.creature_name = NameGeneratorLibrary.generate_name()
 	_pinup.creature.dna = DnaUtils.random_dna()
 	_pinup.creature.chat_theme = CreatureLoader.chat_theme(_pinup.creature.dna)
-	_pinup.creature.set_fatness(Utils.rand_value(Global.FATNESSES))
-	_pinup.creature.set_visual_fatness(_pinup.creature.get_fatness())
+	_pinup.creature.fatness = Utils.rand_value(Global.FATNESSES)
+	_pinup.creature.visual_fatness = _pinup.creature.fatness

--- a/project/src/demo/world/environment/restaurant/restaurant-puzzle-scene-demo.gd
+++ b/project/src/demo/world/environment/restaurant/restaurant-puzzle-scene-demo.gd
@@ -20,7 +20,7 @@ func _input(event: InputEvent) -> void:
 	match Utils.key_scancode(event):
 		KEY_F: _scene.get_customer().feed(Foods.FoodType.BROWN_0)
 		KEY_0, KEY_1, KEY_2, KEY_3, KEY_4, KEY_5, KEY_6, KEY_7, KEY_8, KEY_9:
-			_scene.get_customer().set_fatness(FATNESS_KEYS[Utils.key_num(event)])
+			_scene.get_customer().fatness = FATNESS_KEYS[Utils.key_num(event)]
 		KEY_BRACKETLEFT, KEY_BRACKETRIGHT:
 			_scene.summon_customer(CreatureLoader.random_customer_def())
 		KEY_Q: _scene.current_customer_index = 0

--- a/project/src/demo/world/environment/restaurant/restaurant-view-demo.gd
+++ b/project/src/demo/world/environment/restaurant/restaurant-view-demo.gd
@@ -68,7 +68,7 @@ func _input(event: InputEvent) -> void:
 					KEY_0: _view.get_customer().set_comfort(-1.00) # ate way too much
 			else:
 				# shift not pressed; change customer's fatness
-				_view.get_customer().set_fatness(FATNESS_KEYS[Utils.key_num(event)])
+				_view.get_customer().fatness = FATNESS_KEYS[Utils.key_num(event)]
 		KEY_Q: _view.set_current_customer_index(0)
 		KEY_W: _view.set_current_customer_index(1)
 		KEY_E: _view.set_current_customer_index(2)

--- a/project/src/main/credits/pinup-camera-mover.gd
+++ b/project/src/main/credits/pinup-camera-mover.gd
@@ -20,7 +20,7 @@ func _refresh_zoom_and_headroom() -> void:
 		return
 	
 	play("fat-se")
-	advance(_creature.get_visual_fatness())
+	advance(_creature.visual_fatness)
 	stop()
 
 

--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -120,12 +120,12 @@ func _mutate_allele(creature: Creature, dna: Dictionary, new_palette: Dictionary
 			creature.rename(NameGeneratorLibrary.generate_name())
 		"fatness":
 			var new_fatnesses := Global.FATNESSES.duplicate()
-			while new_fatnesses.has(creature.get_visual_fatness()):
-				new_fatnesses.erase(creature.get_visual_fatness())
+			while new_fatnesses.has(creature.visual_fatness):
+				new_fatnesses.erase(creature.visual_fatness)
 			var new_fatness: float = Utils.rand_value(new_fatnesses)
 			creature.min_fatness = new_fatness
-			creature.set_fatness(new_fatness)
-			creature.set_visual_fatness(new_fatness)
+			creature.fatness = new_fatness
+			creature.visual_fatness = new_fatness
 		"body_rgb":
 			dna["line_rgb"] = new_palette["line_rgb"]
 			dna["body_rgb"] = new_palette["body_rgb"]
@@ -242,12 +242,12 @@ func _tweak_creature(creature: Creature, allele: String, color_mode: int) -> voi
 			creature.rename(NameGeneratorLibrary.generate_name())
 		"fatness":
 			var new_fatnesses := Global.FATNESSES.duplicate()
-			while new_fatnesses.has(creature.get_visual_fatness()):
-				new_fatnesses.erase(creature.get_visual_fatness())
+			while new_fatnesses.has(creature.visual_fatness):
+				new_fatnesses.erase(creature.visual_fatness)
 			var new_fatness: float = Utils.rand_value(new_fatnesses)
 			creature.min_fatness = new_fatness
-			creature.set_fatness(new_fatness)
-			creature.set_visual_fatness(new_fatness)
+			creature.fatness = new_fatness
+			creature.visual_fatness = new_fatness
 		"body_rgb":
 			dna["line_rgb"] = palette["line_rgb"]
 			dna["body_rgb"] = palette["body_rgb"]

--- a/project/src/main/editor/creature/tweak-size-row.gd
+++ b/project/src/main/editor/creature/tweak-size-row.gd
@@ -12,12 +12,12 @@ func _ready() -> void:
 ## Update the creature's size.
 func _on_Edit_value_changed(value: float) -> void:
 	_creature_editor.center_creature.min_fatness = value
-	_creature_editor.center_creature.set_fatness(value)
+	_creature_editor.center_creature.fatness = value
 
 
 ## Update the slider with the creature's size.
 func _on_CreatureEditor_center_creature_changed() -> void:
-	$Edit.value = _creature_editor.center_creature.get_fatness()
+	$Edit.value = _creature_editor.center_creature.fatness
 
 
 func _on_Dna_pressed() -> void:

--- a/project/src/main/puzzle/food-items.gd
+++ b/project/src/main/puzzle/food-items.gd
@@ -59,7 +59,7 @@ func _physics_process(_delta: float) -> void:
 func add_food_item(cell: Vector2, food_type: int, remaining_food: int = 0) -> void:
 	# calculate and store 'food fatness' for customer; how fat the customer will be after eating each item
 	var customer := _puzzle.get_customer()
-	var old_fatness: float = _pending_food_fatness.back() if _pending_food_fatness else customer.get_fatness()
+	var old_fatness: float = _pending_food_fatness.back() if _pending_food_fatness else customer.fatness
 	var base_score := customer.fatness_to_score(customer.base_fatness)
 	var target_fatness := customer.score_to_fatness(base_score + PuzzleState.fatness_score)
 	
@@ -156,7 +156,7 @@ func _on_FoodItem_flight_done(food_item: FoodItem) -> void:
 		_puzzle.feed_customer(food_item.customer, food_item.food_type)
 		
 		var new_fatness: float = _pending_food_fatness.pop_front()
-		food_item.customer.set_fatness(new_fatness)
+		food_item.customer.fatness = new_fatness
 
 
 func _on_StarSeeds_food_spawned(cell: Vector2, remaining_food: int, food_type: int) -> void:

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -194,7 +194,7 @@ func _start_puzzle() -> void:
 			if PlayerData.creature_library.has_fatness(starting_customer_creature_id):
 				# restore their fatness so they start skinny again when replaying a puzzle
 				var fatness: float = PlayerData.creature_library.get_fatness(starting_customer_creature_id)
-				_restaurant_view.get_customer(starting_customer_index).set_fatness(fatness)
+				_restaurant_view.get_customer(starting_customer_index).fatness = fatness
 		
 		# summon the other customers
 		for i in range(_restaurant_view.get_customers().size()):

--- a/project/src/main/world/creature-spawner.gd
+++ b/project/src/main/world/creature-spawner.gd
@@ -77,9 +77,9 @@ func _spawn_target() -> void:
 	_target_creature.position = position
 	for key in target_properties:
 		_target_creature.set(key, target_properties[key])
-	if _target_creature.get_fatness() > max_fatness:
-		_target_creature.set_fatness(max_fatness)
-		_target_creature.set_visual_fatness(max_fatness)
+	if _target_creature.fatness > max_fatness:
+		_target_creature.fatness = max_fatness
+		_target_creature.visual_fatness = max_fatness
 		_target_creature.save_fatness(max_fatness)
 	
 	# mark the creature's stool as occupied

--- a/project/src/main/world/creature/body-sweat.gd
+++ b/project/src/main/world/creature/body-sweat.gd
@@ -14,7 +14,7 @@ func _refresh_sweat() -> void:
 	emitting = _creature_visuals.comfort < -0.4
 	if emitting:
 		var sweat_amount := clamp(inverse_lerp(-0.4, -1.0, _creature_visuals.comfort), 0.0, 1.0)
-		var new_amount: float = _creature_visuals.get_fatness() * lerp(1.5, 4, sweat_amount)
+		var new_amount: float = _creature_visuals.fatness * lerp(1.5, 4, sweat_amount)
 		var new_lifetime: float = lerp(6.0, 3.0, sweat_amount)
 		if abs(amount - new_amount) / max(amount, 1) > 0.33 \
 				or abs(lifetime - new_lifetime) / max(lifetime, 1) > 0.33:

--- a/project/src/main/world/creature/creature-shadow.gd
+++ b/project/src/main/world/creature/creature-shadow.gd
@@ -54,7 +54,7 @@ func _refresh_creature_path() -> void:
 ## Recalculates the CreatureShadow scale property based on the creature's fatness.
 func _refresh_creature_shadow_scale() -> void:
 	_fat_player.play("fat")
-	_fat_player.advance(_creature.get_visual_fatness())
+	_fat_player.advance(_creature.visual_fatness)
 	_fat_player.stop()
 
 

--- a/project/src/main/world/creature/creature-visuals.gd
+++ b/project/src/main/world/creature/creature-visuals.gd
@@ -60,8 +60,8 @@ export (Dictionary) var dna: Dictionary setget set_dna
 ## how fat the creature looks right now; gradually approaches the 'fatness' property
 export (float, 1.0, 10.0) var visual_fatness := 1.0 setget set_visual_fatness
 
-## how fat the creature will become eventually; visual_fatness gradually approaches this value
-var fatness := 1.0 setget set_fatness, get_fatness
+## how fat the creature should be; 5.0 = 5x normal size
+var fatness := 1.0 setget set_fatness
 
 ## comfort improves as the creature eats, and degrades as they overeat. comfort is a number from [-1.0, 1.0]. -1.0 is
 ## very uncomfortable, 1.0 is very comfortable
@@ -167,12 +167,6 @@ func set_comfort(new_comfort: float) -> void:
 func set_visual_fatness(new_visual_fatness: float) -> void:
 	visual_fatness = new_visual_fatness
 	emit_signal("visual_fatness_changed")
-
-
-## Returns the creature's fatness, a float which determines how fat the creature
-## should be; 5.0 = 5x normal size
-func get_fatness() -> float:
-	return fatness
 
 
 ## Increases/decreases the creature's fatness, a float which determines how fat

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -88,6 +88,12 @@ var base_fatness := 1.0
 
 var creature_visuals: CreatureVisuals
 
+## Virtual property; value is only exposed through getters/setters
+var fatness: float setget set_fatness, get_fatness
+
+## Virtual property; value is only exposed through getters/setters
+var visual_fatness: float setget set_visual_fatness, get_visual_fatness
+
 ## 'true' if the creature is being slowed by friction while stopping or turning
 var _friction := false
 
@@ -180,11 +186,11 @@ func set_comfort(new_comfort: float) -> void:
 
 
 func set_fatness(new_fatness: float) -> void:
-	creature_visuals.set_fatness(new_fatness)
+	creature_visuals.fatness = new_fatness
 
 
 func get_fatness() -> float:
-	return creature_visuals.get_fatness() if creature_visuals else 1.0
+	return creature_visuals.fatness if creature_visuals else 1.0
 
 
 func set_visual_fatness(new_visual_fatness: float) -> void:
@@ -356,7 +362,7 @@ func set_creature_def(new_creature_def: CreatureDef) -> void:
 	else:
 		set_fatness(min_fatness)
 	base_fatness = get_fatness()
-	creature_visuals.set_visual_fatness(get_fatness())
+	creature_visuals.visual_fatness = get_fatness()
 	feed_count = 0
 	box_feed_count = 0
 

--- a/project/src/main/world/cutscene-camera.gd
+++ b/project/src/main/world/cutscene-camera.gd
@@ -46,7 +46,7 @@ func _max_fatness_weight() -> float:
 	var max_visual_fatness := 1.0
 	
 	for creature in _overworld_ui.chatters:
-		max_visual_fatness = max(max_visual_fatness, creature.get_visual_fatness())
+		max_visual_fatness = max(max_visual_fatness, creature.visual_fatness)
 	return inverse_lerp(1.0, 10.0, clamp(max_visual_fatness, 1.0, 10.0))
 
 

--- a/project/src/main/world/environment/lava/crowd-surf-camera.gd
+++ b/project/src/main/world/environment/lava/crowd-surf-camera.gd
@@ -101,5 +101,5 @@ func _calculate_zoom() -> Vector2:
 func _max_fatness_weight() -> float:
 	var max_visual_fatness := 1.0
 	for creature in _overworld_environment.get_creatures():
-		max_visual_fatness = max(max_visual_fatness, creature.get_visual_fatness())
+		max_visual_fatness = max(max_visual_fatness, creature.visual_fatness)
 	return inverse_lerp(1.0, 10.0, clamp(max_visual_fatness, 1.0, 10.0))

--- a/project/src/main/world/environment/lava/crowd-walk-camera.gd
+++ b/project/src/main/world/environment/lava/crowd-walk-camera.gd
@@ -101,5 +101,5 @@ func _calculate_zoom() -> Vector2:
 func _max_fatness_weight() -> float:
 	var max_visual_fatness := 1.0
 	for creature in _overworld_environment.get_creatures():
-		max_visual_fatness = max(max_visual_fatness, creature.get_visual_fatness())
+		max_visual_fatness = max(max_visual_fatness, creature.visual_fatness)
 	return inverse_lerp(1.0, 10.0, clamp(max_visual_fatness, 1.0, 10.0))

--- a/project/src/main/world/environment/restaurant/chef-camera-mover.gd
+++ b/project/src/main/world/environment/restaurant/chef-camera-mover.gd
@@ -42,7 +42,7 @@ func set_headroom(new_headroom: float) -> void:
 func _refresh_zoom_and_headroom() -> void:
 	var customer := _restaurant_scene.get_chef()
 	play("fat-se")
-	advance(customer.get_visual_fatness())
+	advance(customer.visual_fatness)
 	stop()
 	_target_camera_position_dirty = true
 

--- a/project/src/main/world/environment/restaurant/customer-camera-mover.gd
+++ b/project/src/main/world/environment/restaurant/customer-camera-mover.gd
@@ -61,7 +61,7 @@ func set_headroom(new_headroom: float) -> void:
 func _refresh_zoom_and_headroom() -> void:
 	var customer := _restaurant_scene.get_customer(_restaurant_scene.current_customer_index)
 	play("fat-se")
-	advance(customer.get_visual_fatness())
+	advance(customer.visual_fatness)
 	stop()
 	_target_camera_position_dirty = true
 


### PR DESCRIPTION
Exposed 'fatness', 'visual_fatness' fields on Creature and CreatureVisuals. Other similar properties like 'dna' had fields with setters and setters, so it was inconsistent to see most of these properties assigned directly but just these two special fatness fields assigned with a method.