### PR TITLE
Preload credits cutscenes. Pinup scroller pool size.

### DIFF
--- a/project/src/main/credits/credits-movie.gd
+++ b/project/src/main/credits/credits-movie.gd
@@ -6,25 +6,30 @@ export (PackedScene) var CrowdSurfCutsceneScene: PackedScene
 
 onready var _viewport := $ViewportContainer/Viewport
 
+onready var _crowd_walk_cutscene := CrowdWalkCutsceneScene.instance()
+onready var _crowd_surf_cutscene := CrowdSurfCutsceneScene.instance()
+
+func _ready() -> void:
+	_viewport.add_child(_crowd_walk_cutscene)
+	_viewport.add_child(_crowd_surf_cutscene)
+
+
 ## Plays a cutscene where the player and Fat Sensei walk through a cheering crowd.
 func play_crowd_walk_cutscene(time_until_launch: float) -> void:
-	var crowd_walk_cutscene := CrowdWalkCutsceneScene.instance()
-	_replace_cutscene(crowd_walk_cutscene)
-	crowd_walk_cutscene.play(time_until_launch)
+	_replace_cutscene(_crowd_walk_cutscene)
+	_crowd_walk_cutscene.play(time_until_launch)
 
 
 ## Plays a cutscene where the player and Fat Sensei crowd surf on a cheering crowd.
 func play_crowd_surf_cutscene() -> void:
-	var crowd_surf_cutscene := CrowdSurfCutsceneScene.instance()
-	_replace_cutscene(crowd_surf_cutscene)
-	crowd_surf_cutscene.play()
+	_replace_cutscene(_crowd_surf_cutscene)
+	_crowd_surf_cutscene.play()
 
 
 func _replace_cutscene(new_cutscene: Node) -> void:
 	# remove the old cutscene
 	for child in _viewport.get_children():
-		child.queue_free()
-		_viewport.remove_child(child)
+		child.hide()
 	
 	# add the new cutscene
-	_viewport.add_child(new_cutscene)
+	new_cutscene.show()

--- a/project/src/main/credits/pinup-scrollers.gd
+++ b/project/src/main/credits/pinup-scrollers.gd
@@ -6,7 +6,7 @@ extends Control
 
 ## Number of creatures stored in the pinup pool. Higher values require more resources, but ensure we won't recycle a
 ## pinup which is still visible.
-const PINUP_POOL_SIZE := 5
+const PINUP_POOL_SIZE := 4
 
 export (PackedScene) var PinupScrollerScene: PackedScene
 

--- a/project/src/main/world/environment/lava/crowd-surf-cutscene.gd
+++ b/project/src/main/world/environment/lava/crowd-surf-cutscene.gd
@@ -3,5 +3,27 @@ extends Node
 
 onready var _crowd_surf_director: CrowdSurfDirector = $Environment/CrowdSurfDirector
 
+onready var _bg := $Bg
+onready var _launch_bg := $LaunchBg
+onready var _environment := $Environment
+onready var _camera := $Camera2D
+
+## Makes the cutscene appear, setting it as the current cutscene within its viewport.
+func show() -> void:
+	_bg.visible = true
+	_launch_bg.visible = false
+	_environment.visible = true
+	_camera.current = true
+
+
+## Makes the cutscene disappear, unsetting it as the current cutscene within its viewport.
+func hide() -> void:
+	_bg.visible = false
+	_launch_bg.visible = false
+	_environment.visible = false
+	_camera.current = false
+
+
+## Plays the cutscene animation.
 func play() -> void:
 	_crowd_surf_director.play()

--- a/project/src/main/world/environment/lava/crowd-walk-cutscene.gd
+++ b/project/src/main/world/environment/lava/crowd-walk-cutscene.gd
@@ -3,5 +3,30 @@ extends Node
 
 onready var _crowd_walk_director: CrowdWalkDirector = $Environment/CrowdWalkDirector
 
+onready var _bg := $Bg
+onready var _launch_bg := $LaunchBg
+onready var _environment := $Environment
+onready var _camera := $Camera2D
+
+## Makes the cutscene appear, setting it as the current cutscene within its viewport.
+func show() -> void:
+	_bg.visible = true
+	_launch_bg.visible = false
+	_environment.visible = true
+	_camera.current = true
+
+
+## Makes the cutscene disappear, unsetting it as the current cutscene within its viewport.
+func hide() -> void:
+	_bg.visible = false
+	_launch_bg.visible = false
+	_environment.visible = false
+	_camera.current = false
+
+
+## Plays the cutscene animation.
+##
+## Parameters:
+## 	'time_until_launch': Delay in seconds until the player and Fat Sensei should be tossed into the air.
 func play(time_until_launch: float) -> void:
 	_crowd_walk_director.play(time_until_launch)


### PR DESCRIPTION
Our initial version of the credits only loaded the cutscenes as needed, which uses about 5.1% less memory but introduces some ugly hiccups as the scenes load. The new credits sequence is smoother.

Decreased pinup scroller pool size from 5 to 4. Only 4 are visible at once.