### PR TITLE
CandyColorPickerDemo: signals, position

### DIFF
--- a/project/src/demo/ui/candy-button/CandyColorPickerDemo.tscn
+++ b/project/src/demo/ui/candy-button/CandyColorPickerDemo.tscn
@@ -18,4 +18,5 @@ margin_top = 286.0
 margin_right = 332.0
 margin_bottom = 326.0
 
+[connection signal="color_changed" from="ColorPicker" to="." method="_on_ColorPicker_color_changed"]
 [connection signal="resized" from="ColorPicker" to="." method="_on_ColorPicker_resized"]

--- a/project/src/demo/ui/candy-button/candy-color-picker-demo.gd
+++ b/project/src/demo/ui/candy-button/candy-color-picker-demo.gd
@@ -54,4 +54,4 @@ func _on_ColorPicker_resized() -> void:
 	if not _color_picker:
 		return
 	
-	_color_picker.rect_position = (get_viewport().size - _color_picker.rect_size) / 2
+	_color_picker.rect_position = (Global.window_size - _color_picker.rect_size) / 2


### PR DESCRIPTION
Restored CandyColorPickerDemo 'color_changed' signal

Fixed 'rect_position' calculation which moved the panel too far to the bottom right if the window was resized