### PR TITLE
Improve 'ui_cancel' behavior with modal dialogs.

### DIFF
--- a/project/src/main/editor/creature/dialogs.gd
+++ b/project/src/main/editor/creature/dialogs.gd
@@ -30,6 +30,7 @@ func _ready() -> void:
 			self, "_on_UnsavedChangesQuitConfirmation_discard_pressed")
 	_unsaved_changes_confirmation.get_close_button().connect("pressed",
 			self, "_on_UnsavedChangesQuitConfirmation_closed")
+	_assign_dialog_cancel_shortcut(_unsaved_changes_confirmation)
 
 
 ## Pops up an "unsaved changes" dialog. After the player chooses "Save" or "Discard", the specified callback is
@@ -60,6 +61,15 @@ func show_export_dialog() -> void:
 func show_error_dialog(text: String) -> void:
 	_error.dialog_text = text
 	_error.popup_centered()
+
+
+## Configures a dialog to be dismissed by the 'ui_cancel' action.
+func _assign_dialog_cancel_shortcut(dialog: WindowDialog) -> void:
+	var new_shortcut := ShortCut.new()
+	var new_input_event_action := InputEventAction.new()
+	new_input_event_action.action = "ui_cancel"
+	new_shortcut.shortcut = new_input_event_action
+	dialog.get_close_button().shortcut = new_shortcut
 
 
 ## Save the changes, and then perform the requested operation (quitting or importing)

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -1398,6 +1398,8 @@ icon_color = Color( 1, 0.866667, 0.6, 1 )
 [connection signal="change_save_cancelled" from="Dialogs" to="." method="_on_Dialogs_change_save_cancelled"]
 [connection signal="change_save_confirmed" from="Dialogs" to="." method="_on_Dialogs_change_save_confirmed"]
 [connection signal="delete_confirmed" from="Dialogs" to="." method="_on_Dialogs_delete_confirmed"]
+[connection signal="dialog_visibility_changed" from="Dialogs" to="Window/UiArea/Bottom" method="_on_Dialogs_dialog_visibility_changed"]
+[connection signal="visibility_changed" from="Dialogs/Backdrop" to="Dialogs" method="_on_Backdrop_visibility_changed"]
 [connection signal="about_to_show" from="Dialogs/ChangeSaveConfirmation" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
 [connection signal="popup_hide" from="Dialogs/ChangeSaveConfirmation" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
 [connection signal="about_to_show" from="Dialogs/DeleteConfirmation1" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]


### PR DESCRIPTION
'ui_cancel' now closes modal dialogs.

'ui_cancel' no longer closes the settings menu if a modal dialog is visible.

Closes #1787.