### PR TITLE
CreatureEditor's color picker supports gamepads

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -84,6 +84,16 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/ui/candy-button/candy-buttons.gd"
 }, {
+"base": "Panel",
+"class": "CandyColorPicker",
+"language": "GDScript",
+"path": "res://src/main/ui/candy-button/candy-color-picker.gd"
+}, {
+"base": "Button",
+"class": "CandyColorPickerButton",
+"language": "GDScript",
+"path": "res://src/main/ui/candy-button/candy-color-picker-button.gd"
+}, {
 "base": "Reference",
 "class": "CareerCutsceneLibrarian",
 "language": "GDScript",
@@ -598,6 +608,11 @@ _global_script_classes=[ {
 "class": "HookableRegionGradeLabel",
 "language": "GDScript",
 "path": "res://src/main/career/ui/hookable-region-grade-label.gd"
+}, {
+"base": "HBoxContainer",
+"class": "HsvSlider",
+"language": "GDScript",
+"path": "res://src/main/ui/candy-button/hsv-slider.gd"
 }, {
 "base": "ColorRect",
 "class": "HudFlash",
@@ -1585,6 +1600,8 @@ _global_script_class_icons={
 "CandyButtonC3": "",
 "CandyButtonCollapsible": "",
 "CandyButtons": "",
+"CandyColorPicker": "",
+"CandyColorPickerButton": "",
 "CareerCutsceneLibrarian": "",
 "CareerData": "",
 "CareerLevel": "",
@@ -1688,6 +1705,7 @@ _global_script_class_icons={
 "HoldPieceDisplays": "",
 "HookableLevelGradeLabel": "",
 "HookableRegionGradeLabel": "",
+"HsvSlider": "",
 "HudFlash": "",
 "IdleTimer": "",
 "ImageButton": "",

--- a/project/src/demo/editor/creature/CreatureColorButtonDemo.tscn
+++ b/project/src/demo/editor/creature/CreatureColorButtonDemo.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://src/main/ui/candy-button/gradient-none.tres" type="Gradient" id=1]
 [ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=2]
 [ext_resource path="res://src/main/editor/creature/CreatureColorButton.tscn" type="PackedScene" id=3]
+[ext_resource path="res://src/demo/editor/creature/creature-color-button-demo.gd" type="Script" id=4]
 
 [sub_resource type="GradientTexture2D" id=1]
 resource_local_to_scene = true
@@ -55,6 +56,7 @@ shader_param/mix_amount = 1.0
 shader_param/gradient = SubResource( 9 )
 
 [node name="Node" type="Node"]
+script = ExtResource( 4 )
 
 [node name="TabContainer" type="TabContainer" parent="."]
 anchor_right = 1.0
@@ -185,3 +187,17 @@ margin_bottom = -46.0
 rect_min_size = Vector2( 80, 64 )
 toggle_mode = false
 shortcut_in_tooltip = false
+
+[node name="ColorAnalysis" type="Control" parent="TabContainer"]
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 4.0
+margin_top = 32.0
+margin_right = -4.0
+margin_bottom = -4.0
+
+[node name="TextEdit" type="TextEdit" parent="TabContainer/ColorAnalysis"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+readonly = true

--- a/project/src/demo/editor/creature/creature-color-button-demo.gd
+++ b/project/src/demo/editor/creature/creature-color-button-demo.gd
@@ -1,0 +1,234 @@
+extends Node
+## Shows off the creature color buttons, and provides utilities for editing creature color palettes.
+##
+## Keys:
+## 	[Q]: Extract new palettes from old palettes.
+## 	[W]: Report duplicate colors from our new palettes.
+## 	[E]: Report creature colors not present in our new palettes.
+
+onready var _tab_container := $TabContainer
+onready var _text_edit := $TabContainer/ColorAnalysis/TextEdit
+
+func _input(event: InputEvent) -> void:
+	match Utils.key_scancode(event):
+		KEY_Q:
+			_extract_colors_from_creature_palettes()
+		KEY_W:
+			_show_similar_colors()
+		KEY_E:
+			_show_missing_colors()
+
+
+## Extract palettes from the old creature editor format and prints them in the new format.
+##
+## The old creature editor relied on the "DnaUtils.CREATURE_PALETTES" field which had unified palettes for all of a
+## creature's parts, such as "Green scales, red eyes and a yellow belly." By contrast, the new creature editor relies
+## on the CreatureEditorLibrary.COLOR_PRESETS_BY_COLOR_PROPERTY field which has independent fields for each of a
+## creature's parts, such as "Red eyes, green eyes, blue eyes."
+func _extract_colors_from_creature_palettes() -> void:
+	var lines := []
+	var creature_palettes := DnaUtils.CREATURE_PALETTES.duplicate(true)
+	for palette in creature_palettes:
+		palette["eye_rgb_0"] = palette["eye_rgb"].split(" ")[0]
+		palette["eye_rgb_1"] = palette["eye_rgb"].split(" ")[1]
+		palette.erase("eye_rgb")
+	
+	var color_properties: Array = creature_palettes[0].keys()
+	color_properties.sort()
+	
+	var colors_by_property := {}
+	for color_property in color_properties:
+		colors_by_property[color_property] = {}
+		for palette in creature_palettes:
+			colors_by_property[color_property][Color(palette[color_property])] = true
+	
+	for color_property in colors_by_property:
+		var colors_string := _string_from_color_array(colors_by_property[color_property].keys())
+		lines.append("\"%s\": [%s]," % [color_property, colors_string])
+	_show_color_analysis(lines)
+
+
+## Converts an array of colors into a GDScript string.
+##
+## Parameters:
+## 	'colors': Color instances to convert
+##
+## Returns:
+## 	A combined color string such as 'Color("ffffff"), Color("eeeeee")'
+func _string_from_color_array(colors: Array) -> String:
+	var result := ""
+	for color in colors:
+		if result:
+			result += ", "
+		result += "Color(\"%s\")" % [color.to_html(false)]
+	return result
+
+
+## Reports any duplicate colors in our color presets.
+##
+## These colors are shown as color swatches in the creature editor, where we don't want to present the player with
+## duplicates. This method checks for any duplicates or near-duplicates and reports them.
+func _show_similar_colors() -> void:
+	var lines := []
+	
+	for color_property in CreatureEditorLibrary.COLOR_PRESETS_BY_COLOR_PROPERTY:
+		var old_color_presets: Array = CreatureEditorLibrary.COLOR_PRESETS_BY_COLOR_PROPERTY[color_property]
+		var redundant_color_presets := _find_redundant_color_presets(old_color_presets)
+		if redundant_color_presets:
+			var new_color_presets := old_color_presets.duplicate()
+			for redundant_color_preset in redundant_color_presets:
+				new_color_presets.remove(new_color_presets.find(redundant_color_preset))
+			lines.append("# %s redundant %s colors found: %s" \
+					% [redundant_color_presets.size(), color_property,
+						_string_from_color_array(redundant_color_presets)])
+			lines.append("\"%s\": [%s]," \
+					% [color_property, _string_from_color_array(new_color_presets)])
+	
+	if not lines:
+		lines.append("No redundant colors found.");
+	
+	_show_color_analysis(lines)
+
+
+## Reports any missing colors in our color presets.
+##
+## Turbo Fat's creatures include many fanmade submissions, but ideally all of their colors should be approximated by
+## color swatches in the creature editor. This method checks for any colors used by creatures which are absent from
+## the creature editor.
+func _show_missing_colors() -> void:
+	var lines := []
+	
+	var creature_dnas := []
+	for creature_id in PlayerData.creature_library.creature_ids():
+		if creature_id == CreatureLibrary.PLAYER_ID:
+			continue
+		creature_dnas.append(PlayerData.creature_library.get_creature_def(creature_id).dna)
+	
+	for color_property in CreatureEditorLibrary.COLOR_PRESETS_BY_COLOR_PROPERTY:
+		if color_property == "line_rgb":
+			# line colors are static
+			continue
+		
+		var old_color_presets: Array = CreatureEditorLibrary.COLOR_PRESETS_BY_COLOR_PROPERTY[color_property]
+		old_color_presets = old_color_presets.duplicate(true)
+		
+		var dna_colors := _colors_from_creature_dna(creature_dnas, color_property)
+		var missing_color_presets := _find_missing_color_presets(old_color_presets, dna_colors)
+		if missing_color_presets:
+			var new_color_presets := old_color_presets.duplicate()
+			new_color_presets.append_array(missing_color_presets)
+			lines.append("# %s missing %s colors found: %s" \
+					% [missing_color_presets.size(), color_property, _string_from_color_array(missing_color_presets)])
+			lines.append("\"%s\": [%s]," \
+					% [color_property, _string_from_color_array(new_color_presets)])
+	
+	if not lines:
+		lines.append("No missing colors found.");
+	
+	_show_color_analysis(lines)
+
+
+## Extracts unique Color values for a specified body part from a list of dna definitions.
+##
+## Parameters:
+## 	'creature_dnas': A list of dna definitions to extract Color values from
+##
+## 	'color_property': The body part to extract Color values for
+##
+## Returns:
+## 	A list of unique Color values for the specified body part.
+func _colors_from_creature_dna(creature_dnas: Array, color_property: String) -> Array:
+	var result := {}
+	for creature_dna in creature_dnas:
+		if color_property == "eye_rgb_0":
+			result[Color(creature_dna["eye_rgb"].split(" ")[0])] = true
+		elif color_property == "eye_rgb_1":
+			result[Color(creature_dna["eye_rgb"].split(" ")[1])] = true
+		elif creature_dna.has(color_property):
+			result[Color(creature_dna[color_property])] = true
+	if not result:
+		push_warning("Color property '%s' is absent from creature dna" % [color_property])
+	return result.keys()
+
+
+## Returns a list of dna colors which are missing from a list of color presets.
+##
+## Parameters:
+## 	'color_presets': Color presets to compare against.
+##
+## 	'dna_colors': Dna Color instances to search for.
+##
+## Returns:
+## 	List of Color values from 'dna_colors' not present in 'color_presets'.
+func _find_missing_color_presets(color_presets: Array, dna_colors: Array) -> Array:
+	var result := []
+	
+	for dna_color in dna_colors:
+		var dna_color_found := false
+		
+		if not dna_color_found:
+			for color_preset in color_presets:
+				if _is_color_similar(color_preset, dna_color, 0.09):
+					dna_color_found = true
+					break
+		
+		if not dna_color_found:
+			for color_preset in result:
+				if _is_color_similar(color_preset, dna_color, 0.09):
+					dna_color_found = true
+					break
+		
+		if not dna_color_found:
+			result.append(dna_color)
+	
+	return result
+
+
+## Reports the specified lines of text in the 'ColorAnalysis' tab.
+##
+## Parameters:
+## 	'lines': List of String instances to show the user.
+func _show_color_analysis(lines: Array) -> void:
+	_tab_container.current_tab = 2
+	_text_edit.text = PoolStringArray(lines).join("\n")
+
+
+## Returns any duplicate colors in a list of color presets.
+##
+## Parameters:
+## 	'color_presets': Color presets to examine.
+##
+## Returns:
+## 	List of duplicate colors which should be removed. If 4 copies of the same color are found, only 3 copies are
+## 	returned, because we want to preserve one of them.
+func _find_redundant_color_presets(color_presets: Array) -> Array:
+	var result := []
+	
+	for i in range(color_presets.size()):
+		var is_redundant := false
+		
+		for j in range(i):
+			if _is_color_similar(color_presets[i], color_presets[j], 0.06):
+				is_redundant = true
+				break
+		
+		if is_redundant:
+			result.append(color_presets[i])
+		
+	return result
+
+
+## Returns 'true' if two colors fall within a similarity threshold.
+##
+## Parameters:
+## 	'color_0': The first color to compare.
+##
+## 	'color_1': The second color to compare.
+##
+## 	'threshold': A number roughly in the range of [0, 1], where 0.1 means colors must be very similar, and 0.9
+## 		means colors do not need to be similar at all.
+##
+## Returns:
+## 	'True' if the two specified colors fall within the given similarity threshold.
+func _is_color_similar(color_0: Color, color_1: Color, threshold: float) -> bool:
+	return Utils.color_distance_rgb(color_0, color_1) <= threshold

--- a/project/src/demo/ui/candy-button/CandyColorPickerDemo.tscn
+++ b/project/src/demo/ui/candy-button/CandyColorPickerDemo.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://src/demo/ui/candy-button/candy-color-picker-demo.gd" type="Script" id=1]
+[ext_resource path="res://src/main/ui/candy-button/CandyColorPicker.tscn" type="PackedScene" id=2]
+
+[node name="Demo" type="Node"]
+script = ExtResource( 1 )
+
+[node name="ColorPicker" parent="." instance=ExtResource( 2 )]
+margin_left = -120.0
+margin_top = 0.0
+margin_right = 120.0
+margin_bottom = 0.0
+
+[node name="ColorRect" type="ColorRect" parent="."]
+margin_left = 292.0
+margin_top = 286.0
+margin_right = 332.0
+margin_bottom = 326.0
+
+[connection signal="resized" from="ColorPicker" to="." method="_on_ColorPicker_resized"]

--- a/project/src/demo/ui/candy-button/candy-color-picker-demo.gd
+++ b/project/src/demo/ui/candy-button/candy-color-picker-demo.gd
@@ -1,0 +1,57 @@
+extends Node
+## Demonstrates the CandyColorPicker with different palettes.
+##
+## Keys:
+## 	[Q]: Assign a palette with 0 colors.
+## 	[W]: Assign a palette with 4 colors.
+## 	[E]: Assign a palette with 8 colors.
+## 	[R]: Assign a palette with 24 colors.
+## 	[T]: Assign a palette with 100 colors.
+
+onready var _color_rect := $ColorRect
+onready var _color_picker: CandyColorPicker = $ColorPicker
+
+func _ready() -> void:
+	_assign_color_presets(24)
+	_color_picker.grab_focus()
+
+
+func _input(event: InputEvent) -> void:
+	match Utils.key_scancode(event):
+		KEY_Q:
+			_assign_color_presets(0)
+		KEY_W:
+			_assign_color_presets(4)
+		KEY_E:
+			_assign_color_presets(8)
+		KEY_R:
+			_assign_color_presets(24)
+		KEY_T:
+			_assign_color_presets(100)
+
+
+func _assign_color_presets(count: int) -> void:
+	_color_picker.color_presets = color_presets(count)
+
+
+func color_presets(count: int) -> Array:
+	var result := []
+	if count >= 8:
+		result.append(Color.white)
+		result.append(Color.gray)
+		result.append(Color.black)
+	while result.size() < count:
+		var random_color := Color(randf(), randf(), randf())
+		result.append(random_color)
+	return result
+
+
+func _on_ColorPicker_color_changed(color: Color) -> void:
+	_color_rect.color = color
+
+
+func _on_ColorPicker_resized() -> void:
+	if not _color_picker:
+		return
+	
+	_color_picker.rect_position = (get_viewport().size - _color_picker.rect_size) / 2

--- a/project/src/main/editor/creature/ColorPickerPopup.tscn
+++ b/project/src/main/editor/creature/ColorPickerPopup.tscn
@@ -1,19 +1,28 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://src/main/editor/creature/color-picker-popup.gd" type="Script" id=1]
+[ext_resource path="res://src/main/ui/candy-button/CandyColorPicker.tscn" type="PackedScene" id=2]
+
+[sub_resource type="StyleBoxEmpty" id=1]
 
 [node name="ColorPickerPopup" type="PopupPanel"]
-margin_right = 316.0
-margin_bottom = 466.0
+self_modulate = Color( 1, 1, 1, 0 )
+margin_right = 248.0
+margin_bottom = 8.0
+custom_styles/panel = SubResource( 1 )
 script = ExtResource( 1 )
 
-[node name="ColorPicker" type="ColorPicker" parent="."]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 4.0
-margin_top = 4.0
-margin_right = -4.0
-margin_bottom = -4.0
-edit_alpha = false
+[node name="ColorPicker" parent="." instance=ExtResource( 2 )]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 0.0
+margin_top = 0.0
+margin_right = 248.0
+margin_bottom = 8.0
 
+[connection signal="about_to_show" from="." to="." method="_on_about_to_show"]
+[connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
 [connection signal="color_changed" from="ColorPicker" to="." method="_on_ColorPicker_color_changed"]
+[connection signal="resized" from="ColorPicker" to="." method="_on_ColorPicker_resized"]

--- a/project/src/main/editor/creature/CreatureColorButton.tscn
+++ b/project/src/main/editor/creature/CreatureColorButton.tscn
@@ -61,11 +61,10 @@ texture_normal = ExtResource( 9 )
 texture_pressed = ExtResource( 8 )
 
 [node name="Popup" parent="." instance=ExtResource( 4 )]
-margin_right = 236.0
-margin_bottom = 406.0
 
 [node name="ClickSound" parent="." instance=ExtResource( 7 )]
 
 [node name="HoverSound" parent="." instance=ExtResource( 5 )]
 
+[connection signal="about_to_show" from="Popup" to="." method="_on_Popup_about_to_show"]
 [connection signal="color_changed" from="Popup" to="." method="_on_Popup_color_changed"]

--- a/project/src/main/editor/creature/allele-buttons.gd
+++ b/project/src/main/editor/creature/allele-buttons.gd
@@ -259,6 +259,8 @@ func _add_color_buttons(category: int) -> void:
 				creature_color_html = _player().dna[color_property]
 		color_button.creature_color = Color(creature_color_html)
 		color_button.enabled_if = _creature_editor_library.get_color_property_enabled_if(category, color_property)
+		color_button.connect("about_to_show", self, "_on_CreatureColorButton_about_to_show",
+				[color_button, color_property])
 		color_button.connect("color_changed", self, "_on_CreatureColorButton_color_changed", [color_property])
 
 
@@ -373,3 +375,10 @@ func _on_OperationButton_pressed(operation_button: OperationButton) -> void:
 	emit_signal("operation_button_pressed", operation_button.id)
 	if operation_button.id == "save":
 		operation_button.disabled = true
+
+
+## Before showing the CreatureColorButton popup, populate the list of color presets.
+##
+## Some of these presets such as for 'line_rgb' change based on the creature's body color.
+func _on_CreatureColorButton_about_to_show(color_button: CreatureColorButton, color_property: String) -> void:
+	color_button.color_presets = _creature_editor_library.get_color_presets(_player().dna, color_property)

--- a/project/src/main/editor/creature/color-picker-popup.gd
+++ b/project/src/main/editor/creature/color-picker-popup.gd
@@ -1,12 +1,20 @@
 extends PopupPanel
 ## A popup which includes a ColorPicker, similar to ColorPickerButton.
 
+## emitted when the color is changed via the color picker ui
 signal color_changed(color)
+
+## Virtual property; value is only exposed through getters/setters
+var color_presets: Array setget set_color_presets
 
 ## Virtual property; value is only exposed through getters/setters
 var selected_color: Color setget set_selected_color, get_selected_color
 
 onready var _color_picker := $ColorPicker
+
+func _ready() -> void:
+	_refresh_size()
+
 
 func _input(event: InputEvent) -> void:
 	if not is_visible_in_tree():
@@ -16,8 +24,14 @@ func _input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.is_pressed():
 		if not get_global_rect().has_point(event.position):
 			hide()
+			get_tree().set_input_as_handled()
 	elif event.is_action_pressed("ui_cancel"):
 		hide()
+		get_tree().set_input_as_handled()
+
+
+func set_color_presets(new_color_presets: Array) -> void:
+	_color_picker.color_presets = new_color_presets
 
 
 func set_selected_color(new_selected_color: Color) -> void:
@@ -28,5 +42,31 @@ func get_selected_color() -> Color:
 	return _color_picker.color
 
 
+func _refresh_size() -> void:
+	rect_size = _color_picker.rect_min_size
+
+
+func _on_about_to_show() -> void:
+	_refresh_size()
+	_color_picker.grab_focus()
+
+
 func _on_ColorPicker_color_changed(color: Color) -> void:
 	emit_signal("color_changed", color)
+
+
+func _on_ColorPicker_resized() -> void:
+	if not _color_picker:
+		# _color_picker's resized signal is called once before our onready signal
+		return
+	
+	# Avoid a Stack Overflow where changing our size triggers another _on_resized() event
+	_color_picker.disconnect("resized", self, "_on_ColorPicker_resized")
+	_refresh_size()
+	_color_picker.connect("resized", self, "_on_ColorPicker_resized")
+
+
+func _on_visibility_changed() -> void:
+	if visible:
+		yield(get_tree(), "idle_frame")
+		_color_picker.grab_focus()

--- a/project/src/main/editor/creature/creature-color-button.gd
+++ b/project/src/main/editor/creature/creature-color-button.gd
@@ -7,10 +7,15 @@ extends TextureButton
 
 signal color_changed(color)
 
+signal about_to_show
+
 ## Repeating piece shapes which decorate the button.
 export (CandyButtons.ButtonShape) var shape setget set_shape
 
 var creature_color: Color setget set_creature_color
+
+## Virtual property; value is only exposed through getters/setters
+var color_presets := [] setget set_color_presets
 
 ## List of String allele combos for which this button should be enabled. If unset, the button is always enabled.
 var enabled_if := []
@@ -56,6 +61,10 @@ func _pressed() -> void:
 	popup_position.y = clamp(popup_position.y, 0, screen_size.y - _popup.rect_size.y)
 	
 	_popup.popup(Rect2(popup_position, _popup.rect_size))
+
+
+func set_color_presets(new_color_presets: Array) -> void:
+	_popup.color_presets = new_color_presets
 
 
 func set_disabled(new_disabled: bool) -> void:
@@ -171,3 +180,7 @@ func _on_mouse_exited() -> void:
 func _on_Popup_color_changed(color: Color) -> void:
 	set_creature_color(color)
 	emit_signal("color_changed", color)
+
+
+func _on_Popup_about_to_show() -> void:
+	emit_signal("about_to_show")

--- a/project/src/main/editor/creature/creature-editor-library.gd
+++ b/project/src/main/editor/creature/creature-editor-library.gd
@@ -6,6 +6,97 @@ extends Node
 
 const CATEGORIES_PATH := "res://assets/main/editor/creature/creature-editor-categories.json"
 
+## key: (String) color property
+## value: (Array, Color) color presets to show in the creature editor
+const COLOR_PRESETS_BY_COLOR_PROPERTY := {
+	"belly_rgb": [
+			Color("c9442a"), Color("fff4b2"), Color("6dcb4c"), Color("e6cf62"), Color("92d8e5"), Color("bb73dd"),
+			Color("fde8c9"), Color("dbbd9e"), Color("e8fa95"), Color("a9aa2f"), Color("fffaff"), Color("dff2f0"),
+			Color("65412e"), Color("eec086"), Color("ffcd78"), Color("a9d252"), Color("7b8780"), Color("4baf20"),
+			Color("c9dac6"), Color("35e1e0"), Color("e055a0"), Color("876edb"), Color("e29b6e"), Color("d58944"),
+			Color("e5d6b7"), Color("8b70a1"), Color("c78e69"), Color("67aa0f"), Color("8fff54"), Color("2a2a2a"),
+			Color("b0b4d1"), Color("f77429"), Color("8f5786"), Color("4e4f4f"), Color("601000"), Color("6a6994"),
+			Color("fed73d"), Color("fe5911"), Color("b72226"), Color("af361f"), Color("0094ea"), Color("f6e183"),
+			Color("afc09a"), Color("de3021"), Color("8c9537"), Color("000000"), Color("f74b29")
+		],
+	"body_rgb": [
+			Color("b23823"), Color("f9bb4a"), Color("41a740"), Color("b47922"), Color("6f83db"), Color("a854cb"),
+			Color("f57e7d"), Color("e17827"), Color("8fea40"), Color("70843a"), Color("ffbfcb"), Color("b1edee"),
+			Color("f9f7d9"), Color("1a1a1e"), Color("7a8289"), Color("0b45a6"), Color("db2a25"), Color("725e96"),
+			Color("3b494f"), Color("68d50a"), Color("9a7f5d"), Color("ffb12c"), Color("fa5c2c"), Color("99ffb5"),
+			Color("23a2e3"), Color("9d3df6"), Color("25785f"), Color("411c17"), Color("dbffc8"), Color("8f1b21"),
+			Color("b24b10"), Color("907027"), Color("48366e"), Color("2c4b9e"), Color("025d28"), Color("664437"),
+			Color("68af25"), Color("e63f2d"), Color("2e2e2e"), Color("a1c48c"), Color("ed9805"), Color("737373"),
+			Color("772628"), Color("feceef"), Color("f5e0c6"), Color("f48fbc"), Color("5ac8e6"), Color("762c97"),
+			Color("fbaf98"), Color("3d95f3"), Color("072b87"), Color("c7ac78"), Color("206fd5"), Color("e60202")
+		],
+	"cloth_rgb": [
+			Color("282828"), Color("f9a74c"), Color("c09a2f"), Color("7d4c21"), Color("374265"), Color("4fa94e"),
+			Color("7ac252"), Color("4aadc5"), Color("816327"), Color("fad4cf"), Color("c1f1f2"), Color("91e6ff"),
+			Color("b8260b"), Color("f5f0d1"), Color("fad541"), Color("41f2ff"), Color("ad1000"), Color("994dbd"),
+			Color("cb5340"), Color("a7b958"), Color("c49877"), Color("415a73"), Color("ecdf32"), Color("ff5c6f"),
+			Color("cb1b2e"), Color("95c152"), Color("546127"), Color("d5c26a"), Color("121011"), Color("a58900"),
+			Color("ccd44d"), Color("74a27f"), Color("ce4224"), Color("4e8eee"), Color("f2c12a"), Color("010000"),
+			Color("a2a500"), Color("777d6f"), Color("88df41"), Color("fffb00"), Color("7786b3"), Color("9999f4"),
+			Color("326728"), Color("ffa2ec"), Color("ffffff"), Color("ffb2ef"), Color("f05236"), Color("6e99ca"),
+			Color("ff73e1"), Color("00e3d8"), Color("c421ac"), Color("280edd")
+		],
+	"eye_rgb_0": [
+			Color("282828"), Color("f9a74c"), Color("c09a2f"), Color("7d4c21"), Color("374265"), Color("924a51"),
+			Color("7ac252"), Color("1492d6"), Color("f5d561"), Color("fad4cf"), Color("c1f1f2"), Color("91e6ff"),
+			Color("b8260b"), Color("f5f0d1"), Color("5ba964"), Color("41f2ff"), Color("ad1000"), Color("994dbd"),
+			Color("cb5340"), Color("a7b958"), Color("e9c57d"), Color("415a73"), Color("ecdf32"), Color("ff5c6f"),
+			Color("ff912e"), Color("8bb253"), Color("546127"), Color("d5c26a"), Color("121011"), Color("a58900"),
+			Color("ccd44d"), Color("74a27f"), Color("ce4224"), Color("4e8eee"), Color("f2c12a"), Color("a6001e"),
+			Color("f92a2a"), Color("13c39e"), Color("d25e00"), Color("87b8f6"), Color("866c95"), Color("000000"),
+			Color("276127"), Color("54c35c"), Color("373535"), Color("8458b9"), Color("977968"), Color("f05236"),
+			Color("084f10"), Color("7c5a46"), Color("9cc6ef"), Color("2c8619"), Color("f6f200")
+		],
+	"eye_rgb_1": [
+			Color("dedede"), Color("fff6df"), Color("f1e398"), Color("e5cd7d"), Color("eaf2f4"), Color("ffe8eb"),
+			Color("33d4f0"), Color("ffffff"), Color("f45e40"), Color("a9e0bb"), Color("d6ffff"), Color("b73a36"),
+			Color("b392df"), Color("606060"), Color("ffb597"), Color("c8cbd6"), Color("ffd061"), Color("a8ad89"),
+			Color("4d6c6a"), Color("ffffa2"), Color("20383f"), Color("ff9c9c"), Color("ec3333"), Color("617d7c"),
+			Color("879f9d"), Color("daaed8"), Color("aba4ce"), Color("828fac")
+		],
+	"glass_rgb": [
+			Color("72d2eb"), Color("1d1d1d"), Color("c5d1d1"), Color("777668"), Color("4e50a9"), Color("d96079"),
+			Color("333332"), Color("f66451"), Color("5376f1"), Color("728eff"), Color("a9b2b2"), Color("f5e194"),
+			Color("f9c0f9"), Color("690a00"), Color("dcd2d0"), Color("a8db69"), Color("bf3a3a"), Color("f4ec80"),
+			Color("c42b3d"), Color("e7bb76"), Color("cbde88"), Color("ffd256"), Color("331d4b"), Color("508e44"),
+			Color("e65738"), Color("f0f3bd"), Color("5d1b2b"), Color("ee2b91"), Color("d0f29f"), Color("000000"),
+			Color("41b34e"), Color("b8d229"), Color("ffffff"), Color("ff8600")
+		],
+	"hair_rgb": [
+			Color("af845c"), Color("b47922"), Color("f1e398"), Color("7f8f69"), Color("47465f"), Color("f57e7d"),
+			Color("dfca7a"), Color("ffffff"), Color("222222"), Color("fbebe5"), Color("4f5651"), Color("40342d"),
+			Color("d37725"), Color("3e7e32"), Color("c5b871"), Color("a6a1a1"), Color("d98227"), Color("bdab30"),
+			Color("3e2d62"), Color("e7b658"), Color("2c3c2b"), Color("c58549"), Color("b0b4d1"), Color("3b5854"),
+			Color("c4c4c5"), Color("73b693"), Color("f50808"), Color("4b974b"), Color("e8a261"), Color("596de6"),
+			Color("d3a01c"), Color("000000"), Color("f05236"), Color("a05f35"), Color("696864"), Color("e5d6b7"),
+			Color("f4351c")
+		],
+	"horn_rgb": [
+			Color("f1e398"), Color("b3b2b5"), Color("f6ff8c"), Color("e38a61"), Color("e9ebf0"), Color("d3af43"),
+			Color("eabc75"), Color("fde9e7"), Color("e1f9f9"), Color("fdfcec"), Color("282828"), Color("1e1e1e"),
+			Color("3c3b3b"), Color("5a635d"), Color("d59fef"), Color("d2c9cd"), Color("529e43"), Color("ac4577"),
+			Color("bdc6c5"), Color("c9d9bd"), Color("caf877"), Color("4c5245"), Color("afa7ae"), Color("828863"),
+			Color("98a49a"), Color("e8a261"), Color("49663a"), Color("63426b"), Color("b47922"), Color("fecbd3"),
+			Color("fa6400"), Color("090909"), Color("9787a2"), Color("404094")
+		],
+	"line_rgb": [
+			Color("6c4331"), Color("41281e"), Color("3c3c3d")
+		],
+	"plastic_rgb": [
+			Color("292828"), Color("f55034"), Color("785537"), Color("3b2416"), Color("b5c4f2"), Color("42a5be"),
+			Color("6f6168"), Color("3d3c3b"), Color("e5e6e0"), Color("442f1c"), Color("f5dfdc"), Color("e3fbfc"),
+			Color("1f1f1f"), Color("66ca72"), Color("de64d9"), Color("545050"), Color("3d7d4b"), Color("c49877"),
+			Color("fc7d8c"), Color("5e885a"), Color("546127"), Color("d5c26a"), Color("121011"), Color("a59131"),
+			Color("d4aa4d"), Color("923b3b"), Color("abb7f5"), Color("f28c2a"), Color("a3a2a6"), Color("79ff19"),
+			Color("ae2222"), Color("e699a1")
+		],
+}
+
 ## List of Category instances with information about the creature editor categories.
 var categories: Array = []
 
@@ -88,6 +179,25 @@ func get_operations_by_category_index(category_index: int) -> Array:
 	var result := []
 	if category_index < categories.size():
 		result = categories[category_index].operations
+	return result
+
+
+## Return the color presets to show in the creature editor.
+##
+## Parameters:
+## 	'creature_dna': The dna for the creature whose presets should be shown.
+##
+## 	'color_property': The color property being edited, such as 'belly_rgb'.
+func get_color_presets(creature_dna: Dictionary, color_property: String) -> Array:
+	var result := []
+	result.append_array(COLOR_PRESETS_BY_COLOR_PROPERTY[color_property])
+	
+	match color_property:
+		"line_rgb":
+			result.append(DnaUtils.darker_line_color(Color(creature_dna["body_rgb"])))
+		"hair_rgb":
+			result.append(Color(creature_dna["body_rgb"]))
+	
 	return result
 
 

--- a/project/src/main/ui/candy-button/CandyColorPicker.tscn
+++ b/project/src/main/ui/candy-button/CandyColorPicker.tscn
@@ -1,0 +1,144 @@
+[gd_scene load_steps=8 format=2]
+
+[ext_resource path="res://src/main/ui/candy-button/HsvSlider.tscn" type="PackedScene" id=1]
+[ext_resource path="res://src/main/ui/candy-button/CandyColorPickerButton.tscn" type="PackedScene" id=2]
+[ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=3]
+[ext_resource path="res://src/main/ui/candy-button/candy-color-picker.gd" type="Script" id=6]
+[ext_resource path="res://src/main/ui/squeak/squeak-theme-h4.tres" type="Theme" id=7]
+
+[sub_resource type="StyleBoxFlat" id=459]
+content_margin_left = 8.0
+content_margin_right = 8.0
+content_margin_top = 8.0
+content_margin_bottom = 8.0
+bg_color = Color( 0.423529, 0.262745, 0.192157, 1 )
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color( 1, 0.866667, 0.6, 1 )
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[sub_resource type="DynamicFont" id=460]
+size = 1
+font_data = ExtResource( 3 )
+
+[node name="ColorPicker" type="Panel"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -512.0
+margin_top = -300.0
+margin_right = -272.0
+margin_bottom = -300.0
+rect_min_size = Vector2( 240, 0 )
+theme = ExtResource( 7 )
+custom_styles/panel = SubResource( 459 )
+script = ExtResource( 6 )
+CandyColorPickerButtonScene = ExtResource( 2 )
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+margin_left = 6.0
+margin_top = 6.0
+margin_right = 234.0
+margin_bottom = 94.0
+
+[node name="PresetsContainer" type="GridContainer" parent="VBoxContainer"]
+margin_right = 228.0
+margin_bottom = 20.0
+columns = 8
+
+[node name="Button" parent="VBoxContainer/PresetsContainer" instance=ExtResource( 2 )]
+custom_fonts/font = SubResource( 460 )
+clip_text = true
+color = Color( 0.854902, 0.321569, 0.321569, 1 )
+
+[node name="Button2" parent="VBoxContainer/PresetsContainer" instance=ExtResource( 2 )]
+margin_left = 29.0
+margin_right = 54.0
+custom_fonts/font = SubResource( 460 )
+clip_text = true
+color = Color( 0.266667, 0.419608, 0.827451, 1 )
+
+[node name="Button3" parent="VBoxContainer/PresetsContainer" instance=ExtResource( 2 )]
+margin_left = 58.0
+margin_right = 83.0
+custom_fonts/font = SubResource( 460 )
+clip_text = true
+color = Color( 0.854902, 0.321569, 0.321569, 1 )
+
+[node name="Button4" parent="VBoxContainer/PresetsContainer" instance=ExtResource( 2 )]
+margin_left = 87.0
+margin_right = 112.0
+custom_fonts/font = SubResource( 460 )
+clip_text = true
+color = Color( 0.266667, 0.419608, 0.827451, 1 )
+
+[node name="Button5" parent="VBoxContainer/PresetsContainer" instance=ExtResource( 2 )]
+margin_left = 116.0
+margin_right = 141.0
+custom_fonts/font = SubResource( 460 )
+clip_text = true
+color = Color( 0.854902, 0.321569, 0.321569, 1 )
+
+[node name="Button6" parent="VBoxContainer/PresetsContainer" instance=ExtResource( 2 )]
+margin_left = 145.0
+margin_right = 170.0
+custom_fonts/font = SubResource( 460 )
+clip_text = true
+color = Color( 0.266667, 0.419608, 0.827451, 1 )
+
+[node name="Button7" parent="VBoxContainer/PresetsContainer" instance=ExtResource( 2 )]
+margin_left = 174.0
+margin_right = 199.0
+custom_fonts/font = SubResource( 460 )
+clip_text = true
+color = Color( 0.854902, 0.321569, 0.321569, 1 )
+
+[node name="Button8" parent="VBoxContainer/PresetsContainer" instance=ExtResource( 2 )]
+margin_left = 203.0
+margin_right = 228.0
+custom_fonts/font = SubResource( 460 )
+clip_text = true
+color = Color( 0.266667, 0.419608, 0.827451, 1 )
+
+[node name="Spacer" type="Control" parent="VBoxContainer"]
+margin_top = 26.0
+margin_right = 228.0
+margin_bottom = 30.0
+rect_min_size = Vector2( 0, 4 )
+
+[node name="HsvContainer" type="VBoxContainer" parent="VBoxContainer"]
+margin_top = 36.0
+margin_right = 228.0
+margin_bottom = 98.0
+custom_constants/separation = 1
+
+[node name="HueSlider" parent="VBoxContainer/HsvContainer" instance=ExtResource( 1 )]
+margin_right = 228.0
+margin_bottom = 20.0
+text = "H"
+value = 100
+
+[node name="SaturationSlider" parent="VBoxContainer/HsvContainer" instance=ExtResource( 1 )]
+margin_top = 21.0
+margin_right = 228.0
+margin_bottom = 41.0
+text = "S"
+value = 100
+
+[node name="ValueSlider" parent="VBoxContainer/HsvContainer" instance=ExtResource( 1 )]
+margin_top = 42.0
+margin_right = 228.0
+margin_bottom = 62.0
+text = "V"
+value = 100
+
+[connection signal="resized" from="VBoxContainer" to="." method="_on_VBoxContainer_resized"]
+[connection signal="value_changed" from="VBoxContainer/HsvContainer/HueSlider" to="." method="_on_HsvSlider_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/HsvContainer/SaturationSlider" to="." method="_on_HsvSlider_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/HsvContainer/ValueSlider" to="." method="_on_HsvSlider_value_changed"]

--- a/project/src/main/ui/candy-button/CandyColorPickerButton.tscn
+++ b/project/src/main/ui/candy-button/CandyColorPickerButton.tscn
@@ -1,0 +1,44 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=1]
+[ext_resource path="res://src/main/ui/candy-button/candy-color-picker-button.gd" type="Script" id=2]
+
+[sub_resource type="DynamicFont" id=460]
+size = 1
+font_data = ExtResource( 1 )
+
+[sub_resource type="StyleBoxFlat" id=461]
+resource_local_to_scene = true
+content_margin_left = 8.0
+content_margin_right = 8.0
+content_margin_top = 8.0
+content_margin_bottom = 8.0
+bg_color = Color( 0.423529, 0.262745, 0.192157, 1 )
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color( 1, 0.866667, 0.6, 1 )
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[node name="Button" type="Button"]
+self_modulate = Color( 1, 1, 1, 0 )
+margin_right = 25.0
+margin_bottom = 20.0
+rect_min_size = Vector2( 25, 20 )
+custom_fonts/font = SubResource( 460 )
+script = ExtResource( 2 )
+
+[node name="Panel" type="Panel" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+custom_styles/panel = SubResource( 461 )
+
+[connection signal="focus_entered" from="." to="." method="_on_focus_entered"]
+[connection signal="focus_exited" from="." to="." method="_on_focus_exited"]
+[connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]
+[connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]

--- a/project/src/main/ui/candy-button/HsvSlider.tscn
+++ b/project/src/main/ui/candy-button/HsvSlider.tscn
@@ -1,0 +1,34 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://src/main/ui/squeak/squeak-theme-h4.tres" type="Theme" id=1]
+[ext_resource path="res://src/main/ui/candy-button/hsv-slider.gd" type="Script" id=2]
+
+[node name="HsvSlider" type="HBoxContainer"]
+size_flags_vertical = 4
+theme = ExtResource( 1 )
+custom_constants/separation = 0
+script = ExtResource( 2 )
+
+[node name="TextLabel" type="Label" parent="."]
+margin_right = 15.0
+margin_bottom = 20.0
+rect_min_size = Vector2( 15, 0 )
+align = 1
+
+[node name="HSlider" type="HSlider" parent="."]
+margin_left = 15.0
+margin_right = 31.0
+margin_bottom = 18.0
+size_flags_horizontal = 3
+max_value = 255.0
+tick_count = 8
+
+[node name="ValueLabel" type="Label" parent="."]
+margin_left = 31.0
+margin_right = 61.0
+margin_bottom = 20.0
+rect_min_size = Vector2( 30, 0 )
+text = "0"
+align = 1
+
+[connection signal="value_changed" from="HSlider" to="." method="_on_HSlider_value_changed"]

--- a/project/src/main/ui/candy-button/candy-color-picker-button.gd
+++ b/project/src/main/ui/candy-button/candy-color-picker-button.gd
@@ -1,0 +1,53 @@
+class_name CandyColorPickerButton
+extends Button
+## Button showing a color preset within the candy color picker.
+
+const DEFAULT_BORDER_COLOR := Color("ffdd99")
+const FOCUSED_BORDER_COLOR := Color.white
+const HOVERED_BORDER_COLOR := Color.white
+
+## The currently selected color.
+export var color: Color = Color.black setget set_color
+
+## Panel which draws the button's graphics.
+onready var _panel := $Panel
+
+func _ready() -> void:
+	_refresh()
+
+
+func set_color(new_color: Color) -> void:
+	color = new_color
+	_refresh()
+
+
+## Update the panel's appearance based on the currently selected color and button state.
+func _refresh() -> void:
+	if not is_inside_tree():
+		return
+	
+	if has_focus():
+		_panel.get("custom_styles/panel").set_border_color(FOCUSED_BORDER_COLOR)
+	elif is_hovered():
+		_panel.get("custom_styles/panel").set_border_color(HOVERED_BORDER_COLOR)
+	else:
+		_panel.get("custom_styles/panel").set_border_color(DEFAULT_BORDER_COLOR)
+	_panel.get("custom_styles/panel").set_bg_color(color)
+
+
+func _on_mouse_entered() -> void:
+	yield(get_tree(), "idle_frame")
+	_refresh()
+
+
+func _on_mouse_exited() -> void:
+	yield(get_tree(), "idle_frame")
+	_refresh()
+
+
+func _on_focus_entered() -> void:
+	_refresh()
+
+
+func _on_focus_exited() -> void:
+	_refresh()

--- a/project/src/main/ui/candy-button/candy-color-picker.gd
+++ b/project/src/main/ui/candy-button/candy-color-picker.gd
@@ -1,0 +1,192 @@
+class_name CandyColorPicker
+extends Panel
+## A widget that provides an interface for selecting or modifying a color.
+##
+## This serves an identical purpose to Godot's ColorPicker widget, but supports gamepads and keyboards, and matches
+## the game's UI.
+
+## Emitted when the color is changed.
+signal color_changed(color)
+
+## Saturation threshold below which a palette color is considered grey, and moved to the end.
+const SATURATION_THRESHOLD := 0.1
+
+## Value threshold above which a palette color is considered black, and moved to the end.
+const VALUE_THRESHOLD := 0.1
+
+export (PackedScene) var CandyColorPickerButtonScene: PackedScene
+
+## The currently selected color.
+var color: Color setget set_color
+
+## (Color) Color presets available to the player.
+var color_presets: Array setget set_color_presets
+
+## If 'true', the HSV sliders will not respond to value changes. (This is used temporarily to prevent the HSV sliders
+## from reacting to themselves.)
+var _suppress_hsv_slider_adjustment := false
+
+onready var _presets_container: Container = $VBoxContainer/PresetsContainer
+
+## Separates the presets from the HSV sliders.
+onready var _spacer: Control = $VBoxContainer/Spacer
+
+onready var _hue_slider: HsvSlider = $VBoxContainer/HsvContainer/HueSlider
+onready var _saturation_slider: HsvSlider = $VBoxContainer/HsvContainer/SaturationSlider
+onready var _value_slider: HsvSlider = $VBoxContainer/HsvContainer/ValueSlider
+onready var _vbox_container := $VBoxContainer
+
+
+func _ready() -> void:
+	_refresh_color()
+	_refresh_color_presets()
+	_refresh_size()
+
+
+## Steals the focus from another control and becomes the focused control.
+##
+## This control itself doesn't have focus, so we delegate to a child control.
+func grab_focus() -> void:
+	var focusable_nodes := Utils.find_focusable_nodes(self)
+	if focusable_nodes:
+		focusable_nodes[0].grab_focus()
+
+
+func set_color(new_color: Color) -> void:
+	if color == new_color:
+		return
+	
+	color = new_color
+	_refresh_color()
+
+
+func set_color_presets(new_color_presets: Array) -> void:
+	color_presets = new_color_presets
+	
+	_refresh_color_presets()
+	_refresh_size()
+
+
+## Updates the currently displayed color, moving the HSV sliders.
+func _refresh_color() -> void:
+	if not is_inside_tree():
+		return
+	
+	if _suppress_hsv_slider_adjustment:
+		# avoid recursively changing the sliders in response to sliders changing
+		pass
+	else:
+		_hue_slider.value = lerp(0, 255, color.h)
+		_saturation_slider.value = lerp(0, 255, color.s)
+		_value_slider.value = lerp(0, 255, color.v)
+
+
+## Recreates our CandyColorPickerButton instances based on our color_presets field.
+func _refresh_color_presets() -> void:
+	if not is_inside_tree():
+		return
+	
+	for child in _presets_container.get_children():
+		child.queue_free()
+	
+	var sorted_color_presets := _sort_color_presets()
+	
+	for color_preset in sorted_color_presets:
+		var candy_color_picker_button: CandyColorPickerButton = CandyColorPickerButtonScene.instance()
+		candy_color_picker_button.color = color_preset
+		_presets_container.add_child(candy_color_picker_button)
+		
+		candy_color_picker_button.connect("pressed", self, "_on_CandyColorPickerButton_pressed", [color_preset])
+	
+	_presets_container.visible = true if color_presets else false
+	_spacer.visible = true if _presets_container.visible else false
+
+
+## Returns a sorted copy of our color_presets field.
+##
+## The color presets are arranged by color from left-to-right, and by brightness from top-to-bottom. Grey colors are
+## sorted to the bottom right.
+func _sort_color_presets() -> Array:
+	var result := []
+	var colors_by_hue := color_presets.duplicate()
+	colors_by_hue.sort_custom(self, "_compare_by_hue")
+	
+	var buckets := []
+	
+	while not colors_by_hue.empty():
+		var end := ceil(colors_by_hue.size() / float(8 - buckets.size())) - 1
+		buckets.append(colors_by_hue.slice(0, end))
+		colors_by_hue = colors_by_hue.slice(end + 1, colors_by_hue.size())
+	
+	for i in range(buckets.size()):
+		buckets[i].sort_custom(self, "_compare_by_brightness")
+	
+	for i in range(color_presets.size()):
+		# warning-ignore:integer_division
+		result.append(buckets[i % 8][int(i / 8)])
+	
+	return result
+
+
+func _compare_by_hue(a: Color, b: Color) -> bool:
+	return fmod(a.h + 0.05, 1.0) + (10 if a.s < SATURATION_THRESHOLD or a.v < VALUE_THRESHOLD else 0) \
+			< fmod(b.h + 0.05, 1.0) + (10 if b.s < SATURATION_THRESHOLD or b.v < VALUE_THRESHOLD else 0)
+
+
+func _compare_by_brightness(a: Color, b: Color) -> bool:
+	return Utils.brightness(a) + (-10 if a.s < SATURATION_THRESHOLD or a.v < VALUE_THRESHOLD else 0) \
+			> Utils.brightness(b) + (-10 if b.s < SATURATION_THRESHOLD or b.v < VALUE_THRESHOLD else 0)
+
+
+## Resize the color picker based on the size of its children.
+func _refresh_size() -> void:
+	if not is_inside_tree():
+		return
+	
+	if not _vbox_container:
+		return
+	
+	var new_rect_size: Vector2 = _vbox_container.rect_size
+	
+	# Godot's Containers such as VBoxContainer and GridContainer visibly collapse invisible elements, so intuitively,
+	# you might expect this to affect their rect_size attributes as well. However, the behavior of containers is
+	# incredibly erratic in this regard.
+	#
+	# This clumsy behavior with a magic value of "22" works, I'm not entirely sure why.
+	if not _presets_container.visible:
+		new_rect_size.y -= 22
+		new_rect_size.y -= _presets_container.get_constant("separation", "VBoxContainer")
+	
+	rect_min_size = new_rect_size + Vector2(12, 12)
+	rect_size = rect_min_size
+
+
+func _on_CandyColorPickerButton_pressed(new_color: Color) -> void:
+	if color == new_color:
+		return
+	
+	set_color(new_color)
+	emit_signal("color_changed", color)
+
+
+func _on_HsvSlider_value_changed(_value: int) -> void:
+	# temporarily prevent the HSV sliders from reacting to themselves
+	_suppress_hsv_slider_adjustment = true
+	
+	var hue := inverse_lerp(0, 255, _hue_slider.value)
+	var saturation := inverse_lerp(0, 255, _saturation_slider.value)
+	var value := inverse_lerp(0, 255, _value_slider.value)
+	var new_color: Color = Color.from_hsv(hue, saturation, value)
+	
+	set_color(new_color)
+	emit_signal("color_changed", color)
+	
+	_suppress_hsv_slider_adjustment = false
+
+
+func _on_VBoxContainer_resized() -> void:
+	if not _vbox_container:
+		# avoid resizing the parent component before its children are initialized
+		return
+	
+	_refresh_size()

--- a/project/src/main/ui/candy-button/hsv-slider.gd
+++ b/project/src/main/ui/candy-button/hsv-slider.gd
@@ -1,0 +1,54 @@
+tool
+class_name HsvSlider
+extends HBoxContainer
+## A slider within the candy color picker which adjusts either the hue, saturation or value
+
+signal value_changed(value)
+
+## Text shown to the left of the slider, such as 'H' for hue
+export (String) var text: String setget set_text
+
+export (int, 0, 255) var value: int setget set_value
+
+onready var _text_label := $TextLabel
+onready var _slider := $HSlider
+onready var _value_label := $ValueLabel
+
+func _ready() -> void:
+	_refresh()
+
+
+## Preemptively initializes onready variables to avoid null references.
+func _enter_tree() -> void:
+	_text_label = $TextLabel
+	_slider = $HSlider
+	_value_label = $ValueLabel
+
+
+func set_text(new_text: String) -> void:
+	text = new_text
+	_refresh()
+
+
+func set_value(new_value: int) -> void:
+	value = new_value
+	_refresh()
+
+
+## Updates the labels and slider based on our properties.
+func _refresh() -> void:
+	if not is_inside_tree():
+		return
+	
+	_text_label.text = text
+	_slider.value = value
+	_value_label.text = str(value)
+
+
+func _on_HSlider_value_changed(new_value: float) -> void:
+	if value == new_value:
+		return
+	
+	value = int(new_value)
+	_refresh()
+	emit_signal("value_changed", value)

--- a/project/src/main/utils/utils.gd
+++ b/project/src/main/utils/utils.gd
@@ -7,6 +7,14 @@ const NUM_SCANCODES := {
 	KEY_5: 5, KEY_6: 6, KEY_7: 7, KEY_8: 8, KEY_9: 9,
 }
 
+## Perceptually adjusted weights for the RGB color channels.
+##
+## These weights emphasize the red and green channels (to which the human eye is most sensitive) while reducing the
+## impact of the blue channel (to which the human eye is least sensitive)
+##
+## The value is equal to "Vector3(0.2990, 0.5871, 0.1140).normalized() * sqrt(3)"
+const PERCEPTUAL_RGB_WEIGHTS := Vector3(0.774529, 1.520822, 0.295305)
+
 
 ## If the specified array item does not exist, this method appends it.
 static func append_if_absent(array: Array, value) -> void:
@@ -474,3 +482,18 @@ static func weighted_rand_value(weights_map: Dictionary):
 			break
 	
 	return selected_value
+
+
+## Returns the perceptual distance between two colors using RGB channel weights.
+##
+## Parameters:
+## 	'color_0': The first color to compare.
+##
+## 	'color_1': The second color to compare.
+##
+## Returns:
+## 	A float representing the perceptual distance between the two colors. A small value like '0.1' indicates the
+## 	colors are similar, a large value like '1.0' indicates they are not similar at all.
+static func color_distance_rgb(a: Color, b: Color) -> float:
+	return (Vector3(a.r, a.g, a.b) * PERCEPTUAL_RGB_WEIGHTS) \
+			.distance_to(Vector3(b.r, b.g, b.b) * PERCEPTUAL_RGB_WEIGHTS)

--- a/project/src/main/world/creature/dna-utils.gd
+++ b/project/src/main/world/creature/dna-utils.gd
@@ -7,7 +7,7 @@ extends Node
 ## Colors used for creature's outlines
 const LINE_COLORS := ["6c4331", "41281e", "3c3c3d"]
 
-## Palettes used for recoloring creatures
+## Palettes used for recoloring creatures. Used for the old creature editor, and for randomly generated customers.
 const CREATURE_PALETTES := [
 	{"line_rgb": "6c4331", "body_rgb": "b23823", "belly_rgb": "c9442a",
 		"hair_rgb": "af845c", "eye_rgb": "282828 dedede", "horn_rgb": "f1e398",

--- a/project/src/test/utils/test-utils.gd
+++ b/project/src/test/utils/test-utils.gd
@@ -202,3 +202,8 @@ func test_is_json_deep_equal_recursive() -> void:
 	assert_eq(false, Utils.is_json_deep_equal(dict1, {"a": 10, "b": 2, "c": {"e": [1, 2, 3]}}))
 	assert_eq(false, Utils.is_json_deep_equal(dict1, {"a": 10, "b": 2, "c": {"d": 4, "e": [1, 2, 3], "f": 5}}))
 	assert_eq(false, Utils.is_json_deep_equal(dict1, {"a": 10, "b": 2, "c": {"d": 5, "e": [1, 2, 3]}}))
+
+
+func test_color_distance_rgb() -> void:
+	assert_eq(0.0, Utils.color_distance_rgb(Color("1a1a1a"), Color("1a1a1a")))
+	assert_almost_eq(sqrt(3), Utils.color_distance_rgb(Color("000000"), Color("ffffff")), 0.001)


### PR DESCRIPTION
Created 'CandyColorPicker', a color picker which supports gamepads. It includes a context-sensitive set of color presets as well as HSV sliders for fully custom colors. It can be navigated well using a gamepad or keyboard.

The presets were collected from both the presets from DnaUtils as well as the creature colors for creatures in the game (e.g Rhonk, Skins). Utilities for repeating this process are in CreatureColorButtonDemo.