### PR TITLE
Fix 'invalid mouth: 0' warnings

### DIFF
--- a/project/src/main/world/creature/dna-loader.gd
+++ b/project/src/main/world/creature/dna-loader.gd
@@ -108,7 +108,7 @@ func unload_dna() -> void:
 ##
 ## This method assumes that any existing animations and connections have been disconnected.
 func load_dna() -> void:
-	if _creature_visuals.dna.has("mouth"):
+	if _creature_visuals.dna.has("mouth") and _creature_visuals.dna.mouth != "0":
 		_add_dna_node(CreatureLoader.new_mouth_player(_creature_visuals.dna.mouth), "mouth",
 				_creature_visuals.dna.mouth, _creature_visuals.get_node("Animations"))
 	


### PR DESCRIPTION
These warnings occurred when trying to add a mouth animation player for a non-existent mouth. THis would happen if the player created a creature with no mouth.