### PR TITLE
Bug: Gut tests were deleting user data.

### DIFF
--- a/project/src/main/data/system-save.gd
+++ b/project/src/main/data/system-save.gd
@@ -28,6 +28,10 @@ const FILENAMES_BY_SAVE_SLOT: Dictionary = {
 ## Filename for saving/loading system data. Can be changed for tests
 var data_filename := "user://config.json"
 
+## 'true' if the data filename has been overridden for tests. Prevents our save slot logic from resetting the filename
+## back to its default.
+var ignore_save_slot_filename := false
+
 ## Filename for loading data older than July 2021. Can be changed for tests
 var legacy_filename := "user://turbofat0.save"
 
@@ -188,8 +192,13 @@ func _load_line(type: String, _key: String, json_value) -> void:
 func _refresh_save_slot() -> void:
 	if not FILENAMES_BY_SAVE_SLOT.has(SystemData.misc_settings.save_slot):
 		SystemData.misc_settings.save_slot = MiscSettings.SaveSlot.SLOT_A
-	var save_slot_filename: String = FILENAMES_BY_SAVE_SLOT[SystemData.misc_settings.save_slot]
-	PlayerSave.data_filename = save_slot_filename
+	
+	if ignore_save_slot_filename:
+		# prevent filenames from changing if we're overriding them for tests
+		pass
+	else:
+		var save_slot_filename: String = FILENAMES_BY_SAVE_SLOT[SystemData.misc_settings.save_slot]
+		PlayerSave.data_filename = save_slot_filename
 
 
 func _on_MiscSettings_save_slot_changed() -> void:

--- a/project/src/test/pre-run-hook.gd
+++ b/project/src/test/pre-run-hook.gd
@@ -1,6 +1,15 @@
 extends GutHookScript
 ## Performs initialization steps for Gut tests.
 
+const TEMP_FILENAME := "test-harbor-unobtainable.json"
+const TEMP_LEGACY_FILENAME := "test-moaning-corn.json"
+
 func run() -> void:
 	# Prevent the player's settings from triggering fullscreen mode or vsync.
 	SystemData.disallow_graphics_customization()
+	
+	# Prevent the tests from deleting the user's save data.
+	SystemSave.data_filename = "user://%s" % TEMP_FILENAME
+	SystemSave.legacy_filename = "user://%s" % TEMP_LEGACY_FILENAME
+	PlayerSave.data_filename = "user://%s" % TEMP_FILENAME
+	SystemSave.ignore_save_slot_filename = true


### PR DESCRIPTION
Gut tests had logic to override the player's data_filename, but this was then being reverted when the SystemSave reacted to the 'save_slot_changed' signal, setting the filename back to the user's save slots. The result was that some tests would delete the user's data instead of deleting the test's data.

I've added two protections for the Gut tests:
1. SystemSave no longer assigns the filenames during tests.
2. Gut tests override the filenames by default in a pre-run hook.