### PR TITLE
Improve steam achievement performance

### DIFF
--- a/project/src/main/career/career-level-library.gd
+++ b/project/src/main/career/career-level-library.gd
@@ -14,6 +14,12 @@ var regions_path := DEFAULT_REGIONS_PATH setget set_regions_path
 ## List of CareerRegion instances containing region and level data, sorted by distance
 var regions: Array = []
 
+## Maps from level ids to region ids. Includes boss levels, intro levels, and regular levels.
+##
+## key: (String) level id
+## value: (String) region id containing the specified level
+var _region_ids_by_level_id: Dictionary
+
 ## Loads the list of levels from JSON
 func _ready() -> void:
 	_load_raw_json_data()
@@ -55,6 +61,14 @@ func region_for_id(region_id: String) -> CareerRegion:
 			result = next_region
 			break
 	return result
+
+
+
+## Returns the region id with the specified level.
+##
+## Includes boss levels, intro levels, and regular levels.
+func region_id_for_level_id(level_id: String) -> String:
+	return _region_ids_by_level_id.get(level_id)
 
 
 ## Returns an appropriate piece speed ID after the player travels a certain distance.
@@ -270,3 +284,17 @@ func _load_raw_json_data() -> void:
 			regions[i].length = regions[i + 1].start - regions[i].start
 		else:
 			regions[i].length = Careers.MAX_DISTANCE_TRAVELLED
+	
+	_populate_region_ids_by_level_id()
+
+
+## Populates the '_region_ids_by_level_id' field.
+func _populate_region_ids_by_level_id() -> void:
+	_region_ids_by_level_id = {}
+	for region in regions:
+		if region.boss_level:
+			_region_ids_by_level_id[region.boss_level.level_id] = region.id
+		if region.intro_level:
+			_region_ids_by_level_id[region.intro_level.level_id] = region.id
+		for level in region.levels:
+			_region_ids_by_level_id[level.level_id] = region.id

--- a/project/src/main/steam/chapter-rank-s-achievement.gd
+++ b/project/src/main/steam/chapter-rank-s-achievement.gd
@@ -7,6 +7,13 @@ export (String) var stat_id: String
 ## The region ID whose unlock status should be tracked.
 export (String) var region_id: String
 
+func _ready() -> void:
+	# avoid checking for 'rank s' every time we save; this changes infrequently and is expensive to check.
+	disconnect_save_signal()
+	
+	PuzzleState.connect("after_game_ended", self, "_on_PuzzleState_after_game_ended")
+
+
 ## Refreshes the achievement based on whether the chapter has been unlocked.
 func refresh_achievement() -> void:
 	var s_rank_percent := _s_rank_percent()
@@ -27,3 +34,10 @@ func _s_rank_percent() -> float:
 			s_rank_count += 1
 	
 	return s_rank_count / float(region.levels.size())
+
+
+## When a level is played, if it corresponds to our region we refresh our achievement status.
+func _on_PuzzleState_after_game_ended() -> void:
+	var level_region_id := CareerLevelLibrary.region_id_for_level_id(CurrentLevel.level_id)
+	if level_region_id == region_id:
+		refresh_achievement()

--- a/project/src/main/steam/chapter-story-finished-achievement.gd
+++ b/project/src/main/steam/chapter-story-finished-achievement.gd
@@ -7,9 +7,23 @@ export (String) var stat_id: String
 ## The region ID whose cutscenes should be tracked.
 export (String) var region_id: String
 
+func _ready() -> void:
+	# avoid checking for story completion every time we save; this changes infrequently and is expensive to check.
+	disconnect_save_signal()
+	
+	CurrentCutscene.connect("cutscene_played", self, "_on_CurrentCutscene_cutscene_played")
+
+
 ## Refreshes the achievement and stat based on how many cutscenes the player has viewed in a chapter.
 func refresh_achievement() -> void:
 	var region_completion := PlayerData.career.region_completion(CareerLevelLibrary.region_for_id(region_id))
 	Steam.set_stat_float(stat_id, 100 * region_completion.cutscene_completion_percent())
 	if region_completion.cutscene_completion_percent() == 1.0:
 		Steam.set_achievement(achievement_id)
+
+
+## When a cutscene is played, if it corresponds to our region we refresh our achievement status.
+func _on_CurrentCutscene_cutscene_played(chat_key: String) -> void:
+	var cutscene_region: CareerRegion = CareerLevelLibrary.region_for_chat_key(chat_key)
+	if cutscene_region and cutscene_region.id == region_id:
+		refresh_achievement()

--- a/project/src/test/career/test-career-level-library.gd
+++ b/project/src/test/career/test-career-level-library.gd
@@ -308,3 +308,15 @@ func test_region_for_chat_key() -> void:
 	assert_eq(CareerLevelLibrary.region_for_chat_key("chat/career/permissible/10_b"), CareerLevelLibrary.regions[0])
 	assert_eq(CareerLevelLibrary.region_for_chat_key("chat/career/cherries/20_a"), CareerLevelLibrary.regions[2])
 	assert_eq(CareerLevelLibrary.region_for_chat_key("chat/career/bogus/30_c"), null)
+
+
+func test_region_id_for_level_id() -> void:
+	CareerLevelLibrary.regions_path = "res://assets/test/career/career-regions-simple.json"
+	
+	assert_eq(CareerLevelLibrary.region_id_for_level_id("intro_211"), "permissible")
+	assert_eq(CareerLevelLibrary.region_id_for_level_id("boss_211"), "permissible")
+	assert_eq(CareerLevelLibrary.region_id_for_level_id("level_211"), "permissible")
+	
+	assert_eq(CareerLevelLibrary.region_id_for_level_id("level_313"), "even")
+	
+	assert_eq(CareerLevelLibrary.region_id_for_level_id("bogus_414"), null)


### PR DESCRIPTION
The 'Chapter Rank S' and 'Chapter story completion' achievements were especially sluggish, taking 0.2 ms and 1.5 ms respectively. This doesn't seem impactful but there are twelve of these achievements so it adds up to 10 ms every save.

These achievements are now only calculated when a corresponding chapter's level or cutscene is played.