### PR TITLE
Redesigned TrainingMenu with LevelButtonScroller

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -674,6 +674,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/world/letter-shooter.gd"
 }, {
+"base": "Control",
+"class": "LevelButtonScroller",
+"language": "GDScript",
+"path": "res://src/main/ui/level-select/level-button-scroller.gd"
+}, {
 "base": "Node",
 "class": "LevelEditor",
 "language": "GDScript",
@@ -1718,6 +1723,7 @@ _global_script_class_icons={
 "LeafPoof": "",
 "LetterProjectile": "",
 "LetterShooter": "",
+"LevelButtonScroller": "",
 "LevelEditor": "",
 "LevelHistory": "",
 "LevelPosse": "",

--- a/project/src/demo/ui/level-select/LevelButtonScrollerDemo.tscn
+++ b/project/src/demo/ui/level-select/LevelButtonScrollerDemo.tscn
@@ -1,0 +1,94 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://src/main/ui/level-select/LevelButtonScroller.tscn" type="PackedScene" id=1]
+[ext_resource path="res://src/main/ui/theme/h3.theme" type="Theme" id=2]
+[ext_resource path="res://src/demo/ui/level-select/level-button-scroller-demo.gd" type="Script" id=3]
+[ext_resource path="res://src/main/ui/theme/h5.theme" type="Theme" id=4]
+
+[node name="LevelButtonScrollerDemo" type="Node"]
+script = ExtResource( 3 )
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -512.0
+margin_top = -217.0
+margin_right = 512.0
+margin_bottom = 217.0
+
+[node name="PressedCheckButton" type="CheckButton" parent="VBoxContainer"]
+margin_left = 361.0
+margin_right = 663.0
+margin_bottom = 40.0
+size_flags_horizontal = 4
+theme = ExtResource( 4 )
+text = "Signal: 'central_button_pressed'"
+
+[node name="Timer" type="Timer" parent="VBoxContainer/PressedCheckButton"]
+one_shot = true
+
+[node name="ChangedCheckButton" type="CheckButton" parent="VBoxContainer"]
+margin_left = 359.0
+margin_top = 44.0
+margin_right = 664.0
+margin_bottom = 84.0
+size_flags_horizontal = 4
+theme = ExtResource( 4 )
+text = "Signal: 'central_button_changed'"
+
+[node name="Timer" type="Timer" parent="VBoxContainer/ChangedCheckButton"]
+one_shot = true
+
+[node name="Button" type="Button" parent="VBoxContainer"]
+margin_left = 462.0
+margin_top = 88.0
+margin_right = 562.0
+margin_bottom = 138.0
+rect_min_size = Vector2( 100, 50 )
+size_flags_horizontal = 4
+theme = ExtResource( 2 )
+text = "Button"
+
+[node name="Button3" type="Button" parent="VBoxContainer"]
+margin_left = 462.0
+margin_top = 142.0
+margin_right = 562.0
+margin_bottom = 192.0
+rect_min_size = Vector2( 100, 50 )
+size_flags_horizontal = 4
+theme = ExtResource( 2 )
+text = "Button"
+
+[node name="LevelButtonScroller" parent="VBoxContainer" instance=ExtResource( 1 )]
+margin_top = 196.0
+margin_right = 1024.0
+margin_bottom = 326.0
+
+[node name="Button2" type="Button" parent="VBoxContainer"]
+margin_left = 462.0
+margin_top = 330.0
+margin_right = 562.0
+margin_bottom = 380.0
+rect_min_size = Vector2( 100, 50 )
+size_flags_horizontal = 4
+theme = ExtResource( 2 )
+text = "Button"
+
+[node name="Button4" type="Button" parent="VBoxContainer"]
+margin_left = 462.0
+margin_top = 384.0
+margin_right = 562.0
+margin_bottom = 434.0
+rect_min_size = Vector2( 100, 50 )
+size_flags_horizontal = 4
+theme = ExtResource( 2 )
+text = "Button"
+
+[connection signal="pressed" from="VBoxContainer/PressedCheckButton" to="." method="_on_PressedCheckButton_pressed"]
+[connection signal="timeout" from="VBoxContainer/PressedCheckButton/Timer" to="." method="_on_PressedTimer_timeout"]
+[connection signal="pressed" from="VBoxContainer/ChangedCheckButton" to="." method="_on_ChangedCheckButton_pressed"]
+[connection signal="timeout" from="VBoxContainer/ChangedCheckButton/Timer" to="." method="_on_ChangedTimer_timeout"]
+[connection signal="central_button_changed" from="VBoxContainer/LevelButtonScroller" to="." method="_on_LevelButtonScroller_central_button_changed"]
+[connection signal="central_button_pressed" from="VBoxContainer/LevelButtonScroller" to="." method="_on_LevelButtonScroller_central_button_pressed"]

--- a/project/src/demo/ui/level-select/level-button-scroller-demo.gd
+++ b/project/src/demo/ui/level-select/level-button-scroller-demo.gd
@@ -1,0 +1,45 @@
+extends Node
+## Demonstrates the horizontal strip of level buttons which the player can scroll through.
+##
+## Radio buttons light up when signals are fired, to facilitate signal testing. Other buttons are shown to test how
+## the keyboard/gamepad moves focus to and from the scroller.
+
+onready var _changed_button: CheckButton = $VBoxContainer/ChangedCheckButton
+onready var _changed_timer: Timer = $VBoxContainer/ChangedCheckButton/Timer
+onready var _pressed_button: CheckButton = $VBoxContainer/PressedCheckButton
+onready var _pressed_timer: Timer = $VBoxContainer/PressedCheckButton/Timer
+onready var _scroller: LevelButtonScroller = $VBoxContainer/LevelButtonScroller
+
+func _ready() -> void:
+	var region: CareerRegion = CareerLevelLibrary.regions[0]
+	_scroller.populate(region)
+	
+	$VBoxContainer/Button.grab_focus()
+
+
+func _on_ChangedCheckButton_pressed() -> void:
+	if _changed_button.pressed:
+		_changed_timer.start()
+
+
+func _on_ChangedTimer_timeout() -> void:
+	_changed_button.pressed = false
+
+
+func _on_PressedCheckButton_pressed() -> void:
+	if _pressed_button.pressed:
+		_pressed_timer.start()
+
+
+func _on_PressedTimer_timeout() -> void:
+	_pressed_button.pressed = false
+
+
+func _on_LevelButtonScroller_central_button_changed() -> void:
+	_changed_button.pressed = true
+	_changed_timer.start()
+
+
+func _on_LevelButtonScroller_central_button_pressed() -> void:
+	_pressed_button.pressed = true
+	_pressed_timer.start()

--- a/project/src/main/ui/HighScoreTable.tscn
+++ b/project/src/main/ui/HighScoreTable.tscn
@@ -1,13 +1,13 @@
 [gd_scene load_steps=3 format=2]
 
+[ext_resource path="res://src/main/ui/squeak/squeak-theme-gy-h4.tres" type="Theme" id=1]
 [ext_resource path="res://src/main/ui/high-score-table.gd" type="Script" id=2]
-[ext_resource path="res://src/main/ui/theme/h4.theme" type="Theme" id=3]
 
 [node name="HighScoreTable" type="VBoxContainer"]
 margin_right = 412.0
 margin_bottom = 152.0
 size_flags_horizontal = 3
-theme = ExtResource( 3 )
+theme = ExtResource( 1 )
 script = ExtResource( 2 )
 
 [node name="Label" type="Label" parent="."]
@@ -18,9 +18,9 @@ text = "Today's Best"
 align = 1
 
 [node name="GridContainer" type="GridContainer" parent="."]
-margin_top = 24.0
+margin_top = 26.0
 margin_right = 412.0
-margin_bottom = 92.0
+margin_bottom = 94.0
 size_flags_horizontal = 3
 custom_constants/hseparation = 20
 columns = 4

--- a/project/src/main/ui/level-select/LevelButtonScroller.tscn
+++ b/project/src/main/ui/level-select/LevelButtonScroller.tscn
@@ -1,0 +1,43 @@
+[gd_scene load_steps=6 format=2]
+
+[ext_resource path="res://src/main/ui/level-select/level-button-scroller.gd" type="Script" id=1]
+[ext_resource path="res://src/main/ui/level-select/LevelSelectButton.tscn" type="PackedScene" id=2]
+[ext_resource path="res://src/main/ui/level-select/HookableLevelGradeLabel.tscn" type="PackedScene" id=3]
+[ext_resource path="res://src/main/ui/level-select/level-grade-labels.gd" type="Script" id=4]
+[ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=6]
+
+[node name="LevelButtonScroller" type="Control"]
+margin_top = 49.0
+margin_right = 896.0
+margin_bottom = 179.0
+rect_min_size = Vector2( 0, 130 )
+script = ExtResource( 1 )
+LevelSelectButtonScene = ExtResource( 2 )
+
+[node name="LevelButtons" type="HBoxContainer" parent="."]
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+margin_top = -65.0
+margin_bottom = 65.0
+alignment = 1
+
+[node name="LevelSelectButton" parent="LevelButtons" instance=ExtResource( 2 )]
+margin_left = 388.0
+margin_top = 25.0
+margin_right = 508.0
+margin_bottom = 105.0
+size_flags_horizontal = 4
+size_flags_vertical = 4
+
+[node name="GradeLabels" type="Control" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+script = ExtResource( 4 )
+GradeLabelScene = ExtResource( 3 )
+
+[node name="CheatCodeDetector" parent="." instance=ExtResource( 6 )]
+codes = [ "unlock" ]
+
+[connection signal="cheat_detected" from="CheatCodeDetector" to="." method="_on_CheatCodeDetector_cheat_detected"]

--- a/project/src/main/ui/level-select/LevelSelectButton.tscn
+++ b/project/src/main/ui/level-select/LevelSelectButton.tscn
@@ -12,7 +12,7 @@ outline_size = 2
 outline_color = Color( 0.423529, 0.262745, 0.192157, 1 )
 font_data = ExtResource( 1 )
 
-[node name="Control" type="Control"]
+[node name="LevelSelectButton" type="Control"]
 margin_right = 120.0
 margin_bottom = 80.0
 rect_min_size = Vector2( 120, 80 )

--- a/project/src/main/ui/level-select/hookable-level-grade-label.gd
+++ b/project/src/main/ui/level-select/hookable-level-grade-label.gd
@@ -22,6 +22,11 @@ func _enter_tree() -> void:
 	_status_icon = $StatusIcon
 
 
+func _process(_delta: float) -> void:
+	modulate.a = button.modulate.a
+	visible = button.visible
+
+
 ## Assigns this label's button, and updates the label's appearance.
 func set_button(new_button: LevelSelectButton) -> void:
 	if button == new_button:

--- a/project/src/main/ui/level-select/level-button-scroller.gd
+++ b/project/src/main/ui/level-select/level-button-scroller.gd
@@ -1,0 +1,282 @@
+class_name LevelButtonScroller
+extends Control
+## Shows a horizontal strip of level buttons which the player can scroll through.
+##
+## Shows a promiment 'central button' with several other secondary translucent buttons beside it.
+
+## Emitted when the central button is pressed.
+signal central_button_pressed
+
+## Emitted when a new central button is selected, such as when the scroller scrolls left and right.
+signal central_button_changed
+
+## Threshold below which the secondary buttons are not interactable.
+const INVISIBLE_BUTTON_THRESHOLD := 0.10
+
+export (PackedScene) var LevelSelectButtonScene: PackedScene
+
+var central_button_index: int setget set_central_button_index
+
+## CareerRegion/OtherRegion instance for the _region whose levels should be shown
+var _region: Object
+
+var _level_ids: Array
+
+## 'true' if the player has temporarily unlocked all levels with a cheat code
+var _unlock_cheat_enabled := false
+
+## key: (String) level id
+## value: (LevelSettings) level settings for the level id
+var _level_settings_by_id: Dictionary = {}
+
+## Smoothly scrolls the level buttons
+var _tween: SceneTreeTween
+
+## true if the central_button_index changed this frame
+var _central_button_just_changed := false
+
+## true if the current 'button_down' even corresponds to the central button
+var _central_button_down := true
+
+onready var _level_buttons_container: HBoxContainer = $LevelButtons
+onready var _grade_labels := $GradeLabels
+
+func _input(event: InputEvent) -> void:
+	if _level_button_has_focus() and event.is_action_pressed("ui_right"):
+		# scroll level buttons right, if possible
+		if central_button_index < _level_buttons_container.get_child_count() - 1:
+			_slide_central_button(central_button_index + 1)
+			_central_button().grab_focus()
+		get_tree().set_input_as_handled()
+
+	if _level_button_has_focus() and event.is_action_pressed("ui_left"):
+		# scroll level buttons left, if possible
+		if central_button_index > 0:
+			_slide_central_button(central_button_index - 1)
+			_central_button().grab_focus()
+		get_tree().set_input_as_handled()
+
+
+func _process(_delta: float) -> void:
+	_central_button_just_changed = false
+	
+	for button in _level_buttons_container.get_children():
+		# Update the button's transparency. The further from the center, the more transparent it is
+		var button_relative_position: Vector2 = button.get_global_rect().get_center() - get_global_rect().get_center()
+		var alpha := clamp(inverse_lerp(rect_size.x * 0.4, 20, abs(button_relative_position.x)), 0, 1)
+		alpha = pow(alpha, 1.3)
+		button.modulate = Utils.to_transparent(Color.white, alpha)
+		
+		# Update the button's focus mode. If it falls below a threshold, it is not interactable.
+		if button.modulate.a < INVISIBLE_BUTTON_THRESHOLD and button.get_focus_mode() == FOCUS_CLICK:
+			button.set_focus_mode(FOCUS_NONE)
+		if button.modulate.a >= INVISIBLE_BUTTON_THRESHOLD and button.get_focus_mode() == FOCUS_NONE:
+			button.set_focus_mode(FOCUS_CLICK)
+
+
+## Populate the scroller with a new set of level buttons.
+##
+## Parameters:
+## 	'new_region': A CareerRegion/OtherRegion instance for the region whose levels should be shown
+##
+## 	'default_level_id': The level whose button is focused after populating the scroller
+func populate(new_region: Object, default_level_id: String = "") -> void:
+	_level_ids = []
+	_region = new_region
+	if _region is CareerRegion:
+		for career_level in _region.levels:
+			_level_ids.append(career_level.level_id)
+		if _region.boss_level and not _region.boss_level.level_id in _level_ids:
+			_level_ids.append(_region.boss_level.level_id)
+		if _region.intro_level and not _region.intro_level.level_id in _level_ids:
+			_level_ids.append(_region.intro_level.level_id)
+	else:
+		_level_ids.append_array(_region.level_ids)
+
+	_refresh()
+	if default_level_id:
+		yield(get_tree(), "idle_frame")
+		set_central_button_index(_level_ids.find(default_level_id))
+
+
+func set_central_button_index(new_central_button_index: int) -> void:
+	if central_button_index == new_central_button_index:
+		return
+	
+	central_button_index = new_central_button_index
+	_central_button_just_changed = true
+	_refresh_central_button_index(false)
+	emit_signal("central_button_changed")
+
+
+## Steals the focus from another control and becomes the focused control.
+##
+## This control itself doesn't have focus, so we delegate to a child control.
+func grab_focus() -> void:
+	_central_button().grab_focus()
+
+
+func get_level_settings() -> LevelSettings:
+	return _level_settings_by_id[_level_ids[central_button_index]]
+
+
+func get_lock_status() -> int:
+	return _central_button().lock_status
+
+
+## Refreshes the buttons and arrows based on our current properties.
+##
+## Removes all buttons and adds new buttons for the current page. Enables/disables the paging arrows, hiding them if
+## the player only has access to a single page of levels.
+func _refresh() -> void:
+	_clear_contents()
+	_refresh_level_settings()
+	_add_buttons()
+
+
+## Removes all buttons
+func _clear_contents() -> void:
+	for child in _level_buttons_container.get_children():
+		_level_buttons_container.remove_child(child)
+		child.queue_free()
+
+
+## Loads the level settings and sorts the level ids by their name
+func _refresh_level_settings() -> void:
+	for level_id in _level_ids:
+		var level_settings := LevelSettings.new()
+		level_settings.load_from_resource(level_id)
+		_level_settings_by_id[level_id] = level_settings
+
+	# Sort the levels
+	if _region is CareerRegion:
+		# Career levels aren't in any particular order so we sort them.
+		_level_ids.sort_custom(self, "_compare_by_level_name")
+	else:
+		# Training/tutorial levels are already sorted from easiest to hardest.
+		pass
+
+
+func _compare_by_level_name(a: String, b: String) -> bool:
+	return _level_settings_by_id[b].name > _level_settings_by_id[a].name
+
+
+## Creates and adds the level buttons.
+func _add_buttons() -> void:
+	if _level_ids.empty():
+		# avoid out of bounds errors when there are zero levels
+		return
+
+	# create and add the level buttons
+	for i in range(_level_ids.size()):
+		var new_level_button: LevelSelectButton = _level_select_button(_level_ids[i])
+		_grade_labels.add_label(new_level_button)
+
+	# make the first button focusable
+	central_button_index = 0
+	_central_button_just_changed = true
+	_refresh_central_button_index(false)
+
+
+## Smoothly slides a new button into into the center.
+func _slide_central_button(new_central_button_index: int) -> void:
+	if central_button_index == new_central_button_index:
+		return
+	
+	central_button_index = new_central_button_index
+	_central_button_just_changed = true
+	_refresh_central_button_index(true)
+	emit_signal("central_button_changed")
+
+
+## Moves a new button into the center.
+##
+## Parameters:
+## 	'animate': If true, the button smoothly slides into the center.
+func _refresh_central_button_index(animate: bool = true) -> void:
+	if not _level_buttons_container.get_children():
+		return
+	
+	# set appropriate focus_mode for all level select buttons
+	for child in _level_buttons_container.get_children():
+		child.set_focus_mode(Control.FOCUS_CLICK)
+	_central_button().set_focus_mode(Control.FOCUS_ALL)
+	
+	# move all buttons so the central button appears in the center
+	var target_x: float = get_parent().rect_size.x / 2 \
+			- _central_button().rect_position.x - _central_button().rect_size.x / 2
+	if animate:
+		_tween = Utils.recreate_tween(self, _tween)
+		_tween.tween_property(_level_buttons_container, "rect_position:x", target_x, 0.4) \
+			.set_trans(Tween.TRANS_CIRC).set_ease(Tween.EASE_OUT)
+	else:
+		_tween = Utils.kill_tween(_tween)
+		_level_buttons_container.rect_position.x = target_x
+
+
+func _central_button() -> LevelSelectButton:
+	return _level_buttons_container.get_children()[central_button_index]
+
+
+## Returns 'true' if any level button in this container has focus.
+func _level_button_has_focus() -> bool:
+	var result := false
+	for child in _level_buttons_container.get_children():
+		if child.has_focus():
+			result = true
+			break
+	return result
+
+
+## Adds a new level select button to the scene tree.
+##
+## Parameters:
+## 	'settings': The level settings which control the button's appearance.
+func _level_select_button(level_id: String) -> LevelSelectButton:
+	var settings: LevelSettings = _level_settings_by_id[level_id]
+	var button: LevelSelectButton = LevelSelectButtonScene.instance()
+	button.decorate_for_level(_region, settings, _unlock_cheat_enabled)
+	button.size_flags_horizontal = 4
+	button.size_flags_vertical = 4
+	
+	button.connect("button_down", self, "_on_LevelSelectButton_button_down")
+	button.connect("pressed", self, "_on_LevelSelectButton_pressed", [button])
+	button.connect("focus_entered", self, "_on_LevelSelectButton_focus_entered", \
+			[_level_buttons_container.get_child_count()])
+	_level_buttons_container.add_child(button)
+
+	_grade_labels.add_label(button)
+	return button
+
+
+func _on_LevelSelectButton_focus_entered(button_index: int) -> void:
+	_slide_central_button(button_index)
+
+
+func _on_LevelSelectButton_button_down() -> void:
+	if _central_button_just_changed:
+		_central_button_down = false
+
+
+func _on_LevelSelectButton_pressed(button: LevelSelectButton) -> void:
+	if button.modulate.a < INVISIBLE_BUTTON_THRESHOLD:
+		return
+	
+	if _central_button_down:
+		emit_signal("central_button_pressed")
+	_central_button_down = true
+
+
+func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDetector) -> void:
+	if cheat == "unlock":
+		_unlock_cheat_enabled = !_unlock_cheat_enabled
+		detector.play_cheat_sound(_unlock_cheat_enabled)
+		var old_central_button_index := central_button_index
+		var old_level_button_has_focus := _level_button_has_focus()
+		
+		_refresh()
+		
+		yield(get_tree(), "idle_frame")
+		set_central_button_index(old_central_button_index)
+		if old_level_button_has_focus:
+			grab_focus()

--- a/project/src/main/ui/level-select/level-select-button.gd
+++ b/project/src/main/ui/level-select/level-select-button.gd
@@ -4,8 +4,14 @@ extends Control
 ##
 ## The button adjusts its rect_min_size based on level duration.
 
-## emitted when a level is launched.
+## emitted when the button is pressed, if the level is not locked.
 signal level_chosen
+
+## emitted when the button is pressed.
+signal pressed
+
+## emitted when the button starts being held down.
+signal button_down
 
 ## short levels have smaller buttons; long levels have larger buttons
 enum LevelSize {
@@ -173,6 +179,20 @@ func grab_focus() -> void:
 	_button_control.grab_focus()
 
 
+## Assigns the focus access mode for the control (None, Click or All).
+##
+## For cosmetic reasons, this control itself doesn't have a focus mode, but the child button control does.
+func set_focus_mode(new_button_focus_mode: int) -> void:
+	_button_control.focus_mode = new_button_focus_mode
+
+
+## Returns the focus access mode for the control (None, Click or All).
+##
+## For cosmetic reasons, this control itself doesn't have a focus mode, but the child button control does.
+func get_focus_mode() -> int:
+	return _button_control.focus_mode
+
+
 ## Updates the button's text, colors, size and icon based on the level and its status.
 func _refresh_appearance() -> void:
 	if not is_inside_tree():
@@ -211,11 +231,9 @@ func _on_resized() -> void:
 
 
 func _on_ButtonControl_pressed() -> void:
-	if lock_status == STATUS_LOCKED:
-		# level is locked, don't launch the level
-		return
+	emit_signal("pressed")
 	
-	if _emit_level_chosen:
+	if lock_status != STATUS_LOCKED and _emit_level_chosen:
 		_emit_level_chosen = false
 		emit_signal("level_chosen")
 
@@ -236,6 +254,8 @@ func _on_ButtonControl_focus_exited() -> void:
 
 
 func _on_ButtonControl_button_down() -> void:
+	emit_signal("button_down")
+	
 	if _focus_just_entered:
 		pass
 	else:

--- a/project/src/main/ui/menu/TrainingMenu.tscn
+++ b/project/src/main/ui/menu/TrainingMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=46 format=2]
+[gd_scene load_steps=47 format=2]
 
 [ext_resource path="res://src/main/ui/menu/PagedRegionPanel.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/ui/ImageButton.tscn" type="PackedScene" id=2]
@@ -8,17 +8,17 @@
 [ext_resource path="res://src/main/ui/theme/h4.theme" type="Theme" id=6]
 [ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=7]
 [ext_resource path="res://src/main/ui/candy-button/gradient-blue-normal.tres" type="Gradient" id=8]
-[ext_resource path="res://src/main/ui/theme/h3.theme" type="Theme" id=9]
+[ext_resource path="res://src/main/ui/level-select/LevelButtonScroller.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/ui/menu/drop-panel.tres" type="StyleBox" id=10]
 [ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=11]
-[ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=12]
+[ext_resource path="res://src/main/ui/squeak/squeak-theme-gy-h4.tres" type="Theme" id=12]
 [ext_resource path="res://src/main/ui/HighScoreTable.tscn" type="PackedScene" id=13]
-[ext_resource path="res://src/main/ui/menu/mode-buttongroup.tres" type="ButtonGroup" id=14]
+[ext_resource path="res://src/main/ui/theme/h3-font-outline.tres" type="DynamicFont" id=14]
 [ext_resource path="res://src/main/ui/menu/PagedLevelPanel.tscn" type="PackedScene" id=15]
 [ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=16]
-[ext_resource path="res://src/main/ui/theme/h2-font-outline.tres" type="DynamicFont" id=17]
-[ext_resource path="res://assets/main/ui/menu/menu-accent-h2-m2.png" type="Texture" id=18]
-[ext_resource path="res://src/main/ui/menu/MenuAccentH2.tscn" type="PackedScene" id=19]
+[ext_resource path="res://src/main/ui/menu/MenuAccentH3.tscn" type="PackedScene" id=17]
+[ext_resource path="res://assets/main/ui/menu/menu-accent-h2-s1.png" type="Texture" id=18]
+[ext_resource path="res://src/main/ui/squeak/squeak-theme-br-h4.tres" type="Theme" id=19]
 [ext_resource path="res://assets/main/ui/candy-button/h3-t-pressed.png" type="Texture" id=20]
 [ext_resource path="res://src/main/ui/candy-button/gradient-red-normal.tres" type="Gradient" id=21]
 [ext_resource path="res://src/main/ui/menu/region-submenu.gd" type="Script" id=22]
@@ -37,6 +37,13 @@
 [ext_resource path="res://assets/main/ui/candy-button/h4-o-pressed.png" type="Texture" id=35]
 [ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=36]
 [ext_resource path="res://src/main/ui/UiMenuShortcut.tres" type="ShortCut" id=37]
+
+[sub_resource type="StyleBoxFlat" id=12]
+bg_color = Color( 0.423529, 0.262745, 0.192157, 1 )
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+corner_radius_bottom_right = 12
+corner_radius_bottom_left = 12
 
 [sub_resource type="GradientTexture2D" id=6]
 resource_local_to_scene = true
@@ -80,7 +87,7 @@ anchor_bottom = 1.0
 rect_min_size = Vector2( 1024, 600 )
 script = ExtResource( 33 )
 high_scores_path = NodePath("MainMenu/DropPanel/VBoxContainer/HighScores")
-level_button_path = NodePath("MainMenu/DropPanel/VBoxContainer/Level/ButtonHolder/Button")
+level_button_scroller_path = NodePath("MainMenu/DropPanel/VBoxContainer/Level/LevelButtonScroller")
 level_description_label_path = NodePath("MainMenu/DropPanel/VBoxContainer/Level/Desc")
 speed_selector_path = NodePath("MainMenu/DropPanel/VBoxContainer/Speed")
 start_button_path = NodePath("MainMenu/DropPanel/VBoxContainer/System/Start")
@@ -107,101 +114,98 @@ margin_left = 14.0
 margin_top = 14.0
 margin_right = -14.0
 margin_bottom = -14.0
-custom_constants/separation = 20
+custom_constants/separation = 5
 
 [node name="Level" type="VBoxContainer" parent="MainMenu/DropPanel/VBoxContainer"]
 margin_right = 896.0
-margin_bottom = 109.0
+margin_bottom = 188.0
+rect_min_size = Vector2( 0, 160 )
 
 [node name="Title" type="Label" parent="MainMenu/DropPanel/VBoxContainer/Level"]
 margin_right = 896.0
-margin_bottom = 45.0
+margin_bottom = 30.0
 size_flags_horizontal = 3
-size_flags_vertical = 3
-custom_fonts/font = ExtResource( 17 )
+size_flags_vertical = 1
+custom_fonts/font = ExtResource( 14 )
 text = "Level"
 align = 1
 valign = 1
 
-[node name="MenuAccentH2" parent="MainMenu/DropPanel/VBoxContainer/Level/Title" instance=ExtResource( 19 )]
-margin_left = -112.5
+[node name="MenuAccentH3" parent="MainMenu/DropPanel/VBoxContainer/Level/Title" instance=ExtResource( 17 )]
+margin_left = -87.5
 margin_top = -37.5
-margin_right = 112.5
+margin_right = 87.5
 margin_bottom = 37.5
+texture = ExtResource( 18 )
 
-[node name="ButtonHolder" type="Control" parent="MainMenu/DropPanel/VBoxContainer/Level"]
-margin_top = 49.0
-margin_right = 896.0
-margin_bottom = 85.0
-rect_min_size = Vector2( 0, 36 )
-
-[node name="Button" type="Button" parent="MainMenu/DropPanel/VBoxContainer/Level/ButtonHolder" groups=["main_practice_inputs"]]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -300.0
-margin_top = -18.0
-margin_right = 300.0
-margin_bottom = 18.0
-rect_min_size = Vector2( 600, 0 )
-theme = ExtResource( 9 )
-shortcut_in_tooltip = false
-group = ExtResource( 14 )
-text = "Sprint: Normal"
+[node name="LevelButtonScroller" parent="MainMenu/DropPanel/VBoxContainer/Level" instance=ExtResource( 9 )]
+margin_top = 34.0
+margin_bottom = 164.0
 
 [node name="Desc" type="Label" parent="MainMenu/DropPanel/VBoxContainer/Level"]
-margin_top = 89.0
+margin_top = 168.0
 margin_right = 896.0
-margin_bottom = 109.0
+margin_bottom = 188.0
 size_flags_horizontal = 3
-size_flags_vertical = 3
+size_flags_vertical = 1
 theme = ExtResource( 6 )
 text = "Score 200 points as quickly as possible!"
 align = 1
 valign = 1
 
 [node name="Speed" type="VBoxContainer" parent="MainMenu/DropPanel/VBoxContainer"]
-margin_top = 154.0
+margin_top = 202.0
 margin_right = 896.0
-margin_bottom = 243.0
+margin_bottom = 284.0
 size_flags_vertical = 6
 script = ExtResource( 34 )
 
 [node name="Title" type="Label" parent="MainMenu/DropPanel/VBoxContainer/Speed"]
 margin_right = 896.0
-margin_bottom = 45.0
+margin_bottom = 30.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-custom_fonts/font = ExtResource( 17 )
+custom_fonts/font = ExtResource( 14 )
 text = "Speed"
 align = 1
 valign = 1
 
-[node name="MenuAccentH2" parent="MainMenu/DropPanel/VBoxContainer/Speed/Title" instance=ExtResource( 19 )]
-margin_left = -112.5
+[node name="MenuAccentH3" parent="MainMenu/DropPanel/VBoxContainer/Speed/Title" instance=ExtResource( 17 )]
+margin_left = -87.5
 margin_top = -37.5
-margin_right = 112.5
+margin_right = 87.5
 margin_bottom = 37.5
 texture = ExtResource( 18 )
-_accent_index = 1
 
-[node name="Slider" type="HSlider" parent="MainMenu/DropPanel/VBoxContainer/Speed" groups=["main_practice_inputs"]]
-margin_left = 148.0
-margin_top = 49.0
-margin_right = 748.0
-margin_bottom = 65.0
+[node name="SliderPanel" type="Panel" parent="MainMenu/DropPanel/VBoxContainer/Speed"]
+margin_left = 144.0
+margin_top = 34.0
+margin_right = 752.0
+margin_bottom = 58.0
+rect_min_size = Vector2( 608, 24 )
+size_flags_horizontal = 4
+custom_styles/panel = SubResource( 12 )
+
+[node name="Slider" type="HSlider" parent="MainMenu/DropPanel/VBoxContainer/Speed/SliderPanel" groups=["main_practice_inputs"]]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -300.0
+margin_top = -9.0
+margin_right = 300.0
+margin_bottom = 9.0
 rect_min_size = Vector2( 600, 0 )
 size_flags_horizontal = 4
-theme = ExtResource( 6 )
+theme = ExtResource( 19 )
 max_value = 3.0
 tick_count = 4
 
 [node name="Labels" type="HBoxContainer" parent="MainMenu/DropPanel/VBoxContainer/Speed"]
 margin_left = 144.0
-margin_top = 69.0
+margin_top = 62.0
 margin_right = 752.0
-margin_bottom = 89.0
+margin_bottom = 82.0
 rect_min_size = Vector2( 608, 0 )
 size_flags_horizontal = 4
 theme = ExtResource( 6 )
@@ -295,6 +299,12 @@ text = "Quit"
 color = 1
 shape = 5
 
+[node name="Spacer" type="Control" parent="MainMenu/DropPanel/VBoxContainer"]
+margin_top = 433.0
+margin_right = 896.0
+margin_bottom = 443.0
+rect_min_size = Vector2( 0, 10 )
+
 [node name="HighScores" type="Panel" parent="MainMenu/DropPanel/VBoxContainer"]
 margin_left = 48.0
 margin_top = 448.0
@@ -303,7 +313,7 @@ margin_bottom = 552.0
 rect_min_size = Vector2( 800, 104 )
 size_flags_horizontal = 4
 size_flags_vertical = 4
-custom_styles/panel = ExtResource( 12 )
+theme = ExtResource( 12 )
 script = ExtResource( 3 )
 
 [node name="Tables" type="HBoxContainer" parent="MainMenu/DropPanel/VBoxContainer/HighScores"]
@@ -424,9 +434,10 @@ action = "ui_cancel"
 
 [node name="MusicPopup" parent="." instance=ExtResource( 16 )]
 
-[connection signal="pressed" from="MainMenu/DropPanel/VBoxContainer/Level/ButtonHolder/Button" to="." method="_on_LevelButton_pressed"]
+[connection signal="central_button_changed" from="MainMenu/DropPanel/VBoxContainer/Level/LevelButtonScroller" to="." method="_on_LevelButtonScroller_central_button_changed"]
+[connection signal="central_button_pressed" from="MainMenu/DropPanel/VBoxContainer/Level/LevelButtonScroller" to="." method="_on_LevelButtonScroller_central_button_pressed"]
 [connection signal="speed_changed" from="MainMenu/DropPanel/VBoxContainer/Speed" to="." method="_on_SpeedSelector_speed_changed"]
-[connection signal="value_changed" from="MainMenu/DropPanel/VBoxContainer/Speed/Slider" to="MainMenu/DropPanel/VBoxContainer/Speed" method="_on_Slider_value_changed"]
+[connection signal="value_changed" from="MainMenu/DropPanel/VBoxContainer/Speed/SliderPanel/Slider" to="MainMenu/DropPanel/VBoxContainer/Speed" method="_on_Slider_value_changed"]
 [connection signal="pressed" from="MainMenu/DropPanel/VBoxContainer/System/Start" to="." method="_on_Start_pressed"]
 [connection signal="pressed" from="MainMenu/DropPanel/VBoxContainer/System/Settings" to="SettingsMenu" method="_on_Settings_pressed"]
 [connection signal="pressed" from="MainMenu/DropPanel/VBoxContainer/System/Quit" to="MainMenu/DropPanel/VBoxContainer/System" method="_on_Quit_pressed"]

--- a/project/src/main/ui/menu/training-speed-selector.gd
+++ b/project/src/main/ui/menu/training-speed-selector.gd
@@ -11,7 +11,7 @@ var speed_names: Array setget set_speed_names
 ## If true, the slider can be interacted with. If false, the value can be changed only by code.
 var editable: bool = false setget set_editable
 
-onready var _slider := $Slider
+onready var _slider := $SliderPanel/Slider
 onready var _labels := $Labels
 
 func set_editable(new_editable: bool) -> void:
@@ -69,7 +69,7 @@ func _refresh_labels() -> void:
 	# toggle color based on editable property
 	for i in range(_labels.get_child_count()):
 		var label: Label = _labels.get_child(i)
-		label.set("custom_colors/font_color", Color.white if editable else Color.black)
+		label.set("custom_colors/font_color", Color.white if editable else Color("41281e"))
 	
 	# outermost labels take up less space; this helps the ticks align better
 	if _labels.get_child_count() > 0:


### PR DESCRIPTION
The training menu previously used an undecorated button which was very wide, and would have been difficult to reskin as a candy button given its width.

The training menu now uses a 'LevelButtonScroller' which uses the same button style as the career mode and level picker. We'd like to eventually amp up these buttons to include some icons or fancy graphics, so that will help this screen look a bit prettier too.

The training menu's high score table now uses the 'squeak-theme-gy' variant, instead of an undecorated 'h4' theme.