### PR TITLE
'Fullscreen' input overrides other inputs.

### DIFF
--- a/project/src/main/chat/ui/chat-ui.gd
+++ b/project/src/main/chat/ui/chat-ui.gd
@@ -47,6 +47,8 @@ func _process(delta: float) -> void:
 
 
 func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("fullscreen"):
+		return
 	if not _chat_frame.is_chat_window_showing() and not _narration_frame.is_narration_window_showing():
 		return
 	

--- a/project/src/main/editor/creature/color-picker-popup.gd
+++ b/project/src/main/editor/creature/color-picker-popup.gd
@@ -17,6 +17,8 @@ func _ready() -> void:
 
 
 func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("fullscreen"):
+		return
 	if not is_visible_in_tree():
 		# ignore input unless our Popup is showing
 		return

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -51,6 +51,9 @@ func _exit_tree() -> void:
 
 
 func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("fullscreen"):
+		return
+	
 	if event.is_action_pressed("ui_menu") and not $Hud/Center/PuzzleMessages.is_settings_button_visible():
 		# if the player presses the 'menu' button during a puzzle, we pop open the settings panel
 		_settings_menu.show()

--- a/project/src/main/ui/button-shortcut-helper.gd
+++ b/project/src/main/ui/button-shortcut-helper.gd
@@ -20,6 +20,8 @@ export (String) var overridden_action: String
 onready var button: BaseButton = get_parent()
 
 func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("fullscreen"):
+		return
 	if not event.is_action(action):
 		return
 	if not get_parent().is_visible_in_tree():

--- a/project/src/main/ui/level-select/level-button-scroller.gd
+++ b/project/src/main/ui/level-select/level-button-scroller.gd
@@ -42,6 +42,9 @@ onready var _level_buttons_container: HBoxContainer = $LevelButtons
 onready var _grade_labels := $GradeLabels
 
 func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("fullscreen"):
+		return
+	
 	if _level_button_has_focus() and event.is_action_pressed("ui_right"):
 		# scroll level buttons right, if possible
 		if central_button_index < _level_buttons_container.get_child_count() - 1:

--- a/project/src/main/ui/menu/paged-level-buttons.gd
+++ b/project/src/main/ui/menu/paged-level-buttons.gd
@@ -51,6 +51,9 @@ func _ready() -> void:
 
 
 func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("fullscreen"):
+		return
+	
 	if _rightmost_level_button_has_focus() and event.is_action_pressed("ui_right"):
 		if _page < _max_selectable_page():
 			_select_next_page()

--- a/project/src/main/ui/menu/paged-region-buttons.gd
+++ b/project/src/main/ui/menu/paged-region-buttons.gd
@@ -43,6 +43,9 @@ func _ready() -> void:
 
 
 func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("fullscreen"):
+		return
+	
 	if _rightmost_region_button_has_focus() and event.is_action_pressed("ui_right"):
 		if _page < _max_selectable_page():
 			_select_next_page()


### PR DESCRIPTION
Before, it was impossible to toggle fullscreen with alt+enter while a cutscene was playing, because chat-ui.gd's get_tree().set_input_as_handled() would prevent system-data.gd from receiving the "fullscreen" input.