### PR TITLE
Fixed bug where 'unlock' cheat moved central button incorrectly

### DIFF
--- a/project/src/main/ui/level-select/level-button-scroller.gd
+++ b/project/src/main/ui/level-select/level-button-scroller.gd
@@ -283,5 +283,6 @@ func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDete
 		
 		yield(get_tree(), "idle_frame")
 		set_central_button_index(old_central_button_index)
+		_refresh_central_button_index(false)
 		if old_level_button_has_focus:
 			grab_focus()


### PR DESCRIPTION
If the leftmost level were selected in the Training menu, the 'unlock' cheat would reposition the button incorrectly