### PR TITLE
Refactor: Remove 'onready' from tweens.

### DIFF
--- a/project/src/main/career/ui/progress-board-clock-label.gd
+++ b/project/src/main/career/ui/progress-board-clock-label.gd
@@ -10,7 +10,7 @@ const FLASH_DURATION := 1.5
 const OUTLINE_COLOR := Color("6c4331")
 
 ## Tween that handles the clock's flash effect.
-onready var _flash_tween: SceneTreeTween
+var _flash_tween: SceneTreeTween
 
 ## Particles emitted when the clock flashes.
 onready var _particles := $Particles

--- a/project/src/main/career/ui/progress-board-clock.gd
+++ b/project/src/main/career/ui/progress-board-clock.gd
@@ -26,10 +26,10 @@ const HAND_POSITIONS_BY_HOUR := {
 ## or future.
 var hours_passed := 0 setget set_hours_passed
 
+var _tween: SceneTreeTween
+
 ## Digital text which shows the time using text like '8:50 pm'
 onready var _label: Label = $Label
-
-onready var _tween: SceneTreeTween
 
 ## Analog clock which shows the time using an and hour and minute hand.
 onready var _visuals: ProgressBoardClockVisuals = $VisualsHolder/Visuals

--- a/project/src/main/career/ui/progress-board-player.gd
+++ b/project/src/main/career/ui/progress-board-player.gd
@@ -28,6 +28,9 @@ var visual_spots_travelled: float setget set_visual_spots_travelled
 ## Height in pixels the player's chalk graphics bounce while advancing.
 var _bounce_height := MAX_BOUNCE_HEIGHT
 
+## Tweens the player's chalk graphic position along the trail.
+var _tween: SceneTreeTween
+
 ## Number label above the player's head which shows how far they will advance.
 onready var _label := $Label
 
@@ -37,9 +40,6 @@ onready var _sprite: Sprite = $PlayerSprite
 ## Animates the player's chalk graphic to wave its arms.
 onready var _sprite_animation_player := $PlayerSprite/AnimationPlayer
 onready var _trail: ProgressBoardTrail = get_node(trail_path)
-
-## Tweens the player's chalk graphic position along the trail.
-onready var _tween: SceneTreeTween
 
 ## Plays a 'donk' sound as the player's chalk graphic bounces along the trail.
 onready var _player_move_sound := $PlayerMoveSound

--- a/project/src/main/music/music-player.gd
+++ b/project/src/main/music/music-player.gd
@@ -31,6 +31,8 @@ var night_filter: bool = false setget set_night_filter
 ## value: (float) desired volume_db for playing music
 var _max_volume_db_by_bgm := {}
 
+var _filter_tween: SceneTreeTween
+
 onready var _chill_bgms := [
 		$ChubHub, $DessertCourse, $HarderButter,
 		$HotFunkSundae, $LoFiChill, $RainbowSherbeat]
@@ -44,7 +46,6 @@ onready var _upbeat_bgms := [
 onready var _credits_bgm := $SugarCrash
 onready var _tutorial_bgms := [$MyFatnessPal]
 onready var _music_tween_manager := $MusicTweenManager
-onready var _filter_tween: SceneTreeTween
 
 func _ready() -> void:
 	all_bgms = _chill_bgms + _upbeat_bgms + _tutorial_bgms

--- a/project/src/main/puzzle/critter/carrot.gd
+++ b/project/src/main/puzzle/critter/carrot.gd
@@ -40,10 +40,10 @@ var hiding := false
 var _mix_color: Color = Color.transparent setget set_mix_color
 
 ## Handles the show/hide animations.
-onready var _show_tween: SceneTreeTween
+var _show_tween: SceneTreeTween
 
 ## Moves the carrot to the top of the screen.
-onready var _move_tween: SceneTreeTween
+var _move_tween: SceneTreeTween
 
 ## Stores details about the carrot's visuals, such as which sprites to use and the smoke location.
 onready var _visuals: Node2D = $Visuals

--- a/project/src/main/puzzle/critter/carrots.gd
+++ b/project/src/main/puzzle/critter/carrots.gd
@@ -28,6 +28,9 @@ var _playfield: Playfield
 ## tracks whether the carrot sfx are playing
 var _move_sfx_state: int = MoveSfxState.STOPPED
 
+## tweens carrot sfx
+var _tween: SceneTreeTween
+
 ## node which contains all of the child carrot nodes
 onready var _carrot_holder: Node2D = $CarrotHolder
 
@@ -36,9 +39,6 @@ onready var _carrot_poof_sound: AudioStreamPlayer = $CarrotPoofSound
 
 ## sound which plays while at least one carrot is moving
 onready var _carrot_move_sound: AudioStreamPlayer = $CarrotMoveSound
-
-## tweens carrot sfx
-onready var _tween: SceneTreeTween
 
 func _ready() -> void:
 	_refresh_playfield_path()

--- a/project/src/main/puzzle/critter/onion.gd
+++ b/project/src/main/puzzle/critter/onion.gd
@@ -38,12 +38,13 @@ var _current_state_index := -1
 ## accidentally popping two states from the queue when the onion first spawns.
 var _already_popped_state := false
 
+var _onion_location_tween: SceneTreeTween
+
 onready var _animation_tree := $AnimationTree
 onready var _onion := $Onion
 onready var _soil := $Soil
 
 onready var _dirt_particles := $DirtParticles
-onready var _onion_location_tween: SceneTreeTween
 
 func _ready() -> void:
 	# The state machine defaults to the 'none' state and not the 'null' state to avoid edge cases

--- a/project/src/main/puzzle/critter/shark-sfx.gd
+++ b/project/src/main/puzzle/critter/shark-sfx.gd
@@ -8,6 +8,12 @@ var pitch_scale := 1.00
 ## Duration in seconds the shark takes to eat.
 var eat_duration := Shark.DEFAULT_EAT_DURATION
 
+## Tweens properties of the eating sound as it plays.
+##
+## The eating sound is a long, sustained sound which is played for an arbitrary duration. We tween its pitch so that
+## it ends less abruptly.
+var _eat_tween: SceneTreeTween
+
 ## Friendly sounds the shark makes when it finishes eating.
 onready var _voice_friendly_sounds := [
 		preload("res://assets/main/puzzle/critter/shark-voice-friendly-0.wav"),
@@ -31,12 +37,6 @@ onready var _voice_short_sounds := [
 		preload("res://assets/main/puzzle/critter/shark-voice-short-6.wav"),
 		preload("res://assets/main/puzzle/critter/shark-voice-short-7.wav"),
 	]
-
-## Tweens properties of the eating sound as it plays.
-##
-## The eating sound is a long, sustained sound which is played for an arbitrary duration. We tween its pitch so that
-## it ends less abruptly.
-onready var _eat_tween: SceneTreeTween
 
 onready var _bite := $Bite
 onready var _eat := $Eat

--- a/project/src/main/puzzle/critter/shark-tooth-cloud.gd
+++ b/project/src/main/puzzle/critter/shark-tooth-cloud.gd
@@ -28,6 +28,9 @@ var eaten_autotile_y := 0
 ## Duration in seconds the shark takes to eat.
 var eat_duration := Shark.DEFAULT_EAT_DURATION
 
+## Tween which ends the eating animation.
+var _eat_tween: SceneTreeTween
+
 ## node which contains any child PuzzleTileMap node
 onready var _tilemap_holder: Control = $TileMapHolder
 
@@ -48,9 +51,6 @@ onready var _cloud_timer: Timer = $CloudTimer
 
 ## Timer which cycles the cyclone of teeth to the next frame.
 onready var _tooth_timer: Timer = $ToothTimer
-
-## Tween which ends the eating animation.
-onready var _eat_tween: SceneTreeTween
 
 func _ready() -> void:
 	_refresh_eating()

--- a/project/src/main/puzzle/goop-glob.gd
+++ b/project/src/main/puzzle/goop-glob.gd
@@ -42,7 +42,8 @@ var velocity := Vector2.ZERO
 ## time in milliseconds between the engine starting and this node being initialized
 var _creation_time := 0.0
 
-onready var _tween: SceneTreeTween
+var _tween: SceneTreeTween
+
 onready var _fade_timer: Timer = $FadeTimer
 
 ## Populates this object from another GoopGlob instance.

--- a/project/src/main/puzzle/leaf-poof.gd
+++ b/project/src/main/puzzle/leaf-poof.gd
@@ -12,7 +12,7 @@ var leaf_frame: int setget set_leaf_frame
 var leaf_type: int
 
 ## turns the leaf invisible
-onready var _tween: SceneTreeTween
+var _tween: SceneTreeTween
 
 ## animates and flips the leaf
 onready var _animation_player: AnimationPlayer = $AnimationPlayer

--- a/project/src/main/puzzle/night/night-mode-toggler.gd
+++ b/project/src/main/puzzle/night/night-mode-toggler.gd
@@ -24,15 +24,15 @@ const TWEEN_DURATION := 0.3
 
 var _night_mode := false
 
+## Adjusts node colors and visibility during day/night transitions.
+var _tween: SceneTreeTween
+
 ## Nodes being tweened to transparent. After the tween completes, we set the 'visible' property on these nodes to
 ## 'false'.
 ##
 ## key: (Node) node being modulated to transparent
 ## kalue: (bool) true
 var _nodes_modulated_to_transparent := {}
-
-## Adjusts node colors and visibility during day/night transitions.
-onready var _tween: SceneTreeTween
 
 func _exit_tree() -> void:
 	# unset night filter if it was enabled

--- a/project/src/main/puzzle/night/night-sky-glow.gd
+++ b/project/src/main/puzzle/night/night-sky-glow.gd
@@ -3,11 +3,11 @@ extends Sprite
 
 export (NodePath) var onion_sprite_path: NodePath
 
+## Increases/decreases our size gradually.
+var _tween: SceneTreeTween
+
 ## Onion which we reference when updating our position.
 onready var onion_sprite: Node2D = get_node(onion_sprite_path)
-
-## Increases/decreases our size gradually.
-onready var _tween: SceneTreeTween
 
 func _ready() -> void:
 	_start_tween()

--- a/project/src/main/puzzle/night/night-sky.gd
+++ b/project/src/main/puzzle/night/night-sky.gd
@@ -1,14 +1,14 @@
 extends ColorRect
 ## Draws the starry sky behind the playfield during night mode.
 
+## rapidly rotates the stars when the playfield shows up, for a time lapse effect
+var _sky_spin_tween: SceneTreeTween
+
 ## two large blue elliptical Sprites which add some texture to the sky
 onready var _sky_sprites := [$SkyA, $SkyB]
 
 ## Particle2Ds which draw a starfield of big, cartoony stars
 onready var _star_nodes := [$NightStarsDark, $NightStarsLight]
-
-## rapidly rotates the stars when the playfield shows up, for a time lapse effect
-onready var _sky_spin_tween: SceneTreeTween
 
 func _ready() -> void:
 	for sprite in _sky_sprites:

--- a/project/src/main/puzzle/pickup.gd
+++ b/project/src/main/puzzle/pickup.gd
@@ -14,12 +14,12 @@ var food_shown: bool = false setget set_food_shown
 var _star_colors: Array = []
 var _star_color_index := 0
 
+## tween used to update the star's color
+var _star_color_tween: SceneTreeTween
+
 onready var _seed := $Seed
 onready var _star := $Star
 onready var _food_item := $FoodItem
-
-## tween used to update the star's color
-onready var _star_color_tween: SceneTreeTween
 
 func _ready() -> void:
 	_seed.visible = true

--- a/project/src/main/puzzle/playfield-fx.gd
+++ b/project/src/main/puzzle/playfield-fx.gd
@@ -81,6 +81,9 @@ var _tile_index_by_color: Dictionary
 ## Array of integer index of rainbow tiles in light_map or glow_map
 var _rainbow_tile_indexes := []
 
+## gradually dims the glowiness
+var _glow_tween: SceneTreeTween
+
 ## lights which turn on and off
 onready var light_map: TileMap = $LightMap
 
@@ -91,9 +94,6 @@ onready var glow_map: TileMap = $GlowMap
 onready var bg_strobe: ColorRect = $BgStrobe
 
 onready var _combo_tracker: ComboTracker = get_node(combo_tracker_path)
-
-## gradually dims the glowiness
-onready var _glow_tween: SceneTreeTween
 
 func _ready() -> void:
 	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")

--- a/project/src/main/puzzle/puzzle-money-hud.gd
+++ b/project/src/main/puzzle/puzzle-money-hud.gd
@@ -7,8 +7,9 @@ const TWEEN_DURATION := 0.1
 ## Path to the label which shows the total each customer paid. The money label responds to these totals.
 export (NodePath) var results_label_path: NodePath
 
+var _money_label_tween: SceneTreeTween
+
 onready var _money_label := $MoneyLabel
-onready var _money_label_tween: SceneTreeTween
 onready var _results_label: ResultsLabel = get_node(results_label_path)
 
 func _ready() -> void:

--- a/project/src/main/world/creature/creature-animations.gd
+++ b/project/src/main/world/creature/creature-animations.gd
@@ -31,11 +31,11 @@ var _near_arm: PackedSprite
 var _tail_z0: PackedSprite
 var _tail_z1: PackedSprite
 
+## recoils the creature's head
+var _tween: SceneTreeTween
+
 ## IdleTimer which launches idle animations periodically
 onready var _idle_timer: Timer = $IdleTimer
-
-## recoils the creature's head
-onready var _tween: SceneTreeTween
 
 ## EmotePlayer which animates moods: blinking, smiling, sweating, etc.
 onready var _emote_player: AnimationPlayer = $EmotePlayer

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -104,10 +104,11 @@ var _non_iso_velocity := Vector2.ZERO
 ## handles animations and audio/visual effects for a creature
 var _creature_outline: CreatureOutline
 
+var _fade_tween: SceneTreeTween
+
 onready var _creature_sfx: CreatureSfx = $CreatureSfx
 onready var _collision_shape: CollisionShape2D = $CollisionShape2D
 onready var _mouth_hook: Node2D = $MouthHook
-onready var _fade_tween: SceneTreeTween
 
 func _ready() -> void:
 	var creature_outline_scene_path := "res://src/main/world/creature/ViewportCreatureOutline.tscn"

--- a/project/src/main/world/creature/emote-player.gd
+++ b/project/src/main/world/creature/emote-player.gd
@@ -154,9 +154,10 @@ var _head_bobber: Sprite
 ## list of sprites to reset when unemoting
 var _emote_sprites: Array
 
+var _reset_tween: SceneTreeTween
+var _volume_db_tween: SceneTreeTween
+
 onready var _emote_sfx := $EmoteSfx
-onready var _reset_tween: SceneTreeTween
-onready var _volume_db_tween: SceneTreeTween
 
 func _ready() -> void:
 	_refresh_creature_visuals_path()

--- a/project/src/main/world/environment/credits/crowd-surfing-buddy.gd
+++ b/project/src/main/world/environment/credits/crowd-surfing-buddy.gd
@@ -39,13 +39,13 @@ var _velocity: Vector2
 ## the creature's desired velocity, based on how close they are to their buddy and destination
 var _desired_velocity: Vector2
 
+var _elevation_tween: SceneTreeTween
+
 ## other creature whom this creature is walking with
 onready var _buddy: Creature = get_node(buddy_path)
 
 ## other creature whom this creature is walking with
 onready var _destination: Node2D = get_node(destination_path)
-
-onready var _elevation_tween: SceneTreeTween
 
 ## periodically changes the creature's mood and orientation
 onready var _mood_timer := $MoodTimer

--- a/project/src/main/world/environment/ripple-sprite.gd
+++ b/project/src/main/world/environment/ripple-sprite.gd
@@ -9,7 +9,7 @@ const FADE_DURATION := 0.3
 
 export (Ripples.RippleState) var ripple_state := Ripples.RippleState.OFF setget set_ripple_state
 
-onready var _fade_tween: SceneTreeTween
+var _fade_tween: SceneTreeTween
 
 func _ready() -> void:
 	modulate = Color.transparent


### PR DESCRIPTION
These were previously onready variables because they were being assigned to a node in the scene tree. Now, they're just created at runtime.