### PR TITLE
Improved pinups scrolling offscreen during credits.

### DIFF
--- a/project/src/main/credits/pinup-scroller.gd
+++ b/project/src/main/credits/pinup-scroller.gd
@@ -2,6 +2,13 @@ class_name PinupScroller
 extends Node2D
 ## A pinup which scrolls vertically during the credits.
 
+enum ScrollerState {
+	VISIBLE,
+	FADING_IN,
+	FADING_OUT,
+	INVISIBLE,
+}
+
 ## which side of the screen the pinup appears on
 enum Side {
 	LEFT,
@@ -15,6 +22,9 @@ const FADE_DURATION := 0.5
 ## Height in units. Used for calculating the scroll speed.
 export (float) var line_height: float
 
+## tracks whether the pinup is currently fading in or out
+var state: int = ScrollerState.VISIBLE
+
 var velocity := Vector2(0, -50)
 var _tween: SceneTreeTween
 
@@ -26,23 +36,38 @@ func _physics_process(delta: float) -> void:
 	
 	position += velocity * delta
 	
-	if global_position.y < -100.0:
+	if position.y < -100.0 and state in [ScrollerState.FADING_IN, ScrollerState.VISIBLE]:
 		stop()
 
 
-## Hides the pinup and stops it from moving.
-func stop() -> void:
+## Immediately hides the pinup and stops it from moving.
+func reset() -> void:
+	state = ScrollerState.INVISIBLE
 	visible = false
 	set_physics_process(false)
 
 
-## Shows the pinup and starts it moving.
-func start() -> void:
+## Fades the pinup out and stops it from moving.
+func stop() -> void:
+	state = ScrollerState.FADING_OUT
 	visible = true
+	set_physics_process(true)
+	
+	_tween = Utils.recreate_tween(self, _tween)
+	_tween.tween_property(self, "modulate", Color.transparent, FADE_DURATION)
+	_tween.tween_callback(self, "set", ["state", ScrollerState.INVISIBLE])
+	_tween.tween_callback(self, "set", ["visible", false])
+	_tween.tween_callback(self, "set_physics_process", [false])
+
+
+## Fades the pinup in and starts it moving.
+func start() -> void:
+	state = ScrollerState.FADING_IN
+	visible = true
+	set_physics_process(true)
 	
 	pinup.reset()
 	modulate = Color.transparent
 	_tween = Utils.recreate_tween(self, _tween)
 	_tween.tween_property(self, "modulate", Color.white, FADE_DURATION)
-	
-	set_physics_process(true)
+	_tween.tween_callback(self, "set", ["state", ScrollerState.VISIBLE])

--- a/project/src/main/credits/pinup-scrollers.gd
+++ b/project/src/main/credits/pinup-scrollers.gd
@@ -20,7 +20,7 @@ onready var _pinup_holder := $PinupHolder
 func _ready() -> void:
 	for _i in range(PINUP_POOL_SIZE):
 		var pinup_scroller: PinupScroller = PinupScrollerScene.instance()
-		pinup_scroller.stop()
+		pinup_scroller.reset()
 		_pinup_holder.add_child(pinup_scroller)
 		_pinup_scroller_pool.append(pinup_scroller)
 


### PR DESCRIPTION
One especially large pinup 'chelle' was blinking out of view unpleasantly. Pinups now slowly fade out after they're above a certain height. This also improves the appearance when the window is very tall, as the pinups fade in from the bottom and fade out at the top, so it's symmetrical. Before, the pinups kept scrolling up all the way offscreen and it looked a bit strange.