### PR TITLE
Increased ResultsHud bar graph scroll speed.

### DIFF
--- a/project/src/main/puzzle/result/receipt-bar-graph.gd
+++ b/project/src/main/puzzle/result/receipt-bar-graph.gd
@@ -59,7 +59,7 @@ func _process(_delta: float) -> void:
 	# slide the bar graph down if it grows too tall
 	if _contents.rect_position.y + _total_label.rect_position.y < CAMERA_TARGET_Y:
 		_contents.rect_position.y = lerp(_contents.rect_position.y, \
-				CAMERA_TARGET_Y - _total_label.rect_position.y, _delta * 3)
+				CAMERA_TARGET_Y - _total_label.rect_position.y, _delta * 5)
 
 
 ## Resets the graph to be empty, with a set of BarGraphGoals based on the current level.


### PR DESCRIPTION
The old scroll speed meant the bad graph was often still scrolling when the stamp got applied to the paper, breaking the illusion that the stamp was on the page.