### PR TITLE
Populated level duration, rank_criteria

### DIFF
--- a/project/assets/demo/puzzle/levels/experiment.json
+++ b/project/assets/demo/puzzle/levels/experiment.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Chompo and Bitey",
   "description": "I call the red one Bitey! They like snack boxes... but who doesn't?",
   "start_speed": "3",
@@ -13,10 +13,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 1.16",
-    "combo_factor 1.21",
-    "extra_seconds_per_piece 2",
-    "master_pickup_score_per_line 17.71",
+    "duration 2060",
+    "rank_criteria m=14000",
     "show_pickups_rank"
   ],
   "triggers": [

--- a/project/assets/demo/puzzle/levels/retired/a-little-garbage.json
+++ b/project/assets/demo/puzzle/levels/retired/a-little-garbage.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "A Little Garbage",
   "description": "Nothing to worry about.",
   "start_speed": "4",
@@ -14,6 +14,10 @@
     "type": "time_over",
     "value": 90
   },
+  "rank": [
+    "duration 90",
+    "rank_criteria m=1850"
+  ],
   "timers": [
     {
       "interval": 6

--- a/project/assets/demo/puzzle/levels/retired/boss-vega.json
+++ b/project/assets/demo/puzzle/levels/retired/boss-vega.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Grand Opening: Chocolava Canyon",
   "description": "Opening a new restaurant can be tough!",
   "start_speed": "6",
@@ -8,6 +8,8 @@
     "value": 1250
   },
   "rank": [
+    "duration 640",
+    "rank_criteria m=85",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/demo/puzzle/levels/retired/bottomless-pit-2.json
+++ b/project/assets/demo/puzzle/levels/retired/bottomless-pit-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Bottomless Pit II",
   "description": "How deep does this thing go!?",
   "start_speed": "5",
@@ -8,8 +8,8 @@
     "value": 115
   },
   "rank": [
-    "box_factor 1.22",
-    "combo_factor 0.8"
+    "duration 115",
+    "rank_criteria m=2250"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/boxing-day.json
+++ b/project/assets/demo/puzzle/levels/retired/boxing-day.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Boxing Day",
   "description": "Don't get boxed in!",
   "start_speed": "5",
@@ -15,7 +15,8 @@
     "piece_v"
   ],
   "rank": [
-    "preplaced_pieces 8"
+    "duration 435",
+    "rank_criteria m=44"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/cleaning-duty.json
+++ b/project/assets/demo/puzzle/levels/retired/cleaning-duty.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Cleaning Duty",
   "description": "Who made this mess! ...Do we need to set up a chore board?",
   "start_speed": "3",
@@ -11,8 +11,8 @@
     "top_out 1"
   ],
   "rank": [
-    "box_factor 0.5",
-    "combo_factor 0.5"
+    "duration 90",
+    "rank_criteria m=1000"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/creeping-crevice.json
+++ b/project/assets/demo/puzzle/levels/retired/creeping-crevice.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Creeping Crevice",
   "description": "It'll sneak up on you!",
   "start_speed": "4",
@@ -11,7 +11,8 @@
     "value": 25
   },
   "rank": [
-    "box_factor 0.94"
+    "duration 190",
+    "rank_criteria m=1100"
   ],
   "tiles": {
     "0": [

--- a/project/assets/demo/puzzle/levels/retired/leftovers.json
+++ b/project/assets/demo/puzzle/levels/retired/leftovers.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Leftovers",
   "description": "Another big mess to clean. Why does this always fall to you?",
   "start_speed": "2",
@@ -8,8 +8,8 @@
     "value": 150
   },
   "rank": [
-    "box_factor 0.51",
-    "combo_factor 0.6"
+    "duration 150",
+    "rank_criteria m=1650"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/lets-all-get-merry.json
+++ b/project/assets/demo/puzzle/levels/retired/lets-all-get-merry.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Let's All Get Merry",
   "description": "It's a dessert party and everybody's invited!",
   "start_speed": "3",
@@ -25,7 +25,8 @@
     "value": 50
   },
   "rank": [
-    "preplaced_pieces 14"
+    "duration 375",
+    "rank_criteria m=1950"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/low-gravity.json
+++ b/project/assets/demo/puzzle/levels/retired/low-gravity.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Low Gravity",
   "description": "What goes up must come down... Eventually?",
   "difficulty": "3",
@@ -11,9 +11,8 @@
     "value": 120
   },
   "rank": [
-    "combo_factor 0.4",
-    "extra_seconds_per_piece 0.2",
-    "preplaced_pieces 12"
+    "duration 120",
+    "rank_criteria m=1600"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/muffin-impossible-2.json
+++ b/project/assets/demo/puzzle/levels/retired/muffin-impossible-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Muffin Impossible II",
   "description": "More awkward mismatched pieces!? When will the pain stop?",
   "start_speed": "8",
@@ -18,7 +18,8 @@
     "piece_v"
   ],
   "rank": [
-    "preplaced_pieces 8"
+    "duration 390",
+    "rank_criteria m=44"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/muffin-impossible-3.json
+++ b/project/assets/demo/puzzle/levels/retired/muffin-impossible-3.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Muffin Impossible III",
   "description": "More awkward mismatched pieces!? When will the pain stop?",
   "start_speed": "A1",
@@ -18,7 +18,8 @@
     "piece_v"
   ],
   "rank": [
-    "preplaced_pieces 6"
+    "duration 455",
+    "rank_criteria m=60"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/muffin-impossible-ex.json
+++ b/project/assets/demo/puzzle/levels/retired/muffin-impossible-ex.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Muffin Impossible EX",
   "description": "More awkward mismatched pieces!? When will the pain stop?",
   "start_speed": "A1",
@@ -18,7 +18,8 @@
     "piece_v"
   ],
   "rank": [
-    "preplaced_pieces 8"
+    "duration 680",
+    "rank_criteria m=90"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/muffin-impossible.json
+++ b/project/assets/demo/puzzle/levels/retired/muffin-impossible.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Muffin Impossible",
   "description": "So many awkward mismatched pieces! This is like solving a jigsaw puzzle with no edges...",
   "start_speed": "5",
@@ -20,7 +20,8 @@
     "start_piece_v"
   ],
   "rank": [
-    "preplaced_pieces 4"
+    "duration 165",
+    "rank_criteria m=19"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/mystery-box.json
+++ b/project/assets/demo/puzzle/levels/retired/mystery-box.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Mystery Box",
   "description": "Can you guess what's inside? Hey, no peeking!",
   "start_speed": "9",
@@ -8,8 +8,8 @@
     "value": 90
   },
   "rank": [
-    "box_factor 0.82",
-    "master_pickup_score 100"
+    "duration 90",
+    "rank_criteria m=1700"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/pineapple-on-its-side-cake.json
+++ b/project/assets/demo/puzzle/levels/retired/pineapple-on-its-side-cake.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Pineapple On Its Side Cake",
   "description": "Why is this cake on its side? Whoever left this here was either very smart, or very stupid...",
   "start_speed": "5",
@@ -12,7 +12,8 @@
     "start_piece_p"
   ],
   "rank": [
-    "preplaced_pieces 4"
+    "duration 220",
+    "rank_criteria m=25"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/teensy-taste.json
+++ b/project/assets/demo/puzzle/levels/retired/teensy-taste.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Teensy Taste",
   "description": "Just a quick bite.",
   "finish_condition": {
@@ -10,7 +10,8 @@
     "start_piece_u"
   ],
   "rank": [
-    "preplaced_pieces 4"
+    "duration 180",
+    "rank_criteria m=13"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/too-fast-to-fast.json
+++ b/project/assets/demo/puzzle/levels/retired/too-fast-to-fast.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Too Fast to Fast",
   "description": "Can you survive the increasing speeds?",
   "start_speed": "5",
@@ -26,7 +26,8 @@
     "start_piece_j"
   ],
   "rank": [
-    "preplaced_pieces 7"
+    "duration 90",
+    "rank_criteria m=1950"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/unfresh-fruits-2.json
+++ b/project/assets/demo/puzzle/levels/retired/unfresh-fruits-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Unfresh Fruits 2",
   "description": "This fruit's going bad soon! Maybe someone will eat it...",
   "start_speed": "2",
@@ -11,7 +11,8 @@
     "start_piece_j"
   ],
   "rank": [
-    "preplaced_pieces 10"
+    "duration 575",
+    "rank_criteria m=42"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/unfresh-fruits.json
+++ b/project/assets/demo/puzzle/levels/retired/unfresh-fruits.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Unfresh Fruits",
   "description": "This fruit's going bad soon! Maybe someone will eat it...",
   "start_speed": "2",
@@ -11,7 +11,8 @@
     "start_piece_j"
   ],
   "rank": [
-    "preplaced_pieces 6"
+    "duration 145",
+    "rank_criteria m=11"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/veggie-haters.json
+++ b/project/assets/demo/puzzle/levels/retired/veggie-haters.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Veggie Haters",
   "description": "Five of the pickiest customers you'll ever meet!",
   "start_speed": "4",
@@ -9,5 +9,9 @@
   "finish_condition": {
     "type": "customers",
     "value": 5
-  }
+  },
+  "rank": [
+    "duration 190",
+    "rank_criteria m=3500"
+  ]
 }

--- a/project/assets/demo/puzzle/levels/retired/veggie-patty.json
+++ b/project/assets/demo/puzzle/levels/retired/veggie-patty.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Veggie Patty",
   "description": "Twice the pace and half the space? ...This is a recipe for disaster!",
   "start_speed": "4",
@@ -9,6 +9,10 @@
   },
   "lose_condition": [
     "top_out 1"
+  ],
+  "rank": [
+    "duration 1200",
+    "rank_criteria m=1500"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/wedding-cake-for-one.json
+++ b/project/assets/demo/puzzle/levels/retired/wedding-cake-for-one.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Wedding Cake For One",
   "description": "One VERY hungry customer and one VERY big cake! ...Are they going eat the entire thing?",
   "difficulty": "5",
@@ -89,11 +89,8 @@
     "piece_o"
   ],
   "rank": [
-    "box_factor 1.38",
-    "combo_factor 1.21",
-    "customer_combo 9",
-    "leftover_lines 3",
-    "preplaced_pieces 10"
+    "duration 15",
+    "rank_criteria m=280"
   ],
   "tiles": {
     "start": [

--- a/project/assets/demo/puzzle/levels/retired/zero-gravity.json
+++ b/project/assets/demo/puzzle/levels/retired/zero-gravity.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Zero Gravity",
   "description": "In space, nobody can hear you scream.",
   "difficulty": "6",
@@ -13,9 +13,8 @@
     "value": 90
   },
   "rank": [
-    "combo_factor 0.3",
-    "extra_seconds_per_piece 1.2",
-    "preplaced_pieces 3"
+    "duration 90",
+    "rank_criteria m=785"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/1000-race.json
+++ b/project/assets/main/puzzle/levels/career/1000-race.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "¥1,000 Race",
   "description": "Earn ¥1,000 as fast as possible. No tricks!",
   "finish_condition": {
@@ -8,5 +8,9 @@
   },
   "icons": [
     "basic"
+  ],
+  "rank": [
+    "duration 890",
+    "rank_criteria m=65"
   ]
 }

--- a/project/assets/main/puzzle/levels/career/200-race.json
+++ b/project/assets/main/puzzle/levels/career/200-race.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "¥200 Race",
   "description": "Earn ¥200 as fast as possible. No tricks!",
   "finish_condition": {
@@ -8,5 +8,9 @@
   },
   "icons": [
     "basic"
+  ],
+  "rank": [
+    "duration 180",
+    "rank_criteria m=17 s-=125"
   ]
 }

--- a/project/assets/main/puzzle/levels/career/500-race.json
+++ b/project/assets/main/puzzle/levels/career/500-race.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "¥500 Race",
   "description": "Earn ¥500 as fast as possible. No tricks!",
   "finish_condition": {
@@ -8,5 +8,9 @@
   },
   "icons": [
     "basic"
+  ],
+  "rank": [
+    "duration 445",
+    "rank_criteria m=35"
   ]
 }

--- a/project/assets/main/puzzle/levels/career/90-second-sprint.json
+++ b/project/assets/main/puzzle/levels/career/90-second-sprint.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "90 Second Sprint",
   "description": "Nothing fancy, let's just cook!",
   "finish_condition": {
@@ -8,5 +8,9 @@
   },
   "icons": [
     "basic"
+  ],
+  "rank": [
+    "duration 90",
+    "rank_criteria m=1850"
   ]
 }

--- a/project/assets/main/puzzle/levels/career/a-little-extra.json
+++ b/project/assets/main/puzzle/levels/career/a-little-extra.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "A Little Extra",
   "description": "Some fun little bonuses at the bottom. But you have to work for it!",
   "finish_condition": {
@@ -10,9 +10,8 @@
     "dig"
   ],
   "rank": [
-    "box_factor 0.16",
-    "combo_factor 0.62",
-    "master_pickup_score_per_line 15.29",
+    "duration 150",
+    "rank_criteria m=2450",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/a-little-garbage-2.json
+++ b/project/assets/main/puzzle/levels/career/a-little-garbage-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "A Little Garbage 2",
   "description": "Is that food? Don't eat out of the garbage!",
   "start_speed": "1",
@@ -14,9 +14,8 @@
     "dig"
   ],
   "rank": [
-    "box_factor 0.11",
-    "combo_factor 0.58",
-    "master_pickup_score_per_line 21.42",
+    "duration 120",
+    "rank_criteria m=2250",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/a-thousand-moles.json
+++ b/project/assets/main/puzzle/levels/career/a-thousand-moles.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "A Thousand Moles",
   "description": "Making my way downtown...",
   "finish_condition": {
@@ -10,7 +10,8 @@
     "dig"
   ],
   "rank": [
-    "master_pickup_score_per_line 7.97",
+    "duration 80",
+    "rank_criteria m=2000 s-=345",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/above-and-below.json
+++ b/project/assets/main/puzzle/levels/career/above-and-below.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Above and Below",
   "description": "Build some delicious snack boxes above while befriending some moles below.",
   "start_speed": "1",
@@ -16,8 +16,8 @@
     "slow"
   ],
   "rank": [
-    "extra_seconds_per_piece 0.4",
-    "master_pickup_score_per_line 23.91",
+    "duration 150",
+    "rank_criteria m=1450",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/accelerator.json
+++ b/project/assets/main/puzzle/levels/career/accelerator.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Accelerator",
   "description": "Hurry up and finish before things get out of control!",
   "start_speed": "2",
@@ -82,5 +82,9 @@
   "icons": [
     "basic",
     "fast"
+  ],
+  "rank": [
+    "duration 125",
+    "rank_criteria m=48"
   ]
 }

--- a/project/assets/main/puzzle/levels/career/angle-grinder.json
+++ b/project/assets/main/puzzle/levels/career/angle-grinder.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Angle Grinder",
   "description": "So many bendy pieces! Need a helping hand? ...Or a helping jaw?",
   "start_speed": "5",
@@ -18,10 +18,8 @@
     "piece_z"
   ],
   "rank": [
-    "box_factor 1.23",
-    "combo_factor 1.21",
-    "extra_seconds_per_piece 2",
-    "master_pickup_score_per_line 29.23",
+    "duration 28",
+    "rank_criteria m=1750",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/asparagus-trio.json
+++ b/project/assets/main/puzzle/levels/career/asparagus-trio.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "The Asparagus Trio",
   "description": "Why is it when something happens, it is always you three?",
   "start_speed": "4",
@@ -15,8 +15,8 @@
     "narrow"
   ],
   "rank": [
-    "box_factor 0.3",
-    "combo_factor 1.11"
+    "duration 415",
+    "rank_criteria m=52"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/asparagus-vault.json
+++ b/project/assets/main/puzzle/levels/career/asparagus-vault.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Asparagus Vault",
   "description": "Are you planning a robbery? I'm onto you!",
   "start_speed": "2",
@@ -23,9 +23,8 @@
     "start_piece_t"
   ],
   "rank": [
-    "box_factor 0.62",
-    "combo_factor 0.66",
-    "master_pickup_score_per_line 7.94",
+    "duration 120",
+    "rank_criteria m=1700",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/back-to-back.json
+++ b/project/assets/main/puzzle/levels/career/back-to-back.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Back to Back",
   "description": "Now where did I put those two line pieces?",
   "start_speed": "1",
@@ -12,7 +12,8 @@
     "narrow"
   ],
   "rank": [
-    "preplaced_pieces 14"
+    "duration 80",
+    "rank_criteria m=1900"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/blindy-asparagus.json
+++ b/project/assets/main/puzzle/levels/career/blindy-asparagus.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Blindy Asparagus",
   "description": "What you can't see CAN hurt you!",
   "start_speed": "2",
@@ -40,10 +40,8 @@
     "piece_v"
   ],
   "rank": [
-    "box_factor 0.65",
-    "combo_factor 1.21",
-    "extra_seconds_per_piece 0.25",
-    "master_pickup_score 120"
+    "duration 255",
+    "rank_criteria m=1500"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/block-blockers.json
+++ b/project/assets/main/puzzle/levels/career/block-blockers.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Block Blockers",
   "description": "They're just here to get in the way!",
   "start_speed": "3",
@@ -25,10 +25,8 @@
     "piece_v"
   ],
   "rank": [
-    "box_factor 1.14",
-    "combo_factor 1.21",
-    "extra_seconds_per_piece 0.22",
-    "master_pickup_score_per_line 19.13",
+    "duration 160",
+    "rank_criteria m=33",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/bon-appetit.json
+++ b/project/assets/main/puzzle/levels/career/bon-appetit.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Bon Appetit",
   "description": "Dig in!",
   "finish_condition": {
@@ -10,7 +10,8 @@
     "basic"
   ],
   "rank": [
-    "preplaced_pieces 4"
+    "duration 60",
+    "rank_criteria m=1400 s-=190"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/boss-lava.json
+++ b/project/assets/main/puzzle/levels/career/boss-lava.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Grand Opening: Starberry Mountain",
   "description": "Opening a new restaurant can be tough!",
   "speed_ups": [
@@ -71,6 +71,8 @@
     "top_out 1"
   ],
   "rank": [
+    "duration 620",
+    "rank_criteria m=4250",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/career/boss-lemon.json
+++ b/project/assets/main/puzzle/levels/career/boss-lemon.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Trial: Fat Sensei",
   "description": "Opening a new restaurant can be tough!",
   "start_speed": "3",
@@ -11,6 +11,8 @@
     "basic"
   ],
   "rank": [
+    "duration 195",
+    "rank_criteria m=25 s-=180",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/career/boss-marsh.json
+++ b/project/assets/main/puzzle/levels/career/boss-marsh.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Grand Opening: Chocolava Canyon",
   "description": "Opening a new restaurant can be tough!",
   "start_speed": "5",
@@ -12,6 +12,8 @@
     "slow"
   ],
   "rank": [
+    "duration 2250",
+    "rank_criteria m=2650",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/career/boss-poki.json
+++ b/project/assets/main/puzzle/levels/career/boss-poki.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Grand Opening: Kflab",
   "description": "Opening a new restaurant can be tough!",
   "start_speed": "3",
@@ -28,6 +28,8 @@
     "basic"
   ],
   "rank": [
+    "duration 385",
+    "rank_criteria m=42",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/career/boss-sand.json
+++ b/project/assets/main/puzzle/levels/career/boss-sand.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Grand Opening: Merrymellow Marsh",
   "description": "Opening a new restaurant can be tough!",
   "start_speed": "3",
@@ -33,6 +33,8 @@
     "basic"
   ],
   "rank": [
+    "duration 210",
+    "rank_criteria m=3850",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/career/boss-welcome.json
+++ b/project/assets/main/puzzle/levels/career/boss-welcome.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Grand Opening: Lemony Thickets",
   "description": "We're officially open! Let's attract enough customers to make sure we stay that way.",
   "start_speed": "2",
@@ -7,11 +7,13 @@
     "type": "time_over",
     "value": 180
   },
-  "rank": [
-    "success_bonus 2"
-  ],
   "icons": [
     "basic"
+  ],
+  "rank": [
+    "duration 180",
+    "rank_criteria m=3350 s-=580",
+    "success_bonus 2"
   ],
   "success_condition": {
     "type": "score",

--- a/project/assets/main/puzzle/levels/career/bottomless-pit.json
+++ b/project/assets/main/puzzle/levels/career/bottomless-pit.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Bottomless Pit",
   "description": "It just keeps going...",
   "finish_condition": {
@@ -11,8 +11,8 @@
     "narrow"
   ],
   "rank": [
-    "box_factor 1.35",
-    "combo_factor 0.56"
+    "duration 100",
+    "rank_criteria m=1900 s-=325"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/carrot-alley.json
+++ b/project/assets/main/puzzle/levels/career/carrot-alley.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Carrot Alley",
   "description": "Carrots... Why did it have to be carrots?",
   "start_speed": "3",
@@ -48,6 +48,10 @@
     "piece_j",
     "piece_o",
     "piece_p"
+  ],
+  "rank": [
+    "duration 105",
+    "rank_criteria m=2100"
   ],
   "tiles": {
     "0": [

--- a/project/assets/main/puzzle/levels/career/carrot-cake-2.json
+++ b/project/assets/main/puzzle/levels/career/carrot-cake-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Carrot Cake II",
   "description": "Even cakier cakes! ...Even chonkier carrots! This level is a menace!!!",
   "start_speed": "3",
@@ -13,9 +13,8 @@
     "annoying"
   ],
   "rank": [
-    "box_factor 2.12",
-    "combo_factor 1.21",
-    "extra_seconds_per_piece 0.13"
+    "duration 205",
+    "rank_criteria m=26"
   ],
   "score": [
     "cake_all 20"

--- a/project/assets/main/puzzle/levels/career/carrot-cake.json
+++ b/project/assets/main/puzzle/levels/career/carrot-cake.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Carrot Cake",
   "description": "Hmph, I guess I'll just try to eat around the carrot part....",
   "finish_condition": {
@@ -9,6 +9,10 @@
   "icons": [
     "carrot",
     "cake_box"
+  ],
+  "rank": [
+    "duration 180",
+    "rank_criteria m=17 s-=100"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/checkerboard-vault.json
+++ b/project/assets/main/puzzle/levels/career/checkerboard-vault.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Checkerboard Vault",
   "description": "Do you have the combination?",
   "blocks_during": [
@@ -20,9 +20,8 @@
     "annoying"
   ],
   "rank": [
-    "box_factor 0.14",
-    "combo_factor 0",
-    "master_pickup_score_per_line 4.57",
+    "duration 120",
+    "rank_criteria m=640",
     "hide_combos_rank",
     "show_pickups_rank"
   ],

--- a/project/assets/main/puzzle/levels/career/cheerleaders.json
+++ b/project/assets/main/puzzle/levels/career/cheerleaders.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Cheerleaders",
   "description": "They're just happy to be included!",
   "start_speed": "1",
@@ -13,6 +13,10 @@
   "piece_types": [
     "start_piece_q",
     "start_piece_l"
+  ],
+  "rank": [
+    "duration 85",
+    "rank_criteria m=1750 s-=300"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/cheese-mountain.json
+++ b/project/assets/main/puzzle/levels/career/cheese-mountain.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "On Top of Cheese Mountain",
   "description": "...Did anybody lose a meatball?",
   "start_speed": "7",
@@ -26,7 +26,8 @@
     "start_piece_k"
   ],
   "rank": [
-    "master_pickup_score_per_line 5.53",
+    "duration 365",
+    "rank_criteria m=56",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/chocolate-star.json
+++ b/project/assets/main/puzzle/levels/career/chocolate-star.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Chocolate Star",
   "description": "Close your eyes and make a chocolate wish!",
   "finish_condition": {
@@ -21,8 +21,8 @@
     "piece_o"
   ],
   "rank": [
-    "box_factor 1.32",
-    "master_pickup_score 100"
+    "duration 75",
+    "rank_criteria m=755 s-=100"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/chompo-and-bitey.json
+++ b/project/assets/main/puzzle/levels/career/chompo-and-bitey.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Chompo and Bitey",
   "description": "I call the red one Bitey! They like snack boxes... but who doesn't?",
   "start_speed": "3",
@@ -13,10 +13,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 1.16",
-    "combo_factor 1.21",
-    "extra_seconds_per_piece 2",
-    "master_pickup_score_per_line 17.71",
+    "duration 205",
+    "rank_criteria m=1500",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/chunky-greens.json
+++ b/project/assets/main/puzzle/levels/career/chunky-greens.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Chunky Greens",
   "description": "Just pile them beside my plate, where I can ignore them.",
   "start_speed": "5",
@@ -7,6 +7,11 @@
     "type": "lines",
     "value": 25
   },
+  "icons": [
+    "piece_p",
+    "spear",
+    "slow"
+  ],
   "piece_types": [
     "piece_j",
     "piece_j",
@@ -17,14 +22,9 @@
     "piece_u",
     "piece_v"
   ],
-  "icons": [
-    "piece_p",
-    "spear",
-    "slow"
-  ],
   "rank": [
-    "extra_seconds_per_piece 0.3",
-    "master_pickup_score 120"
+    "duration 145",
+    "rank_criteria m=1150"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/cocoa-canyon.json
+++ b/project/assets/main/puzzle/levels/career/cocoa-canyon.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Cocoa Canyon",
   "description": "Excavate the chocolate! Hurry, hurry!",
   "start_speed": "2",
@@ -18,9 +18,8 @@
     "tile_set veggie"
   ],
   "rank": [
-    "box_factor 0.59",
-    "combo_factor 0.85",
-    "master_pickup_score_per_line 16.7",
+    "duration 80",
+    "rank_criteria m=1550",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/cookie-crevice.json
+++ b/project/assets/main/puzzle/levels/career/cookie-crevice.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Cookie Crevice",
   "description": "The good stuff's at the bottom!",
   "start_speed": "2",
@@ -12,8 +12,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 1.21",
-    "preplaced_pieces 14"
+    "duration 150",
+    "rank_criteria m=1050"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/cookies.json
+++ b/project/assets/main/puzzle/levels/career/cookies.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Cookies",
   "description": "Let's make some cookies! Who brought the U-Blocks?",
   "finish_condition": {
@@ -11,9 +11,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 1.16",
-    "master_pickup_score 40",
-    "preplaced_pieces 2"
+    "duration 150",
+    "rank_criteria m=1050 s-=145"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/creeping-crevice-2.json
+++ b/project/assets/main/puzzle/levels/career/creeping-crevice-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Creeping Crevice II",
   "description": "It just keeps going...",
   "start_speed": "6",
@@ -16,7 +16,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 0.8"
+    "duration 265",
+    "rank_criteria m=1300"
   ],
   "tiles": {
     "0": [

--- a/project/assets/main/puzzle/levels/career/curly-queue-2.json
+++ b/project/assets/main/puzzle/levels/career/curly-queue-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Curly Queue II",
   "description": "They won't stop spinning! This is hurting my head a little...",
   "start_speed": "1",
@@ -24,8 +24,8 @@
     "annoying"
   ],
   "rank": [
-    "extra_seconds_per_piece 0.4",
-    "preplaced_pieces 3"
+    "duration 120",
+    "rank_criteria m=1800"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/curly-queue.json
+++ b/project/assets/main/puzzle/levels/career/curly-queue.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Curly Queue",
   "description": "Augh who keeps spinning the next queue? Oh wait, it's me.",
   "start_speed": "1",
@@ -18,9 +18,8 @@
     "start_piece_j"
   ],
   "rank": [
-    "box_factor 1.1",
-    "extra_seconds_per_piece 0.25",
-    "preplaced_pieces 4",
+    "duration 90",
+    "rank_criteria m=1650",
     "hide_combos_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/dark/3000-race.json
+++ b/project/assets/main/puzzle/levels/career/dark/3000-race.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "¥3,000 Race EX",
   "description": "Earn ¥3,000 as fast as possible. No tricks!",
   "start_speed": "A1",
@@ -9,5 +9,9 @@
   },
   "icons": [
     "basic"
+  ],
+  "rank": [
+    "duration 1140",
+    "rank_criteria m=160"
   ]
 }

--- a/project/assets/main/puzzle/levels/career/dark/a-little-extra.json
+++ b/project/assets/main/puzzle/levels/career/dark/a-little-extra.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "A Little Extra EX",
   "description": "Some fun little bonuses at the bottom. But you have to work for it!",
   "start_speed": "A1",
@@ -11,9 +11,8 @@
     "dig"
   ],
   "rank": [
-    "box_factor 0.16",
-    "combo_factor 0.62",
-    "master_pickup_score_per_line 15.29",
+    "duration 150",
+    "rank_criteria m=2800",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/dark/a-little-garbage-2.json
+++ b/project/assets/main/puzzle/levels/career/dark/a-little-garbage-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "A Little Garbage EX",
   "description": "Is that food? Don't eat out of the garbage!",
   "start_speed": "4",
@@ -26,9 +26,8 @@
     "dig"
   ],
   "rank": [
-    "box_factor 0.49",
-    "combo_factor 0.48",
-    "master_pickup_score_per_line 9.57",
+    "duration 120",
+    "rank_criteria m=1800",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/dark/above-and-below.json
+++ b/project/assets/main/puzzle/levels/career/dark/above-and-below.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Above and Below EX",
   "description": "Build some delicious snack boxes above while befriending some moles below.",
   "start_speed": "A1",
@@ -16,10 +16,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 0.71",
-    "combo_factor 0.45",
-    "extra_seconds_per_piece 0.4",
-    "master_pickup_score_per_line 10.77",
+    "duration 210",
+    "rank_criteria m=2500",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/dark/all-nighter.json
+++ b/project/assets/main/puzzle/levels/career/dark/all-nighter.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "All Nighter",
   "description": "When the onion hits your eye like a big pizza pie, that's a painful...",
   "start_speed": "AB",
@@ -16,10 +16,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 0.55",
-    "combo_factor 0.42",
-    "extra_seconds_per_piece 0.37",
-    "master_pickup_score 100"
+    "duration 370",
+    "rank_criteria m=1150"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/dark/asparagus-fondue.json
+++ b/project/assets/main/puzzle/levels/career/dark/asparagus-fondue.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Asparagus Fondue",
   "description": "Why is it when something happens, it is always you four?",
   "start_speed": "AB",
@@ -26,8 +26,8 @@
     "piece_u"
   ],
   "rank": [
-    "box_factor 0.97",
-    "combo_factor 0.62"
+    "duration 275",
+    "rank_criteria m=105"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/dark/asparagus-gang.json
+++ b/project/assets/main/puzzle/levels/career/dark/asparagus-gang.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Asparagus Gang",
   "description": "People called them 'bad seeds', but they're all grown up now!",
   "start_speed": "A8",
@@ -15,8 +15,8 @@
     "narrow"
   ],
   "rank": [
-    "box_factor 0.34",
-    "combo_factor 0.97"
+    "duration 460",
+    "rank_criteria m=135"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/dark/block-blockers.json
+++ b/project/assets/main/puzzle/levels/career/dark/block-blockers.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Block Blockers EX",
   "description": "They're still here to get in the way... and they have some new tricks!",
   "start_speed": "A9",
@@ -25,9 +25,8 @@
     "piece_v"
   ],
   "rank": [
-    "box_factor 0.76",
-    "extra_seconds_per_piece 0.14",
-    "master_pickup_score_per_line 11.1",
+    "duration 230",
+    "rank_criteria m=175",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/dark/boxing-day.json
+++ b/project/assets/main/puzzle/levels/career/dark/boxing-day.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Boxing Day EX",
   "description": "Don't get boxed in!",
   "start_speed": "A1",
@@ -20,7 +20,8 @@
     "piece_v"
   ],
   "rank": [
-    "preplaced_pieces 8"
+    "duration 565",
+    "rank_criteria m=75"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/dark/cheddarbox-blitz.json
+++ b/project/assets/main/puzzle/levels/career/dark/cheddarbox-blitz.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Cheddarbox Blitz",
   "description": "Can two triangles really make a square? Oh okay, I guess that checks out...",
   "start_speed": "A5",
@@ -26,8 +26,8 @@
     "piece_u"
   ],
   "rank": [
-    "box_factor 2.38",
-    "extra_seconds_per_piece 0.39",
+    "duration 175",
+    "rank_criteria m=4300",
     "hide_combos_rank"
   ],
   "score": [

--- a/project/assets/main/puzzle/levels/career/dark/five-course-meal.json
+++ b/project/assets/main/puzzle/levels/career/dark/five-course-meal.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Five Course Meal",
   "description": "Five courses? ...I'll have five desserts, please!",
   "start_speed": "7",
@@ -18,8 +18,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 1.8",
-    "combo_factor 0.29",
+    "duration 375",
+    "rank_criteria m=2050",
     "hide_combos_rank"
   ],
   "score": [

--- a/project/assets/main/puzzle/levels/career/dark/fondue-chasm.json
+++ b/project/assets/main/puzzle/levels/career/dark/fondue-chasm.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Fondue Chasm",
   "description": "Yum, fruit fondue! Wait, where is the chocolate...?",
   "start_speed": "A8",
@@ -43,8 +43,8 @@
     "piece_u"
   ],
   "rank": [
-    "box_factor 0.91",
-    "combo_factor 0.85"
+    "duration 145",
+    "rank_criteria m=2800"
   ],
   "tiles": {
     "0": [

--- a/project/assets/main/puzzle/levels/career/dark/fruit-on-the-top.json
+++ b/project/assets/main/puzzle/levels/career/dark/fruit-on-the-top.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Fruit on the Top EX",
   "description": "It needs to settle first.",
   "start_speed": "F0",
@@ -19,9 +19,8 @@
     "fast"
   ],
   "rank": [
-    "box_factor 0.33",
-    "combo_factor 0.08",
-    "master_pickup_score_per_line 3.66",
+    "duration 80",
+    "rank_criteria m=1150",
     "hide_combos_rank",
     "show_pickups_rank"
   ],

--- a/project/assets/main/puzzle/levels/career/dark/fruit-salad.json
+++ b/project/assets/main/puzzle/levels/career/dark/fruit-salad.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Fruit Salad EX",
   "description": "Ick! Salad. ...You said there would be fruit!",
   "start_speed": "A1",
@@ -19,9 +19,8 @@
     "tile_set veggie"
   ],
   "rank": [
-    "box_factor 0.49",
-    "combo_factor 0.48",
-    "master_pickup_score_per_line 9.57",
+    "duration 395",
+    "rank_criteria m=1450",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/dark/garbage-disposal.json
+++ b/project/assets/main/puzzle/levels/career/dark/garbage-disposal.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Garbage Disposal EX",
   "description": "These pieces are garbage. Lucky thing we've got a garbage disposal! Om nom nom nom nom.",
   "start_speed": "A9",
@@ -11,10 +11,8 @@
     "shark"
   ],
   "rank": [
-    "box_factor 0.81",
-    "combo_factor 1.21",
-    "extra_seconds_per_piece 0.44",
-    "master_pickup_score_per_line 11.81",
+    "duration 125",
+    "rank_criteria m=200",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/dark/hungry-moles.json
+++ b/project/assets/main/puzzle/levels/career/dark/hungry-moles.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Hungry Moles EX",
   "description": "You had my curiosity... but now you have my attention!",
   "start_speed": "A1",
@@ -13,10 +13,8 @@
     "cake_box"
   ],
   "rank": [
-    "box_factor 0",
-    "combo_factor 1.21",
-    "extra_seconds_per_piece 0.2",
-    "master_pickup_score_per_line 15.23",
+    "duration 400",
+    "rank_criteria m=200",
     "hide_boxes_rank",
     "show_pickups_rank"
   ],

--- a/project/assets/main/puzzle/levels/career/dark/it-takes-two.json
+++ b/project/assets/main/puzzle/levels/career/dark/it-takes-two.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "It Takes Two",
   "description": "What takes two? ...Oh please no, not that...",
   "start_speed": "A1",
@@ -19,9 +19,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 0.96",
-    "combo_factor 0.58",
-    "extra_seconds_per_piece 0.39"
+    "duration 940",
+    "rank_criteria m=2250"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/dark/its-square-to-be-square.json
+++ b/project/assets/main/puzzle/levels/career/dark/its-square-to-be-square.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "It's Square to be Square EX",
   "description": "Can you handle all this sugar, or will you go down swinging?",
   "start_speed": "A1",
@@ -18,7 +18,8 @@
     "piece_v"
   ],
   "rank": [
-    "preplaced_pieces 3"
+    "duration 565",
+    "rank_criteria m=80"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/dark/no-smoking-section-2.json
+++ b/project/assets/main/puzzle/levels/career/dark/no-smoking-section-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "No Smoking Section II",
   "description": "Cough! Cough! ...Carrots! Too many!",
   "start_speed": "A4",
@@ -43,6 +43,10 @@
     "carrot",
     "blind",
     "annoying"
+  ],
+  "rank": [
+    "duration 275",
+    "rank_criteria m=100"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/dark/onion-cranny.json
+++ b/project/assets/main/puzzle/levels/career/dark/onion-cranny.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Onion Cranny",
   "description": "This looks just like another level! The resemblance is onion-cranny.",
   "start_speed": "A1",
@@ -15,9 +15,8 @@
     "dig"
   ],
   "rank": [
-    "box_factor 1.05",
-    "combo_factor 0.58",
-    "extra_seconds_per_piece 0.07"
+    "duration 690",
+    "rank_criteria m=130"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/dark/secret-brownies.json
+++ b/project/assets/main/puzzle/levels/career/dark/secret-brownies.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Secret Brownies EX",
   "description": "Secret brownies? Where? ...I must have them!",
   "start_speed": "A1",
@@ -31,11 +31,8 @@
     "sneaky"
   ],
   "rank": [
-    "box_factor 0.9",
-    "combo_factor 0.9",
-    "master_pickup_score 55",
-    "master_pickup_score_per_line 18.16",
-    "preplaced_pieces 4",
+    "duration 355",
+    "rank_criteria m=115",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/dark/sharky-cheese-2.json
+++ b/project/assets/main/puzzle/levels/career/dark/sharky-cheese-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Sharky Cheese 2",
   "description": "This time with actual cheese! ...Wait, isn't cheese bad for sharks?",
   "start_speed": "A3",
@@ -33,9 +33,8 @@
     "piece_u"
   ],
   "rank": [
-    "box_factor 0.85",
-    "combo_factor 0.71",
-    "master_pickup_score_per_line 11.9",
+    "duration 385",
+    "rank_criteria m=3100",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/dark/strawberry-shortcut.json
+++ b/project/assets/main/puzzle/levels/career/dark/strawberry-shortcut.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Strawberry Shortcut EX",
   "description": "Take a shortcut. ...A strawberry shortcut!",
   "start_speed": "A1",
@@ -34,9 +34,8 @@
     "basic"
   ],
   "rank": [
-    "box_factor 0.28",
-    "combo_factor 0.57",
-    "master_pickup_score_per_line 13.11",
+    "duration 150",
+    "rank_criteria m=2700",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/dark/surprise-guests.json
+++ b/project/assets/main/puzzle/levels/career/dark/surprise-guests.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Surprise Guests EX",
   "description": "Surpriiiise! ...We just thought we'd drop in.",
   "start_speed": "A1",
@@ -12,10 +12,8 @@
     "surprising"
   ],
   "rank": [
-    "box_factor 0.9",
-    "combo_factor 0.9",
-    "extra_seconds_per_piece 0.2",
-    "master_pickup_score_per_line 9.03",
+    "duration 135",
+    "rank_criteria m=2800",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/dark/sweet-dreams.json
+++ b/project/assets/main/puzzle/levels/career/dark/sweet-dreams.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Sweet Dreams",
   "description": "Who left these chocolates under my pillow? They're all melted now!",
   "start_speed": "AB",
@@ -10,6 +10,10 @@
   "icons": [
     "mole",
     "onion"
+  ],
+  "rank": [
+    "duration 125",
+    "rank_criteria m=2750"
   ],
   "triggers": [
     {

--- a/project/assets/main/puzzle/levels/career/dark/three-minute-sprint.json
+++ b/project/assets/main/puzzle/levels/career/dark/three-minute-sprint.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Three Minute Sprint EX",
   "description": "Nothing fancy, let's just cook!",
   "start_speed": "A1",
@@ -9,5 +9,9 @@
   },
   "icons": [
     "basic"
+  ],
+  "rank": [
+    "duration 180",
+    "rank_criteria m=3850"
   ]
 }

--- a/project/assets/main/puzzle/levels/career/dark/too-fast-to-fast.json
+++ b/project/assets/main/puzzle/levels/career/dark/too-fast-to-fast.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Too Fast to Fast EX",
   "description": "It was already too fast before! This is nonsense...",
   "start_speed": "A1",
@@ -34,5 +34,9 @@
   ],
   "lose_condition": [
     "top_out 1"
+  ],
+  "rank": [
+    "duration 80",
+    "rank_criteria m=1850"
   ]
 }

--- a/project/assets/main/puzzle/levels/career/day-night-psycho.json
+++ b/project/assets/main/puzzle/levels/career/day-night-psycho.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Day/Night Psycho",
   "description": "Sometimes the days just seem to fly by.",
   "start_speed": "5",
@@ -18,8 +18,8 @@
     "piece_o"
   ],
   "rank": [
-    "box_factor 0.65",
-    "extra_seconds_per_piece 0.28"
+    "duration 255",
+    "rank_criteria m=52"
   ],
   "triggers": [
     {

--- a/project/assets/main/puzzle/levels/career/destroy-them-with-boxes.json
+++ b/project/assets/main/puzzle/levels/career/destroy-them-with-boxes.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Destroy Them With Boxes!",
   "description": "Ack, sweets! My only weakness!",
   "start_speed": "9",
@@ -10,6 +10,10 @@
   "icons": [
     "carrot",
     "snack_box"
+  ],
+  "rank": [
+    "duration 565",
+    "rank_criteria m=80"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/destroy-them-with-combos.json
+++ b/project/assets/main/puzzle/levels/career/destroy-them-with-combos.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Destroy Them With Combos!",
   "description": "No no, I was talking about the carrots! ...Please don't destroy the customers.",
   "start_speed": "1",
@@ -18,7 +18,8 @@
     "carrot"
   ],
   "rank": [
-    "extra_seconds_per_piece 0.1"
+    "duration 100",
+    "rank_criteria m=1850"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/donuts.json
+++ b/project/assets/main/puzzle/levels/career/donuts.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Donuts",
   "description": "Ooh donuts! Don't mind if I do...",
   "finish_condition": {
@@ -13,9 +13,8 @@
     "start_piece_t"
   ],
   "rank": [
-    "box_factor 0.76",
-    "master_pickup_score 30",
-    "preplaced_pieces 2"
+    "duration 70",
+    "rank_criteria m=11 s-=80"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/extra-cream.json
+++ b/project/assets/main/puzzle/levels/career/extra-cream.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Extra Cream",
   "description": "Too much of a good thing is still a good thing!",
   "start_speed": "5",
@@ -24,10 +24,8 @@
     "piece_v"
   ],
   "rank": [
-    "box_factor 0.61",
-    "combo_factor 0.56",
-    "master_pickup_score 140",
-    "preplaced_pieces 2"
+    "duration 265",
+    "rank_criteria m=945"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/fat-stacks.json
+++ b/project/assets/main/puzzle/levels/career/fat-stacks.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Fat Stacks",
   "description": "Stack 'em up, we have customers to serve!",
   "finish_condition": {
@@ -10,7 +10,8 @@
     "basic"
   ],
   "rank": [
-    "preplaced_pieces 3"
+    "duration 60",
+    "rank_criteria m=1350 s-=230"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/fruit-on-the-top.json
+++ b/project/assets/main/puzzle/levels/career/fruit-on-the-top.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Fruit on the Top",
   "description": "It needs to settle first.",
   "blocks_during": [
@@ -18,9 +18,8 @@
     "fast"
   ],
   "rank": [
-    "box_factor 0.33",
-    "combo_factor 0.08",
-    "master_pickup_score_per_line 3.66",
+    "duration 50",
+    "rank_criteria m=550",
     "hide_combos_rank",
     "show_pickups_rank"
   ],

--- a/project/assets/main/puzzle/levels/career/fruit-salad.json
+++ b/project/assets/main/puzzle/levels/career/fruit-salad.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Fruit Salad",
   "description": "Ick! Salad. ...You said there would be fruit!",
   "start_speed": "4",
@@ -19,9 +19,8 @@
     "tile_set veggie"
   ],
   "rank": [
-    "box_factor 0.49",
-    "combo_factor 0.48",
-    "master_pickup_score_per_line 9.57",
+    "duration 300",
+    "rank_criteria m=945",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/garbage-disposal.json
+++ b/project/assets/main/puzzle/levels/career/garbage-disposal.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Garbage Disposal",
   "description": "These pieces are garbage. Lucky thing we've got a garbage disposal! Om nom nom nom nom.",
   "start_speed": "2",
@@ -11,10 +11,8 @@
     "shark"
   ],
   "rank": [
-    "box_factor 0.81",
-    "combo_factor 1.21",
-    "extra_seconds_per_piece 0.44",
-    "master_pickup_score_per_line 11.81",
+    "duration 135",
+    "rank_criteria m=31",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/hungry-moles.json
+++ b/project/assets/main/puzzle/levels/career/hungry-moles.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Hungry Moles",
   "description": "You had my curiosity... but now you have my attention!",
   "start_speed": "7",
@@ -13,10 +13,8 @@
     "cake_box"
   ],
   "rank": [
-    "box_factor 0",
-    "combo_factor 1.21",
-    "extra_seconds_per_piece 0.55",
-    "master_pickup_score_per_line 22.89",
+    "duration 165",
+    "rank_criteria m=155",
     "hide_boxes_rank",
     "show_pickups_rank"
   ],

--- a/project/assets/main/puzzle/levels/career/its-nibbler.json
+++ b/project/assets/main/puzzle/levels/career/its-nibbler.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "It's Nibbler",
   "description": "Aww, they take such tiny bites. ...Oww! My finger!",
   "start_speed": "7",
@@ -11,10 +11,8 @@
     "shark"
   ],
   "rank": [
-    "box_factor 1.65",
-    "combo_factor 1.21",
-    "extra_seconds_per_piece 1.37",
-    "master_pickup_score_per_line 8.64",
+    "duration 75",
+    "rank_criteria m=1300",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/its-square-to-be-square.json
+++ b/project/assets/main/puzzle/levels/career/its-square-to-be-square.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "It's Square to be Square",
   "description": "Can you handle all this sugar, or will you go down swinging?",
   "start_speed": "2",
@@ -18,7 +18,8 @@
     "piece_v"
   ],
   "rank": [
-    "preplaced_pieces 3"
+    "duration 215",
+    "rank_criteria m=19"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/its-tee-time.json
+++ b/project/assets/main/puzzle/levels/career/its-tee-time.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "It's Tee Time",
   "description": "Augh, bread overload! And half the end pieces are missing...",
   "start_speed": "2",
@@ -22,10 +22,8 @@
     "start_piece_t"
   ],
   "rank": [
-    "box_factor 1.19",
-    "combo_factor 1.21",
-    "extra_seconds_per_piece 0.41",
-    "preplaced_pieces 3"
+    "duration 75",
+    "rank_criteria m=1450 s-=250"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/just-bread.json
+++ b/project/assets/main/puzzle/levels/career/just-bread.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Just Bread",
   "description": "No jam. No butter. Just anger!",
   "finish_condition": {
@@ -19,8 +19,8 @@
     "piece_t"
   ],
   "rank": [
-    "box_factor 0.73",
-    "preplaced_pieces 3"
+    "duration 80",
+    "rank_criteria m=1500 s-=205"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/just-cream.json
+++ b/project/assets/main/puzzle/levels/career/just-cream.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Just Cream",
   "description": "What are these pieces!? LOLOLOL",
   "blocks_during": [
@@ -23,8 +23,8 @@
     "piece_v"
   ],
   "rank": [
-    "box_factor 0.76",
-    "master_pickup_score_per_line 3.84",
+    "duration 50",
+    "rank_criteria m=1100 s-=150",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/just-fruit.json
+++ b/project/assets/main/puzzle/levels/career/just-fruit.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Just Fruit",
   "description": "Do we really need a recipe?",
   "finish_condition": {
@@ -20,6 +20,7 @@
     "piece_j"
   ],
   "rank": [
-    "box_factor 1.31"
+    "duration 80",
+    "rank_criteria m=9 s-=65"
   ]
 }

--- a/project/assets/main/puzzle/levels/career/left-shark.json
+++ b/project/assets/main/puzzle/levels/career/left-shark.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Left Shark",
   "description": "Fins to the left, pentominos to the right. And no tetrominos in sight!",
   "start_speed": "7",
@@ -18,10 +18,8 @@
     "piece_v"
   ],
   "rank": [
-    "box_factor 1.06",
-    "combo_factor 1.21",
-    "extra_seconds_per_piece 0.78",
-    "master_pickup_score_per_line 14.35",
+    "duration 170",
+    "rank_criteria m=2850",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/lo-kcal.json
+++ b/project/assets/main/puzzle/levels/career/lo-kcal.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Lo kCal",
   "description": "Can you scrape together ¥100 on veggies alone?",
   "finish_condition": {
@@ -24,8 +24,8 @@
     "piece_z"
   ],
   "rank": [
-    "box_factor 0",
-    "master_pickup_score 20",
+    "duration 120",
+    "rank_criteria m=21 s-=155",
     "hide_boxes_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/midnight-snack.json
+++ b/project/assets/main/puzzle/levels/career/midnight-snack.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Midnight Snack",
   "description": "We already turned the lights off! Come back tomorrow.",
   "start_speed": "1",
@@ -25,8 +25,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 0.81",
-    "extra_seconds_per_piece 0.21"
+    "duration 115",
+    "rank_criteria m=1900"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/mole-money-mole-problems.json
+++ b/project/assets/main/puzzle/levels/career/mole-money-mole-problems.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Mole Money Mole Problems",
   "description": "This cave isn't big enough for the eight of us...",
   "finish_condition": {
@@ -11,9 +11,8 @@
     "sneaky"
   ],
   "rank": [
-    "box_factor 0.53",
-    "combo_factor 1.21",
-    "master_pickup_score_per_line 5.86",
+    "duration 60",
+    "rank_criteria m=1300 s-=225",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/moonshower.json
+++ b/project/assets/main/puzzle/levels/career/moonshower.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Moonshower",
   "description": "It's pretty when all the stars are out.",
   "start_speed": "2",
@@ -12,8 +12,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 0.93",
-    "extra_seconds_per_piece 0.06"
+    "duration 190",
+    "rank_criteria m=1100"
   ],
   "triggers": [
     {

--- a/project/assets/main/puzzle/levels/career/mozzarella-sticks.json
+++ b/project/assets/main/puzzle/levels/career/mozzarella-sticks.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Mozzarella Sticks",
   "description": "Speak softly and eat a big mozzarella stick.",
   "start_speed": "7",
@@ -26,8 +26,8 @@
     "piece_u"
   ],
   "rank": [
-    "combo_factor 1.21",
-    "master_pickup_score_per_line 15.3",
+    "duration 355",
+    "rank_criteria m=65",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/new-onion-friend.json
+++ b/project/assets/main/puzzle/levels/career/new-onion-friend.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Your New Onion Friend",
   "description": "Who could ever say no to a new friend?",
   "start_speed": "1",
@@ -19,8 +19,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 0.77",
-    "extra_seconds_per_piece 0.38"
+    "duration 220",
+    "rank_criteria m=1150"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/nice-and-cheesy.json
+++ b/project/assets/main/puzzle/levels/career/nice-and-cheesy.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Nice and Cheesy",
   "description": "Let's learn to cook with cheese!",
   "start_speed": "4",
@@ -40,7 +40,8 @@
     "piece_u"
   ],
   "rank": [
-    "master_pickup_score 120",
+    "duration 300",
+    "rank_criteria m=1600",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/no-smoking-section.json
+++ b/project/assets/main/puzzle/levels/career/no-smoking-section.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "No Smoking Section",
   "description": "Carrot smoke is the healthiest kind of smoke! But, we still don't like it very much.",
   "start_speed": "1",
@@ -11,6 +11,10 @@
     "carrot",
     "blind",
     "annoying"
+  ],
+  "rank": [
+    "duration 220",
+    "rank_criteria m=21"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/nowhere-to-turn.json
+++ b/project/assets/main/puzzle/levels/career/nowhere-to-turn.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Nowhere To Turn",
   "description": "You really can't turn the pieces? I think there might be a way...",
   "start_speed": "3",
@@ -18,8 +18,8 @@
     "start_piece_p"
   ],
   "rank": [
-    "box_factor 0.8",
-    "preplaced_pieces 6"
+    "duration 120",
+    "rank_criteria m=2200"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/one-shark-two-shark.json
+++ b/project/assets/main/puzzle/levels/career/one-shark-two-shark.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "One Shark Two Shark Red Shark Blue Shark",
   "description": "Why do sharks smell so good? ...Is it because they are always in the bath?",
   "start_speed": "4",
@@ -16,10 +16,8 @@
     "start_piece_p"
   ],
   "rank": [
-    "box_factor 1.06",
-    "combo_factor 1.21",
-    "extra_seconds_per_piece 0.78",
-    "master_pickup_score_per_line 14.35",
+    "duration 140",
+    "rank_criteria m=2400",
     "show_pickups_rank"
   ],
   "tiles": {
@@ -193,7 +191,7 @@
       "phases": [
         "line_cleared n=15"
       ],
-      "effect": "add_sharks count=2 size=small"
+      "effect": "add_sharks count=2 patience=0 size=small"
     },
     {
       "phases": [

--- a/project/assets/main/puzzle/levels/career/one-step-ahead.json
+++ b/project/assets/main/puzzle/levels/career/one-step-ahead.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "One Step Ahead",
   "description": "It's easy if you make a plan.",
   "start_speed": "3",
@@ -19,9 +19,8 @@
     "start_piece_v"
   ],
   "rank": [
-    "box_factor 0.8",
-    "extra_seconds_per_piece 0.6",
-    "preplaced_pieces 1"
+    "duration 150",
+    "rank_criteria m=1700"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/paranormal-tetrominon.json
+++ b/project/assets/main/puzzle/levels/career/paranormal-tetrominon.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Paranormal Tetrominon",
   "description": "A visit from some familiar friends.",
   "finish_condition": {
@@ -20,7 +20,7 @@
     "piece_z"
   ],
   "rank": [
-    "box_factor 1.43",
-    "combo_factor 0.23"
+    "duration 180",
+    "rank_criteria m=2750 s-=475"
   ]
 }

--- a/project/assets/main/puzzle/levels/career/perfect-fit.json
+++ b/project/assets/main/puzzle/levels/career/perfect-fit.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Perfect Fit",
   "description": "This is my hole! It was made for me!",
   "finish_condition": {
@@ -16,6 +16,10 @@
     "piece_l",
     "piece_p",
     "piece_q"
+  ],
+  "rank": [
+    "duration 450",
+    "rank_criteria m=690 s-=95"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/real-meal.json
+++ b/project/assets/main/puzzle/levels/career/real-meal.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Real Meal",
   "description": "If you're going to indulge, you may as well make it worth it!",
   "finish_condition": {
@@ -14,7 +14,8 @@
     "start_piece_j"
   ],
   "rank": [
-    "preplaced_pieces 5"
+    "duration 445",
+    "rank_criteria m=29"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/rice-bear-island.json
+++ b/project/assets/main/puzzle/levels/career/rice-bear-island.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Rice Bear Island",
   "description": "What on earth is a rice bear? ...This just seems like a regular island.",
   "start_speed": "2",
@@ -13,7 +13,8 @@
     "slow"
   ],
   "rank": [
-    "master_pickup_score_per_line 5.31",
+    "duration 225",
+    "rank_criteria m=1450 s-=250",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/secret-brownies.json
+++ b/project/assets/main/puzzle/levels/career/secret-brownies.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Secret Brownies",
   "description": "Secret brownies? Where? ...I must have them!",
   "blocks_during": [
@@ -14,10 +14,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 0.71",
-    "combo_factor 1.21",
-    "master_pickup_score_per_line 16.3",
-    "preplaced_pieces 3",
+    "duration 115",
+    "rank_criteria m=1000 s-=135",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/serving-on-a-rocket.json
+++ b/project/assets/main/puzzle/levels/career/serving-on-a-rocket.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Serving On A Rocket",
   "description": "Time for flying rockets. Let's serve up some delicious treats!",
   "start_speed": "2",
@@ -9,6 +9,10 @@
   },
   "icons": [
     "carrot"
+  ],
+  "rank": [
+    "duration 95",
+    "rank_criteria m=1900"
   ],
   "timers": [
     {

--- a/project/assets/main/puzzle/levels/career/shark-bait.json
+++ b/project/assets/main/puzzle/levels/career/shark-bait.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Shark Bait",
   "description": "This is almost TOO easy! ...Is there a trick?",
   "start_speed": "2",
@@ -18,10 +18,8 @@
     "start_piece_u"
   ],
   "rank": [
-    "box_factor 1.92",
-    "combo_factor 0.6",
-    "extra_seconds_per_piece 2",
-    "master_pickup_score_per_line 292.27",
+    "duration 7",
+    "rank_criteria m=1500",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/sharky-cheese.json
+++ b/project/assets/main/puzzle/levels/career/sharky-cheese.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Sharky Cheese",
   "description": "Sharks never struggle with downstacking! They just eat everything...",
   "start_speed": "9",
@@ -13,10 +13,8 @@
     "dig"
   ],
   "rank": [
-    "box_factor 0.72",
-    "combo_factor 0.76",
-    "extra_seconds_per_piece 0.09",
-    "master_pickup_score_per_line 8.08",
+    "duration 160",
+    "rank_criteria m=2700",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/sharp-curds.json
+++ b/project/assets/main/puzzle/levels/career/sharp-curds.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Sharp Curds",
   "description": "Dig efficiently to turn up some high-scoring snacks!",
   "start_speed": "7",
@@ -23,9 +23,8 @@
     "piece_u"
   ],
   "rank": [
-    "box_factor 0.68",
-    "combo_factor 0.97",
-    "master_pickup_score_per_line 6.64",
+    "duration 360",
+    "rank_criteria m=1900",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/shelf.json
+++ b/project/assets/main/puzzle/levels/career/shelf.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Shelf",
   "description": "Who came up with this stupid shelf anyway!? ...Ooh! Cookies!",
   "blocks_during": [
@@ -14,9 +14,8 @@
     "confusing"
   ],
   "rank": [
-    "box_factor 0.73",
-    "combo_factor 0.91",
-    "master_pickup_score_per_line 4.65",
+    "duration 365",
+    "rank_criteria m=35",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/shoots-and-leaves.json
+++ b/project/assets/main/puzzle/levels/career/shoots-and-leaves.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Shoots and Leaves",
   "description": "Stop me if you've heard this one before...",
   "start_speed": "6",
@@ -29,9 +29,8 @@
     "annoying"
   ],
   "rank": [
-    "box_factor 0.83",
-    "combo_factor 0.67",
-    "master_pickup_score 90"
+    "duration 130",
+    "rank_criteria m=1950"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/slow-service-2.json
+++ b/project/assets/main/puzzle/levels/career/slow-service-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Slower Service",
   "description": "May... I... take... your... order...?",
   "start_speed": "8",
@@ -18,9 +18,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 2.65",
-    "combo_factor 0",
-    "extra_seconds_per_piece 0.34",
+    "duration 930",
+    "rank_criteria m=2600",
     "hide_combos_rank"
   ],
   "score": [

--- a/project/assets/main/puzzle/levels/career/slow-service.json
+++ b/project/assets/main/puzzle/levels/career/slow-service.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Slow Service",
   "description": "May... I... take... your... order...?",
   "start_speed": "1",
@@ -18,9 +18,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 1.25",
-    "combo_factor 1.21",
-    "extra_seconds_per_piece 1.12",
+    "duration 85",
+    "rank_criteria m=975 s-=165",
     "hide_combos_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/snack-box-blitz.json
+++ b/project/assets/main/puzzle/levels/career/snack-box-blitz.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Snack Box Blitz",
   "description": "Everyone's in a hurry today. Get those cakes out!",
   "start_speed": "6",
@@ -14,10 +14,8 @@
     "turn"
   ],
   "rank": [
-    "box_factor 2.68",
-    "combo_factor 0",
-    "extra_seconds_per_piece 0.47",
-    "preplaced_pieces 5",
+    "duration 75",
+    "rank_criteria m=1750",
     "hide_combos_rank"
   ],
   "score": [

--- a/project/assets/main/puzzle/levels/career/square-curse.json
+++ b/project/assets/main/puzzle/levels/career/square-curse.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Square Curse",
   "description": "...And they don't stop coming!",
   "finish_condition": {
@@ -26,6 +26,7 @@
     "start_piece_o"
   ],
   "rank": [
-    "box_factor 0.45"
+    "duration 90",
+    "rank_criteria m=530 s-=70"
   ]
 }

--- a/project/assets/main/puzzle/levels/career/strawberry-sharkcake.json
+++ b/project/assets/main/puzzle/levels/career/strawberry-sharkcake.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Strawberry Sharkcake",
   "description": "It says in this cookbook it takes a long time to rise.",
   "start_speed": "2",
@@ -26,10 +26,8 @@
     "piece_q"
   ],
   "rank": [
-    "box_factor 0.94",
-    "combo_factor 0.96",
-    "extra_seconds_per_piece 0.14",
-    "master_pickup_score_per_line 22.1",
+    "duration 85",
+    "rank_criteria m=2350",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/strawberry-shortcut.json
+++ b/project/assets/main/puzzle/levels/career/strawberry-shortcut.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Strawberry Shortcut",
   "description": "Take a shortcut. ...A strawberry shortcut!",
   "start_speed": "4",
@@ -12,9 +12,8 @@
     "basic"
   ],
   "rank": [
-    "box_factor 0.28",
-    "combo_factor 0.57",
-    "master_pickup_score_per_line 13.11",
+    "duration 120",
+    "rank_criteria m=1900",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/surprise-guests.json
+++ b/project/assets/main/puzzle/levels/career/surprise-guests.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Surprise Guests",
   "description": "Surpriiiise! ...We just thought we'd drop in.",
   "start_speed": "7",
@@ -12,10 +12,8 @@
     "surprising"
   ],
   "rank": [
-    "box_factor 0.9",
-    "combo_factor 0.9",
-    "extra_seconds_per_piece 0.2",
-    "master_pickup_score_per_line 6.69",
+    "duration 145",
+    "rank_criteria m=2550",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/tempting-jellies.json
+++ b/project/assets/main/puzzle/levels/career/tempting-jellies.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Tempting Jellies",
   "description": "Throw caution to the wind this once!",
   "start_speed": "3",
@@ -40,9 +40,8 @@
     "top_out 1"
   ],
   "rank": [
-    "box_factor 0.25",
-    "master_pickup_score_per_line 17.78",
-    "preplaced_pieces 6",
+    "duration 375",
+    "rank_criteria m=2150",
     "show_pickups_rank"
   ],
   "score": [

--- a/project/assets/main/puzzle/levels/career/the-last-100.json
+++ b/project/assets/main/puzzle/levels/career/the-last-100.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "The Last ¥100",
   "description": "Why is the last mile the hardest mile?",
   "start_speed": "4",
@@ -12,8 +12,8 @@
     "sneaky"
   ],
   "rank": [
-    "box_factor 0.66",
-    "extra_seconds_per_piece 0.03"
+    "duration 240",
+    "rank_criteria m=32"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/three-course-meal.json
+++ b/project/assets/main/puzzle/levels/career/three-course-meal.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Three Course Meal",
   "description": "It's important to bring out all three courses at once! ...Or is that something else...",
   "blocks_during": [
@@ -15,10 +15,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 0.9",
-    "combo_factor 1.05",
-    "extra_seconds_per_piece 0.69",
-    "master_pickup_score_per_line 14.31",
+    "duration 190",
+    "rank_criteria m=1450 s-=250",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/three-nights.json
+++ b/project/assets/main/puzzle/levels/career/three-nights.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Three Nights",
   "description": "I'm not afraid of the dark! It's just very annoying...",
   "start_speed": "2",
@@ -11,9 +11,8 @@
     "onion"
   ],
   "rank": [
-    "box_factor 0.95",
-    "combo_factor 1.06",
-    "extra_seconds_per_piece 0.1"
+    "duration 110",
+    "rank_criteria m=2000"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/traffic-jam-2.json
+++ b/project/assets/main/puzzle/levels/career/traffic-jam-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Another Traffic Jam",
   "description": "An even bigger, and even slower H! ...But what does the H stand for?",
   "start_speed": "2",
@@ -30,9 +30,8 @@
     "annoying"
   ],
   "rank": [
-    "box_factor 0.91",
-    "combo_factor 0.96",
-    "extra_seconds_per_piece 0.24"
+    "duration 445",
+    "rank_criteria m=65"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/traffic-jam.json
+++ b/project/assets/main/puzzle/levels/career/traffic-jam.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Traffic Jam",
   "description": "Nobody knows what the 'H' stands for! We just know it is annoying and gets in the way...",
   "start_speed": "1",
@@ -17,7 +17,8 @@
     "stop"
   ],
   "rank": [
-    "combo_factor 1.21"
+    "duration 165",
+    "rank_criteria m=19 s-=110"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/triangle-curse.json
+++ b/project/assets/main/puzzle/levels/career/triangle-curse.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Triangle Curse",
   "description": "Squares and triangles. Together at last!",
   "start_speed": "8",
@@ -23,8 +23,8 @@
     "piece_k"
   ],
   "rank": [
-    "box_factor 1.66",
-    "combo_factor 0.8"
+    "duration 120",
+    "rank_criteria m=2800"
   ],
   "score": [
     "cake_all 20",

--- a/project/assets/main/puzzle/levels/career/tulip.json
+++ b/project/assets/main/puzzle/levels/career/tulip.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Tulip",
   "description": "It belongs in a museum! Or maybe on the refrigerator.",
   "finish_condition": {
@@ -10,9 +10,8 @@
     "basic"
   ],
   "rank": [
-    "box_factor 0.7",
-    "master_pickup_score 40",
-    "preplaced_pieces 2"
+    "duration 165",
+    "rank_criteria m=19 s-=140"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/tunnel-snakes.json
+++ b/project/assets/main/puzzle/levels/career/tunnel-snakes.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Tunnel Snakes",
   "description": "Asparagus. Why'd it have to be asparagus?",
   "start_speed": "8",
@@ -23,9 +23,8 @@
     "piece_t"
   ],
   "rank": [
-    "box_factor 0.64",
-    "combo_factor 1.21",
-    "master_pickup_score 80"
+    "duration 160",
+    "rank_criteria m=2850"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/two-box-buffet.json
+++ b/project/assets/main/puzzle/levels/career/two-box-buffet.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Two Box Buffet",
   "description": "Surely, six columns should be enough for anybody!",
   "start_speed": "3",
@@ -21,9 +21,8 @@
     "slow"
   ],
   "rank": [
-    "box_factor 0.67",
-    "combo_factor 0.94",
-    "master_pickup_score_per_line 4.72",
+    "duration 150",
+    "rank_criteria m=2700 s-=465",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/up-in-smoke.json
+++ b/project/assets/main/puzzle/levels/career/up-in-smoke.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Up In Smoke",
   "description": "I don't love carrots, but I promise to hate them slightly less if they stay over there...",
   "speed_ups": [
@@ -21,6 +21,10 @@
   "icons": [
     "carrot",
     "blind"
+  ],
+  "rank": [
+    "duration 90",
+    "rank_criteria m=1850 s-=320"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/wall-greens.json
+++ b/project/assets/main/puzzle/levels/career/wall-greens.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Wall Greens",
   "description": "Asparagus evolved its disgusting spines as a defense against being eaten.",
   "start_speed": "7",
@@ -26,10 +26,8 @@
     "spear"
   ],
   "rank": [
-    "box_factor 1.15",
-    "combo_factor 1.21",
-    "extra_seconds_per_piece 0.38",
-    "master_pickup_score_per_line 12.15",
+    "duration 95",
+    "rank_criteria m=2100",
     "show_pickups_rank"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/career/wedge.json
+++ b/project/assets/main/puzzle/levels/career/wedge.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Wedge",
   "description": "A fun shape to climb, if only it wasn't so sticky...",
   "finish_condition": {
@@ -10,7 +10,8 @@
     "basic"
   ],
   "rank": [
-    "preplaced_pieces 4"
+    "duration 180",
+    "rank_criteria m=13 s-=95"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/practice/marathon-expert.json
+++ b/project/assets/main/puzzle/levels/practice/marathon-expert.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Marathon: Expert (300 lines)",
   "description": "A grueling test of endurance ramping up to instant gravity! Can you clear 300 lines?",
   "start_speed": "A5",
@@ -46,6 +46,10 @@
   ],
   "lose_condition": [
     "top_out 1"
+  ],
+  "rank": [
+    "duration 560",
+    "rank_criteria m=10000"
   ],
   "success_condition": {
     "type": "lines",

--- a/project/assets/main/puzzle/levels/practice/marathon-hard.json
+++ b/project/assets/main/puzzle/levels/practice/marathon-hard.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Marathon: Hard (200 lines)",
   "description": "A true test of endurance with faster pieces than before! Can you clear 200 lines?",
   "start_speed": "A1",
@@ -60,6 +60,10 @@
   ],
   "lose_condition": [
     "top_out 1"
+  ],
+  "rank": [
+    "duration 710",
+    "rank_criteria m=6900"
   ],
   "success_condition": {
     "type": "lines",

--- a/project/assets/main/puzzle/levels/practice/marathon-master.json
+++ b/project/assets/main/puzzle/levels/practice/marathon-master.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Marathon: Master (500 lines)",
   "description": "An impossible test of endurance for true Turbo Fat masters! Can you clear 500 lines?",
   "start_speed": "FA",
@@ -42,6 +42,10 @@
   ],
   "lose_condition": [
     "top_out 1"
+  ],
+  "rank": [
+    "duration 355",
+    "rank_criteria m=16500"
   ],
   "success_condition": {
     "type": "lines",

--- a/project/assets/main/puzzle/levels/practice/marathon-normal.json
+++ b/project/assets/main/puzzle/levels/practice/marathon-normal.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Marathon: Normal (100 lines)",
   "description": "A test of endurance against faster and faster pieces! Can you clear 100 lines?",
   "speed_ups": [
@@ -59,6 +59,10 @@
   ],
   "lose_condition": [
     "top_out 1"
+  ],
+  "rank": [
+    "duration 750",
+    "rank_criteria m=3600"
   ],
   "success_condition": {
     "type": "lines",

--- a/project/assets/main/puzzle/levels/practice/sandbox-expert.json
+++ b/project/assets/main/puzzle/levels/practice/sandbox-expert.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Sandbox: Expert",
   "description": "Practice with faster pieces! There is no way to win or lose this mode.",
   "start_speed": "A5",
@@ -14,6 +14,8 @@
     "top_out 999999"
   ],
   "rank": [
+    "duration 600",
+    "rank_criteria m=1",
     "unranked"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/practice/sandbox-master.json
+++ b/project/assets/main/puzzle/levels/practice/sandbox-master.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Sandbox: Master",
   "description": "Practice with instant gravity! There is no way to win or lose this mode.",
   "start_speed": "FA",
@@ -14,6 +14,8 @@
     "top_out 999999"
   ],
   "rank": [
+    "duration 600",
+    "rank_criteria m=1",
     "unranked"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/practice/sandbox-normal.json
+++ b/project/assets/main/puzzle/levels/practice/sandbox-normal.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Sandbox: Normal",
   "description": "Just relax! There is no way to win or lose this mode.",
   "blocks_during": [
@@ -14,6 +14,8 @@
     "top_out 999999"
   ],
   "rank": [
+    "duration 600",
+    "rank_criteria m=1",
     "unranked"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/practice/sprint-expert.json
+++ b/project/assets/main/puzzle/levels/practice/sprint-expert.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Sprint: Expert (3:00)",
   "description": "Earn as much money as you can in 3:00. Use the faster pieces to set a high score!",
   "start_speed": "F0",
@@ -9,5 +9,9 @@
   },
   "icons": [
     "basic"
+  ],
+  "rank": [
+    "duration 180",
+    "rank_criteria m=6750"
   ]
 }

--- a/project/assets/main/puzzle/levels/practice/sprint-normal.json
+++ b/project/assets/main/puzzle/levels/practice/sprint-normal.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Sprint: Normal (2:30)",
   "description": "Earn as much money as you can in 2:30!",
   "finish_condition": {
@@ -8,5 +8,9 @@
   },
   "icons": [
     "basic"
+  ],
+  "rank": [
+    "duration 150",
+    "rank_criteria m=2850"
   ]
 }

--- a/project/assets/main/puzzle/levels/practice/ultra-expert.json
+++ b/project/assets/main/puzzle/levels/practice/ultra-expert.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Ultra: Expert (¥3,000)",
   "description": "Earn ¥3,000 as fast as possible, with faster piece movement!",
   "start_speed": "F0",
@@ -9,5 +9,9 @@
   },
   "icons": [
     "basic"
+  ],
+  "rank": [
+    "duration 140",
+    "rank_criteria m=90"
   ]
 }

--- a/project/assets/main/puzzle/levels/practice/ultra-hard.json
+++ b/project/assets/main/puzzle/levels/practice/ultra-hard.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Ultra: Hard (¥1,000)",
   "description": "Earn ¥1,000 as fast as possible!",
   "start_speed": "A0",
@@ -9,5 +9,9 @@
   },
   "icons": [
     "basic"
+  ],
+  "rank": [
+    "duration 455",
+    "rank_criteria m=55"
   ]
 }

--- a/project/assets/main/puzzle/levels/practice/ultra-normal.json
+++ b/project/assets/main/puzzle/levels/practice/ultra-normal.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Ultra: Normal (¥200)",
   "description": "Earn ¥200 as fast as possible!",
   "finish_condition": {
@@ -8,5 +8,9 @@
   },
   "icons": [
     "basic"
+  ],
+  "rank": [
+    "duration 180",
+    "rank_criteria m=17"
   ]
 }

--- a/project/assets/main/puzzle/levels/rank/10d.json
+++ b/project/assets/main/puzzle/levels/rank/10d.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "10 Dan",
   "description": "An escalating set of challenges. Finish in 6:00 to achieve this rank!",
   "color": "orange",
@@ -16,6 +16,8 @@
     "top_out 1"
   ],
   "rank": [
+    "duration 210",
+    "rank_criteria m=255",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/1d.json
+++ b/project/assets/main/puzzle/levels/rank/1d.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "1 Dan",
   "description": "An escalating set of challenges. Finish with ¥1,200 to achieve this rank!",
   "color": "green",
@@ -37,6 +37,8 @@
     "top_out 1"
   ],
   "rank": [
+    "duration 870",
+    "rank_criteria m=6250",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/1k.json
+++ b/project/assets/main/puzzle/levels/rank/1k.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "1 Kyu",
   "description": "An escalating set of challenges. Finish with ¥1,000 to achieve this rank!",
   "color": "blue",
@@ -62,6 +62,8 @@
     "top_out 1"
   ],
   "rank": [
+    "duration 1130",
+    "rank_criteria m=5250",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/2d.json
+++ b/project/assets/main/puzzle/levels/rank/2d.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "2 Dan",
   "description": "An escalating set of challenges. Finish in 5:00 to achieve this rank!",
   "color": "green",
@@ -15,6 +15,8 @@
     "top_out 1"
   ],
   "rank": [
+    "duration 360",
+    "rank_criteria m=85",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/2k.json
+++ b/project/assets/main/puzzle/levels/rank/2k.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "2 Kyu",
   "description": "An escalating set of challenges. Finish in 3:00 to achieve this rank!",
   "color": "blue",
@@ -13,6 +13,8 @@
     "slow"
   ],
   "rank": [
+    "duration 255",
+    "rank_criteria m=37",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/3d.json
+++ b/project/assets/main/puzzle/levels/rank/3d.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "3 Dan",
   "description": "An escalating set of challenges. Finish with ¥1,200 to achieve this rank!",
   "color": "green",
@@ -77,6 +77,8 @@
     "top_out 1"
   ],
   "rank": [
+    "duration 295",
+    "rank_criteria m=3600",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/3k.json
+++ b/project/assets/main/puzzle/levels/rank/3k.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "3 Kyu",
   "description": "An escalating set of challenges. Finish with ¥999 to achieve this rank!",
   "color": "blue",
@@ -7,15 +7,17 @@
   "blocks_during": [
     "clear_on_top_out"
   ],
-  "icons": [
-    "basic",
-    "slow"
-  ],
   "finish_condition": {
     "type": "time_over",
     "value": 540
   },
+  "icons": [
+    "basic",
+    "slow"
+  ],
   "rank": [
+    "duration 540",
+    "rank_criteria m=9450",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/4d.json
+++ b/project/assets/main/puzzle/levels/rank/4d.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "4 Dan",
   "description": "An escalating set of challenges. Finish with ¥2,000 to achieve this rank!",
   "color": "green",
@@ -15,6 +15,8 @@
     "top_out 1"
   ],
   "rank": [
+    "duration 300",
+    "rank_criteria m=6200",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/4k.json
+++ b/project/assets/main/puzzle/levels/rank/4k.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "4 Kyu",
   "description": "An escalating set of challenges. Finish with ¥200 to achieve this rank!",
   "color": "blue",
@@ -13,6 +13,8 @@
     "slow"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=2800",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/5d.json
+++ b/project/assets/main/puzzle/levels/rank/5d.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "5 Dan",
   "description": "An escalating set of challenges. Finish with ¥2,500 to achieve this rank!",
   "color": "green",
@@ -42,6 +42,8 @@
     "top_out 1"
   ],
   "rank": [
+    "duration 485",
+    "rank_criteria m=6900",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/5k.json
+++ b/project/assets/main/puzzle/levels/rank/5k.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "5 Kyu",
   "description": "An escalating set of challenges. Finish with ¥500 to achieve this rank!",
   "color": "blue",
@@ -13,6 +13,8 @@
     "slow"
   ],
   "rank": [
+    "duration 750",
+    "rank_criteria m=3600",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/6d.json
+++ b/project/assets/main/puzzle/levels/rank/6d.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "6 Dan",
   "description": "An escalating set of challenges. Finish in 3:00 to achieve this rank!",
   "color": "yellow",
@@ -16,6 +16,8 @@
     "top_out 1"
   ],
   "rank": [
+    "duration 185",
+    "rank_criteria m=100",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/6k.json
+++ b/project/assets/main/puzzle/levels/rank/6k.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "6 Kyu",
   "description": "An escalating set of challenges. Finish with ¥200 to achieve this rank!",
   "color": "blue",
@@ -13,6 +13,8 @@
     "slow"
   ],
   "rank": [
+    "duration 180",
+    "rank_criteria m=3350",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/7d.json
+++ b/project/assets/main/puzzle/levels/rank/7d.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "7 Dan",
   "description": "An escalating set of challenges. Finish with ¥5,000 to achieve this rank!",
   "color": "yellow",
@@ -83,6 +83,8 @@
     "top_out 1"
   ],
   "rank": [
+    "duration 460",
+    "rank_criteria m=13500",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/7k.json
+++ b/project/assets/main/puzzle/levels/rank/7k.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "7 Kyu",
   "description": "An escalating set of challenges. Finish with in 5:00 to achieve this rank!",
   "color": "blue",
@@ -13,6 +13,8 @@
     "slow"
   ],
   "rank": [
+    "duration 160",
+    "rank_criteria m=19",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/8d.json
+++ b/project/assets/main/puzzle/levels/rank/8d.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "8 Dan",
   "description": "An escalating set of challenges. Finish with ¥3,000 to achieve this rank!",
   "color": "yellow",
@@ -16,6 +16,8 @@
     "top_out 1"
   ],
   "rank": [
+    "duration 240",
+    "rank_criteria m=8900",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/9d.json
+++ b/project/assets/main/puzzle/levels/rank/9d.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "9 Dan",
   "description": "An escalating set of challenges. Finish with ¥5,000 to achieve this rank!",
   "color": "orange",
@@ -16,6 +16,8 @@
     "top_out 1"
   ],
   "rank": [
+    "duration 195",
+    "rank_criteria m=6900",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/m.json
+++ b/project/assets/main/puzzle/levels/rank/m.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Master",
   "description": "An escalating set of challenges. Finish with ¥10,000 to achieve this rank!",
   "color": "red",
@@ -54,6 +54,8 @@
     "top_out 1"
   ],
   "rank": [
+    "duration 410",
+    "rank_criteria m=20000",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/tutorial/basics-0.json
+++ b/project/assets/main/puzzle/levels/tutorial/basics-0.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Basic Techniques",
   "description": "Learn to clear lines, to make snack boxes and to squish pieces.",
   "start_speed": "T",
@@ -13,6 +13,8 @@
     "piece_t"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/basics-1.json
+++ b/project/assets/main/puzzle/levels/tutorial/basics-1.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "lose_condition": [
     "top_out 999999"
@@ -16,6 +16,8 @@
     "start_piece_l"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/basics-2.json
+++ b/project/assets/main/puzzle/levels/tutorial/basics-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "lose_condition": [
     "top_out 999999"
@@ -12,6 +12,8 @@
     "piece_o"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/basics-3.json
+++ b/project/assets/main/puzzle/levels/tutorial/basics-3.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "lose_condition": [
     "top_out 999999"
@@ -13,6 +13,8 @@
     "piece_t"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/basics-4.json
+++ b/project/assets/main/puzzle/levels/tutorial/basics-4.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "finish_condition": {
     "type": "score",
     "value": 100
@@ -16,6 +16,8 @@
     "start_piece_l"
   ],
   "rank": [
+    "duration 90",
+    "rank_criteria m=50040",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/cakes-0.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-0.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Make Cakes",
   "description": "Learn all eight different cake box recipes.",
   "start_speed": "T",
@@ -15,6 +15,8 @@
     "start_piece_v"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/cakes-1.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-1.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "lose_condition": [
     "top_out 999999"
@@ -10,6 +10,8 @@
     "tutorial"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ]

--- a/project/assets/main/puzzle/levels/tutorial/cakes-2.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -17,6 +17,8 @@
     "start_piece_o"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/cakes-3.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-3.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -18,6 +18,8 @@
     "start_piece_t"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/cakes-4.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-4.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -19,6 +19,8 @@
     "start_piece_t"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/cakes-5.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-5.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "lose_condition": [
     "top_out 999999"
@@ -10,6 +10,8 @@
     "tutorial"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ]

--- a/project/assets/main/puzzle/levels/tutorial/cakes-6.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-6.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -19,6 +19,8 @@
     "start_piece_v"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ]

--- a/project/assets/main/puzzle/levels/tutorial/cakes-7.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-7.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -20,6 +20,8 @@
     "start_piece_v"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ]

--- a/project/assets/main/puzzle/levels/tutorial/cakes-8.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-8.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -21,6 +21,8 @@
     "start_piece_v"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ]

--- a/project/assets/main/puzzle/levels/tutorial/cakes-9.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-9.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "finish_condition": {
     "type": "time_over",
     "value": 45
@@ -18,6 +18,8 @@
     "start_piece_u"
   ],
   "rank": [
+    "duration 45",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/combo-0.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-0.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Build Combos",
   "description": "Learn how combos work, and learn to make snack boxes and cake boxes during your combos.",
   "start_speed": "T",
@@ -11,6 +11,8 @@
     "tutorial"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/combo-1.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-1.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "lose_condition": [
     "top_out 999999"
@@ -11,6 +11,8 @@
     "tutorial"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ]

--- a/project/assets/main/puzzle/levels/tutorial/combo-2.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "lose_condition": [
     "top_out 999999"
@@ -17,6 +17,8 @@
     "start_piece_q"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/combo-3.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-3.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "input_replay": [
     "25 +rotate_cw",
@@ -52,6 +52,8 @@
     "start_piece_l"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/combo-4.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-4.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "input_replay": [
     "17 +move_piece_right",
@@ -54,6 +54,8 @@
     "start_piece_l"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/combo-5.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-5.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "lose_condition": [
     "top_out 999999"
@@ -15,6 +15,8 @@
     "piece_o"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/combo-6.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-6.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "finish_condition": {
     "type": "score",
     "value": 120
@@ -13,6 +13,8 @@
     "start_level tutorial/combo_0"
   ],
   "rank": [
+    "duration 110",
+    "rank_criteria m=50040",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/oh-my.json
+++ b/project/assets/main/puzzle/levels/tutorial/oh-my.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "A1",
   "finish_condition": {
     "type": "lines",
@@ -20,6 +20,8 @@
     "piece_l"
   ],
   "rank": [
+    "duration 660",
+    "rank_criteria m=3600",
     "skip_results"
   ],
   "tiles": {

--- a/project/assets/main/puzzle/levels/tutorial/spins-0-example.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-0-example.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -28,6 +28,8 @@
     "piece_p"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/spins-0.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-0.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Meet Spins",
   "description": "Learn to spin and flip pieces in tight spaces.",
   "start_speed": "T",
@@ -17,6 +17,8 @@
     "piece_p"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/spins-1-fixed.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-1-fixed.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -16,6 +16,8 @@
     "piece_j"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/spins-1.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-1.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -16,6 +16,8 @@
     "piece_j"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/spins-2.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -16,6 +16,8 @@
     "piece_u"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/spins-3.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-3.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -16,6 +16,8 @@
     "piece_l"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/spins-4-example.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-4-example.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -48,6 +48,8 @@
     "piece_j"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/spins-4.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-4.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -16,6 +16,8 @@
     "piece_j"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/spins-5.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-5.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -16,6 +16,8 @@
     "piece_t"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/spins-6.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-6.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -16,6 +16,8 @@
     "piece_t"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/spins-7.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-7.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -16,6 +16,8 @@
     "piece_t"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/spins-8.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-8.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "5",
   "finish_condition": {
     "type": "pieces",
@@ -16,6 +16,8 @@
     "start_piece_j"
   ],
   "rank": [
+    "duration 300",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/spins-secret.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-secret.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -16,6 +16,8 @@
     "piece_u"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/squish-0.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-0.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "name": "Squish and Recover",
   "description": "Learn how squish moves work and when to use them.",
   "start_speed": "T",
@@ -15,6 +15,8 @@
     "piece_v"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/squish-1.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-1.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "lose_condition": [
     "top_out 999999"
@@ -10,6 +10,8 @@
     "tutorial"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ]

--- a/project/assets/main/puzzle/levels/tutorial/squish-2.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-2.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "lose_condition": [
     "top_out 999999"
@@ -12,6 +12,8 @@
     "piece_p"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/squish-3.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-3.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "lose_condition": [
     "top_out 999999"
@@ -12,6 +12,8 @@
     "piece_v"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/squish-4.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-4.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "lose_condition": [
     "top_out 999999"
@@ -12,6 +12,8 @@
     "piece_u"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/squish-5.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-5.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -34,6 +34,8 @@
     "start_piece_u"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/squish-6.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-6.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",
@@ -48,6 +48,8 @@
     "start_piece_q"
   ],
   "rank": [
+    "duration 150",
+    "rank_criteria m=1",
     "skip_results",
     "unranked"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/squish-7.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-7.json
@@ -1,5 +1,5 @@
 {
-  "version": "4c5c",
+  "version": "59c3",
   "finish_condition": {
     "type": "score",
     "value": 150
@@ -12,6 +12,8 @@
     "start_level tutorial/squish_0"
   ],
   "rank": [
+    "duration 135",
+    "rank_criteria m=50040",
     "skip_results",
     "unranked"
   ],


### PR DESCRIPTION
These fields were populated by adding a line of code to 'fix-levels-button.gd' to call LegacyRankCriteriaCalculator's populate_rank_fields method. I removed this line of code afterwards, since it was only needed during the one upgrade.