### PR TITLE
Added 'duration' parameter for SceneTransition signals.

### DIFF
--- a/project/src/main/music/music-transition.gd
+++ b/project/src/main/music/music-transition.gd
@@ -12,7 +12,7 @@ func _ready() -> void:
 
 
 ## When the scene fades back in, we un-fade any music we previously faded out.
-func _on_SceneTransition_fade_in_started() -> void:
+func _on_SceneTransition_fade_in_started(_duration: float) -> void:
 	if _faded_bgm:
 		# If we faded the music out, we fade it back in
 		MusicPlayer.play_bgm(_faded_bgm, _faded_bgm.get_playback_position())
@@ -25,7 +25,7 @@ func _on_SceneTransition_fade_in_started() -> void:
 ## When fading out the scene, we fade out the music for web targets.
 ##
 ## On web targets, the music sounds choppy and bad if we leave it running during scene transitions.
-func _on_SceneTransition_fade_out_started() -> void:
+func _on_SceneTransition_fade_out_started(duration: float) -> void:
 	if OS.has_feature("web"):
 		_faded_bgm = MusicPlayer.current_bgm
-		MusicPlayer.stop(SceneTransition.next_fade_out_duration * 0.5)
+		MusicPlayer.stop(duration * 0.5)

--- a/project/src/main/ui/scene-transition.gd
+++ b/project/src/main/ui/scene-transition.gd
@@ -2,8 +2,8 @@ extends CanvasLayer
 ## Plays scene transition animations.
 
 ## Scene transition emits these two signals in order as the screen fades out and fades back in
-signal fade_in_started
-signal fade_out_started
+signal fade_in_started(duration)
+signal fade_out_started(duration)
 
 enum TransitionType {
 	DEFAULT,
@@ -104,7 +104,7 @@ func fade_in(flags: Dictionary = {}) -> void:
 	var max_audio_start := max(0.0, _audio_stream_player.stream.get_length() - _fade_out_duration(flags))
 	_audio_stream_player.play(rand_range(0.0, max_audio_start))
 	
-	emit_signal("fade_in_started")
+	emit_signal("fade_in_started", _fade_in_duration(flags))
 
 
 ## Launches the 'fade out' visual transition.
@@ -124,7 +124,7 @@ func fade_out(flags: Dictionary = {}, breadcrumb_method: FuncRef = null, breadcr
 		_animation_player.disconnect("animation_finished", self, "_on_AnimationPlayer_animation_finished_change_scene")
 	_animation_player.connect("animation_finished", self, "_on_AnimationPlayer_animation_finished_change_scene", \
 			[flags, breadcrumb_method, breadcrumb_arg_array])
-	emit_signal("fade_out_started")
+	emit_signal("fade_out_started", _fade_out_duration(flags))
 
 
 func _fade_out_duration(flags: Dictionary) -> float:

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -634,7 +634,7 @@ func _on_CreatureVisuals_talking_changed() -> void:
 
 
 ## When a new scene is loaded, creatures fade in. This conceals visual glitches as their body parts load.
-func _on_SceneTransition_fade_in_started() -> void:
+func _on_SceneTransition_fade_in_started(_duration: float) -> void:
 	if visible:
 		visible = false
 		fade_in()

--- a/project/src/main/world/creature/free-roam-player.gd
+++ b/project/src/main/world/creature/free-roam-player.gd
@@ -41,6 +41,6 @@ func _on_OverworldUi_showed_chat_choices() -> void:
 		set_non_iso_walk_direction(Vector2.ZERO)
 
 
-func _on_SceneTransition_fade_out_started() -> void:
+func _on_SceneTransition_fade_out_started(_duration: float) -> void:
 	# suppress 'bonk' sound effects, otherwise it sounds like the player bumps into the door
 	set_suppress_sfx(true)


### PR DESCRIPTION
MusicTransition needs to know the duration of the scene transition on web targets so that it can fade out the music. It was still relying on SceneTransition.next_fade_out_duration, but this property was removed in 74b790ec.