### PR TITLE
Tweaked resource cache to avoid 'namory set_path warning'

### DIFF
--- a/project/src/main/utils/ResourceCache.tscn
+++ b/project/src/main/utils/ResourceCache.tscn
@@ -4,6 +4,6 @@
 
 [node name="ResourceCache" type="Node"]
 script = ExtResource( 1 )
-low_priority_resource_paths = [ "res://src/main/career/CareerMap.tscn", "res://src/main/career/ui/CareerWin.tscn", "res://src/main/puzzle/Puzzle.tscn", "res://src/main/world/Cutscene.tscn" ]
+low_priority_resource_paths = [ "res://src/main/career/CareerMap.tscn", "res://src/main/career/ui/CareerWin.tscn", "res://src/main/puzzle/Puzzle.tscn", "res://src/main/world/Cutscene.tscn", "res://src/main/credits/CreditsScroll.tscn", "res://src/main/credits/Pinup.tscn" ]
 skipped_resource_paths = [ "res://assets/main/world/environment", "res://src/main/world/environment" ]
 load_seconds = 6.0


### PR DESCRIPTION
The following warning was appearing on startup in the Godot console:

```
set_path: Another resource is loaded from path 'res://assets/main/credits/pinup-namory.png' (possible cyclic resource inclusion).
```

I think this is because the pinup scene was being loaded at the same time as the pinup resource. I've made the pinup and credits scroll scenes 'low priority resources' which should have probably been done before -- they both point to a lot of big resources.