### PR TITLE
MiscSettings.save_slot_changed signal emitted by from_json_dict

### DIFF
--- a/project/src/main/data/system-save.gd
+++ b/project/src/main/data/system-save.gd
@@ -36,8 +36,8 @@ var _upgrader := SystemSaveUpgrader.new().new_save_item_upgrader()
 
 func _ready() -> void:
 	load_system_data()
-	SystemData.misc_settings.connect("save_slot_changed", self, "_on_MiscSettings_save_slot_changed")
 	_refresh_save_slot()
+	SystemData.misc_settings.connect("save_slot_changed", self, "_on_MiscSettings_save_slot_changed")
 	PlayerSave.load_player_data()
 
 

--- a/project/src/main/settings/misc-settings.gd
+++ b/project/src/main/settings/misc-settings.gd
@@ -67,7 +67,7 @@ func to_json_dict() -> Dictionary:
 
 
 func from_json_dict(json: Dictionary) -> void:
-	save_slot = int(json.get("save_slot", SaveSlot.SLOT_A))
+	set_save_slot(int(json.get("save_slot", SaveSlot.SLOT_A)))
 	
 	var new_locale: String
 	if json.has("locale"):


### PR DESCRIPTION
Most 'from_json_dict' methods emit corresponding signals, but there was a blind spot for this one property.

Reordered SystemSave initialization to prevent the save slot from being set twice.