### PR TITLE
Changed export presets to zips. Linux +x flag.

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -12,54 +12,10 @@ version=$(grep "config/version=" project/project.godot | awk -F "\"" '{print $2}
 echo "version=$version"
 
 ################################################################################
-# Package the windows release
-
-win_export_path="project/export/windows"
-win_zip_filename="$win_export_path/turbofat-win-v$version.zip"
-
-# Delete the existing windows zip file
-if [ -f "$win_zip_filename" ]; then
-  echo "Deleting $win_zip_filename"
-  rm "$win_zip_filename"
-fi
-
-# Assemble the windows zip file
-echo "Packaging $win_zip_filename"
-zip "$win_zip_filename" "$win_export_path/turbofat-win-v$version.*" -x "*.zip" -j
-
-################################################################################
-# Package the linux release
-
-linux_export_path="project/export/linux-x11"
-linux_zip_filename="$linux_export_path/turbofat-linux-v$version.zip"
-
-# Delete the existing linux zip file
-if [ -f "$linux_zip_filename" ]; then
-  echo "Deleting $linux_zip_filename"
-  rm "$linux_zip_filename"
-fi
-
-# Assemble the linux zip file
-echo "Packaging $linux_zip_filename"
-zip "$linux_zip_filename" "$linux_export_path/turbofat-linux-v$version.*" -x "*.zip" -j
-
-################################################################################
 # Package the html5 release
 
 html5_export_path="project/export/html5"
-html5_old_index_filename="$html5_export_path/turbofat.html"
-html5_new_index_filename="$html5_export_path/index.html"
 html5_zip_filename="$html5_export_path/turbofat-html5-v$version.zip"
-
-# Rename the 'turbofat.html' file to 'index.html', as required by itch.io
-if [ -f "$html5_old_index_filename" ]; then
-  if [ -f "$html5_new_index_filename" ]; then
-    echo "Deleting $html5_new_index_filename"
-    rm "$html5_new_index_filename"
-  fi
-  echo "Renaming turbofat.html to index.html"
-  mv "$html5_export_path/turbofat.html" $html5_new_index_filename
-fi
 
 # Delete the existing html5 zip file
 if [ -f "$html5_zip_filename" ]; then

--- a/project/export_presets.cfg.template
+++ b/project/export_presets.cfg.template
@@ -7,7 +7,7 @@ custom_features=""
 export_filter="all_resources"
 include_filter="*.chat, *.json, *.txt"
 exclude_filter="src/test/*, src/demo/*, assets/test/*, assets/demo/*"
-export_path="export/windows/turbofat-win-v##VERSION##.exe"
+export_path="export/windows/turbofat-win-v##VERSION##.zip"
 script_export_mode=1
 script_encryption_key=""
 
@@ -49,7 +49,7 @@ custom_features=""
 export_filter="all_resources"
 include_filter="*.chat, *.json, *.txt"
 exclude_filter="src/test/*, src/demo/*, assets/test/*, assets/demo/*"
-export_path="export/linux-x11/turbofat-linux-v##VERSION##.x86_64"
+export_path="export/linux-x11/turbofat-linux-v##VERSION##.x86_64.zip"
 script_export_mode=1
 script_encryption_key=""
 
@@ -106,7 +106,7 @@ custom_features=""
 export_filter="all_resources"
 include_filter="*.chat, *.json, *.txt"
 exclude_filter="src/test/*, src/demo/*, assets/test/*, assets/demo/*"
-export_path="export/html5/turbofat.html"
+export_path="export/html5/index.html"
 script_export_mode=1
 script_encryption_key=""
 


### PR DESCRIPTION
Changed windows, linux export presets from .exe/.x86_64 to .zip. This lets us get rid of our custom packaging code and automatically sets the executable flag for linux systems, so that players don't need chmod +x the executable before running it.

I could not change the html export to use a '.zip' -- this is not supported, and instead exports the game into a 'turbofat.zip.html' html file.

Renamed 'turbofat.html' to 'index.html' to avoid unnecessary packaging step.