### PR TITLE
Removed CandyButtons cruft from MainMenu, SystemButtons

### DIFF
--- a/project/src/main/ui/menu/MainMenu.tscn
+++ b/project/src/main/ui/menu/MainMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=55 format=2]
+[gd_scene load_steps=37 format=2]
 
 [ext_resource path="res://src/main/ui/menu/main-menu.gd" type="Script" id=1]
 [ext_resource path="res://assets/main/ui/candy-button/h3-p.png" type="Texture" id=2]
@@ -20,20 +20,14 @@
 [ext_resource path="res://assets/main/ui/candy-button/h3-t-pressed.png" type="Texture" id=19]
 [ext_resource path="res://assets/main/ui/candy-button/h3-o.png" type="Texture" id=20]
 [ext_resource path="res://assets/main/ui/candy-button/h3-q-pressed.png" type="Texture" id=21]
-[ext_resource path="res://src/main/ui/candy-button/gradient-green-normal.tres" type="Gradient" id=22]
-[ext_resource path="res://src/main/ui/candy-button/gradient-orange-normal.tres" type="Gradient" id=23]
-[ext_resource path="res://src/main/ui/candy-button/gradient-violet-normal.tres" type="Gradient" id=24]
 [ext_resource path="res://assets/main/ui/candy-button/h3-u-pressed.png" type="Texture" id=25]
 [ext_resource path="res://assets/main/ui/candy-button/h3-u.png" type="Texture" id=26]
 [ext_resource path="res://assets/main/ui/candy-button/h3-p-pressed.png" type="Texture" id=27]
-[ext_resource path="res://src/main/ui/candy-button/gradient-blue-normal.tres" type="Gradient" id=28]
-[ext_resource path="res://src/main/ui/candy-button/gradient-indigo-normal.tres" type="Gradient" id=29]
 [ext_resource path="res://assets/main/ui/icon-practice.png" type="Texture" id=30]
 [ext_resource path="res://assets/main/ui/icon-tutorials.png" type="Texture" id=31]
 [ext_resource path="res://assets/main/ui/icon-career.png" type="Texture" id=32]
 [ext_resource path="res://assets/main/ui/icon-create-levels.png" type="Texture" id=33]
 [ext_resource path="res://assets/main/ui/icon-create-creatures.png" type="Texture" id=34]
-[ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=35]
 [ext_resource path="res://src/main/ui/menu/MenuAccentH2.tscn" type="PackedScene" id=36]
 [ext_resource path="res://assets/main/ui/menu/menu-accent-h2-s1.png" type="Texture" id=37]
 [ext_resource path="res://src/main/ui/menu/MenuAccentTitle.tscn" type="PackedScene" id=38]
@@ -47,66 +41,6 @@ size = 72
 outline_size = 6
 outline_color = Color( 0.254902, 0.156863, 0.117647, 1 )
 font_data = ExtResource( 3 )
-
-[sub_resource type="GradientTexture2D" id=2]
-resource_local_to_scene = true
-gradient = ExtResource( 22 )
-
-[sub_resource type="ShaderMaterial" id=3]
-resource_local_to_scene = true
-shader = ExtResource( 35 )
-shader_param/mix_amount = 1.0
-shader_param/gradient = SubResource( 2 )
-
-[sub_resource type="GradientTexture2D" id=4]
-resource_local_to_scene = true
-gradient = ExtResource( 24 )
-
-[sub_resource type="ShaderMaterial" id=5]
-resource_local_to_scene = true
-shader = ExtResource( 35 )
-shader_param/mix_amount = 1.0
-shader_param/gradient = SubResource( 4 )
-
-[sub_resource type="GradientTexture2D" id=6]
-resource_local_to_scene = true
-gradient = ExtResource( 23 )
-
-[sub_resource type="ShaderMaterial" id=7]
-resource_local_to_scene = true
-shader = ExtResource( 35 )
-shader_param/mix_amount = 1.0
-shader_param/gradient = SubResource( 6 )
-
-[sub_resource type="GradientTexture2D" id=8]
-resource_local_to_scene = true
-gradient = ExtResource( 29 )
-
-[sub_resource type="ShaderMaterial" id=9]
-resource_local_to_scene = true
-shader = ExtResource( 35 )
-shader_param/mix_amount = 1.0
-shader_param/gradient = SubResource( 8 )
-
-[sub_resource type="GradientTexture2D" id=10]
-resource_local_to_scene = true
-gradient = ExtResource( 28 )
-
-[sub_resource type="ShaderMaterial" id=11]
-resource_local_to_scene = true
-shader = ExtResource( 35 )
-shader_param/mix_amount = 1.0
-shader_param/gradient = SubResource( 10 )
-
-[sub_resource type="GradientTexture2D" id=12]
-resource_local_to_scene = true
-gradient = ExtResource( 22 )
-
-[sub_resource type="ShaderMaterial" id=13]
-resource_local_to_scene = true
-shader = ExtResource( 35 )
-shader_param/mix_amount = 1.0
-shader_param/gradient = SubResource( 12 )
 
 [node name="MainMenu" type="Control"]
 anchor_right = 1.0
@@ -164,7 +98,6 @@ margin_bottom = 37.5
 texture = ExtResource( 37 )
 
 [node name="Career" parent="DropPanel/Play" instance=ExtResource( 15 )]
-material = SubResource( 3 )
 margin_left = 131.0
 margin_top = 67.0
 margin_right = 331.0
@@ -180,7 +113,6 @@ color = 4
 shape = 3
 
 [node name="Practice" parent="DropPanel/Play" instance=ExtResource( 15 )]
-material = SubResource( 5 )
 margin_left = 131.0
 margin_top = 127.0
 margin_right = 331.0
@@ -196,7 +128,6 @@ color = 7
 shape = 6
 
 [node name="Tutorials" parent="DropPanel/Play" instance=ExtResource( 15 )]
-material = SubResource( 7 )
 margin_left = 131.0
 margin_top = 187.0
 margin_right = 331.0
@@ -238,7 +169,6 @@ texture = ExtResource( 39 )
 _accent_index = 1
 
 [node name="Creatures" parent="DropPanel/Create" instance=ExtResource( 15 )]
-material = SubResource( 9 )
 margin_left = 131.0
 margin_top = 97.0
 margin_right = 331.0
@@ -254,7 +184,6 @@ color = 6
 shape = 7
 
 [node name="Levels" parent="DropPanel/Create" instance=ExtResource( 15 )]
-material = SubResource( 11 )
 margin_left = 131.0
 margin_top = 157.0
 margin_right = 331.0
@@ -285,7 +214,6 @@ margin_bottom = -18.0
 script = ExtResource( 12 )
 
 [node name="StressTest" parent="DropPanel/Debug" instance=ExtResource( 40 )]
-material = SubResource( 13 )
 margin_left = 0.0
 margin_top = 0.0
 margin_right = 120.0

--- a/project/src/main/ui/menu/SystemButtons.tscn
+++ b/project/src/main/ui/menu/SystemButtons.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=23 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://src/main/ui/theme/h4.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/ui/menu/system-buttons.gd" type="Script" id=2]
@@ -6,46 +6,12 @@
 [ext_resource path="res://src/main/ui/UiMenuShortcut.tres" type="ShortCut" id=4]
 [ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=5]
 [ext_resource path="res://assets/main/ui/candy-button/h4-o.png" type="Texture" id=6]
-[ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=7]
 [ext_resource path="res://src/main/ui/candy-button/CandyButtonH4.tscn" type="PackedScene" id=8]
-[ext_resource path="res://src/main/ui/candy-button/gradient-violet-normal.tres" type="Gradient" id=9]
-[ext_resource path="res://src/main/ui/candy-button/gradient-red-normal.tres" type="Gradient" id=10]
-[ext_resource path="res://src/main/ui/candy-button/gradient-yellow-normal.tres" type="Gradient" id=11]
 [ext_resource path="res://assets/main/ui/candy-button/h4-o-pressed.png" type="Texture" id=12]
 [ext_resource path="res://assets/main/ui/candy-button/h4-q.png" type="Texture" id=13]
 [ext_resource path="res://assets/main/ui/candy-button/h4-q-pressed.png" type="Texture" id=14]
 [ext_resource path="res://assets/main/ui/candy-button/h4-p.png" type="Texture" id=15]
 [ext_resource path="res://assets/main/ui/candy-button/h4-p-pressed.png" type="Texture" id=16]
-
-[sub_resource type="GradientTexture2D" id=1]
-resource_local_to_scene = true
-gradient = ExtResource( 9 )
-
-[sub_resource type="ShaderMaterial" id=2]
-resource_local_to_scene = true
-shader = ExtResource( 7 )
-shader_param/mix_amount = 1.0
-shader_param/gradient = SubResource( 1 )
-
-[sub_resource type="GradientTexture2D" id=3]
-resource_local_to_scene = true
-gradient = ExtResource( 11 )
-
-[sub_resource type="ShaderMaterial" id=4]
-resource_local_to_scene = true
-shader = ExtResource( 7 )
-shader_param/mix_amount = 1.0
-shader_param/gradient = SubResource( 3 )
-
-[sub_resource type="GradientTexture2D" id=5]
-resource_local_to_scene = true
-gradient = ExtResource( 10 )
-
-[sub_resource type="ShaderMaterial" id=6]
-resource_local_to_scene = true
-shader = ExtResource( 7 )
-shader_param/mix_amount = 1.0
-shader_param/gradient = SubResource( 5 )
 
 [node name="System" type="VBoxContainer"]
 anchor_top = 1.0
@@ -57,7 +23,6 @@ custom_constants/separation = 10
 script = ExtResource( 2 )
 
 [node name="Settings" parent="." instance=ExtResource( 8 )]
-material = SubResource( 2 )
 margin_left = 452.0
 margin_top = 0.0
 margin_right = 572.0
@@ -77,7 +42,6 @@ action = "ui_cancel"
 overridden_action = "ui_menu"
 
 [node name="Credits" parent="." instance=ExtResource( 8 )]
-material = SubResource( 4 )
 margin_left = 452.0
 margin_top = 40.0
 margin_right = 572.0
@@ -92,7 +56,6 @@ color = 3
 shape = 4
 
 [node name="Quit" parent="." instance=ExtResource( 8 )]
-material = SubResource( 6 )
 margin_left = 452.0
 margin_top = 80.0
 margin_right = 572.0


### PR DESCRIPTION
Adding a CandyButton instance automatically adds a bunch of unnecessary GradientTexture2D and ShaderMaterial instances.