### PR TITLE
Disable outer space background for indoor scenes

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -1009,6 +1009,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/main/world/environment/oval-shadow.gd"
 }, {
+"base": "CanvasLayer",
+"class": "OverworldBg",
+"language": "GDScript",
+"path": "res://src/main/world/overworld-bg.gd"
+}, {
 "base": "Node",
 "class": "OverworldEnvironment",
 "language": "GDScript",
@@ -1830,6 +1835,7 @@ _global_script_class_icons={
 "OtherRegion": "",
 "OtherRules": "",
 "OvalShadow": "",
+"OverworldBg": "",
 "OverworldEnvironment": "",
 "OverworldObstacle": "",
 "OverworldUi": "",

--- a/project/src/demo/world/FreeRoamDemo.tscn
+++ b/project/src/demo/world/FreeRoamDemo.tscn
@@ -12,6 +12,7 @@
 script = ExtResource( 2 )
 
 [node name="Bg" parent="." instance=ExtResource( 7 )]
+outer_space_visible = true
 
 [node name="World" type="Node" parent="."]
 script = ExtResource( 1 )

--- a/project/src/main/career/CareerMap.tscn
+++ b/project/src/main/career/CareerMap.tscn
@@ -49,6 +49,7 @@ shortcut = SubResource( 22 )
 script = ExtResource( 2 )
 
 [node name="Bg" parent="." instance=ExtResource( 4 )]
+outer_space_visible = true
 
 [node name="World" type="Node" parent="."]
 script = ExtResource( 25 )

--- a/project/src/main/chat/chat-tree.gd
+++ b/project/src/main/chat/chat-tree.gd
@@ -49,6 +49,15 @@ const ENVIRONMENT_SCENE_PATHS_BY_ID := {
 	"filming": "res://src/main/world/environment/sand/FilmingEnvironment.tscn",
 }
 
+## indoor location IDs which should not have the scrolling outer space background
+const INDOOR_LOCATION_IDS := [
+	"inside_turbo_fat",
+	"credits/gift_shop",
+	"lava/zagma",
+	"sand/banana_hq",
+	"filming",
+]
+
 ## unique key to identify this conversation in the chat history
 var chat_key: String
 

--- a/project/src/main/world/Cutscene.tscn
+++ b/project/src/main/world/Cutscene.tscn
@@ -1,11 +1,13 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://src/main/world/cutscene-world.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/environment/EmptyEnvironment.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/world/cutscene-camera.gd" type="Script" id=3]
 [ext_resource path="res://src/main/world/CutsceneUi.tscn" type="PackedScene" id=4]
+[ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=5]
 [ext_resource path="res://src/main/world/ChatLetters.tscn" type="PackedScene" id=6]
 [ext_resource path="res://src/main/world/OverworldBg.tscn" type="PackedScene" id=7]
+[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=8]
 
 [node name="Cutscene" type="Node"]
 
@@ -13,8 +15,13 @@
 
 [node name="World" type="Node" parent="."]
 script = ExtResource( 1 )
+overworld_bg_path = NodePath("../Bg")
 
-[node name="Environment" parent="World" instance=ExtResource( 2 )]
+[node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 2 )]
+script = ExtResource( 5 )
+environment_shadows_path = NodePath("Ground/Shadows")
+obstacles_path = NodePath("Obstacles")
+CreatureScene = ExtResource( 8 )
 
 [node name="ChatLetters" parent="World" instance=ExtResource( 6 )]
 

--- a/project/src/main/world/OverworldBg.tscn
+++ b/project/src/main/world/OverworldBg.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://assets/main/world/environment/outer-space.png" type="Texture" id=1]
 [ext_resource path="res://src/main/world/environment/scrolling-texture.shader" type="Shader" id=2]
+[ext_resource path="res://src/main/world/overworld-bg.gd" type="Script" id=3]
 
 [sub_resource type="ShaderMaterial" id=2]
 resource_local_to_scene = true
@@ -11,8 +12,15 @@ shader_param/scroll_velocity = Vector2( -0.271, 0.233 )
 
 [node name="Bg" type="CanvasLayer"]
 layer = -1
+script = ExtResource( 3 )
+
+[node name="ColorRect" type="ColorRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color( 0.423529, 0.262745, 0.192157, 1 )
 
 [node name="OuterSpace" type="TextureRect" parent="."]
+visible = false
 material = SubResource( 2 )
 anchor_right = 1.0
 anchor_bottom = 1.0

--- a/project/src/main/world/cutscene-world.gd
+++ b/project/src/main/world/cutscene-world.gd
@@ -3,7 +3,10 @@ class_name CutsceneWorld
 extends OverworldWorld
 ## Populates/unpopulates the creatures and obstacles during cutscenes.
 
+export (NodePath) var overworld_bg_path: NodePath
+
 onready var _camera: CutsceneCamera = $Camera
+onready var _overworld_bg: OverworldBg = get_node(overworld_bg_path)
 
 func _ready() -> void:
 	if Engine.editor_hint:
@@ -24,6 +27,7 @@ func initial_environment_path() -> String:
 ##
 ## Replaces the environment's creatures with those necessary for the cutscene and plays the cutscene's chat tree.
 func _launch_cutscene() -> void:
+	_prepare_bg()
 	_remove_all_creatures()
 	_add_cutscene_creatures()
 	_arrange_creatures()
@@ -32,6 +36,12 @@ func _launch_cutscene() -> void:
 
 	Global.get_overworld_ui().start_chat(CurrentCutscene.chat_tree)
 	_camera.snap_into_position()
+
+
+## Updates the background to include an outer space background for outdoor cutscenes.
+func _prepare_bg() -> void:
+	var outer_space_visible := not CurrentCutscene.chat_tree.location_id in ChatTree.INDOOR_LOCATION_IDS
+	_overworld_bg.outer_space_visible = outer_space_visible
 
 
 ## Removes all creatures from the overworld except for the player and sensei.

--- a/project/src/main/world/environment/credits/CrowdSurfCutscene.tscn
+++ b/project/src/main/world/environment/credits/CrowdSurfCutscene.tscn
@@ -17,8 +17,10 @@ shader_param/scroll_velocity = Vector2( -0.25, 0.25 )
 script = ExtResource( 2 )
 
 [node name="Bg" parent="." instance=ExtResource( 4 )]
+outer_space_visible = true
 
-[node name="OuterSpace" parent="Bg" index="0"]
+[node name="OuterSpace" parent="Bg" index="1"]
+visible = true
 material = SubResource( 1 )
 
 [node name="LaunchBg" parent="." instance=ExtResource( 3 )]

--- a/project/src/main/world/environment/credits/CrowdWalkCutscene.tscn
+++ b/project/src/main/world/environment/credits/CrowdWalkCutscene.tscn
@@ -17,8 +17,10 @@ shader_param/scroll_velocity = Vector2( -0.25, 0.25 )
 script = ExtResource( 1 )
 
 [node name="Bg" parent="." instance=ExtResource( 5 )]
+outer_space_visible = true
 
-[node name="OuterSpace" parent="Bg" index="0"]
+[node name="OuterSpace" parent="Bg" index="1"]
+visible = true
 material = SubResource( 1 )
 
 [node name="LaunchBg" parent="." instance=ExtResource( 3 )]

--- a/project/src/main/world/environment/restaurant/RestaurantPuzzleScene.tscn
+++ b/project/src/main/world/environment/restaurant/RestaurantPuzzleScene.tscn
@@ -1,12 +1,10 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://src/main/world/OverworldBg.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/puzzle-world.gd" type="Script" id=2]
 [ext_resource path="res://src/main/world/environment/restaurant/restaurant-puzzle-scene.gd" type="Script" id=3]
 [ext_resource path="res://src/main/world/environment/EmptyEnvironment.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/world/environment/restaurant/door-chime.gd" type="Script" id=5]
-[ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=6]
-[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=7]
 
 [node name="RestaurantPuzzleScene" type="Node"]
 script = ExtResource( 3 )
@@ -16,11 +14,7 @@ script = ExtResource( 3 )
 [node name="World" type="Node" parent="."]
 script = ExtResource( 2 )
 
-[node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 4 )]
-script = ExtResource( 6 )
-environment_shadows_path = NodePath("Ground/Shadows")
-obstacles_path = NodePath("Obstacles")
-CreatureScene = ExtResource( 7 )
+[node name="Environment" parent="World" instance=ExtResource( 4 )]
 
 [node name="DoorChime" type="AudioStreamPlayer2D" parent="."]
 position = Vector2( 130, 314 )

--- a/project/src/main/world/overworld-bg.gd
+++ b/project/src/main/world/overworld-bg.gd
@@ -1,0 +1,29 @@
+tool
+class_name OverworldBg
+extends CanvasLayer
+## Draws the background behind overworld scenes.
+
+## If 'true', the background shows a scrolling outer space texture. If 'false', the background is blank.
+export (bool) var outer_space_visible: bool = false setget set_outer_space_visible
+
+onready var _outer_space := $OuterSpace
+
+func _ready() -> void:
+	_refresh_outer_space_visible()
+
+
+## Preemptively initializes onready variables to avoid null references.
+func _enter_tree() -> void:
+	_outer_space = $OuterSpace
+
+
+func set_outer_space_visible(new_outer_space_visible: bool) -> void:
+	outer_space_visible = new_outer_space_visible
+	_refresh_outer_space_visible()
+
+
+func _refresh_outer_space_visible() -> void:
+	if not is_inside_tree():
+		return
+	
+	_outer_space.visible = outer_space_visible


### PR DESCRIPTION
The outer space background was especially distracting during the 'Zagma HQ' cutscenes, but in indoor cutscenes it just too strange and distracting.