### PR TITLE
Added 'new_page' flag for Starberry Mountain

### DIFF
--- a/project/assets/main/puzzle/career-regions.json
+++ b/project/assets/main/puzzle/career-regions.json
@@ -525,6 +525,9 @@
       "description": "A slew of insurmountable challenges sure to drive even the most seasoned chefs to the brink of insanity. The true Turbo Fat starts here!",
       "icon": "rainbow",
       "piece_speed": "A1-AD",
+      "flags": [
+        "new_page"
+      ],
       "levels": [
         {
           "id": "career/dark/3000_race"

--- a/project/src/main/career/career-region.gd
+++ b/project/src/main/career/career-region.gd
@@ -1,6 +1,9 @@
 class_name CareerRegion
 ## Stores information about a group of levels for career mode.
 
+## Flag for regions which should appear separate from the previous region, such as Starberry Mountain
+const FLAG_NEW_PAGE := "new_page"
+
 ## Flag for regions where Fat Sensei is not following the player
 const FLAG_NO_SENSEI := "no_sensei"
 

--- a/project/src/main/ui/menu/paged-region-buttons.gd
+++ b/project/src/main/ui/menu/paged-region-buttons.gd
@@ -74,7 +74,8 @@ func set_regions(new_regions: Array) -> void:
 		if i == 0:
 			same_group = false
 		elif regions[i] is CareerRegion and regions[i - 1] is CareerRegion:
-			pass
+			if regions[i].has_flag(CareerRegion.FLAG_NEW_PAGE):
+				same_group = false
 		elif regions[i] is OtherRegion and regions[i - 1] is OtherRegion:
 			var curr_region_is_tutorial: bool = regions[i].id == OtherRegion.ID_TUTORIAL
 			var prev_region_is_tutorial: bool = regions[i - 1].id == OtherRegion.ID_TUTORIAL


### PR DESCRIPTION
Added 'new_page' flag to force Starberry Mountain to appear on its own page. Currently, the number of regions is coincidentally the maximum page count of the PagedRegionPanel, but we plan to remove Vega Churn Twelve shortly.