### PR TITLE
Refactor: Gut warnings, orphans

### DIFF
--- a/project/src/main/puzzle/piece/piece-type.gd
+++ b/project/src/main/puzzle/piece/piece-type.gd
@@ -65,7 +65,7 @@ func get_cell_color(orientation: int, cell_index: int) -> Vector2:
 ## For a null piece, this returns 0. This allows code centered around "what color should these piece crumbs be" or
 ## "which sprite should I show" to fail more gracefully, instead of throwing an out of bounds error.
 func get_box_type() -> int:
-	return color_arr[0][0].y if color_arr and color_arr[0] else 0
+	return int(color_arr[0][0].y) if color_arr and color_arr[0] else 0
 
 
 ## Changes the PuzzleTileMap's food color index for this piece (brown, pink, bread, white)

--- a/project/src/test/career/test-career-rewinder.gd
+++ b/project/src/test/career/test-career-rewinder.gd
@@ -3,17 +3,15 @@ extends GutTest
 var career_rewinder: CareerRewinder
 
 func before_all() -> void:
-	career_rewinder = CareerRewinder.new()
 	CareerLevelLibrary.regions_path = "res://assets/test/career/career-regions-simple.json"
 
 
 func before_each() -> void:
 	PlayerData.chat_history.reset()
+	career_rewinder = autofree(CareerRewinder.new())
 
 
 func after_all() -> void:
-	career_rewinder.free()
-	
 	PlayerData.chat_history.reset()
 	CareerLevelLibrary.regions_path = CareerLevelLibrary.DEFAULT_REGIONS_PATH
 

--- a/project/src/test/data/test-player-save-upgrader.gd
+++ b/project/src/test/data/test-player-save-upgrader.gd
@@ -247,7 +247,7 @@ func test_4ceb_career_data() -> void:
 	assert_eq(PlayerData.career.prev_distance_travelled, [134, 114])
 	assert_eq(PlayerData.career.prev_money, [4156, 2268])
 	assert_eq(PlayerData.career.remain_in_region, false)
-	assert_eq(PlayerData.career.seconds_played, 525)
+	assert_eq(PlayerData.career.seconds_played, 525.0)
 	assert_eq(PlayerData.career.skipped_previous_level, false)
 	assert_eq(PlayerData.career.steps, 25)
 	assert_eq(PlayerData.career.top_out_count, 1)

--- a/project/src/test/puzzle/test-line-clearer.gd
+++ b/project/src/test/puzzle/test-line-clearer.gd
@@ -2,17 +2,9 @@ extends GutTest
 
 var clearer: LineClearer
 
-func before_all() -> void:
-	clearer = LineClearer.new()
-
-
 func before_each() -> void:
 	CurrentLevel.settings = LevelSettings.new()
-	clearer.reset()
-
-
-func after_all() -> void:
-	clearer.free()
+	clearer = autofree(LineClearer.new())
 
 
 func test_filled_line_clear_delay() -> void:

--- a/project/src/test/world/test-career-data.gd
+++ b/project/src/test/world/test-career-data.gd
@@ -5,7 +5,7 @@ const TEMP_PLAYER_FILENAME := "test997.save"
 var _data: CareerData
 
 func before_each() -> void:
-	_data = CareerData.new()
+	_data = autofree(CareerData.new())
 	add_child(_data)
 	
 	CareerLevelLibrary.regions_path = "res://assets/test/career/career-regions-simple.json"
@@ -16,11 +16,6 @@ func before_each() -> void:
 	PlayerData.level_history.add_result("intro_311", RankResult.new())
 	PlayerData.level_history.add_result("intro_411", RankResult.new())
 	_data.best_distance_travelled = Careers.MAX_DISTANCE_TRAVELLED
-
-
-func after_each() -> void:
-	## we use 'free' instead of 'queue_free' to avoid warnings from Gut about new orphans
-	_data.free()
 
 
 func test_prev_money() -> void:


### PR DESCRIPTION
Fixed some int/float comparison warnings in Gut tests. One of these affected the actual game too, PieceType.get_box_type() was returning a float.

Fixed some orphan node warnings in Gut tests. These were false positives, as the nodes were being cleaned up in after_all. But I've updated the tests to use Gut's new 'autofree' functionality anyway.