### PR TITLE
Refactor: More use of DeconflictedAudioStreamPlayer

### DIFF
--- a/project/src/main/puzzle/critter/Critters.tscn
+++ b/project/src/main/puzzle/critter/Critters.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=2]
+[gd_scene load_steps=19 format=2]
 
 [ext_resource path="res://src/main/puzzle/critter/moles.gd" type="Script" id=1]
 [ext_resource path="res://src/main/puzzle/critter/critters.gd" type="Script" id=2]
@@ -16,6 +16,7 @@
 [ext_resource path="res://src/main/puzzle/critter/critter-manager.gd" type="Script" id=14]
 [ext_resource path="res://src/main/puzzle/critter/spears.gd" type="Script" id=15]
 [ext_resource path="res://src/main/puzzle/critter/Spear.tscn" type="PackedScene" id=16]
+[ext_resource path="res://src/main/utils/DeconflictedAudioStreamPlayer.tscn" type="PackedScene" id=17]
 [ext_resource path="res://src/main/puzzle/critter/SpearWide.tscn" type="PackedScene" id=18]
 
 [node name="Critters" type="Control"]
@@ -59,15 +60,13 @@ CarrotScene = ExtResource( 5 )
 
 [node name="CarrotHolder" type="Node2D" parent="Carrots"]
 
-[node name="CarrotPoofSound" type="AudioStreamPlayer" parent="Carrots"]
+[node name="CarrotPoofSound" parent="Carrots" instance=ExtResource( 17 )]
 stream = ExtResource( 7 )
 volume_db = -4.0
-bus = "Sound Bus"
 
-[node name="CarrotMoveSound" type="AudioStreamPlayer" parent="Carrots"]
+[node name="CarrotMoveSound" parent="Carrots" instance=ExtResource( 17 )]
 stream = ExtResource( 6 )
 volume_db = -2.0
-bus = "Sound Bus"
 
 [node name="CellCritterManager" type="Node" parent="."]
 script = ExtResource( 14 )

--- a/project/src/main/puzzle/critter/Mole.tscn
+++ b/project/src/main/puzzle/critter/Mole.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=2]
+[gd_scene load_steps=23 format=2]
 
 [ext_resource path="res://assets/main/puzzle/critter/mole-sheet.png" type="Texture" id=1]
 [ext_resource path="res://assets/main/puzzle/critter/critter-wait-sheet.png" type="Texture" id=2]
@@ -15,6 +15,7 @@
 [ext_resource path="res://assets/main/puzzle/critter/critter-poof.wav" type="AudioStream" id=13]
 [ext_resource path="res://assets/main/puzzle/critter/mole-dig.wav" type="AudioStream" id=14]
 [ext_resource path="res://assets/main/puzzle/critter/mole-found.wav" type="AudioStream" id=15]
+[ext_resource path="res://src/main/utils/DeconflictedAudioStreamPlayer.tscn" type="PackedScene" id=16]
 
 [sub_resource type="Animation" id=1]
 length = 0.001
@@ -558,22 +559,18 @@ anims/wait = SubResource( 4 )
 [node name="MoleSfx" type="Node" parent="."]
 script = ExtResource( 12 )
 
-[node name="Poof" type="AudioStreamPlayer" parent="MoleSfx"]
+[node name="Poof" parent="MoleSfx" instance=ExtResource( 16 )]
 stream = ExtResource( 13 )
 volume_db = -4.0
-bus = "Sound Bus"
 
-[node name="Dig0" type="AudioStreamPlayer" parent="MoleSfx"]
+[node name="Dig0" parent="MoleSfx" instance=ExtResource( 16 )]
 stream = ExtResource( 14 )
-bus = "Sound Bus"
 
-[node name="Dig1" type="AudioStreamPlayer" parent="MoleSfx"]
+[node name="Dig1" parent="MoleSfx" instance=ExtResource( 16 )]
 stream = ExtResource( 14 )
-bus = "Sound Bus"
 
-[node name="Found" type="AudioStreamPlayer" parent="MoleSfx"]
+[node name="Found" parent="MoleSfx" instance=ExtResource( 16 )]
 stream = ExtResource( 15 )
 volume_db = -4.0
-bus = "Sound Bus"
 
 [connection signal="animation_finished" from="Poof" to="." method="_on_Poof_animation_finished"]

--- a/project/src/main/puzzle/critter/Onion.tscn
+++ b/project/src/main/puzzle/critter/Onion.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=51 format=2]
+[gd_scene load_steps=52 format=2]
 
 [ext_resource path="res://src/main/puzzle/critter/OnionStateMachine.tres" type="AnimationNodeStateMachine" id=1]
 [ext_resource path="res://src/main/puzzle/critter/onion.gd" type="Script" id=2]
@@ -29,6 +29,7 @@
 [ext_resource path="res://assets/main/puzzle/critter/onion-thump.wav" type="AudioStream" id=27]
 [ext_resource path="res://assets/main/puzzle/critter/onion-kaboom.wav" type="AudioStream" id=28]
 [ext_resource path="res://assets/main/puzzle/critter/onion-crickets.wav" type="AudioStream" id=29]
+[ext_resource path="res://src/main/utils/DeconflictedAudioStreamPlayer.tscn" type="PackedScene" id=30]
 
 [sub_resource type="CanvasItemMaterial" id=4]
 particles_animation = true
@@ -1290,118 +1291,95 @@ parameters/conditions/not_floating = false
 [node name="Sfx" type="Node" parent="."]
 script = ExtResource( 20 )
 
-[node name="Crickets" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Crickets" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 29 )
 volume_db = 4.0
-bus = "Sound Bus"
 
-[node name="Down" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Down" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 24 )
 volume_db = -8.0
 pitch_scale = 0.73
-bus = "Sound Bus"
 
-[node name="Kaboom" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Kaboom" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 28 )
 volume_db = 4.0
-bus = "Sound Bus"
 
-[node name="Poof" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Poof" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 3 )
 volume_db = -4.0
-bus = "Sound Bus"
 
-[node name="Rooster0" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Rooster0" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 26 )
 volume_db = -12.0
-bus = "Sound Bus"
 
-[node name="Rooster1" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Rooster1" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 25 )
 volume_db = -12.0
-bus = "Sound Bus"
 
-[node name="Thump" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Thump" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 27 )
 volume_db = 2.0
-bus = "Sound Bus"
 
-[node name="Up" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Up" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 23 )
 volume_db = -8.0
 pitch_scale = 0.8
-bus = "Sound Bus"
 
-[node name="Voice00" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Voice00" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 19 )
 volume_db = -2.0
-bus = "Sound Bus"
 
-[node name="Voice01" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Voice01" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 14 )
 volume_db = -2.0
-bus = "Sound Bus"
 
-[node name="Voice02" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Voice02" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 9 )
 volume_db = -2.0
-bus = "Sound Bus"
 
-[node name="Voice03" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Voice03" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 13 )
 volume_db = -2.0
-bus = "Sound Bus"
 
-[node name="Voice04" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Voice04" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 10 )
 volume_db = -2.0
-bus = "Sound Bus"
 
-[node name="Voice05" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Voice05" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 8 )
 volume_db = -2.0
-bus = "Sound Bus"
 
-[node name="Voice06" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Voice06" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 15 )
 volume_db = -2.0
-bus = "Sound Bus"
 
-[node name="Voice07" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Voice07" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 12 )
 volume_db = -2.0
-bus = "Sound Bus"
 
-[node name="Voice08" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Voice08" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 17 )
 volume_db = -2.0
-bus = "Sound Bus"
 
-[node name="Voice09" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Voice09" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 18 )
 volume_db = -2.0
-bus = "Sound Bus"
 
-[node name="Voice10" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Voice10" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 6 )
 volume_db = -2.0
-bus = "Sound Bus"
 
-[node name="Voice11" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Voice11" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 4 )
 volume_db = -2.0
-bus = "Sound Bus"
 
-[node name="Voice12" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Voice12" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 7 )
 volume_db = -2.0
-bus = "Sound Bus"
 
-[node name="VoiceWow" type="AudioStreamPlayer" parent="Sfx"]
+[node name="VoiceWow" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 21 )
 volume_db = 2.0
-bus = "Sound Bus"
 
-[node name="Zap" type="AudioStreamPlayer" parent="Sfx"]
+[node name="Zap" parent="Sfx" instance=ExtResource( 30 )]
 stream = ExtResource( 22 )
-bus = "Sound Bus"

--- a/project/src/main/puzzle/critter/Shark.tscn
+++ b/project/src/main/puzzle/critter/Shark.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=50 format=2]
+[gd_scene load_steps=51 format=2]
 
 [ext_resource path="res://assets/main/puzzle/critter/shark-sheet.png" type="Texture" id=1]
 [ext_resource path="res://src/main/puzzle/critter/shark-sfx.gd" type="Script" id=2]
@@ -18,6 +18,7 @@
 [ext_resource path="res://assets/main/puzzle/critter/shark-tooth-sheet.png" type="Texture" id=16]
 [ext_resource path="res://src/main/puzzle/critter/shark-tooth-cloud.gd" type="Script" id=17]
 [ext_resource path="res://src/main/puzzle/PuzzleTileMap.tscn" type="PackedScene" id=18]
+[ext_resource path="res://src/main/utils/DeconflictedAudioStreamPlayer.tscn" type="PackedScene" id=19]
 [ext_resource path="res://src/main/puzzle/critter/SharkCloudPart.tscn" type="PackedScene" id=20]
 [ext_resource path="res://assets/main/puzzle/crumbs.png" type="Texture" id=21]
 [ext_resource path="res://src/main/puzzle/critter/shark-crumbs.gd" type="Script" id=22]
@@ -1369,34 +1370,28 @@ anims/wait = SubResource( 4 )
 [node name="SharkSfx" type="Node" parent="."]
 script = ExtResource( 2 )
 
-[node name="Bite" type="AudioStreamPlayer" parent="SharkSfx"]
+[node name="Bite" parent="SharkSfx" instance=ExtResource( 19 )]
 stream = ExtResource( 27 )
 volume_db = -4.0
-bus = "Sound Bus"
 
-[node name="Eat" type="AudioStreamPlayer" parent="SharkSfx"]
+[node name="Eat" parent="SharkSfx" instance=ExtResource( 19 )]
 stream = ExtResource( 25 )
 volume_db = -12.0
-bus = "Sound Bus"
 
-[node name="Poof" type="AudioStreamPlayer" parent="SharkSfx"]
+[node name="Poof" parent="SharkSfx" instance=ExtResource( 19 )]
 stream = ExtResource( 11 )
 volume_db = -4.0
-bus = "Sound Bus"
 
-[node name="Squish" type="AudioStreamPlayer" parent="SharkSfx"]
+[node name="Squish" parent="SharkSfx" instance=ExtResource( 19 )]
 stream = ExtResource( 24 )
-bus = "Sound Bus"
 
-[node name="VoiceFriendly" type="AudioStreamPlayer" parent="SharkSfx"]
+[node name="VoiceFriendly" parent="SharkSfx" instance=ExtResource( 19 )]
 stream = ExtResource( 23 )
 volume_db = -4.0
-bus = "Sound Bus"
 
-[node name="VoiceShort" type="AudioStreamPlayer" parent="SharkSfx"]
+[node name="VoiceShort" parent="SharkSfx" instance=ExtResource( 19 )]
 stream = ExtResource( 26 )
 volume_db = -4.0
-bus = "Sound Bus"
 
 [connection signal="finished_eating" from="ToothCloud" to="." method="_on_ToothCloud_finished_eating"]
 [connection signal="timeout" from="ToothCloud/CloudTimer" to="ToothCloud" method="_on_CloudTimer_timeout"]

--- a/project/src/main/puzzle/critter/Spear.tscn
+++ b/project/src/main/puzzle/critter/Spear.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=41 format=2]
+[gd_scene load_steps=42 format=2]
 
 [ext_resource path="res://assets/main/puzzle/critter/spear-stalk.png" type="Texture" id=1]
 [ext_resource path="res://assets/main/puzzle/critter/spear-face-sheet.png" type="Texture" id=2]
@@ -14,6 +14,7 @@
 [ext_resource path="res://src/main/utils/state-machine.gd" type="Script" id=12]
 [ext_resource path="res://assets/main/puzzle/critter/onion-dirt-clod-sheet.png" type="Texture" id=13]
 [ext_resource path="res://assets/main/puzzle/critter/spear-pop.wav" type="AudioStream" id=14]
+[ext_resource path="res://src/main/utils/DeconflictedAudioStreamPlayer.tscn" type="PackedScene" id=15]
 [ext_resource path="res://src/main/puzzle/critter/spear-sfx.gd" type="Script" id=18]
 [ext_resource path="res://src/main/puzzle/critter/spear-face.gd" type="Script" id=20]
 [ext_resource path="res://src/main/puzzle/critter/spear-waiting.gd" type="Script" id=21]
@@ -273,24 +274,20 @@ script = ExtResource( 10 )
 [node name="SpearSfx" type="Node" parent="."]
 script = ExtResource( 18 )
 
-[node name="Poof" type="AudioStreamPlayer" parent="SpearSfx"]
+[node name="Poof" parent="SpearSfx" instance=ExtResource( 15 )]
 stream = ExtResource( 24 )
 volume_db = -8.0
-bus = "Sound Bus"
 
-[node name="Pop" type="AudioStreamPlayer" parent="SpearSfx"]
+[node name="Pop" parent="SpearSfx" instance=ExtResource( 15 )]
 stream = ExtResource( 14 )
-bus = "Sound Bus"
 
-[node name="VoiceWarn" type="AudioStreamPlayer" parent="SpearSfx"]
+[node name="VoiceWarn" parent="SpearSfx" instance=ExtResource( 15 )]
 stream = ExtResource( 27 )
 volume_db = 4.0
-bus = "Sound Bus"
 
-[node name="VoiceHello" type="AudioStreamPlayer" parent="SpearSfx"]
+[node name="VoiceHello" parent="SpearSfx" instance=ExtResource( 15 )]
 stream = ExtResource( 28 )
 volume_db = 4.0
-bus = "Sound Bus"
 
 [connection signal="timeout" from="SpearHolder/Spear/Face/WiggleTimer" to="SpearHolder/Spear/Face" method="_on_WiggleTimer_timeout"]
 [connection signal="timeout" from="SpearHolder/Spear/Face/OpenEyesTimer" to="SpearHolder/Spear/Face" method="_on_OpenEyesTimer_timeout"]

--- a/project/src/main/puzzle/critter/carrots.gd
+++ b/project/src/main/puzzle/critter/carrots.gd
@@ -86,7 +86,7 @@ func add_carrots(config: CarrotConfig) -> void:
 	
 	for i in range(min(config.count, potential_carrot_x_coords.size())):
 		_add_carrot(Vector2(potential_carrot_x_coords[i], PuzzleTileMap.ROW_COUNT), config)
-	SfxDeconflicter.play(_carrot_poof_sound)
+	_carrot_poof_sound.play()
 
 
 func _refresh_playfield_path() -> void:
@@ -197,7 +197,7 @@ func _on_Playfield_blocks_prepared() -> void:
 
 
 func _on_Carrot_started_hiding() -> void:
-	SfxDeconflicter.play(_carrot_poof_sound)
+	_carrot_poof_sound.play()
 	_refresh_carrot_move_sound()
 
 

--- a/project/src/main/puzzle/critter/mole-sfx.gd
+++ b/project/src/main/puzzle/critter/mole-sfx.gd
@@ -13,17 +13,17 @@ onready var _poof := $Poof
 
 func play_poof_sound() -> void:
 	_poof.pitch_scale = rand_range(0.95, 1.05)
-	SfxDeconflicter.play(_poof)
+	_poof.play()
 
 
 func play_dig_sound() -> void:
 	var dig: AudioStreamPlayer = _digs[_dig_index]
 	dig.volume_db = rand_range(0.0, -4.0)
 	dig.pitch_scale = rand_range(0.95, 1.05)
-	SfxDeconflicter.play(dig)
+	dig.play()
 	_dig_index = (_dig_index + 1) % _digs.size()
 
 
 func play_found_sound() -> void:
 	_found.pitch_scale = rand_range(0.95, 1.05)
-	SfxDeconflicter.play(_found)
+	_found.play()

--- a/project/src/main/puzzle/critter/onion-sfx.gd
+++ b/project/src/main/puzzle/critter/onion-sfx.gd
@@ -26,8 +26,8 @@ onready var _voices := [
 
 ## Plays a sound for the onion's voice when dancing.
 func play_voice_sound() -> void:
-	SfxDeconflicter.play(Utils.rand_value(_voices))
+	Utils.rand_value(_voices).play()
 
 
 func play_rooster_sound() -> void:
-	SfxDeconflicter.play(Utils.rand_value(_roosters))
+	Utils.rand_value(_roosters).play()

--- a/project/src/main/puzzle/critter/shark-sfx.gd
+++ b/project/src/main/puzzle/critter/shark-sfx.gd
@@ -47,19 +47,19 @@ onready var _voice_short := $VoiceShort
 
 func play_poof_sound() -> void:
 	_poof.pitch_scale = rand_range(0.95, 1.05)
-	SfxDeconflicter.play(_poof)
+	_poof.play()
 
 
 func play_voice_friendly_sound() -> void:
 	_voice_friendly.stream = Utils.rand_value(_voice_friendly_sounds)
 	_voice_friendly.pitch_scale = rand_range(pitch_scale * 0.9, pitch_scale * 1.1)
-	SfxDeconflicter.play(_voice_friendly)
+	_voice_friendly.play()
 
 
 func play_voice_short_sound() -> void:
 	_voice_short.stream = Utils.rand_value(_voice_short_sounds)
 	_voice_short.pitch_scale = rand_range(pitch_scale * 0.9, pitch_scale * 1.1)
-	SfxDeconflicter.play(_voice_short)
+	_voice_short.play()
 
 
 ## Plays a sustained eating sound, like a grinding saw.
@@ -73,13 +73,13 @@ func play_eat_sound() -> void:
 			pitch_scale_end, eat_duration) \
 			.set_trans(Tween.TRANS_CIRC).set_ease(Tween.EASE_IN)
 	
-	SfxDeconflicter.play(_eat, rand_range(0.0, 0.2))
+	_eat.play(rand_range(0.0, 0.2))
 
 
 ## Plays a brief eating sound, like a cartoony "chomp" noise.
 func play_bite_sound() -> void:
 	_bite.pitch_scale = rand_range(pitch_scale * 0.95, pitch_scale * 1.05)
-	SfxDeconflicter.play(_bite)
+	_bite.play()
 
 
 func stop_eat_sound() -> void:
@@ -87,4 +87,4 @@ func stop_eat_sound() -> void:
 
 
 func play_squish_sound() -> void:
-	SfxDeconflicter.play(_squish)
+	_squish.play()

--- a/project/src/main/puzzle/critter/spear-sfx.gd
+++ b/project/src/main/puzzle/critter/spear-sfx.gd
@@ -12,19 +12,19 @@ onready var _voice_hello: AudioStreamPlayer = $VoiceHello
 
 func play_poof_sound() -> void:
 	_poof.pitch_scale = rand_range(0.95, 1.05)
-	SfxDeconflicter.play(_poof)
+	_poof.play()
 
 
 func play_pop_sound() -> void:
 	_pop.pitch_scale = rand_range(0.95, 1.05)
-	SfxDeconflicter.play(_pop)
+	_pop.play()
 
 
 func play_warning_voice() -> void:
 	_voice_warn.pitch_scale = rand_range(0.45, 0.55) if wide else rand_range(0.9, 1.1)
-	SfxDeconflicter.play(_voice_warn)
+	_voice_warn.play()
 
 
 func play_hello_voice() -> void:
 	_voice_hello.pitch_scale = rand_range(0.45, 0.55) if wide else rand_range(0.9, 1.1)
-	SfxDeconflicter.play(_voice_hello)
+	_voice_hello.play()

--- a/project/src/main/utils/DeconflictedAudioStreamPlayer2D.tscn
+++ b/project/src/main/utils/DeconflictedAudioStreamPlayer2D.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/main/utils/deconflicted-audio-stream-player-2d.gd" type="Script" id=1]
+
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D"]
+bus = "Sound Bus"
+script = ExtResource( 1 )

--- a/project/src/main/utils/deconflicted-audio-stream-player-2d.gd
+++ b/project/src/main/utils/deconflicted-audio-stream-player-2d.gd
@@ -1,0 +1,6 @@
+extends AudioStreamPlayer2D
+## AudioStreamPlayer2D which ensures multiple copies of the same sound don't play simultaneously.
+
+func play(from_position = 0.0) -> void:
+	if SfxDeconflicter.should_play(self):
+		.play(from_position)

--- a/project/src/main/world/creature/Creature.tscn
+++ b/project/src/main/world/creature/Creature.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=9 format=2]
 
+[ext_resource path="res://src/main/utils/DeconflictedAudioStreamPlayer2D.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/creature/creature.gd" type="Script" id=3]
 [ext_resource path="res://assets/main/world/creature/move-bonk.wav" type="AudioStream" id=5]
 [ext_resource path="res://assets/main/world/creature/move-hop.wav" type="AudioStream" id=7]
@@ -357,15 +358,13 @@ bus = "Voice Bus"
 [node name="MunchSound" type="AudioStreamPlayer" parent="CreatureSfx"]
 bus = "Sound Bus"
 
-[node name="HopSound" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+[node name="HopSound" parent="CreatureSfx" instance=ExtResource( 1 )]
 stream = ExtResource( 7 )
 volume_db = -4.0
-bus = "Sound Bus"
 
-[node name="BonkSound" type="AudioStreamPlayer2D" parent="CreatureSfx"]
+[node name="BonkSound" parent="CreatureSfx" instance=ExtResource( 1 )]
 stream = ExtResource( 5 )
 volume_db = -4.0
-bus = "Sound Bus"
 
 [node name="SuppressSfxTimer" type="Timer" parent="CreatureSfx"]
 one_shot = true

--- a/project/src/main/world/creature/creature-sfx.gd
+++ b/project/src/main/world/creature/creature-sfx.gd
@@ -108,14 +108,14 @@ func play_bonk_sound() -> void:
 	if not should_play_sfx:
 		return
 	
-	SfxDeconflicter.play(_bonk_sound)
+	_bonk_sound.play()
 
 
 func play_hop_sound() -> void:
 	if not should_play_sfx:
 		return
 	
-	SfxDeconflicter.play(_hop_sound)
+	_hop_sound.play()
 
 
 ## Temporarily suppresses creature-related sound effects.


### PR DESCRIPTION
Replaced calls to 'SfxDeconflicter.play()' with DeconflictedAudioStreamPlayer, and a new DeconflictedAudioStreamPlayer2D. This slightly reduces code and repetition.