### PR TITLE
Extract 'delete_all_backups'. Fix tests removing user data.

### DIFF
--- a/project/src/main/data/rolling-backups.gd
+++ b/project/src/main/data/rolling-backups.gd
@@ -159,3 +159,10 @@ func _rotate_backup(this_save: int, prev_save: int, rotate_millis: int) -> void:
 	if not dir.file_exists(this_filename):
 		# populate the 'this-xxx' backup from the current save
 		dir.copy(data_filename, this_filename)
+
+
+## Delete the current save and all backups.
+func delete_all_backups() -> void:
+	for backup in [CURRENT, THIS_HOUR, PREV_HOUR, THIS_DAY, PREV_DAY, THIS_WEEK, PREV_WEEK]:
+		var rolling_filename := rolling_filename(backup)
+		Directory.new().remove(rolling_filename)

--- a/project/src/main/data/system-save.gd
+++ b/project/src/main/data/system-save.gd
@@ -145,16 +145,9 @@ func get_save_slot_name(save_slot: int) -> String:
 ## Deletes the specified save slot and all of its backups.
 func delete_save_slot(save_slot: int) -> void:
 	var save_slot_filename: String = FILENAMES_BY_SAVE_SLOT[save_slot]
-	
 	var rolling_backups := RollingBackups.new()
 	rolling_backups.data_filename = save_slot_filename
-	for backup in [RollingBackups.CURRENT,
-			RollingBackups.THIS_HOUR, RollingBackups.PREV_HOUR,
-			RollingBackups.THIS_DAY, RollingBackups.PREV_DAY,
-			RollingBackups.THIS_WEEK, RollingBackups.PREV_WEEK]:
-		var rolling_filename := rolling_backups.rolling_filename(backup)
-		Directory.new().remove(rolling_filename)
-	
+	rolling_backups.delete_all_backups()
 	emit_signal("save_slot_deleted")
 
 

--- a/project/src/test/data/test-player-save.gd
+++ b/project/src/test/data/test-player-save.gd
@@ -17,14 +17,9 @@ func before_each() -> void:
 
 
 func after_each() -> void:
-	var dir := Directory.new()
-	for backup in [
-			RollingBackups.CURRENT,
-			RollingBackups.THIS_HOUR, RollingBackups.PREV_HOUR,
-			RollingBackups.THIS_DAY, RollingBackups.PREV_DAY,
-			RollingBackups.THIS_WEEK, RollingBackups.PREV_WEEK,
-			RollingBackups.LEGACY]:
-		dir.remove(PlayerSave.rolling_backups.rolling_filename(backup))
+	var rolling_backups := RollingBackups.new()
+	rolling_backups.data_filename = TEMP_FILENAME
+	rolling_backups.delete_all_backups()
 
 
 func test_save_and_load() -> void:

--- a/project/src/test/data/test-rolling-backups.gd
+++ b/project/src/test/data/test-rolling-backups.gd
@@ -9,14 +9,7 @@ func before_each() -> void:
 
 
 func after_each() -> void:
-	var dir := Directory.new()
-	dir.remove(_backups.rolling_filename(RollingBackups.CURRENT))
-	dir.remove(_backups.rolling_filename(RollingBackups.THIS_HOUR))
-	dir.remove(_backups.rolling_filename(RollingBackups.PREV_HOUR))
-	dir.remove(_backups.rolling_filename(RollingBackups.THIS_DAY))
-	dir.remove(_backups.rolling_filename(RollingBackups.PREV_DAY))
-	dir.remove(_backups.rolling_filename(RollingBackups.THIS_WEEK))
-	dir.remove(_backups.rolling_filename(RollingBackups.PREV_WEEK))
+	_backups.delete_all_backups()
 
 
 func test_rolling_filename() -> void:

--- a/project/src/test/data/test-system-save.gd
+++ b/project/src/test/data/test-system-save.gd
@@ -15,13 +15,9 @@ func after_each() -> void:
 	var dir := Directory.new()
 	dir.remove(TEMP_SYSTEM_FILENAME)
 	dir.remove(TEMP_LEGACY_FILENAME)
-	for backup in [
-			RollingBackups.CURRENT,
-			RollingBackups.THIS_HOUR, RollingBackups.PREV_HOUR,
-			RollingBackups.THIS_DAY, RollingBackups.PREV_DAY,
-			RollingBackups.THIS_WEEK, RollingBackups.PREV_WEEK,
-			RollingBackups.LEGACY]:
-		dir.remove(PlayerSave.rolling_backups.rolling_filename(backup))
+	var rolling_backups := RollingBackups.new()
+	rolling_backups.data_filename = TEMP_PLAYER_FILENAME
+	rolling_backups.delete_all_backups()
 
 
 func test_save_and_load() -> void:


### PR DESCRIPTION
Extracted RollingBackups.delete_all_backups() method which is used by the 'delete save slot' functionality and by certain tests.

This partially addresses a bug where running the Gut tests would occasionally delete the user's save slot. This bug occurred because the SystemData.reset() method would change the active save slot, resetting the PlayerSave.data_filename which had been overridden for the tests. Howveer, with this change the cleanup logic will still delete the data from the temporary location, and not the player's user data.