### PR TITLE
Update version to '0.8416-steam'.

### DIFF
--- a/generate-export-presets.sh
+++ b/generate-export-presets.sh
@@ -42,5 +42,5 @@ sed -i "s/##ANDROID_KEYSTORE_RELEASE_PASSWORD##/$ANDROID_KEYSTORE_RELEASE_PASSWO
 echo "Updated export_presets.cfg"
 
 # Update project.godot
-sed -i "s/^config\/version=\".*\"$/config\/version=\"$version\"/g" project/project.godot
+sed -i "s/^config\/version=\".*\"$/config\/version=\"$version-steam\"/g" project/project.godot
 echo "Updated project.godot"

--- a/project/project.godot
+++ b/project/project.godot
@@ -1794,7 +1794,7 @@ config/name="Turbo Fat"
 run/main_scene="res://src/main/ui/menu/LoadingScreen.tscn"
 config/icon="res://assets/main/ui/icon.png"
 config/windows_native_icon="res://assets/main/ui/icon.ico"
-config/version="0.8305"
+config/version="0.8416-steam"
 
 [audio]
 


### PR DESCRIPTION
generate-export-presets.sh now suffixes the version number with '-steam'. The steam version is likely to diverge slightly as we add things like achievement support. It could have its own bugs, so it's good to keep the version numbers separate so we can differentiate them when users report problems.