### PR TITLE
Avoid creature editor save prompts when reimporting

### DIFF
--- a/project/src/main/editor/creature/CreatureEditor.tscn
+++ b/project/src/main/editor/creature/CreatureEditor.tscn
@@ -987,6 +987,7 @@ bus = "Sound Bus"
 [connection signal="popup_hide" from="Buttons/Dialogs/UnsavedChangesConfirmation" to="Buttons/Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
 [connection signal="about_to_show" from="Buttons/Dialogs/Import" to="Buttons/Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
 [connection signal="file_selected" from="Buttons/Dialogs/Import" to="." method="_on_Import_file_selected"]
+[connection signal="file_selected" from="Buttons/Dialogs/Import" to="CreatureSaver" method="_on_Import_file_selected"]
 [connection signal="popup_hide" from="Buttons/Dialogs/Import" to="Buttons/Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
 [connection signal="about_to_show" from="Buttons/Dialogs/Export" to="Buttons/Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
 [connection signal="file_selected" from="Buttons/Dialogs/Export" to="." method="_on_Export_file_selected"]

--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -26,7 +26,7 @@ func _perform_export_operation() -> void:
 
 
 func _perform_import_operation() -> void:
-	if _creature_saver.has_unsaved_changes():
+	if _creature_saver.has_unsaved_changes() and not _creature_saver.is_freshly_imported_creature_def():
 		_dialogs.show_unsaved_changes_confirmation(self, "_show_import_dialog")
 	else:
 		_show_import_dialog()


### PR DESCRIPTION
When repeatedly importing different creatures, the CreatureEditor would prompt to save each time. It no longer prompts if the current creature definition matches the most recently imported one.