### PR TITLE
Added goal hype music: 'Extra Sprinkles'

### DIFF
--- a/project/assets/main/puzzle/career-regions.json
+++ b/project/assets/main/puzzle/career-regions.json
@@ -99,7 +99,7 @@
       "music": {
         "menu": "hot_funk_sundae",
         "puzzle": [
-          "+pressure_cooker",
+          "+sugar_crash",
           "chunky_obake",
           "acid_reflux"
         ]
@@ -474,7 +474,7 @@
       "music": {
         "menu": "harder_butter",
         "puzzle": [
-          "+extra_sprinkles",
+          "+pressure_cooker",
           "mystic_muffin",
           "juicer_mixer_grinder"
         ]
@@ -554,13 +554,13 @@
       "music": {
         "menu": "rainbow_sherbeat",
         "puzzle": [
+          "+extra_sprinkles",
           "sugar_crash",
           "acid_reflux",
           "chocolate_chip",
           "chub_n_bass",
           "chunky_obake",
           "doo_doo_doo",
-          "extra_sprinkles",
           "gingerbread_house",
           "juicer_mixer_grinder",
           "mystic_muffin",

--- a/project/src/main/career/region-music.gd
+++ b/project/src/main/career/region-music.gd
@@ -5,7 +5,7 @@ class_name RegionMusic
 ## in MusicPlayer.tracks_by_id. The list of puzzle music track ids obey two unusual rules:
 ##
 ## 1. The first item in the list of puzzle music track ids is the 'main puzzle music track id'. This main puzzle track
-## is played for the first puzzle of each career data and for the boss level.
+## is played for the first puzzle of each career data.
 ##
 ## 2. Json puzzle music track ids prefixed with a '+' will play twice as often.
 
@@ -34,7 +34,7 @@ func random_puzzle_track_id() -> String:
 
 ## Returns the main music track id to play while the player is playing a level from this region.
 ##
-## The main music track id is played at the start of every career day, and for every boss level.
+## The main music track id is played at the start of every career day.
 func main_puzzle_track_id() -> String:
 	return puzzle_track_ids[0]
 

--- a/project/src/main/career/ui/ProgressBoard.tscn
+++ b/project/src/main/career/ui/ProgressBoard.tscn
@@ -849,6 +849,7 @@ wait_time = 0.5
 one_shot = true
 
 [connection signal="visibility_changed" from="Backdrop" to="." method="_on_Backdrop_visibility_changed"]
+[connection signal="travelling_finished" from="ChalkboardRegion/Player" to="." method="_on_Player_travelling_finished"]
 [connection signal="travelling_finished" from="ChalkboardRegion/Player" to="ChalkboardRegion/Trail" method="_on_Player_travelling_finished"]
 [connection signal="travelling_finished" from="ChalkboardRegion/Player" to="ChalkboardRegion/GoalLabel" method="_on_Player_travelling_finished"]
 [connection signal="travelling_finished" from="ChalkboardRegion/Player" to="ChalkboardRegion/SplashMessage" method="_on_Player_travelling_finished"]

--- a/project/src/main/career/ui/progress-board.gd
+++ b/project/src/main/career/ui/progress-board.gd
@@ -230,3 +230,8 @@ func _on_HideTimer_timeout() -> void:
 ## When the AnimateStartTimer times out, we launch the clock and player animations.
 func _on_AnimateStartTimer_timeout() -> void:
 	play()
+
+
+func _on_Player_travelling_finished() -> void:
+	if PlayerData.career.is_boss_level() and not PlayerData.career.is_day_over():
+		MusicPlayer.play_boss_track(false)

--- a/project/src/main/music/music-player.gd
+++ b/project/src/main/music/music-player.gd
@@ -50,11 +50,11 @@ onready var _menu_tracks := [
 onready var _puzzle_tracks := [
 		$AcidReflux, $ChocolateChip, $ChubNBass, $ChunkyObake,
 		$DooDooDoo, $ExtraSprinkles, $GingerbreadHouse, $JuicerMixerGrinder,
-		$MysticMuffin, $PressureCooker, $SugarCrash, $TripleThiccShake,
-		]
+		$MysticMuffin, $PressureCooker, $SugarCrash, $TripleThiccShake]
 
 onready var _credits_track := $SugarCrash
 onready var _tutorial_tracks := [$MyFatnessPal]
+onready var _boss_tracks := [$ExtraSprinkles]
 onready var _music_tween_manager := $MusicTweenManager
 
 func _ready() -> void:
@@ -126,6 +126,14 @@ func play_puzzle_track(fade_in: bool = true) -> void:
 		_previous_level_id = CurrentLevel.level_id
 	else:
 		_play_next_track(_puzzle_tracks, fade_in)
+
+
+func play_boss_track(fade_in: bool = true) -> void:
+	_play_next_track(_boss_tracks, fade_in)
+
+
+func is_playing_boss_track() -> bool:
+	return current_track in _boss_tracks
 
 
 ## Plays a 'tutorial track'; something suitable when the player is following a puzzle tutorial.

--- a/project/src/main/puzzle/puzzle-music-manager.gd
+++ b/project/src/main/puzzle/puzzle-music-manager.gd
@@ -7,7 +7,10 @@ func _ready() -> void:
 
 
 func start_puzzle_music() -> void:
-	if CurrentLevel.is_tutorial():
+	if PlayerData.career.is_career_mode() and MusicPlayer.is_playing_boss_track():
+		# don't interrupt boss music during career mode; it keeps playing from the level select to the puzzle
+		pass
+	elif CurrentLevel.is_tutorial():
 		MusicPlayer.play_tutorial_track(false)
 	else:
 		MusicPlayer.play_puzzle_track(false)

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -11,7 +11,11 @@ onready var _night_mode_toggler: NightModeToggler = $NightModeToggler
 
 func _ready() -> void:
 	ResourceCache.substitute_singletons()
-	MusicPlayer.play_menu_track()
+	if PlayerData.career.is_career_mode() and MusicPlayer.is_playing_boss_track():
+		# don't interrupt boss music during career mode; it keeps playing from the level select to the puzzle
+		pass
+	else:
+		MusicPlayer.play_menu_track()
 	
 	PuzzleState.connect("game_started", self, "_on_PuzzleState_game_started")
 	PuzzleState.connect("game_ended", self, "_on_PuzzleState_game_ended")

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -37,7 +37,11 @@ func _ready() -> void:
 		# For regular players the Breadcrumb trail will already be initialized by the menus.
 		Breadcrumb.initialize_trail()
 	
-	MusicPlayer.play_menu_track()
+	if PlayerData.career.is_boss_level() and not PlayerData.career.is_day_over() \
+			and (PlayerData.career.show_progress != Careers.ShowProgress.ANIMATED):
+		MusicPlayer.play_boss_track()
+	else:
+		MusicPlayer.play_menu_track()
 	PlayerData.career.connect("distance_travelled_changed", self, "_on_CareerData_distance_travelled_changed")
 	
 	var redirected := false

--- a/project/src/main/world/career-world.gd
+++ b/project/src/main/world/career-world.gd
@@ -76,6 +76,11 @@ func _input(event: InputEvent) -> void:
 			PlayerData.career.distance_travelled = clamp(PlayerData.career.distance_travelled + distance,
 					region.start, region.end)
 			_move_objects_to_path()
+		
+		if PlayerData.career.is_boss_level():
+			MusicPlayer.play_boss_track()
+		else:
+			MusicPlayer.play_menu_track()
 
 
 func initial_environment_path() -> String:

--- a/project/src/main/world/cutscene-world.gd
+++ b/project/src/main/world/cutscene-world.gd
@@ -15,7 +15,11 @@ func _ready() -> void:
 	if CurrentCutscene.chat_tree.meta.has("fixed_zoom"):
 		_camera.fixed_zoom = CurrentCutscene.chat_tree.meta["fixed_zoom"]
 	
-	MusicPlayer.play_menu_track()
+	if PlayerData.career.is_career_mode() and MusicPlayer.is_playing_boss_track():
+		# don't interrupt boss music during career mode; it keeps playing from the level select to the puzzle
+		pass
+	else:
+		MusicPlayer.play_menu_track()
 	_launch_cutscene()
 
 


### PR DESCRIPTION
'Extra sprinkles' plays for boss levels. It plays once the player reaches the boss level, and under certain other edge cases like if the player quits and re-enters career mode when they're at a boss level.

Removed 'Extra Sprinkles' as Chocolava Canyon's signature song. Sugar Crash is now the signature song for the first two regions, and Pressure Cooker is the signature song for Chocolava Canyon. This is good for a few reasons imho: Sugar Crash shows up in the credits, so it's good to cement it in the player's head a little more. Also Extra Sprinkles is a really good song so it's good for the player to hear it early, as opposed to saving it for levels which only a few players will reach.