### PR TITLE
Fixed version label layout, stays in bottom-right

### DIFF
--- a/project/src/main/ui/VersionLabel.tscn
+++ b/project/src/main/ui/VersionLabel.tscn
@@ -8,10 +8,13 @@ anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = -110.0
+margin_left = -68.0
 margin_top = -30.0
-margin_right = -9.99988
+margin_right = -10.0
+margin_bottom = -10.0
 theme = ExtResource( 2 )
 text = "v1.2.3.4"
 align = 2
 script = ExtResource( 1 )
+
+[connection signal="resized" from="." to="." method="_on_resized"]

--- a/project/src/main/ui/version-label.gd
+++ b/project/src/main/ui/version-label.gd
@@ -1,5 +1,10 @@
 extends Label
-## Displays a version label like '0.3100'.
+## Displays a version label like '0.3100' in the bottom right corner.
 
 func _ready() -> void:
 	text = ProjectSettings.get_setting("application/config/version")
+
+
+## When the label is resized, we move it to the bottom-right corner.
+func _on_resized() -> void:
+	set_global_position(get_viewport_rect().size - rect_size - Vector2(10, 10))


### PR DESCRIPTION
Before, the version label was always at position (956, 570) which was usually OK but would look strange if the version number was very long or very short.

The version label now stays locked in the bottom right corner regardless of the version text.