### PR TITLE
Can click to exit credits. 'ui_click'

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -1939,6 +1939,11 @@ ui_menu={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
+ui_click={
+"deadzone": 0.5,
+"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":1,"pressed":false,"doubleclick":false,"script":null)
+ ]
+}
 rewind_text={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777237,"physical_scancode":0,"unicode":0,"echo":false,"script":null)

--- a/project/src/main/ui/exit-credits-popup.gd
+++ b/project/src/main/ui/exit-credits-popup.gd
@@ -32,21 +32,32 @@ var _popup_state: int = PopupState.POPPED_OUT
 var _tween: SceneTreeTween
 
 onready var _panel := $Panel
+onready var _label := $Panel/Label
 
 func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_accept", true):
-		match _popup_state:
-			POPPING_OUT, POPPED_OUT:
-				_pop_in()
-			POPPED_IN:
-				emit_signal("exit_pressed")
-			POPPING_IN:
-				# we ignore additional button presses until we're fully popped in, so that the player doesn't
-				# accidentally mash through the credits
-				pass
+		_handle_press_event()
+		if _popup_state != POPPED_IN:
+			_label.text = tr("Press again to exit")
+	elif event.is_action_pressed("ui_click"):
+		_handle_press_event()
+		if _popup_state != POPPED_IN:
+			_label.text = tr("Click again to exit")
 	
 	if event.is_action_pressed("ui_cancel", true):
 		emit_signal("exit_pressed")
+
+
+func _handle_press_event() -> void:
+	match _popup_state:
+		POPPING_OUT, POPPED_OUT:
+			_pop_in()
+		POPPED_IN:
+			emit_signal("exit_pressed")
+		POPPING_IN:
+			# we ignore additional button presses until we're fully popped in, so that the player doesn't
+			# accidentally mash through the credits
+			pass
 
 
 func _pop_in() -> void:


### PR DESCRIPTION
Added new 'ui_click' event. This seems like a cleaner way to handle mouse events rather than manually checking the mouse mask. The existing 'mouse mask' code has some bugs. I've created #2433 to capture these.