### PR TITLE
Music renames: chill/upbeat/song/music -> menu/puzzle/track

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -225,9 +225,9 @@ _global_script_classes=[ {
 "path": "res://src/main/ui/cheat-code-detector.gd"
 }, {
 "base": "AudioStreamPlayer",
-"class": "CheckpointSong",
+"class": "CheckpointMusicTrack",
 "language": "GDScript",
-"path": "res://src/main/music/checkpoint-song.gd"
+"path": "res://src/main/music/checkpoint-music-track.gd"
 }, {
 "base": "Reference",
 "class": "ComboBreakRules",
@@ -1643,7 +1643,7 @@ _global_script_class_icons={
 "ChatTree": "",
 "ChatscriptParser": "",
 "CheatCodeDetector": "",
-"CheckpointSong": "",
+"CheckpointMusicTrack": "",
 "ComboBreakRules": "",
 "ComboBurst": "",
 "ComboTracker": "",

--- a/project/src/demo/credits/credits-scroll-demo.gd
+++ b/project/src/demo/credits/credits-scroll-demo.gd
@@ -101,9 +101,9 @@ func _input(event: InputEvent) -> void:
 
 func _set_time_scale(new_time_scale: float) -> void:
 	Engine.time_scale = new_time_scale
-	if MusicPlayer.current_bgm:
-		MusicPlayer.current_bgm.pitch_scale = new_time_scale
-		MusicPlayer.current_bgm.play(_total_time)
+	if MusicPlayer.current_track:
+		MusicPlayer.current_track.pitch_scale = new_time_scale
+		MusicPlayer.current_track.play(_total_time)
 
 
 func _physics_process(delta: float) -> void:

--- a/project/src/demo/editor/creature-old/creature-editor-old.gd
+++ b/project/src/demo/editor/creature-old/creature-editor-old.gd
@@ -38,7 +38,7 @@ onready var outer_creatures := [
 	$World/Creatures/SeCreature,
 ]
 
-## UI which tracks things like mutagen level and locked/unlocked alleles
+## UI which monitors things like mutagen level and locked/unlocked alleles
 onready var _mutate_ui := $Ui/TabContainer/Mutate
 onready var _reroll_ui := $Ui/Reroll
 

--- a/project/src/demo/music/music-player-demo.gd
+++ b/project/src/demo/music/music-player-demo.gd
@@ -5,15 +5,15 @@ extends Node
 ## When playing a music track, it skips to the least stale parts of the track.
 ##
 ## Keys:
-## 	[1]: Play chill song
-## 	[2]: Play upbeat song
-## 	[3]: Play tutorial song
+## 	[1]: Play menu music track
+## 	[2]: Play puzzle music track
+## 	[3]: Play tutorial music track
 ##
 ## 	[N]: Toggle night filter
 ##
-## 	[-]: Fade out the current song
-## 	[=]: Fade in the current song
-## 	Right brace: Skip to next checkpoint in song
+## 	[-]: Fade out the current music track
+## 	[=]: Fade in the current music track
+## 	Right brace: Skip to next checkpoint in music track
 
 func _ready() -> void:
 	SystemData.volume_settings.set_bus_volume_linear(VolumeSettings.MUSIC, 0.5)
@@ -21,34 +21,34 @@ func _ready() -> void:
 
 func _input(event: InputEvent) -> void:
 	match Utils.key_scancode(event):
-		KEY_1: MusicPlayer.play_chill_bgm(false)
-		KEY_2: MusicPlayer.play_upbeat_bgm(false)
-		KEY_3: MusicPlayer.play_tutorial_bgm(false)
+		KEY_1: MusicPlayer.play_menu_track(false)
+		KEY_2: MusicPlayer.play_puzzle_track(false)
+		KEY_3: MusicPlayer.play_tutorial_track(false)
 		KEY_N: MusicPlayer.night_filter = not MusicPlayer.night_filter
 		KEY_MINUS: MusicPlayer.stop()
 		KEY_EQUAL:
-			if not MusicPlayer.current_bgm:
-				MusicPlayer.play_chill_bgm()
+			if not MusicPlayer.current_track:
+				MusicPlayer.play_menu_track()
 			MusicPlayer.fade_in()
 		KEY_BRACKETRIGHT: next_checkpoint()
 
 
 func next_checkpoint() -> void:
-	if not MusicPlayer.current_bgm:
+	if not MusicPlayer.current_track:
 		return
 	
-	var checkpoints: Array = MusicPlayer.current_bgm.checkpoints
-	var curr_playback_position := MusicPlayer.current_bgm.get_playback_position()
+	var checkpoints: Array = MusicPlayer.current_track.checkpoints
+	var curr_playback_position := MusicPlayer.current_track.get_playback_position()
 	var closest_checkpoint := 0.0
 	for checkpoint in checkpoints:
 		if checkpoint >= curr_playback_position:
 			if closest_checkpoint < curr_playback_position \
 					or (checkpoint - curr_playback_position < closest_checkpoint - curr_playback_position):
 				closest_checkpoint = checkpoint
-	MusicPlayer.current_bgm.seek(closest_checkpoint)
+	MusicPlayer.current_track.seek(closest_checkpoint)
 
 
 func _on_Timer_timeout() -> void:
 	$RichTextLabel.clear()
-	for bgm in MusicPlayer.all_bgms:
-		$RichTextLabel.text += "%s %s\n" % [bgm.name, bgm._staleness_record]
+	for track in MusicPlayer.all_tracks:
+		$RichTextLabel.text += "%s %s\n" % [track.name, track._staleness_record]

--- a/project/src/demo/toolkit/fix-levels-button.gd
+++ b/project/src/demo/toolkit/fix-levels-button.gd
@@ -103,25 +103,25 @@ func _report_invalid_career_levels() -> void:
 		_output_label.add_line("Invalid levels in career regions: %s" % [keys_to_print])
 
 
-## Reports any regions in career-regions.json with missing or invalid music ids
+## Reports any regions in career-regions.json with missing or invalid music track ids
 func _report_invalid_career_music() -> void:
 	var invalid_region_ids := {}
 	
 	for region in CareerLevelLibrary.regions:
-		if region.music.menu_music_id == null:
-			push_warning("%s - menu_music_id is empty" % [region.id])
+		if region.music.menu_track_id == null:
+			push_warning("%s - menu_track_id is empty" % [region.id])
 			invalid_region_ids[region.id] = true
-		elif MusicPlayer.bgm_for_id(region.music.menu_music_id) == null:
-			push_warning("%s - invalid menu_music_id: %s" % [region.id, region.music.menu_music_id])
+		elif MusicPlayer.track_for_id(region.music.menu_track_id) == null:
+			push_warning("%s - invalid menu_track_id: %s" % [region.id, region.music.menu_track_id])
 			invalid_region_ids[region.id] = true
 		
-		if not region.music.puzzle_music_ids:
-			push_warning("%s - puzzle_music_ids is empty" % [region.id])
+		if not region.music.puzzle_track_ids:
+			push_warning("%s - puzzle_track_ids is empty" % [region.id])
 			invalid_region_ids[region.id] = true
 		else:
-			for puzzle_music_id in region.music.puzzle_music_ids:
-				if MusicPlayer.bgm_for_id(puzzle_music_id) == null:
-					push_warning("%s - invalid puzzle_music_id: %s" % [region.id, puzzle_music_id])
+			for puzzle_track_id in region.music.puzzle_track_ids:
+				if MusicPlayer.track_for_id(puzzle_track_id) == null:
+					push_warning("%s - invalid puzzle_track_id: %s" % [region.id, puzzle_track_id])
 					invalid_region_ids[region.id] = true
 	
 	if invalid_region_ids:

--- a/project/src/demo/world/cutscene-demo.gd
+++ b/project/src/demo/world/cutscene-demo.gd
@@ -19,7 +19,7 @@ func _ready() -> void:
 	# Initialize the Breadcrumb trail so that cutscenes will return to this demo after they finish.
 	Breadcrumb.initialize_trail()
 	
-	# stop any music which was playing during the cutscene
+	# stop any music track which was playing during the cutscene
 	MusicPlayer.stop()
 	
 	_load_demo_data()

--- a/project/src/demo/world/free-roam-demo.gd
+++ b/project/src/demo/world/free-roam-demo.gd
@@ -10,4 +10,4 @@ func _ready() -> void:
 		# For regular players the Breadcrumb trail will already be initialized by the menus.
 		Breadcrumb.initialize_trail()
 	
-	MusicPlayer.play_chill_bgm()
+	MusicPlayer.play_menu_track()

--- a/project/src/main/career/career-cutscene-library.gd
+++ b/project/src/main/career/career-cutscene-library.gd
@@ -312,7 +312,7 @@ func chat_keys(chat_key_roots: Array) -> Array:
 func find_chat_key_pairs(chat_key_roots: Array, search_flags: CutsceneSearchFlags) -> Array:
 	var potential_chat_key_pairs := []
 	
-	# We traverse the tree top-down. This queue tracks the child nodes we haven't traversed:
+	# We traverse the tree top-down. This queue monitors the child nodes we haven't traversed:
 	#
 	# [['00-a-01', '00-a-02], ['00-b', '00-c'], ['01']]
 	#

--- a/project/src/main/career/region-music.gd
+++ b/project/src/main/career/region-music.gd
@@ -1,51 +1,51 @@
 class_name RegionMusic
 ## Describes the music in a career region.
 ##
-## Each region defines a menu music id and set of puzzle music ids. These music ids correspond to entries in
-## MusicPlayer.bgms_by_id. The list of puzzle music ids obey two unusual rules:
+## Each region defines a menu music track id and set of puzzle music track ids. These track ids correspond to entries
+## in MusicPlayer.tracks_by_id. The list of puzzle music track ids obey two unusual rules:
 ##
-## 1. The first item in the list of puzzle music ids is the 'main puzzle music id'. This main puzzle music is played
-## for the first puzzle of each career data and for the boss level.
+## 1. The first item in the list of puzzle music track ids is the 'main puzzle music track id'. This main puzzle track
+## is played for the first puzzle of each career data and for the boss level.
 ##
-## 2. Json puzzle music ids prefixed with a '+' will play twice as often.
+## 2. Json puzzle music track ids prefixed with a '+' will play twice as often.
 
 ## Music to play while the player navigates menus
-var menu_music_id: String
+var menu_track_id: String
 
-## String music ids to play while the player is playing a level
-var puzzle_music_ids: Array
+## String music track ids to play while the player is playing a level
+var puzzle_track_ids: Array
 
-## Puzzle music which should be played more frequently than other music
+## Puzzle track which should be played more frequently than other music
 ##
-## key: (String) music id
+## key: (String) music track id
 ## value: (bool) true
-var _favored_puzzle_music_ids := {}
+var _favored_puzzle_track_ids := {}
 
-## Returns a random music id to play while the player is playing a level from this region.
-func random_puzzle_music_id() -> String:
-	var music_id_pool: Array = []
-	for puzzle_music_id in puzzle_music_ids:
-		music_id_pool.append(puzzle_music_id)
-		if _favored_puzzle_music_ids.has(puzzle_music_id):
-			music_id_pool.append(puzzle_music_id)
+## Returns a random music track id to play while the player is playing a level from this region.
+func random_puzzle_track_id() -> String:
+	var track_id_pool: Array = []
+	for puzzle_track_id in puzzle_track_ids:
+		track_id_pool.append(puzzle_track_id)
+		if _favored_puzzle_track_ids.has(puzzle_track_id):
+			track_id_pool.append(puzzle_track_id)
 	
-	return Utils.rand_value(music_id_pool)
+	return Utils.rand_value(track_id_pool)
 
 
-## Returns the main music id to play while the player is playing a level from this region.
+## Returns the main music track id to play while the player is playing a level from this region.
 ##
-## The main music id is played at the start of every career day, and for every boss level.
-func main_puzzle_music_id() -> String:
-	return puzzle_music_ids[0]
+## The main music track id is played at the start of every career day, and for every boss level.
+func main_puzzle_track_id() -> String:
+	return puzzle_track_ids[0]
 
 
 func from_json_dict(json: Dictionary) -> void:
-	_favored_puzzle_music_ids.clear()
-	menu_music_id = json.get("menu", "")
-	for puzzle_music_id in json.get("puzzle", []):
-		var new_puzzle_music_id: String = puzzle_music_id
-		if puzzle_music_id.begins_with("+"):
-			# json puzzle music ids prefixed with a '+' will play twice as often
-			new_puzzle_music_id = puzzle_music_id.trim_prefix("+")
-			_favored_puzzle_music_ids[new_puzzle_music_id] = true
-		puzzle_music_ids.append(new_puzzle_music_id)
+	_favored_puzzle_track_ids.clear()
+	menu_track_id = json.get("menu", "")
+	for puzzle_track_id in json.get("puzzle", []):
+		var new_puzzle_track_id: String = puzzle_track_id
+		if puzzle_track_id.begins_with("+"):
+			# json puzzle music track ids prefixed with a '+' will play twice as often
+			new_puzzle_track_id = puzzle_track_id.trim_prefix("+")
+			_favored_puzzle_track_ids[new_puzzle_track_id] = true
+		puzzle_track_ids.append(new_puzzle_track_id)

--- a/project/src/main/career/ui/career-win.gd
+++ b/project/src/main/career/ui/career-win.gd
@@ -9,7 +9,7 @@ onready var _applause_sound := $Bg/ApplauseSound
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
-	MusicPlayer.play_chill_bgm()
+	MusicPlayer.play_menu_track()
 	
 	_refresh_mood()
 	

--- a/project/src/main/chat/chat-history.gd
+++ b/project/src/main/chat/chat-history.gd
@@ -8,7 +8,7 @@ class_name ChatHistory
 ## conversation before.
 const CHAT_AGE_NEVER := 99999999
 
-## Tracks which conversations the player has had with each creature. The value is a per-creature index which starts
+## Monitors which conversations the player has had with each creature. The value is a per-creature index which starts
 ## from 0 and increments with each conversation with that creature.
 ##
 ## key: (String) chat key

--- a/project/src/main/chat/chatscript-parser.gd
+++ b/project/src/main/chat/chatscript-parser.gd
@@ -4,7 +4,7 @@ class_name ChatscriptParser
 ## This class is stateful and intended to be used once and thrown away. If it is reused, the previously parsed
 ## chat tree will be erased.
 
-## Tracks the state for the parser.
+## Monitors the state for the parser.
 ##
 ## The ChatscriptParser has different states based on whether it's parsing chat, characters, locations, or something
 ## else.

--- a/project/src/main/credits/credits-director.gd
+++ b/project/src/main/credits/credits-director.gd
@@ -104,7 +104,7 @@ func _ready() -> void:
 
 ## Schedules all of the credits events for the "cool credits" after the player beats the game.
 func play_cool_credits() -> void:
-	MusicPlayer.play_credits_bgm()
+	MusicPlayer.play_credits_track()
 	_music_sync_player.play("play")
 	
 	# initialize total_time to a particular value, so the letters which hit the header are 'T', 'u', 'r'...
@@ -141,7 +141,7 @@ func play_cool_credits() -> void:
 
 ## Schedules all of the credits events for the "boring credits" before the player beats the game.
 func play_boring_credits() -> void:
-	MusicPlayer.play_chill_bgm()
+	MusicPlayer.play_menu_track()
 	var credits_tween := get_tree().create_tween()
 	
 	var boring_credits := []
@@ -166,8 +166,9 @@ func play_boring_credits() -> void:
 ## lags, the game will end up ahead and this will be a negative number.
 func get_desync_amount() -> float:
 	var result := 0.0
-	if _music_sync_player.current_animation == "play" and _music_sync_player.is_playing() and MusicPlayer.current_bgm:
-		result = MusicPlayer.current_bgm.get_playback_position() - _music_sync_player.current_animation_position
+	if _music_sync_player.current_animation == "play" and _music_sync_player.is_playing() \
+			and MusicPlayer.current_track:
+		result = MusicPlayer.current_track.get_playback_position() - _music_sync_player.current_animation_position
 	return result
 
 

--- a/project/src/main/credits/credits-orb.gd
+++ b/project/src/main/credits/credits-orb.gd
@@ -9,7 +9,7 @@ extends Sprite
 ## Number of frames in our animation. Each frame launches a different puzzle piece.
 const FRAME_COUNT := 8
 
-## Rate at which to launch puzzle pieces. This is synchronized with the song "Sugar Crash" for the end credits.
+## Rate at which to launch puzzle pieces. This is synchronized with the music track "Sugar Crash" for the end credits.
 const PIECES_PER_SECOND := 4.10000
 
 export (NodePath) var wallpaper_path: NodePath

--- a/project/src/main/credits/pinup-scroller.gd
+++ b/project/src/main/credits/pinup-scroller.gd
@@ -22,7 +22,7 @@ const FADE_DURATION := 0.5
 ## Height in units. Used for calculating the scroll speed.
 export (float) var line_height: float
 
-## tracks whether the pinup is currently fading in or out
+## monitors whether the pinup is currently fading in or out
 var state: int = ScrollerState.VISIBLE
 
 var velocity := Vector2(0, -50)

--- a/project/src/main/music/CheckpointMusicTrack.tscn
+++ b/project/src/main/music/CheckpointMusicTrack.tscn
@@ -1,8 +1,8 @@
 [gd_scene load_steps=2 format=2]
 
-[ext_resource path="res://src/main/music/checkpoint-song.gd" type="Script" id=2]
+[ext_resource path="res://src/main/music/checkpoint-music-track.gd" type="Script" id=2]
 
-[node name="CheckpointSong" type="AudioStreamPlayer"]
+[node name="CheckpointMusicTrack" type="AudioStreamPlayer"]
 bus = "Music Bus"
 script = ExtResource( 2 )
 

--- a/project/src/main/music/MusicPlayer.tscn
+++ b/project/src/main/music/MusicPlayer.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=23 format=2]
 
 [ext_resource path="res://src/main/music/music-player.gd" type="Script" id=1]
-[ext_resource path="res://src/main/music/CheckpointSong.tscn" type="PackedScene" id=2]
+[ext_resource path="res://src/main/music/CheckpointMusicTrack.tscn" type="PackedScene" id=2]
 [ext_resource path="res://assets/main/music/triple-thicc-shake.ogg" type="AudioStream" id=3]
 [ext_resource path="res://src/main/music/music-tween-manager.gd" type="Script" id=4]
 [ext_resource path="res://assets/main/music/juicer-mixer-grinder.ogg" type="AudioStream" id=5]
@@ -30,137 +30,137 @@ script = ExtResource( 1 )
 [node name="AcidReflux" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 18 )
 checkpoints = [ 0.0, 32.912, 65.827, 87.771, 120.686 ]
-song_title = "Acid Reflux"
-song_color = Color( 0.3245, 0.55, 0.22, 1 )
+track_title = "Acid Reflux"
+track_color = Color( 0.3245, 0.55, 0.22, 1 )
 id = "acid_reflux"
 
 [node name="ChocolateChip" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 22 )
 checkpoints = [ 0.0, 15.476, 30.964 ]
-song_title = "Chocolate Chip Hipster"
-song_color = Color( 0.521569, 0.309804, 0.215686, 1 )
+track_title = "Chocolate Chip Hipster"
+track_color = Color( 0.521569, 0.309804, 0.215686, 1 )
 id = "chocolate_chip"
 
 [node name="ChubHub" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 13 )
 checkpoints = [ 0.0, 12.489, 32.489, 42.489, 142.489, 152.489, 162.489 ]
-song_title = "Chub Hub"
-song_color = Color( 0.352941, 0.666667, 0.301961, 1 )
+track_title = "Chub Hub"
+track_color = Color( 0.352941, 0.666667, 0.301961, 1 )
 id = "chub_hub"
 
 [node name="ChubNBass" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 15 )
 checkpoints = [ 0.0, 22.575, 101.642 ]
-song_title = "Chub 'n Bass"
-song_color = Color( 0.24, 0.75, 0.3675, 1 )
+track_title = "Chub 'n Bass"
+track_color = Color( 0.24, 0.75, 0.3675, 1 )
 id = "chub_n_bass"
 
 [node name="ChunkyObake" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 14 )
 checkpoints = [ 0.0, 31.473, 62.95, 94.422, 188.845 ]
-song_title = "Chunky Obake"
-song_color = Color( 0.988235, 0.588235, 0.929412, 1 )
+track_title = "Chunky Obake"
+track_color = Color( 0.988235, 0.588235, 0.929412, 1 )
 id = "chunky_obake"
 
 [node name="DessertCourse" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 17 )
 checkpoints = [ 0.0, 9.141, 18.286, 27.429, 36.571, 127.983 ]
-song_title = "Dessert Course (With No Name)"
-song_color = Color( 0.921569, 0.905882, 0.486275, 1 )
+track_title = "Dessert Course (With No Name)"
+track_color = Color( 0.921569, 0.905882, 0.486275, 1 )
 id = "dessert_course"
 
 [node name="DooDooDoo" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 7 )
 checkpoints = [ 0.0, 15.233, 45.721, 76.196, 106.67, 167.613 ]
-song_title = "Doo Doo Doo"
-song_color = Color( 0.494118, 0.905882, 0.423529, 1 )
+track_title = "Doo Doo Doo"
+track_color = Color( 0.494118, 0.905882, 0.423529, 1 )
 id = "doo_doo_doo"
 
 [node name="ExtraSprinkles" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 20 )
 volume_db = -3.0
 checkpoints = [ 0.0 ]
-song_title = "Extra Sprinkles"
-song_color = Color( 1, 0.74902, 0.34902, 1 )
+track_title = "Extra Sprinkles"
+track_color = Color( 1, 0.74902, 0.34902, 1 )
 id = "extra_sprinkles"
 
 [node name="GingerbreadHouse" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 21 )
 checkpoints = [ 0.0, 15.231, 30.476, 60.949, 137.143, 152.377 ]
-song_title = "Gingerbread House"
-song_color = Color( 0.913725, 0.905882, 0.47451, 1 )
+track_title = "Gingerbread House"
+track_color = Color( 0.913725, 0.905882, 0.47451, 1 )
 id = "gingerbread_house"
 
 [node name="LoFiChill" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 6 )
 checkpoints = [ 0.0, 10.646, 21.326, 63.988, 85.33, 213.328 ]
-song_title = "24/7 Lo-Fi Chill Hip Hop Beats to Eat & Get Fat To"
-song_color = Color( 0.360784, 0.427451, 0.847059, 1 )
+track_title = "24/7 Lo-Fi Chill Hip Hop Beats to Eat & Get Fat To"
+track_color = Color( 0.360784, 0.427451, 0.847059, 1 )
 id = "lo_fi_chill"
 
 [node name="HarderButter" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 16 )
 checkpoints = [ 0.0, 17.454, 34.908, 157.087 ]
-song_title = "Harder, Butter, Fatter, Stronger"
-song_color = Color( 0.678431, 0.678431, 0.678431, 1 )
+track_title = "Harder, Butter, Fatter, Stronger"
+track_color = Color( 0.678431, 0.678431, 0.678431, 1 )
 id = "harder_butter"
 
 [node name="HotFunkSundae" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 10 )
 checkpoints = [ 0.0, 8.707, 17.456, 69.826, 165.814 ]
-song_title = "Hot Funk Sundae"
-song_color = Color( 0.776471, 0.52549, 0.419608, 1 )
+track_title = "Hot Funk Sundae"
+track_color = Color( 0.776471, 0.52549, 0.419608, 1 )
 id = "hot_funk_sundae"
 
 [node name="JuicerMixerGrinder" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 5 )
 volume_db = -3.0
 checkpoints = [ 0.0, 12.916, 29.532, 88.61 ]
-song_title = "Juicer Mixer Grinder"
-song_color = Color( 0.909804, 0.439216, 0.435294, 1 )
+track_title = "Juicer Mixer Grinder"
+track_color = Color( 0.909804, 0.439216, 0.435294, 1 )
 id = "juicer_mixer_grinder"
 
 [node name="MyFatnessPal" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 11 )
 volume_db = 4.0
 checkpoints = [ 0.0, 25.098, 50.196, 74.681 ]
-song_title = "My Fatness Pal"
-song_color = Color( 0.709804, 0.486275, 0.917647, 1 )
+track_title = "My Fatness Pal"
+track_color = Color( 0.709804, 0.486275, 0.917647, 1 )
 id = "my_fatness_pal"
 
 [node name="MysticMuffin" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 8 )
 checkpoints = [ 0.0, 15.23, 30.474 ]
-song_title = "Mystic Muffin"
-song_color = Color( 0.709804, 0.486275, 0.917647, 1 )
+track_title = "Mystic Muffin"
+track_color = Color( 0.709804, 0.486275, 0.917647, 1 )
 id = "mystic_muffin"
 
 [node name="PressureCooker" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 12 )
 checkpoints = [ 0.0, 14.989, 29.982, 59.993 ]
-song_title = "Pressure Cooker"
-song_color = Color( 0.980392, 0.709804, 0.419608, 1 )
+track_title = "Pressure Cooker"
+track_color = Color( 0.980392, 0.709804, 0.419608, 1 )
 id = "pressure_cooker"
 
 [node name="RainbowSherbeat" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 19 )
 checkpoints = [ 0.0, 20.206, 101.058 ]
-song_title = "Rainbow Sherbeat"
-song_color = Color( 0.538333, 0.3825, 0.85, 1 )
+track_title = "Rainbow Sherbeat"
+track_color = Color( 0.538333, 0.3825, 0.85, 1 )
 id = "rainbow_sherbeat"
 
 [node name="SugarCrash" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 9 )
 checkpoints = [ 0.0, 1.951, 204.877 ]
-song_title = "Sugar Crash"
-song_color = Color( 0.321569, 0.686275, 0.890196, 1 )
+track_title = "Sugar Crash"
+track_color = Color( 0.321569, 0.686275, 0.890196, 1 )
 id = "sugar_crash"
 
 [node name="TripleThiccShake" parent="." instance=ExtResource( 2 )]
 stream = ExtResource( 3 )
 checkpoints = [ 0.0, 7.747, 23.229, 38.696 ]
-song_title = "Triple Thicc Shake"
-song_color = Color( 0.494118, 0.905882, 0.423529, 1 )
+track_title = "Triple Thicc Shake"
+track_color = Color( 0.494118, 0.905882, 0.423529, 1 )
 id = "triple_thicc_shake"
 
 [node name="MusicTweenManager" type="Node" parent="."]

--- a/project/src/main/music/checkpoint-music-track.gd
+++ b/project/src/main/music/checkpoint-music-track.gd
@@ -1,22 +1,22 @@
-class_name CheckpointSong
+class_name CheckpointMusicTrack
 extends AudioStreamPlayer
-## Plays a music track from different checkpoints to avoid playing the beginning of the song too much.
+## Plays a music track from different checkpoints to avoid playing the beginning of the music track too much.
 ##
-## If looped songs always played from the start, players would hear the beginning more than the ending. This class
-## tracks which parts of the song have been played so the MusicPlayer can skip to the parts which have been played the
-## least.
+## If looped tracks always played from the start, players would hear the beginning more than the ending. This class
+## monitors which parts of the track have been played so the MusicPlayer can skip to the parts which have been played
+## the least.
 
 ## we measure which 'chunks' of music have been played the least, this defines the chunk size
 const CHUNK_SIZE := 6.0
 
-## array of floats corresponding to good start positions in each song
+## array of floats corresponding to good start positions in each track
 export (Array, float) var checkpoints: Array = []
 
-## song title and color shown in the toaster popup
-export var song_title: String
-export var song_color: Color
+## track title and color shown in the toaster popup
+export var track_title: String
+export var track_color: Color
 
-## song id referenced by career-regions.json
+## track id referenced by career-regions.json
 export var id: String
 
 ## array of ints corresponding to how much each 'chunk' of music has been played
@@ -30,14 +30,14 @@ func _ready() -> void:
 	for _i in range(ceil(stream.get_length() / CHUNK_SIZE)):
 		_staleness_record.append(randi() % 3)
 	if not checkpoints:
-		push_warning("CheckpointSong %s checkpoints=%s" % [name, checkpoints])
+		push_warning("CheckpointMusicTrack %s checkpoints=%s" % [name, checkpoints])
 
 
-## Plays this song from the specified position, or somewhere in the middle.
+## Plays this track from the specified position, or somewhere in the middle.
 ##
 ## Parameters:
-## 	'from_position': If 0 or greater, the song will begin playing from the specified position. If unspecified or
-## 		negative, the song will start somewhere in the middle based on an algorithm.
+## 	'from_position': If 0 or greater, the track will begin playing from the specified position. If unspecified or
+## 		negative, the track will start somewhere in the middle based on an algorithm.
 func play(from_position: float = -1.0) -> void:
 	if from_position < 0:
 		# calculate the start position based on an algorithm
@@ -60,21 +60,21 @@ func get_nearest_checkpoint(start: float) -> float:
 	return result
 
 
-## Increases the staleness of the part of the song currently playing.
+## Increases the staleness of the part of the track currently playing.
 func _increase_staleness() -> void:
 	if playing:
 		_played = true
 		var staleness_index := int(get_playback_position() / CHUNK_SIZE)
 		if staleness_index < _staleness_record.size():
-			# in some edge cases, playback position can go past the end of a song
+			# in some edge cases, playback position can go past the end of a track
 			_staleness_record[staleness_index] += 1
 
 
-## Calculates the ideal position to start playing the specified song.
+## Calculates the ideal position to start playing the specified track.
 ##
 ## The algorithm we follow is to create a window with the left half of the 'freshness record'. We gradually advance it
-## through the entire song, and figure out which half of the song has been played the least. We return the position of
-## the song at the start of that half.
+## through the entire track, and figure out which half of the track has been played the least. We return the position
+## of the track at the start of that half.
 func _freshest_start() -> float:
 	var freshest_start_index := 0
 	var min_staleness: int = 0
@@ -96,7 +96,7 @@ func _freshest_start() -> float:
 	
 	var start := freshest_start_index * CHUNK_SIZE
 	if not _played:
-		# the first time playing a particular song, we start at a checkpoint. this way the player doesn't boot up the
+		# the first time playing a particular track, we start at a checkpoint. this way the player doesn't boot up the
 		# game by hearing a musical solo or bridge without context. after the first time, anywhere is OK.
 		start = get_nearest_checkpoint(freshest_start_index)
 	return start

--- a/project/src/main/music/music-player.gd
+++ b/project/src/main/music/music-player.gd
@@ -3,7 +3,7 @@ extends Node
 ##
 ## Ensures only one music track is playing at once. Organizes music by category and fades music in and out.
 
-signal current_bgm_changed(value)
+signal current_track_changed(value)
 
 ## highest cutoff for the low-pass night filter; this should render the filter unnoticable
 const MAX_FILTER_HZ := 20000.0
@@ -17,134 +17,134 @@ const MIN_VOLUME := -40.0
 ## volume to fade in to
 const MAX_VOLUME := 0.0
 
-var all_bgms: Array
+var all_tracks: Array
 
 ## music currently playing
-var current_bgm: CheckpointSong
+var current_track: CheckpointMusicTrack
 
 ## true if the music should have a low-pass filter applied; used during nighttime
 var night_filter: bool = false setget set_night_filter
 
-## key: (String) music id
-## value: (CheckpointSong) music
-var bgms_by_id := {}
+## key: (String) music track id
+## value: (CheckpointMusicTrack) music
+var tracks_by_id := {}
 
 ## volume_db changes when we fade in/fade out so we cache the original value.
 ##
-## key: (String) bgm node name
+## key: (String) track node name
 ## value: (float) desired volume_db for playing music
-var _max_volume_db_by_bgm := {}
+var _max_volume_db_by_track := {}
 
 var _filter_tween: SceneTreeTween
 
-## Level id for the newest played puzzle music. We track this to ensure repeating a puzzle also repeats the music.
+## Level id for the newest played puzzle music. We monitor this to ensure repeating a puzzle also repeats the music.
 var _previous_level_id: String
 
-## Music id for the newest played puzzle music. We track this to ensure repeating a puzzle also repeats the music.
-var _previous_puzzle_bgm_id: String
+## Track id for the newest played puzzle music. We monitor this to ensure repeating a puzzle also repeats the music.
+var _previous_puzzle_track_id: String
 
-onready var _chill_bgms := [
+onready var _menu_tracks := [
 		$ChubHub, $DessertCourse, $HarderButter,
 		$HotFunkSundae, $LoFiChill, $RainbowSherbeat]
 
-onready var _upbeat_bgms := [
+onready var _puzzle_tracks := [
 		$AcidReflux, $ChocolateChip, $ChubNBass, $ChunkyObake,
 		$DooDooDoo, $ExtraSprinkles, $GingerbreadHouse, $JuicerMixerGrinder,
 		$MysticMuffin, $PressureCooker, $SugarCrash, $TripleThiccShake,
 		]
 
-onready var _credits_bgm := $SugarCrash
-onready var _tutorial_bgms := [$MyFatnessPal]
+onready var _credits_track := $SugarCrash
+onready var _tutorial_tracks := [$MyFatnessPal]
 onready var _music_tween_manager := $MusicTweenManager
 
 func _ready() -> void:
-	all_bgms = _chill_bgms + _upbeat_bgms + _tutorial_bgms
-	for bgm in all_bgms:
-		bgms_by_id[bgm.id] = bgm
-	_chill_bgms.shuffle()
-	_upbeat_bgms.shuffle()
+	all_tracks = _menu_tracks + _puzzle_tracks + _tutorial_tracks
+	for track in all_tracks:
+		tracks_by_id[track.id] = track
+	_menu_tracks.shuffle()
+	_puzzle_tracks.shuffle()
 	
-	for bgm in all_bgms:
-		_max_volume_db_by_bgm[bgm.name] = bgm.volume_db
+	for track in all_tracks:
+		_max_volume_db_by_track[track.name] = track.volume_db
 
 
-func bgm_for_id(id: String) -> CheckpointSong:
-	return bgms_by_id.get(id)
+func track_for_id(id: String) -> CheckpointMusicTrack:
+	return tracks_by_id.get(id)
 
 
-## Plays a 'chill' song; something suitable for background music when the player's navigating menus or wandering the
-## free roam overworld.
+## Plays a menu track; something suitable for background music when the player's navigating menus.
 ##
-## If a chill song is already playing, this method has no effect.
-func play_chill_bgm(fade_in: bool = true) -> void:
-	if PlayerData.menu_region and PlayerData.menu_region.music.menu_music_id:
-		var new_bgm_id: String = PlayerData.menu_region.music.menu_music_id
-		if current_bgm and current_bgm.id == new_bgm_id:
-			# song is already playing; don't interrupt it
+## If a menu track is already playing, this method has no effect.
+func play_menu_track(fade_in: bool = true) -> void:
+	if PlayerData.menu_region and PlayerData.menu_region.music.menu_track_id:
+		var new_track_id: String = PlayerData.menu_region.music.menu_track_id
+		if current_track and current_track.id == new_track_id:
+			# track is already playing; don't interrupt it
 			pass
 		else:
-			var new_bgm: CheckpointSong = bgm_for_id(new_bgm_id)
+			var new_track: CheckpointMusicTrack = track_for_id(new_track_id)
 			
-			play_bgm(new_bgm)
+			play_track(new_track)
 			if fade_in:
 				fade_in()
 	else:
-		_play_next_bgm(_chill_bgms, fade_in)
+		_play_next_track(_menu_tracks, fade_in)
 
 
-## Plays an 'upbeat' song; something suitable when the player's playing a puzzle level.
+## Plays a puzzle track; something suitable when the player's playing a puzzle level.
 ##
-## If an upbeat song is already playing, this method has no effect.
-func play_upbeat_bgm(fade_in: bool = true) -> void:
-	if PlayerData.menu_region and PlayerData.menu_region.music.puzzle_music_ids:
+## If an puzzle track is already playing, this method has no effect.
+func play_puzzle_track(fade_in: bool = true) -> void:
+	if PlayerData.menu_region and PlayerData.menu_region.music.puzzle_track_ids:
 		var region_music: RegionMusic = PlayerData.menu_region.music
 		
-		var new_bgm_id: String
+		var new_track_id: String
 		
 		if PlayerData.career.hours_passed == 0:
-			# if it's the first level, play the 'main puzzle song'
-			new_bgm_id = region_music.main_puzzle_music_id()
+			# if it's the first level, play the 'main puzzle track'
+			new_track_id = region_music.main_puzzle_track_id()
 		elif PlayerData.career.is_boss_level():
-			# if it's a boss level, play the 'main puzzle song'
-			new_bgm_id = region_music.main_puzzle_music_id()
-		elif _previous_level_id == CurrentLevel.level_id and _previous_puzzle_bgm_id in region_music.puzzle_music_ids:
-			# if replaying a level, play the same song
-			new_bgm_id = _previous_puzzle_bgm_id
+			# if it's a boss level, play the 'main puzzle track'
+			new_track_id = region_music.main_puzzle_track_id()
+		elif _previous_level_id == CurrentLevel.level_id \
+				and _previous_puzzle_track_id in region_music.puzzle_track_ids:
+			# if replaying a level, play the same track
+			new_track_id = _previous_puzzle_track_id
 		else:
-			# otherwise, play a random song
-			new_bgm_id = region_music.random_puzzle_music_id()
+			# otherwise, play a random track
+			new_track_id = region_music.random_puzzle_track_id()
 		
-		if current_bgm and current_bgm.id == new_bgm_id:
-			# song is already playing; don't interrupt it
+		if current_track and current_track.id == new_track_id:
+			# track is already playing; don't interrupt it
 			pass
 		else:
-			play_bgm(bgm_for_id(new_bgm_id))
+			play_track(track_for_id(new_track_id))
 			if fade_in:
 				fade_in()
 		
-		_previous_puzzle_bgm_id = new_bgm_id
+		_previous_puzzle_track_id = new_track_id
 		_previous_level_id = CurrentLevel.level_id
 	else:
-		_play_next_bgm(_upbeat_bgms, fade_in)
+		_play_next_track(_puzzle_tracks, fade_in)
 
 
-## Plays a 'tutorial song'; something suitable when the player is following a puzzle tutorial.
+## Plays a 'tutorial track'; something suitable when the player is following a puzzle tutorial.
 ##
-## If a tutorial song is already playing, this method has no effect.
-func play_tutorial_bgm(fade_in: bool = true) -> void:
-	_play_next_bgm(_tutorial_bgms, fade_in)
+## If a tutorial track is already playing, this method has no effect.
+func play_tutorial_track(fade_in: bool = true) -> void:
+	_play_next_track(_tutorial_tracks, fade_in)
 
 
-func play_credits_bgm() -> void:
-	play_bgm(_credits_bgm, false)
+func play_credits_track() -> void:
+	play_track(_credits_track, false)
 
 
 ## Gradually fades a track in.
 ##
 ## Usually it's OK for a track to start abrubtly, but sometimes we want to fade music in more gradually.
 func fade_in(duration: float = MusicTweenManager.FADE_IN_DURATION) -> void:
-	current_bgm.volume_db = MIN_VOLUME
-	_music_tween_manager.fade_in(current_bgm, _max_volume_db_by_bgm[current_bgm.name], duration)
+	current_track.volume_db = MIN_VOLUME
+	_music_tween_manager.fade_in(current_track, _max_volume_db_by_track[current_track.name], duration)
 
 
 func is_fading_in() -> bool:
@@ -153,31 +153,31 @@ func is_fading_in() -> bool:
 
 ## Fades out the currently playing track.
 func stop(duration: float = MusicTweenManager.FADE_OUT_DURATION) -> void:
-	if current_bgm == null:
+	if current_track == null:
 		return
 	
-	_music_tween_manager.fade_out(current_bgm, MIN_VOLUME, duration)
-	current_bgm = null
+	_music_tween_manager.fade_out(current_track, MIN_VOLUME, duration)
+	current_track = null
 
 
-## Plays the specified song.
+## Plays the specified track.
 ##
-## Any currently playing song is faded out.
+## Any currently playing track is faded out.
 ##
 ## Parameters:
-## 	'from_position': If 0 or greater, the song will begin playing from the specified position. If unspecified or
-## 		negative, the song will start somewhere in the middle based on an algorithm.
-func play_bgm(new_bgm: CheckpointSong, from_position: float = -1.0) -> void:
-	var old_bgm := current_bgm
-	if old_bgm == new_bgm:
+## 	'from_position': If 0 or greater, the track will begin playing from the specified position. If unspecified or
+## 		negative, the track will start somewhere in the middle based on an algorithm.
+func play_track(new_track: CheckpointMusicTrack, from_position: float = -1.0) -> void:
+	var old_track := current_track
+	if old_track == new_track:
 		return
 	
-	if current_bgm:
+	if current_track:
 		stop()
-	current_bgm = new_bgm
-	current_bgm.volume_db = _max_volume_db_by_bgm[current_bgm.name]
-	current_bgm.play(from_position)
-	emit_signal("current_bgm_changed", current_bgm)
+	current_track = new_track
+	current_track.volume_db = _max_volume_db_by_track[current_track.name]
+	current_track.play(from_position)
+	emit_signal("current_track_changed", current_track)
 
 
 ## Enables or disables the low-pass filter used during nighttime.
@@ -207,23 +207,23 @@ func set_night_filter(new_night_filter: bool) -> void:
 		_filter_tween.tween_callback(self, "_on_Tween_unfilter_completed")
 
 
-## Plays the first song from the specified list, and reorders the songs.
+## Plays the first track from the specified list, and reorders the tracks.
 ##
-## If a song from the specified list is already playing, this method has no effect. Otherwise, any currently playing
-## song is faded out.
+## If a track from the specified list is already playing, this method has no effect. Otherwise, any currently playing
+## track is faded out.
 ##
 ## Parameters:
-## 	'bgms': Array of CheckpointSong instances to play
+## 	'tracks': Array of CheckpointMusicTrack instances to play
 ##
 ## 	'fade_in': 'true' if the music should fade in
-func _play_next_bgm(bgms: Array, fade_in: bool) -> void:
-	if current_bgm in bgms:
-		# a song from the specified list is already playing; don't interrupt it
+func _play_next_track(tracks: Array, fade_in: bool) -> void:
+	if current_track in tracks:
+		# a track from the specified list is already playing; don't interrupt it
 		return
 	
-	var new_bgm: CheckpointSong = bgms.pop_front()
-	bgms.append(new_bgm)
-	play_bgm(new_bgm)
+	var new_track: CheckpointMusicTrack = tracks.pop_front()
+	tracks.append(new_track)
+	play_track(new_track)
 	if fade_in:
 		fade_in()
 

--- a/project/src/main/music/music-transition.gd
+++ b/project/src/main/music/music-transition.gd
@@ -4,7 +4,7 @@ extends Node
 ## On web targets, the music sounds choppy and bad if we leave it running during scene transitions, so we fade out the
 ## music. On other targets, the music sounds fine.
 
-var _faded_bgm: CheckpointSong
+var _faded_track: CheckpointMusicTrack
 
 func _ready() -> void:
 	SceneTransition.connect("fade_out_started", self, "_on_SceneTransition_fade_out_started")
@@ -13,13 +13,13 @@ func _ready() -> void:
 
 ## When the scene fades back in, we un-fade any music we previously faded out.
 func _on_SceneTransition_fade_in_started(_duration: float) -> void:
-	if _faded_bgm:
+	if _faded_track:
 		# If we faded the music out, we fade it back in
-		MusicPlayer.play_bgm(_faded_bgm, _faded_bgm.get_playback_position())
+		MusicPlayer.play_track(_faded_track, _faded_track.get_playback_position())
 		MusicPlayer.fade_in(SceneTransition.DEFAULT_FADE_IN_DURATION * 1.5)
 		
-		# reset _faded_bgm to avoid fading the same song in twice
-		_faded_bgm = null
+		# reset _faded_track to avoid fading the same track in twice
+		_faded_track = null
 
 
 ## When fading out the scene, we fade out the music for web targets.
@@ -27,5 +27,5 @@ func _on_SceneTransition_fade_in_started(_duration: float) -> void:
 ## On web targets, the music sounds choppy and bad if we leave it running during scene transitions.
 func _on_SceneTransition_fade_out_started(duration: float) -> void:
 	if OS.has_feature("web"):
-		_faded_bgm = MusicPlayer.current_bgm
+		_faded_track = MusicPlayer.current_track
 		MusicPlayer.stop(duration * 0.5)

--- a/project/src/main/music/music-tween-manager.gd
+++ b/project/src/main/music/music-tween-manager.gd
@@ -18,9 +18,9 @@ const FADE_IN_DURATION := 2.5
 ## Enum from FadingState representing whether the music is fading in or out
 var fading_state: int = FADING_NONE
 
-## key: (AudioStreamPlayer) song
+## key: (AudioStreamPlayer) track
 ## value: (SceneTreeTween) tween adjusting volume
-var _tweens_by_song: Dictionary = {}
+var _tweens_by_track: Dictionary = {}
 
 ## Gradually silences a music track.
 func fade_out(player: AudioStreamPlayer, min_volume: float, duration: float = FADE_OUT_DURATION) -> void:
@@ -36,10 +36,10 @@ func fade_in(player: AudioStreamPlayer, max_volume: float, duration: float = FAD
 
 ## Gradually adjusts a music track's volume.
 func _fade(player: AudioStreamPlayer, new_volume_db: float, duration: float) -> void:
-	if _tweens_by_song.has(player):
-		_tweens_by_song[player].kill()
-	_tweens_by_song[player] = create_tween()
-	var fade_tween: SceneTreeTween = _tweens_by_song[player]
+	if _tweens_by_track.has(player):
+		_tweens_by_track[player].kill()
+	_tweens_by_track[player] = create_tween()
+	var fade_tween: SceneTreeTween = _tweens_by_track[player]
 	fade_tween.tween_property(player, "volume_db", new_volume_db, duration)
 	fade_tween.tween_callback(self, "_on_Tween_completed", [player])
 

--- a/project/src/main/puzzle/bursts.gd
+++ b/project/src/main/puzzle/bursts.gd
@@ -11,7 +11,7 @@ export (PackedScene) var TechMoveBurstScene: PackedScene
 ## Stores the x position of the previous combo burst to ensure consecutive bursts aren't vertically aligned
 var _previous_cell_x := -1
 
-## Tracks the x position of the most recent piece placed in each row
+## Monitors the x position of the most recent piece placed in each row
 ## key: (int) y value of a recently dropped piece
 ## value: (float) average x position of the piece's blocks in that row
 var _piece_x_by_y: Dictionary

--- a/project/src/main/puzzle/critter/carrots.gd
+++ b/project/src/main/puzzle/critter/carrots.gd
@@ -7,7 +7,7 @@ extends Node2D
 
 signal carrot_added
 
-## tracks whether the carrot sfx are playing
+## monitors whether the carrot sfx are playing
 enum MoveSfxState {
 	STOPPED, # sfx are not playing
 	STARTING, # sfx are playing, and volume is increasing
@@ -27,7 +27,7 @@ var playfield_path: NodePath setget set_playfield_path
 
 var _playfield: Playfield
 
-## tracks whether the carrot sfx are playing
+## monitors whether the carrot sfx are playing
 var _move_sfx_state: int = MoveSfxState.STOPPED
 
 ## tweens carrot sfx

--- a/project/src/main/puzzle/critter/mole.gd
+++ b/project/src/main/puzzle/critter/mole.gd
@@ -50,7 +50,7 @@ var _free_after_poof := false
 ## Queue of enums from State for the mole's upcoming animation states.
 var _next_states := []
 
-## 'true' if a state has already been popped from the _next_states queue this frame. We track this to avoid
+## 'true' if a state has already been popped from the _next_states queue this frame. We monitor this to avoid
 ## accidentally popping two states from the queue when the mole first spawns.
 var _already_popped_state := false
 

--- a/project/src/main/puzzle/critter/onion.gd
+++ b/project/src/main/puzzle/critter/onion.gd
@@ -34,7 +34,7 @@ var _next_states := []
 ## Index in next_states for the onion's current state.
 var _current_state_index := -1
 
-## 'true' if a state has already been popped from the _next_states queue this frame. We track this to avoid
+## 'true' if a state has already been popped from the _next_states queue this frame. We monitor this to avoid
 ## accidentally popping two states from the queue when the onion first spawns.
 var _already_popped_state := false
 

--- a/project/src/main/puzzle/critter/shark.gd
+++ b/project/src/main/puzzle/critter/shark.gd
@@ -74,7 +74,7 @@ var _free_after_poof := false
 ## Queue of enums from State for the shark's upcoming animation states.
 var _next_states := []
 
-## 'true' if a state has already been popped from the _next_states queue this frame. We track this to avoid
+## 'true' if a state has already been popped from the _next_states queue this frame. We monitor this to avoid
 ## accidentally popping two states from the queue when the shark first spawns.
 var _already_popped_state := false
 

--- a/project/src/main/puzzle/critter/spear.gd
+++ b/project/src/main/puzzle/critter/spear.gd
@@ -44,7 +44,7 @@ var pop_anim_duration := 0.6
 ## short spears, or a large number for longer spears.
 var pop_length := 450
 
-## 'true' if a state has already been popped from the _next_states queue this frame. We track this to avoid
+## 'true' if a state has already been popped from the _next_states queue this frame. We monitor this to avoid
 ## accidentally popping two states from the queue when the spear first spawns.
 var _already_popped_state := false
 

--- a/project/src/main/puzzle/food-item.gd
+++ b/project/src/main/puzzle/food-item.gd
@@ -21,7 +21,7 @@ var velocity := Vector2(0, -25)
 ## Creature who this food will fly towards
 var customer: Creature
 
-## Incremented as the customer changes to track the intended recipient of each food item.
+## Incremented as the customer changes to monitor the intended recipient of each food item.
 var customer_index: int
 
 ## Enum from FoodType corresponding to the food to show

--- a/project/src/main/puzzle/food-items.gd
+++ b/project/src/main/puzzle/food-items.gd
@@ -8,7 +8,7 @@ export (PackedScene) var FoodScene: PackedScene
 ## Array of floats corresponding to how fat the creature should become after eating each upcoming food item.
 var _pending_food_fatness := []
 
-## Increments as the customer changes to track the intended recipient of each food item.
+## Increments as the customer changes to monitor the intended recipient of each food item.
 var _customer_index := 0
 
 ## Queue of FoodItem objects which have floated awhile, and can now fly into a customer's mouth.
@@ -178,7 +178,7 @@ func _on_FoodFlightTimer_timeout() -> void:
 	food_item.emit_signal("ready_to_fly")
 
 
-## We track when the customer changes to ensure food goes to the proper place, and that it doesn't get eaten by the
+## We monitor when the customer changes to ensure food goes to the proper place, and that it doesn't get eaten by the
 ## wrong customer.
 func _on_RestaurantView_customer_changed() -> void:
 	_customer_change_timer.start()

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -34,7 +34,7 @@ var customers: Array
 ## Creature who will be the chef for the level. If absent, the player will be the chef.
 var chef_id: String
 
-## Tracks when the player finishes a level.
+## Monitors when the player finishes a level.
 var best_result: int = Levels.Result.NONE setget set_best_result
 
 ## How many times the player has tried the level in this session.

--- a/project/src/main/puzzle/level/levels.gd
+++ b/project/src/main/puzzle/level/levels.gd
@@ -4,7 +4,7 @@ class_name Levels
 ## This prevents cyclic dependency errors which arise if these constants and enums are pushed down to individual
 ## scripts.
 
-## Tracks whether the player has lost, finished, or met a success condition. These enums should be ordered from worst
+## Monitors whether the player has lost, finished, or met a success condition. These enums should be ordered from worst
 ## to best so that we can calculate the player's best result by comparing enums numerically.
 enum Result {
 	NONE, # The player didn't place any pieces.

--- a/project/src/main/puzzle/line-clearer.gd
+++ b/project/src/main/puzzle/line-clearer.gd
@@ -58,7 +58,7 @@ var _remaining_line_erase_timings := []
 ## value: (bool) true
 var _lines_to_preserve_at_end := {}
 
-## tracks the age of lines which have been filled, but not yet cleared due to the level's rules
+## monitors the age of lines which have been filled, but not yet cleared due to the level's rules
 ## key: (int) line index
 ## value: (int) number of times this line has been full during 'calculate_lines_to_clear'
 var _line_filled_age := {}
@@ -70,7 +70,7 @@ var _total_cleared_line_count := 0
 ## Maximum score the player has reached.
 ##
 ## Level triggers can fire when the player reaches a score threshold. The player's score can decrease if they top out,
-## so we track their max score to ensure score triggers only fire once.
+## so we monitor their max score to ensure score triggers only fire once.
 var _max_trigger_score := 0
 
 onready var _tile_map: PuzzleTileMap = get_node(tile_map_path)

--- a/project/src/main/puzzle/milestone-manager.gd
+++ b/project/src/main/puzzle/milestone-manager.gd
@@ -1,5 +1,5 @@
 extends Node
-## Tracks the player's progress towards milestones.
+## Monitors the player's progress towards milestones.
 ##
 ## Milestones can involve reaching a certain score, clearing a certain number of lines or surviving a certain number of
 ## seconds.

--- a/project/src/main/puzzle/piece/frame-input.gd
+++ b/project/src/main/puzzle/piece/frame-input.gd
@@ -1,10 +1,10 @@
 class_name FrameInput
 extends Node
-## Tracks the state of an input action over time.
+## Monitors the state of an input action over time.
 ##
 ## Also provides support for buffered inputs. The buffer duration is dictated by the child timer.
 
-## Action to track
+## Action to monitor
 export (String) var action: String
 
 ## Action which negates this one if pressed. For example if the player holds move_piece_left and presses

--- a/project/src/main/puzzle/puzzle-music-manager.gd
+++ b/project/src/main/puzzle/puzzle-music-manager.gd
@@ -8,9 +8,9 @@ func _ready() -> void:
 
 func start_puzzle_music() -> void:
 	if CurrentLevel.is_tutorial():
-		MusicPlayer.play_tutorial_bgm(false)
+		MusicPlayer.play_tutorial_track(false)
 	else:
-		MusicPlayer.play_upbeat_bgm(false)
+		MusicPlayer.play_puzzle_track(false)
 
 
 func _on_PuzzleState_game_prepared() -> void:
@@ -18,4 +18,4 @@ func _on_PuzzleState_game_prepared() -> void:
 
 
 func _on_PuzzleState_game_ended() -> void:
-	MusicPlayer.play_chill_bgm()
+	MusicPlayer.play_menu_track()

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -233,7 +233,7 @@ func make_player_lose() -> void:
 
 ## Immediately ends the game, triggering any other end-of-game effects.
 ##
-## End-of-game effects include calculating the player's final score, restoring the chill background music and
+## End-of-game effects include calculating the player's final score, restoring the menu background music and
 ## triggering the chef's reaction. End-of-game effects do not include clearing the player's remaining boxes -- this
 ## occurs before the game ends.
 func end_game() -> void:

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -11,7 +11,7 @@ onready var _night_mode_toggler: NightModeToggler = $NightModeToggler
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
-	MusicPlayer.play_chill_bgm()
+	MusicPlayer.play_menu_track()
 	
 	PuzzleState.connect("game_started", self, "_on_PuzzleState_game_started")
 	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")

--- a/project/src/main/puzzle/results-label.gd
+++ b/project/src/main/puzzle/results-label.gd
@@ -17,7 +17,7 @@ var _beat_duration := 60 / 136.0
 ## 1.0 = normal, 2.0 = fastest, 6.0 = fastestestest, 1000000.0 = fastestest
 var _text_speed := 1.0
 
-## These two fields are used to track unshown text which is gradually revealed. RichTextLabel defines a
+## These two fields are used to monitor unshown text which is gradually revealed. RichTextLabel defines a
 ## 'visible_characters' field which supports this capability, but it does not mesh well with the scroll bar or the
 ## 'scroll_following' property. So we reimplement the concept of invisible characters our own way.
 var _unshown_text := ""

--- a/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-basics-module.gd
@@ -3,14 +3,14 @@ extends TutorialModule
 ##
 ## Shows messages and advances the player through the tutorial as they complete tasks.
 
-## tracks what the player has done so far during this tutorial
+## monitors what the player has done so far during this tutorial
 var _line_clears := 0
 var _box_clears := 0
 var _boxes_built := 0
 var _squish_moves := 0
 var _snack_stacks := 0
 
-## tracks what the player did with their newest piece
+## monitors what the player did with their newest piece
 var _did_line_clear := false
 var _did_box_clear := false
 var _did_build_box := false

--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -119,7 +119,7 @@ func _on_PuzzleState_after_level_changed() -> void:
 	
 	if _start_customer_countdown:
 		_start_customer_countdown = false
-		MusicPlayer.play_upbeat_bgm(false)
+		MusicPlayer.play_puzzle_track(false)
 		PuzzleState.game_active = true
 		puzzle.start_level_countdown()
 

--- a/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
@@ -6,11 +6,11 @@ extends TutorialModule
 const SQUISH_DIAGRAM_0 := preload("res://assets/main/puzzle/tutorial/squish-diagram-0.png")
 const SQUISH_DIAGRAM_1 := preload("res://assets/main/puzzle/tutorial/squish-diagram-1.png")
 
-## tracks what the player has done during the current tutorial section
+## monitors what the player has done during the current tutorial section
 var _squish_moves := 0
 var _boxes_built := 0
 
-## tracks what the player did with the most recent piece
+## monitors what the player did with the most recent piece
 var _did_squish_move := false
 var _did_build_box := false
 

--- a/project/src/main/ui/exit-credits-popup.gd
+++ b/project/src/main/ui/exit-credits-popup.gd
@@ -26,7 +26,7 @@ const TWEEN_DURATION := 0.2
 ## how many seconds to stay popped in
 const LINGER_DURATION := 3.0
 
-## tracks whether the popup is currently popping in or out
+## monitors whether the popup is currently popping in or out
 var _popup_state: int = PopupState.POPPED_OUT
 
 var _tween: SceneTreeTween

--- a/project/src/main/ui/h-slider-gamepad-helper.gd
+++ b/project/src/main/ui/h-slider-gamepad-helper.gd
@@ -24,7 +24,7 @@ var _slider_value_float: float
 
 onready var _slider: HSlider = get_parent()
 
-## Timer which tracks whether a D-Pad input was recently pressed.
+## Timer which monitors whether a D-Pad input was recently pressed.
 onready var _delay_timer: Timer
 
 func _ready() -> void:

--- a/project/src/main/ui/menu/career-region-select-menu.gd
+++ b/project/src/main/ui/menu/career-region-select-menu.gd
@@ -7,7 +7,7 @@ onready var _region_buttons := get_node(region_buttons_path)
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
-	MusicPlayer.play_chill_bgm()
+	MusicPlayer.play_menu_track()
 	
 	_region_buttons.set_regions(CareerLevelLibrary.regions)
 	

--- a/project/src/main/ui/menu/loading-orb.gd
+++ b/project/src/main/ui/menu/loading-orb.gd
@@ -7,7 +7,7 @@ extends Sprite
 ## Number of frames in our animation. Each frame launches a different puzzle piece.
 const FRAME_COUNT := 8
 
-## Rate at which to launch puzzle pieces. This is synchronized with the song "Sugar Crash" for the end credits.
+## Rate at which to launch puzzle pieces. This is synchronized with the music track "Sugar Crash" for the end credits.
 const PIECES_PER_SECOND := 4.10000
 
 ## The loading orb rotates and moves. This field is used to calculate the rotation/position

--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -6,7 +6,7 @@ extends Control
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
-	MusicPlayer.play_chill_bgm()
+	MusicPlayer.play_menu_track()
 	
 	$DropPanel/Adventure/Play.grab_focus()
 

--- a/project/src/main/ui/menu/splash-screen.gd
+++ b/project/src/main/ui/menu/splash-screen.gd
@@ -3,7 +3,7 @@ extends Control
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
-	MusicPlayer.play_chill_bgm(false)
+	MusicPlayer.play_menu_track(false)
 	
 	$DropPanel/PlayHolder/Play.grab_focus()
 	if PlayerSave.corrupt_filenames:

--- a/project/src/main/ui/menu/training-menu.gd
+++ b/project/src/main/ui/menu/training-menu.gd
@@ -31,7 +31,7 @@ onready var _region_submenu := $RegionSubmenu
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
-	MusicPlayer.play_chill_bgm()
+	MusicPlayer.play_menu_track()
 	
 	_assign_default_recent_data()
 	_load_recent_data()

--- a/project/src/main/ui/menu/tutorial-menu.gd
+++ b/project/src/main/ui/menu/tutorial-menu.gd
@@ -5,7 +5,7 @@ onready var _paged_level_panel := $Panel
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
-	MusicPlayer.play_chill_bgm()
+	MusicPlayer.play_menu_track()
 	
 	var tutorial_region := OtherLevelLibrary.region_for_id(OtherRegion.ID_TUTORIAL)
 	if tutorial_region:

--- a/project/src/main/ui/music-popup-tween-manager.gd
+++ b/project/src/main/ui/music-popup-tween-manager.gd
@@ -18,7 +18,7 @@ const POPUP_DURATION := 4.0
 const POP_IN_Y := 32
 const POP_OUT_Y := 0
 
-## tracks whether the popup is currently popping in or out
+## monitors whether the popup is currently popping in or out
 var _popup_state: int = PopupState.POPPED_OUT
 
 var _tween: SceneTreeTween

--- a/project/src/main/ui/music-popup.gd
+++ b/project/src/main/ui/music-popup.gd
@@ -1,47 +1,47 @@
 extends Control
-## Toaster popup which shows the current song title.
+## Toaster popup which shows the current track title.
 
-## bgm which was last shown in this popup
-var _shown_bgm: CheckpointSong
+## track which was last shown in this popup
+var _shown_track: CheckpointMusicTrack
 
 onready var _music_label := $Panel/HBoxContainer/Label
 onready var _music_panel := $Panel
 onready var _popup_tween_manager := $PopupTweenManager
 
 func _ready() -> void:
-	MusicPlayer.connect("current_bgm_changed", self, "_on_MusicPlayer_current_bgm_changed")
-	_refresh_panel(MusicPlayer.current_bgm)
+	MusicPlayer.connect("current_track_changed", self, "_on_MusicPlayer_current_track_changed")
+	_refresh_panel(MusicPlayer.current_track)
 	_music_label.connect("item_rect_changed", self, "_on_Label_item_rect_changed")
 
 
-## Update the popup's appearance based on the current song, and maybe show it.
+## Update the popup's appearance based on the current track, and maybe show it.
 ##
-## The popup is only shown if the song changes, and if the song is audible.
+## The popup is only shown if the track changes, and if the track is audible.
 ##
 ## Parameters:
-## 	'value': The song to show in the popup
-func _refresh_panel(value: CheckpointSong) -> void:
-	if _shown_bgm == value or not is_inside_tree():
+## 	'value': The track to show in the popup
+func _refresh_panel(value: CheckpointMusicTrack) -> void:
+	if _shown_track == value or not is_inside_tree():
 		return
 	
 	# if no music is audible, don't show a music popup
 	if SystemData.volume_settings.is_bus_mute(VolumeSettings.MUSIC) \
 			or SystemData.volume_settings.is_bus_mute(VolumeSettings.MASTER):
-		_shown_bgm = null
+		_shown_track = null
 	else:
-		_shown_bgm = value
+		_shown_track = value
 	
 	# show the appropriate popup
-	if _shown_bgm:
-		_music_label.text = _shown_bgm.song_title
+	if _shown_track:
+		_music_label.text = _shown_track.track_title
 		
 		# we delay a few seconds if the music is fading in slowly
 		var pop_in_delay := 2.0 if MusicPlayer.is_fading_in() else 0.0
 		_popup_tween_manager.pop_in_and_out(pop_in_delay)
-		_music_panel.get("custom_styles/panel").set("bg_color", _shown_bgm.song_color)
+		_music_panel.get("custom_styles/panel").set("bg_color", _shown_track.track_color)
 
 
-func _on_MusicPlayer_current_bgm_changed(value: CheckpointSong) -> void:
+func _on_MusicPlayer_current_track_changed(value: CheckpointMusicTrack) -> void:
 	_refresh_panel(value)
 
 

--- a/project/src/main/utils/sfx-deconflicter.gd
+++ b/project/src/main/utils/sfx-deconflicter.gd
@@ -1,9 +1,9 @@
 extends Node
 ## Ensures multiple copies of the same sound don't play simultaneously.
 ##
-## By calling SfxDeconflicter.play() with multiple AudioStreamPlayers, this script tracks when those AudioStreamPlayers
-## play to prevent two copies of the same sound from playing simultaneously. This prevents the player from hearing one
-## very loud sound effect when several things happen at once.
+## By calling SfxDeconflicter.play() with multiple AudioStreamPlayers, this script monitors when those
+## AudioStreamPlayers play to prevent two copies of the same sound from playing simultaneously. This prevents the
+## player from hearing one very loud sound effect when several things happen at once.
 
 ## Number of milliseconds before the same sound can play a second time.
 const SUPPRESS_SFX_MSEC := 20

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -37,7 +37,7 @@ func _ready() -> void:
 		# For regular players the Breadcrumb trail will already be initialized by the menus.
 		Breadcrumb.initialize_trail()
 	
-	MusicPlayer.play_chill_bgm()
+	MusicPlayer.play_menu_track()
 	PlayerData.career.connect("distance_travelled_changed", self, "_on_CareerData_distance_travelled_changed")
 	
 	var redirected := false

--- a/project/src/main/world/cutscene-world.gd
+++ b/project/src/main/world/cutscene-world.gd
@@ -12,7 +12,7 @@ func _ready() -> void:
 	if CurrentCutscene.chat_tree.meta.has("fixed_zoom"):
 		_camera.fixed_zoom = CurrentCutscene.chat_tree.meta["fixed_zoom"]
 	
-	MusicPlayer.play_chill_bgm()
+	MusicPlayer.play_menu_track()
 	_launch_cutscene()
 
 

--- a/project/src/main/world/environment/credits/crowd-surfing-buddy.gd
+++ b/project/src/main/world/environment/credits/crowd-surfing-buddy.gd
@@ -15,7 +15,7 @@ const TOO_FAR_THRESHOLD := 240.0
 
 const AVERAGE_TRAVEL_SPEED := 60.0
 
-## Rate at which to bounce. This is synchronized with the song "Sugar Crash" for the end credits.
+## Rate at which to bounce. This is synchronized with the music track "Sugar Crash" for the end credits.
 const BOUNCES_PER_SECOND := 2.05000
 
 ## Creature's elevation at the bottom of their bounce.

--- a/pybabel-extract.sh
+++ b/pybabel-extract.sh
@@ -8,7 +8,7 @@ pybabel extract -F project/assets/main/locale/babelrc \
 	-k dialog_text \
 	-k keybind_value \
 	-k label_text \
-	-k song_title \
+	-k track_title \
 	-k text \
 	-k tr \
 	-k window_title \


### PR DESCRIPTION
Renamed 'chill/upbeat' music to 'menu/puzzle' music. This is more descriptive

Renamed 'song', 'bgm', 'music' references to 'music track' or 'track' for short. This avoids complications where some places were referring to 'bgm_id', 'music_id', 'song_title'  and it was unpredictable which term they should use.