### PR TITLE
Level button tweaks: extra_spacing, ButtonControlHolder

### DIFF
--- a/project/src/main/ui/level-select/HardcoreLevelSelectButton.tscn
+++ b/project/src/main/ui/level-select/HardcoreLevelSelectButton.tscn
@@ -1,21 +1,21 @@
-[gd_scene load_steps=29 format=2]
+[gd_scene load_steps=26 format=2]
 
 [ext_resource path="res://src/main/ui/level-select/hardcore-level-select-button.gd" type="Script" id=1]
-[ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=2]
+[ext_resource path="res://src/main/ui/level-select/LevelSelectButtonControlHolder.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/career/ui/HardcoreFgSkulls.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/career/ui/HardcoreBgSkulls.tscn" type="PackedScene" id=4]
-[ext_resource path="res://src/main/ui/level-select/LevelSelectButtonFocus.tres" type="StyleBox" id=5]
-[ext_resource path="res://src/main/ui/level-select/LevelSelectButtonFont.tres" type="DynamicFont" id=6]
-[ext_resource path="res://src/main/ui/level-select/LevelSelectButtonPressed.tres" type="StyleBox" id=7]
-[ext_resource path="res://src/main/ui/level-select/LevelSelectButtonNormal.tres" type="StyleBox" id=8]
+[ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=5]
 [ext_resource path="res://assets/main/fuzzy-circle-256.png" type="Texture" id=9]
 [ext_resource path="res://src/main/ui/level-select/hardcore-button-halo.gd" type="Script" id=10]
 
-[sub_resource type="DynamicFont" id=1]
+[sub_resource type="DynamicFont" id=23]
+resource_local_to_scene = true
 outline_size = 2
 outline_color = Color( 0.423529, 0.262745, 0.192157, 1 )
 use_filter = true
-font_data = ExtResource( 2 )
+extra_spacing_top = -2
+extra_spacing_bottom = -2
+font_data = ExtResource( 5 )
 
 [sub_resource type="Gradient" id=4]
 offsets = PoolRealArray( 0, 0.683824, 1 )
@@ -155,35 +155,10 @@ rect_min_size = Vector2( 120, 80 )
 mouse_filter = 1
 script = ExtResource( 1 )
 
-[node name="ButtonControlHolder" type="Node2D" parent="."]
-z_index = 1
+[node name="ButtonControlHolder" parent="." instance=ExtResource( 2 )]
 
-[node name="ButtonControl" type="Button" parent="ButtonControlHolder" groups=["level_select_buttons"]]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_right = 120.0
-margin_bottom = 80.0
-custom_colors/font_color = Color( 1, 1, 1, 1 )
-custom_fonts/font = SubResource( 1 )
-custom_styles/hover = ExtResource( 8 )
-custom_styles/pressed = ExtResource( 7 )
-custom_styles/focus = ExtResource( 5 )
-custom_styles/normal = ExtResource( 8 )
-
-[node name="Label" type="Label" parent="ButtonControlHolder/ButtonControl"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 4.0
-margin_top = 4.0
-margin_right = -4.0
-margin_bottom = -4.0
-size_flags_vertical = 1
-custom_fonts/font = ExtResource( 6 )
-text = "Just getting started"
-align = 1
-valign = 1
-autowrap = true
-clip_text = true
+[node name="Label" parent="ButtonControlHolder/ButtonControl" index="0"]
+custom_fonts/font = SubResource( 23 )
 
 [node name="Decorations" type="Control" parent="."]
 anchor_right = 1.0
@@ -245,5 +220,6 @@ texture = ExtResource( 9 )
 [connection signal="pressed" from="ButtonControlHolder/ButtonControl" to="." method="_on_ButtonControl_pressed"]
 [connection signal="resized" from="Halo" to="Halo" method="_on_resized"]
 
+[editable path="ButtonControlHolder"]
 [editable path="Decorations/BottomLeft/FgSkulls"]
 [editable path="Decorations/BottomRight/FgSkulls"]

--- a/project/src/main/ui/level-select/LevelSelectButton.tscn
+++ b/project/src/main/ui/level-select/LevelSelectButton.tscn
@@ -1,17 +1,17 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=5 format=2]
 
-[ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=1]
+[ext_resource path="res://src/main/ui/level-select/LevelSelectButtonControlHolder.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/ui/level-select/level-select-button.gd" type="Script" id=2]
-[ext_resource path="res://src/main/ui/level-select/LevelSelectButtonNormal.tres" type="StyleBox" id=3]
-[ext_resource path="res://src/main/ui/level-select/LevelSelectButtonPressed.tres" type="StyleBox" id=4]
-[ext_resource path="res://src/main/ui/level-select/LevelSelectButtonFocus.tres" type="StyleBox" id=5]
-[ext_resource path="res://src/main/ui/level-select/LevelSelectButtonFont.tres" type="DynamicFont" id=6]
+[ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=3]
 
 [sub_resource type="DynamicFont" id=1]
+resource_local_to_scene = true
 outline_size = 2
 outline_color = Color( 0.423529, 0.262745, 0.192157, 1 )
 use_filter = true
-font_data = ExtResource( 1 )
+extra_spacing_top = -2
+extra_spacing_bottom = -2
+font_data = ExtResource( 3 )
 
 [node name="LevelSelectButton" type="Control"]
 margin_right = 120.0
@@ -20,35 +20,10 @@ rect_min_size = Vector2( 120, 80 )
 mouse_filter = 1
 script = ExtResource( 2 )
 
-[node name="ButtonControlHolder" type="Node2D" parent="."]
-z_index = 1
+[node name="ButtonControlHolder" parent="." instance=ExtResource( 1 )]
 
-[node name="ButtonControl" type="Button" parent="ButtonControlHolder" groups=["level_select_buttons"]]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_right = 120.0
-margin_bottom = 80.0
-custom_colors/font_color = Color( 1, 1, 1, 1 )
+[node name="Label" parent="ButtonControlHolder/ButtonControl" index="0"]
 custom_fonts/font = SubResource( 1 )
-custom_styles/hover = ExtResource( 3 )
-custom_styles/pressed = ExtResource( 4 )
-custom_styles/focus = ExtResource( 5 )
-custom_styles/normal = ExtResource( 3 )
-
-[node name="Label" type="Label" parent="ButtonControlHolder/ButtonControl"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 4.0
-margin_top = 4.0
-margin_right = -4.0
-margin_bottom = -4.0
-size_flags_vertical = 1
-custom_fonts/font = ExtResource( 6 )
-text = "Just getting started"
-align = 1
-valign = 1
-autowrap = true
-clip_text = true
 
 [node name="GradeHook" type="RemoteTransform2D" parent="."]
 position = Vector2( 12, 6 )
@@ -61,3 +36,5 @@ z_index = 1
 [connection signal="focus_entered" from="ButtonControlHolder/ButtonControl" to="." method="_on_ButtonControl_focus_entered"]
 [connection signal="focus_exited" from="ButtonControlHolder/ButtonControl" to="." method="_on_ButtonControl_focus_exited"]
 [connection signal="pressed" from="ButtonControlHolder/ButtonControl" to="." method="_on_ButtonControl_pressed"]
+
+[editable path="ButtonControlHolder"]

--- a/project/src/main/ui/level-select/LevelSelectButtonControlHolder.tscn
+++ b/project/src/main/ui/level-select/LevelSelectButtonControlHolder.tscn
@@ -1,0 +1,43 @@
+[gd_scene load_steps=7 format=2]
+
+[ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=1]
+[ext_resource path="res://src/main/ui/level-select/LevelSelectButtonFocus.tres" type="StyleBox" id=4]
+[ext_resource path="res://src/main/ui/level-select/LevelSelectButtonFont.tres" type="DynamicFont" id=5]
+[ext_resource path="res://src/main/ui/level-select/LevelSelectButtonPressed.tres" type="StyleBox" id=6]
+[ext_resource path="res://src/main/ui/level-select/LevelSelectButtonNormal.tres" type="StyleBox" id=7]
+
+[sub_resource type="DynamicFont" id=1]
+outline_size = 2
+outline_color = Color( 0.423529, 0.262745, 0.192157, 1 )
+use_filter = true
+font_data = ExtResource( 1 )
+
+[node name="ButtonControlHolder" type="Node2D"]
+z_index = 1
+
+[node name="ButtonControl" type="Button" parent="." groups=["level_select_buttons"]]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_right = 120.0
+margin_bottom = 80.0
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_fonts/font = SubResource( 1 )
+custom_styles/hover = ExtResource( 7 )
+custom_styles/pressed = ExtResource( 6 )
+custom_styles/focus = ExtResource( 4 )
+custom_styles/normal = ExtResource( 7 )
+
+[node name="Label" type="Label" parent="ButtonControl"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 4.0
+margin_top = 4.0
+margin_right = -4.0
+margin_bottom = -4.0
+size_flags_vertical = 1
+custom_fonts/font = ExtResource( 5 )
+text = "Just getting started"
+align = 1
+valign = 1
+autowrap = true
+clip_text = true

--- a/project/src/main/ui/level-select/LevelSelectButtonFont.tres
+++ b/project/src/main/ui/level-select/LevelSelectButtonFont.tres
@@ -7,4 +7,6 @@ resource_local_to_scene = true
 outline_size = 2
 outline_color = Color( 0.423529, 0.262745, 0.192157, 1 )
 use_filter = true
+extra_spacing_top = -2
+extra_spacing_bottom = -2
 font_data = ExtResource( 1 )

--- a/project/src/main/ui/level-select/level-select-button.gd
+++ b/project/src/main/ui/level-select/level-select-button.gd
@@ -46,9 +46,6 @@ const SHORT := LevelSize.SHORT
 const MEDIUM := LevelSize.MEDIUM
 const LONG := LevelSize.LONG
 
-const MAX_BUTTON_HEIGHT := 120
-const VERTICAL_SPACING := 6
-
 var level_id: String
 
 ## Enum from LevelSize for the duration of the level. This affects the button size
@@ -211,9 +208,9 @@ func _refresh_appearance() -> void:
 		return
 	
 	match level_duration:
-		LevelSize.SHORT: rect_min_size.y = MAX_BUTTON_HEIGHT * 0.5
-		LevelSize.MEDIUM: rect_min_size.y = MAX_BUTTON_HEIGHT * 0.75 + VERTICAL_SPACING * 0.5
-		LevelSize.LONG: rect_min_size.y = MAX_BUTTON_HEIGHT + VERTICAL_SPACING
+		LevelSize.SHORT: rect_min_size.y = 80
+		LevelSize.MEDIUM: rect_min_size.y = 100
+		LevelSize.LONG: rect_min_size.y = 120
 	
 	_label.text = StringUtils.default_if_empty(level_name, "-")
 	


### PR DESCRIPTION
Updated LevelSelectButtonFont 'extra_spacing' property to vertically condense the text.

Extracted 'LevelSelectButtonControlHolder' to reduce repetition between LevelSelectButton and HardcoreLevelSelectButton.

Changed LevelSelectButton heights from 60/93/126 to 80/100/120. They still get taller for longer levels, but the calculations are simpler and the heights are less variable. This makes it easier to accommodate button icons in an upcoming commit.