### PR TITLE
Added missing menu actions: 'next_tab', 'prev_tab'

### DIFF
--- a/project/src/main/settings/keybind-settings.gd
+++ b/project/src/main/settings/keybind-settings.gd
@@ -44,6 +44,8 @@ const MENU_ACTION_NAMES := {
 	"ui_right": true,
 	"ui_accept": true,
 	"ui_cancel": true,
+	"next_tab": true,
+	"prev_tab": true,
 }
 
 ## Set of inputs accepted on the overworld.


### PR DESCRIPTION
Having these omitted from the list of menu actions meant they could potentially have UI-breaking conflicts with other UI controls.