### PR TITLE
Godot #90079 workaround (wandering controls)

### DIFF
--- a/project/src/main/career/ui/ProgressBoard.tscn
+++ b/project/src/main/career/ui/ProgressBoard.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=31 format=2]
+[gd_scene load_steps=32 format=2]
 
 [ext_resource path="res://src/main/career/ui/progress-board-clock-label.gd" type="Script" id=1]
 [ext_resource path="res://assets/main/career/ui/map/landmark-forest.png" type="Texture" id=2]
@@ -21,6 +21,7 @@
 [ext_resource path="res://src/main/career/ui/progress-board-map-holder.gd" type="Script" id=19]
 [ext_resource path="res://src/main/ui/DiagonalParticles.tscn" type="PackedScene" id=20]
 [ext_resource path="res://assets/main/career/ui/progress-board-grain.png" type="Texture" id=21]
+[ext_resource path="res://src/main/ui/AnimationPlayerUnscrewerupper.tscn" type="PackedScene" id=22]
 
 [sub_resource type="ShaderMaterial" id=29]
 shader = ExtResource( 9 )
@@ -703,6 +704,8 @@ bus = "Sound Bus"
 anims/RESET = SubResource( 34 )
 anims/hide = SubResource( 36 )
 anims/show = SubResource( 31 )
+
+[node name="AnimationPlayerUnscrewerupper" parent="ShowAnimationPlayer" instance=ExtResource( 22 )]
 
 [node name="HideTimer" type="Timer" parent="."]
 wait_time = 1.5

--- a/project/src/main/career/ui/animation-player-unscrewerupper.gd
+++ b/project/src/main/career/ui/animation-player-unscrewerupper.gd
@@ -1,0 +1,29 @@
+## Prevents Controls used by AnimationPlayers from randomly changing their position and size.
+##
+## Workaround for Godot #90079 (https://github.com/godotengine/godot/issues/90079). Godot has an exciting feature
+## where Controls animated by an AnimationPlayer randomly change their position or size. This only affects the editor,
+## and results an exciting and fun surprise for developers. But for developers who don't like excitement or fun, this
+## node can be added to an AnimationPlayer to forcibly reset the control to reset its position.
+##
+## To use this node, add it as the child of an AnimationPlayer.
+tool
+extends Node
+
+## Manually reset Control nodes affected by our parent AnimationPlayer.
+export (bool) var _unscrewup: bool setget unscrewup
+
+onready var animation_player: AnimationPlayer = get_parent()
+
+func _ready() -> void:
+	if Engine.editor_hint:
+		unscrewup()
+
+
+## Preemptively initializes onready variables to avoid null references.
+func _enter_tree() -> void:
+	animation_player = get_parent()
+
+
+func unscrewup(_value: bool = false) -> void:
+	if Engine.editor_hint:
+		animation_player.play("RESET")

--- a/project/src/main/ui/AnimationPlayerUnscrewerupper.tscn
+++ b/project/src/main/ui/AnimationPlayerUnscrewerupper.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/main/career/ui/animation-player-unscrewerupper.gd" type="Script" id=1]
+
+[node name="AnimationPlayerUnscrewerupper" type="Node"]
+script = ExtResource( 1 )


### PR DESCRIPTION
Workaround for Godot #90079 (https://github.com/godotengine/godot/issues/90079).

Godot has an exciting feature where Controls animated by an AnimationPlayer randomly change their position or size. This only affects the editor, and results an exciting and fun surprise for developers.

I've added a workaround to prevent controls from randomly changing their position and size.