### PR TITLE
Crowd cutscene collision bugs. Added 'stop'.

### DIFF
--- a/project/src/demo/world/environment/lava/crowd-surf-cutscene-demo.gd
+++ b/project/src/demo/world/environment/lava/crowd-surf-cutscene-demo.gd
@@ -2,7 +2,8 @@ extends Node
 ## Demonstrates a unique cutscene where the player and Fat Sensei crowd surf on a cheering crowd.
 ##
 ## Keys:
-## 	Space: Restart the cutscene.
+## 	[P]: Play the cutscene.
+## 	[S]: Stop the cutscene.
 
 ## Number of seconds the demo has been running, shown on the time label
 var _total_time := 0.0
@@ -12,9 +13,11 @@ onready var _time_label := $TimeLabel
 
 func _input(event: InputEvent) -> void:
 	match Utils.key_scancode(event):
-		KEY_SPACE:
+		KEY_P:
 			_total_time = 0.0
 			_director.play()
+		KEY_S:
+			_director.stop()
 
 
 func _process(delta: float) -> void:

--- a/project/src/demo/world/environment/lava/crowd-walk-cutscene-demo.gd
+++ b/project/src/demo/world/environment/lava/crowd-walk-cutscene-demo.gd
@@ -3,6 +3,7 @@ extends Node
 ##
 ## Keys:
 ## 	[Q,W,E,R]: Restart the cutscene with 10, 5, 3 or 1 second until the player is tossed into the air.
+## 	[S]: Stop the cutscene.
 ## 	[=/-]: Change the number of bouncing crowdies.
 
 ## Number of seconds the demo has been running, shown on the time label
@@ -25,6 +26,8 @@ func _input(event: InputEvent) -> void:
 			restart_cutscene(3)
 		KEY_R:
 			restart_cutscene(1)
+		KEY_S:
+			_director.stop()
 
 
 func _process(delta: float) -> void:

--- a/project/src/main/credits/crowd-surfing-buddy.gd
+++ b/project/src/main/credits/crowd-surfing-buddy.gd
@@ -51,12 +51,28 @@ onready var _elevation_tween: SceneTreeTween
 onready var _mood_timer := $MoodTimer
 
 func _ready() -> void:
-	set_elevation(SURF_HEIGHT)
+	stop()
 
 
 func _process(delta: float) -> void:
 	_velocity = lerp(_velocity, _desired_velocity, 0.01)
 	position += _velocity * delta
+
+
+## Stops the timers and tweens which handle the creature's mood and movement.
+func stop() -> void:
+	# stop bounce animation
+	_elevation_tween = Utils.kill_tween(_elevation_tween)
+	set_elevation(SURF_HEIGHT)
+	
+	# stop mood timer
+	_mood_timer.stop()
+	play_mood(Creatures.Mood.DEFAULT)
+	
+	# stop movement
+	set_process(false)
+	_desired_velocity = Vector2.ZERO
+	_velocity = Vector2.ZERO
 
 
 ## Initializes the timers and tweens which handle the creature's mood and movement.
@@ -73,7 +89,8 @@ func play_bounce_animation() -> void:
 	_randomize_mood()
 	_mood_timer.start(MOOD_TIMER_MAX_DURATION * randf())
 	
-	# initialize velocity
+	# start movement
+	set_process(true)
 	_refresh_desired_velocity()
 	_velocity = _desired_velocity
 

--- a/project/src/main/world/environment/lava/CrowdSurfEnvironment.tscn
+++ b/project/src/main/world/environment/lava/CrowdSurfEnvironment.tscn
@@ -99,6 +99,7 @@ position = Vector2( -8254.98, 4631.72 )
 position = Vector2( 360.692, 301.109 )
 collision_layer = 0
 collision_mask = 2
+monitoring = false
 script = ExtResource( 18 )
 target_path = NodePath("../Player")
 
@@ -1921,5 +1922,6 @@ sensei_path = NodePath("../Obstacles/Sensei")
 [connection signal="timeout" from="Obstacles/CrowdRecycler/ReenableCollisionTimer" to="Obstacles/CrowdRecycler" method="_on_ReenableCollisionTimer_timeout"]
 [connection signal="played" from="CrowdSurfDirector" to="." method="_on_Director_played"]
 [connection signal="played" from="CrowdSurfDirector" to="Obstacles/CrowdRecycler" method="_on_Director_played"]
+[connection signal="stopped" from="CrowdSurfDirector" to="Obstacles/CrowdRecycler" method="_on_Director_stopped"]
 
 [editable path="Ground/GroundMap"]

--- a/project/src/main/world/environment/lava/CrowdWalkEnvironment.tscn
+++ b/project/src/main/world/environment/lava/CrowdWalkEnvironment.tscn
@@ -276,6 +276,7 @@ leader_or_follower = 2
 position = Vector2( 360.692, 301.109 )
 collision_layer = 0
 collision_mask = 2
+monitoring = false
 script = ExtResource( 13 )
 target_path = NodePath("../Player")
 
@@ -1632,5 +1633,6 @@ anims/look_around = SubResource( 1 )
 [connection signal="timeout" from="Obstacles/CrowdRecycler/ReenableCollisionTimer" to="Obstacles/CrowdRecycler" method="_on_ReenableCollisionTimer_timeout"]
 [connection signal="played" from="CrowdWalkDirector" to="." method="_on_Director_played"]
 [connection signal="played" from="CrowdWalkDirector" to="Obstacles/CrowdRecycler" method="_on_Director_played"]
+[connection signal="stopped" from="CrowdWalkDirector" to="Obstacles/CrowdRecycler" method="_on_Director_stopped"]
 
 [editable path="Ground/GroundMap"]

--- a/project/src/main/world/environment/lava/crowd-surf-cutscene.gd
+++ b/project/src/main/world/environment/lava/crowd-surf-cutscene.gd
@@ -22,6 +22,7 @@ func hide() -> void:
 	_launch_bg.visible = false
 	_environment.visible = false
 	_camera.current = false
+	_crowd_surf_director.stop()
 
 
 ## Plays the cutscene animation.

--- a/project/src/main/world/environment/lava/crowd-surf-director.gd
+++ b/project/src/main/world/environment/lava/crowd-surf-director.gd
@@ -5,6 +5,9 @@ extends Node
 ## Emitted when creatures are moved to their starting positions for the cutscene.
 signal played
 
+## Emitted when the cutscenes animations are stopped.
+signal stopped
+
 export (NodePath) var player_path: NodePath
 export (NodePath) var sensei_path: NodePath
 
@@ -27,6 +30,13 @@ func play() -> void:
 	_sensei.play_bounce_animation()
 	
 	emit_signal("played")
+
+
+## Stops any cutscene animations.
+func stop() -> void:
+	_player.stop()
+	_sensei.stop()
+	emit_signal("stopped")
 
 
 ## Saves all creature positions to _initial_positions_by_node

--- a/project/src/main/world/environment/lava/crowd-walk-cutscene.gd
+++ b/project/src/main/world/environment/lava/crowd-walk-cutscene.gd
@@ -22,6 +22,7 @@ func hide() -> void:
 	_launch_bg.visible = false
 	_environment.visible = false
 	_camera.current = false
+	_crowd_walk_director.stop()
 
 
 ## Plays the cutscene animation.

--- a/project/src/main/world/environment/lava/crowd-walk-director.gd
+++ b/project/src/main/world/environment/lava/crowd-walk-director.gd
@@ -7,6 +7,9 @@ extends Node
 ## Emitted when creatures are moved to their starting positions for the cutscene.
 signal played
 
+## Emitted when the cutscenes animations are stopped.
+signal stopped
+
 ## Number in the range [0.0, 1.0] for how many creatures should jump up and down with their arms raised.
 export (float, 0.0, 1.0) var bouncing_crowd_percent := 0.0 setget set_bouncing_crowd_percent
 
@@ -97,6 +100,15 @@ func play(time_until_launch: float) -> void:
 	_tween.tween_callback(self, "crowd_launch").set_delay(time_until_launch)
 	
 	emit_signal("played")
+
+
+## Stops any cutscene animations.
+func stop() -> void:
+	_player.stop_walking()
+	_sensei.stop_walking()
+	_animation_player.stop()
+	_tween = Utils.kill_tween(_tween)
+	emit_signal("stopped")
 
 
 func set_bouncing_crowd_percent(new_bouncing_crowd_percent: float) -> void:


### PR DESCRIPTION
Fixed crowd cutscene collision bugs. CrowdSurfEnvironment and CrowdWalkEnvironment both use a CrowdRecycler to shuffle creatures around when they collide with an Area2D. However in fabd4cc8 we started loading both these environments simultaneously to reduce lag. This had the unintended side effect of these two Area2Ds interacting with creatures in the other environment.

I've fixed the bug by disabling these Area2D collision areas when they are not in use. Cutscenes are now considered active when 'play' is called, and they are considered inactive when a new 'stop' method is called. Inactive cutscenes have all their animations stopped and their CrowdRecyclers disabled.

This new 'stop' method is also available in CrowdWalkCutsceneDemo and CrowdSurfCutsceneDemo.