### PR TITLE
Updating achievement timing

### DIFF
--- a/project/src/main/steam/chapter-rank-s-achievement.gd
+++ b/project/src/main/steam/chapter-rank-s-achievement.gd
@@ -7,10 +7,10 @@ export (String) var stat_id: String
 ## The region ID whose unlock status should be tracked.
 export (String) var region_id: String
 
-func _ready() -> void:
+func connect_signals() -> void:
+	.connect_signals()
 	# avoid checking for 'rank s' every time we save; this changes infrequently and is expensive to check.
 	disconnect_save_signal()
-	
 	PuzzleState.connect("after_game_ended", self, "_on_PuzzleState_after_game_ended")
 
 

--- a/project/src/main/steam/chapter-story-finished-achievement.gd
+++ b/project/src/main/steam/chapter-story-finished-achievement.gd
@@ -7,10 +7,10 @@ export (String) var stat_id: String
 ## The region ID whose cutscenes should be tracked.
 export (String) var region_id: String
 
-func _ready() -> void:
+func connect_signals() -> void:
+	.connect_signals()
 	# avoid checking for story completion every time we save; this changes infrequently and is expensive to check.
 	disconnect_save_signal()
-	
 	CurrentCutscene.connect("cutscene_played", self, "_on_CurrentCutscene_cutscene_played")
 
 

--- a/project/src/main/steam/combo-achievement.gd
+++ b/project/src/main/steam/combo-achievement.gd
@@ -6,7 +6,8 @@ export (int) var target_combo: int = 0
 ## Highest combo the player has achieved since launching the game.
 var _max_combo := 0
 
-func _ready() -> void:
+func connect_signals() -> void:
+	.connect_signals()
 	disconnect_save_signal()
 	disconnect_load_signal()
 	PuzzleState.connect("combo_changed", self, "_on_PuzzleState_combo_changed")

--- a/project/src/main/steam/create-creature-achievement.gd
+++ b/project/src/main/steam/create-creature-achievement.gd
@@ -1,7 +1,8 @@
 extends SteamAchievement
 ## Unlocks an achievement when the player customizes their creature.
 
-func _ready() -> void:
+func connect_signals() -> void:
+	.connect_signals()
 	# The creature editor does not fire a 'save_scheduled' signal when saving; we connect a 'before_save' signal
 	# instead
 	disconnect_save_signal()

--- a/project/src/main/steam/customer-score-achievement.gd
+++ b/project/src/main/steam/customer-score-achievement.gd
@@ -6,7 +6,8 @@ export (int) var target_score: int = 0
 ## Highest single-customer score the player has achieved since launching the game.
 var _max_score := 0
 
-func _ready() -> void:
+func connect_signals() -> void:
+	.connect_signals()
 	disconnect_save_signal()
 	disconnect_load_signal()
 	PuzzleState.connect("score_changed", self, "_on_PuzzleState_score_changed")

--- a/project/src/main/steam/leftovers-score-achievement.gd
+++ b/project/src/main/steam/leftovers-score-achievement.gd
@@ -6,7 +6,8 @@ export (int) var target_score: int = 0
 ## Highest leftover lines score the player has achieved since launching the game.
 var _max_score := 0
 
-func _ready() -> void:
+func connect_signals() -> void:
+	.connect_signals()
 	disconnect_save_signal()
 	disconnect_load_signal()
 	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")

--- a/project/src/main/steam/rank-m-achievement.gd
+++ b/project/src/main/steam/rank-m-achievement.gd
@@ -4,7 +4,8 @@ extends SteamAchievement
 ## The best rank the player has achieved on any level since launching the game.
 var _best_level_rank: float = RankCalculator.WORST_RANK
 
-func _ready() -> void:
+func connect_signals() -> void:
+	.connect_signals()
 	disconnect_save_signal()
 	disconnect_load_signal()
 	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")

--- a/project/src/main/steam/shark-smush-achievement.gd
+++ b/project/src/main/steam/shark-smush-achievement.gd
@@ -1,7 +1,8 @@
 extends SteamAchievement
 ## Unlocks an achievement when the player squishes a shark with a piece.
 
-func _ready() -> void:
+func connect_signals() -> void:
+	.connect_signals()
 	disconnect_save_signal()
 	disconnect_load_signal()
 	Breadcrumb.connect("after_scene_changed", self, "_on_Breadcrumb_after_scene_changed")

--- a/project/src/main/steam/steam-achievement.gd
+++ b/project/src/main/steam/steam-achievement.gd
@@ -8,9 +8,20 @@ extends Node
 export (String) var achievement_id: String
 
 func _ready() -> void:
+	add_to_group("steam_achievements")
+	
+	# avoid flooding the steam API with calls on startup; otherwise the game can crash
+	yield(get_tree().create_timer(3), "timeout")
+	connect_signals()
+
+
+## Connects signals needed for this achievement. Can be overridden by child scripts to connect other signals.
+##
+## Signals are connected a few seconds after startup to avoid immediately flooding the Steam API with calls when
+## loading the player's initial save. Otherwise the game can crash.
+func connect_signals() -> void:
 	PlayerSave.connect("save_scheduled", self, "_on_PlayerSave_save_scheduled")
 	PlayerSave.connect("after_load", self, "_on_PlayerSave_after_load")
-	add_to_group("steam_achievements")
 
 
 func disconnect_save_signal() -> void:

--- a/project/src/main/steam/unique-level-achievement.gd
+++ b/project/src/main/steam/unique-level-achievement.gd
@@ -13,7 +13,8 @@ extends SteamAchievement
 ## The level ID whose achievement condition should be checked.
 export (String) var level_id: String
 
-func _ready() -> void:
+func connect_signals() -> void:
+	.connect_signals()
 	disconnect_save_signal()
 	disconnect_load_signal()
 	Breadcrumb.connect("after_scene_changed", self, "_on_Breadcrumb_after_scene_changed")


### PR DESCRIPTION
Steam Achievements now connect their signals 3 seconds after startup. This prevents us from immediately flooding the Steam API with calls on startup, which was causing the game to crash.