### PR TITLE
Creature editor plays music. Substitute singletons call.

### DIFF
--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -10,7 +10,14 @@ onready var _dialogs: CreatureEditorDialogs = get_node(dialogs_path)
 onready var _creature_saver: CreatureSaver = get_node(creature_saver_path)
 
 func _ready() -> void:
+	ResourceCache.substitute_singletons()
+	MusicPlayer.play_menu_track()
+	
 	$Buttons/VBoxContainer/CategorySelector.set_selected_category_index(0)
+
+
+func _exit_tree() -> void:
+	ResourceCache.remove_singletons()
 
 
 func _quit() -> void:

--- a/project/src/main/ui/menu/main-menu-adventure.gd
+++ b/project/src/main/ui/menu/main-menu-adventure.gd
@@ -18,5 +18,4 @@ func _on_Career_pressed() -> void:
 
 
 func _on_Avatar_pressed() -> void:
-	MusicPlayer.stop()
 	SceneTransition.push_trail("res://src/main/editor/creature/CreatureEditor.tscn")


### PR DESCRIPTION
Added a missing substitute singletons call to the CreatureEditor. To my knowledge, this mostly affects the wallpaper in a very subtle way, but it's more future-proofing for other singletons I may have forgotten about.