### PR TITLE
Bug: Z/X disabled focus on most screens.

### DIFF
--- a/project/src/main/ui/tab-input-enabler.gd
+++ b/project/src/main/ui/tab-input-enabler.gd
@@ -41,6 +41,10 @@ func _ready() -> void:
 
 ## Handle left/right inputs while the TabContainer is focused.
 func _unhandled_input(event: InputEvent) -> void:
+	if not get_parent().is_visible_in_tree():
+		# ignore input unless our TabContainer is visible
+		return
+	
 	if focused:
 		if event.is_action_pressed("ui_left"):
 			_select_prev_tab()


### PR DESCRIPTION
TabInputEnabler is intended to select different tabs within the SettingsMenu, but it was even activating when the SettingsMenu was not visible, causing it to leave no nodes with keyboard focus.