### PR TITLE
Extracted 'ShineTextureRect' for CandyButtons

### DIFF
--- a/project/src/main/editor/creature/AlleleButton.tscn
+++ b/project/src/main/editor/creature/AlleleButton.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=18 format=2]
 
 [ext_resource path="res://src/main/utils/icon-outline.shader" type="Shader" id=1]
 [ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=2]
@@ -10,7 +10,9 @@
 [ext_resource path="res://src/main/ui/candy-button/gradient-none.tres" type="Gradient" id=8]
 [ext_resource path="res://src/main/ui/candy-button/ClickSound.tscn" type="PackedScene" id=9]
 [ext_resource path="res://assets/main/ui/candy-button/c3-focused.png" type="Texture" id=10]
+[ext_resource path="res://src/main/ui/candy-button/ShineTextureRect.tscn" type="PackedScene" id=11]
 [ext_resource path="res://src/main/editor/creature/allele-button.gd" type="Script" id=12]
+[ext_resource path="res://assets/main/ui/candy-button/c3-shine-pressed.png" type="Texture" id=13]
 
 [sub_resource type="GradientTexture2D" id=9]
 resource_local_to_scene = true
@@ -84,12 +86,10 @@ align = 1
 valign = 1
 clip_text = true
 
-[node name="Shine" type="TextureRect" parent="."]
-modulate = Color( 1, 1, 1, 0.831373 )
-anchor_right = 1.0
-anchor_bottom = 1.0
+[node name="Shine" parent="." instance=ExtResource( 11 )]
 texture = ExtResource( 4 )
-expand = true
+texture_normal = ExtResource( 4 )
+texture_pressed = ExtResource( 13 )
 
 [node name="ClickSound" parent="." instance=ExtResource( 9 )]
 

--- a/project/src/main/editor/creature/CreatureColorButton.tscn
+++ b/project/src/main/editor/creature/CreatureColorButton.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://assets/main/ui/candy-button/c3-blank-pressed.png" type="Texture" id=1]
 [ext_resource path="res://assets/main/ui/candy-button/c3-blank.png" type="Texture" id=2]
@@ -7,10 +7,12 @@
 [ext_resource path="res://src/main/ui/candy-button/HoverSound.tscn" type="PackedScene" id=5]
 [ext_resource path="res://assets/main/ui/candy-button/c3-focused.png" type="Texture" id=6]
 [ext_resource path="res://src/main/ui/candy-button/ClickSound.tscn" type="PackedScene" id=7]
+[ext_resource path="res://assets/main/ui/candy-button/c3-shine-pressed.png" type="Texture" id=8]
 [ext_resource path="res://assets/main/ui/candy-button/c3-shine.png" type="Texture" id=9]
 [ext_resource path="res://src/main/editor/creature/creature-color-button.gd" type="Script" id=10]
 [ext_resource path="res://assets/main/editor/creature/icon-color.png" type="Texture" id=11]
 [ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=12]
+[ext_resource path="res://src/main/ui/candy-button/ShineTextureRect.tscn" type="PackedScene" id=13]
 
 [sub_resource type="GradientTexture2D" id=9]
 resource_local_to_scene = true
@@ -53,12 +55,10 @@ size_flags_vertical = 4
 texture = ExtResource( 11 )
 expand = true
 
-[node name="Shine" type="TextureRect" parent="."]
-modulate = Color( 1, 1, 1, 0.831373 )
-anchor_right = 1.0
-anchor_bottom = 1.0
+[node name="Shine" parent="." instance=ExtResource( 13 )]
 texture = ExtResource( 9 )
-expand = true
+texture_normal = ExtResource( 9 )
+texture_pressed = ExtResource( 8 )
 
 [node name="Popup" parent="." instance=ExtResource( 4 )]
 margin_right = 236.0

--- a/project/src/main/editor/creature/CreatureNameButton.tscn
+++ b/project/src/main/editor/creature/CreatureNameButton.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=2]
+[gd_scene load_steps=20 format=2]
 
 [ext_resource path="res://src/main/ui/candy-button/gradient-none.tres" type="Gradient" id=1]
 [ext_resource path="res://src/main/editor/creature/NamePickerPopup.tscn" type="PackedScene" id=2]
@@ -10,9 +10,11 @@
 [ext_resource path="res://assets/main/editor/creature/icon-name.png" type="Texture" id=8]
 [ext_resource path="res://assets/main/ui/candy-button/c3-focused.png" type="Texture" id=9]
 [ext_resource path="res://assets/main/ui/candy-button/c3-blank.png" type="Texture" id=10]
+[ext_resource path="res://src/main/ui/candy-button/ShineTextureRect.tscn" type="PackedScene" id=11]
 [ext_resource path="res://assets/main/ui/candy-button/c3-blank-pressed.png" type="Texture" id=12]
 [ext_resource path="res://src/main/utils/icon-outline.shader" type="Shader" id=13]
 [ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=14]
+[ext_resource path="res://assets/main/ui/candy-button/c3-shine-pressed.png" type="Texture" id=15]
 
 [sub_resource type="GradientTexture2D" id=9]
 resource_local_to_scene = true
@@ -86,12 +88,10 @@ align = 1
 valign = 1
 clip_text = true
 
-[node name="Shine" type="TextureRect" parent="."]
-modulate = Color( 1, 1, 1, 0.831373 )
-anchor_right = 1.0
-anchor_bottom = 1.0
+[node name="Shine" parent="." instance=ExtResource( 11 )]
 texture = ExtResource( 6 )
-expand = true
+texture_normal = ExtResource( 6 )
+texture_pressed = ExtResource( 15 )
 
 [node name="NamePickerPopup" parent="." instance=ExtResource( 2 )]
 

--- a/project/src/main/editor/creature/OperationButton.tscn
+++ b/project/src/main/editor/creature/OperationButton.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=18 format=2]
 
 [ext_resource path="res://src/main/editor/creature/operation-button.gd" type="Script" id=1]
 [ext_resource path="res://assets/main/ui/candy-button/c3-v-pressed.png" type="Texture" id=2]
@@ -11,6 +11,8 @@
 [ext_resource path="res://src/main/ui/candy-button/HoverSound.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/ui/candy-button/gradient-none.tres" type="Gradient" id=10]
 [ext_resource path="res://src/main/ui/candy-button/ClickSound.tscn" type="PackedScene" id=11]
+[ext_resource path="res://src/main/ui/candy-button/ShineTextureRect.tscn" type="PackedScene" id=12]
+[ext_resource path="res://assets/main/ui/candy-button/c3-shine-pressed.png" type="Texture" id=13]
 
 [sub_resource type="GradientTexture2D" id=9]
 resource_local_to_scene = true
@@ -83,12 +85,10 @@ align = 1
 valign = 1
 clip_text = true
 
-[node name="Shine" type="TextureRect" parent="."]
-modulate = Color( 1, 1, 1, 0.831373 )
-anchor_right = 1.0
-anchor_bottom = 1.0
+[node name="Shine" parent="." instance=ExtResource( 12 )]
 texture = ExtResource( 4 )
-expand = true
+texture_normal = ExtResource( 4 )
+texture_pressed = ExtResource( 13 )
 
 [node name="ClickSound" parent="." instance=ExtResource( 11 )]
 

--- a/project/src/main/editor/creature/creature-color-button.gd
+++ b/project/src/main/editor/creature/creature-color-button.gd
@@ -7,12 +7,6 @@ extends TextureButton
 
 signal color_changed(color)
 
-## Bright shiny reflection texture which overlays the button and text when the button is not pressed.
-const SHINE_TEXTURE_NORMAL: Texture = preload("res://assets/main/ui/candy-button/c3-shine.png")
-
-## Less shiny reflection texture which overlays the button and text when the button is pressed.
-const SHINE_TEXTURE_PRESSED: Texture = preload("res://assets/main/ui/candy-button/c3-shine-pressed.png")
-
 ## Repeating piece shapes which decorate the button.
 export (CandyButtons.ButtonShape) var shape setget set_shape
 
@@ -29,16 +23,11 @@ onready var _icon := $Icon
 
 onready var _popup := $Popup
 
-## Shiny reflection effect which overlays the button and text
-onready var _shine := $Shine
-
 func _ready() -> void:
 	# Connect signals in code to prevent them from showing up in the Godot editor.
 	#
 	# This is a generic button used in many places, we want to be able to quickly see the unique signals connected to
 	# each button instance, not the generic signals connected to all button instances.
-	connect("button_down", self, "_on_button_down")
-	connect("button_up", self, "_on_button_up")
 	connect("focus_entered", self, "_on_focus_entered")
 	connect("focus_exited", self, "_on_focus_exited")
 	connect("mouse_entered", self, "_on_mouse_entered")
@@ -47,7 +36,6 @@ func _ready() -> void:
 	_refresh_shape()
 	_refresh_color()
 	_refresh_creature_color()
-	_refresh_shine()
 
 
 ## Preemptively initializes onready variables to avoid null references.
@@ -83,7 +71,6 @@ func _initialize_onready_variables() -> void:
 	_hover_sound = $HoverSound
 	_icon = $Icon
 	_popup = $Popup
-	_shine = $Shine
 
 
 ## Calculates the gradient which should color the button based on its color and state.
@@ -153,11 +140,6 @@ func _refresh_shape() -> void:
 	texture_hover = textures[0]
 
 
-## Updates the shine texture for our button.
-func _refresh_shine() -> void:
-	_shine.texture = SHINE_TEXTURE_PRESSED if pressed else SHINE_TEXTURE_NORMAL
-
-
 ## When we gain focus, we reapply a bright cyan color for our texture, text and icons.
 func _on_focus_entered() -> void:
 	_refresh_color()
@@ -184,14 +166,6 @@ func _on_mouse_exited() -> void:
 	if not disabled:
 		yield(get_tree(), "idle_frame")
 		_refresh_color()
-
-
-func _on_button_down() -> void:
-	_refresh_shine()
-
-
-func _on_button_up() -> void:
-	_refresh_shine()
 
 
 func _on_Popup_color_changed(color: Color) -> void:

--- a/project/src/main/ui/candy-button/CandyButtonC3.tscn
+++ b/project/src/main/ui/candy-button/CandyButtonC3.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=18 format=2]
 
 [ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=1]
 [ext_resource path="res://assets/main/ui/candy-button/c3-focused.png" type="Texture" id=2]
@@ -9,6 +9,8 @@
 [ext_resource path="res://src/main/ui/candy-button/ClickSound.tscn" type="PackedScene" id=7]
 [ext_resource path="res://assets/main/ui/candy-button/c3-shine.png" type="Texture" id=8]
 [ext_resource path="res://src/main/ui/candy-button/HoverSound.tscn" type="PackedScene" id=9]
+[ext_resource path="res://src/main/ui/candy-button/ShineTextureRect.tscn" type="PackedScene" id=10]
+[ext_resource path="res://assets/main/ui/candy-button/c3-shine-pressed.png" type="Texture" id=11]
 [ext_resource path="res://src/main/ui/candy-button/candy-button-c3.gd" type="Script" id=12]
 [ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=14]
 
@@ -86,12 +88,10 @@ align = 1
 valign = 1
 clip_text = true
 
-[node name="Shine" type="TextureRect" parent="."]
-modulate = Color( 1, 1, 1, 0.831373 )
-anchor_right = 1.0
-anchor_bottom = 1.0
+[node name="Shine" parent="." instance=ExtResource( 10 )]
 texture = ExtResource( 8 )
-expand = true
+texture_normal = ExtResource( 8 )
+texture_pressed = ExtResource( 11 )
 
 [node name="ClickSound" parent="." instance=ExtResource( 7 )]
 

--- a/project/src/main/ui/candy-button/CandyButtonCollapsible.tscn
+++ b/project/src/main/ui/candy-button/CandyButtonCollapsible.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=2]
+[gd_scene load_steps=19 format=2]
 
 [ext_resource path="res://src/main/ui/candy-button/HoverSound.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/ui/candy-button/gradient-none.tres" type="Gradient" id=2]
@@ -10,6 +10,8 @@
 [ext_resource path="res://assets/main/ui/candy-button/c3-blank-pressed.png" type="Texture" id=8]
 [ext_resource path="res://assets/main/ui/candy-button/c3-shine.png" type="Texture" id=9]
 [ext_resource path="res://src/main/ui/candy-button/ClickSound.tscn" type="PackedScene" id=10]
+[ext_resource path="res://assets/main/ui/candy-button/c3-shine-pressed.png" type="Texture" id=11]
+[ext_resource path="res://src/main/ui/candy-button/ShineTextureRect.tscn" type="PackedScene" id=12]
 
 [sub_resource type="GradientTexture2D" id=9]
 resource_local_to_scene = true
@@ -206,13 +208,6 @@ texture_focused = ExtResource( 6 )
 expand = true
 script = ExtResource( 3 )
 
-[node name="Shine" type="TextureRect" parent="."]
-modulate = Color( 1, 1, 1, 0.831373 )
-anchor_right = 1.0
-anchor_bottom = 1.0
-texture = ExtResource( 9 )
-expand = true
-
 [node name="Icon" type="TextureRect" parent="."]
 visible = false
 material = SubResource( 7 )
@@ -220,13 +215,18 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-margin_left = -25.0
-margin_top = -25.0
-margin_right = 25.0
-margin_bottom = 25.0
+margin_left = 55.0
+margin_top = 39.0
+margin_right = 105.0
+margin_bottom = 89.0
 rect_min_size = Vector2( 50, 50 )
 size_flags_vertical = 4
 expand = true
+
+[node name="Shine" parent="." instance=ExtResource( 12 )]
+texture = ExtResource( 9 )
+texture_normal = ExtResource( 9 )
+texture_pressed = ExtResource( 11 )
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 anims/RESET = SubResource( 10 )

--- a/project/src/main/ui/candy-button/CandyButtonH3.tscn
+++ b/project/src/main/ui/candy-button/CandyButtonH3.tscn
@@ -1,7 +1,7 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=18 format=2]
 
 [ext_resource path="res://assets/main/ui/candy-button/h3-blank-pressed.png" type="Texture" id=1]
-[ext_resource path="res://assets/main/ui/candy-button/h3-shine.png" type="Texture" id=2]
+[ext_resource path="res://src/main/ui/candy-button/ShineTextureRect.tscn" type="PackedScene" id=2]
 [ext_resource path="res://assets/main/ui/candy-button/h3-focused.png" type="Texture" id=3]
 [ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=4]
 [ext_resource path="res://src/main/ui/candy-button/candy-button-h3.gd" type="Script" id=5]
@@ -11,6 +11,8 @@
 [ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=9]
 [ext_resource path="res://src/main/ui/candy-button/ClickSound.tscn" type="PackedScene" id=10]
 [ext_resource path="res://src/main/ui/candy-button/HoverSound.tscn" type="PackedScene" id=11]
+[ext_resource path="res://assets/main/ui/candy-button/h3-shine-pressed.png" type="Texture" id=12]
+[ext_resource path="res://assets/main/ui/candy-button/h3-shine.png" type="Texture" id=13]
 
 [sub_resource type="GradientTexture2D" id=9]
 resource_local_to_scene = true
@@ -116,12 +118,10 @@ margin_right = 190.0
 margin_bottom = 50.0
 size_flags_horizontal = 3
 
-[node name="Shine" type="TextureRect" parent="."]
-modulate = Color( 1, 1, 1, 0.831373 )
-anchor_right = 1.0
-anchor_bottom = 1.0
-texture = ExtResource( 2 )
-expand = true
+[node name="Shine" parent="." instance=ExtResource( 2 )]
+texture = ExtResource( 13 )
+texture_normal = ExtResource( 13 )
+texture_pressed = ExtResource( 12 )
 
 [node name="ClickSound" parent="." instance=ExtResource( 10 )]
 

--- a/project/src/main/ui/candy-button/CandyButtonH4.tscn
+++ b/project/src/main/ui/candy-button/CandyButtonH4.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://src/main/ui/candy-button/candy-button-h4.gd" type="Script" id=1]
 [ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=2]
@@ -9,7 +9,9 @@
 [ext_resource path="res://assets/main/ui/candy-button/h4-shine.png" type="Texture" id=7]
 [ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=8]
 [ext_resource path="res://src/main/ui/candy-button/HoverSound.tscn" type="PackedScene" id=9]
+[ext_resource path="res://assets/main/ui/candy-button/h4-shine-pressed.png" type="Texture" id=10]
 [ext_resource path="res://src/main/ui/candy-button/gradient-none.tres" type="Gradient" id=11]
+[ext_resource path="res://src/main/ui/candy-button/ShineTextureRect.tscn" type="PackedScene" id=12]
 
 [sub_resource type="GradientTexture2D" id=9]
 resource_local_to_scene = true
@@ -54,12 +56,10 @@ text = "Text"
 align = 1
 valign = 1
 
-[node name="Shine" type="TextureRect" parent="."]
-modulate = Color( 1, 1, 1, 0.831373 )
-anchor_right = 1.0
-anchor_bottom = 1.0
+[node name="Shine" parent="." instance=ExtResource( 12 )]
 texture = ExtResource( 7 )
-expand = true
+texture_normal = ExtResource( 7 )
+texture_pressed = ExtResource( 10 )
 
 [node name="ClickSound" parent="." instance=ExtResource( 3 )]
 

--- a/project/src/main/ui/candy-button/ShineTextureRect.tscn
+++ b/project/src/main/ui/candy-button/ShineTextureRect.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/main/ui/candy-button/candy-button-shine.gd" type="Script" id=1]
+
+[node name="Shine" type="TextureRect"]
+modulate = Color( 1, 1, 1, 0.831373 )
+anchor_right = 1.0
+anchor_bottom = 1.0
+expand = true
+script = ExtResource( 1 )

--- a/project/src/main/ui/candy-button/candy-button-c3.gd
+++ b/project/src/main/ui/candy-button/candy-button-c3.gd
@@ -5,12 +5,6 @@ extends TextureButton
 ##
 ## This button is small and squareish, and is used throughout the creature editor.
 
-## Bright shiny reflection texture which overlays the button and text when the button is not pressed.
-const SHINE_TEXTURE_NORMAL: Texture = preload("res://assets/main/ui/candy-button/c3-shine.png")
-
-## Less shiny reflection texture which overlays the button and text when the button is pressed.
-const SHINE_TEXTURE_PRESSED: Texture = preload("res://assets/main/ui/candy-button/c3-shine-pressed.png")
-
 export (String) var text setget set_text
 
 ## Icon shown to the top of the button's text.
@@ -52,20 +46,16 @@ func _ready() -> void:
 	#
 	# This is a generic button used in many places, we want to be able to quickly see the unique signals connected to
 	# each button instance, not the generic signals connected to all button instances.
-	connect("button_down", self, "_on_button_down")
-	connect("button_up", self, "_on_button_up")
 	connect("focus_entered", self, "_on_focus_entered")
 	connect("focus_exited", self, "_on_focus_exited")
 	connect("mouse_entered", self, "_on_mouse_entered")
 	connect("mouse_exited", self, "_on_mouse_exited")
-	connect("toggled", self, "_on_toggled")
 	
 	_refresh_icons()
 	_refresh_font_size()
 	_refresh_text()
 	_refresh_shape()
 	_refresh_color()
-	_refresh_shine()
 
 
 ## Preemptively initializes onready variables to avoid null references.
@@ -217,11 +207,6 @@ func _refresh_shape() -> void:
 	texture_hover = textures[0]
 
 
-## Updates the shine texture for our button.
-func _refresh_shine() -> void:
-	_shine.texture = SHINE_TEXTURE_PRESSED if pressed else SHINE_TEXTURE_NORMAL
-
-
 ## Updates our label's text.
 func _refresh_text() -> void:
 	if not is_inside_tree():
@@ -262,15 +247,3 @@ func _on_mouse_exited() -> void:
 	if not disabled:
 		yield(get_tree(), "idle_frame")
 		_refresh_color()
-
-
-func _on_button_down() -> void:
-	_refresh_shine()
-
-
-func _on_button_up() -> void:
-	_refresh_shine()
-
-
-func _on_toggled(_button_pressed: bool) -> void:
-	_refresh_shine()

--- a/project/src/main/ui/candy-button/candy-button-collapsible.gd
+++ b/project/src/main/ui/candy-button/candy-button-collapsible.gd
@@ -70,12 +70,6 @@ export (CandyButtons.ButtonShape) var shape setget set_shape
 ## 'true' if the button is in its narrow 'a3' size, or 'false' if the button is in its wider 'c3' size.
 export (bool) var collapsed := false setget set_collapsed
 
-## Bright shiny reflection texture which overlays the button and text when the button is not pressed.
-var _shine_texture_normal: Texture = SHINE_TEXTURE_UNCOLLAPSED_NORMAL
-
-## Less shiny reflection texture which overlays the button and text when the button is pressed.
-var _shine_texture_pressed: Texture = SHINE_TEXTURE_UNCOLLAPSED_PRESSED
-
 ## Textures for the various ButtonShape presets.
 ##
 ## key: (int) Enum from ButtonShape
@@ -107,8 +101,6 @@ func _ready() -> void:
 	#
 	# This is a generic button used in many places, we want to be able to quickly see the unique signals connected to
 	# each button instance, not the generic signals connected to all button instances.
-	connect("button_down", self, "_on_button_down")
-	connect("button_up", self, "_on_button_up")
 	connect("focus_entered", self, "_on_focus_entered")
 	connect("focus_exited", self, "_on_focus_exited")
 	connect("mouse_entered", self, "_on_mouse_entered")
@@ -119,7 +111,6 @@ func _ready() -> void:
 	_refresh_icons()
 	_refresh_shape()
 	_refresh_color()
-	_refresh_shine()
 
 
 ## Preemptively initializes onready variables to avoid null references.
@@ -141,7 +132,6 @@ func set_disabled(new_disabled: bool) -> void:
 func set_collapsed(new_collapsed: bool) -> void:
 	collapsed = new_collapsed
 	_refresh_collapsed()
-	_refresh_shine()
 	_refresh_shape()
 
 
@@ -181,18 +171,18 @@ func collapse(animate: bool = false) -> void:
 
 
 func assign_collapsed_textures() -> void:
-	_shine_texture_normal = SHINE_TEXTURE_COLLAPSED_NORMAL
+	_shine.texture_normal = SHINE_TEXTURE_COLLAPSED_NORMAL
+	_shine.texture_pressed = SHINE_TEXTURE_COLLAPSED_PRESSED
 	_textures_by_shape = TEXTURES_BY_SHAPE_COLLAPSED
 	texture_focused = TEXTURE_FOCUSED_COLLAPSED
-	_refresh_shine()
 	_refresh_shape()
 
 
 func assign_uncollapsed_textures() -> void:
-	_shine_texture_normal = SHINE_TEXTURE_UNCOLLAPSED_NORMAL
+	_shine.texture_normal = SHINE_TEXTURE_UNCOLLAPSED_NORMAL
+	_shine.texture_pressed = SHINE_TEXTURE_UNCOLLAPSED_PRESSED
 	_textures_by_shape = CandyButtons.C3_TEXTURES_BY_SHAPE
 	texture_focused = TEXTURE_FOCUSED_UNCOLLAPSED
-	_refresh_shine()
 	_refresh_shape()
 
 
@@ -298,19 +288,6 @@ func _refresh_shape() -> void:
 	texture_hover = textures[0]
 
 
-## Updates the shine texture for our button.
-func _refresh_shine() -> void:
-	if not is_inside_tree():
-		return
-	
-	if Engine.editor_hint:
-		if not _shine:
-			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
-			_initialize_onready_variables()
-	
-	_shine.texture = _shine_texture_pressed if pressed else _shine_texture_normal
-
-
 func _refresh_icon_position() -> void:
 	_icon_node.rect_position = rect_size / 2 - _icon_node.rect_size / 2
 
@@ -341,14 +318,6 @@ func _on_mouse_exited() -> void:
 	if not disabled:
 		yield(get_tree(), "idle_frame")
 		_refresh_color()
-
-
-func _on_button_down() -> void:
-	_refresh_shine()
-
-
-func _on_button_up() -> void:
-	_refresh_shine()
 
 
 func _on_Icon_resized() -> void:

--- a/project/src/main/ui/candy-button/candy-button-h3.gd
+++ b/project/src/main/ui/candy-button/candy-button-h3.gd
@@ -4,12 +4,6 @@ extends TextureButton
 ##
 ## This button is extremely narrow, and used for the collapsed categories in the creature editor.
 
-## Bright shiny reflection texture which overlays the button and text when the button is not pressed.
-const SHINE_TEXTURE_NORMAL: Texture = preload("res://assets/main/ui/candy-button/h3-shine.png")
-
-## Less shiny reflection texture which overlays the button and text when the button is pressed.
-const SHINE_TEXTURE_PRESSED: Texture = preload("res://assets/main/ui/candy-button/h3-shine-pressed.png")
-
 ## Textures for the various ButtonShape presets.
 ##
 ## key: (int) Enum from ButtonShape
@@ -78,16 +72,11 @@ onready var _icon_node_right := $HBoxContainer/IconRight
 ## Label containing the button's text
 onready var _label := $HBoxContainer/Label
 
-## Shiny reflection effect which overlays the button and text
-onready var _shine := $Shine
-
 func _ready() -> void:
 	# Connect signals in code to prevent them from showing up in the Godot editor.
 	#
 	# This is a generic button used in many places, we want to be able to quickly see the unique signals connected to
 	# each button instance, not the generic signals connected to all button instances.
-	connect("button_down", self, "_on_button_down")
-	connect("button_up", self, "_on_button_up")
 	connect("focus_entered", self, "_on_focus_entered")
 	connect("focus_exited", self, "_on_focus_exited")
 	connect("mouse_entered", self, "_on_mouse_entered")
@@ -98,7 +87,6 @@ func _ready() -> void:
 	_refresh_text()
 	_refresh_shape()
 	_refresh_color()
-	_refresh_shine()
 
 
 ## Preemptively initializes onready variables to avoid null references.
@@ -150,7 +138,6 @@ func _initialize_onready_variables() -> void:
 	_label = $HBoxContainer/Label
 	_icon_node_left = $HBoxContainer/IconLeft
 	_icon_node_right = $HBoxContainer/IconRight
-	_shine = $Shine
 
 
 ## Calculates the gradient which should color the button based on its color and state.
@@ -261,11 +248,6 @@ func _refresh_shape() -> void:
 	texture_hover = textures[0]
 
 
-## Updates the shine texture for our button.
-func _refresh_shine() -> void:
-	_shine.texture = SHINE_TEXTURE_PRESSED if pressed else SHINE_TEXTURE_NORMAL
-
-
 ## Updates our label's text.
 func _refresh_text() -> void:
 	if not is_inside_tree():
@@ -305,11 +287,3 @@ func _on_mouse_exited() -> void:
 	if not disabled:
 		yield(get_tree(), "idle_frame")
 		_refresh_color()
-
-
-func _on_button_down() -> void:
-	_refresh_shine()
-
-
-func _on_button_up() -> void:
-	_refresh_shine()

--- a/project/src/main/ui/candy-button/candy-button-h4.gd
+++ b/project/src/main/ui/candy-button/candy-button-h4.gd
@@ -2,12 +2,6 @@ tool
 extends TextureButton
 ## An eye-catching button with customizable colors and textures.
 
-## Bright shiny reflection texture which overlays the button and text when the button is not pressed.
-const SHINE_TEXTURE_NORMAL: Texture = preload("res://assets/main/ui/candy-button/h4-shine.png")
-
-## Less shiny reflection texture which overlays the button and text when the button is pressed.
-const SHINE_TEXTURE_PRESSED: Texture = preload("res://assets/main/ui/candy-button/h4-shine-pressed.png")
-
 ## Textures for the various ButtonShape presets.
 ##
 ## key: (int) Enum from ButtonShape
@@ -64,16 +58,11 @@ onready var _hover_sound := $HoverSound
 ## Label containing the button's text
 onready var _label := $Label
 
-## Shiny reflection effect which overlays the button and text
-onready var _shine := $Shine
-
 func _ready() -> void:
 	# Connect signals in code to prevent them from showing up in the Godot editor.
 	#
 	# This is a generic button used in many places, we want to be able to quickly see the unique signals connected to
 	# each button instance, not the generic signals connected to all button instances.
-	connect("button_down", self, "_on_button_down")
-	connect("button_up", self, "_on_button_up")
 	connect("focus_entered", self, "_on_focus_entered")
 	connect("focus_exited", self, "_on_focus_exited")
 	connect("mouse_entered", self, "_on_mouse_entered")
@@ -83,7 +72,6 @@ func _ready() -> void:
 	_refresh_text()
 	_refresh_shape()
 	_refresh_color()
-	_refresh_shine()
 
 
 ## Preemptively initializes onready variables to avoid null references.
@@ -121,7 +109,6 @@ func set_disabled(new_disabled: bool) -> void:
 ## Preemptively initializes onready variables to avoid null references.
 func _initialize_onready_variables() -> void:
 	_label = $Label
-	_shine = $Shine
 
 
 ## Calculates the gradient which should color the button based on its color and state.
@@ -203,11 +190,6 @@ func _refresh_shape() -> void:
 	texture_hover = textures[0]
 
 
-## Updates the shine texture for our button.
-func _refresh_shine() -> void:
-	_shine.texture = SHINE_TEXTURE_PRESSED if pressed else SHINE_TEXTURE_NORMAL
-
-
 ## Updates our label's text.
 func _refresh_text() -> void:
 	if not is_inside_tree():
@@ -247,11 +229,3 @@ func _on_mouse_exited() -> void:
 	if not disabled:
 		yield(get_tree(), "idle_frame")
 		_refresh_color()
-
-
-func _on_button_down() -> void:
-	_refresh_shine()
-
-
-func _on_button_up() -> void:
-	_refresh_shine()

--- a/project/src/main/ui/candy-button/candy-button-shine.gd
+++ b/project/src/main/ui/candy-button/candy-button-shine.gd
@@ -1,0 +1,44 @@
+extends TextureRect
+
+## Bright shiny reflection texture which overlays the button and text when the button is not pressed.
+export (Texture) var texture_normal: Texture setget set_texture_normal
+
+## Less shiny reflection texture which overlays the button and text when the button is pressed.
+export (Texture) var texture_pressed: Texture setget set_texture_pressed
+
+onready var _button := get_parent()
+
+func _ready() -> void:
+	_button.connect("button_down", self, "_on_Button_button_down")
+	_button.connect("button_up", self, "_on_Button_button_up")
+	_button.connect("toggled", self, "_on_Button_toggled")
+	_refresh_shine()
+
+
+func set_texture_normal(new_texture_normal: Texture) -> void:
+	texture_normal = new_texture_normal
+	_refresh_shine()
+
+
+func set_texture_pressed(new_texture_pressed: Texture) -> void:
+	texture_pressed = new_texture_pressed
+	_refresh_shine()
+
+
+func _refresh_shine() -> void:
+	if not is_inside_tree():
+		return
+	
+	texture = texture_pressed if _button.pressed else texture_normal
+
+
+func _on_Button_button_down() -> void:
+	_refresh_shine()
+
+
+func _on_Button_button_up() -> void:
+	_refresh_shine()
+
+
+func _on_Button_toggled(_button_pressed: bool) -> void:
+	_refresh_shine()


### PR DESCRIPTION
All candy buttons had the concept of "Toggle the Shine Texture between
these two textures based on whether the button is pressed or not". I've
extracted a common ShineTextureRect scene to unify this logic.