### PR TITLE
Support tab navigation with gamepad bumpers.

### DIFF
--- a/project/assets/main/keybind/guideline-hold.json
+++ b/project/assets/main/keybind/guideline-hold.json
@@ -298,5 +298,27 @@
       "device": 0,
       "button_index": 12
     }
+  ],
+  "next_tab": [
+    {
+      "type": "joypad_button",
+      "device": 0,
+      "button_index": 5
+    },
+    {
+      "type": "key",
+      "scancode": 88
+    }
+  ],
+  "prev_tab": [
+    {
+      "type": "joypad_button",
+      "device": 0,
+      "button_index": 4
+    },
+    {
+      "type": "key",
+      "scancode": 90
+    }
   ]
 }

--- a/project/assets/main/keybind/guideline.json
+++ b/project/assets/main/keybind/guideline.json
@@ -288,5 +288,27 @@
       "device": 0,
       "button_index": 12
     }
+  ],
+  "next_tab": [
+    {
+      "type": "joypad_button",
+      "device": 0,
+      "button_index": 5
+    },
+    {
+      "type": "key",
+      "scancode": 88
+    }
+  ],
+  "prev_tab": [
+    {
+      "type": "joypad_button",
+      "device": 0,
+      "button_index": 4
+    },
+    {
+      "type": "key",
+      "scancode": 90
+    }
   ]
 }

--- a/project/assets/main/keybind/wasd-hold.json
+++ b/project/assets/main/keybind/wasd-hold.json
@@ -275,5 +275,27 @@
       "device": 0,
       "button_index": 12
     }
+  ],
+  "next_tab": [
+    {
+      "type": "joypad_button",
+      "device": 0,
+      "button_index": 5
+    },
+    {
+      "type": "key",
+      "scancode": 88
+    }
+  ],
+  "prev_tab": [
+    {
+      "type": "joypad_button",
+      "device": 0,
+      "button_index": 4
+    },
+    {
+      "type": "key",
+      "scancode": 90
+    }
   ]
 }

--- a/project/assets/main/keybind/wasd.json
+++ b/project/assets/main/keybind/wasd.json
@@ -269,5 +269,27 @@
       "device": 0,
       "button_index": 12
     }
+  ],
+  "next_tab": [
+    {
+      "type": "joypad_button",
+      "device": 0,
+      "button_index": 5
+    },
+    {
+      "type": "key",
+      "scancode": 88
+    }
+  ],
+  "prev_tab": [
+    {
+      "type": "joypad_button",
+      "device": 0,
+      "button_index": 4
+    },
+    {
+      "type": "key",
+      "scancode": 90
+    }
   ]
 }

--- a/project/project.godot
+++ b/project/project.godot
@@ -2013,6 +2013,18 @@ swap_hold_piece={
 "deadzone": 0.5,
 "events": [  ]
 }
+next_tab={
+"deadzone": 0.5,
+"events": [ Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":5,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":88,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+prev_tab={
+"deadzone": 0.5,
+"events": [ Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":4,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":90,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [locale]
 

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -572,13 +572,13 @@ follow_focus = true
 
 [node name="CenterContainer" type="CenterContainer" parent="Window/UiArea/TabContainer/Controls/PresetScrollContainer"]
 margin_right = 736.0
-margin_bottom = 260.0
+margin_bottom = 300.0
 size_flags_horizontal = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Window/UiArea/TabContainer/Controls/PresetScrollContainer/CenterContainer"]
 margin_left = 118.0
 margin_right = 618.0
-margin_bottom = 260.0
+margin_bottom = 300.0
 rect_min_size = Vector2( 500, 0 )
 size_flags_horizontal = 0
 custom_constants/separation = 0
@@ -658,6 +658,20 @@ margin_bottom = 220.0
 description = "Back in Menus"
 keybind_value = "Escape"
 
+[node name="NextTabInMenus" parent="Window/UiArea/TabContainer/Controls/PresetScrollContainer/CenterContainer/VBoxContainer" instance=ExtResource( 14 )]
+margin_top = 200.0
+margin_right = 500.0
+margin_bottom = 220.0
+description = "Next Tab"
+keybind_value = "X"
+
+[node name="PrevTabInMenus" parent="Window/UiArea/TabContainer/Controls/PresetScrollContainer/CenterContainer/VBoxContainer" instance=ExtResource( 14 )]
+margin_top = 200.0
+margin_right = 500.0
+margin_bottom = 220.0
+description = "Previous Tab"
+keybind_value = "Z"
+
 [node name="Spacer2" type="Control" parent="Window/UiArea/TabContainer/Controls/PresetScrollContainer/CenterContainer/VBoxContainer"]
 margin_top = 220.0
 margin_right = 500.0
@@ -682,13 +696,13 @@ follow_focus = true
 
 [node name="CenterContainer" type="CenterContainer" parent="Window/UiArea/TabContainer/Controls/CustomScrollContainer"]
 margin_right = 736.0
-margin_bottom = 561.0
+margin_bottom = 619.0
 size_flags_horizontal = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Window/UiArea/TabContainer/Controls/CustomScrollContainer/CenterContainer"]
 margin_left = 118.0
 margin_right = 618.0
-margin_bottom = 561.0
+margin_bottom = 619.0
 rect_min_size = Vector2( 500, 0 )
 size_flags_horizontal = 0
 custom_constants/separation = 2
@@ -806,6 +820,20 @@ margin_right = 500.0
 margin_bottom = 457.0
 description = "Back in Menus"
 action_name = "ui_cancel"
+
+[node name="NextTab" parent="Window/UiArea/TabContainer/Controls/CustomScrollContainer/CenterContainer/VBoxContainer" instance=ExtResource( 16 )]
+margin_top = 430.0
+margin_right = 500.0
+margin_bottom = 457.0
+description = "Next Tab"
+action_name = "next_tab"
+
+[node name="PrevTab" parent="Window/UiArea/TabContainer/Controls/CustomScrollContainer/CenterContainer/VBoxContainer" instance=ExtResource( 16 )]
+margin_top = 430.0
+margin_right = 500.0
+margin_bottom = 457.0
+description = "Previous Tab"
+action_name = "prev_tab"
 
 [node name="Spacer3" type="Control" parent="Window/UiArea/TabContainer/Controls/CustomScrollContainer/CenterContainer/VBoxContainer"]
 margin_top = 459.0

--- a/project/src/main/ui/tab-input-enabler.gd
+++ b/project/src/main/ui/tab-input-enabler.gd
@@ -41,15 +41,18 @@ func _ready() -> void:
 
 ## Handle left/right inputs while the TabContainer is focused.
 func _unhandled_input(event: InputEvent) -> void:
-	if not focused:
-		return
+	if focused:
+		if event.is_action_pressed("ui_left"):
+			_select_prev_tab()
+		if event.is_action_pressed("ui_right"):
+			_select_next_tab()
 	
-	if event.is_action_pressed("ui_left"):
-		tab_container.current_tab = clamp(tab_container.current_tab - 1, 0, tab_container.get_tab_count() - 1)
-	
-	if event.is_action_pressed("ui_right"):
-		tab_container.current_tab = clamp(tab_container.current_tab + 1, 0, tab_container.get_tab_count() - 1)
-
+	if event.is_action_pressed("prev_tab"):
+		_select_prev_tab()
+		_focus_top_node_in_current_tab()
+	if event.is_action_pressed("next_tab"):
+		_select_next_tab()
+		_focus_top_node_in_current_tab()
 
 ## Refreshes our tab's appearance based on whether or not we're currently focused.
 ##
@@ -61,6 +64,14 @@ func set_focused(new_focused: bool) -> void:
 	focused = new_focused
 	
 	_refresh_focused()
+
+
+func _select_next_tab() -> void:
+	tab_container.current_tab = clamp(tab_container.current_tab + 1, 0, tab_container.get_tab_count() - 1)
+
+
+func _select_prev_tab() -> void:
+	tab_container.current_tab = clamp(tab_container.current_tab - 1, 0, tab_container.get_tab_count() - 1)
 
 
 ## Updates the focus_neighbor fields for the TabContainer, its children, and its neighbours.
@@ -79,11 +90,8 @@ func _refresh_focus_neighbours_for_current_tab() -> void:
 	if tab_container.current_tab == -1:
 		return
 	
-	var top_focusable_node: Control = _find_control_by_func(
-			tab_container.get_child(tab_container.current_tab), self, "_compare_by_min_y")
-	
-	var bottom_focusable_node: Control = _find_control_by_func(
-			tab_container.get_child(tab_container.current_tab), self, "_compare_by_max_y")
+	var top_focusable_node: Control = _find_top_focusable_node_in_current_tab()
+	var bottom_focusable_node: Control = _find_bottom_focusable_node_in_current_tab()
 	
 	## Navigating down from the TabContainer focuses the top item within the TabContainer.
 	if top_focusable_node:
@@ -105,6 +113,27 @@ func _refresh_focus_neighbours_for_current_tab() -> void:
 		if highest_node_in_column:
 			highest_node_in_column.focus_neighbour_top = bottom_focusable_node.get_path()
 
+
+## Focuses the top node in the current tab.
+##
+## When the player uses the keyboard or gamepad to hop between tabs, the currently focused tab becomes invisible and
+## unfocused. This method ensures a visible node remains focused when changing tabs.
+##
+## If no nodes are visible in the current tab, the tab container itself is focused.
+func _focus_top_node_in_current_tab() -> void:
+	var top_focusable_node: Control = _find_top_focusable_node_in_current_tab()
+	if top_focusable_node:
+		top_focusable_node.grab_focus()
+	else:
+		tab_container.grab_focus()
+
+
+func _find_top_focusable_node_in_current_tab() -> Node:
+	return _find_control_by_func(tab_container.get_child(tab_container.current_tab), self, "_compare_by_min_y")
+
+
+func _find_bottom_focusable_node_in_current_tab() -> Node:
+	return _find_control_by_func(tab_container.get_child(tab_container.current_tab), self, "_compare_by_max_y")
 
 ## Searches through all of a node's descendents for the best visible Control according to a custom method.
 ##


### PR DESCRIPTION
Tab navigation is now supported with Z, X, or the gamepad bumpers. We also continue to support arrowing up into the TabContainer, but the gamepad bumpers are a bit faster.

The real reason for implementing this is that the Creature Editor redesign will use a similar tabbed approach, and I'd like to streamline it with bumpers.

Closes #2526.