### PR TITLE
Spanish numbers for spanish sentences

### DIFF
--- a/project/assets/main/locale/en.po
+++ b/project/assets/main/locale/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-09-02 15:44-0400\n"
+"POT-Creation-Date: 2024-09-09 12:34-0400\n"
 "PO-Revision-Date: 2023-03-13 12:16-0400\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -14167,13 +14167,13 @@ msgstr ""
 msgid "Spanish"
 msgstr ""
 
-#: project/src/main/career/CareerMap.tscn:142
+#: project/src/main/career/CareerMap.tscn:136
 #: project/src/main/career/ui/ChalkboardMapRow.tscn:179
 #: project/src/main/career/ui/Landmark.tscn:37
 msgid "999,999"
 msgstr "999,999"
 
-#: project/src/main/career/CareerMap.tscn:177
+#: project/src/main/career/CareerMap.tscn:171
 msgid "12:05 am"
 msgstr "12:05 am"
 
@@ -16679,7 +16679,7 @@ msgstr ""
 msgid "Stress Test"
 msgstr "Stress Test"
 
-#: project/src/main/ui/menu/PagedLevelPanel.tscn:55
+#: project/src/main/ui/menu/PagedLevelPanel.tscn:54
 #: project/src/main/ui/menu/PagedRegionPanel.tscn:55
 msgid "Level Select"
 msgstr "Level Select"
@@ -17246,7 +17246,7 @@ msgstr ""
 msgid "Voice Volume"
 msgstr ""
 
-#: project/src/main/ui/settings/keybind/custom-keybind-button.gd:47
+#: project/src/main/ui/settings/keybind/custom-keybind-button.gd:53
 msgid "<Enter Key>"
 msgstr "<Enter Key>"
 
@@ -17297,6 +17297,90 @@ msgstr "Left, Right, Kp 7, Kp 9"
 #: project/src/main/ui/settings/keybind/settings-keybinds-control.gd:63
 msgid "Shift, Kp Enter"
 msgstr "Shift, Kp Enter"
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "zero"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "one"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "two"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "three"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "four"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "five"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:100
+msgid "six"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:100
+msgid "seven"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:100
+msgid "eight"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:100
+msgid "nine"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:100
+msgid "ten"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:101
+msgid "eleven"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:101
+msgid "twelve"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:101
+msgid "thirteen"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:101
+msgid "fourteen"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:101
+msgid "fifteen"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:102
+msgid "sixteen"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:102
+msgid "seventeen"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:102
+msgid "eighteen"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:102
+msgid "nineteen"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:102
+msgid "twenty"
+msgstr ""
 
 #: project/src/main/world/LetterProjectile.tscn:113
 msgid "O"

--- a/project/assets/main/locale/es.po
+++ b/project/assets/main/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-09-02 15:44-0400\n"
+"POT-Creation-Date: 2024-09-09 12:34-0400\n"
 "PO-Revision-Date: 2024-06-27 10:27-0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -14848,13 +14848,13 @@ msgstr "Inglés"
 msgid "Spanish"
 msgstr "Español"
 
-#: project/src/main/career/CareerMap.tscn:142
+#: project/src/main/career/CareerMap.tscn:136
 #: project/src/main/career/ui/ChalkboardMapRow.tscn:179
 #: project/src/main/career/ui/Landmark.tscn:37
 msgid "999,999"
 msgstr "999.999"
 
-#: project/src/main/career/CareerMap.tscn:177
+#: project/src/main/career/CareerMap.tscn:171
 msgid "12:05 am"
 msgstr "12:05 am"
 
@@ -17388,7 +17388,7 @@ msgstr ""
 msgid "Stress Test"
 msgstr "Prueba de Estrés"
 
-#: project/src/main/ui/menu/PagedLevelPanel.tscn:55
+#: project/src/main/ui/menu/PagedLevelPanel.tscn:54
 #: project/src/main/ui/menu/PagedRegionPanel.tscn:55
 msgid "Level Select"
 msgstr "Selección de Nivel"
@@ -17975,7 +17975,7 @@ msgstr ""
 msgid "Voice Volume"
 msgstr ""
 
-#: project/src/main/ui/settings/keybind/custom-keybind-button.gd:47
+#: project/src/main/ui/settings/keybind/custom-keybind-button.gd:53
 msgid "<Enter Key>"
 msgstr "<Tecla>"
 
@@ -18026,6 +18026,90 @@ msgstr "Izquierda, Derecha, Numpad 7, Numpad 9"
 #: project/src/main/ui/settings/keybind/settings-keybinds-control.gd:63
 msgid "Shift, Kp Enter"
 msgstr "Shift, Numpad Intro"
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "zero"
+msgstr "cero"
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "one"
+msgstr "uno"
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "two"
+msgstr "dos"
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "three"
+msgstr "tres"
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "four"
+msgstr "cuatro"
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "five"
+msgstr "cinco"
+
+#: project/src/main/utils/string-utils.gd:100
+msgid "six"
+msgstr "seis"
+
+#: project/src/main/utils/string-utils.gd:100
+msgid "seven"
+msgstr "siete"
+
+#: project/src/main/utils/string-utils.gd:100
+msgid "eight"
+msgstr "ocho"
+
+#: project/src/main/utils/string-utils.gd:100
+msgid "nine"
+msgstr "nueve"
+
+#: project/src/main/utils/string-utils.gd:100
+msgid "ten"
+msgstr "diez"
+
+#: project/src/main/utils/string-utils.gd:101
+msgid "eleven"
+msgstr "once"
+
+#: project/src/main/utils/string-utils.gd:101
+msgid "twelve"
+msgstr "doce"
+
+#: project/src/main/utils/string-utils.gd:101
+msgid "thirteen"
+msgstr "trece"
+
+#: project/src/main/utils/string-utils.gd:101
+msgid "fourteen"
+msgstr "catorce"
+
+#: project/src/main/utils/string-utils.gd:101
+msgid "fifteen"
+msgstr "quince"
+
+#: project/src/main/utils/string-utils.gd:102
+msgid "sixteen"
+msgstr "dieciséis"
+
+#: project/src/main/utils/string-utils.gd:102
+msgid "seventeen"
+msgstr "diecisiete"
+
+#: project/src/main/utils/string-utils.gd:102
+msgid "eighteen"
+msgstr "dieciocho"
+
+#: project/src/main/utils/string-utils.gd:102
+msgid "nineteen"
+msgstr "diecinueve"
+
+#: project/src/main/utils/string-utils.gd:102
+msgid "twenty"
+msgstr "veinte"
 
 #: project/src/main/world/LetterProjectile.tscn:113
 msgid "O"

--- a/project/assets/main/locale/messages.pot
+++ b/project/assets/main/locale/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-09-02 15:44-0400\n"
+"POT-Creation-Date: 2024-09-09 12:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13288,13 +13288,13 @@ msgstr ""
 msgid "Spanish"
 msgstr ""
 
-#: project/src/main/career/CareerMap.tscn:142
+#: project/src/main/career/CareerMap.tscn:136
 #: project/src/main/career/ui/ChalkboardMapRow.tscn:179
 #: project/src/main/career/ui/Landmark.tscn:37
 msgid "999,999"
 msgstr ""
 
-#: project/src/main/career/CareerMap.tscn:177
+#: project/src/main/career/CareerMap.tscn:171
 msgid "12:05 am"
 msgstr ""
 
@@ -15467,7 +15467,7 @@ msgstr ""
 msgid "Stress Test"
 msgstr ""
 
-#: project/src/main/ui/menu/PagedLevelPanel.tscn:55
+#: project/src/main/ui/menu/PagedLevelPanel.tscn:54
 #: project/src/main/ui/menu/PagedRegionPanel.tscn:55
 msgid "Level Select"
 msgstr ""
@@ -16033,7 +16033,7 @@ msgstr ""
 msgid "Voice Volume"
 msgstr ""
 
-#: project/src/main/ui/settings/keybind/custom-keybind-button.gd:47
+#: project/src/main/ui/settings/keybind/custom-keybind-button.gd:53
 msgid "<Enter Key>"
 msgstr ""
 
@@ -16083,6 +16083,90 @@ msgstr ""
 
 #: project/src/main/ui/settings/keybind/settings-keybinds-control.gd:63
 msgid "Shift, Kp Enter"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "zero"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "one"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "two"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "three"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "four"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:99
+msgid "five"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:100
+msgid "six"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:100
+msgid "seven"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:100
+msgid "eight"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:100
+msgid "nine"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:100
+msgid "ten"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:101
+msgid "eleven"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:101
+msgid "twelve"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:101
+msgid "thirteen"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:101
+msgid "fourteen"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:101
+msgid "fifteen"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:102
+msgid "sixteen"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:102
+msgid "seventeen"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:102
+msgid "eighteen"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:102
+msgid "nineteen"
+msgstr ""
+
+#: project/src/main/utils/string-utils.gd:102
+msgid "twenty"
 msgstr ""
 
 #: project/src/main/world/LetterProjectile.tscn:113

--- a/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
@@ -255,13 +255,13 @@ func _on_PuzzleState_game_ended() -> void:
 			hud.set_message(tr("Ahhh... you only made one cake?\n\nWell, cake boxes can be tricky. Keep practicing!"))
 		elif _cakes_built <= 4:
 			hud.set_message(tr("Oh, you made %s cakes!\n\nAll that training paid off. Look at those happy customers!")
-					% [StringUtils.english_number(_cakes_built)])
+					% [StringUtils.english_number(self, _cakes_built)])
 		elif _cakes_built <= 8:
 			hud.set_message(tr("Wow, you made %s cakes? Maybe you should be training me!")
-					% [StringUtils.english_number(_cakes_built)])
+					% [StringUtils.english_number(self, _cakes_built)])
 			hud.enqueue_message(tr("Just kidding, I should still be training you.\n\nBut you did really well! Wow!"))
 		else:
 			hud.set_message(tr("%s CAKES!? Okay, well that's just ridiculous!")
-					% [StringUtils.english_number(_cakes_built).to_upper()])
+					% [StringUtils.english_number(self, _cakes_built).to_upper()])
 			hud.enqueue_message(tr("I'll have to think of some harder tutorials for someone like you."
 					+ "\n\nYou little troublemaker!"))

--- a/project/src/main/utils/string-utils.gd
+++ b/project/src/main/utils/string-utils.gd
@@ -87,19 +87,28 @@ static func default_if_empty(s: String, default: String) -> String:
 	return s if s else default
 
 
-## Returns an english representation of a number suitable for a message.
+## Returns an english (or other language) representation of a number suitable for a message.
 ##
 ## This is useful for messages like 'You need to beat three more levels' or 'You need 3,125 more points.' We don't want
 ## to display messages like 'You need three thousand one hundred and twenty-five more points', so we leave larger
 ## numbers alone.
-static func english_number(i: int) -> String:
+##
+## Parameters:
+## 	'o': The object containing reference to message translation catalogs. Static utility classes cannot call the
+## 		'tr' function.
+##
+## 	'i': The number to translate
+##
+## Returns:
+## 	An english (or other language) string representing the specified number, such as "three" or "3,125".
+static func english_number(o: Object, i: int) -> String:
 	if i < 0 or i > 20:
 		return comma_sep(i)
 	
-	return ["zero", "one", "two", "three", "four", "five", \
-			"six", "seven", "eight", "nine", "ten", \
-			"eleven", "twelve", "thirteen", "fourteen", "fifteen", \
-			"sixteen", "seventeen", "eighteen", "nineteen", "twenty"][i];
+	return [o.tr("zero"), o.tr("one"), o.tr("two"), o.tr("three"), o.tr("four"), o.tr("five"),
+			o.tr("six"), o.tr("seven"), o.tr("eight"), o.tr("nine"), o.tr("ten"),
+			o.tr("eleven"), o.tr("twelve"), o.tr("thirteen"), o.tr("fourteen"), o.tr("fifteen"),
+			o.tr("sixteen"), o.tr("seventeen"), o.tr("eighteen"), o.tr("nineteen"), o.tr("twenty")][i];
 
 
 ## Formats a duration like 63.159 into '1:04'

--- a/project/src/test/utils/test-string-utils.gd
+++ b/project/src/test/utils/test-string-utils.gd
@@ -130,13 +130,33 @@ func test_default_if_empty() -> void:
 
 
 func test_english_number() -> void:
-	assert_eq(StringUtils.english_number(-1000), "-1,000")
-	assert_eq(StringUtils.english_number(-10), "-10")
-	assert_eq(StringUtils.english_number(0), "zero")
-	assert_eq(StringUtils.english_number(10), "ten")
-	assert_eq(StringUtils.english_number(20), "twenty")
-	assert_eq(StringUtils.english_number(30), "30")
-	assert_eq(StringUtils.english_number(1000), "1,000")
+	var original_locale := TranslationServer.get_locale()
+	TranslationServer.set_locale("en")
+	
+	assert_eq(StringUtils.english_number(self, -1000), "-1,000")
+	assert_eq(StringUtils.english_number(self, -10), "-10")
+	assert_eq(StringUtils.english_number(self, 0), "zero")
+	assert_eq(StringUtils.english_number(self, 10), "ten")
+	assert_eq(StringUtils.english_number(self, 20), "twenty")
+	assert_eq(StringUtils.english_number(self, 30), "30")
+	assert_eq(StringUtils.english_number(self, 1000), "1,000")
+	
+	TranslationServer.set_locale(original_locale)
+
+
+func test_english_number_spanish() -> void:
+	var original_locale := TranslationServer.get_locale()
+	TranslationServer.set_locale("es")
+	
+	assert_eq(StringUtils.english_number(self, -1000), "-1,000")
+	assert_eq(StringUtils.english_number(self, -10), "-10")
+	assert_eq(StringUtils.english_number(self, 0), "cero")
+	assert_eq(StringUtils.english_number(self, 10), "diez")
+	assert_eq(StringUtils.english_number(self, 20), "veinte")
+	assert_eq(StringUtils.english_number(self, 30), "30")
+	assert_eq(StringUtils.english_number(self, 1000), "1,000")
+	
+	TranslationServer.set_locale(original_locale)
 
 
 func test_format_duration() -> void:


### PR DESCRIPTION
We have the smallest 21 numbers in English hard-coded in our code. These numbers are now localized and translated into spanish.