### PR TITLE
Tighter credits desync threshold. CreditsDemo shift -> space

### DIFF
--- a/project/src/demo/credits/credits-scroll-demo.gd
+++ b/project/src/demo/credits/credits-scroll-demo.gd
@@ -13,7 +13,7 @@ extends Node
 ## 	[Shift + F]: Transform all header letters into bubbly blocks.
 ## 	[Keypad 7,8,9]: Move the credits to the left, top, or right position and hide the header.
 ## 	[Keypad 1,2,3]: Move the credits to the left, bottom, or right position and show the header.
-## 	Shift: Hold to speed up the credits.
+## 	[Space]: Hold to speed up the credits.
 
 ## Number of seconds the demo has been running, shown on the time label
 var _total_time := 0.0
@@ -70,7 +70,7 @@ func _input(event: InputEvent) -> void:
 		KEY_KP_3:
 			_scroll.credits_position = Credits.CreditsPosition.BOTTOM_RIGHT
 	
-	if event is InputEventKey and event.scancode == KEY_SHIFT and not event.is_echo():
+	if event is InputEventKey and event.scancode == KEY_SPACE and not event.is_echo():
 		if event.is_pressed():
 			# disable 'adjusting_time_scale' so that CreditsDirector doesn't take change the time_scale while we're
 			# fast-forwarding

--- a/project/src/main/credits/credits-director.gd
+++ b/project/src/main/credits/credits-director.gd
@@ -8,7 +8,7 @@ extends Node
 ## 	PART_3: Additional credits scroll
 
 ## Threshold where the credits adjust their visuals to sync back up with the music.
-const DESYNC_THRESHOLD_MSEC := 100
+const DESYNC_THRESHOLD_MSEC := 40
 
 ## Duration in seconds for the first part of the credits, the initial credits scroll.
 const PART_1_DURATION := 40.0


### PR DESCRIPTION
Tightened credits desync threshold. 100 ms results in a very noticable audio delay for some of the sound effect cues.

Changed CreditsDemo speed up key from shift to space. Shift is a useful modifier key, and it's awkward to not be able to press it without speeding up the credits.