### PR TITLE
Bug: CandyButton ToggleButton shine behavior

### DIFF
--- a/project/src/main/ui/candy-button/candy-button-shine.gd
+++ b/project/src/main/ui/candy-button/candy-button-shine.gd
@@ -33,11 +33,11 @@ func _refresh_shine() -> void:
 
 
 func _on_Button_button_down() -> void:
-	_refresh_shine()
+	texture = texture_pressed
 
 
 func _on_Button_button_up() -> void:
-	_refresh_shine()
+	texture = texture_normal
 
 
 func _on_Button_toggled(_button_pressed: bool) -> void:


### PR DESCRIPTION
When toggling a CandyButton into the pressed state, the button appeared unpressd until releasing the mouse button. This is because the 'button_down' signal is called before the button's 'pressed' state is updated. I've changed the signal methods to not rely on the button's 'pressed' state.