### PR TITLE
Pinup fixes: play_mood_by_name, public pinup field

### DIFF
--- a/project/src/main/credits/pinup-scroller.gd
+++ b/project/src/main/credits/pinup-scroller.gd
@@ -18,7 +18,7 @@ export (float) var line_height: float
 var velocity := Vector2(0, -50)
 var _tween: SceneTreeTween
 
-onready var _pinup := $Pinup
+onready var pinup := $Pinup
 
 func _physics_process(delta: float) -> void:
 	if Engine.editor_hint:

--- a/project/src/main/credits/pinup-scrollers.gd
+++ b/project/src/main/credits/pinup-scrollers.gd
@@ -47,8 +47,8 @@ func add_pinup(creature_id: String, pinup_side: int) -> void:
 		 scroller.position.x = 512 - scroller.position.x
 	
 	# initialize it to the correct creature ID
-	scroller._pinup.creature_id = creature_id
-	scroller._pinup.orientation = \
+	scroller.pinup.creature_id = creature_id
+	scroller.pinup.orientation = \
 			Creatures.SOUTHEAST if pinup_side == PinupScroller.SIDE_LEFT else Creatures.SOUTHWEST
 	
 	# initialize velocity

--- a/project/src/main/world/environment/lava/CrowdWalkEnvironment.tscn
+++ b/project/src/main/world/environment/lava/CrowdWalkEnvironment.tscn
@@ -95,11 +95,14 @@ tracks/3/loop_wrap = true
 tracks/3/imported = false
 tracks/3/enabled = true
 tracks/3/keys = {
-"times": PoolRealArray( 0.2 ),
-"transitions": PoolRealArray( 1 ),
+"times": PoolRealArray( 0.19, 0.2 ),
+"transitions": PoolRealArray( 1, 1 ),
 "values": [ {
-"args": [  ],
-"method": "play_mood_smile0"
+"args": [ 0.0 ],
+"method": "stop_walking"
+}, {
+"args": [ "smile0" ],
+"method": "play_mood_by_name"
 } ]
 }
 tracks/4/type = "method"
@@ -109,11 +112,14 @@ tracks/4/loop_wrap = true
 tracks/4/imported = false
 tracks/4/enabled = true
 tracks/4/keys = {
-"times": PoolRealArray( 0.2 ),
-"transitions": PoolRealArray( 1 ),
+"times": PoolRealArray( 0.19, 0.2 ),
+"transitions": PoolRealArray( 1, 1 ),
 "values": [ {
-"args": [  ],
-"method": "play_mood_smile0"
+"args": [ 0.0 ],
+"method": "stop_walking"
+}, {
+"args": [ "smile0" ],
+"method": "play_mood_by_name"
 } ]
 }
 tracks/5/type = "method"
@@ -144,11 +150,14 @@ tracks/0/loop_wrap = true
 tracks/0/imported = false
 tracks/0/enabled = true
 tracks/0/keys = {
-"times": PoolRealArray( 0 ),
-"transitions": PoolRealArray( 1 ),
+"times": PoolRealArray( 0, 0.01 ),
+"transitions": PoolRealArray( 1, 1 ),
 "values": [ {
-"args": [  ],
-"method": "play_mood_think0"
+"args": [ 0.0 ],
+"method": "stop_walking"
+}, {
+"args": [ "think0" ],
+"method": "play_mood_by_name"
 } ]
 }
 tracks/1/type = "method"
@@ -158,11 +167,14 @@ tracks/1/loop_wrap = true
 tracks/1/imported = false
 tracks/1/enabled = true
 tracks/1/keys = {
-"times": PoolRealArray( 0.3 ),
-"transitions": PoolRealArray( 1 ),
+"times": PoolRealArray( 0.3, 0.31 ),
+"transitions": PoolRealArray( 1, 1 ),
 "values": [ {
-"args": [  ],
-"method": "play_mood_think0"
+"args": [ 0.0 ],
+"method": "stop_walking"
+}, {
+"args": [ "think0" ],
+"method": "play_mood_by_name"
 } ]
 }
 tracks/2/type = "value"

--- a/project/src/main/world/environment/lava/crowd-walking-buddy.gd
+++ b/project/src/main/world/environment/lava/crowd-walking-buddy.gd
@@ -7,11 +7,10 @@ func _ready() -> void:
 	stop_walking()
 
 
-func play_mood_think0() -> void:
-	stop_walking()
-	play_mood(Creatures.Mood.THINK0)
-
-
-func play_mood_smile0() -> void:
-	stop_walking()
-	play_mood(Creatures.Mood.SMILE0)
+## Animates the creature's appearance according to the specified mood: happy, angry, etc...
+##
+## Parameters:
+## 	'mood_name': A snake-case enum from Creatures.Mood such as 'think0'
+func play_mood_by_name(mood_name: String) -> void:
+	var mood := Utils.enum_from_snake_case(Creatures.Mood, mood_name)
+	play_mood(mood)


### PR DESCRIPTION
Replaced '_play_mood_foo' methods with generic '_play_mood_by_name' method. Removed the implicit 'stop_walking()' call and added an explicit call to the animation player.

Changed PinupScroller to expose its pinup field. PinupScrollers was already illegally accessing this field, so it should have just been public in the first place.