### PR TITLE
Crowd cutscene refactoring: played, _on_Director, unused tween

### DIFF
--- a/project/src/main/world/environment/lava/CrowdSurfEnvironment.tscn
+++ b/project/src/main/world/environment/lava/CrowdSurfEnvironment.tscn
@@ -1919,7 +1919,7 @@ sensei_path = NodePath("../Obstacles/Sensei")
 
 [connection signal="body_entered" from="Obstacles/CrowdRecycler" to="Obstacles/CrowdRecycler" method="_on_body_entered"]
 [connection signal="timeout" from="Obstacles/CrowdRecycler/ReenableCollisionTimer" to="Obstacles/CrowdRecycler" method="_on_ReenableCollisionTimer_timeout"]
-[connection signal="creatures_arranged" from="CrowdSurfDirector" to="." method="_on_CrowdWalkDirector_creatures_arranged"]
-[connection signal="creatures_arranged" from="CrowdSurfDirector" to="Obstacles/CrowdRecycler" method="_on_CrowdWalkDirector_creatures_arranged"]
+[connection signal="played" from="CrowdSurfDirector" to="." method="_on_Director_played"]
+[connection signal="played" from="CrowdSurfDirector" to="Obstacles/CrowdRecycler" method="_on_Director_played"]
 
 [editable path="Ground/GroundMap"]

--- a/project/src/main/world/environment/lava/CrowdWalkEnvironment.tscn
+++ b/project/src/main/world/environment/lava/CrowdWalkEnvironment.tscn
@@ -1630,7 +1630,7 @@ anims/look_around = SubResource( 1 )
 
 [connection signal="body_entered" from="Obstacles/CrowdRecycler" to="Obstacles/CrowdRecycler" method="_on_body_entered"]
 [connection signal="timeout" from="Obstacles/CrowdRecycler/ReenableCollisionTimer" to="Obstacles/CrowdRecycler" method="_on_ReenableCollisionTimer_timeout"]
-[connection signal="creatures_arranged" from="CrowdWalkDirector" to="." method="_on_CrowdWalkDirector_creatures_arranged"]
-[connection signal="creatures_arranged" from="CrowdWalkDirector" to="Obstacles/CrowdRecycler" method="_on_CrowdWalkDirector_creatures_arranged"]
+[connection signal="played" from="CrowdWalkDirector" to="." method="_on_Director_played"]
+[connection signal="played" from="CrowdWalkDirector" to="Obstacles/CrowdRecycler" method="_on_Director_played"]
 
 [editable path="Ground/GroundMap"]

--- a/project/src/main/world/environment/lava/crowd-recycler.gd
+++ b/project/src/main/world/environment/lava/crowd-recycler.gd
@@ -11,7 +11,7 @@ var _move_direction: Vector2
 
 ## 'True' if the crowd walk director just moved all of the crowdies. When this happens, we take measures to avoid
 ## moving them a second time, which would result in them overshooting the camera area.
-var _just_creatures_arranged := false
+var _just_arranged_creatures := false
 
 onready var _target: Node2D = get_node(target_path)
 
@@ -35,22 +35,22 @@ func _move_crowd(crowd: Node2D) -> void:
 
 ## When the player runs past a crowdie, we move the crowdie and change their appearance.
 func _on_body_entered(body: Node2D) -> void:
-	if _just_creatures_arranged:
+	if _just_arranged_creatures:
 		return
 	
 	_move_crowd(body)
 
 
 ## When the crowd walk director moves all crowdies, we temporarily ignore collisions.
-func _on_CrowdWalkDirector_creatures_arranged() -> void:
-	_just_creatures_arranged = true
+func _on_Director_played() -> void:
+	_just_arranged_creatures = true
 	_reenable_collision_timer.start()
 
 
 ## When the crowd walk director moves all crowdies, we temporarily ignore collisions. This method reenables
 ## collisions afterward.
 func _on_ReenableCollisionTimer_timeout() -> void:
-	_just_creatures_arranged = false
+	_just_arranged_creatures = false
 	
 	# move all overlapping crowdies
 	for crowd in get_tree().get_nodes_in_group("recyclable_crowds"):

--- a/project/src/main/world/environment/lava/crowd-surf-director.gd
+++ b/project/src/main/world/environment/lava/crowd-surf-director.gd
@@ -3,12 +3,10 @@ extends Node
 ## Orchestrates a unique cutscene where the player and Fat Sensei crowd surf on a cheering crowd.
 
 ## Emitted when creatures are moved to their starting positions for the cutscene.
-signal creatures_arranged
+signal played
 
 export (NodePath) var player_path: NodePath
 export (NodePath) var sensei_path: NodePath
-
-var _tween: SceneTreeTween
 
 ## key: (Node2D) node whose position should be initialized
 ## value: (Vector2) initial position
@@ -28,7 +26,7 @@ func play() -> void:
 	_player.play_bounce_animation()
 	_sensei.play_bounce_animation()
 	
-	emit_signal("creatures_arranged")
+	emit_signal("played")
 
 
 ## Saves all creature positions to _initial_positions_by_node

--- a/project/src/main/world/environment/lava/crowd-walk-director.gd
+++ b/project/src/main/world/environment/lava/crowd-walk-director.gd
@@ -5,7 +5,7 @@ extends Node
 ## Arranges nodes and schedules events to synchronize the cutscene with the music.
 
 ## Emitted when creatures are moved to their starting positions for the cutscene.
-signal creatures_arranged
+signal played
 
 ## Number in the range [0.0, 1.0] for how many creatures should jump up and down with their arms raised.
 export (float, 0.0, 1.0) var bouncing_crowd_percent := 0.0 setget set_bouncing_crowd_percent
@@ -96,7 +96,7 @@ func play(time_until_launch: float) -> void:
 	_tween.tween_callback(_animation_player, "play", ["launch"]).set_delay(time_until_launch)
 	_tween.tween_callback(self, "crowd_launch").set_delay(time_until_launch)
 	
-	emit_signal("creatures_arranged")
+	emit_signal("played")
 
 
 func set_bouncing_crowd_percent(new_bouncing_crowd_percent: float) -> void:

--- a/project/src/main/world/environment/lava/crowd-walk-environment.gd
+++ b/project/src/main/world/environment/lava/crowd-walk-environment.gd
@@ -17,5 +17,5 @@ func set_midair(new_midair: bool) -> void:
 ## When the CrowdWalkDirector initializes the character positions, we reset the 'midair' value to false.
 ##
 ## This is mostly useful for demo and debugging purposes, as the animation should only play once during the credits.
-func _on_CrowdWalkDirector_creatures_arranged() -> void:
+func _on_Director_played() -> void:
 	set_midair(false)


### PR DESCRIPTION
Renamed 'creatures_arranged' signal to more generic 'played'. A future expansion of this method will add new methods and signals named 'stop' and 'stopped', so this is more consistent and simple.

Renamed '_on_CrowdWalkDirector_creatures_arranged' signal to '_on_Director_creatures_arranged'. This signal method is used for the CrowdSurfDirector as well, so the name should be generic.

Removed unused CrowdSurfDirector._tween field.