### PR TITLE
Renaming creatures no longer changes creature_id

### DIFF
--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -119,6 +119,7 @@ func _mutate_allele(creature: Creature, dna: Dictionary, new_palette: Dictionary
 	match property:
 		"name":
 			creature.rename(NameGeneratorLibrary.generate_name())
+			creature.creature_id = NameUtils.short_name_to_id(creature.creature_short_name)
 		"fatness":
 			var new_fatnesses := Global.FATNESSES.duplicate()
 			while new_fatnesses.has(creature.visual_fatness):
@@ -241,6 +242,7 @@ func _tweak_creature(creature: Creature, allele: String, color_mode: int) -> voi
 	match allele:
 		"name":
 			creature.rename(NameGeneratorLibrary.generate_name())
+			creature.creature_id = NameUtils.short_name_to_id(creature.creature_short_name)
 		"fatness":
 			var new_fatnesses := Global.FATNESSES.duplicate()
 			while new_fatnesses.has(creature.visual_fatness):

--- a/project/src/main/editor/creature/tweak-name-row.gd
+++ b/project/src/main/editor/creature/tweak-name-row.gd
@@ -22,6 +22,8 @@ func grab_focus() -> void:
 func _finish_name_edit(text: String) -> void:
 	var new_name: String = NameUtils.sanitize_name(text)
 	_creature_editor.center_creature.rename(new_name)
+	_creature_editor.center_creature.creature_id \
+		= NameUtils.short_name_to_id(_creature_editor.center_creature.creature_short_name)
 	_refresh_name_ui()
 
 

--- a/project/src/main/world/creature/creature-def.gd
+++ b/project/src/main/world/creature/creature-def.gd
@@ -163,7 +163,6 @@ func from_json_path(path: String) -> CreatureDef:
 func rename(new_creature_name: String) -> void:
 	creature_name = new_creature_name
 	creature_short_name = NameUtils.sanitize_short_name(creature_name)
-	creature_id = NameUtils.short_name_to_id(creature_short_name)
 
 
 ## Returns true if this creature can show up as a random customer.

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -341,7 +341,6 @@ func feed(food_type: int) -> void:
 func rename(new_creature_name: String) -> void:
 	set_creature_name(new_creature_name)
 	creature_short_name = NameUtils.sanitize_short_name(creature_name)
-	creature_id = NameUtils.short_name_to_id(creature_short_name)
 
 
 func restart_idle_timer() -> void:


### PR DESCRIPTION
This behavior was tedious to counteract, because setting the creature_id causes the creature to be loaded from the creature library.