### PR TITLE
Bug: credits movies were at top, not center

### DIFF
--- a/project/src/main/credits/CreditsScroll.tscn
+++ b/project/src/main/credits/CreditsScroll.tscn
@@ -164,7 +164,7 @@ tracks/1/keys = {
 } ]
 }
 tracks/2/type = "method"
-tracks/2/path = NodePath("Movie")
+tracks/2/path = NodePath("FixedContainer/Movie")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -549,45 +549,6 @@ TurboFatCreditsLineScene = ExtResource( 6 )
 
 [node name="Wallpaper" parent="." instance=ExtResource( 10 )]
 
-[node name="Movie" type="Node2D" parent="."]
-script = ExtResource( 15 )
-CrowdWalkCutsceneScene = ExtResource( 14 )
-CrowdSurfCutsceneScene = ExtResource( 20 )
-
-[node name="Clip" type="Light2D" parent="Movie"]
-position = Vector2( 256, 300 )
-texture = ExtResource( 16 )
-texture_scale = 0.5
-mode = 3
-range_item_cull_mask = 2
-
-[node name="ViewportContainer" type="ViewportContainer" parent="Movie"]
-light_mask = 2
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 52.5
-margin_top = 52.5
-margin_right = 459.5
-margin_bottom = 547.5
-stretch = true
-stretch_shrink = 4
-script = ExtResource( 17 )
-world_viewport_path = NodePath("Viewport")
-
-[node name="Viewport" type="Viewport" parent="Movie/ViewportContainer"]
-size = Vector2( 101, 123 )
-handle_input_locally = false
-hdr = false
-usage = 0
-render_target_update_mode = 3
-
-[node name="Panel" type="Panel" parent="Movie"]
-margin_left = 50.0
-margin_top = 50.0
-margin_right = 462.0
-margin_bottom = 550.0
-custom_styles/panel = SubResource( 2 )
-
 [node name="FixedContainer" type="Control" parent="."]
 anchor_left = 0.5
 anchor_top = 0.5
@@ -597,6 +558,59 @@ margin_left = -512.0
 margin_top = -300.0
 margin_right = 512.0
 margin_bottom = 300.0
+
+[node name="Movie" type="Control" parent="FixedContainer"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -512.0
+margin_top = -300.0
+margin_right = 512.0
+margin_bottom = 300.0
+script = ExtResource( 15 )
+CrowdWalkCutsceneScene = ExtResource( 14 )
+CrowdSurfCutsceneScene = ExtResource( 20 )
+
+[node name="Clip" type="Light2D" parent="FixedContainer/Movie"]
+position = Vector2( 256, 300 )
+texture = ExtResource( 16 )
+texture_scale = 0.5
+mode = 3
+range_item_cull_mask = 2
+
+[node name="ViewportContainer" type="ViewportContainer" parent="FixedContainer/Movie"]
+light_mask = 2
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -459.5
+margin_top = -247.5
+margin_right = -52.5
+margin_bottom = 247.5
+stretch = true
+stretch_shrink = 4
+script = ExtResource( 17 )
+world_viewport_path = NodePath("Viewport")
+
+[node name="Viewport" type="Viewport" parent="FixedContainer/Movie/ViewportContainer"]
+size = Vector2( 101, 123 )
+handle_input_locally = false
+hdr = false
+usage = 0
+render_target_update_mode = 3
+
+[node name="Panel" type="Panel" parent="FixedContainer/Movie"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -462.0
+margin_top = -250.0
+margin_right = -50.0
+margin_bottom = 250.0
+custom_styles/panel = SubResource( 2 )
 
 [node name="FadeOutPoint" type="Node2D" parent="FixedContainer"]
 position = Vector2( 0, 110 )

--- a/project/src/main/credits/credits-movie.gd
+++ b/project/src/main/credits/credits-movie.gd
@@ -1,4 +1,4 @@
-extends Node2D
+extends Control
 ## Plays different movies during the credits scroll.
 
 export (PackedScene) var CrowdWalkCutsceneScene: PackedScene

--- a/project/src/main/credits/credits-scroll.gd
+++ b/project/src/main/credits/credits-scroll.gd
@@ -76,12 +76,12 @@ onready var _lines := $FixedContainer/ScrollingContainer/Lines
 onready var _credits_pieces: CreditsPieces = $FixedContainer/OrbHolder/Pieces
 
 ## Movie which plays alongside the credits lines.
-onready var _movie: Node2D = $Movie
+onready var _movie: Control = $FixedContainer/Movie
 
 func _ready() -> void:
 	MusicPlayer.play_credits_bgm()
 	
-	_movie.position = MOVIE_POSITION_OFFSCREEN_LEFT
+	_movie.rect_position = MOVIE_POSITION_OFFSCREEN_LEFT
 	
 	# initialize the movie to visible but transparent; this way the tweens don't have to toggle the 'visible' property
 	_movie.visible = true
@@ -259,7 +259,7 @@ func _shift_movie(old_movie_visible: bool, new_movie_visible: bool, \
 			new_movie_position = MOVIE_POSITION_OFFSCREEN_RIGHT
 		else:
 			new_movie_position = MOVIE_POSITION_OFFSCREEN_LEFT
-		_movie_tween_x.parallel().tween_property(_movie, "position", new_movie_position, 0.5) \
+		_movie_tween_x.parallel().tween_property(_movie, "rect_position", new_movie_position, 0.5) \
 				.set_trans(Tween.TRANS_CIRC).set_ease(Tween.EASE_IN_OUT)
 	
 	if tweening_in:
@@ -267,13 +267,13 @@ func _shift_movie(old_movie_visible: bool, new_movie_visible: bool, \
 			_movie_tween_x = Utils.recreate_tween(self, _movie_tween_x)
 		
 		# Set the movie position so that it swoops in from the correct direction offscreen
-		if tweening_out or _movie.position in [MOVIE_POSITION_OFFSCREEN_LEFT, MOVIE_POSITION_OFFSCREEN_RIGHT]:
+		if tweening_out or _movie.rect_position in [MOVIE_POSITION_OFFSCREEN_LEFT, MOVIE_POSITION_OFFSCREEN_RIGHT]:
 			var new_source_movie_position: Vector2
 			if Credits.is_position_right(new_credits_position):
 				new_source_movie_position = MOVIE_POSITION_OFFSCREEN_LEFT
 			else:
 				new_source_movie_position = MOVIE_POSITION_OFFSCREEN_RIGHT
-			_movie_tween_x.tween_callback(_movie, "set", ["position", new_source_movie_position])
+			_movie_tween_x.tween_callback(_movie, "set", ["rect_position", new_source_movie_position])
 		
 		_movie_tween_x.tween_property(_movie, "modulate", Color.white, 0.1).set_delay(0.2)
 		var new_movie_position: Vector2
@@ -281,7 +281,7 @@ func _shift_movie(old_movie_visible: bool, new_movie_visible: bool, \
 			new_movie_position = MOVIE_POSITION_RIGHT
 		else:
 			new_movie_position = MOVIE_POSITION_LEFT
-		_movie_tween_x.parallel().tween_property(_movie, "position", new_movie_position, 0.5) \
+		_movie_tween_x.parallel().tween_property(_movie, "rect_position", new_movie_position, 0.5) \
 				.set_trans(Tween.TRANS_CIRC).set_ease(Tween.EASE_IN_OUT)
 
 


### PR DESCRIPTION
If the window was taller than 1024x600, the movies which played alongside the credits would appear at the top of the credits window instead of the center. I've moved the credits movies inside the 'fixed container' so that they'll be aligned with everything else.