### PR TITLE
Removed unused 'ui_has_focus' property.

### DIFF
--- a/project/src/demo/world/FreeRoamUi.tscn
+++ b/project/src/demo/world/FreeRoamUi.tscn
@@ -134,16 +134,13 @@ quit_type = 1
 
 [node name="MusicPopup" parent="." instance=ExtResource( 17 )]
 
-[connection signal="chat_choice_chosen" from="ChatUi" to="." method="_on_ChatUi_chat_choice_chosen"]
 [connection signal="chat_event_played" from="ChatUi" to="." method="_on_ChatUi_chat_event_played"]
 [connection signal="chat_finished" from="ChatUi" to="." method="_on_ChatUi_chat_finished"]
 [connection signal="showed_choices" from="ChatUi" to="." method="_on_ChatUi_showed_choices"]
 [connection signal="pressed" from="Buttons/Northeast/SettingsButton" to="." method="_on_SettingsButton_pressed"]
 [connection signal="cheat_detected" from="CheatCodeDetector" to="Labels/SoutheastLabels/FpsLabel" method="_on_CheatCodeDetector_cheat_detected"]
-[connection signal="hide" from="SettingsMenu" to="." method="_on_SettingsMenu_hide"]
 [connection signal="hide" from="SettingsMenu" to="TouchButtons" method="_on_Menu_hide"]
 [connection signal="hide" from="SettingsMenu" to="Buttons" method="_on_Menu_hide"]
 [connection signal="quit_pressed" from="SettingsMenu" to="." method="_on_SettingsMenu_quit_pressed"]
-[connection signal="show" from="SettingsMenu" to="." method="_on_SettingsMenu_show"]
 [connection signal="show" from="SettingsMenu" to="TouchButtons" method="_on_Menu_show"]
 [connection signal="show" from="SettingsMenu" to="Buttons" method="_on_Menu_show"]

--- a/project/src/main/world/CutsceneUi.tscn
+++ b/project/src/main/world/CutsceneUi.tscn
@@ -57,7 +57,6 @@ codes = [ "bigfps" ]
 
 [node name="MusicPopup" parent="." instance=ExtResource( 13 )]
 
-[connection signal="chat_choice_chosen" from="ChatUi" to="." method="_on_ChatUi_chat_choice_chosen"]
 [connection signal="chat_event_played" from="ChatUi" to="." method="_on_ChatUi_chat_event_played"]
 [connection signal="chat_finished" from="ChatUi" to="." method="_on_ChatUi_chat_finished"]
 [connection signal="showed_choices" from="ChatUi" to="." method="_on_ChatUi_showed_choices"]

--- a/project/src/main/world/creature/free-roam-player.gd
+++ b/project/src/main/world/creature/free-roam-player.gd
@@ -2,9 +2,6 @@ class_name FreeRoamPlayer
 extends Creature
 ## Script for manipulating the player-controlled character in the overworld.
 
-## if 'true' the ui has focus and the player shouldn't move when keys are pressed.
-var ui_has_focus := false setget set_ui_has_focus
-
 ## if 'true' the player is in free roam mode and can move with the arrow keys.
 var free_roam := false
 
@@ -18,21 +15,10 @@ func _unhandled_input(event: InputEvent) -> void:
 		# disable movement outside of free roam mode
 		return
 	
-	if ui_has_focus:
-		# disable movement when navigating menus
-		return
-	
 	if Utils.ui_pressed_dir(event) or Utils.ui_released_dir(event):
 		# calculate the direction the player wants to move
 		set_non_iso_walk_direction(Utils.ui_pressed_dir())
 		get_tree().set_input_as_handled()
-
-
-func set_ui_has_focus(new_ui_has_focus: bool) -> void:
-	ui_has_focus = new_ui_has_focus
-	if ui_has_focus and non_iso_walk_direction:
-		# if the player is moving when something grabs focus, stop their movement
-		set_non_iso_walk_direction(Vector2.ZERO)
 
 
 ## Stop moving when a chat choice appears.

--- a/project/src/main/world/overworld-ui.gd
+++ b/project/src/main/world/overworld-ui.gd
@@ -39,15 +39,11 @@ var _current_chat_tree: ChatTree
 
 var _overworld_environment: OverworldEnvironment
 
-## if 'true' the ui has focus and the player shouldn't move when keys are pressed.
-var _ui_has_focus: bool = false
-
 onready var _chat_ui := $ChatUi
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
 	_refresh_overworld_environment_path()
-	_refresh_ui_has_focus()
 	_update_visible()
 
 
@@ -58,7 +54,6 @@ func _exit_tree() -> void:
 func set_overworld_environment_path(new_overworld_environment_path: NodePath) -> void:
 	overworld_environment_path = new_overworld_environment_path
 	_refresh_overworld_environment_path()
-	_refresh_ui_has_focus()
 
 
 ## Plays the specified chat tree.
@@ -139,17 +134,6 @@ func _refresh_overworld_environment_path() -> void:
 	
 	_chat_ui.overworld_environment_path = \
 			_chat_ui.get_path_to(_overworld_environment) if overworld_environment_path else NodePath()
-
-
-func _refresh_ui_has_focus() -> void:
-	if not is_inside_tree():
-		return
-	
-	if not _overworld_environment:
-		return
-	
-	if _overworld_environment.player is FreeRoamPlayer:
-		_overworld_environment.player.ui_has_focus = _ui_has_focus
 
 
 func _find_creatures_in_chat_tree(chat_tree: ChatTree) -> Array:
@@ -274,13 +258,6 @@ func _on_Creature_fade_out_finished(_creature: Creature) -> void:
 
 func _on_ChatUi_showed_choices() -> void:
 	emit_signal("showed_chat_choices")
-	_ui_has_focus = true
-	_refresh_ui_has_focus()
-
-
-func _on_ChatUi_chat_choice_chosen(_chat_choice: int) -> void:
-	_ui_has_focus = false
-	_refresh_ui_has_focus()
 
 
 func _on_SettingsMenu_quit_pressed() -> void:
@@ -289,16 +266,6 @@ func _on_SettingsMenu_quit_pressed() -> void:
 
 func _on_SettingsButton_pressed() -> void:
 	$SettingsMenu.show()
-
-
-func _on_SettingsMenu_show() -> void:
-	_ui_has_focus = true
-	_refresh_ui_has_focus()
-
-
-func _on_SettingsMenu_hide() -> void:
-	_ui_has_focus = false
-	_refresh_ui_has_focus()
 
 
 func _on_OverworldWorld_overworld_environment_changed(value: OverworldEnvironment) -> void:


### PR DESCRIPTION
This was used in FreeRoam mode when the player could move with the arrow keys and talk to other creatures. When the dialog boxes popped up, we didn't want them moving around when trying to select chat choices. This functionality is no longer in the game, not even in demos, so we don't need this property anymore.