### PR TITLE
Refactor: Simplified default dialog path behavior.

### DIFF
--- a/project/src/demo/editor/creature-old/dialogs.gd
+++ b/project/src/demo/editor/creature-old/dialogs.gd
@@ -9,6 +9,23 @@ onready var _import_dialog := $Import
 onready var _export_dialog := $Export
 onready var _save_confirmation := $SaveConfirmation
 
+func _ready() -> void:
+	_assign_default_dialog_paths()
+
+
+## Assign default dialog paths. These path properties were removed in Godot 3.5 in 2022 as a security precaution and
+## can no longer be assigned in the Godot editor, so we assign them here. See Godot #29674
+## (https://github.com/godotengine/godot/issues/29674)
+func _assign_default_dialog_paths() -> void:
+	# During development, the second of these assignments will succeed, but at runtime the assignment will have no
+	# effect. This gives us a more convenient default directory when authoring Turbo Fat's creatures.
+	_import_dialog.current_dir = OS.get_system_dir(OS.SYSTEM_DIR_DOCUMENTS)
+	_import_dialog.current_dir = ProjectSettings.globalize_path("res://assets/main/creatures/nonstory/")
+	
+	_export_dialog.current_dir = OS.get_system_dir(OS.SYSTEM_DIR_DOCUMENTS)
+	_export_dialog.current_dir = ProjectSettings.globalize_path("res://assets/main/creatures/nonstory/")
+
+
 func _show_import_export_not_supported_error() -> void:
 	_error_dialog.dialog_text = "Import/export isn't supported over the web. Sorry!"
 	_error_dialog.popup_centered()
@@ -25,7 +42,6 @@ func _on_ImportButton_pressed() -> void:
 		_show_import_export_not_supported_error()
 		return
 	
-	Utils.assign_default_dialog_path(_import_dialog, "res://assets/main/creatures/nonstory/")
 	_import_dialog.popup_centered()
 
 
@@ -46,7 +62,6 @@ func _on_ExportButton_pressed() -> void:
 		_show_import_export_not_supported_error()
 		return
 	
-	Utils.assign_default_dialog_path(_export_dialog, "res://assets/main/creatures/nonstory/")
 	var exported_creature: Creature = _creature_editor.center_creature
 	var sanitized_creature_name := StringUtils.sanitize_file_root(exported_creature.creature_short_name)
 	_export_dialog.current_file = "%s.json" % sanitized_creature_name

--- a/project/src/main/editor/creature/dialogs.gd
+++ b/project/src/main/editor/creature/dialogs.gd
@@ -16,15 +16,11 @@ onready var _unsaved_changes_confirmation := $UnsavedChangesConfirmation
 onready var _overworld_environment: OverworldEnvironment = get_node(overworld_environment_path)
 
 func _ready() -> void:
-	# Workaround for Godot #29674 (https://github.com/godotengine/godot/issues/29674).
-	#
 	# Assign default dialog paths. These path properties were removed in Godot 3.5 in 2022 as a security precaution
-	# and can no longer be assigned in the Godot editor, so we assign them here.
-	_export.current_dir = "/"
-	_export.current_file = "509e7c82-9399-425a-9f15-9370c2b3de8b"
-	
-	_import.current_dir = "/"
-	_import.current_file = "509e7c82-9399-425a-9f15-9370c2b3de8b"
+	# and can no longer be assigned in the Godot editor, so we assign them here. See Godot #29674
+	# (https://github.com/godotengine/godot/issues/29674)
+	_import.current_dir = OS.get_system_dir(OS.SYSTEM_DIR_DOCUMENTS)
+	_export.current_dir = OS.get_system_dir(OS.SYSTEM_DIR_DOCUMENTS)
 	
 	_unsaved_changes_confirmation.get_ok().text = tr("Save")
 	_unsaved_changes_confirmation.get_cancel().text = tr("Discard")
@@ -52,13 +48,10 @@ func show_unsaved_changes_confirmation(target: Object, method: String) -> void:
 
 
 func show_import_dialog() -> void:
-	assign_default_dialog_dir(_import, OS.get_system_dir(OS.SYSTEM_DIR_DOCUMENTS), "")
 	_import.popup_centered()
 
 
 func show_export_dialog() -> void:
-	assign_default_dialog_dir(_export, OS.get_system_dir(OS.SYSTEM_DIR_DOCUMENTS), "")
-	
 	var sanitized_creature_name := StringUtils.sanitize_file_root(_overworld_environment.player.creature_short_name)
 	_export.current_file = "%s.json" % sanitized_creature_name
 	_export.popup_centered()
@@ -87,17 +80,3 @@ func _on_UnsavedChangesQuitConfirmation_discard_pressed() -> void:
 ## Don't save the changes, and don't perform the requested operation (quitting or importing)
 func _on_UnsavedChangesQuitConfirmation_closed() -> void:
 	pass
-
-
-## Assigns a default path for a FileDialog.
-##
-## At runtime, this will default to the user data directory. During development, this will default to a resource path
-## for convenience when authoring Turbo Fat's creature's/levels.
-##
-## Note: We only want to assign the path the first time, but we can't check 'is the path empty' because an empty path
-## is a valid choice -- a player can navigate to the root directory. So instead of checking 'is the path empty' we
-## check 'is the path this specific UUID' since that's something the user will never navigate to accidentally.
-static func assign_default_dialog_dir(dialog: FileDialog, default_dir: String, default_file) -> void:
-	if dialog.current_path == "/509e7c82-9399-425a-9f15-9370c2b3de8b":
-		dialog.current_dir = default_dir
-		dialog.current_file = default_file

--- a/project/src/main/editor/puzzle/dialogs.gd
+++ b/project/src/main/editor/puzzle/dialogs.gd
@@ -10,19 +10,23 @@ onready var _open_resource_dialog := $OpenResource
 onready var _save_dialog := $Save
 
 func _ready() -> void:
-	# Assign default dialog paths. These path properties were removed in Godot 3.5 in 2022 as a security precaution
-	# and can no longer be assigned in the Godot editor, so we assign them here. See Godot #29674
-	# (https://github.com/godotengine/godot/issues/29674)
-	_open_file_dialog.current_dir = "/"
-	_open_file_dialog.current_file = "509e7c82-9399-425a-9f15-9370c2b3de8b"
-	_open_file_dialog.current_path = "/509e7c82-9399-425a-9f15-9370c2b3de8b"
+	_assign_default_dialog_paths()
+
+
+## Assign default dialog paths. These path properties were removed in Godot 3.5 in 2022 as a security precaution and
+## can no longer be assigned in the Godot editor, so we assign them here. See Godot #29674
+## (https://github.com/godotengine/godot/issues/29674)
+func _assign_default_dialog_paths() -> void:
+	# During development, the second of these assignments will succeed, but at runtime the assignment will have no
+	# effect. This gives us a more convenient default directory when authoring Turbo Fat's levels.
+	_open_file_dialog.current_dir = OS.get_system_dir(OS.SYSTEM_DIR_DOCUMENTS)
+	_open_file_dialog.current_dir = ProjectSettings.globalize_path("res://assets/main/puzzle/levels/practice/")
 	
-	_open_resource_dialog.current_dir = "res://assets/main/puzzle/levels"
-	_open_resource_dialog.current_path = "res://assets/main/puzzle/levels/"
+	_open_resource_dialog.current_dir = OS.get_system_dir(OS.SYSTEM_DIR_DOCUMENTS)
+	_open_resource_dialog.current_dir = ProjectSettings.globalize_path("res://assets/main/puzzle/levels/practice/")
 	
-	_save_dialog.current_dir = "/"
-	_save_dialog.current_file = "509e7c82-9399-425a-9f15-9370c2b3de8b"
-	_save_dialog.current_path = "/509e7c82-9399-425a-9f15-9370c2b3de8b"
+	_save_dialog.current_dir = OS.get_system_dir(OS.SYSTEM_DIR_DOCUMENTS)
+	_save_dialog.current_dir = ProjectSettings.globalize_path("res://assets/main/puzzle/levels/practice/")
 
 
 func _show_save_load_not_supported_error() -> void:
@@ -64,13 +68,10 @@ func _on_OpenFile_pressed() -> void:
 		_show_save_load_not_supported_error()
 		return
 	
-	Utils.assign_default_dialog_path(_open_file_dialog, "res://assets/main/puzzle/levels/practice/")
 	_open_file_dialog.popup_centered()
 
 
 func _on_OpenResource_pressed() -> void:
-	_open_resource_dialog.popup_centered()
-	Utils.assign_default_dialog_path(_open_resource_dialog, "res://assets/main/puzzle/levels/practice/")
 	_open_resource_dialog.popup_centered()
 
 
@@ -79,7 +80,6 @@ func _on_Save_pressed() -> void:
 		_show_save_load_not_supported_error()
 		return
 	
-	Utils.assign_default_dialog_path(_save_dialog, "res://assets/main/puzzle/levels/practice/")
 	_save_dialog.popup_centered()
 	if not _save_dialog.current_file:
 		# We assign a sensible filename based on the current level, like "level_512". Unfortunately, this filename is

--- a/project/src/main/utils/utils.gd
+++ b/project/src/main/utils/utils.gd
@@ -14,22 +14,6 @@ static func append_if_absent(array: Array, value) -> void:
 		array.append(value)
 
 
-## Assigns a default path for a FileDialog.
-##
-## At runtime, this will default to the user data directory. During development, this will default to a resource path
-## for convenience when authoring Turbo Fat's creature's/levels.
-##
-## Note: We only want to assign the path the first time, but we can't check 'is the path empty' because an empty path
-## is a valid choice -- a player can navigate to the root directory. So instead of checking 'is the path empty' we
-## check 'is the path this specific UUID' since that's something the user will never navigate to accidentally.
-static func assign_default_dialog_path(dialog: FileDialog, default_resource_path: String) -> void:
-	if dialog.current_path == "/509e7c82-9399-425a-9f15-9370c2b3de8b":
-		var current_path := ProjectSettings.globalize_path(default_resource_path)
-		if not Directory.new().dir_exists(current_path):
-			current_path = OS.get_user_data_dir()
-		dialog.current_path = current_path
-
-
 ## Returns the perceived brightness of a color.
 ##
 ## This allows UI elements to avoid combinations like dark blue on black or light green on white.


### PR DESCRIPTION
Eliminated 'assign_default_dialog_path' method. The purpose of this method was to detect whether a dialog had been launched or not, and if not, to assign it a default path. It is much simpler to instead assign the default path in the _ready() function. It no longer requires a specialized function or weird UUID path.

Changed level editor and old creature editor from defaulting to 'C:\' or '<snip>/AppData/Roaming/Godot/app_userdata/Turbo Fat' to 'Documents'

Removed redundant level editor 'OpenResourceDialog.popup_centered' call. This was being called twice by mistake.