### PR TITLE
Initial focus for Level Editor, Creature Editor

### DIFF
--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -54,6 +54,8 @@ func _ready() -> void:
 	new_center_creature_def.creature_id = NameUtils.short_name_to_id(new_center_creature_def.creature_short_name)
 	set_center_creature_def(new_center_creature_def)
 	mutate_all_creatures()
+	
+	$Ui/TabContainer/Tweak/ScrollContainer/MarginContainer/VBoxContainer/Name.grab_focus()
 
 
 ## Regenerates all of the outer creatures to be variations of the center creature.

--- a/project/src/main/editor/creature/tweak-name-row.gd
+++ b/project/src/main/editor/creature/tweak-name-row.gd
@@ -11,6 +11,13 @@ func _ready() -> void:
 	$Edit/ShortName.max_length = NameUtils.MAX_CREATURE_SHORT_NAME_LENGTH
 
 
+## Steals the focus from another control and becomes the focused control.
+##
+## This control itself doesn't have focus, so we delegate to a child control.
+func grab_focus() -> void:
+	$Edit/Name.grab_focus()
+
+
 ## Update the creature's name and short name.
 func _finish_name_edit(text: String) -> void:
 	var new_name: String = NameUtils.sanitize_name(text)

--- a/project/src/main/editor/puzzle/level-editor.gd
+++ b/project/src/main/editor/puzzle/level-editor.gd
@@ -14,9 +14,13 @@ var _test_scene: Node
 
 onready var level_id_label := $HBoxContainer/SideButtons/LevelId
 onready var _level_json := $HBoxContainer/SideButtons/Json
+onready var _test_button := $HBoxContainer/SideButtons/Test
 
 func _ready() -> void:
 	var level_text := FileUtils.get_file_as_text(LevelSettings.path_from_level_key(DEFAULT_LEVEL_ID))
+	
+	# grab initial focus for controller/keyboard
+	_test_button.grab_focus()
 	
 	# immediately parse and upgrade the level; LevelEditor will behave strangely with older level formats
 	_parse_level(DEFAULT_LEVEL_ID, level_text)


### PR DESCRIPTION
Level Editor, Creature Editor grab initial focus so that the player can navigate with keyboard or controllers. They still don't work well with keyboard or controllers overall, but they at least have focus initially