### PR TITLE
package.sh can now handle version suffixes

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -7,8 +7,9 @@
 # combines them into a zip file. Some exports only produce a single file, so
 # those are left alone.
 
-# Calculate the version string
-version=$(grep "config/version=" project/project.godot | awk -F "\"" '{print $2}')
+# Calculate the version string from project.godot, trimming off any suffix
+# such as '-steam'
+version=$(grep "config/version=" project/project.godot | awk -F "[\"-]" '{print $2}')
 echo "version=$version"
 
 ################################################################################


### PR DESCRIPTION
We want to show the user a version like '1.2.3-steam' for steam, but we don't want this suffix to pollute places like the Android Play store. This suffix would probably violate the syntax of some platforms.