### PR TITLE
'One Step Ahead' bugs: Spin move noise sfx, unrotateable pieces

### DIFF
--- a/project/src/main/puzzle/piece-sfx.gd
+++ b/project/src/main/puzzle/piece-sfx.gd
@@ -54,42 +54,60 @@ func _on_PieceManager_squish_moved(_piece: ActivePiece, _old_pos: Vector2) -> vo
 ## Rotation events ----------------------------------------------------------------
 
 func _on_PieceManager_initial_rotated_ccw(piece: ActivePiece) -> void:
-	if piece.is_sealed():
+	if piece.is_sealed() \
+			and not CurrentLevel.settings.other.suppress_piece_rotation in [
+				OtherRules.SuppressPieceRotation.ROTATION_AND_SIGNALS,
+				OtherRules.SuppressPieceRotation.ROTATION]:
 		$RotateSealed0Sound.play()
 	else:
 		$Rotate0Sound.play()
 
 
 func _on_PieceManager_initial_rotated_cw(piece: ActivePiece) -> void:
-	if piece.is_sealed():
+	if piece.is_sealed() \
+			and not CurrentLevel.settings.other.suppress_piece_rotation in [
+				OtherRules.SuppressPieceRotation.ROTATION_AND_SIGNALS,
+				OtherRules.SuppressPieceRotation.ROTATION]:
 		$RotateSealed0Sound.play()
 	else:
 		$Rotate0Sound.play()
 
 
 func _on_PieceManager_initial_rotated_180(piece: ActivePiece) -> void:
-	if piece.is_sealed():
+	if piece.is_sealed() \
+			and not CurrentLevel.settings.other.suppress_piece_rotation in [
+				OtherRules.SuppressPieceRotation.ROTATION_AND_SIGNALS,
+				OtherRules.SuppressPieceRotation.ROTATION]:
 		$RotateSealed0Sound.play()
 	else:
 		$Rotate0Sound.play()
 
 
 func _on_PieceManager_rotated_ccw(piece: ActivePiece) -> void:
-	if piece.is_sealed():
+	if piece.is_sealed() \
+			and not CurrentLevel.settings.other.suppress_piece_rotation in [
+				OtherRules.SuppressPieceRotation.ROTATION_AND_SIGNALS,
+				OtherRules.SuppressPieceRotation.ROTATION]:
 		$RotateSealed0Sound.play()
 	else:
 		$Rotate0Sound.play()
 
 
 func _on_PieceManager_rotated_cw(piece: ActivePiece) -> void:
-	if piece.is_sealed():
+	if piece.is_sealed() \
+			and not CurrentLevel.settings.other.suppress_piece_rotation in [
+				OtherRules.SuppressPieceRotation.ROTATION_AND_SIGNALS,
+				OtherRules.SuppressPieceRotation.ROTATION]:
 		$RotateSealed1Sound.play()
 	else:
 		$Rotate1Sound.play()
 
 
 func _on_PieceManager_rotated_180(piece: ActivePiece) -> void:
-	if piece.is_sealed():
+	if piece.is_sealed() \
+			and not CurrentLevel.settings.other.suppress_piece_rotation in [
+				OtherRules.SuppressPieceRotation.ROTATION_AND_SIGNALS,
+				OtherRules.SuppressPieceRotation.ROTATION]:
 		$RotateSealed0Sound.play()
 	else:
 		$Rotate0Sound.play()

--- a/project/src/main/puzzle/piece/piece-rotator.gd
+++ b/project/src/main/puzzle/piece/piece-rotator.gd
@@ -94,7 +94,13 @@ func apply_rotate_input(piece: ActivePiece) -> void:
 			if not piece.can_move_to_target():
 				piece.kick_piece()
 		
-		if piece.target_pos.y < piece.pos.y and not piece.can_floor_kick():
+		if CurrentLevel.settings.other.suppress_piece_rotation in [
+				OtherRules.SuppressPieceRotation.ROTATION_AND_SIGNALS,
+				OtherRules.SuppressPieceRotation.ROTATION]:
+			# don't suppress rotation signals for levels where the current piece does not rotate; otherwise it's
+			# unintuitive that rotation triggers occur conditionally based on the state of the current piece
+			pass
+		elif piece.target_pos.y < piece.pos.y and not piece.can_floor_kick():
 			# tried to flip but we don't have any floor kicks for it
 			rotation_signal = ""
 		elif not piece.can_move_to_target():


### PR DESCRIPTION
Fixed bug in 'One Step Ahead' where spin move sfx would play if the piece was locked in place, where it required a spin move.

Fixed bug in 'One Step Ahead' where the next piece would not rotate if the piece was locked in place, where it could not rotate.