### PR TITLE
Refactor: Removed CreatureEditorLibrary autoload singleton

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -280,6 +280,11 @@ _global_script_classes=[ {
 "path": "res://src/main/editor/creature/dialogs.gd"
 }, {
 "base": "Node",
+"class": "CreatureEditorLibrary",
+"language": "GDScript",
+"path": "res://src/main/editor/creature/creature-editor-library.gd"
+}, {
+"base": "Node",
 "class": "CreatureEditorOld",
 "language": "GDScript",
 "path": "res://src/demo/editor/creature-old/creature-editor-old.gd"
@@ -1619,6 +1624,7 @@ _global_script_class_icons={
 "CreatureDef": "",
 "CreatureEditorCategory": "",
 "CreatureEditorDialogs": "",
+"CreatureEditorLibrary": "",
 "CreatureEditorOld": "",
 "CreatureLibrary": "",
 "CreatureNameButton": "",
@@ -1913,6 +1919,7 @@ MusicTransition="*res://src/main/music/music-transition.gd"
 NameGeneratorLibrary="*res://src/main/world/creature/name-generator-library.gd"
 OtherLevelLibrary="*res://src/main/puzzle/other-level-library.gd"
 Pauser="*res://src/main/utils/pauser.gd"
+PhaseConditions="*res://src/main/puzzle/level/phase-conditions.gd"
 PlayerData="*res://src/main/data/player-data.gd"
 PlayerSave="*res://src/main/data/player-save.gd"
 PuzzleState="*res://src/main/puzzle/PuzzleState.tscn"
@@ -1922,8 +1929,6 @@ SfxDeconflicter="*res://src/main/utils/SfxDeconflicter.tscn"
 SfxKeeper="*res://src/main/utils/sfx-keeper.gd"
 SystemData="*res://src/main/data/system-data.gd"
 SystemSave="*res://src/main/data/system-save.gd"
-PhaseConditions="*res://src/main/puzzle/level/phase-conditions.gd"
-CreatureEditorLibrary="*res://src/main/editor/creature/creature-editor-library.gd"
 
 [debug]
 

--- a/project/src/demo/toolkit/ReleaseToolkit.tscn
+++ b/project/src/demo/toolkit/ReleaseToolkit.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://src/demo/toolkit/fix-levels-button.gd" type="Script" id=1]
 [ext_resource path="res://src/demo/toolkit/extract-localizables-button.gd" type="Script" id=2]
@@ -7,6 +7,7 @@
 [ext_resource path="res://src/demo/toolkit/fix-chats-button.gd" type="Script" id=5]
 [ext_resource path="res://src/demo/toolkit/fix-creatures-button.gd" type="Script" id=6]
 [ext_resource path="res://src/demo/toolkit/release-toolkit-output.gd" type="Script" id=7]
+[ext_resource path="res://src/main/editor/creature/CreatureEditorLibrary.tscn" type="PackedScene" id=8]
 
 [node name="ReleaseToolkit" type="Control"]
 anchor_right = 1.0
@@ -82,6 +83,8 @@ theme = ExtResource( 4 )
 align = 1
 autowrap = true
 script = ExtResource( 7 )
+
+[node name="CreatureEditorLibrary" parent="." instance=ExtResource( 8 )]
 
 [connection signal="pressed" from="VBoxContainer/ExtractLocalizables" to="VBoxContainer/ExtractLocalizables" method="_on_pressed"]
 [connection signal="pressed" from="VBoxContainer/FixChats" to="VBoxContainer/FixChats" method="_on_pressed"]

--- a/project/src/demo/toolkit/extract-localizables-button.gd
+++ b/project/src/demo/toolkit/extract-localizables-button.gd
@@ -20,6 +20,8 @@ var _scancode_localizables := []
 ## label for outputting messages to the user
 onready var _output_label := get_node(output_label_path)
 
+onready var _creature_editor_library := Global.get_creature_editor_library()
+
 ## Extracts localizable strings from levels and chats and writes them to a file.
 func _extract_and_write_localizables() -> void:
 	_localizables.clear()
@@ -106,7 +108,7 @@ func _extract_localizables_from_chat_trees() -> void:
 
 
 func _extract_localizables_from_creature_editor() -> void:
-	for category in CreatureEditorLibrary.categories:
+	for category in _creature_editor_library.categories:
 		_localizables.append(category.name)
 
 

--- a/project/src/main/editor/creature/CreatureEditor.tscn
+++ b/project/src/main/editor/creature/CreatureEditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=120 format=2]
+[gd_scene load_steps=121 format=2]
 
 [ext_resource path="res://assets/main/editor/creature/icon-category-eye.png" type="Texture" id=1]
 [ext_resource path="res://assets/main/editor/creature/icon-category-nose.png" type="Texture" id=2]
@@ -82,6 +82,7 @@
 [ext_resource path="res://src/main/editor/creature/fatness-changer.gd" type="Script" id=80]
 [ext_resource path="res://src/main/editor/creature/category-label.gd" type="Script" id=81]
 [ext_resource path="res://src/main/editor/creature/creature-editor-system-buttons.gd" type="Script" id=82]
+[ext_resource path="res://src/main/editor/creature/CreatureEditorLibrary.tscn" type="PackedScene" id=83]
 
 [sub_resource type="StyleBoxFlat" id=52]
 resource_local_to_scene = true
@@ -974,6 +975,8 @@ overworld_environment_path = NodePath("../Preview/World/Environment")
 stream = ExtResource( 18 )
 volume_db = -4.0
 bus = "Sound Bus"
+
+[node name="CreatureEditorLibrary" parent="." instance=ExtResource( 83 )]
 
 [connection signal="category_selected" from="Buttons/VBoxContainer/CategorySelector" to="DropPanel/CategoryLabel" method="_on_CategorySelector_category_selected"]
 [connection signal="category_selected" from="Buttons/VBoxContainer/CategorySelector" to="Buttons/VBoxContainer/AlleleButtons" method="_on_CategorySelector_category_selected"]

--- a/project/src/main/editor/creature/CreatureEditorLibrary.tscn
+++ b/project/src/main/editor/creature/CreatureEditorLibrary.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/main/editor/creature/creature-editor-library.gd" type="Script" id=1]
+
+[node name="CreatureEditorLibrary" type="Node" groups=["creature_editor_library"]]
+script = ExtResource( 1 )

--- a/project/src/main/editor/creature/allele-buttons.gd
+++ b/project/src/main/editor/creature/allele-buttons.gd
@@ -47,6 +47,7 @@ var _new_focus_target: Control = null
 onready var _category_selector: CategorySelector = get_node(category_selector_path)
 onready var _overworld_environment: OverworldEnvironment = get_node(overworld_environment_path)
 onready var _creature_saver: CreatureSaver = get_node(creature_saver_path)
+onready var _creature_editor_library := Global.get_creature_editor_library()
 
 ## Deletes and recreates all buttons for the specified category.
 func _refresh_allele_buttons(category: int) -> void:
@@ -81,7 +82,7 @@ func _refresh_allele_buttons(category: int) -> void:
 ## Adds all operation buttons for the specified category.
 func _add_operation_buttons(category: int) -> void:
 	var category_button := _category_selector.get_category_button(category)
-	var operations := CreatureEditorLibrary.get_operations_by_category_index(category)
+	var operations := _creature_editor_library.get_operations_by_category_index(category)
 	
 	for operation_obj in operations:
 		var operation: Operation = operation_obj
@@ -137,7 +138,7 @@ func _initialize_operation_button(button: OperationButton, operation: Operation)
 func _add_allele_buttons(category: int) -> void:
 	var category_button := _category_selector.get_category_button(category)
 	
-	var allele_combos := CreatureEditorLibrary.get_allele_combos_by_category_index(category)
+	var allele_combos := _creature_editor_library.get_allele_combos_by_category_index(category)
 	var allele_buttons := []
 	
 	# create the correct number of buttons; position appropriately
@@ -230,7 +231,7 @@ func _is_allele_assigned(allele_string: String) -> bool:
 func _add_color_buttons(category: int) -> void:
 	var category_button := _category_selector.get_category_button(category)
 	
-	var color_properties := CreatureEditorLibrary.get_color_properties_by_category_index(category)
+	var color_properties := _creature_editor_library.get_color_properties_by_category_index(category)
 	var color_buttons := []
 	
 	# create the correct number of buttons; position appropriately
@@ -257,7 +258,7 @@ func _add_color_buttons(category: int) -> void:
 			_:
 				creature_color_html = _player().dna[color_property]
 		color_button.creature_color = Color(creature_color_html)
-		color_button.enabled_if = CreatureEditorLibrary.get_color_property_enabled_if(category, color_property)
+		color_button.enabled_if = _creature_editor_library.get_color_property_enabled_if(category, color_property)
 		color_button.connect("color_changed", self, "_on_CreatureColorButton_color_changed", [color_property])
 
 

--- a/project/src/main/editor/creature/category-label.gd
+++ b/project/src/main/editor/creature/category-label.gd
@@ -9,6 +9,7 @@ var _tween: SceneTreeTween
 
 onready var _category_selector: CategorySelector = get_node(category_selector_path)
 onready var _accent := $MenuAccentH3
+onready var _creature_editor_library := Global.get_creature_editor_library()
 
 func _ready() -> void:
 	# Workaround for Godot #20623 (https://github.com/godotengine/godot/issues/20623)
@@ -24,7 +25,7 @@ func _ready() -> void:
 
 func _on_CategorySelector_category_selected(category: int) -> void:
 	# update text
-	text = CreatureEditorLibrary.get_name_by_category_index(category, tr("???"))
+	text = _creature_editor_library.get_name_by_category_index(category, tr("???"))
 	
 	# update accent
 	_accent.refresh()

--- a/project/src/main/editor/creature/creature-editor-library.gd
+++ b/project/src/main/editor/creature/creature-editor-library.gd
@@ -1,4 +1,5 @@
 tool
+class_name CreatureEditorLibrary
 extends Node
 ## Manages data for the creature editor. This includes the list of category names, which buttons should be shown,
 ## their positions, and when those buttons should be enabled or disabled.

--- a/project/src/main/utils/global.gd
+++ b/project/src/main/utils/global.gd
@@ -73,6 +73,11 @@ func get_overworld_ui() -> OverworldUi:
 	return nodes[0] if nodes else null
 
 
+func get_creature_editor_library() -> CreatureEditorLibrary:
+	var nodes := get_tree().get_nodes_in_group("creature_editor_library")
+	return nodes[0] if nodes else null
+
+
 ## Convert a coordinate from global coordinates to isometric (squashed) coordinates
 static func to_iso(vector: Vector2) -> Vector2:
 	return vector * ISO_FACTOR


### PR DESCRIPTION
This node is only used in the creature editor, so I've changed it into a regular node accessible through Global.get_creature_editor_library()