### PR TITLE
Gut no longer triggers fullscreen mode.

### DIFF
--- a/project/src/main/data/system-data.gd
+++ b/project/src/main/data/system-data.gd
@@ -31,6 +31,18 @@ func _ready() -> void:
 	_schedule_refresh_graphics_settings()
 
 
+## Prevents the player's settings from triggering fullscreen mode or vsync.
+##
+## This is called when running Gut tests to prevent the Gut window from becoming fullscreen. This could happen if the
+## developer enables fullscreen mode, or when a test loads system data with fullscreen mode enabled.
+func disallow_graphics_customization() -> void:
+	graphics_settings.disconnect("fullscreen_changed", self, "_on_GraphicsSettings_fullscreen_changed")
+	graphics_settings.disconnect("use_vsync_changed", self, "_on_GraphicsSettings_use_vsync_changed")
+	if _refresh_graphics_settings_timer:
+		_refresh_graphics_settings_timer.disconnect("timeout", self, "_on_RefreshGraphicsSettingsTimer_timeout")
+		_refresh_graphics_settings_timer = null
+
+
 ## Resets the system's in-memory data to a default state.
 func reset() -> void:
 	gameplay_settings.reset()

--- a/project/src/test/pre-run-hook.gd
+++ b/project/src/test/pre-run-hook.gd
@@ -1,0 +1,6 @@
+extends GutHookScript
+## Performs initialization steps for Gut tests.
+
+func run() -> void:
+	# Prevent the player's settings from triggering fullscreen mode or vsync.
+	SystemData.disallow_graphics_customization()


### PR DESCRIPTION
Added 'SystemData.disallow_graphics_customization' method which unhooks the player's settings from triggering graphics updates. This is called by a GutHookScript so that running the Gut tests does not enter fullscreen mode.