### PR TITLE
Removed meta flags: edit_group, edit_lock, shadow_scale

### DIFF
--- a/project/src/demo/puzzle/level/LevelRankDemo.tscn
+++ b/project/src/demo/puzzle/level/LevelRankDemo.tscn
@@ -87,9 +87,6 @@ pause_mode = 2
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
-__meta__ = {
-"_edit_lock_": true
-}
 
 [node name="Backdrop" parent="Dialogs" instance=ExtResource( 3 )]
 

--- a/project/src/demo/world/CutsceneDemo.tscn
+++ b/project/src/demo/world/CutsceneDemo.tscn
@@ -120,9 +120,6 @@ pause_mode = 2
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
-__meta__ = {
-"_edit_lock_": true
-}
 
 [node name="Backdrop" parent="Dialogs" instance=ExtResource( 3 )]
 

--- a/project/src/demo/world/environment/lemon/Lemon2FreeRoamEnvironment.tscn
+++ b/project/src/demo/world/environment/lemon/Lemon2FreeRoamEnvironment.tscn
@@ -171,9 +171,6 @@ sfx_disabled = true
 
 [node name="TurboFatRestaurant3" parent="Obstacles" instance=ExtResource( 27 )]
 position = Vector2( 4889.83, 2387.49 )
-__meta__ = {
-"_edit_group_": true
-}
 
 [node name="BrotSpot" parent="Obstacles" instance=ExtResource( 32 )]
 position = Vector2( 3134.11, 3031.79 )

--- a/project/src/main/world/CreatureSpawner.tscn
+++ b/project/src/main/world/CreatureSpawner.tscn
@@ -8,9 +8,6 @@
 scale = Vector2( 0.6, 0.6 )
 texture = ExtResource( 2 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 target_properties = {
 "creature_id": "",
 "elevation": 0.0,

--- a/project/src/main/world/ObstacleSpawner.tscn
+++ b/project/src/main/world/ObstacleSpawner.tscn
@@ -4,6 +4,3 @@
 
 [node name="ObstacleSpawner" type="Sprite"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}

--- a/project/src/main/world/creature/Creature.tscn
+++ b/project/src/main/world/creature/Creature.tscn
@@ -15,7 +15,6 @@ extents = Vector2( 28, 14 )
 [node name="Creature" type="KinematicBody2D" groups=["creatures"]]
 script = ExtResource( 3 )
 __meta__ = {
-"_edit_group_": true,
 "chat_id": "",
 "dna": {
 "accessory": "0",

--- a/project/src/main/world/creature/CreatureVisuals.tscn
+++ b/project/src/main/world/creature/CreatureVisuals.tscn
@@ -682,9 +682,6 @@ material = SubResource( 25 )
 scale = Vector2( 2, 2 )
 texture = ExtResource( 4 )
 offset = Vector2( 0, -239 )
-__meta__ = {
-"_edit_group_": true
-}
 
 [node name="EmoteBrain" type="Node2D" parent="Neck0/HeadBobber"]
 modulate = Color( 1, 1, 1, 0 )

--- a/project/src/main/world/environment/MileMarker.tscn
+++ b/project/src/main/world/environment/MileMarker.tscn
@@ -15,9 +15,6 @@ font_data = ExtResource( 4 )
 [node name="MileMarker" type="KinematicBody2D" groups=["mile_markers"]]
 position = Vector2( 60.0678, 68.7442 )
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.25
 mile_number = 100
 

--- a/project/src/main/world/environment/lava/CarbcraftRestaurant.tscn
+++ b/project/src/main/world/environment/lava/CarbcraftRestaurant.tscn
@@ -13,9 +13,6 @@ shader_param/edge_fix_factor = 1.0
 
 [node name="Carbcraft" type="KinematicBody2D"]
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 5.5
 
 [node name="Restaurant" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lava/LavaCake.tscn
+++ b/project/src/main/world/environment/lava/LavaCake.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 36, 18 )
 
 [node name="LavaCake" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.6
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lava/LavaCrowdie.tscn
+++ b/project/src/main/world/environment/lava/LavaCrowdie.tscn
@@ -28,9 +28,6 @@ extents = Vector2( 28, 14 )
 [node name="Crowdie" type="KinematicBody2D" groups=["lava_crowdies"]]
 position = Vector2( 561.443, 360.624 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.4
 
 [node name="SpriteHolder" type="Node2D" parent="."]

--- a/project/src/main/world/environment/lava/LavaFlag.tscn
+++ b/project/src/main/world/environment/lava/LavaFlag.tscn
@@ -49,9 +49,6 @@ extents = Vector2( 40, 28 )
 
 [node name="Flag" type="KinematicBody2D"]
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.5
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lava/LavaRestaurant1.tscn
+++ b/project/src/main/world/environment/lava/LavaRestaurant1.tscn
@@ -13,9 +13,6 @@ shader_param/edge_fix_factor = 1.0
 
 [node name="LavaRestaurant1" type="KinematicBody2D"]
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 4.5
 
 [node name="Restaurant" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lava/LavaRestaurant2.tscn
+++ b/project/src/main/world/environment/lava/LavaRestaurant2.tscn
@@ -13,9 +13,6 @@ shader_param/edge_fix_factor = 1.0
 
 [node name="LavaRestaurant2" type="KinematicBody2D"]
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 3.0
 
 [node name="Restaurant" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lava/LavaRestaurant3.tscn
+++ b/project/src/main/world/environment/lava/LavaRestaurant3.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 400, 100 )
 
 [node name="LavaRestaurant3" type="KinematicBody2D"]
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 5.5
 
 [node name="Restaurant" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lava/MushroomLarge.tscn
+++ b/project/src/main/world/environment/lava/MushroomLarge.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 18, 12 )
 
 [node name="MushroomLarge" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.4
 shuffle_frames = [ 0, 5 ]
 

--- a/project/src/main/world/environment/lava/MushroomLargeFire.tscn
+++ b/project/src/main/world/environment/lava/MushroomLargeFire.tscn
@@ -67,9 +67,6 @@ tracks/0/keys = {
 
 [node name="MushroomLargeFire" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lava/MushroomSmall.tscn
+++ b/project/src/main/world/environment/lava/MushroomSmall.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 18, 12 )
 
 [node name="MushroomSmall" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lava/VolcanoLarge.tscn
+++ b/project/src/main/world/environment/lava/VolcanoLarge.tscn
@@ -16,9 +16,6 @@ animations = [ {
 
 [node name="VolcanoLarge" type="KinematicBody2D"]
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 3.2
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]

--- a/project/src/main/world/environment/lava/VolcanoSmall.tscn
+++ b/project/src/main/world/environment/lava/VolcanoSmall.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 136, 52 )
 
 [node name="VolcanoSmall" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 1.6
 shuffle_frames = [ 0, 1, 6, 7 ]
 

--- a/project/src/main/world/environment/lava/VolcanoSmallActive.tscn
+++ b/project/src/main/world/environment/lava/VolcanoSmallActive.tscn
@@ -67,9 +67,6 @@ tracks/0/keys = {
 
 [node name="VolcanoSmallActive" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 1.6
 variant = 1
 

--- a/project/src/main/world/environment/lava/ZagmaBridge.tscn
+++ b/project/src/main/world/environment/lava/ZagmaBridge.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 100, 52 )
 
 [node name="ZagmaBridge" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 1.5
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lava/ZagmaMainBuilding.tscn
+++ b/project/src/main/world/environment/lava/ZagmaMainBuilding.tscn
@@ -51,9 +51,6 @@ extents = Vector2( 270, 60 )
 [node name="ZagmaMainBuilding" type="KinematicBody2D"]
 position = Vector2( 3843.47, 2146.26 )
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 4.0
 
 [node name="Building" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lava/ZagmaStool.tscn
+++ b/project/src/main/world/environment/lava/ZagmaStool.tscn
@@ -17,10 +17,6 @@ extents = Vector2( 28, 14 )
 
 [node name="Stool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true,
-"shadow_scale": 0.5
-}
 shadow_scale = 0.5
 occupied_texture = ExtResource( 4 )
 unoccupied_texture = ExtResource( 3 )

--- a/project/src/main/world/environment/lava/ZagmaStoolSmall.tscn
+++ b/project/src/main/world/environment/lava/ZagmaStoolSmall.tscn
@@ -17,10 +17,6 @@ extents = Vector2( 28, 14 )
 
 [node name="Stool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 4 )
-__meta__ = {
-"_edit_group_": true,
-"shadow_scale": 0.5
-}
 shadow_scale = 0.5
 occupied_texture = ExtResource( 2 )
 unoccupied_texture = ExtResource( 3 )

--- a/project/src/main/world/environment/lava/ZagmaTable.tscn
+++ b/project/src/main/world/environment/lava/ZagmaTable.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 60, 20 )
 
 [node name="Table" type="KinematicBody2D"]
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.9
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lava/ZagmaTower.tscn
+++ b/project/src/main/world/environment/lava/ZagmaTower.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 100, 52 )
 
 [node name="ZagmaTower" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 1.6
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lemon/BrotSpot.tscn
+++ b/project/src/main/world/environment/lemon/BrotSpot.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 270, 85 )
 
 [node name="BrotSpot" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 4.5
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lemon/BrotSpotStool.tscn
+++ b/project/src/main/world/environment/lemon/BrotSpotStool.tscn
@@ -15,10 +15,6 @@ extents = Vector2( 38, 18 )
 
 [node name="Stool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true,
-"shadow_scale": 0.5
-}
 shadow_scale = 0.5
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lemon/BrotSpotTable.tscn
+++ b/project/src/main/world/environment/lemon/BrotSpotTable.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 80, 26 )
 
 [node name="BrotSpotTable" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.9
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lemon/GravesiteCup.tscn
+++ b/project/src/main/world/environment/lemon/GravesiteCup.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 16, 8 )
 
 [node name="GravesiteCup" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.2
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lemon/GravesiteGrave.tscn
+++ b/project/src/main/world/environment/lemon/GravesiteGrave.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 20, 10 )
 
 [node name="GravesiteGrave" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.3
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lemon/Lemon2Environment.tscn
+++ b/project/src/main/world/environment/lemon/Lemon2Environment.tscn
@@ -239,10 +239,6 @@ mouth_type = 4
 
 [node name="LemonTree13" parent="Obstacles" instance=ExtResource( 23 )]
 position = Vector2( 1486.32, 1849.77 )
-__meta__ = {
-"_edit_group_": true,
-"shadow_scale": 1.0
-}
 mouth_type = 7
 
 [node name="LemonTree14" parent="Obstacles" instance=ExtResource( 23 )]

--- a/project/src/main/world/environment/lemon/LemonCookieLarge.tscn
+++ b/project/src/main/world/environment/lemon/LemonCookieLarge.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 64, 32 )
 
 [node name="LemonCookieLarge" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.9
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lemon/LemonCookieSmall.tscn
+++ b/project/src/main/world/environment/lemon/LemonCookieSmall.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 36, 18 )
 
 [node name="LemonCookieSmall" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.7
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lemon/LemonLemon.tscn
+++ b/project/src/main/world/environment/lemon/LemonLemon.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 36, 18 )
 
 [node name="LemonLemon" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lemon/LemonTree.tscn
+++ b/project/src/main/world/environment/lemon/LemonTree.tscn
@@ -301,10 +301,6 @@ extents = Vector2( 28, 14 )
 [node name="LemonTree" type="KinematicBody2D"]
 position = Vector2( 531.162, 536.052 )
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_group_": true,
-"shadow_scale": 1.0
-}
 
 [node name="Leaves" type="Sprite" parent="."]
 material = ExtResource( 2 )

--- a/project/src/main/world/environment/lemon/PlayerHouse.tscn
+++ b/project/src/main/world/environment/lemon/PlayerHouse.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 125, 60 )
 
 [node name="PlayerHouse" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 2.5
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/lemon/SenseiHouse.tscn
+++ b/project/src/main/world/environment/lemon/SenseiHouse.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 300, 90 )
 
 [node name="SenseiHouse" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 5.0
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/marsh/ButtercupRestaurant.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupRestaurant.tscn
@@ -17,9 +17,6 @@ extents = Vector2( 210, 97.262 )
 [node name="ButtercupRestaurant" type="KinematicBody2D"]
 position = Vector2( -554.999, 704.673 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 4.7
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/marsh/ButtercupSign.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupSign.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 105, 10 )
 
 [node name="ButtercupSign" type="KinematicBody2D"]
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 1.5
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/marsh/ButtercupStool.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupStool.tscn
@@ -15,10 +15,6 @@ extents = Vector2( 38, 18 )
 
 [node name="Stool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true,
-"shadow_scale": 0.5
-}
 shadow_scale = 0.5
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/marsh/ButtercupStoolSpawnerG.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupStoolSpawnerG.tscn
@@ -11,9 +11,6 @@ texture = ExtResource( 5 )
 centered = false
 offset = Vector2( -76, -110 )
 script = ExtResource( 4 )
-__meta__ = {
-"_edit_group_": true
-}
 TargetScene = ExtResource( 1 )
 target_properties = {
 "occupied_texture": ExtResource( 2 ),

--- a/project/src/main/world/environment/marsh/ButtercupStoolSpawnerW.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupStoolSpawnerW.tscn
@@ -11,9 +11,6 @@ texture = ExtResource( 2 )
 centered = false
 offset = Vector2( -76, -110 )
 script = ExtResource( 4 )
-__meta__ = {
-"_edit_group_": true
-}
 TargetScene = ExtResource( 1 )
 target_properties = {
 "occupied_texture": ExtResource( 3 ),

--- a/project/src/main/world/environment/marsh/ButtercupTable.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupTable.tscn
@@ -17,9 +17,6 @@ extents = Vector2( 80, 26 )
 [node name="ButtercupTable" type="KinematicBody2D"]
 position = Vector2( -209.971, 976.928 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.9
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/marsh/ButtercupTableSpawner.tscn
+++ b/project/src/main/world/environment/marsh/ButtercupTableSpawner.tscn
@@ -10,7 +10,4 @@ texture = ExtResource( 1 )
 centered = false
 offset = Vector2( -125, -200 )
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 TargetScene = ExtResource( 3 )

--- a/project/src/main/world/environment/marsh/MarshBush.tscn
+++ b/project/src/main/world/environment/marsh/MarshBush.tscn
@@ -43,9 +43,6 @@ extents = Vector2( 50, 16 )
 [node name="MarshBush" type="KinematicBody2D"]
 position = Vector2( 301.162, 506.052 )
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_group_": true
-}
 
 [node name="Sprite" type="Sprite" parent="."]
 material = ExtResource( 1 )

--- a/project/src/main/world/environment/marsh/MarshCrystal.tscn
+++ b/project/src/main/world/environment/marsh/MarshCrystal.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 24, 12 )
 
 [node name="MarshCrystal" type="KinematicBody2D"]
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/marsh/MarshCrystalSpawner.tscn
+++ b/project/src/main/world/environment/marsh/MarshCrystalSpawner.tscn
@@ -10,7 +10,4 @@ texture = ExtResource( 3 )
 centered = false
 offset = Vector2( -70, -102 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 TargetScene = ExtResource( 2 )

--- a/project/src/main/world/environment/marsh/MarshHouse.tscn
+++ b/project/src/main/world/environment/marsh/MarshHouse.tscn
@@ -17,9 +17,6 @@ extents = Vector2( 140, 70 )
 [node name="MarshHouse" type="KinematicBody2D"]
 position = Vector2( -672.062, 948.923 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 2.2
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/marsh/MarshTree.tscn
+++ b/project/src/main/world/environment/marsh/MarshTree.tscn
@@ -43,9 +43,6 @@ extents = Vector2( 28, 14 )
 [node name="MarshTree" type="KinematicBody2D"]
 position = Vector2( 531.162, 536.052 )
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_group_": true
-}
 
 [node name="Sprite" type="Sprite" parent="."]
 material = ExtResource( 1 )

--- a/project/src/main/world/environment/poki/PokiCactusHuge.tscn
+++ b/project/src/main/world/environment/poki/PokiCactusHuge.tscn
@@ -9,9 +9,6 @@ extents = Vector2( 28, 14 )
 [node name="CactusHuge" type="KinematicBody2D"]
 position = Vector2( 566.612, 247.67 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.8
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/poki/PokiCactusLarge.tscn
+++ b/project/src/main/world/environment/poki/PokiCactusLarge.tscn
@@ -10,9 +10,6 @@ extents = Vector2( 50, 14 )
 [node name="CactusLarge" type="KinematicBody2D"]
 position = Vector2( 486.489, 339.411 )
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.7
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/poki/PokiCactusPlaque.tscn
+++ b/project/src/main/world/environment/poki/PokiCactusPlaque.tscn
@@ -9,9 +9,6 @@ extents = Vector2( 58, 25 )
 [node name="CactusPlaque" type="KinematicBody2D"]
 position = Vector2( 566.612, 247.67 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/poki/PokiCactusSmall.tscn
+++ b/project/src/main/world/environment/poki/PokiCactusSmall.tscn
@@ -10,9 +10,6 @@ extents = Vector2( 28, 14 )
 [node name="CactusSmall" type="KinematicBody2D"]
 position = Vector2( 480.957, 462.977 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/poki/PokiCrowdie.tscn
+++ b/project/src/main/world/environment/poki/PokiCrowdie.tscn
@@ -9,9 +9,6 @@ extents = Vector2( 28, 14 )
 [node name="Crowdie" type="KinematicBody2D"]
 position = Vector2( 561.443, 360.624 )
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/poki/PokiCrowdieSpawner.tscn
+++ b/project/src/main/world/environment/poki/PokiCrowdieSpawner.tscn
@@ -10,9 +10,6 @@ texture = ExtResource( 1 )
 centered = false
 offset = Vector2( -195, -375 )
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 TargetScene = ExtResource( 3 )
 target_properties = {
 "crowd_color_index": 0,

--- a/project/src/main/world/environment/poki/PokiMarshmallow.tscn
+++ b/project/src/main/world/environment/poki/PokiMarshmallow.tscn
@@ -10,9 +10,6 @@ extents = Vector2( 50, 14 )
 [node name="Marshmallow" type="KinematicBody2D"]
 position = Vector2( 536.121, 330.356 )
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.6
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/poki/Tent.tscn
+++ b/project/src/main/world/environment/poki/Tent.tscn
@@ -10,9 +10,6 @@ extents = Vector2( 120, 14 )
 [node name="Tent" type="KinematicBody2D"]
 position = Vector2( 486.489, 339.411 )
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 1.2
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/poki/TentSpawner.tscn
+++ b/project/src/main/world/environment/poki/TentSpawner.tscn
@@ -9,8 +9,5 @@ scale = Vector2( 0.539, 0.539 )
 texture = ExtResource( 2 )
 offset = Vector2( 0, -100 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 TargetScene = ExtResource( 3 )
 spawn_if = "false"

--- a/project/src/main/world/environment/poki/WeAccept.tscn
+++ b/project/src/main/world/environment/poki/WeAccept.tscn
@@ -17,9 +17,6 @@ extents = Vector2( 138, 50 )
 [node name="WeAccept" type="KinematicBody2D"]
 position = Vector2( 508.542, 419.547 )
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 2.5
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/restaurant/BoxStool1.tscn
+++ b/project/src/main/world/environment/restaurant/BoxStool1.tscn
@@ -17,10 +17,6 @@ extents = Vector2( 28, 14 )
 
 [node name="BoxStool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 4 )
-__meta__ = {
-"_edit_group_": true,
-"shadow_scale": 0.5
-}
 shadow_scale = 0.5
 occupied_texture = ExtResource( 5 )
 unoccupied_texture = ExtResource( 2 )

--- a/project/src/main/world/environment/restaurant/BoxStool2.tscn
+++ b/project/src/main/world/environment/restaurant/BoxStool2.tscn
@@ -17,10 +17,6 @@ extents = Vector2( 28, 14 )
 
 [node name="BoxStool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 4 )
-__meta__ = {
-"_edit_group_": true,
-"shadow_scale": 0.5
-}
 shadow_scale = 0.5
 occupied_texture = ExtResource( 3 )
 unoccupied_texture = ExtResource( 2 )

--- a/project/src/main/world/environment/restaurant/BoxStool3.tscn
+++ b/project/src/main/world/environment/restaurant/BoxStool3.tscn
@@ -17,10 +17,6 @@ extents = Vector2( 28, 14 )
 
 [node name="BoxStool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 4 )
-__meta__ = {
-"_edit_group_": true,
-"shadow_scale": 0.5
-}
 shadow_scale = 0.5
 occupied_texture = ExtResource( 3 )
 unoccupied_texture = ExtResource( 2 )

--- a/project/src/main/world/environment/restaurant/CrateTable.tscn
+++ b/project/src/main/world/environment/restaurant/CrateTable.tscn
@@ -17,9 +17,6 @@ extents = Vector2( 60, 20 )
 [node name="CrateTable" type="KinematicBody2D"]
 position = Vector2( 380, 405 )
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.9
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/restaurant/TurboFatRestaurant.tscn
+++ b/project/src/main/world/environment/restaurant/TurboFatRestaurant.tscn
@@ -22,9 +22,6 @@ extents = Vector2( 325.999, 97.2622 )
 [node name="TurboFatRestaurant" type="KinematicBody2D"]
 position = Vector2( 903.99, 1070.05 )
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 5.5
 SmokeClusterScene = ExtResource( 6 )
 

--- a/project/src/main/world/environment/restaurant/TurboFatStool.tscn
+++ b/project/src/main/world/environment/restaurant/TurboFatStool.tscn
@@ -17,10 +17,6 @@ extents = Vector2( 28, 14 )
 
 [node name="Stool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true,
-"shadow_scale": 0.5
-}
 shadow_scale = 0.5
 occupied_texture = ExtResource( 4 )
 unoccupied_texture = ExtResource( 3 )

--- a/project/src/main/world/environment/restaurant/WoodPillar.tscn
+++ b/project/src/main/world/environment/restaurant/WoodPillar.tscn
@@ -17,9 +17,6 @@ extents = Vector2( 28, 14 )
 [node name="WoodPillar" type="KinematicBody2D"]
 position = Vector2( 531.162, 105 )
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/restaurant/WoodTable.tscn
+++ b/project/src/main/world/environment/restaurant/WoodTable.tscn
@@ -17,9 +17,6 @@ extents = Vector2( 60, 20 )
 [node name="WoodTable" type="KinematicBody2D"]
 position = Vector2( 380, 405 )
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.9
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/sand/BananaStool.tscn
+++ b/project/src/main/world/environment/sand/BananaStool.tscn
@@ -17,10 +17,6 @@ extents = Vector2( 28, 14 )
 
 [node name="BananaStool" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_group_": true,
-"shadow_scale": 0.5
-}
 shadow_scale = 0.5
 occupied_texture = ExtResource( 2 )
 unoccupied_texture = ExtResource( 5 )

--- a/project/src/main/world/environment/sand/BananaStoolLarge.tscn
+++ b/project/src/main/world/environment/sand/BananaStoolLarge.tscn
@@ -17,10 +17,6 @@ extents = Vector2( 28, 14 )
 
 [node name="BananaStoolLarge" type="KinematicBody2D" groups=["stools"]]
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_group_": true,
-"shadow_scale": 0.5
-}
 shadow_scale = 0.5
 occupied_texture = ExtResource( 5 )
 unoccupied_texture = ExtResource( 1 )

--- a/project/src/main/world/environment/sand/BananaTentacleBack.tscn
+++ b/project/src/main/world/environment/sand/BananaTentacleBack.tscn
@@ -17,9 +17,6 @@ extents = Vector2( 86, 24 )
 [node name="BananaTentacleBack" type="KinematicBody2D"]
 position = Vector2( 171.378, 140.204 )
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 
 [node name="Sprite" type="Sprite" parent="."]
 material = SubResource( 1 )

--- a/project/src/main/world/environment/sand/BananaTentacleFront.tscn
+++ b/project/src/main/world/environment/sand/BananaTentacleFront.tscn
@@ -17,9 +17,6 @@ extents = Vector2( 118, 24 )
 [node name="BananaTentacleFront" type="KinematicBody2D"]
 position = Vector2( 171.378, 140.204 )
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 
 [node name="Sprite" type="Sprite" parent="."]
 material = SubResource( 1 )

--- a/project/src/main/world/environment/sand/Bottle.tscn
+++ b/project/src/main/world/environment/sand/Bottle.tscn
@@ -14,6 +14,3 @@ shader_param/edge_fix_factor = 1.0
 material = SubResource( 1 )
 scale = Vector2( 0.539, 0.539 )
 texture = ExtResource( 3 )
-__meta__ = {
-"_edit_group_": true
-}

--- a/project/src/main/world/environment/sand/BottleMat.tscn
+++ b/project/src/main/world/environment/sand/BottleMat.tscn
@@ -15,6 +15,3 @@ material = SubResource( 1 )
 position = Vector2( 177.429, 159.77 )
 scale = Vector2( 0.539, 0.539 )
 texture = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}

--- a/project/src/main/world/environment/sand/Mic1.tscn
+++ b/project/src/main/world/environment/sand/Mic1.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 24, 12 )
 
 [node name="Mic1" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/sand/Mic2.tscn
+++ b/project/src/main/world/environment/sand/Mic2.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 24, 12 )
 
 [node name="Mic2" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.4
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/sand/RobotDog.tscn
+++ b/project/src/main/world/environment/sand/RobotDog.tscn
@@ -360,9 +360,6 @@ tracks/4/keys = {
 
 [node name="RobotDog" type="KinematicBody2D"]
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.5
 
 [node name="Tail" type="Sprite" parent="."]

--- a/project/src/main/world/environment/sand/SandBanana.tscn
+++ b/project/src/main/world/environment/sand/SandBanana.tscn
@@ -17,9 +17,6 @@ extents = Vector2( 64.4, 25.2 )
 [node name="Banana" type="KinematicBody2D"]
 position = Vector2( 84.9487, 113.265 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.7
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/sand/SandCream.tscn
+++ b/project/src/main/world/environment/sand/SandCream.tscn
@@ -17,9 +17,6 @@ extents = Vector2( 56, 28 )
 [node name="Cream" type="KinematicBody2D"]
 position = Vector2( 84.9487, 113.265 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 0.7
 frame = 4
 flip_h = true

--- a/project/src/main/world/environment/sand/SandGrass.tscn
+++ b/project/src/main/world/environment/sand/SandGrass.tscn
@@ -63,9 +63,6 @@ offset = Vector2( 0, -50 )
 hframes = 3
 vframes = 2
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 anims/RESET = SubResource( 3 )

--- a/project/src/main/world/environment/sand/SandHouse.tscn
+++ b/project/src/main/world/environment/sand/SandHouse.tscn
@@ -16,9 +16,6 @@ extents = Vector2( 215, 70 )
 
 [node name="SandHouse" type="KinematicBody2D"]
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 5.1
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/project/src/main/world/environment/sand/SandTree.tscn
+++ b/project/src/main/world/environment/sand/SandTree.tscn
@@ -43,9 +43,6 @@ extents = Vector2( 40, 28 )
 [node name="Tree" type="KinematicBody2D"]
 position = Vector2( 531.162, 536.052 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_group_": true
-}
 shadow_scale = 1.4
 
 [node name="Sprite" type="Sprite" parent="."]


### PR DESCRIPTION
Removed unnecessary meta flags. Some of these like 'shadow_scale' are redundant, or might actually cause weird behavior where one specific tree has a slightly smaller shadow than the others.

We might wish to restore some of these 'edit_lock' or 'edit_group' flags in the future. But in general, I think these were set by accident, so I'm removing them.