### PR TITLE
Z no longer activates 'ui_accept'.

### DIFF
--- a/project/assets/main/keybind/guideline-hold.json
+++ b/project/assets/main/keybind/guideline-hold.json
@@ -178,10 +178,6 @@
       "scancode": 32
     },
     {
-      "type": "key",
-      "scancode": 90
-    },
-    {
       "type": "joypad_button",
       "device": 0,
       "button_index": 0

--- a/project/assets/main/keybind/guideline.json
+++ b/project/assets/main/keybind/guideline.json
@@ -168,10 +168,6 @@
       "scancode": 32
     },
     {
-      "type": "key",
-      "scancode": 90
-    },
-    {
       "type": "joypad_button",
       "device": 0,
       "button_index": 0

--- a/project/assets/main/keybind/wasd-hold.json
+++ b/project/assets/main/keybind/wasd-hold.json
@@ -155,10 +155,6 @@
       "scancode": 32
     },
     {
-      "type": "key",
-      "scancode": 90
-    },
-    {
       "type": "joypad_button",
       "device": 0,
       "button_index": 0

--- a/project/assets/main/keybind/wasd.json
+++ b/project/assets/main/keybind/wasd.json
@@ -149,10 +149,6 @@
       "scancode": 32
     },
     {
-      "type": "key",
-      "scancode": 90
-    },
-    {
       "type": "joypad_button",
       "device": 0,
       "button_index": 0

--- a/project/project.godot
+++ b/project/project.godot
@@ -1891,7 +1891,6 @@ ui_accept={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777222,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":90,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
 ui_select={


### PR DESCRIPTION
This was originally done back when the game had an interactive overworld, where it felt intuitive that the player would talk with people using the same keys they play with the game with. But it now causes a conflict with the tab navigation buttons, which are also Z/X.