### PR TITLE
Bug: Black (#000000) creature colors caused texture issues

### DIFF
--- a/project/src/main/world/creature/creature-loader.gd
+++ b/project/src/main/world/creature/creature-loader.gd
@@ -416,8 +416,8 @@ func _load_colors(dna: Dictionary) -> void:
 
 ## Assigns shader colors for the specified creature node.
 func _set_krgb(dna: Dictionary, path: String, black: Color,
-		red: Color = Color.black, green: Color = Color.black, blue: Color = Color.black):
+		red: Color = Color.transparent, green: Color = Color.transparent, blue: Color = Color.transparent):
 	dna["shader:%s:black" % path] = black
-	if red: dna["shader:%s:red" % path] = red
-	if green: dna["shader:%s:green" % path] = green
-	if blue: dna["shader:%s:blue" % path] = blue
+	if red != Color.transparent: dna["shader:%s:red" % path] = red
+	if green != Color.transparent: dna["shader:%s:green" % path] = green
+	if blue != Color.transparent: dna["shader:%s:blue" % path] = blue


### PR DESCRIPTION
CreatureLoader treated 'black' as 'null' when assigning shader colors. Black is a pickable eye color in the creature editor, and the player can also pick it with the sliders.

'Transparent' is now treated as null instead. The player can't pick this with the creature editor, so it's more suitable as a 'null' value.