### PR TITLE
Bug: "winish" cheat caused bizarre output for ResultsHud

### DIFF
--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -306,7 +306,19 @@ func _complete_milestone(milestone: Milestone) -> void:
 		Milestone.PIECES:
 			PuzzleState.level_performance.pieces = milestone.adjusted_value()
 		Milestone.SCORE:
-			PuzzleState.level_performance.score = milestone.adjusted_value()
+			var score := milestone.adjusted_value()
+			
+			# update all score fields; otherwise the results hud might be have strangely
+			PuzzleState.level_performance.score = score
+			PuzzleState.level_performance.box_score = int(score * 0.4)
+			PuzzleState.level_performance.combo_score = int(score * 0.4)
+			PuzzleState.level_performance.leftover_score = int(score * 0.1)
+			PuzzleState.level_performance.pickup_score = PuzzleState.level_performance.score \
+				- PuzzleState.level_performance.box_score \
+				- PuzzleState.level_performance.combo_score \
+				- PuzzleState.level_performance.leftover_score \
+				- PuzzleState.level_performance.lines
+			
 			PuzzleState.level_performance.seconds += 9999
 		Milestone.TIME_OVER, Milestone.TIME_UNDER:
 			PuzzleState.level_performance.seconds = milestone.adjusted_value()

--- a/project/src/main/puzzle/result/results-hud-blueprint.gd
+++ b/project/src/main/puzzle/result/results-hud-blueprint.gd
@@ -41,7 +41,7 @@ func combo_score() -> int:
 
 
 func extra_score() -> int:
-	return rank_result.lines + rank_result.pickup_score + rank_result.leftover_score
+	return int(max(0, rank_result.score - rank_result.box_score - rank_result.combo_score))
 
 
 func box_duration() -> float:


### PR DESCRIPTION
Toggling the "winish" or "finish" cheats adjusts the player's score, but didn't adjust their score components. The result is that the ResultsHud would count up a total of $0 and then award an SS+ grade, which makes no sense.

The "winish" and "finish" cheats now make up arbitrary values for the combined scores.

Also made a minor adjustment to ResultsHudBlueprint to explicitly calculate the 'extra' value as 'everything but boxes and combos'. This helps handle edge cases where they don't add up otherwise. It also helps future-proof the code in case the score calculation changes in the future.