### PR TITLE
Each career region has its own music.

### DIFF
--- a/project/assets/main/puzzle/career-regions.json
+++ b/project/assets/main/puzzle/career-regions.json
@@ -6,6 +6,14 @@
       "start": 0,
       "description": "Locate the mysterious Fat Sensei and launch your first successful restaurant. ...And maybe make some woodland friends along the way!",
       "icon": "forest",
+      "music": {
+        "menu": "hot_funk_sundae",
+        "puzzle": [
+          "+sugar_crash",
+          "mystic_muffin",
+          "acid_reflux"
+        ]
+      },
       "overworld_environment": "lemon",
       "puzzle_environment": "lemon",
       "region_button": "lemon",
@@ -88,6 +96,14 @@
       "start": 8,
       "description": "We're not done yet, there's a heckton of work which goes into setting up a restaurant! ...Oh wait, there isn't? Never mind then!",
       "icon": "forest",
+      "music": {
+        "menu": "hot_funk_sundae",
+        "puzzle": [
+          "+pressure_cooker",
+          "chunky_obake",
+          "acid_reflux"
+        ]
+      },
       "overworld_environment": "lemon_2",
       "puzzle_environment": "lemon_2",
       "region_button": "lemon_2",
@@ -171,6 +187,14 @@
       "start": 20,
       "description": "Oh no, there's nobody here. ....Except for THOSE fifty billion people! Where did THEY all come from!?",
       "icon": "cactus",
+      "music": {
+        "menu": "dessert_course",
+        "puzzle": [
+          "+chocolate_chip",
+          "chunky_obake",
+          "chub_n_bass"
+        ]
+      },
       "overworld_environment": "poki",
       "region_button": "poki",
       "piece_speed": "1-3",
@@ -259,6 +283,14 @@
       "start": 32,
       "description": "The wacky council members running this island might be able to help our restaurant! If they would only stop arguing...",
       "icon": "island",
+      "music": {
+        "menu": "lo_fi_chill",
+        "puzzle": [
+          "+doo_doo_doo",
+          "gingerbread_house",
+          "chub_n_bass"
+        ]
+      },
       "overworld_environment": "sand",
       "region_button": "sand",
       "piece_speed": "2-5",
@@ -340,6 +372,14 @@
       "start": 46,
       "description": "The quirky chefs at the Merrymellow Marsh location can't seem to do anything right. They really need our help!",
       "icon": "skull",
+      "music": {
+        "menu": "chub_hub",
+        "puzzle": [
+          "+triple_thicc_shake",
+          "gingerbread_house",
+          "juicer_mixer_grinder"
+        ]
+      },
       "overworld_environment": "marsh",
       "region_button": "marsh",
       "piece_speed": "3-7",
@@ -434,6 +474,14 @@
       "start": 62,
       "description": "Can we complete the ultimate challenge to obtain the coveted 'Chef Of The Year' plaque!? All our hopes are riding on this!",
       "icon": "volcano",
+      "music": {
+        "menu": "harder_butter",
+        "puzzle": [
+          "+extra_sprinkles",
+          "mystic_muffin",
+          "juicer_mixer_grinder"
+        ]
+      },
       "overworld_environment": "lava",
       "region_button": "lava",
       "piece_speed": "6-9",
@@ -506,6 +554,23 @@
       "start": 82,
       "description": "A slew of insurmountable challenges sure to drive even the most seasoned chefs to the brink of insanity. The true Turbo Fat starts here!",
       "icon": "rainbow",
+      "music": {
+        "menu": "rainbow_sherbeat",
+        "puzzle": [
+          "sugar_crash",
+          "acid_reflux",
+          "chocolate_chip",
+          "chub_n_bass",
+          "chunky_obake",
+          "doo_doo_doo",
+          "extra_sprinkles",
+          "gingerbread_house",
+          "juicer_mixer_grinder",
+          "mystic_muffin",
+          "pressure_cooker",
+          "triple_thicc_shake"
+        ]
+      },
       "piece_speed": "A1-AD",
       "flags": [
         "new_page"

--- a/project/project.godot
+++ b/project/project.godot
@@ -1279,6 +1279,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/career/region-completion.gd"
 }, {
+"base": "Reference",
+"class": "RegionMusic",
+"language": "GDScript",
+"path": "res://src/main/career/region-music.gd"
+}, {
 "base": "MarginContainer",
 "class": "RegionSelectButton",
 "language": "GDScript",
@@ -1844,6 +1849,7 @@ _global_script_class_icons={
 "RankRules": "",
 "RectFitLabel": "",
 "RegionCompletion": "",
+"RegionMusic": "",
 "RegionSelectButton": "",
 "ReleaseToolkitOutput": "",
 "RestaurantPuzzleScene": "",

--- a/project/src/demo/toolkit/fix-levels-button.gd
+++ b/project/src/demo/toolkit/fix-levels-button.gd
@@ -103,6 +103,33 @@ func _report_invalid_career_levels() -> void:
 		_output_label.add_line("Invalid levels in career regions: %s" % [keys_to_print])
 
 
+## Reports any regions in career-regions.json with missing or invalid music ids
+func _report_invalid_career_music() -> void:
+	var invalid_region_ids := {}
+	
+	for region in CareerLevelLibrary.regions:
+		if region.music.menu_music_id == null:
+			push_warning("%s - menu_music_id is empty" % [region.id])
+			invalid_region_ids[region.id] = true
+		elif MusicPlayer.bgm_for_id(region.music.menu_music_id) == null:
+			push_warning("%s - invalid menu_music_id: %s" % [region.id, region.music.menu_music_id])
+			invalid_region_ids[region.id] = true
+		
+		if not region.music.puzzle_music_ids:
+			push_warning("%s - puzzle_music_ids is empty" % [region.id])
+			invalid_region_ids[region.id] = true
+		else:
+			for puzzle_music_id in region.music.puzzle_music_ids:
+				if MusicPlayer.bgm_for_id(puzzle_music_id) == null:
+					push_warning("%s - invalid puzzle_music_id: %s" % [region.id, puzzle_music_id])
+					invalid_region_ids[region.id] = true
+	
+	if invalid_region_ids:
+		var keys_to_print := invalid_region_ids.keys()
+		keys_to_print.sort()
+		_output_label.add_line("Invalid music in career regions: %s" % [keys_to_print])
+
+
 ## Reports any levels in CAREER_LEVEL_DIRS which are not actually available in career mode.
 func _report_unused_career_levels() -> void:
 	var level_keys_in_dir := []
@@ -183,6 +210,7 @@ func _on_pressed() -> void:
 	_output_label.text = ""
 	_upgrade_levels()
 	_report_invalid_career_levels()
+	_report_invalid_career_music()
 	_report_unused_career_levels()
 	_report_bad_show_rank()
 	_alphabetize_career_levels()

--- a/project/src/main/career/career-region.gd
+++ b/project/src/main/career/career-region.gd
@@ -61,6 +61,9 @@ var cutscene_path: String
 ## Describes the creatures in this region.
 var population := Population.new()
 
+## Describes the music in this region.
+var music := RegionMusic.new()
+
 ## Human-readable tagline describing this career region.
 var description: String
 
@@ -114,6 +117,8 @@ func from_json_dict(json: Dictionary) -> void:
 		var level: CareerLevel = CareerLevel.new()
 		level.from_json_dict(level_json)
 		levels.append(level)
+	if json.has("music"):
+		music.from_json_dict(json.get("music"))
 	overworld_environment_id = json.get("overworld_environment", "")
 	region_button_id = json.get("region_button", "")
 	var piece_speed_string: String = json.get("piece_speed", "0")

--- a/project/src/main/career/region-music.gd
+++ b/project/src/main/career/region-music.gd
@@ -1,0 +1,51 @@
+class_name RegionMusic
+## Describes the music in a career region.
+##
+## Each region defines a menu music id and set of puzzle music ids. These music ids correspond to entries in
+## MusicPlayer.bgms_by_id. The list of puzzle music ids obey two unusual rules:
+##
+## 1. The first item in the list of puzzle music ids is the 'main puzzle music id'. This main puzzle music is played
+## for the first puzzle of each career data and for the boss level.
+##
+## 2. Json puzzle music ids prefixed with a '+' will play twice as often.
+
+## Music to play while the player navigates menus
+var menu_music_id: String
+
+## String music ids to play while the player is playing a level
+var puzzle_music_ids: Array
+
+## Puzzle music which should be played more frequently than other music
+##
+## key: (String) music id
+## value: (bool) true
+var _favored_puzzle_music_ids := {}
+
+## Returns a random music id to play while the player is playing a level from this region.
+func random_puzzle_music_id() -> String:
+	var music_id_pool: Array = []
+	for puzzle_music_id in puzzle_music_ids:
+		music_id_pool.append(puzzle_music_id)
+		if _favored_puzzle_music_ids.has(puzzle_music_id):
+			music_id_pool.append(puzzle_music_id)
+	
+	return Utils.rand_value(music_id_pool)
+
+
+## Returns the main music id to play while the player is playing a level from this region.
+##
+## The main music id is played at the start of every career day, and for every boss level.
+func main_puzzle_music_id() -> String:
+	return puzzle_music_ids[0]
+
+
+func from_json_dict(json: Dictionary) -> void:
+	_favored_puzzle_music_ids.clear()
+	menu_music_id = json.get("menu", "")
+	for puzzle_music_id in json.get("puzzle", []):
+		var new_puzzle_music_id: String = puzzle_music_id
+		if puzzle_music_id.begins_with("+"):
+			# json puzzle music ids prefixed with a '+' will play twice as often
+			new_puzzle_music_id = puzzle_music_id.trim_prefix("+")
+			_favored_puzzle_music_ids[new_puzzle_music_id] = true
+		puzzle_music_ids.append(new_puzzle_music_id)

--- a/project/src/main/data/player-data.gd
+++ b/project/src/main/data/player-data.gd
@@ -34,6 +34,9 @@ var seconds_played := 0.0
 ## periodically increments the 'seconds_played' value
 var seconds_played_timer: Timer
 
+## decides the music and menu theme
+var menu_region: CareerRegion
+
 func _ready() -> void:
 	career = CareerData.new()
 	add_child(career)
@@ -56,6 +59,7 @@ func reset() -> void:
 	practice.reset()
 	money = 0
 	seconds_played = 0.0
+	menu_region = CareerLevelLibrary.regions[0]
 	
 	emit_signal("level_history_changed")
 

--- a/project/src/main/data/player-save.gd
+++ b/project/src/main/data/player-save.gd
@@ -90,6 +90,7 @@ func save_player_data() -> void:
 	save_json.append(SaveItem.new("chat_history", PlayerData.chat_history.to_json_dict()).to_json_dict())
 	save_json.append(SaveItem.new("creature_library", PlayerData.creature_library.to_json_dict()).to_json_dict())
 	save_json.append(SaveItem.new("career", PlayerData.career.to_json_dict()).to_json_dict())
+	save_json.append(SaveItem.new("menu_region", PlayerData.menu_region.id).to_json_dict())
 	save_json.append(SaveItem.new("practice", PlayerData.practice.to_json_dict()).to_json_dict())
 	save_json.append(SaveItem.new("successful_levels",
 			PlayerData.level_history.successful_levels).to_json_dict())
@@ -226,6 +227,10 @@ func _load_line(type: String, key: String, json_value) -> void:
 		"career":
 			var value: Dictionary = json_value
 			PlayerData.career.from_json_dict(value)
+		"menu_region":
+			var value: String = json_value
+			if CareerLevelLibrary.region_for_id(value):
+				PlayerData.menu_region = CareerLevelLibrary.region_for_id(value)
 		"practice":
 			var value: Dictionary = json_value
 			PlayerData.practice.from_json_dict(value)

--- a/project/src/main/music/MusicPlayer.tscn
+++ b/project/src/main/music/MusicPlayer.tscn
@@ -32,42 +32,49 @@ stream = ExtResource( 18 )
 checkpoints = [ 0.0, 32.912, 65.827, 87.771, 120.686 ]
 song_title = "Acid Reflux"
 song_color = Color( 0.3245, 0.55, 0.22, 1 )
+id = "acid_reflux"
 
 [node name="ChocolateChip" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 22 )
 checkpoints = [ 0.0, 15.476, 30.964 ]
 song_title = "Chocolate Chip Hipster"
 song_color = Color( 0.521569, 0.309804, 0.215686, 1 )
+id = "chocolate_chip"
 
 [node name="ChubHub" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 13 )
 checkpoints = [ 0.0, 12.489, 32.489, 42.489, 142.489, 152.489, 162.489 ]
 song_title = "Chub Hub"
 song_color = Color( 0.352941, 0.666667, 0.301961, 1 )
+id = "chub_hub"
 
 [node name="ChubNBass" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 15 )
 checkpoints = [ 0.0, 22.575, 101.642 ]
 song_title = "Chub 'n Bass"
 song_color = Color( 0.24, 0.75, 0.3675, 1 )
+id = "chub_n_bass"
 
 [node name="ChunkyObake" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 14 )
 checkpoints = [ 0.0, 31.473, 62.95, 94.422, 188.845 ]
 song_title = "Chunky Obake"
 song_color = Color( 0.988235, 0.588235, 0.929412, 1 )
+id = "chunky_obake"
 
 [node name="DessertCourse" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 17 )
 checkpoints = [ 0.0, 9.141, 18.286, 27.429, 36.571, 127.983 ]
 song_title = "Dessert Course (With No Name)"
 song_color = Color( 0.921569, 0.905882, 0.486275, 1 )
+id = "dessert_course"
 
 [node name="DooDooDoo" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 7 )
 checkpoints = [ 0.0, 15.233, 45.721, 76.196, 106.67, 167.613 ]
 song_title = "Doo Doo Doo"
 song_color = Color( 0.494118, 0.905882, 0.423529, 1 )
+id = "doo_doo_doo"
 
 [node name="ExtraSprinkles" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 20 )
@@ -75,30 +82,35 @@ volume_db = -3.0
 checkpoints = [ 0.0 ]
 song_title = "Extra Sprinkles"
 song_color = Color( 1, 0.74902, 0.34902, 1 )
+id = "extra_sprinkles"
 
 [node name="GingerbreadHouse" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 21 )
 checkpoints = [ 0.0, 15.231, 30.476, 60.949, 137.143, 152.377 ]
 song_title = "Gingerbread House"
 song_color = Color( 0.913725, 0.905882, 0.47451, 1 )
+id = "gingerbread_house"
 
 [node name="LoFiChill" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 6 )
 checkpoints = [ 0.0, 10.646, 21.326, 63.988, 85.33, 213.328 ]
 song_title = "24/7 Lo-Fi Chill Hip Hop Beats to Eat & Get Fat To"
 song_color = Color( 0.360784, 0.427451, 0.847059, 1 )
+id = "lo_fi_chill"
 
 [node name="HarderButter" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 16 )
 checkpoints = [ 0.0, 17.454, 34.908, 157.087 ]
 song_title = "Harder, Butter, Fatter, Stronger"
 song_color = Color( 0.678431, 0.678431, 0.678431, 1 )
+id = "harder_butter"
 
 [node name="HotFunkSundae" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 10 )
 checkpoints = [ 0.0, 8.707, 17.456, 69.826, 165.814 ]
 song_title = "Hot Funk Sundae"
 song_color = Color( 0.776471, 0.52549, 0.419608, 1 )
+id = "hot_funk_sundae"
 
 [node name="JuicerMixerGrinder" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 5 )
@@ -106,6 +118,7 @@ volume_db = -3.0
 checkpoints = [ 0.0, 12.916, 29.532, 88.61 ]
 song_title = "Juicer Mixer Grinder"
 song_color = Color( 0.909804, 0.439216, 0.435294, 1 )
+id = "juicer_mixer_grinder"
 
 [node name="MyFatnessPal" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 11 )
@@ -113,36 +126,42 @@ volume_db = 4.0
 checkpoints = [ 0.0, 25.098, 50.196, 74.681 ]
 song_title = "My Fatness Pal"
 song_color = Color( 0.709804, 0.486275, 0.917647, 1 )
+id = "my_fatness_pal"
 
 [node name="MysticMuffin" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 8 )
 checkpoints = [ 0.0, 15.23, 30.474 ]
 song_title = "Mystic Muffin"
 song_color = Color( 0.709804, 0.486275, 0.917647, 1 )
+id = "mystic_muffin"
 
 [node name="PressureCooker" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 12 )
 checkpoints = [ 0.0, 14.989, 29.982, 59.993 ]
 song_title = "Pressure Cooker"
 song_color = Color( 0.980392, 0.709804, 0.419608, 1 )
+id = "pressure_cooker"
 
 [node name="RainbowSherbeat" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 19 )
 checkpoints = [ 0.0, 20.206, 101.058 ]
 song_title = "Rainbow Sherbeat"
 song_color = Color( 0.538333, 0.3825, 0.85, 1 )
+id = "rainbow_sherbeat"
 
 [node name="SugarCrash" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 9 )
 checkpoints = [ 0.0, 1.951, 204.877 ]
 song_title = "Sugar Crash"
 song_color = Color( 0.321569, 0.686275, 0.890196, 1 )
+id = "sugar_crash"
 
 [node name="TripleThiccShake" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 3 )
 checkpoints = [ 0.0, 7.747, 23.229, 38.696 ]
 song_title = "Triple Thicc Shake"
 song_color = Color( 0.494118, 0.905882, 0.423529, 1 )
+id = "triple_thicc_shake"
 
 [node name="MusicTweenManager" type="Node" parent="."]
 script = ExtResource( 4 )

--- a/project/src/main/music/checkpoint-song.gd
+++ b/project/src/main/music/checkpoint-song.gd
@@ -16,6 +16,9 @@ export (Array, float) var checkpoints: Array = []
 export var song_title: String
 export var song_color: Color
 
+## song id referenced by career-regions.json
+export var id: String
+
 ## array of ints corresponding to how much each 'chunk' of music has been played
 var _staleness_record: Array
 

--- a/project/src/main/music/music-player.gd
+++ b/project/src/main/music/music-player.gd
@@ -25,6 +25,10 @@ var current_bgm: CheckpointSong
 ## true if the music should have a low-pass filter applied; used during nighttime
 var night_filter: bool = false setget set_night_filter
 
+## key: (String) music id
+## value: (CheckpointSong) music
+var bgms_by_id := {}
+
 ## volume_db changes when we fade in/fade out so we cache the original value.
 ##
 ## key: (String) bgm node name
@@ -32,6 +36,12 @@ var night_filter: bool = false setget set_night_filter
 var _max_volume_db_by_bgm := {}
 
 var _filter_tween: SceneTreeTween
+
+## Level id for the newest played puzzle music. We track this to ensure repeating a puzzle also repeats the music.
+var _previous_level_id: String
+
+## Music id for the newest played puzzle music. We track this to ensure repeating a puzzle also repeats the music.
+var _previous_puzzle_bgm_id: String
 
 onready var _chill_bgms := [
 		$ChubHub, $DessertCourse, $HarderButter,
@@ -49,6 +59,8 @@ onready var _music_tween_manager := $MusicTweenManager
 
 func _ready() -> void:
 	all_bgms = _chill_bgms + _upbeat_bgms + _tutorial_bgms
+	for bgm in all_bgms:
+		bgms_by_id[bgm.id] = bgm
 	_chill_bgms.shuffle()
 	_upbeat_bgms.shuffle()
 	
@@ -56,19 +68,64 @@ func _ready() -> void:
 		_max_volume_db_by_bgm[bgm.name] = bgm.volume_db
 
 
+func bgm_for_id(id: String) -> CheckpointSong:
+	return bgms_by_id.get(id)
+
+
 ## Plays a 'chill' song; something suitable for background music when the player's navigating menus or wandering the
 ## free roam overworld.
 ##
 ## If a chill song is already playing, this method has no effect.
 func play_chill_bgm(fade_in: bool = true) -> void:
-	_play_next_bgm(_chill_bgms, fade_in)
+	if PlayerData.menu_region and PlayerData.menu_region.music.menu_music_id:
+		var new_bgm_id: String = PlayerData.menu_region.music.menu_music_id
+		if current_bgm and current_bgm.id == new_bgm_id:
+			# song is already playing; don't interrupt it
+			pass
+		else:
+			var new_bgm: CheckpointSong = bgm_for_id(new_bgm_id)
+			
+			play_bgm(new_bgm)
+			if fade_in:
+				fade_in()
+	else:
+		_play_next_bgm(_chill_bgms, fade_in)
 
 
 ## Plays an 'upbeat' song; something suitable when the player's playing a puzzle level.
 ##
 ## If an upbeat song is already playing, this method has no effect.
 func play_upbeat_bgm(fade_in: bool = true) -> void:
-	_play_next_bgm(_upbeat_bgms, fade_in)
+	if PlayerData.menu_region and PlayerData.menu_region.music.puzzle_music_ids:
+		var region_music: RegionMusic = PlayerData.menu_region.music
+		
+		var new_bgm_id: String
+		
+		if PlayerData.career.hours_passed == 0:
+			# if it's the first level, play the 'main puzzle song'
+			new_bgm_id = region_music.main_puzzle_music_id()
+		elif PlayerData.career.is_boss_level():
+			# if it's a boss level, play the 'main puzzle song'
+			new_bgm_id = region_music.main_puzzle_music_id()
+		elif _previous_level_id == CurrentLevel.level_id and _previous_puzzle_bgm_id in region_music.puzzle_music_ids:
+			# if replaying a level, play the same song
+			new_bgm_id = _previous_puzzle_bgm_id
+		else:
+			# otherwise, play a random song
+			new_bgm_id = region_music.random_puzzle_music_id()
+		
+		if current_bgm and current_bgm.id == new_bgm_id:
+			# song is already playing; don't interrupt it
+			pass
+		else:
+			play_bgm(bgm_for_id(new_bgm_id))
+			if fade_in:
+				fade_in()
+		
+		_previous_puzzle_bgm_id = new_bgm_id
+		_previous_level_id = CurrentLevel.level_id
+	else:
+		_play_next_bgm(_upbeat_bgms, fade_in)
 
 
 ## Plays a 'tutorial song'; something suitable when the player is following a puzzle tutorial.

--- a/project/src/main/ui/menu/career-region-select-menu.gd
+++ b/project/src/main/ui/menu/career-region-select-menu.gd
@@ -28,6 +28,8 @@ func _on_RegionButtons_region_chosen(region: CareerRegion) -> void:
 	PlayerData.career.distance_travelled = region.start
 	PlayerData.career.remain_in_region = region.end < PlayerData.career.best_distance_travelled
 	PlayerData.career.show_progress = Careers.ShowProgress.STATIC
+	if region is CareerRegion:
+		PlayerData.menu_region = region
 	
 	if Breadcrumb.trail.front() == Global.SCENE_CAREER_REGION_SELECT_MENU:
 		Breadcrumb.trail.pop_front()

--- a/project/src/main/ui/menu/training-menu.gd
+++ b/project/src/main/ui/menu/training-menu.gd
@@ -187,6 +187,8 @@ func _on_RegionSubmenu_visibility_changed() -> void:
 func _on_LevelSelect_level_chosen(region: Object, settings: LevelSettings) -> void:
 	_region = region
 	PlayerData.practice.region_id = _region.id
+	if region is CareerRegion:
+		PlayerData.menu_region = _region
 	_level_settings = settings
 	PlayerData.practice.level_id = settings.id
 	_level_submenu.hide()


### PR DESCRIPTION
Career regions define their own menu music and puzzle music. This music is validated by the Release Toolkit. The menu music and puzzle music is controlled by a new 'PlayerData.menu_region' field. This field is updated when the player selects a new career region in Career Mode or Training Mode.

Puzzle music defines multiple songs for each region. Each region has a 'main song' which plays at the start of each career data and during boss levels. Each region can also define songs which play more frequently.

The twelve songs are arranged such that some songs play twice as frequently in a single area, while others play half as frequently in two areas. Overall, they should all play about the same amount of time.