### PR TITLE
Refactor: CreatureSaver.creature_saved -> save_button_pressed

### DIFF
--- a/project/src/main/editor/creature/CreatureEditor.tscn
+++ b/project/src/main/editor/creature/CreatureEditor.tscn
@@ -993,4 +993,4 @@ bus = "Sound Bus"
 [connection signal="file_selected" from="Buttons/Dialogs/Export" to="." method="_on_Export_file_selected"]
 [connection signal="popup_hide" from="Buttons/Dialogs/Export" to="Buttons/Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
 [connection signal="quit_pressed" from="SettingsMenu" to="." method="_on_Quit_pressed"]
-[connection signal="creature_saved" from="CreatureSaver" to="Buttons/SaveLabel" method="_on_CreatureSaver_creature_saved"]
+[connection signal="save_button_pressed" from="CreatureSaver" to="Buttons/SaveLabel" method="_on_CreatureSaver_save_button_pressed"]

--- a/project/src/main/editor/creature/creature-saver.gd
+++ b/project/src/main/editor/creature/creature-saver.gd
@@ -4,7 +4,7 @@ extends Node
 ##
 ## This occurs either in response to the player clicking the "save" button or answering a dialog prompt.
 
-signal creature_saved
+signal save_button_pressed
 
 export (NodePath) var overworld_environment_path: NodePath
 
@@ -33,7 +33,7 @@ func save_creature() -> void:
 			Creatures.Mood.YES0,
 			Creatures.Mood.YES1,
 	]))
-	emit_signal("creature_saved")
+	emit_signal("save_button_pressed")
 
 
 func has_unsaved_changes() -> bool:

--- a/project/src/main/editor/creature/save-message.gd
+++ b/project/src/main/editor/creature/save-message.gd
@@ -3,5 +3,5 @@ extends Label
 
 onready var _animation_player := $AnimationPlayer
 
-func _on_CreatureSaver_creature_saved() -> void:
+func _on_CreatureSaver_save_button_pressed() -> void:
 	_animation_player.play("play")


### PR DESCRIPTION
The signal 'creature_saved' is a little misleading as it doesn't apply when the creature is saved due to the player answering a dialog prompt.