### PR TITLE
Refactor: Enum comments, shader comments, array type comments

### DIFF
--- a/project/src/demo/chat/ui/chatscript-table-demo.gd
+++ b/project/src/demo/chat/ui/chatscript-table-demo.gd
@@ -30,7 +30,7 @@ const LOCATION_DESCRIPTIONS_BY_ID := {
 ## Number of columns in the BBCode table
 var _table_width := 1
 
-## key: (Creatures.Mood)
+## key: (int) Enum from Creatures.Mood
 ## value: (Array, String) string chat prefixes (emoticons)
 var _prefixes_by_mood := {}
 

--- a/project/src/demo/editor/creature-old/creature-editor-old.gd
+++ b/project/src/demo/editor/creature-old/creature-editor-old.gd
@@ -22,7 +22,7 @@ var _rng := RandomNumberGenerator.new()
 var _next_line_color_index := 0
 
 ## key: (String) allele
-## value: (Array) String values which have been randomly chosen by the 'tweak dna' button
+## value: (Array, String) allele values which have been randomly chosen by the 'tweak dna' button
 var _recent_tweaked_allele_values := {}
 
 ## creature the player is editing

--- a/project/src/demo/puzzle/level/rank-mode-demo.gd
+++ b/project/src/demo/puzzle/level/rank-mode-demo.gd
@@ -7,7 +7,7 @@ extends Node
 ## This was used to assign a roughly increasing level of difficulty for rank levels.
 
 ## key: (String) level name
-## value: (Array) array containing 3 elements representing the level difficulty:
+## value: (Array, String) array containing 3 elements representing the level difficulty:
 ## 	value[0]: (String) The desired rank like "2" or "48" for the player's expected skill. These correspond to the
 ## 		integers in RankCalculator.GRADE_RANKS
 ## 	value[1]: (String) The slowest piece speed like "3" or "FA" which the player is constrained to. Levels with

--- a/project/src/main/career/career-cutscene-library.gd
+++ b/project/src/main/career/career-cutscene-library.gd
@@ -73,8 +73,8 @@ var _chat_key_pairs_by_preroll := {}
 ## key: (String) Interlude preroll chat key like 'chat/career/general_00_a', or a parent path like
 ## 	'chat/career/general'.
 ##
-## value: (Array) List of child chat key fragments, like ['00', '01', '02']. Each fragment corresponds to a suffix
-## 	which can be appended to the chat key, along with an appropriate delimeter, to create a new path.
+## value: (Array, String) List of child chat key fragments, like ['00', '01', '02']. Each fragment corresponds to a
+## 	suffix which can be appended to the chat key, along with an appropriate delimeter, to create a new path.
 var _preroll_tree := {}
 
 ## List of String interlude chat keys in the 'general' chat key root path featuring fat sensei

--- a/project/src/main/credits/pinup-scrollers.gd
+++ b/project/src/main/credits/pinup-scrollers.gd
@@ -33,7 +33,7 @@ func _ready() -> void:
 ## Parameters:
 ## 	'creature_id': The creature to show
 ##
-## 	'pinup_side': An enum from PinupScroller.Side for the side of the screen the pinup appears on
+## 	'pinup_side': Enum from PinupScroller.Side for the side of the screen the pinup appears on
 func add_pinup(creature_id: String, pinup_side: int, bg_color: Color) -> void:
 	# grab the oldest pinup out of the pool
 	var scroller: PinupScroller = _pinup_scroller_pool.pop_front()

--- a/project/src/main/puzzle/critter/shark.gd
+++ b/project/src/main/puzzle/critter/shark.gd
@@ -43,7 +43,7 @@ const SQUISHED := State.SQUISHED
 ## Shorter sharks need the tooth cloud moved lower so it will line up with their mouth. This constant stores the tooth
 ## cloud height for different shark types.
 ##
-## key: (SharkConfig.SharkSize)
+## key: (int) Enum from SharkConfig.SharkSize
 ## value: (float) y coordinate for the tooth cloud for the specified shark size.
 const TOOTH_CLOUD_Y_BY_SHARK_SIZE := {
 	SharkConfig.SharkSize.SMALL: -12.0,
@@ -51,7 +51,7 @@ const TOOTH_CLOUD_Y_BY_SHARK_SIZE := {
 	SharkConfig.SharkSize.LARGE: -36.0,
 }
 
-## key: (SharkConfig.SharkSize)
+## key: (int) Enum from SharkConfig.SharkSize
 ## value: (float) pitch scale for the specified shark size
 const PITCH_SCALE_BY_SHARK_SIZE := {
 	SharkConfig.SharkSize.SMALL: 1.55,

--- a/project/src/main/puzzle/foods.gd
+++ b/project/src/main/puzzle/foods.gd
@@ -66,7 +66,7 @@ const COLOR_VEG_CHEESE := Color("c1a57e")
 const COLORS_VEG_ALL := [COLOR_VEG_GREEN, COLOR_VEG_RED, COLOR_VEG_BREAD, COLOR_VEG_WHITE, COLOR_VEG_CHEESE]
 
 
-## key: (FoodType)
+## key: (int) Enum from FoodType
 ## value: (BoxType) corresponding box
 const BOX_TYPES_BY_FOOD_TYPE := {
 	FoodType.BROWN_0: BoxType.BROWN,
@@ -116,7 +116,7 @@ const COLORS_BY_FOOD_TYPE := {
 	FoodType.CAKE_CTU: [COLOR_CHEESE, COLOR_BREAD, COLOR_BREAD],
 }
 
-## key: (BoxType)
+## key: (int) Enum from BoxType
 ## value: (Array, FoodType) FoodTypes for the corresponding food items
 const FOOD_TYPES_BY_BOX_TYPE := {
 	BoxType.BROWN: [FoodType.BROWN_0, FoodType.BROWN_1],
@@ -137,7 +137,7 @@ const FOOD_TYPES_BY_BOX_TYPE := {
 	BoxType.CAKE_CTU: [FoodType.CAKE_CTU],
 }
 
-## key: (BoxType)
+## key: (int) Enum from BoxType
 ## value: (Array, Color) Food colors for the corresponding food items
 const COLORS_BY_BOX_TYPE := {
 	BoxType.BROWN: [COLOR_BROWN],

--- a/project/src/main/puzzle/level/level-triggers.gd
+++ b/project/src/main/puzzle/level/level-triggers.gd
@@ -6,7 +6,7 @@ class_name LevelTriggers
 ## invisible every time the player places a piece.
 
 ## key: (int) Enum from LevelTrigger.LevelTriggerPhase
-## value: (Array) LevelTriggers which should happen during that phase
+## value: (Array, LevelTrigger) LevelTriggers which should happen during that phase
 var triggers := {}
 
 ## Runs all triggers for the specified phase.

--- a/project/src/main/puzzle/level/phase-conditions.gd
+++ b/project/src/main/puzzle/level/phase-conditions.gd
@@ -184,8 +184,8 @@ class BoxBuiltPhaseCondition extends PhaseCondition:
 	## Note: This dictionary does not have entries for one-to-many keys like RequiredBoxType.ANY or
 	## RequiredBoxType.CAKE.
 	##
-	## key: (RequiredBoxType)
-	## value: (Foods.BoxType)
+	## key: (int) Enum from RequiredBoxType
+	## value: (int) Enum from Foods.BoxType
 	const BOX_TYPE_BY_REQUIRED_BOX_TYPE := {
 		RequiredBoxType.BROWN: Foods.BoxType.BROWN,
 		RequiredBoxType.PINK: Foods.BoxType.PINK,

--- a/project/src/main/ui/candy-button/candy-button-collapsible.gd
+++ b/project/src/main/ui/candy-button/candy-button-collapsible.gd
@@ -43,7 +43,7 @@ var _shine_texture_pressed: Texture = _shine_texture_uncollapsed_pressed
 ## Textures for the various ButtonShape presets.
 ##
 ## key: (int) Enum from ButtonShape
-## value: (Array) Array with two entries for the textures for the specified shape:
+## value: (Array, Texture) Array with two entries for the textures for the specified shape:
 ## 	value[0]: (Texture) texture to use when the button is not pressed.
 ## 	value[1]: (Texture) texture to use when the button is pressed.
 var _textures_by_button_shape_collapsed := {
@@ -79,7 +79,7 @@ var _textures_by_button_shape_collapsed := {
 ## Textures for the various ButtonShape presets.
 ##
 ## key: (int) Enum from ButtonShape
-## value: (Array) Array with two entries for the textures for the specified shape:
+## value: (Array, Texture) Array with two entries for the textures for the specified shape:
 ## 	value[0]: (Texture) texture to use when the button is not pressed.
 ## 	value[1]: (Texture) texture to use when the button is pressed.
 var _textures_by_button_shape := CandyButtons.C3_TEXTURES_BY_BUTTON_SHAPE

--- a/project/src/main/ui/candy-button/candy-button-h3.gd
+++ b/project/src/main/ui/candy-button/candy-button-h3.gd
@@ -33,7 +33,7 @@ var _shine_texture_pressed: Texture = preload("res://assets/main/ui/candy-button
 ## Textures for the various ButtonShape presets.
 ##
 ## key: (int) Enum from ButtonShape
-## value: (Array) Array with two entries for the textures for the specified shape:
+## value: (Array, Texture) Array with two entries for the textures for the specified shape:
 ## 	value[0]: (Texture) texture to use when the button is not pressed.
 ## 	value[1]: (Texture) texture to use when the button is pressed.
 var _textures_by_button_shape := {

--- a/project/src/main/ui/candy-button/candy-button-h4.gd
+++ b/project/src/main/ui/candy-button/candy-button-h4.gd
@@ -25,7 +25,7 @@ var _shine_texture_pressed: Texture = preload("res://assets/main/ui/candy-button
 ## Textures for the various ButtonShape presets.
 ##
 ## key: (int) Enum from ButtonShape
-## value: (Array) Array with two entries for the textures for the specified shape:
+## value: (Array, Texture) Array with two entries for the textures for the specified shape:
 ## 	value[0]: (Texture) texture to use when the button is not pressed.
 ## 	value[1]: (Texture) texture to use when the button is pressed.
 var _textures_by_button_shape := {

--- a/project/src/main/ui/candy-button/candy-buttons.gd
+++ b/project/src/main/ui/candy-button/candy-buttons.gd
@@ -40,7 +40,7 @@ const GRADIENT_DISABLED_HOVER := preload("res://src/main/ui/candy-button/gradien
 ## Gradients for the various ButtonColor presets.
 ##
 ## key: (int) Enum from ButtonColor
-## value: (Array) Array with two entries for the gradients for the specified color:
+## value: (Array, Gradient) Array with two entries for the gradients for the specified color:
 ## 	value[0]: (Gradient) Gradient to use when the button is not hovered.
 ## 	value[1]: (Gradient) Gradient to use when the button is hovered.
 const GRADIENTS_BY_BUTTON_COLOR := {
@@ -75,7 +75,7 @@ const GRADIENTS_BY_BUTTON_COLOR := {
 ## Textures for the various ButtonShape presets.
 ##
 ## key: (int) Enum from ButtonShape
-## value: (Array) Array with two entries for the textures for the specified shape:
+## value: (Array, Texture) Array with two entries for the textures for the specified shape:
 ## 	value[0]: (Texture) texture to use when the button is not pressed.
 ## 	value[1]: (Texture) texture to use when the button is pressed.
 const C3_TEXTURES_BY_BUTTON_SHAPE := {

--- a/project/src/main/ui/candy-button/gradient-map.shader
+++ b/project/src/main/ui/candy-button/gradient-map.shader
@@ -1,10 +1,10 @@
-/*
+shader_type canvas_item;
+render_mode unshaded;
+/**
  * Applies a gradient map to a texture. Obtained from GDQuest's Gradient Map tutorial, 2024-05-14
  *
  * https://www.gdquest.com/tutorial/godot/shaders/gradient-map/
  */
-shader_type canvas_item;
-render_mode unshaded;
 
 // Gradient used in the mapping; light and dark tones are mapped to colors in this gradient.
 uniform sampler2D gradient: hint_black;

--- a/project/src/main/ui/region-select-button.gd
+++ b/project/src/main/ui/region-select-button.gd
@@ -47,7 +47,7 @@ var ranks := []
 ## Number in the range [0.0, 1.0] for how close the player is to completing the region.
 var completion_percent := 0.0
 
-## key: (Type)
+## key: (int) Enum from Type
 ## value: (Array, Resource) pair of texture resources to use when the button is enabled or disabled
 var _texture_pairs_by_type := {
 	Type.NONE: [preload("res://assets/main/career/ui/region-default.png"),

--- a/project/src/main/ui/transition-mask.shader
+++ b/project/src/main/ui/transition-mask.shader
@@ -1,10 +1,10 @@
-/*
+shader_type canvas_item;
+render_mode unshaded;
+/**
  * Renders a greyscale image as a single-color mask with an alpha component.
  *
  * Used to black out the screen during scene transitions.
  */
-shader_type canvas_item;
-render_mode unshaded;
 
 // The red value which defines the cutoff for what's opaque
 uniform float cutoff : hint_range(0.0, 1.0);

--- a/project/src/main/utils/icon-outline.shader
+++ b/project/src/main/utils/icon-outline.shader
@@ -1,5 +1,5 @@
 shader_type canvas_item;
-/*
+/**
  * Recolors and draws an outline around a single-color sprite.
  *
  * Opaque parts of the sprite are recolored as a single color. The icon outline is sampled in 24 directions by default,

--- a/project/src/main/utils/outline.shader
+++ b/project/src/main/utils/outline.shader
@@ -1,9 +1,9 @@
-/*
+shader_type canvas_item;
+/**
  * Draws an outline around a sprite. Adapted from outline.shader obtained from GDQuest's godot-demos, 2020-04-01
  *
  * https://github.com/GDQuest/godot-demos/blob/master/2018/09-20-shaders/shaders/outline.shader
  */
-shader_type canvas_item;
 
 uniform float width: hint_range(0.0, 16.0);
 uniform vec4 black: hint_color;

--- a/project/src/main/utils/sfx-deconflicter.gd
+++ b/project/src/main/utils/sfx-deconflicter.gd
@@ -8,9 +8,9 @@ extends Node
 ## Number of milliseconds before the same sound can play a second time.
 const SUPPRESS_SFX_MSEC := 20
 
-## key: audio stream resource path
-## value: the amount of time passed in milliseconds between when the engine started and when the sound effect was last
-## 	played
+## key: (String) audio stream resource path
+## value: (int) the amount of time passed in milliseconds between when the engine started and when the sound effect was
+## 	last played
 var last_played_msec_by_resource_path := {}
 
 ## Plays the specified sound effect, unless it was recently played.

--- a/project/src/main/world/creature/creature-curve.gd
+++ b/project/src/main/world/creature/creature-curve.gd
@@ -17,7 +17,7 @@ export (bool) var editing := true
 export (bool) var _save_curve: bool setget save_curve
 
 ## defines the shadow curve coordinates for each of the creature's levels of fatness.
-export (Array) var curve_defs: Array setget set_curve_defs
+export (Array, Dictionary) var curve_defs: Array setget set_curve_defs
 
 ## if false, the body will not render this curve when the creature faces away from the camera.
 export (bool) var drawn_when_facing_north: bool = true

--- a/project/src/main/world/creature/name-generator-library.gd
+++ b/project/src/main/world/creature/name-generator-library.gd
@@ -1,7 +1,7 @@
 extends Node
 ## Generates names for different species using different algorithms.
 
-## key: (Creatures.Type) creature type such as 'squirrel'
+## key: (int) Enum from Creatures.Type such as 'squirrel'
 ## value: (NameGenerator) generator for the specified creature type
 var _generators_by_type := {}
 

--- a/project/src/main/world/environment/goop-overworld-tiler.gd
+++ b/project/src/main/world/environment/goop-overworld-tiler.gd
@@ -236,13 +236,14 @@ export (int) var corner_tile_index: int
 ## (https://github.com/godotengine/godot/issues/11855)
 export (bool) var _autotile: bool setget autotile
 
-## key: (TileType)
+## key: (int) Enum from TileType
 ## value: (int) tile index from the parent tilemap for the specified enum, as defined by no_goop_tile_index,
 ## 	some_goop_tile_index and all_goop_tile_index
 var _tile_indexes_by_type := {}
 
 ## key: (int) tile index from the parent tilemap
-## value: (TileType) tile index, as defined by no_goop_tile_index, some_goop_tile_index and all_goop_tile_index
+## value: (int) Enum from TileType for the tile index, as defined by no_goop_tile_index, some_goop_tile_index and
+## 	all_goop_tile_index
 var _tile_types_by_index := {}
 
 ## indexes of cake tiles in the parent tilemap, both goopy and goopless

--- a/project/src/main/world/environment/restaurant/kitchen-obstacle-tiler.gd
+++ b/project/src/main/world/environment/restaurant/kitchen-obstacle-tiler.gd
@@ -87,7 +87,7 @@ const GRILL_ORIENTATION_BY_CELL := {
 	Vector2(3, 7): RIGHT,
 }
 
-## key: (Array) array containing 3 elements representing TileSet bindings and metadata:
+## key: (Array, int) array containing 3 elements representing TileSet bindings and metadata:
 ## 	key[0]: (int) direction which the grill is currently facing (UP, DOWN, LEFT, RIGHT)
 ## 	key[1]: (int) union of TileSet bindings for adjacent cells containing grills
 ## 	key[2]: (int) union of TileSet bindings for adjacent cells containing grills and countertops
@@ -144,7 +144,7 @@ const SINK_ORIENTATION_BY_CELL := {
 	Vector2(2, 3): RIGHT,
 }
 
-## key: (Array) array containing 3 elements representing TileSet bindings and metadata:
+## key: (Array, int) array containing 3 elements representing TileSet bindings and metadata:
 ## 	key[0]: (int) direction which the sink is currently facing (UP, DOWN, LEFT, RIGHT)
 ## 	key[1]: (int) union of TileSet bindings for adjacent cells containing sinks
 ## value: (Vector2) sink autotile coordinate

--- a/project/src/main/world/environment/ripples.gd
+++ b/project/src/main/world/environment/ripples.gd
@@ -18,7 +18,7 @@ enum RippleState {
 	CONNECTED_BOTH,
 }
 
-## key: (RippleDirection)
+## key: (int) Enum from RippleDirection
 ## value: (Vector2) unit vector for use in tilemaps; northeast points up
 const TILEMAP_VECTOR_BY_RIPPLE_DIRECTION := {
 	RippleDirection.NORTHEAST: Vector2.UP,
@@ -27,7 +27,7 @@ const TILEMAP_VECTOR_BY_RIPPLE_DIRECTION := {
 	RippleDirection.NORTHWEST: Vector2.LEFT,
 }
 
-## key: (RippleDirection)
+## key: (int) Enum from RippleDirection
 ## value: (Vector2) unit vector where abs(x) = abs(2y); northeast points right and slightly up
 const ISO_VECTOR_BY_RIPPLE_DIRECTION := {
 	RippleDirection.NORTHEAST: Vector2(0.89443, -0.44721),

--- a/project/src/main/world/rgb-palette.shader
+++ b/project/src/main/world/rgb-palette.shader
@@ -1,4 +1,5 @@
-/*
+shader_type canvas_item;
+/**
  * A shader which takes an RGB image, and replaces the red component with one color, the green component with a second
  * color, and the blue component with a third color. Black pixels are also replaced with a fourth color. A pixel
  * which is mostly red but a little green will be replaced with the first and second colors.
@@ -7,7 +8,6 @@
  * graphics card. It's performant and looks reasonable even if the sprite is resized before being passed off to the
  * graphics card.
  */
-shader_type canvas_item;
 
 // replacement colors for red, green and blue channels
 uniform vec4 red : hint_color;


### PR DESCRIPTION
'## key: (Creatures.Mood)' -> '## key: (int) Enum from Creatures.Mood)'

Moved shader comments below 'shader_type' declaration. Reformatted as '/**' block comments.

'value: (Array)' -> 'value: (Array, String)