### PR TITLE
Refactor: Prefix test filenames with 'user://'

### DIFF
--- a/project/src/test/data/test-player-save-upgrader.gd
+++ b/project/src/test/data/test-player-save-upgrader.gd
@@ -1,11 +1,11 @@
 extends GutTest
 
-const TEMP_FILENAME := "test-ground-lucky.save"
-const TEMP_LEGACY_FILENAME := "test-snatch-lucky.save"
+const TEMP_FILENAME := "user://test-ground-lucky.save"
+const TEMP_LEGACY_FILENAME := "user://test-snatch-lucky.save"
 
 func before_each() -> void:
-	PlayerSave.data_filename = "user://%s" % TEMP_FILENAME
-	PlayerSave.legacy_filename = "user://%s" % TEMP_LEGACY_FILENAME
+	PlayerSave.data_filename = TEMP_FILENAME
+	PlayerSave.legacy_filename = TEMP_LEGACY_FILENAME
 	
 	# don't increment playtime during this test or it ruins our assertions
 	PlayerData.seconds_played_timer.stop()
@@ -13,21 +13,20 @@ func before_each() -> void:
 
 
 func after_each() -> void:
-	var save_dir := Directory.new()
-	save_dir.open("user://")
-	save_dir.remove(TEMP_FILENAME)
-	save_dir.remove(TEMP_LEGACY_FILENAME)
+	var dir := Directory.new()
+	dir.remove(TEMP_FILENAME)
+	dir.remove(TEMP_LEGACY_FILENAME)
 
 
 func load_legacy_player_data(filename: String) -> void:
 	var dir := Directory.new()
-	dir.copy("res://assets/test/data/%s" % filename, "user://%s" % TEMP_LEGACY_FILENAME)
+	dir.copy("res://assets/test/data/%s" % filename, TEMP_LEGACY_FILENAME)
 	PlayerSave.load_player_data()
 
 
 func load_player_data(filename: String) -> void:
 	var dir := Directory.new()
-	dir.copy("res://assets/test/data/%s" % filename, "user://%s" % TEMP_FILENAME)
+	dir.copy("res://assets/test/data/%s" % filename, TEMP_FILENAME)
 	PlayerSave.load_player_data()
 
 

--- a/project/src/test/data/test-player-save.gd
+++ b/project/src/test/data/test-player-save.gd
@@ -1,11 +1,11 @@
 extends GutTest
 
-const TEMP_FILENAME := "test936.save"
+const TEMP_FILENAME := "user://test936.save"
 
 var _rank_result: RankResult
 
 func before_each() -> void:
-	PlayerSave.data_filename = "user://%s" % TEMP_FILENAME
+	PlayerSave.data_filename = TEMP_FILENAME
 	PlayerData.reset()
 	
 	_rank_result = RankResult.new()

--- a/project/src/test/data/test-rolling-backups.gd
+++ b/project/src/test/data/test-rolling-backups.gd
@@ -1,11 +1,11 @@
 extends GutTest
 
-const TEMP_FILENAME := "test837.save"
+const TEMP_FILENAME := "user://test837.save"
 
 var _backups := RollingBackups.new()
 
 func before_each() -> void:
-	_backups.data_filename = "user://%s" % TEMP_FILENAME
+	_backups.data_filename = TEMP_FILENAME
 
 
 func after_each() -> void:

--- a/project/src/test/data/test-system-save-upgrader.gd
+++ b/project/src/test/data/test-system-save-upgrader.gd
@@ -1,30 +1,29 @@
 extends GutTest
 
-const TEMP_FILENAME := "test-ripe-bucket.json"
-const TEMP_LEGACY_FILENAME := "test-oven-bucket.save"
+const TEMP_FILENAME := "user://test-ripe-bucket.json"
+const TEMP_LEGACY_FILENAME := "user://test-oven-bucket.save"
 
 func before_each() -> void:
-	SystemSave.data_filename = "user://%s" % TEMP_FILENAME
-	SystemSave.legacy_filename = "user://%s" % TEMP_LEGACY_FILENAME
+	SystemSave.data_filename = TEMP_FILENAME
+	SystemSave.legacy_filename = TEMP_LEGACY_FILENAME
 	SystemData.reset()
 
 
 func after_each() -> void:
-	var save_dir := Directory.new()
-	save_dir.open("user://")
-	save_dir.remove(TEMP_FILENAME)
-	save_dir.remove(TEMP_LEGACY_FILENAME)
+	var dir := Directory.new()
+	dir.remove(TEMP_FILENAME)
+	dir.remove(TEMP_LEGACY_FILENAME)
 
 
 func load_player_data(filename: String) -> void:
 	var dir := Directory.new()
-	dir.copy("res://assets/test/data/%s" % filename, "user://%s" % TEMP_FILENAME)
+	dir.copy("res://assets/test/data/%s" % filename, TEMP_FILENAME)
 	SystemSave.load_system_data()
 
 
 func load_legacy_player_data(filename: String) -> void:
 	var dir := Directory.new()
-	dir.copy("res://assets/test/data/%s" % filename, "user://%s" % TEMP_LEGACY_FILENAME)
+	dir.copy("res://assets/test/data/%s" % filename, TEMP_LEGACY_FILENAME)
 	SystemSave.load_system_data()
 
 

--- a/project/src/test/data/test-system-save.gd
+++ b/project/src/test/data/test-system-save.gd
@@ -1,19 +1,18 @@
 extends GutTest
 
-const TEMP_PLAYER_FILENAME := "test253.save"
-const TEMP_SYSTEM_FILENAME := "test254.json"
-const TEMP_LEGACY_FILENAME := "test255.save"
+const TEMP_PLAYER_FILENAME := "user://test253.save"
+const TEMP_SYSTEM_FILENAME := "user://test254.json"
+const TEMP_LEGACY_FILENAME := "user://test255.save"
 
 func before_each() -> void:
-	PlayerSave.data_filename = "user://%s" % TEMP_PLAYER_FILENAME
-	SystemSave.data_filename = "user://%s" % TEMP_SYSTEM_FILENAME
-	SystemSave.legacy_filename = "user://%s" % TEMP_LEGACY_FILENAME
+	PlayerSave.data_filename = TEMP_PLAYER_FILENAME
+	SystemSave.data_filename = TEMP_SYSTEM_FILENAME
+	SystemSave.legacy_filename = TEMP_LEGACY_FILENAME
 	SystemData.reset()
 
 
 func after_each() -> void:
 	var dir := Directory.new()
-	dir.open("user://")
 	dir.remove(TEMP_SYSTEM_FILENAME)
 	dir.remove(TEMP_LEGACY_FILENAME)
 	for backup in [


### PR DESCRIPTION
Filenames elsewhere were prefixed with 'user://' but test filenames followed a different convention. This led to extra code as we had to prefix the 'user://' throughout the test instead of just applying it to the constant.