### PR TITLE
Refactor: Extracted GradeLabels.tscn

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -559,6 +559,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/ui/level-select/grade-label.gd"
 }, {
+"base": "Control",
+"class": "GradeLabels",
+"language": "GDScript",
+"path": "res://src/main/ui/level-select/level-grade-labels.gd"
+}, {
 "base": "Node",
 "class": "GradientHelper",
 "language": "GDScript",
@@ -1705,6 +1710,7 @@ _global_script_class_icons={
 "GoopGlob": "",
 "GoopViewports": "",
 "GradeLabel": "",
+"GradeLabels": "",
 "GradientHelper": "",
 "GraphicsSettings": "",
 "GutHookScript": "",

--- a/project/src/demo/ui/level-select/LevelSelectButtonDemo.tscn
+++ b/project/src/demo/ui/level-select/LevelSelectButtonDemo.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://src/demo/ui/level-select/level-select-button-demo.gd" type="Script" id=1]
 [ext_resource path="res://src/main/ui/level-select/LevelSelectButton.tscn" type="PackedScene" id=2]
-[ext_resource path="res://src/main/ui/level-select/HookableLevelGradeLabel.tscn" type="PackedScene" id=3]
-[ext_resource path="res://src/main/ui/level-select/level-grade-labels.gd" type="Script" id=4]
+[ext_resource path="res://src/main/ui/level-select/GradeLabels.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/ui/level-select/HardcoreLevelSelectButton.tscn" type="PackedScene" id=5]
 
 [sub_resource type="StyleBoxFlat" id=1]
@@ -37,9 +36,4 @@ anchor_bottom = 1.0
 size_flags_vertical = 4
 columns = 6
 
-[node name="GradeLabels" type="Control" parent="Control"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-script = ExtResource( 4 )
-GradeLabelScene = ExtResource( 3 )
+[node name="GradeLabels" parent="Control" instance=ExtResource( 3 )]

--- a/project/src/main/career/CareerMap.tscn
+++ b/project/src/main/career/CareerMap.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=35 format=2]
+[gd_scene load_steps=34 format=2]
 
-[ext_resource path="res://src/main/ui/level-select/level-grade-labels.gd" type="Script" id=1]
+[ext_resource path="res://src/main/ui/level-select/GradeLabels.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/career-map.gd" type="Script" id=2]
-[ext_resource path="res://src/main/ui/level-select/HookableLevelGradeLabel.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/world/OverworldBg.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=5]
 [ext_resource path="res://src/main/ui/level-select/LevelSelectButton.tscn" type="PackedScene" id=6]
@@ -80,12 +79,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 size_flags_vertical = 3
 
-[node name="GradeLabels" type="Control" parent="LevelSelect/Control"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-script = ExtResource( 1 )
-GradeLabelScene = ExtResource( 3 )
+[node name="GradeLabels" parent="LevelSelect/Control" instance=ExtResource( 1 )]
 
 [node name="ProgressBoardHolder" parent="." instance=ExtResource( 9 )]
 visible = false

--- a/project/src/main/ui/level-select/GradeLabels.tscn
+++ b/project/src/main/ui/level-select/GradeLabels.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://src/main/ui/level-select/level-grade-labels.gd" type="Script" id=1]
+[ext_resource path="res://src/main/ui/level-select/HookableLevelGradeLabel.tscn" type="PackedScene" id=2]
+
+[node name="GradeLabels" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+script = ExtResource( 1 )
+GradeLabelScene = ExtResource( 2 )

--- a/project/src/main/ui/level-select/LevelButtonScroller.tscn
+++ b/project/src/main/ui/level-select/LevelButtonScroller.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://src/main/ui/level-select/level-button-scroller.gd" type="Script" id=1]
 [ext_resource path="res://src/main/ui/level-select/LevelSelectButton.tscn" type="PackedScene" id=2]
-[ext_resource path="res://src/main/ui/level-select/HookableLevelGradeLabel.tscn" type="PackedScene" id=3]
-[ext_resource path="res://src/main/ui/level-select/level-grade-labels.gd" type="Script" id=4]
+[ext_resource path="res://src/main/ui/level-select/GradeLabels.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=6]
 
 [node name="LevelButtonScroller" type="Control"]
@@ -30,12 +29,7 @@ margin_bottom = 105.0
 size_flags_horizontal = 4
 size_flags_vertical = 4
 
-[node name="GradeLabels" type="Control" parent="."]
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-script = ExtResource( 4 )
-GradeLabelScene = ExtResource( 3 )
+[node name="GradeLabels" parent="." instance=ExtResource( 3 )]
 
 [node name="CheatCodeDetector" parent="." instance=ExtResource( 6 )]
 codes = [ "unlock" ]

--- a/project/src/main/ui/level-select/level-grade-labels.gd
+++ b/project/src/main/ui/level-select/level-grade-labels.gd
@@ -1,3 +1,4 @@
+class_name GradeLabels
 extends Control
 ## Manages grade labels which overlay level select buttons.
 ##
@@ -21,10 +22,6 @@ func add_label(button: LevelSelectButton) -> void:
 	new_label.button = button
 	
 	button.connect("tree_exited", self, "_on_LevelSelectButton_tree_exited", [button])
-
-
-func _on_LevelButtons_button_added(button: LevelSelectButton) -> void:
-	add_label(button)
 
 
 func _on_LevelSelectButton_tree_exited(button: LevelSelectButton) -> void:

--- a/project/src/main/ui/menu/PagedLevelPanel.tscn
+++ b/project/src/main/ui/menu/PagedLevelPanel.tscn
@@ -1,14 +1,13 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://src/main/ui/level-select/LevelSelectButton.tscn" type="PackedScene" id=1]
-[ext_resource path="res://src/main/ui/level-select/HookableLevelGradeLabel.tscn" type="PackedScene" id=2]
+[ext_resource path="res://src/main/ui/level-select/GradeLabels.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/ui/squeak/gy/SqueakButton.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/ui/menu/paged-level-buttons.gd" type="Script" id=5]
 [ext_resource path="res://src/main/ui/squeak/gy/squeak-theme-h4.tres" type="Theme" id=6]
 [ext_resource path="res://src/main/ui/menu/paged-level-panel.gd" type="Script" id=7]
 [ext_resource path="res://src/main/ui/level-select/level-submenu-info-panel.gd" type="Script" id=8]
-[ext_resource path="res://src/main/ui/level-select/level-grade-labels.gd" type="Script" id=10]
 [ext_resource path="res://src/main/ui/level-select/level-submenu-description-panel.gd" type="Script" id=11]
 [ext_resource path="res://src/main/ui/theme/h2.theme" type="Theme" id=13]
 [ext_resource path="res://src/main/ui/theme/h4.theme" type="Theme" id=14]
@@ -73,6 +72,7 @@ margin_bottom = 145.0
 alignment = 1
 script = ExtResource( 5 )
 LevelButtonScene = ExtResource( 1 )
+grade_labels_path = NodePath("../GradeLabels")
 
 [node name="LeftArrow" parent="VBoxContainer/Top/LevelButtons" instance=ExtResource( 4 )]
 margin_left = 364.0
@@ -108,12 +108,7 @@ theme = ExtResource( 6 )
 enabled_focus_mode = 1
 text = ">"
 
-[node name="GradeLabels" type="Control" parent="VBoxContainer/Top"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-mouse_filter = 2
-script = ExtResource( 10 )
-GradeLabelScene = ExtResource( 2 )
+[node name="GradeLabels" parent="VBoxContainer/Top" instance=ExtResource( 2 )]
 
 [node name="Bottom" type="Control" parent="VBoxContainer"]
 margin_top = 380.0
@@ -178,7 +173,6 @@ valign = 1
 [node name="CheatCodeDetector" parent="." instance=ExtResource( 3 )]
 codes = [ "unlock" ]
 
-[connection signal="button_added" from="VBoxContainer/Top/LevelButtons" to="VBoxContainer/Top/GradeLabels" method="_on_LevelButtons_button_added"]
 [connection signal="level_chosen" from="VBoxContainer/Top/LevelButtons" to="." method="_on_LevelButtons_level_chosen"]
 [connection signal="locked_level_focused" from="VBoxContainer/Top/LevelButtons" to="VBoxContainer/Bottom/HBoxContainer/Description" method="_on_LevelButtons_locked_level_focused"]
 [connection signal="locked_level_focused" from="VBoxContainer/Top/LevelButtons" to="VBoxContainer/Bottom/HBoxContainer/Info" method="_on_LevelButtons_locked_level_focused"]

--- a/project/src/main/ui/menu/paged-level-buttons.gd
+++ b/project/src/main/ui/menu/paged-level-buttons.gd
@@ -20,6 +20,8 @@ const MAX_LEVELS_PER_PAGE := 18
 
 export (PackedScene) var LevelButtonScene: PackedScene
 
+export (NodePath) var grade_labels_path: NodePath
+
 ## CareerRegion or OtherRegion instance whose levels are being shown
 var region: Object setget set_region
 
@@ -41,6 +43,8 @@ onready var _grid_container := $GridContainer
 ## arrows for paging left and right
 onready var _left_arrow := $LeftArrow
 onready var _right_arrow := $RightArrow
+
+onready var _grade_labels: GradeLabels = get_node(grade_labels_path)
 
 func _ready() -> void:
 	_refresh()
@@ -138,6 +142,7 @@ func _add_buttons() -> void:
 				level_ids[i], max_shown_level - min_shown_level + 1)
 		
 		_grid_container.add_child(new_level_button)
+		_grade_labels.add_label(new_level_button)
 		emit_signal("button_added", new_level_button)
 	
 	# assign default focus to the first button


### PR DESCRIPTION
Extracted GradeLabels node. The script was already reused, but the node encapsulates the 'HookableLevelGradeLabel' packed scene, mouse filter, anchors and other node properties.

Removed LevelGradeLabels 'button_added' signal receiver. This was a bit of a 'gotcha' when extracting this scene, and I don't like the design. This signal method is only used by PagedLevelPanel, and it makes more sense to be on one of PagedLevelPanel's scripts instead.