### PR TITLE
Refactor: Extract 'LevelSelectButton.decorate_for_level'

### DIFF
--- a/project/src/main/career/ui/career-map-level-select.gd
+++ b/project/src/main/career/ui/career-map-level-select.gd
@@ -7,7 +7,6 @@ signal level_button_focused(button_index)
 export (PackedScene) var LevelSelectButtonScene: PackedScene
 export (PackedScene) var HardcoreLevelSelectButtonScene: PackedScene
 
-var _duration_calculator := DurationCalculator.new()
 var _prev_focused_level_button_index := -1
 
 onready var _control := $Control
@@ -53,18 +52,10 @@ func add_level_select_button(settings: LevelSettings) -> LevelSelectButton:
 		button = HardcoreLevelSelectButtonScene.instance()
 	else:
 		button = LevelSelectButtonScene.instance()
+	button.decorate_for_level(PlayerData.career.current_region(), settings, true)
 	button.rect_min_size = Vector2(200, 120)
 	button.size_flags_horizontal = 6
 	button.size_flags_vertical = 4
-	button.level_name = settings.name
-	button.level_id = settings.id
-	var duration := _duration_calculator.duration(settings)
-	if duration < 100:
-		button.level_duration = LevelSelectButton.SHORT
-	elif duration < 200:
-		button.level_duration = LevelSelectButton.MEDIUM
-	else:
-		button.level_duration = LevelSelectButton.LONG
 	
 	button.connect("focus_entered", self, "_on_LevelSelectButton_focus_entered", \
 			[_level_buttons_container.get_child_count()])

--- a/project/src/main/ui/level-select/level-select-button.gd
+++ b/project/src/main/ui/level-select/level-select-button.gd
@@ -66,6 +66,8 @@ var _focus_just_entered := false
 ## 'true' if the 'level started' signal should be emitted in response to a button click.
 var _emit_level_chosen := false
 
+var _duration_calculator := DurationCalculator.new()
+
 onready var _button_control := $ButtonControlHolder/ButtonControl
 onready var _label := $ButtonControlHolder/ButtonControl/Label
 
@@ -103,6 +105,49 @@ func set_level_name(new_level_name: String) -> void:
 func set_level_duration(new_level_duration: int) -> void:
 	level_duration = new_level_duration
 	_refresh_appearance()
+
+
+## Updates the button's fields based on the specified level.
+##
+## Specifically, this updates the level_id, level_name, lock_status, duration and bg_color fields.
+func decorate_for_level(region: Object, settings: LevelSettings, force_unlock: bool = false) -> void:
+	level_id = settings.id
+	level_name = settings.name
+
+	# calculate the lock status
+	lock_status = STATUS_NONE
+	if region is CareerRegion and not PlayerData.level_history.has_result(settings.id) and not force_unlock:
+		# career levels are locked if the player hasn't played them
+		lock_status = STATUS_LOCKED
+	elif region.id == OtherRegion.ID_TUTORIAL:
+		# tutorial levels show a checkmark if completed
+		if PlayerData.level_history.is_level_finished(settings.id):
+			lock_status = STATUS_CLEARED
+	elif region is OtherRegion and region.id in [OtherRegion.ID_RANK, OtherRegion.ID_MARATHON]:
+		# rank/marathon levels show a crown if completed
+		if PlayerData.level_history.is_level_success(settings.id):
+			lock_status = STATUS_CROWN
+	
+	var duration := _duration_calculator.duration(settings)
+	if duration < 100:
+		level_duration = SHORT
+	elif duration < 200:
+		level_duration = MEDIUM
+	else:
+		level_duration = LONG
+	
+	# calculate the background color. this is usually random, but for rank mode we use specific colors
+	if settings.color_string:
+		match settings.color_string:
+			"red": set_bg_color(BUTTON_COLOR_RED)
+			"orange": set_bg_color(BUTTON_COLOR_ORANGE)
+			"yellow": set_bg_color(BUTTON_COLOR_YELLOW)
+			"green": set_bg_color(BUTTON_COLOR_GREEN)
+			"blue": set_bg_color(BUTTON_COLOR_BLUE)
+			"purple": set_bg_color(BUTTON_COLOR_PURPLE)
+			_:
+				push_warning("Unrecognized color string '%s'" % [settings.color_string])
+				pass
 
 
 ## Updates the button's style colors. Can be overridden by child buttons who use different styles.

--- a/project/src/main/ui/menu/paged-level-buttons.gd
+++ b/project/src/main/ui/menu/paged-level-buttons.gd
@@ -171,38 +171,9 @@ func _max_selectable_page() -> int:
 ## 	A new orphaned LevelSelectButton instance for the specified level
 func _level_select_button(level_id: String, level_count: int) -> Node:
 	var level_settings: LevelSettings = _level_settings_by_id[level_id]
-	
 	var level_button: LevelSelectButton = LevelButtonScene.instance()
-	level_button.level_id = level_id
+	level_button.decorate_for_level(region, level_settings, _unlock_cheat_enabled)
 	level_button.level_duration = LevelSelectButton.MEDIUM if level_count >= 10 else LevelSelectButton.LONG
-	level_button.level_name = level_settings.name
-	
-	# calculate the lock status
-	level_button.lock_status = LevelSelectButton.STATUS_NONE
-	if region is CareerRegion and not PlayerData.level_history.has_result(level_id) and not _unlock_cheat_enabled:
-		# career levels are locked if the player hasn't played them
-		level_button.lock_status = LevelSelectButton.STATUS_LOCKED
-	elif region.id == OtherRegion.ID_TUTORIAL:
-		# tutorial levels show a checkmark if completed
-		if PlayerData.level_history.is_level_finished(level_id):
-			level_button.lock_status = LevelSelectButton.STATUS_CLEARED
-	elif region is OtherRegion and region.id in [OtherRegion.ID_RANK, OtherRegion.ID_MARATHON]:
-		# rank/marathon levels show a crown if completed
-		if PlayerData.level_history.is_level_success(level_id):
-			level_button.lock_status = LevelSelectButton.STATUS_CROWN
-	
-	# calculate the background color. this is usually random, but for rank mode we use specific colors
-	if level_settings.color_string:
-		match level_settings.color_string:
-			"red": level_button.set_bg_color(LevelSelectButton.BUTTON_COLOR_RED)
-			"orange": level_button.set_bg_color(LevelSelectButton.BUTTON_COLOR_ORANGE)
-			"yellow": level_button.set_bg_color(LevelSelectButton.BUTTON_COLOR_YELLOW)
-			"green": level_button.set_bg_color(LevelSelectButton.BUTTON_COLOR_GREEN)
-			"blue": level_button.set_bg_color(LevelSelectButton.BUTTON_COLOR_BLUE)
-			"purple": level_button.set_bg_color(LevelSelectButton.BUTTON_COLOR_PURPLE)
-			_:
-				push_warning("Unrecognized color string '%s'" % [level_settings.color_string])
-				pass
 	
 	level_button.connect("focus_entered", self, "_on_LevelButton_focus_entered", [level_button, level_id])
 	level_button.connect("level_chosen", self, "_on_LevelButton_level_chosen", [level_settings])


### PR DESCRIPTION
Assignment of the level name, id, duration and color was behavior partially shared between PagedLevelButtons and CareerMapLevelSelect. With the upcoming TrainingMenu improvements, it's convenient to have this code in one place.