### PR TITLE
Restored crufty CandyButton shaders/gradients

### DIFF
--- a/project/src/main/puzzle/PuzzleMessages.tscn
+++ b/project/src/main/puzzle/PuzzleMessages.tscn
@@ -1,18 +1,52 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=24 format=2]
 
 [ext_resource path="res://src/main/puzzle/PuzzleMessage.tscn" type="PackedScene" id=1]
 [ext_resource path="res://assets/main/ui/candy-button/h4-o.png" type="Texture" id=2]
+[ext_resource path="res://src/main/ui/candy-button/gradient-blue-normal.tres" type="Gradient" id=3]
 [ext_resource path="res://src/main/ui/UiCancelShortcut.tres" type="ShortCut" id=4]
 [ext_resource path="res://src/main/puzzle/puzzle-messages.gd" type="Script" id=5]
+[ext_resource path="res://src/main/ui/candy-button/gradient-red-normal.tres" type="Gradient" id=6]
 [ext_resource path="res://src/main/ui/UiMenuShortcut.tres" type="ShortCut" id=7]
+[ext_resource path="res://src/main/ui/candy-button/gradient-violet-normal.tres" type="Gradient" id=8]
 [ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/ui/candy-button/CandyButtonH3.tscn" type="PackedScene" id=10]
 [ext_resource path="res://src/main/ui/candy-button/CandyButtonH4.tscn" type="PackedScene" id=11]
 [ext_resource path="res://assets/main/ui/candy-button/h3-v.png" type="Texture" id=12]
 [ext_resource path="res://assets/main/ui/candy-button/h3-v-pressed.png" type="Texture" id=13]
 [ext_resource path="res://assets/main/ui/candy-button/h4-o-pressed.png" type="Texture" id=14]
+[ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=15]
 [ext_resource path="res://assets/main/ui/candy-button/h4-q-pressed.png" type="Texture" id=17]
 [ext_resource path="res://assets/main/ui/candy-button/h4-q.png" type="Texture" id=18]
+
+[sub_resource type="GradientTexture2D" id=1]
+resource_local_to_scene = true
+gradient = ExtResource( 3 )
+
+[sub_resource type="ShaderMaterial" id=2]
+resource_local_to_scene = true
+shader = ExtResource( 15 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 1 )
+
+[sub_resource type="GradientTexture2D" id=3]
+resource_local_to_scene = true
+gradient = ExtResource( 8 )
+
+[sub_resource type="ShaderMaterial" id=4]
+resource_local_to_scene = true
+shader = ExtResource( 15 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 3 )
+
+[sub_resource type="GradientTexture2D" id=5]
+resource_local_to_scene = true
+gradient = ExtResource( 6 )
+
+[sub_resource type="ShaderMaterial" id=6]
+resource_local_to_scene = true
+shader = ExtResource( 15 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 5 )
 
 [node name="PuzzleMessages" type="Control"]
 margin_left = 364.0
@@ -29,6 +63,7 @@ margin_bottom = 136.0
 custom_constants/separation = 10
 
 [node name="Start" parent="Buttons" instance=ExtResource( 10 )]
+material = SubResource( 2 )
 margin_left = 62.0
 margin_top = 0.0
 margin_right = 262.0
@@ -43,6 +78,7 @@ color = 5
 shape = 8
 
 [node name="Settings" parent="Buttons" instance=ExtResource( 11 )]
+material = SubResource( 4 )
 margin_left = 102.0
 margin_top = 60.0
 margin_right = 222.0
@@ -62,6 +98,7 @@ action = "ui_cancel"
 overridden_action = "ui_menu"
 
 [node name="Back" parent="Buttons" instance=ExtResource( 11 )]
+material = SubResource( 6 )
 margin_left = 102.0
 margin_top = 100.0
 margin_right = 222.0

--- a/project/src/main/ui/menu/MainMenu.tscn
+++ b/project/src/main/ui/menu/MainMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=37 format=2]
+[gd_scene load_steps=55 format=2]
 
 [ext_resource path="res://src/main/ui/menu/main-menu.gd" type="Script" id=1]
 [ext_resource path="res://assets/main/ui/candy-button/h3-p.png" type="Texture" id=2]
@@ -10,6 +10,7 @@
 [ext_resource path="res://src/main/ui/settings/SettingsMenu.tscn" type="PackedScene" id=8]
 [ext_resource path="res://src/main/ui/theme/h2-font-outline.tres" type="DynamicFont" id=9]
 [ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=10]
+[ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=11]
 [ext_resource path="res://src/main/ui/menu/main-menu-debug.gd" type="Script" id=12]
 [ext_resource path="res://src/main/ui/menu/main-menu-play.gd" type="Script" id=13]
 [ext_resource path="res://src/main/ui/menu/main-menu-create.gd" type="Script" id=14]
@@ -20,9 +21,14 @@
 [ext_resource path="res://assets/main/ui/candy-button/h3-t-pressed.png" type="Texture" id=19]
 [ext_resource path="res://assets/main/ui/candy-button/h3-o.png" type="Texture" id=20]
 [ext_resource path="res://assets/main/ui/candy-button/h3-q-pressed.png" type="Texture" id=21]
+[ext_resource path="res://src/main/ui/candy-button/gradient-green-normal.tres" type="Gradient" id=22]
+[ext_resource path="res://src/main/ui/candy-button/gradient-indigo-normal.tres" type="Gradient" id=23]
+[ext_resource path="res://src/main/ui/candy-button/gradient-blue-normal.tres" type="Gradient" id=24]
 [ext_resource path="res://assets/main/ui/candy-button/h3-u-pressed.png" type="Texture" id=25]
 [ext_resource path="res://assets/main/ui/candy-button/h3-u.png" type="Texture" id=26]
 [ext_resource path="res://assets/main/ui/candy-button/h3-p-pressed.png" type="Texture" id=27]
+[ext_resource path="res://src/main/ui/candy-button/gradient-orange-normal.tres" type="Gradient" id=28]
+[ext_resource path="res://src/main/ui/candy-button/gradient-violet-normal.tres" type="Gradient" id=29]
 [ext_resource path="res://assets/main/ui/icon-practice.png" type="Texture" id=30]
 [ext_resource path="res://assets/main/ui/icon-tutorials.png" type="Texture" id=31]
 [ext_resource path="res://assets/main/ui/icon-career.png" type="Texture" id=32]
@@ -41,6 +47,66 @@ size = 72
 outline_size = 6
 outline_color = Color( 0.254902, 0.156863, 0.117647, 1 )
 font_data = ExtResource( 3 )
+
+[sub_resource type="GradientTexture2D" id=2]
+resource_local_to_scene = true
+gradient = ExtResource( 22 )
+
+[sub_resource type="ShaderMaterial" id=3]
+resource_local_to_scene = true
+shader = ExtResource( 11 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 2 )
+
+[sub_resource type="GradientTexture2D" id=4]
+resource_local_to_scene = true
+gradient = ExtResource( 29 )
+
+[sub_resource type="ShaderMaterial" id=5]
+resource_local_to_scene = true
+shader = ExtResource( 11 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 4 )
+
+[sub_resource type="GradientTexture2D" id=6]
+resource_local_to_scene = true
+gradient = ExtResource( 28 )
+
+[sub_resource type="ShaderMaterial" id=7]
+resource_local_to_scene = true
+shader = ExtResource( 11 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 6 )
+
+[sub_resource type="GradientTexture2D" id=8]
+resource_local_to_scene = true
+gradient = ExtResource( 23 )
+
+[sub_resource type="ShaderMaterial" id=9]
+resource_local_to_scene = true
+shader = ExtResource( 11 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 8 )
+
+[sub_resource type="GradientTexture2D" id=10]
+resource_local_to_scene = true
+gradient = ExtResource( 24 )
+
+[sub_resource type="ShaderMaterial" id=11]
+resource_local_to_scene = true
+shader = ExtResource( 11 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 10 )
+
+[sub_resource type="GradientTexture2D" id=12]
+resource_local_to_scene = true
+gradient = ExtResource( 22 )
+
+[sub_resource type="ShaderMaterial" id=13]
+resource_local_to_scene = true
+shader = ExtResource( 11 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 12 )
 
 [node name="MainMenu" type="Control"]
 anchor_right = 1.0
@@ -98,6 +164,7 @@ margin_bottom = 37.5
 texture = ExtResource( 37 )
 
 [node name="Career" parent="DropPanel/Play" instance=ExtResource( 15 )]
+material = SubResource( 3 )
 margin_left = 131.0
 margin_top = 67.0
 margin_right = 331.0
@@ -113,6 +180,7 @@ color = 4
 shape = 3
 
 [node name="Practice" parent="DropPanel/Play" instance=ExtResource( 15 )]
+material = SubResource( 5 )
 margin_left = 131.0
 margin_top = 127.0
 margin_right = 331.0
@@ -128,6 +196,7 @@ color = 7
 shape = 6
 
 [node name="Tutorials" parent="DropPanel/Play" instance=ExtResource( 15 )]
+material = SubResource( 7 )
 margin_left = 131.0
 margin_top = 187.0
 margin_right = 331.0
@@ -169,6 +238,7 @@ texture = ExtResource( 39 )
 _accent_index = 1
 
 [node name="Creatures" parent="DropPanel/Create" instance=ExtResource( 15 )]
+material = SubResource( 9 )
 margin_left = 131.0
 margin_top = 97.0
 margin_right = 331.0
@@ -184,6 +254,7 @@ color = 6
 shape = 7
 
 [node name="Levels" parent="DropPanel/Create" instance=ExtResource( 15 )]
+material = SubResource( 11 )
 margin_left = 131.0
 margin_top = 157.0
 margin_right = 331.0
@@ -214,6 +285,7 @@ margin_bottom = -18.0
 script = ExtResource( 12 )
 
 [node name="StressTest" parent="DropPanel/Debug" instance=ExtResource( 40 )]
+material = SubResource( 13 )
 margin_left = 0.0
 margin_top = 0.0
 margin_right = 120.0

--- a/project/src/main/ui/menu/PracticeMenu.tscn
+++ b/project/src/main/ui/menu/PracticeMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=36 format=2]
+[gd_scene load_steps=46 format=2]
 
 [ext_resource path="res://src/main/ui/menu/PagedRegionPanel.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/ui/ImageButton.tscn" type="PackedScene" id=2]
@@ -7,6 +7,7 @@
 [ext_resource path="res://src/main/ui/menu/system-buttons.gd" type="Script" id=5]
 [ext_resource path="res://src/main/ui/theme/h4.theme" type="Theme" id=6]
 [ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=7]
+[ext_resource path="res://src/main/ui/candy-button/gradient-blue-normal.tres" type="Gradient" id=8]
 [ext_resource path="res://src/main/ui/theme/h3.theme" type="Theme" id=9]
 [ext_resource path="res://src/main/ui/menu/drop-panel.tres" type="StyleBox" id=10]
 [ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=11]
@@ -19,10 +20,12 @@
 [ext_resource path="res://assets/main/ui/menu/menu-accent-h2-m2.png" type="Texture" id=18]
 [ext_resource path="res://src/main/ui/menu/MenuAccentH2.tscn" type="PackedScene" id=19]
 [ext_resource path="res://assets/main/ui/candy-button/h3-t-pressed.png" type="Texture" id=20]
+[ext_resource path="res://src/main/ui/candy-button/gradient-red-normal.tres" type="Gradient" id=21]
 [ext_resource path="res://src/main/ui/menu/region-submenu.gd" type="Script" id=22]
 [ext_resource path="res://src/main/ui/candy-button/CandyButtonH3.tscn" type="PackedScene" id=23]
 [ext_resource path="res://src/main/ui/menu/level-submenu.gd" type="Script" id=24]
 [ext_resource path="res://assets/main/ui/candy-button/h3-t.png" type="Texture" id=25]
+[ext_resource path="res://src/main/ui/candy-button/gradient-violet-normal.tres" type="Gradient" id=26]
 [ext_resource path="res://assets/main/ui/candy-button/h4-o.png" type="Texture" id=27]
 [ext_resource path="res://src/main/ui/candy-button/CandyButtonH4.tscn" type="PackedScene" id=28]
 [ext_resource path="res://assets/main/ui/candy-button/h4-q-pressed.png" type="Texture" id=29]
@@ -32,7 +35,38 @@
 [ext_resource path="res://src/main/ui/menu/practice-menu.gd" type="Script" id=33]
 [ext_resource path="res://src/main/ui/menu/practice-speed-selector.gd" type="Script" id=34]
 [ext_resource path="res://assets/main/ui/candy-button/h4-o-pressed.png" type="Texture" id=35]
+[ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=36]
 [ext_resource path="res://src/main/ui/UiMenuShortcut.tres" type="ShortCut" id=37]
+
+[sub_resource type="GradientTexture2D" id=6]
+resource_local_to_scene = true
+gradient = ExtResource( 8 )
+
+[sub_resource type="ShaderMaterial" id=7]
+resource_local_to_scene = true
+shader = ExtResource( 36 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 6 )
+
+[sub_resource type="GradientTexture2D" id=8]
+resource_local_to_scene = true
+gradient = ExtResource( 26 )
+
+[sub_resource type="ShaderMaterial" id=9]
+resource_local_to_scene = true
+shader = ExtResource( 36 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 8 )
+
+[sub_resource type="GradientTexture2D" id=10]
+resource_local_to_scene = true
+gradient = ExtResource( 21 )
+
+[sub_resource type="ShaderMaterial" id=11]
+resource_local_to_scene = true
+shader = ExtResource( 36 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 10 )
 
 [sub_resource type="InputEventAction" id=4]
 action = "ui_cancel"
@@ -213,6 +247,7 @@ custom_constants/separation = 10
 script = ExtResource( 5 )
 
 [node name="Start" parent="MainMenu/VBoxContainer/System" groups=["main_practice_inputs"] instance=ExtResource( 23 )]
+material = SubResource( 7 )
 margin_left = 392.0
 margin_top = 0.0
 margin_right = 592.0
@@ -227,6 +262,7 @@ color = 5
 shape = 6
 
 [node name="Settings" parent="MainMenu/VBoxContainer/System" groups=["main_practice_inputs"] instance=ExtResource( 28 )]
+material = SubResource( 9 )
 margin_left = 432.0
 margin_top = 60.0
 margin_right = 552.0
@@ -245,6 +281,7 @@ shape = 3
 action = "ui_cancel"
 
 [node name="Quit" parent="MainMenu/VBoxContainer/System" groups=["main_practice_inputs"] instance=ExtResource( 28 )]
+material = SubResource( 11 )
 margin_left = 432.0
 margin_top = 100.0
 margin_right = 552.0

--- a/project/src/main/ui/menu/SplashScreen.tscn
+++ b/project/src/main/ui/menu/SplashScreen.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=18 format=2]
 
 [ext_resource path="res://src/main/ui/menu/splash-screen.gd" type="Script" id=1]
 [ext_resource path="res://src/main/ui/VersionLabel.tscn" type="PackedScene" id=2]
@@ -11,6 +11,8 @@
 [ext_resource path="res://src/main/ui/menu/MenuAccentTitle.tscn" type="PackedScene" id=9]
 [ext_resource path="res://assets/main/ui/candy-button/h3-v-pressed.png" type="Texture" id=10]
 [ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=11]
+[ext_resource path="res://src/main/ui/candy-button/gradient-green-normal.tres" type="Gradient" id=12]
+[ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=13]
 [ext_resource path="res://src/main/ui/candy-button/CandyButtonH3.tscn" type="PackedScene" id=14]
 
 [sub_resource type="DynamicFont" id=1]
@@ -18,6 +20,16 @@ size = 72
 outline_size = 6
 outline_color = Color( 0.254902, 0.156863, 0.117647, 1 )
 font_data = ExtResource( 3 )
+
+[sub_resource type="GradientTexture2D" id=2]
+resource_local_to_scene = true
+gradient = ExtResource( 12 )
+
+[sub_resource type="ShaderMaterial" id=3]
+resource_local_to_scene = true
+shader = ExtResource( 13 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 2 )
 
 [node name="SplashScreen" type="Control"]
 anchor_right = 1.0
@@ -57,6 +69,7 @@ margin_top = 150.0
 margin_bottom = -100.0
 
 [node name="Play" parent="DropPanel/PlayHolder" instance=ExtResource( 14 )]
+material = SubResource( 3 )
 margin_left = 362.0
 margin_top = 100.0
 margin_right = 562.0

--- a/project/src/main/ui/menu/SystemButtons.tscn
+++ b/project/src/main/ui/menu/SystemButtons.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=2]
+[gd_scene load_steps=23 format=2]
 
 [ext_resource path="res://src/main/ui/theme/h4.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/ui/menu/system-buttons.gd" type="Script" id=2]
@@ -6,12 +6,46 @@
 [ext_resource path="res://src/main/ui/UiMenuShortcut.tres" type="ShortCut" id=4]
 [ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=5]
 [ext_resource path="res://assets/main/ui/candy-button/h4-o.png" type="Texture" id=6]
+[ext_resource path="res://src/main/ui/candy-button/gradient-yellow-normal.tres" type="Gradient" id=7]
 [ext_resource path="res://src/main/ui/candy-button/CandyButtonH4.tscn" type="PackedScene" id=8]
+[ext_resource path="res://src/main/ui/candy-button/gradient-red-normal.tres" type="Gradient" id=9]
+[ext_resource path="res://src/main/ui/candy-button/gradient-violet-normal.tres" type="Gradient" id=10]
+[ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=11]
 [ext_resource path="res://assets/main/ui/candy-button/h4-o-pressed.png" type="Texture" id=12]
 [ext_resource path="res://assets/main/ui/candy-button/h4-q.png" type="Texture" id=13]
 [ext_resource path="res://assets/main/ui/candy-button/h4-q-pressed.png" type="Texture" id=14]
 [ext_resource path="res://assets/main/ui/candy-button/h4-p.png" type="Texture" id=15]
 [ext_resource path="res://assets/main/ui/candy-button/h4-p-pressed.png" type="Texture" id=16]
+
+[sub_resource type="GradientTexture2D" id=1]
+resource_local_to_scene = true
+gradient = ExtResource( 10 )
+
+[sub_resource type="ShaderMaterial" id=2]
+resource_local_to_scene = true
+shader = ExtResource( 11 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 1 )
+
+[sub_resource type="GradientTexture2D" id=3]
+resource_local_to_scene = true
+gradient = ExtResource( 7 )
+
+[sub_resource type="ShaderMaterial" id=4]
+resource_local_to_scene = true
+shader = ExtResource( 11 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 3 )
+
+[sub_resource type="GradientTexture2D" id=5]
+resource_local_to_scene = true
+gradient = ExtResource( 9 )
+
+[sub_resource type="ShaderMaterial" id=6]
+resource_local_to_scene = true
+shader = ExtResource( 11 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 5 )
 
 [node name="System" type="VBoxContainer"]
 anchor_top = 1.0
@@ -23,6 +57,7 @@ custom_constants/separation = 10
 script = ExtResource( 2 )
 
 [node name="Settings" parent="." instance=ExtResource( 8 )]
+material = SubResource( 2 )
 margin_left = 452.0
 margin_top = 0.0
 margin_right = 572.0
@@ -42,6 +77,7 @@ action = "ui_cancel"
 overridden_action = "ui_menu"
 
 [node name="Credits" parent="." instance=ExtResource( 8 )]
+material = SubResource( 4 )
 margin_left = 452.0
 margin_top = 40.0
 margin_right = 572.0
@@ -56,6 +92,7 @@ color = 3
 shape = 4
 
 [node name="Quit" parent="." instance=ExtResource( 8 )]
+material = SubResource( 6 )
 margin_left = 452.0
 margin_top = 80.0
 margin_right = 572.0


### PR DESCRIPTION
I thought I could prevent these from appearing by tweaking the materials once when the buttons were loaded, but these shaders/gradients reappear every time the file is saved. I'm restoring them all just to avoid the churn when I edit these files.