### PR TITLE
Improved level/chapter next/prev buttons

### DIFF
--- a/project/src/main/career/ui/CareerRegionSelectMenu.tscn
+++ b/project/src/main/career/ui/CareerRegionSelectMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=23 format=2]
+[gd_scene load_steps=24 format=2]
 
 [ext_resource path="res://src/main/ui/theme/h2.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=2]
@@ -8,9 +8,9 @@
 [ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=6]
 [ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=7]
 [ext_resource path="res://src/main/ui/ImageButton.tscn" type="PackedScene" id=8]
+[ext_resource path="res://src/main/ui/squeak/gy/SqueakButton.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/ui/RegionSelectButton.tscn" type="PackedScene" id=10]
 [ext_resource path="res://src/main/ui/menu/drop-panel.tres" type="StyleBox" id=11]
-[ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=12]
 [ext_resource path="res://assets/main/ui/touch/close.png" type="Texture" id=13]
 [ext_resource path="res://assets/main/ui/touch/close-pressed.png" type="Texture" id=14]
 [ext_resource path="res://src/main/ui/menu/career-region-select-menu.gd" type="Script" id=15]
@@ -19,6 +19,7 @@
 [ext_resource path="res://src/main/ui/menu/region-grade-labels.gd" type="Script" id=18]
 [ext_resource path="res://src/main/ui/menu/paged-region-buttons.gd" type="Script" id=19]
 [ext_resource path="res://src/main/ui/theme/h4.theme" type="Theme" id=20]
+[ext_resource path="res://src/main/ui/squeak/gy/squeak-theme-h4.tres" type="Theme" id=21]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 5.0
@@ -105,14 +106,16 @@ alignment = 1
 script = ExtResource( 19 )
 RegionButtonScene = ExtResource( 10 )
 
-[node name="LeftArrow" type="Button" parent="RegionSelect/VBoxContainer/Top/RegionButtons"]
+[node name="LeftArrow" parent="RegionSelect/VBoxContainer/Top/RegionButtons" instance=ExtResource( 9 )]
 margin_left = 374.0
-margin_top = 132.0
+margin_top = 130.0
 margin_right = 398.0
-margin_bottom = 158.0
+margin_bottom = 159.0
 rect_min_size = Vector2( 24, 24 )
+focus_mode = 1
 size_flags_vertical = 4
-theme = ExtResource( 20 )
+theme = ExtResource( 21 )
+enabled_focus_mode = 1
 text = "<"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="RegionSelect/VBoxContainer/Top/RegionButtons"]
@@ -125,14 +128,16 @@ custom_constants/separation = 5
 
 [node name="RegionButton" parent="RegionSelect/VBoxContainer/Top/RegionButtons/HBoxContainer" instance=ExtResource( 10 )]
 
-[node name="RightArrow" type="Button" parent="RegionSelect/VBoxContainer/Top/RegionButtons"]
+[node name="RightArrow" parent="RegionSelect/VBoxContainer/Top/RegionButtons" instance=ExtResource( 9 )]
 margin_left = 506.0
-margin_top = 132.0
+margin_top = 130.0
 margin_right = 530.0
-margin_bottom = 158.0
+margin_bottom = 159.0
 rect_min_size = Vector2( 24, 24 )
+focus_mode = 1
 size_flags_vertical = 4
-theme = ExtResource( 20 )
+theme = ExtResource( 21 )
+enabled_focus_mode = 1
 text = ">"
 
 [node name="GradeLabels" type="Control" parent="RegionSelect/VBoxContainer/Top"]
@@ -151,12 +156,12 @@ rect_min_size = Vector2( 0, 100 )
 [node name="HBoxContainer" type="HBoxContainer" parent="RegionSelect/VBoxContainer/Bottom"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+theme = ExtResource( 21 )
 
 [node name="Description" type="Panel" parent="RegionSelect/VBoxContainer/Bottom/HBoxContainer"]
-margin_right = 450.0
+margin_right = 449.0
 margin_bottom = 100.0
 size_flags_horizontal = 3
-custom_styles/panel = ExtResource( 12 )
 script = ExtResource( 16 )
 
 [node name="MarginContainer" type="MarginContainer" parent="RegionSelect/VBoxContainer/Bottom/HBoxContainer/Description"]
@@ -170,7 +175,7 @@ custom_constants/margin_bottom = 5
 [node name="Label" type="Label" parent="RegionSelect/VBoxContainer/Bottom/HBoxContainer/Description/MarginContainer"]
 margin_left = 20.0
 margin_top = 5.0
-margin_right = 430.0
+margin_right = 429.0
 margin_bottom = 95.0
 size_flags_vertical = 1
 theme = ExtResource( 20 )
@@ -179,11 +184,10 @@ valign = 1
 autowrap = true
 
 [node name="Info" type="Panel" parent="RegionSelect/VBoxContainer/Bottom/HBoxContainer"]
-margin_left = 454.0
+margin_left = 455.0
 margin_right = 904.0
 margin_bottom = 100.0
 size_flags_horizontal = 3
-custom_styles/panel = ExtResource( 12 )
 script = ExtResource( 17 )
 
 [node name="MarginContainer" type="MarginContainer" parent="RegionSelect/VBoxContainer/Bottom/HBoxContainer/Info"]
@@ -197,7 +201,7 @@ custom_constants/margin_bottom = 5
 [node name="Label" type="Label" parent="RegionSelect/VBoxContainer/Bottom/HBoxContainer/Info/MarginContainer"]
 margin_left = 20.0
 margin_top = 5.0
-margin_right = 430.0
+margin_right = 429.0
 margin_bottom = 95.0
 size_flags_vertical = 1
 theme = ExtResource( 20 )

--- a/project/src/main/ui/menu/PagedLevelPanel.tscn
+++ b/project/src/main/ui/menu/PagedLevelPanel.tscn
@@ -1,12 +1,13 @@
-[gd_scene load_steps=13 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://src/main/ui/level-select/LevelSelectButton.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/ui/level-select/HookableLevelGradeLabel.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=3]
+[ext_resource path="res://src/main/ui/squeak/gy/SqueakButton.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/ui/menu/paged-level-buttons.gd" type="Script" id=5]
+[ext_resource path="res://src/main/ui/squeak/gy/squeak-theme-h4.tres" type="Theme" id=6]
 [ext_resource path="res://src/main/ui/menu/paged-level-panel.gd" type="Script" id=7]
 [ext_resource path="res://src/main/ui/level-select/level-submenu-info-panel.gd" type="Script" id=8]
-[ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=9]
 [ext_resource path="res://src/main/ui/level-select/level-grade-labels.gd" type="Script" id=10]
 [ext_resource path="res://src/main/ui/level-select/level-submenu-description-panel.gd" type="Script" id=11]
 [ext_resource path="res://src/main/ui/theme/h2.theme" type="Theme" id=13]
@@ -73,37 +74,38 @@ alignment = 1
 script = ExtResource( 5 )
 LevelButtonScene = ExtResource( 1 )
 
-[node name="LeftArrow" type="Button" parent="VBoxContainer/Top/LevelButtons"]
-margin_left = 354.0
-margin_top = 132.0
-margin_right = 378.0
-margin_bottom = 158.0
+[node name="LeftArrow" parent="VBoxContainer/Top/LevelButtons" instance=ExtResource( 4 )]
+margin_left = 364.0
+margin_top = 130.0
+margin_right = 388.0
+margin_bottom = 159.0
 rect_min_size = Vector2( 24, 24 )
+focus_mode = 1
 size_flags_vertical = 4
-theme = ExtResource( 14 )
+theme = ExtResource( 6 )
+enabled_focus_mode = 1
 text = "<"
 
 [node name="GridContainer" type="GridContainer" parent="VBoxContainer/Top/LevelButtons"]
-margin_left = 382.0
-margin_top = 115.0
-margin_right = 522.0
-margin_bottom = 175.0
+margin_left = 392.0
+margin_top = 105.0
+margin_right = 512.0
+margin_bottom = 185.0
 size_flags_vertical = 4
 columns = 6
 
 [node name="Button" parent="VBoxContainer/Top/LevelButtons/GridContainer" instance=ExtResource( 1 )]
-margin_right = 140.0
-margin_bottom = 60.0
-rect_min_size = Vector2( 140, 60 )
 
-[node name="RightArrow" type="Button" parent="VBoxContainer/Top/LevelButtons"]
-margin_left = 526.0
-margin_top = 132.0
-margin_right = 550.0
-margin_bottom = 158.0
+[node name="RightArrow" parent="VBoxContainer/Top/LevelButtons" instance=ExtResource( 4 )]
+margin_left = 516.0
+margin_top = 130.0
+margin_right = 540.0
+margin_bottom = 159.0
 rect_min_size = Vector2( 24, 24 )
+focus_mode = 1
 size_flags_vertical = 4
-theme = ExtResource( 14 )
+theme = ExtResource( 6 )
+enabled_focus_mode = 1
 text = ">"
 
 [node name="GradeLabels" type="Control" parent="VBoxContainer/Top"]
@@ -122,12 +124,12 @@ rect_min_size = Vector2( 0, 100 )
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/Bottom"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+theme = ExtResource( 6 )
 
 [node name="Description" type="Panel" parent="VBoxContainer/Bottom/HBoxContainer"]
-margin_right = 450.0
+margin_right = 449.0
 margin_bottom = 100.0
 size_flags_horizontal = 3
-custom_styles/panel = ExtResource( 9 )
 script = ExtResource( 11 )
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/Bottom/HBoxContainer/Description"]
@@ -141,7 +143,7 @@ custom_constants/margin_bottom = 5
 [node name="Label" type="Label" parent="VBoxContainer/Bottom/HBoxContainer/Description/MarginContainer"]
 margin_left = 20.0
 margin_top = 5.0
-margin_right = 430.0
+margin_right = 429.0
 margin_bottom = 95.0
 size_flags_vertical = 1
 theme = ExtResource( 14 )
@@ -150,11 +152,10 @@ valign = 1
 autowrap = true
 
 [node name="Info" type="Panel" parent="VBoxContainer/Bottom/HBoxContainer"]
-margin_left = 454.0
+margin_left = 455.0
 margin_right = 904.0
 margin_bottom = 100.0
 size_flags_horizontal = 3
-custom_styles/panel = ExtResource( 9 )
 script = ExtResource( 8 )
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/Bottom/HBoxContainer/Info"]
@@ -168,7 +169,7 @@ custom_constants/margin_bottom = 5
 [node name="Label" type="Label" parent="VBoxContainer/Bottom/HBoxContainer/Info/MarginContainer"]
 margin_left = 20.0
 margin_top = 5.0
-margin_right = 430.0
+margin_right = 429.0
 margin_bottom = 95.0
 size_flags_vertical = 1
 theme = ExtResource( 14 )

--- a/project/src/main/ui/menu/PagedRegionPanel.tscn
+++ b/project/src/main/ui/menu/PagedRegionPanel.tscn
@@ -1,10 +1,10 @@
 [gd_scene load_steps=13 format=2]
 
-[ext_resource path="res://src/main/puzzle/PuzzleHudStyleBox.tres" type="StyleBox" id=1]
+[ext_resource path="res://src/main/ui/squeak/gy/squeak-theme-h4.tres" type="Theme" id=1]
 [ext_resource path="res://src/main/ui/menu/region-grade-labels.gd" type="Script" id=2]
 [ext_resource path="res://src/main/ui/menu/region-info-panel.gd" type="Script" id=3]
 [ext_resource path="res://src/main/ui/menu/region-description-panel.gd" type="Script" id=4]
-[ext_resource path="res://src/main/ui/theme/h4.theme" type="Theme" id=5]
+[ext_resource path="res://src/main/ui/squeak/gy/SqueakButton.tscn" type="PackedScene" id=5]
 [ext_resource path="res://src/main/ui/theme/h2.theme" type="Theme" id=6]
 [ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=7]
 [ext_resource path="res://src/main/ui/menu/paged-region-buttons.gd" type="Script" id=8]
@@ -74,14 +74,16 @@ alignment = 1
 script = ExtResource( 8 )
 RegionButtonScene = ExtResource( 9 )
 
-[node name="LeftArrow" type="Button" parent="VBoxContainer/Top/RegionButtons"]
+[node name="LeftArrow" parent="VBoxContainer/Top/RegionButtons" instance=ExtResource( 5 )]
 margin_left = 374.0
-margin_top = 132.0
+margin_top = 130.0
 margin_right = 398.0
-margin_bottom = 158.0
+margin_bottom = 159.0
 rect_min_size = Vector2( 24, 24 )
+focus_mode = 1
 size_flags_vertical = 4
-theme = ExtResource( 5 )
+theme = ExtResource( 1 )
+enabled_focus_mode = 1
 text = "<"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/Top/RegionButtons"]
@@ -94,14 +96,16 @@ custom_constants/separation = 5
 
 [node name="RegionButton" parent="VBoxContainer/Top/RegionButtons/HBoxContainer" instance=ExtResource( 9 )]
 
-[node name="RightArrow" type="Button" parent="VBoxContainer/Top/RegionButtons"]
+[node name="RightArrow" parent="VBoxContainer/Top/RegionButtons" instance=ExtResource( 5 )]
 margin_left = 506.0
-margin_top = 132.0
+margin_top = 130.0
 margin_right = 530.0
-margin_bottom = 158.0
+margin_bottom = 159.0
 rect_min_size = Vector2( 24, 24 )
+focus_mode = 1
 size_flags_vertical = 4
-theme = ExtResource( 5 )
+theme = ExtResource( 1 )
+enabled_focus_mode = 1
 text = ">"
 
 [node name="GradeLabels" type="Control" parent="VBoxContainer/Top"]
@@ -120,12 +124,12 @@ rect_min_size = Vector2( 0, 100 )
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/Bottom"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+theme = ExtResource( 1 )
 
 [node name="Description" type="Panel" parent="VBoxContainer/Bottom/HBoxContainer"]
-margin_right = 450.0
+margin_right = 449.0
 margin_bottom = 100.0
 size_flags_horizontal = 3
-custom_styles/panel = ExtResource( 1 )
 script = ExtResource( 4 )
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/Bottom/HBoxContainer/Description"]
@@ -139,20 +143,18 @@ custom_constants/margin_bottom = 5
 [node name="Label" type="Label" parent="VBoxContainer/Bottom/HBoxContainer/Description/MarginContainer"]
 margin_left = 20.0
 margin_top = 5.0
-margin_right = 430.0
+margin_right = 429.0
 margin_bottom = 95.0
 size_flags_vertical = 1
-theme = ExtResource( 5 )
 align = 1
 valign = 1
 autowrap = true
 
 [node name="Info" type="Panel" parent="VBoxContainer/Bottom/HBoxContainer"]
-margin_left = 454.0
+margin_left = 455.0
 margin_right = 904.0
 margin_bottom = 100.0
 size_flags_horizontal = 3
-custom_styles/panel = ExtResource( 1 )
 script = ExtResource( 3 )
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/Bottom/HBoxContainer/Info"]
@@ -166,10 +168,9 @@ custom_constants/margin_bottom = 5
 [node name="Label" type="Label" parent="VBoxContainer/Bottom/HBoxContainer/Info/MarginContainer"]
 margin_left = 20.0
 margin_top = 5.0
-margin_right = 430.0
+margin_right = 429.0
 margin_bottom = 95.0
 size_flags_vertical = 1
-theme = ExtResource( 5 )
 valign = 1
 
 [node name="CheatCodeDetector" parent="." instance=ExtResource( 7 )]

--- a/project/src/main/ui/menu/paged-level-buttons.gd
+++ b/project/src/main/ui/menu/paged-level-buttons.gd
@@ -46,6 +46,38 @@ func _ready() -> void:
 	_refresh()
 
 
+func _input(event: InputEvent) -> void:
+	if _rightmost_level_button_has_focus() and event.is_action_pressed("ui_right"):
+		if _page < _max_selectable_page():
+			_select_next_page()
+		get_tree().set_input_as_handled()
+
+	if _leftmost_level_button_has_focus() and event.is_action_pressed("ui_left"):
+		if _page > 0:
+			_select_previous_page()
+		get_tree().set_input_as_handled()
+
+
+## Returns 'true' if a button in the rightmost column has focus.
+func _rightmost_level_button_has_focus() -> bool:
+	var result := false
+	for i in _grid_container.get_child_count():
+		if i % _grid_container.columns == _grid_container.columns - 1 and _grid_container.get_child(i).has_focus():
+			result = true
+			break
+	return result
+
+
+## Returns 'true' if a button in the leftmost column has focus.
+func _leftmost_level_button_has_focus() -> bool:
+	var result := false
+	for i in _grid_container.get_child_count():
+		if i % _grid_container.columns == 0 and _grid_container.get_child(i).has_focus():
+			result = true
+			break
+	return result
+
+
 ## Focuses a specific level button, possibly changing the current page.
 ##
 ## Parameters:
@@ -180,6 +212,18 @@ func _level_select_button(level_id: String, level_count: int) -> Node:
 	return level_button
 
 
+func _select_previous_page() -> void:
+	_page = max(0, _page - 1)
+	_refresh()
+	_grid_container.get_children().back().grab_focus()
+
+
+func _select_next_page() -> void:
+	_page = min(_max_selectable_page(), _page + 1)
+	_refresh()
+	_grid_container.get_children().front().grab_focus()
+
+
 ## When the player clicks a level button once, we emit a signal to show more information.
 func _on_LevelButton_focus_entered(level_button: LevelSelectButton, level_id: String) -> void:
 	if level_button.lock_status == LevelSelectButton.STATUS_LOCKED:
@@ -194,13 +238,11 @@ func _on_LevelButton_level_chosen(level_settings: LevelSettings) -> void:
 
 
 func _on_LeftArrow_pressed() -> void:
-	_page = max(0, _page - 1)
-	_refresh()
+	_select_previous_page()
 
 
 func _on_RightArrow_pressed() -> void:
-	_page = min(_max_selectable_page(), _page + 1)
-	_refresh()
+	_select_next_page()
 
 
 func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDetector) -> void:

--- a/project/src/main/ui/menu/paged-region-buttons.gd
+++ b/project/src/main/ui/menu/paged-region-buttons.gd
@@ -42,6 +42,18 @@ func _ready() -> void:
 	_refresh()
 
 
+func _input(event: InputEvent) -> void:
+	if _rightmost_region_button_has_focus() and event.is_action_pressed("ui_right"):
+		if _page < _max_selectable_page():
+			_select_next_page()
+		get_tree().set_input_as_handled()
+
+	if _leftmost_region_button_has_focus() and event.is_action_pressed("ui_left"):
+		if _page > 0:
+			_select_previous_page()
+		get_tree().set_input_as_handled()
+
+
 ## Focuses a specific region button, possibly changing the current page.
 ##
 ## Parameters:
@@ -89,6 +101,18 @@ func set_regions(new_regions: Array) -> void:
 		_regions_by_page.back().append(regions[i])
 	
 	_refresh()
+
+
+func _rightmost_region_button_has_focus() -> bool:
+	if not _hbox_container.get_children():
+		return false
+	return _hbox_container.get_children().back().has_focus()
+
+
+func _leftmost_region_button_has_focus() -> bool:
+	if not _hbox_container.get_children():
+		return false
+	return _hbox_container.get_children().front().has_focus()
 
 
 ## Refreshes the buttons and arrows based on our current properties.
@@ -193,6 +217,18 @@ func _region_select_button(button_index: int, region_obj: Object) -> RegionSelec
 	return region_button
 
 
+func _select_previous_page() -> void:
+	_page = max(0, _page - 1)
+	_refresh()
+	_hbox_container.get_children().back().grab_focus()
+
+
+func _select_next_page() -> void:
+	_page = min(_max_selectable_page(), _page + 1)
+	_refresh()
+	_hbox_container.get_children().front().grab_focus()
+
+
 ## When the player clicks a region button once, we emit a signal to show more information.
 func _on_RegionButton_focus_entered(region_button: RegionSelectButton, region: Object) -> void:
 	if region_button.disabled:
@@ -207,13 +243,11 @@ func _on_RegionButton_region_chosen(region: Object) -> void:
 
 
 func _on_LeftArrow_pressed() -> void:
-	_page = max(0, _page - 1)
-	_refresh()
+	_select_previous_page()
 
 
 func _on_RightArrow_pressed() -> void:
-	_page = min(_max_selectable_page(), _page + 1)
-	_refresh()
+	_select_next_page()
 
 
 func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDetector) -> void:

--- a/project/src/main/ui/region-select-button.gd
+++ b/project/src/main/ui/region-select-button.gd
@@ -122,6 +122,13 @@ func set_region_name(new_region_name: String) -> void:
 	_refresh()
 
 
+## Returns true if this button is currently focused.
+##
+## For cosmetic reasons, this control itself doesn't have focus, but the child button control does.
+func has_focus() -> bool:
+	return _button.has_focus()
+
+
 func grab_focus() -> void:
 	_button.grab_focus()
 


### PR DESCRIPTION
Level/chapter next/prev buttons no longer use default UI, and instead use 'gy/squeak-theme-h4'

Keyboard/gamepad now work better in level/chapter select. Instead of navigating to the 'next' button and pressing it, navigating off the page automatically selects the next page.