### PR TITLE
MoodDemo uses canon appearances, not player's custom fatness

### DIFF
--- a/project/src/demo/chat/ui/mood-demo.gd
+++ b/project/src/demo/chat/ui/mood-demo.gd
@@ -38,6 +38,8 @@ onready var _creature := $Creature
 onready var _creature_animations: CreatureAnimations = $Creature.creature_visuals.get_node("Animations")
 
 func _ready() -> void:
+	PlayerData.creature_library.clear_all_fatness()
+	
 	if creature_path:
 		_creature.creature_def = CreatureDef.new().from_json_path(creature_path)
 	else:


### PR DESCRIPTION
I've made a lot of creatures very fat through gameplay, but I still want to draw them at their canon sizes. Having MoodDemo reset their fatnesses makes this simpler