### PR TITLE
Bug: Toggling candy button 'disabled' didn't update color

### DIFF
--- a/project/src/main/ui/candy-button/candy-button-c3.gd
+++ b/project/src/main/ui/candy-button/candy-button-c3.gd
@@ -81,6 +81,7 @@ func set_disabled(new_disabled: bool) -> void:
 		return
 	
 	disabled = new_disabled
+	_refresh_color()
 	emit_signal("disabled_changed")
 
 

--- a/project/src/main/ui/candy-button/candy-button-collapsible.gd
+++ b/project/src/main/ui/candy-button/candy-button-collapsible.gd
@@ -136,6 +136,7 @@ func set_disabled(new_disabled: bool) -> void:
 		return
 	
 	disabled = new_disabled
+	_refresh_color()
 	emit_signal("disabled_changed")
 
 

--- a/project/src/main/ui/candy-button/candy-button-h3.gd
+++ b/project/src/main/ui/candy-button/candy-button-h3.gd
@@ -112,6 +112,7 @@ func set_disabled(new_disabled: bool) -> void:
 		return
 	
 	disabled = new_disabled
+	_refresh_color()
 	emit_signal("disabled_changed")
 
 

--- a/project/src/main/ui/candy-button/candy-button-h4.gd
+++ b/project/src/main/ui/candy-button/candy-button-h4.gd
@@ -114,6 +114,7 @@ func set_disabled(new_disabled: bool) -> void:
 		return
 	
 	disabled = new_disabled
+	_refresh_color()
 	emit_signal("disabled_changed")
 
 


### PR DESCRIPTION
Toggling a candy button's 'disabled' property didn't change its appearance. I've added a '_refresh_color()' call to the candy button's set_disabled function.