### PR TITLE
Signals for achievements: after_scene_changed, creature_saved, etc

### DIFF
--- a/project/src/main/puzzle/critter/carrots.gd
+++ b/project/src/main/puzzle/critter/carrots.gd
@@ -5,6 +5,8 @@ extends Node2D
 ## Carrots remain onscreen for several seconds. They have many different sizes, and can also leave behind a smokescreen
 ## which blocks the player's vision for even longer.
 
+signal carrot_added
+
 ## tracks whether the carrot sfx are playing
 enum MoveSfxState {
 	STOPPED, # sfx are not playing
@@ -87,6 +89,12 @@ func add_carrots(config: CarrotConfig) -> void:
 	for i in range(min(config.count, potential_carrot_x_coords.size())):
 		_add_carrot(Vector2(potential_carrot_x_coords[i], PuzzleTileMap.ROW_COUNT), config)
 	_carrot_poof_sound.play()
+	emit_signal("carrot_added")
+
+
+## Returns the number of child carrot nodes on the playfield.
+func get_carrot_count() -> int:
+	return _carrot_holder.get_child_count()
 
 
 func _refresh_playfield_path() -> void:

--- a/project/src/main/puzzle/critter/sharks.gd
+++ b/project/src/main/puzzle/critter/sharks.gd
@@ -5,6 +5,8 @@ extends Node2D
 ## Sharks wait on the playfield until bumped by a piece. Depending on the size of the shark, they may take a small bite
 ## from the piece, a big bite from the piece, or eat the entire piece.
 
+signal shark_squished(shark)
+
 export (PackedScene) var SharkScene: PackedScene
 export (NodePath) var critter_manager_path: NodePath
 
@@ -151,6 +153,7 @@ func _refresh_sharks_for_piece() -> void:
 		if _did_hard_drop and piece_overlaps_shark \
 				and shark.state in [Shark.DANCING, Shark.DANCING_END, Shark.EATING, Shark.FED]:
 			shark.squish()
+			emit_signal("shark_squished", shark)
 		
 		if shark.state in [Shark.DANCING, Shark.DANCING_END] and piece_overlaps_shark:
 			match shark.shark_size:

--- a/project/src/main/utils/breadcrumb.gd
+++ b/project/src/main/utils/breadcrumb.gd
@@ -13,6 +13,9 @@ signal trail_popped(prev_path)
 ## Emitted before this class changes the running scene.
 signal before_scene_changed
 
+## Emitted after this class changes the running scene.
+signal after_scene_changed
+
 var trail := []
 
 ## Initializes the trail to be empty except for the current scene.
@@ -71,3 +74,8 @@ func change_scene() -> void:
 		ResourceCache.minimal_resources = false
 		scene_path = "res://src/main/ui/menu/LoadingScreen.tscn"
 	get_tree().change_scene_to(ResourceCache.get_resource(scene_path))
+
+	# The scene change is deferred, which means that event listeners won't be able to access it immediately after the
+	# change_scene_to call. We defer the signal until the next idle_frame.
+	yield(get_tree(), "idle_frame")
+	emit_signal("after_scene_changed")


### PR DESCRIPTION
Steam achievements want to receive signals for a few specific arbitrary events like 'there are 6 carrots visible' or 'the player squished a shark' so I've added signal support for these events.

Added Breadcrumb.after_scene_changed signal.