### PR TITLE
Move CandyButton signals from .tscn to script.

### DIFF
--- a/project/src/main/ui/candy-button/CandyButtonH3.tscn
+++ b/project/src/main/ui/candy-button/CandyButtonH3.tscn
@@ -1,9 +1,12 @@
 [gd_scene load_steps=17 format=2]
 
+[ext_resource path="res://assets/main/ui/candy-button/h3-blank-pressed.png" type="Texture" id=1]
+[ext_resource path="res://assets/main/ui/candy-button/h3-shine.png" type="Texture" id=2]
 [ext_resource path="res://assets/main/ui/candy-button/h3-focused.png" type="Texture" id=3]
 [ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=4]
 [ext_resource path="res://src/main/ui/candy-button/candy-button-h3.gd" type="Script" id=5]
 [ext_resource path="res://src/main/ui/candy-button/gradient-none.tres" type="Gradient" id=6]
+[ext_resource path="res://assets/main/ui/candy-button/h3-blank.png" type="Texture" id=7]
 [ext_resource path="res://src/main/utils/icon-outline.shader" type="Shader" id=8]
 [ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=9]
 [ext_resource path="res://assets/main/ui/button-hover.wav" type="AudioStream" id=10]
@@ -20,14 +23,6 @@ shader = ExtResource( 9 )
 shader_param/mix_amount = 1.0
 shader_param/gradient = SubResource( 9 )
 
-[sub_resource type="StreamTexture" id=13]
-flags = 13
-load_path = "res://.import/candy-button.png-2ed4e542581c2066541e7913ae64e8a5.stex"
-
-[sub_resource type="StreamTexture" id=12]
-flags = 13
-load_path = "res://.import/candy-button-pressed.png-438bffc49a3c8aa425bdc4c8295291bb.stex"
-
 [sub_resource type="ShaderMaterial" id=7]
 resource_local_to_scene = true
 shader = ExtResource( 8 )
@@ -36,16 +31,12 @@ shader_param/white = Color( 1, 1, 1, 1 )
 shader_param/black = Color( 0.149412, 0.135882, 0.15, 1 )
 shader_param/sample_count = 24
 
-[sub_resource type="DynamicFont" id=14]
+[sub_resource type="DynamicFont" id=10]
 resource_local_to_scene = true
 size = 24
 outline_size = 2
 outline_color = Color( 0.149412, 0.135882, 0.15, 1 )
 font_data = ExtResource( 4 )
-
-[sub_resource type="StreamTexture" id=11]
-flags = 13
-load_path = "res://.import/candy-button-shine-normal.png-858dafea438a5e5083b2ee9e72ed1d44.stex"
 
 [node name="CandyButton" type="TextureButton"]
 material = SubResource( 8 )
@@ -54,9 +45,9 @@ margin_top = 84.7441
 margin_right = 435.173
 margin_bottom = 134.744
 rect_min_size = Vector2( 200, 50 )
-texture_normal = SubResource( 13 )
-texture_pressed = SubResource( 12 )
-texture_hover = SubResource( 13 )
+texture_normal = ExtResource( 7 )
+texture_pressed = ExtResource( 1 )
+texture_hover = ExtResource( 7 )
 texture_focused = ExtResource( 3 )
 expand = true
 script = ExtResource( 5 )
@@ -97,7 +88,7 @@ margin_top = 10.0
 margin_right = 123.0
 margin_bottom = 40.0
 size_flags_horizontal = 3
-custom_fonts/font = SubResource( 14 )
+custom_fonts/font = SubResource( 10 )
 text = "Text"
 align = 1
 valign = 1
@@ -129,7 +120,7 @@ size_flags_horizontal = 3
 modulate = Color( 1, 1, 1, 0.831373 )
 anchor_right = 1.0
 anchor_bottom = 1.0
-texture = SubResource( 11 )
+texture = ExtResource( 2 )
 expand = true
 
 [node name="ClickSound" type="AudioStreamPlayer" parent="."]
@@ -139,10 +130,3 @@ bus = "Sound Bus"
 [node name="HoverSound" parent="." instance=ExtResource( 12 )]
 stream = ExtResource( 10 )
 volume_db = -4.0
-
-[connection signal="button_down" from="." to="." method="_on_button_down"]
-[connection signal="button_up" from="." to="." method="_on_button_up"]
-[connection signal="focus_entered" from="." to="." method="_on_focus_entered"]
-[connection signal="focus_exited" from="." to="." method="_on_focus_exited"]
-[connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]
-[connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]

--- a/project/src/main/ui/candy-button/CandyButtonH4.tscn
+++ b/project/src/main/ui/candy-button/CandyButtonH4.tscn
@@ -4,8 +4,8 @@
 [ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=2]
 [ext_resource path="res://src/main/utils/DeconflictedAudioStreamPlayer.tscn" type="PackedScene" id=3]
 [ext_resource path="res://assets/main/ui/candy-button/h4-focused.png" type="Texture" id=4]
-[ext_resource path="res://assets/main/ui/candy-button/h4-v-pressed.png" type="Texture" id=5]
-[ext_resource path="res://assets/main/ui/candy-button/h4-v.png" type="Texture" id=6]
+[ext_resource path="res://assets/main/ui/candy-button/h4-blank.png" type="Texture" id=5]
+[ext_resource path="res://assets/main/ui/candy-button/h4-blank-pressed.png" type="Texture" id=6]
 [ext_resource path="res://assets/main/ui/candy-button/h4-shine.png" type="Texture" id=7]
 [ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=8]
 [ext_resource path="res://assets/main/ui/button-hover.wav" type="AudioStream" id=9]
@@ -35,12 +35,13 @@ margin_top = 66.0563
 margin_right = 215.682
 margin_bottom = 96.0563
 rect_min_size = Vector2( 120, 30 )
-texture_normal = ExtResource( 6 )
-texture_pressed = ExtResource( 5 )
-texture_hover = ExtResource( 6 )
+texture_normal = ExtResource( 5 )
+texture_pressed = ExtResource( 6 )
+texture_hover = ExtResource( 5 )
 texture_focused = ExtResource( 4 )
 expand = true
 script = ExtResource( 1 )
+text = "Text"
 
 [node name="Label" type="Label" parent="."]
 anchor_right = 1.0
@@ -49,6 +50,7 @@ margin_left = 5.0
 margin_right = -5.0
 size_flags_horizontal = 3
 custom_fonts/font = SubResource( 10 )
+text = "Text"
 align = 1
 valign = 1
 
@@ -66,10 +68,3 @@ bus = "Sound Bus"
 [node name="HoverSound" parent="." instance=ExtResource( 3 )]
 stream = ExtResource( 9 )
 volume_db = -4.0
-
-[connection signal="button_down" from="." to="." method="_on_button_down"]
-[connection signal="button_up" from="." to="." method="_on_button_up"]
-[connection signal="focus_entered" from="." to="." method="_on_focus_entered"]
-[connection signal="focus_exited" from="." to="." method="_on_focus_exited"]
-[connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]
-[connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]

--- a/project/src/main/ui/candy-button/candy-button-h3.gd
+++ b/project/src/main/ui/candy-button/candy-button-h3.gd
@@ -144,6 +144,17 @@ onready var _label := $HBoxContainer/Label
 onready var _shine := $Shine
 
 func _ready() -> void:
+	# Connect signals in code to prevent them from showing up in the Godot editor.
+	#
+	# This is a generic button used in many places, we want to be able to quickly see the unique signals connected to
+	# each button instance, not the generic signals connected to all button instances.
+	connect("button_down", self, "_on_button_down")
+	connect("button_up", self, "_on_button_up")
+	connect("focus_entered", self, "_on_focus_entered")
+	connect("focus_exited", self, "_on_focus_exited")
+	connect("mouse_entered", self, "_on_mouse_entered")
+	connect("mouse_exited", self, "_on_mouse_exited")
+	
 	_refresh_icons()
 	_refresh_font_size()
 	_refresh_text()

--- a/project/src/main/ui/candy-button/candy-button-h4.gd
+++ b/project/src/main/ui/candy-button/candy-button-h4.gd
@@ -131,6 +131,17 @@ onready var _label := $Label
 onready var _shine := $Shine
 
 func _ready() -> void:
+	# Connect signals in code to prevent them from showing up in the Godot editor.
+	#
+	# This is a generic button used in many places, we want to be able to quickly see the unique signals connected to
+	# each button instance, not the generic signals connected to all button instances.
+	connect("button_down", self, "_on_button_down")
+	connect("button_up", self, "_on_button_up")
+	connect("focus_entered", self, "_on_focus_entered")
+	connect("focus_exited", self, "_on_focus_exited")
+	connect("mouse_entered", self, "_on_mouse_entered")
+	connect("mouse_exited", self, "_on_mouse_exited")
+	
 	_refresh_font_size()
 	_refresh_text()
 	_refresh_shape()


### PR DESCRIPTION
Moved CandyButton signals so they no longer appear in the editor. This is a generic button used in many places, we want to be able to quickly see the unique signals connected to each button instance, not the generic signals connected to all button instances.

Assigned more suitable default textures/color to CandyButtonH4.