### PR TITLE
CandyButton tweaks: shortcut_in_tooltip, pause_mode

### DIFF
--- a/project/src/main/ui/candy-button/CandyButtonH3.tscn
+++ b/project/src/main/ui/candy-button/CandyButtonH3.tscn
@@ -45,6 +45,7 @@ margin_top = 84.7441
 margin_right = 435.173
 margin_bottom = 134.744
 rect_min_size = Vector2( 200, 50 )
+shortcut_in_tooltip = false
 texture_normal = ExtResource( 7 )
 texture_pressed = ExtResource( 1 )
 texture_hover = ExtResource( 7 )
@@ -124,9 +125,11 @@ texture = ExtResource( 2 )
 expand = true
 
 [node name="ClickSound" type="AudioStreamPlayer" parent="."]
+pause_mode = 2
 stream = ExtResource( 11 )
 bus = "Sound Bus"
 
 [node name="HoverSound" parent="." instance=ExtResource( 12 )]
+pause_mode = 2
 stream = ExtResource( 10 )
 volume_db = -4.0

--- a/project/src/main/ui/candy-button/CandyButtonH4.tscn
+++ b/project/src/main/ui/candy-button/CandyButtonH4.tscn
@@ -35,6 +35,7 @@ margin_top = 66.0563
 margin_right = 215.682
 margin_bottom = 96.0563
 rect_min_size = Vector2( 120, 30 )
+shortcut_in_tooltip = false
 texture_normal = ExtResource( 5 )
 texture_pressed = ExtResource( 6 )
 texture_hover = ExtResource( 5 )
@@ -62,9 +63,11 @@ texture = ExtResource( 7 )
 expand = true
 
 [node name="ClickSound" type="AudioStreamPlayer" parent="."]
+pause_mode = 2
 stream = ExtResource( 10 )
 bus = "Sound Bus"
 
 [node name="HoverSound" parent="." instance=ExtResource( 3 )]
+pause_mode = 2
 stream = ExtResource( 9 )
 volume_db = -4.0


### PR DESCRIPTION
Disabled 'shortcut_in_tooltip'. This baffling default Godot functionality makes it so that hovering any button results in a cryptic message like '(InputEventAction : action=ui_cancel, pressed=(false) My Tooltip)'.

There is luckily a workaround, but it's honestly baffling that a workaround is necessary in the first place.

Changed 'pauze_mode' for button sound effects. Otherwise when clicking the Settings button, no sounds will play because the sound effect nodes are paused.