### PR TITLE
Refactor: Extracted 'GradientHelper' from CandyButton

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -544,6 +544,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/ui/level-select/grade-label.gd"
 }, {
+"base": "Node",
+"class": "GradientHelper",
+"language": "GDScript",
+"path": "res://src/main/ui/candy-button/gradient-helper.gd"
+}, {
 "base": "Reference",
 "class": "GraphicsSettings",
 "language": "GDScript",
@@ -1667,6 +1672,7 @@ _global_script_class_icons={
 "GoopGlob": "",
 "GoopViewports": "",
 "GradeLabel": "",
+"GradientHelper": "",
 "GraphicsSettings": "",
 "GutHookScript": "",
 "GutTest": "",

--- a/project/src/main/editor/creature/AlleleButton.tscn
+++ b/project/src/main/editor/creature/AlleleButton.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=2]
+[gd_scene load_steps=19 format=2]
 
 [ext_resource path="res://src/main/utils/icon-outline.shader" type="Shader" id=1]
 [ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=2]
@@ -13,6 +13,7 @@
 [ext_resource path="res://src/main/ui/candy-button/ShineTextureRect.tscn" type="PackedScene" id=11]
 [ext_resource path="res://src/main/editor/creature/allele-button.gd" type="Script" id=12]
 [ext_resource path="res://assets/main/ui/candy-button/c3-shine-pressed.png" type="Texture" id=13]
+[ext_resource path="res://src/main/ui/candy-button/gradient-helper.gd" type="Script" id=14]
 
 [sub_resource type="GradientTexture2D" id=9]
 resource_local_to_scene = true
@@ -94,3 +95,6 @@ texture_pressed = ExtResource( 13 )
 [node name="ClickSound" parent="." instance=ExtResource( 9 )]
 
 [node name="HoverSound" parent="." instance=ExtResource( 7 )]
+
+[node name="GradientHelper" type="Node" parent="."]
+script = ExtResource( 14 )

--- a/project/src/main/editor/creature/CreatureNameButton.tscn
+++ b/project/src/main/editor/creature/CreatureNameButton.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=20 format=2]
+[gd_scene load_steps=21 format=2]
 
 [ext_resource path="res://src/main/ui/candy-button/gradient-none.tres" type="Gradient" id=1]
 [ext_resource path="res://src/main/editor/creature/NamePickerPopup.tscn" type="PackedScene" id=2]
@@ -15,6 +15,7 @@
 [ext_resource path="res://src/main/utils/icon-outline.shader" type="Shader" id=13]
 [ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=14]
 [ext_resource path="res://assets/main/ui/candy-button/c3-shine-pressed.png" type="Texture" id=15]
+[ext_resource path="res://src/main/ui/candy-button/gradient-helper.gd" type="Script" id=16]
 
 [sub_resource type="GradientTexture2D" id=9]
 resource_local_to_scene = true
@@ -98,5 +99,8 @@ texture_pressed = ExtResource( 15 )
 [node name="ClickSound" parent="." instance=ExtResource( 3 )]
 
 [node name="HoverSound" parent="." instance=ExtResource( 4 )]
+
+[node name="GradientHelper" type="Node" parent="."]
+script = ExtResource( 16 )
 
 [connection signal="name_changed" from="NamePickerPopup" to="." method="_on_NamePickerPopup_name_changed"]

--- a/project/src/main/editor/creature/OperationButton.tscn
+++ b/project/src/main/editor/creature/OperationButton.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=2]
+[gd_scene load_steps=19 format=2]
 
 [ext_resource path="res://src/main/editor/creature/operation-button.gd" type="Script" id=1]
 [ext_resource path="res://assets/main/ui/candy-button/c3-v-pressed.png" type="Texture" id=2]
@@ -13,6 +13,7 @@
 [ext_resource path="res://src/main/ui/candy-button/ClickSound.tscn" type="PackedScene" id=11]
 [ext_resource path="res://src/main/ui/candy-button/ShineTextureRect.tscn" type="PackedScene" id=12]
 [ext_resource path="res://assets/main/ui/candy-button/c3-shine-pressed.png" type="Texture" id=13]
+[ext_resource path="res://src/main/ui/candy-button/gradient-helper.gd" type="Script" id=14]
 
 [sub_resource type="GradientTexture2D" id=9]
 resource_local_to_scene = true
@@ -93,3 +94,6 @@ texture_pressed = ExtResource( 13 )
 [node name="ClickSound" parent="." instance=ExtResource( 11 )]
 
 [node name="HoverSound" parent="." instance=ExtResource( 9 )]
+
+[node name="GradientHelper" type="Node" parent="."]
+script = ExtResource( 14 )

--- a/project/src/main/ui/candy-button/CandyButtonC3.tscn
+++ b/project/src/main/ui/candy-button/CandyButtonC3.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=2]
+[gd_scene load_steps=19 format=2]
 
 [ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=1]
 [ext_resource path="res://assets/main/ui/candy-button/c3-focused.png" type="Texture" id=2]
@@ -12,6 +12,7 @@
 [ext_resource path="res://src/main/ui/candy-button/ShineTextureRect.tscn" type="PackedScene" id=10]
 [ext_resource path="res://assets/main/ui/candy-button/c3-shine-pressed.png" type="Texture" id=11]
 [ext_resource path="res://src/main/ui/candy-button/candy-button-c3.gd" type="Script" id=12]
+[ext_resource path="res://src/main/ui/candy-button/gradient-helper.gd" type="Script" id=13]
 [ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=14]
 
 [sub_resource type="GradientTexture2D" id=9]
@@ -96,3 +97,6 @@ texture_pressed = ExtResource( 11 )
 [node name="ClickSound" parent="." instance=ExtResource( 7 )]
 
 [node name="HoverSound" parent="." instance=ExtResource( 9 )]
+
+[node name="GradientHelper" type="Node" parent="."]
+script = ExtResource( 13 )

--- a/project/src/main/ui/candy-button/CandyButtonCollapsible.tscn
+++ b/project/src/main/ui/candy-button/CandyButtonCollapsible.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=2]
+[gd_scene load_steps=20 format=2]
 
 [ext_resource path="res://src/main/ui/candy-button/HoverSound.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/ui/candy-button/gradient-none.tres" type="Gradient" id=2]
@@ -12,6 +12,7 @@
 [ext_resource path="res://src/main/ui/candy-button/ClickSound.tscn" type="PackedScene" id=10]
 [ext_resource path="res://assets/main/ui/candy-button/c3-shine-pressed.png" type="Texture" id=11]
 [ext_resource path="res://src/main/ui/candy-button/ShineTextureRect.tscn" type="PackedScene" id=12]
+[ext_resource path="res://src/main/ui/candy-button/gradient-helper.gd" type="Script" id=13]
 
 [sub_resource type="GradientTexture2D" id=9]
 resource_local_to_scene = true
@@ -215,10 +216,10 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-margin_left = 55.0
-margin_top = 39.0
-margin_right = 105.0
-margin_bottom = 89.0
+margin_left = -25.0
+margin_top = -25.0
+margin_right = 25.0
+margin_bottom = 25.0
 rect_min_size = Vector2( 50, 50 )
 size_flags_vertical = 4
 expand = true
@@ -236,6 +237,9 @@ anims/uncollapse = SubResource( 12 )
 [node name="ClickSound" parent="." instance=ExtResource( 10 )]
 
 [node name="HoverSound" parent="." instance=ExtResource( 1 )]
+
+[node name="GradientHelper" type="Node" parent="."]
+script = ExtResource( 13 )
 
 [connection signal="item_rect_changed" from="." to="." method="_on_CandyButton_item_rect_changed"]
 [connection signal="resized" from="Icon" to="." method="_on_Icon_resized"]

--- a/project/src/main/ui/candy-button/CandyButtonH3.tscn
+++ b/project/src/main/ui/candy-button/CandyButtonH3.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=2]
+[gd_scene load_steps=19 format=2]
 
 [ext_resource path="res://assets/main/ui/candy-button/h3-blank-pressed.png" type="Texture" id=1]
 [ext_resource path="res://src/main/ui/candy-button/ShineTextureRect.tscn" type="PackedScene" id=2]
@@ -13,6 +13,7 @@
 [ext_resource path="res://src/main/ui/candy-button/HoverSound.tscn" type="PackedScene" id=11]
 [ext_resource path="res://assets/main/ui/candy-button/h3-shine-pressed.png" type="Texture" id=12]
 [ext_resource path="res://assets/main/ui/candy-button/h3-shine.png" type="Texture" id=13]
+[ext_resource path="res://src/main/ui/candy-button/gradient-helper.gd" type="Script" id=14]
 
 [sub_resource type="GradientTexture2D" id=9]
 resource_local_to_scene = true
@@ -126,3 +127,6 @@ texture_pressed = ExtResource( 12 )
 [node name="ClickSound" parent="." instance=ExtResource( 10 )]
 
 [node name="HoverSound" parent="." instance=ExtResource( 11 )]
+
+[node name="GradientHelper" type="Node" parent="."]
+script = ExtResource( 14 )

--- a/project/src/main/ui/candy-button/CandyButtonH4.tscn
+++ b/project/src/main/ui/candy-button/CandyButtonH4.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=17 format=2]
 
 [ext_resource path="res://src/main/ui/candy-button/candy-button-h4.gd" type="Script" id=1]
 [ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=2]
@@ -12,6 +12,7 @@
 [ext_resource path="res://assets/main/ui/candy-button/h4-shine-pressed.png" type="Texture" id=10]
 [ext_resource path="res://src/main/ui/candy-button/gradient-none.tres" type="Gradient" id=11]
 [ext_resource path="res://src/main/ui/candy-button/ShineTextureRect.tscn" type="PackedScene" id=12]
+[ext_resource path="res://src/main/ui/candy-button/gradient-helper.gd" type="Script" id=13]
 
 [sub_resource type="GradientTexture2D" id=9]
 resource_local_to_scene = true
@@ -64,3 +65,6 @@ texture_pressed = ExtResource( 10 )
 [node name="ClickSound" parent="." instance=ExtResource( 3 )]
 
 [node name="HoverSound" parent="." instance=ExtResource( 9 )]
+
+[node name="GradientHelper" type="Node" parent="."]
+script = ExtResource( 13 )

--- a/project/src/main/ui/candy-button/candy-button-c3.gd
+++ b/project/src/main/ui/candy-button/candy-button-c3.gd
@@ -5,6 +5,12 @@ extends TextureButton
 ##
 ## This button is small and squareish, and is used throughout the creature editor.
 
+signal color_changed
+
+signal disabled_changed
+
+signal hovered_changed
+
 export (String) var text setget set_text
 
 ## Icon shown to the top of the button's text.
@@ -41,15 +47,17 @@ onready var _label := $VBoxContainer/Label
 ## Shiny reflection effect which overlays the button and text
 onready var _shine := $Shine
 
+onready var _gradient_helper: GradientHelper = $GradientHelper
+
 func _ready() -> void:
 	# Connect signals in code to prevent them from showing up in the Godot editor.
 	#
 	# This is a generic button used in many places, we want to be able to quickly see the unique signals connected to
 	# each button instance, not the generic signals connected to all button instances.
 	connect("focus_entered", self, "_on_focus_entered")
-	connect("focus_exited", self, "_on_focus_exited")
 	connect("mouse_entered", self, "_on_mouse_entered")
 	connect("mouse_exited", self, "_on_mouse_exited")
+	_gradient_helper.connect("gradient_changed", self, "_on_GradientHelper_gradient_changed")
 	
 	_refresh_icons()
 	_refresh_font_size()
@@ -69,9 +77,11 @@ func _pressed() -> void:
 
 
 func set_disabled(new_disabled: bool) -> void:
-	if disabled != new_disabled:
-		disabled = new_disabled
-		_refresh_color()
+	if disabled == new_disabled:
+		return
+	
+	disabled = new_disabled
+	emit_signal("disabled_changed")
 
 
 func set_icon(new_icon: Texture) -> void:
@@ -89,6 +99,7 @@ func set_text(new_text: String) -> void:
 func set_color(new_color: int) -> void:
 	color = new_color
 	_refresh_color()
+	emit_signal("color_changed")
 
 
 func set_shape(new_shape: int) -> void:
@@ -101,21 +112,7 @@ func _initialize_onready_variables() -> void:
 	_label = $VBoxContainer/Label
 	_icon_node = $VBoxContainer/Icon
 	_shine = $Shine
-
-
-## Calculates the gradient which should color the button based on its color and state.
-func _gradient() -> Gradient:
-	var result: Gradient
-	if has_focus():
-		# if the button is focused, we use a bright cyan color
-		result = CandyButtons.GRADIENT_FOCUSED_HOVER if is_hovered() else CandyButtons.GRADIENT_FOCUSED
-	elif disabled:
-		result = CandyButtons.GRADIENT_DISABLED_HOVER if is_hovered() else CandyButtons.GRADIENT_DISABLED
-	else:
-		# if the button is not focused, we use the user-specified color
-		var gradients: Array = CandyButtons.GRADIENTS_BY_COLOR[color]
-		result = gradients[1] if is_hovered() else gradients[0]
-	return result
+	_gradient_helper = $GradientHelper
 
 
 ## Reapplies the colors for our texture, text and icons.
@@ -128,7 +125,7 @@ func _refresh_color() -> void:
 			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
 			_initialize_onready_variables()
 	
-	material.get_shader_param("gradient").gradient = _gradient()
+	material.get_shader_param("gradient").gradient = _gradient_helper.gradient
 	_refresh_icon_color()
 	_refresh_label_color()
 
@@ -165,7 +162,7 @@ func _refresh_font_size() -> void:
 ## Reapplies the colors for our icons.
 func _refresh_icon_color() -> void:
 	# both icons use the same material; setting one sets the other
-	_icon_node.material.set_shader_param("black", _gradient().interpolate(0.15))
+	_icon_node.material.set_shader_param("black", _gradient_helper.gradient.interpolate(0.15))
 
 
 ## Toggles the visibility of the icon and updates its properties.
@@ -188,7 +185,7 @@ func _refresh_icons() -> void:
 
 ## Reapplies the colors for our label.
 func _refresh_label_color() -> void:
-	_label.get_font("font").outline_color = _gradient().interpolate(0.15)
+	_label.get_font("font").outline_color = _gradient_helper.gradient.interpolate(0.15)
 
 
 ## Reapplies the various textures for our button.
@@ -223,27 +220,29 @@ func _refresh_text() -> void:
 
 ## When we gain focus, we reapply a bright cyan color for our texture, text and icons.
 func _on_focus_entered() -> void:
-	_refresh_color()
 	_hover_sound.pitch_scale = rand_range(0.95, 1.05)
 	SfxKeeper.copy(_hover_sound).play()
 
 
-## When we lose focus, we reapply the normal color for our texture, text and icons.
-func _on_focus_exited() -> void:
-	_refresh_color()
-
-
 ## When the player hovers over us, we reapply a brighter color for our texture, text and icons.
 func _on_mouse_entered() -> void:
-	if not disabled:
-		yield(get_tree(), "idle_frame")
-		_refresh_color()
-		_hover_sound.pitch_scale = rand_range(0.95, 1.05)
-		SfxKeeper.copy(_hover_sound).play()
+	if disabled:
+		return
+	
+	yield(get_tree(), "idle_frame")
+	emit_signal("hovered_changed")
+	_hover_sound.pitch_scale = rand_range(0.95, 1.05)
+	SfxKeeper.copy(_hover_sound).play()
 
 
 ## When the player hovers away from us, we reapply the normal color for our texture, text and icons.
 func _on_mouse_exited() -> void:
-	if not disabled:
-		yield(get_tree(), "idle_frame")
-		_refresh_color()
+	if disabled:
+		return
+	
+	yield(get_tree(), "idle_frame")
+	emit_signal("hovered_changed")
+
+
+func _on_GradientHelper_gradient_changed() -> void:
+	_refresh_color()

--- a/project/src/main/ui/candy-button/candy-button-h3.gd
+++ b/project/src/main/ui/candy-button/candy-button-h3.gd
@@ -4,6 +4,12 @@ extends TextureButton
 ##
 ## This button is extremely narrow, and used for the collapsed categories in the creature editor.
 
+signal color_changed
+
+signal disabled_changed
+
+signal hovered_changed
+
 ## Textures for the various ButtonShape presets.
 ##
 ## key: (int) Enum from ButtonShape
@@ -72,15 +78,17 @@ onready var _icon_node_right := $HBoxContainer/IconRight
 ## Label containing the button's text
 onready var _label := $HBoxContainer/Label
 
+onready var _gradient_helper: GradientHelper = $GradientHelper
+
 func _ready() -> void:
 	# Connect signals in code to prevent them from showing up in the Godot editor.
 	#
 	# This is a generic button used in many places, we want to be able to quickly see the unique signals connected to
 	# each button instance, not the generic signals connected to all button instances.
 	connect("focus_entered", self, "_on_focus_entered")
-	connect("focus_exited", self, "_on_focus_exited")
 	connect("mouse_entered", self, "_on_mouse_entered")
 	connect("mouse_exited", self, "_on_mouse_exited")
+	_gradient_helper.connect("gradient_changed", self, "_on_GradientHelper_gradient_changed")
 	
 	_refresh_icons()
 	_refresh_font_size()
@@ -100,9 +108,11 @@ func _pressed() -> void:
 
 
 func set_disabled(new_disabled: bool) -> void:
-	if disabled != new_disabled:
-		disabled = new_disabled
-		_refresh_color()
+	if disabled == new_disabled:
+		return
+	
+	disabled = new_disabled
+	emit_signal("disabled_changed")
 
 
 func set_icon_left(new_icon_left: Texture) -> void:
@@ -125,7 +135,7 @@ func set_text(new_text: String) -> void:
 
 func set_color(new_color: int) -> void:
 	color = new_color
-	_refresh_color()
+	emit_signal("color_changed")
 
 
 func set_shape(new_shape: int) -> void:
@@ -138,21 +148,7 @@ func _initialize_onready_variables() -> void:
 	_label = $HBoxContainer/Label
 	_icon_node_left = $HBoxContainer/IconLeft
 	_icon_node_right = $HBoxContainer/IconRight
-
-
-## Calculates the gradient which should color the button based on its color and state.
-func _gradient() -> Gradient:
-	var result: Gradient
-	if has_focus():
-		# if the button is focused, we use a bright cyan color
-		result = CandyButtons.GRADIENT_FOCUSED_HOVER if is_hovered() else CandyButtons.GRADIENT_FOCUSED
-	elif disabled:
-		result = CandyButtons.GRADIENT_DISABLED_HOVER if is_hovered() else CandyButtons.GRADIENT_DISABLED
-	else:
-		# if the button is not focused, we use the user-specified color
-		var gradients: Array = CandyButtons.GRADIENTS_BY_COLOR[color]
-		result = gradients[1] if is_hovered() else gradients[0]
-	return result
+	_gradient_helper = $GradientHelper
 
 
 ## Reapplies the colors for our texture, text and icons.
@@ -165,7 +161,7 @@ func _refresh_color() -> void:
 			# initialize variables to avoid nil reference errors in the editor when editing tool scripts
 			_initialize_onready_variables()
 	
-	material.get_shader_param("gradient").gradient = _gradient()
+	material.get_shader_param("gradient").gradient = _gradient_helper.gradient
 	_refresh_icon_color()
 	_refresh_label_color()
 
@@ -206,7 +202,7 @@ func _refresh_font_size() -> void:
 ## Reapplies the colors for our icons.
 func _refresh_icon_color() -> void:
 	# both icons use the same material; setting one sets the other
-	_icon_node_left.material.set_shader_param("black", _gradient().interpolate(0.15))
+	_icon_node_left.material.set_shader_param("black", _gradient_helper.gradient.interpolate(0.15))
 
 
 ## Toggles the visibility of the left and right icons and updates their properties.
@@ -229,7 +225,7 @@ func _refresh_icons() -> void:
 
 ## Reapplies the colors for our label.
 func _refresh_label_color() -> void:
-	_label.get_font("font").outline_color = _gradient().interpolate(0.15)
+	_label.get_font("font").outline_color = _gradient_helper.gradient.interpolate(0.15)
 
 
 ## Reapplies the various textures for our button.
@@ -263,27 +259,29 @@ func _refresh_text() -> void:
 
 ## When we gain focus, we reapply a bright cyan color for our texture, text and icons.
 func _on_focus_entered() -> void:
-	_refresh_color()
 	_hover_sound.pitch_scale = rand_range(0.95, 1.05)
 	SfxKeeper.copy(_hover_sound).play()
 
 
-## When we lose focus, we reapply the normal color for our texture, text and icons.
-func _on_focus_exited() -> void:
-	_refresh_color()
-
-
 ## When the player hovers over us, we reapply a brighter color for our texture, text and icons.
 func _on_mouse_entered() -> void:
-	if not disabled:
-		yield(get_tree(), "idle_frame")
-		_refresh_color()
-		_hover_sound.pitch_scale = rand_range(0.95, 1.05)
-		SfxKeeper.copy(_hover_sound).play()
+	if disabled:
+		return
+	
+	yield(get_tree(), "idle_frame")
+	emit_signal("hovered_changed")
+	_hover_sound.pitch_scale = rand_range(0.95, 1.05)
+	SfxKeeper.copy(_hover_sound).play()
 
 
 ## When the player hovers away from us, we reapply the normal color for our texture, text and icons.
 func _on_mouse_exited() -> void:
-	if not disabled:
-		yield(get_tree(), "idle_frame")
-		_refresh_color()
+	if disabled:
+		return
+	
+	yield(get_tree(), "idle_frame")
+	emit_signal("hovered_changed")
+
+
+func _on_GradientHelper_gradient_changed() -> void:
+	_refresh_color()

--- a/project/src/main/ui/candy-button/gradient-helper.gd
+++ b/project/src/main/ui/candy-button/gradient-helper.gd
@@ -1,0 +1,67 @@
+tool
+class_name GradientHelper
+extends Node
+## Calculates the currently active gradient for a CandyButton.
+##
+## CandyButtons are colored using a gradient, and this gradient changes based on the button's color, focus state,
+## hovered state and disabled state.
+
+## Emitted when the gradient changes due to a change in the button's properties, such as whether it's focused or not.
+signal gradient_changed
+
+## CandyButton used to decide the active gradient.
+onready var _button := get_parent()
+
+var gradient: Gradient = preload("res://src/main/ui/candy-button/gradient-none.tres") setget set_gradient
+
+func _ready() -> void:
+	_button.connect("color_changed", self, "_on_Button_color_changed")
+	_button.connect("disabled_changed", self, "_on_Button_disabled_changed")
+	_button.connect("focus_entered", self, "_on_Button_focus_entered")
+	_button.connect("focus_exited", self, "_on_Button_focus_exited")
+	_button.connect("hovered_changed", self, "_on_Button_hovered_changed")
+	_refresh_gradient()
+
+
+func set_gradient(new_gradient: Gradient) -> void:
+	if gradient == new_gradient:
+		return
+	
+	gradient = new_gradient
+	emit_signal("gradient_changed")
+
+
+## Updates our gradient based on the button's properties, such as whether it's focused or not.
+func _refresh_gradient() -> void:
+	var new_gradient: Gradient
+	if _button.has_focus():
+		# if the button is focused, we use a bright cyan color
+		new_gradient = CandyButtons.GRADIENT_FOCUSED_HOVER if _button.is_hovered() else CandyButtons.GRADIENT_FOCUSED
+	elif _button.disabled:
+		new_gradient = CandyButtons.GRADIENT_DISABLED_HOVER if _button.is_hovered() else CandyButtons.GRADIENT_DISABLED
+	else:
+		# if the button is not focused, we use the user-specified color
+		var gradients: Array = CandyButtons.GRADIENTS_BY_COLOR[_button.color]
+		new_gradient = gradients[1] if _button.is_hovered() else gradients[0]
+	
+	set_gradient(new_gradient)
+
+
+func _on_Button_color_changed() -> void:
+	_refresh_gradient()
+
+
+func _on_Button_disabled_changed() -> void:
+	_refresh_gradient()
+
+
+func _on_Button_focus_entered() -> void:
+	_refresh_gradient()
+
+
+func _on_Button_focus_exited() -> void:
+	_refresh_gradient()
+
+
+func _on_Button_hovered_changed() -> void:
+	_refresh_gradient()


### PR DESCRIPTION
This avoids some copy/paste code for calculating which color to use as the button becomes hovered, focused, etc.

This GradientHelper could not be reused for CreatureColorButton because its behavior is slightly specialized and it does not use gradients in the same way.