### PR TITLE
CandyButtons in menus: SplashScreen, PracticeMenu, etc...

### DIFF
--- a/project/src/main/puzzle/PuzzleMessages.tscn
+++ b/project/src/main/puzzle/PuzzleMessages.tscn
@@ -1,12 +1,18 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://src/main/puzzle/PuzzleMessage.tscn" type="PackedScene" id=1]
-[ext_resource path="res://src/main/ui/theme/h4.theme" type="Theme" id=3]
-[ext_resource path="res://src/main/ui/theme/h3.theme" type="Theme" id=4]
+[ext_resource path="res://assets/main/ui/candy-button/h4-o.png" type="Texture" id=2]
+[ext_resource path="res://src/main/ui/UiCancelShortcut.tres" type="ShortCut" id=4]
 [ext_resource path="res://src/main/puzzle/puzzle-messages.gd" type="Script" id=5]
-[ext_resource path="res://src/main/ui/UiCancelShortcut.tres" type="ShortCut" id=7]
-[ext_resource path="res://src/main/ui/UiMenuShortcut.tres" type="ShortCut" id=8]
+[ext_resource path="res://src/main/ui/UiMenuShortcut.tres" type="ShortCut" id=7]
 [ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=9]
+[ext_resource path="res://src/main/ui/candy-button/CandyButtonH3.tscn" type="PackedScene" id=10]
+[ext_resource path="res://src/main/ui/candy-button/CandyButtonH4.tscn" type="PackedScene" id=11]
+[ext_resource path="res://assets/main/ui/candy-button/h3-v.png" type="Texture" id=12]
+[ext_resource path="res://assets/main/ui/candy-button/h3-v-pressed.png" type="Texture" id=13]
+[ext_resource path="res://assets/main/ui/candy-button/h4-o-pressed.png" type="Texture" id=14]
+[ext_resource path="res://assets/main/ui/candy-button/h4-q-pressed.png" type="Texture" id=17]
+[ext_resource path="res://assets/main/ui/candy-button/h4-q.png" type="Texture" id=18]
 
 [node name="PuzzleMessages" type="Control"]
 margin_left = 364.0
@@ -22,44 +28,53 @@ anchor_bottom = 0.5
 margin_bottom = 136.0
 custom_constants/separation = 10
 
-[node name="Start" type="Button" parent="Buttons"]
-margin_left = 72.0
-margin_right = 252.0
-margin_bottom = 60.0
-rect_min_size = Vector2( 180, 60 )
+[node name="Start" parent="Buttons" instance=ExtResource( 10 )]
+margin_left = 62.0
+margin_top = 0.0
+margin_right = 262.0
+margin_bottom = 50.0
 size_flags_horizontal = 4
 size_flags_vertical = 4
-theme = ExtResource( 4 )
-shortcut_in_tooltip = false
+texture_normal = ExtResource( 12 )
+texture_pressed = ExtResource( 13 )
+texture_hover = ExtResource( 12 )
 text = "Start"
+color = 5
+shape = 8
 
-[node name="Settings" type="Button" parent="Buttons"]
-margin_left = 104.0
-margin_top = 70.0
-margin_right = 220.0
-margin_bottom = 98.0
-rect_min_size = Vector2( 116, 28 )
+[node name="Settings" parent="Buttons" instance=ExtResource( 11 )]
+margin_left = 102.0
+margin_top = 60.0
+margin_right = 222.0
+margin_bottom = 90.0
 size_flags_horizontal = 4
-theme = ExtResource( 3 )
-shortcut_in_tooltip = false
-shortcut = ExtResource( 8 )
+size_flags_vertical = 4
+shortcut = ExtResource( 7 )
+texture_normal = ExtResource( 2 )
+texture_pressed = ExtResource( 14 )
+texture_hover = ExtResource( 2 )
 text = "Settings"
+color = 7
+shape = 3
 
 [node name="ShortcutHelper" parent="Buttons/Settings" instance=ExtResource( 9 )]
 action = "ui_cancel"
 overridden_action = "ui_menu"
 
-[node name="Back" type="Button" parent="Buttons"]
-margin_left = 104.0
-margin_top = 108.0
-margin_right = 220.0
-margin_bottom = 136.0
-rect_min_size = Vector2( 116, 28 )
+[node name="Back" parent="Buttons" instance=ExtResource( 11 )]
+margin_left = 102.0
+margin_top = 100.0
+margin_right = 222.0
+margin_bottom = 130.0
 size_flags_horizontal = 4
-theme = ExtResource( 3 )
-shortcut_in_tooltip = false
-shortcut = ExtResource( 7 )
+size_flags_vertical = 4
+shortcut = ExtResource( 4 )
+texture_normal = ExtResource( 18 )
+texture_pressed = ExtResource( 17 )
+texture_hover = ExtResource( 18 )
 text = "Back"
+color = 1
+shape = 5
 
 [node name="PuzzleMessage" parent="." instance=ExtResource( 1 )]
 mouse_filter = 2

--- a/project/src/main/puzzle/puzzle-messages.gd
+++ b/project/src/main/puzzle/puzzle-messages.gd
@@ -29,8 +29,10 @@ func _ready() -> void:
 		# they can't go back in career mode
 		if CurrentLevel.hardcore:
 			_back_button.text = tr("Give Up")
+			_back_button.color = CandyButtons.ButtonColor.RED
 		else:
 			_back_button.text = tr("Skip")
+			_back_button.color = CandyButtons.ButtonColor.RED
 	
 	_refresh_start_button(0)
 	
@@ -69,13 +71,24 @@ func hide_buttons() -> void:
 func _refresh_start_button(new_attempt_count: int) -> void:
 	if PlayerData.career.is_career_mode():
 		match new_attempt_count:
-			0: _start_button.text = tr("Start")
-			1: _start_button.text = tr("Practice")
-			_: _start_button.text = tr("Retry")
+			0:
+				_start_button.text = tr("Start")
+				_start_button.color = CandyButtons.ButtonColor.BLUE
+			1:
+				# Practicing a level shouldn't be the default behavior, so we use a less welcoming indigo color.
+				_start_button.text = tr("Practice")
+				_start_button.color = CandyButtons.ButtonColor.INDIGO
+			_:
+				_start_button.text = tr("Retry")
+				_start_button.color = CandyButtons.ButtonColor.BLUE
 	else:
 		match new_attempt_count:
-			0: _start_button.text = tr("Start")
-			_: _start_button.text = tr("Retry")
+			0:
+				_start_button.text = tr("Start")
+				_start_button.color = CandyButtons.ButtonColor.BLUE
+			_:
+				_start_button.text = tr("Retry")
+				_start_button.color = CandyButtons.ButtonColor.BLUE
 
 
 func _hide_all_clear_message() -> void:
@@ -161,6 +174,7 @@ func _on_PuzzleState_after_game_ended() -> void:
 	
 	if PlayerData.career.is_career_mode():
 		_back_button.text = tr("Continue")
+		_back_button.color = CandyButtons.ButtonColor.BLUE
 	
 	# determine the default button to focus
 	var buttons_to_focus := [_back_button, _start_button]
@@ -179,7 +193,7 @@ func _on_PuzzleState_after_game_ended() -> void:
 	
 	# grab focus so the player can retry or navigate with the keyboard
 	for button_to_focus_obj in buttons_to_focus:
-		var button_to_focus: Button = button_to_focus_obj
+		var button_to_focus: BaseButton = button_to_focus_obj
 		if button_to_focus.is_visible_in_tree():
 			button_to_focus.grab_focus()
 			break
@@ -189,9 +203,15 @@ func _on_PuzzleState_after_game_ended() -> void:
 func _on_Level_best_result_changed() -> void:
 	match CurrentLevel.best_result:
 		Levels.Result.FINISHED, Levels.Result.WON:
-			_back_button.text = tr("Back") if CurrentLevel.keep_retrying else tr("Continue")
+			if CurrentLevel.keep_retrying:
+				_back_button.text = tr("Back")
+				_back_button.color = CandyButtons.ButtonColor.RED
+			else:
+				_back_button.text = tr("Continue")
+				_back_button.color = CandyButtons.ButtonColor.BLUE
 		_:
 			_back_button.text = tr("Back")
+			_back_button.color = CandyButtons.ButtonColor.RED
 
 
 func _on_Playfield_all_lines_cleared() -> void:

--- a/project/src/main/ui/menu/PracticeMenu.tscn
+++ b/project/src/main/ui/menu/PracticeMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=28 format=2]
+[gd_scene load_steps=36 format=2]
 
 [ext_resource path="res://src/main/ui/menu/PagedRegionPanel.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/ui/ImageButton.tscn" type="PackedScene" id=2]
@@ -7,7 +7,6 @@
 [ext_resource path="res://src/main/ui/menu/system-buttons.gd" type="Script" id=5]
 [ext_resource path="res://src/main/ui/theme/h4.theme" type="Theme" id=6]
 [ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=7]
-[ext_resource path="res://src/main/ui/UiMenuShortcut.tres" type="ShortCut" id=8]
 [ext_resource path="res://src/main/ui/theme/h3.theme" type="Theme" id=9]
 [ext_resource path="res://src/main/ui/menu/drop-panel.tres" type="StyleBox" id=10]
 [ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=11]
@@ -19,12 +18,21 @@
 [ext_resource path="res://src/main/ui/theme/h2-font-outline.tres" type="DynamicFont" id=17]
 [ext_resource path="res://assets/main/ui/menu/menu-accent-h2-m2.png" type="Texture" id=18]
 [ext_resource path="res://src/main/ui/menu/MenuAccentH2.tscn" type="PackedScene" id=19]
+[ext_resource path="res://assets/main/ui/candy-button/h3-t-pressed.png" type="Texture" id=20]
 [ext_resource path="res://src/main/ui/menu/region-submenu.gd" type="Script" id=22]
+[ext_resource path="res://src/main/ui/candy-button/CandyButtonH3.tscn" type="PackedScene" id=23]
 [ext_resource path="res://src/main/ui/menu/level-submenu.gd" type="Script" id=24]
+[ext_resource path="res://assets/main/ui/candy-button/h3-t.png" type="Texture" id=25]
+[ext_resource path="res://assets/main/ui/candy-button/h4-o.png" type="Texture" id=27]
+[ext_resource path="res://src/main/ui/candy-button/CandyButtonH4.tscn" type="PackedScene" id=28]
+[ext_resource path="res://assets/main/ui/candy-button/h4-q-pressed.png" type="Texture" id=29]
+[ext_resource path="res://assets/main/ui/candy-button/h4-q.png" type="Texture" id=30]
 [ext_resource path="res://assets/main/ui/touch/close.png" type="Texture" id=31]
 [ext_resource path="res://assets/main/ui/touch/close-pressed.png" type="Texture" id=32]
 [ext_resource path="res://src/main/ui/menu/practice-menu.gd" type="Script" id=33]
 [ext_resource path="res://src/main/ui/menu/practice-speed-selector.gd" type="Script" id=34]
+[ext_resource path="res://assets/main/ui/candy-button/h4-o-pressed.png" type="Texture" id=35]
+[ext_resource path="res://src/main/ui/UiMenuShortcut.tres" type="ShortCut" id=37]
 
 [sub_resource type="InputEventAction" id=4]
 action = "ui_cancel"
@@ -197,51 +205,58 @@ text = "3"
 align = 2
 
 [node name="System" type="VBoxContainer" parent="MainMenu/VBoxContainer"]
-margin_top = 295.0
+margin_top = 301.0
 margin_right = 984.0
 margin_bottom = 431.0
 size_flags_vertical = 10
 custom_constants/separation = 10
 script = ExtResource( 5 )
 
-[node name="Start" type="Button" parent="MainMenu/VBoxContainer/System" groups=["main_practice_inputs"]]
-margin_left = 402.0
-margin_right = 582.0
-margin_bottom = 60.0
-rect_min_size = Vector2( 180, 60 )
+[node name="Start" parent="MainMenu/VBoxContainer/System" groups=["main_practice_inputs"] instance=ExtResource( 23 )]
+margin_left = 392.0
+margin_top = 0.0
+margin_right = 592.0
+margin_bottom = 50.0
 size_flags_horizontal = 4
 size_flags_vertical = 4
-theme = ExtResource( 9 )
-shortcut_in_tooltip = false
+texture_normal = ExtResource( 25 )
+texture_pressed = ExtResource( 20 )
+texture_hover = ExtResource( 25 )
 text = "Start"
+color = 5
+shape = 6
 
-[node name="Settings" type="Button" parent="MainMenu/VBoxContainer/System" groups=["main_practice_inputs"]]
-margin_left = 434.0
-margin_top = 70.0
-margin_right = 550.0
-margin_bottom = 98.0
-rect_min_size = Vector2( 116, 28 )
+[node name="Settings" parent="MainMenu/VBoxContainer/System" groups=["main_practice_inputs"] instance=ExtResource( 28 )]
+margin_left = 432.0
+margin_top = 60.0
+margin_right = 552.0
+margin_bottom = 90.0
 size_flags_horizontal = 4
 size_flags_vertical = 4
-theme = ExtResource( 6 )
-shortcut_in_tooltip = false
-shortcut = ExtResource( 8 )
+shortcut = ExtResource( 37 )
+texture_normal = ExtResource( 27 )
+texture_pressed = ExtResource( 35 )
+texture_hover = ExtResource( 27 )
 text = "Settings"
+color = 7
+shape = 3
 
 [node name="ShortcutHelper" parent="MainMenu/VBoxContainer/System/Settings" instance=ExtResource( 7 )]
 action = "ui_cancel"
 
-[node name="Quit" type="Button" parent="MainMenu/VBoxContainer/System" groups=["main_practice_inputs"]]
-margin_left = 434.0
-margin_top = 108.0
-margin_right = 550.0
-margin_bottom = 136.0
-rect_min_size = Vector2( 116, 28 )
+[node name="Quit" parent="MainMenu/VBoxContainer/System" groups=["main_practice_inputs"] instance=ExtResource( 28 )]
+margin_left = 432.0
+margin_top = 100.0
+margin_right = 552.0
+margin_bottom = 130.0
 size_flags_horizontal = 4
 size_flags_vertical = 4
-theme = ExtResource( 6 )
-shortcut_in_tooltip = false
+texture_normal = ExtResource( 30 )
+texture_pressed = ExtResource( 29 )
+texture_hover = ExtResource( 30 )
 text = "Quit"
+color = 1
+shape = 5
 
 [node name="HighScores" type="Panel" parent="MainMenu/VBoxContainer"]
 margin_left = 92.0

--- a/project/src/main/ui/menu/SplashScreen.tscn
+++ b/project/src/main/ui/menu/SplashScreen.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://src/main/ui/menu/splash-screen.gd" type="Script" id=1]
 [ext_resource path="res://src/main/ui/VersionLabel.tscn" type="PackedScene" id=2]
@@ -6,10 +6,12 @@
 [ext_resource path="res://src/main/ui/menu/drop-panel.tres" type="StyleBox" id=4]
 [ext_resource path="res://src/main/ui/menu/SystemButtons.tscn" type="PackedScene" id=5]
 [ext_resource path="res://src/main/ui/settings/SettingsMenu.tscn" type="PackedScene" id=6]
-[ext_resource path="res://src/main/ui/theme/h1.theme" type="Theme" id=7]
+[ext_resource path="res://assets/main/ui/candy-button/h3-v.png" type="Texture" id=7]
 [ext_resource path="res://src/main/ui/menu/BadSaveDataControl.tscn" type="PackedScene" id=8]
 [ext_resource path="res://src/main/ui/menu/MenuAccentTitle.tscn" type="PackedScene" id=9]
+[ext_resource path="res://assets/main/ui/candy-button/h3-v-pressed.png" type="Texture" id=10]
 [ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=11]
+[ext_resource path="res://src/main/ui/candy-button/CandyButtonH3.tscn" type="PackedScene" id=14]
 
 [sub_resource type="DynamicFont" id=1]
 size = 72
@@ -54,14 +56,17 @@ anchor_bottom = 1.0
 margin_top = 150.0
 margin_bottom = -100.0
 
-[node name="Play" type="Button" parent="DropPanel/PlayHolder"]
-margin_left = 365.0
-margin_top = 92.0
-margin_right = 558.0
-margin_bottom = 157.0
-rect_min_size = Vector2( 193, 47 )
-theme = ExtResource( 7 )
+[node name="Play" parent="DropPanel/PlayHolder" instance=ExtResource( 14 )]
+margin_left = 362.0
+margin_top = 100.0
+margin_right = 562.0
+margin_bottom = 150.0
+texture_normal = ExtResource( 7 )
+texture_pressed = ExtResource( 10 )
+texture_hover = ExtResource( 7 )
 text = "Play"
+color = 4
+shape = 8
 
 [node name="System" parent="DropPanel" instance=ExtResource( 5 )]
 alignment = 1

--- a/project/src/main/ui/menu/practice-menu.gd
+++ b/project/src/main/ui/menu/practice-menu.gd
@@ -24,7 +24,7 @@ onready var _high_scores: Panel = get_node(high_scores_path)
 onready var _level_button: Button = get_node(level_button_path)
 onready var _level_description_label: Label = get_node(level_description_label_path)
 onready var _speed_selector: PracticeSpeedSelector = get_node(speed_selector_path)
-onready var _start_button: Button = get_node(start_button_path)
+onready var _start_button: BaseButton = get_node(start_button_path)
 
 onready var _level_submenu := $LevelSubmenu
 onready var _region_submenu := $RegionSubmenu


### PR DESCRIPTION
CandyButtons in PuzzleMessages screen change color based on the intent of the buttons. In Career mode, finishing the puzzle is going forward and uses an encouraging blue. In Practice mode, finishing the puzzle is going back and uses a discouraging red.