### PR TITLE
Fixed overlapping cheat sfx for 'unlock' cheat in training menu

### DIFF
--- a/project/src/main/ui/CheatCodeDetector.tscn
+++ b/project/src/main/ui/CheatCodeDetector.tscn
@@ -1,18 +1,17 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://assets/main/ui/cheat-disable.wav" type="AudioStream" id=1]
 [ext_resource path="res://assets/main/ui/cheat-enable.wav" type="AudioStream" id=2]
 [ext_resource path="res://src/main/ui/cheat-code-detector.gd" type="Script" id=3]
+[ext_resource path="res://src/main/utils/DeconflictedAudioStreamPlayer.tscn" type="PackedScene" id=4]
 
 [node name="CheatCodeDetector" type="Node"]
 script = ExtResource( 3 )
 
-[node name="CheatDisableSound" type="AudioStreamPlayer" parent="."]
+[node name="CheatDisableSound" parent="." instance=ExtResource( 4 )]
 stream = ExtResource( 1 )
 volume_db = -4.0
-bus = "Sound Bus"
 
-[node name="CheatEnableSound" type="AudioStreamPlayer" parent="."]
+[node name="CheatEnableSound" parent="." instance=ExtResource( 4 )]
 stream = ExtResource( 2 )
 volume_db = -4.0
-bus = "Sound Bus"


### PR DESCRIPTION
The LevelButtonScroller and PagedLevelButtons both tried to play the same sound effect, resulting in an unpleasant sfx overlap when entering the cheat code