### PR TITLE
'Level failed...' when not scoring enough for a boss level.

### DIFF
--- a/project/src/main/music/music-player.gd
+++ b/project/src/main/music/music-player.gd
@@ -103,7 +103,7 @@ func play_puzzle_track(fade_in: bool = true) -> void:
 		if PlayerData.career.hours_passed == 0:
 			# if it's the first level, play the 'main puzzle track'
 			new_track_id = region_music.main_puzzle_track_id()
-		elif PlayerData.career.is_boss_level():
+		elif CurrentLevel.boss_level:
 			# if it's a boss level, play the 'main puzzle track'
 			new_track_id = region_music.main_puzzle_track_id()
 		elif _previous_level_id == CurrentLevel.level_id \

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -17,6 +17,9 @@ var settings := LevelSettings.new() setget switch_level
 ## If 'true' the player only gets one life.
 var hardcore := false
 
+## If 'true' the player selected a career mode boss level.
+var boss_level: bool
+
 var puzzle: Puzzle
 
 ## The level which was originally launched. Some tutorial levels transition
@@ -52,6 +55,7 @@ func reset() -> void:
 	keep_retrying = false
 	settings = LevelSettings.new()
 	hardcore = false
+	boss_level = false
 	puzzle = null
 	level_id = ""
 	piece_speed = ""

--- a/project/src/main/puzzle/result/receipt-header.gd
+++ b/project/src/main/puzzle/result/receipt-header.gd
@@ -17,7 +17,15 @@ func play(blueprint: ResultsHudBlueprint) -> void:
 	visible = true
 	_animation_player.play("play")
 	
+	var level_failed := false
 	if blueprint.rank_result.lost:
+		# player quit or lost all their lives
+		level_failed = true
+	elif CurrentLevel.boss_level and not blueprint.rank_result.success:
+		# player failed a career mode boss level
+		level_failed = true
+	
+	if level_failed:
 		_label.text = tr("Level\nFailed...")
 	else:
 		_label.text = tr("Level\nComplete!")

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -300,6 +300,7 @@ func _on_LevelSelectButton_level_chosen(level_index: int) -> void:
 	CurrentLevel.set_launched_level(level_settings.id)
 	CurrentLevel.piece_speed = _piece_speed
 	CurrentLevel.hardcore = level_settings.lose_condition.top_out == 1
+	CurrentLevel.boss_level = PlayerData.career.is_boss_level()
 	
 	var level_posse: LevelPosse = _level_posses[level_index]
 	CurrentLevel.customers = level_posse.customer_ids
@@ -336,6 +337,7 @@ func _on_LevelSelectButton_level_chosen(level_index: int) -> void:
 		"chef_id": CurrentLevel.chef_id,
 		"customers": CurrentLevel.customers,
 		"hardcore": CurrentLevel.hardcore,
+		"boss_level": CurrentLevel.boss_level,
 		"puzzle_environment_id": CurrentLevel.puzzle_environment_id,
 	})
 	

--- a/project/src/main/world/cutscene-queue.gd
+++ b/project/src/main/world/cutscene-queue.gd
@@ -131,6 +131,8 @@ func _pop_level() -> void:
 		CurrentLevel.customers = level_properties["customers"]
 	if level_properties.has("hardcore"):
 		CurrentLevel.hardcore = level_properties["hardcore"]
+	if level_properties.has("boss_level"):
+		CurrentLevel.boss_level = level_properties["boss_level"]
 	if level_properties.has("puzzle_environment_id"):
 		CurrentLevel.puzzle_environment_id = level_properties["puzzle_environment_id"]
 	PlayerData.customer_queue.pop_standard_customers(CurrentLevel.get_creature_ids())


### PR DESCRIPTION
ResultsHud now shows 'Level Failed...' when failing to meet the success criteria for a boss level. Before, it only showed a failure message if you quit or lost all your lives.

Added 'CurrentLevel.boss_level' flag. This is necessary because the CareerData.is_boss_level() method is based purely on the player's distance, but this distance is unreliable during a level, as it is adjusted when the player plays or finishes a level