### PR TITLE
RankCalculator.rank() -> average_rank_for_grade()

### DIFF
--- a/project/src/demo/puzzle/level/level-rank-demo.gd
+++ b/project/src/demo/puzzle/level/level-rank-demo.gd
@@ -134,7 +134,7 @@ func _best_result() -> RankResult:
 
 ## Returns the rank corresponding to the grade chosen in the demo.
 func _target_rank() -> float:
-	return RankCalculator.rank(_grade_input.value)
+	return RankCalculator.average_rank_for_grade(_grade_input.value)
 
 
 ## Reads the developer's in-memory data from a save file.

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -304,7 +304,7 @@ func add_line_score(combo_score: int, box_score: int) -> void:
 		level_performance.box_score += box_score
 		_add_line()
 	else:
-		# boxes left on the screen count towards a 'finish_score'
+		# boxes left on the screen count towards a 'leftover_score'
 		level_performance.leftover_score += combo_score + box_score + 1
 	
 	combo += 1

--- a/project/src/main/puzzle/rank-calculator.gd
+++ b/project/src/main/puzzle/rank-calculator.gd
@@ -482,10 +482,10 @@ static func next_grade(grade: String) -> String:
 	return result
 
 
-## Converts a letter grade such as 'S+' into a numeric rating such as '12.6'.
+## Returns the average rank such as '5.5' for a letter grade such as 'SS+'.
 ##
-## The resulting rating is an average rating for that grade -- not a minimum cutoff.
-static func rank(grade: String) -> float:
+## Grades correspond to a range of ranks. This method returns the middle of the range for a particular grade.
+static func average_rank_for_grade(grade: String) -> float:
 	var rank_lo := WORST_RANK
 	var rank_hi := WORST_RANK
 	
@@ -495,6 +495,20 @@ static func rank(grade: String) -> float:
 			rank_hi = GRADE_RANKS[i][1]
 	
 	return 0.5 * (rank_lo + rank_hi)
+
+
+## Returns the required rank such as '16.0' for a a letter grade such as 'S+'.
+##
+## Grades correspond to a range of ranks, and high rank values like 50.0 correspond to bad grades. This method returns
+## the highest (worst) rank value which will still achieve the specified grade.
+static func required_rank_for_grade(grade: String) -> float:
+	var rank_hi := WORST_RANK
+	
+	for i in range(GRADE_RANKS.size() - 1):
+		if grade == GRADE_RANKS[i][0]:
+			rank_hi = GRADE_RANKS[i][1]
+	
+	return rank_hi
 
 
 ## Returns the maximum box score per line for the specified level.


### PR DESCRIPTION
The name 'rank' was ambiguous, and a reasonable misinterpretation of the function is that it would convert a grade like 'A' to the minimum requirement such as '44.0'.

I've renamed the method to 'average_rank_per_grade' and added a new method 'required_rank_for_grade' to provide the utility I needed.