### PR TITLE
Bug: Tutorial replays broke if player held a key

### DIFF
--- a/project/src/demo/puzzle/PuzzleDemo.tscn
+++ b/project/src/demo/puzzle/PuzzleDemo.tscn
@@ -5,6 +5,6 @@
 
 [node name="PuzzleDemo" type="Node"]
 script = ExtResource( 2 )
-level_path = "res://assets/demo/puzzle/levels/experiment.json"
+level_path = "res://assets/main/puzzle/levels/tutorial/combo-0.json"
 
 [node name="Puzzle" parent="." instance=ExtResource( 1 )]

--- a/project/src/main/puzzle/piece/frame-input.gd
+++ b/project/src/main/puzzle/piece/frame-input.gd
@@ -23,6 +23,10 @@ var _print_inputs := false
 ## If this timer is active, the input was recently pressed and can be popped with pop_buffered_input
 onready var _buffer_timer: Timer = $BufferTimer
 
+func _ready() -> void:
+	PuzzleState.connect("after_level_changed", self, "_on_PuzzleState_after_level_changed")
+
+
 func _unhandled_input(event: InputEvent) -> void:
 	if not CurrentLevel.settings.input_replay.empty():
 		# don't process button presses when replaying prerecorded input
@@ -91,6 +95,17 @@ func is_das_active() -> bool:
 	return _pressed and pressed_frames >= PieceSpeeds.current_speed.delayed_auto_shift_delay
 
 
+## Resets the input action state to unpressed.
+##
+## This is used during tutorials to ensure the replay doesn't break if the player keeps a button held during the level
+## transition.
+func reset_input() -> void:
+	pressed_frames = 0
+	_just_pressed = false
+	_pressed = false
+	_buffer = false
+
+
 ## Applies prerecorded puzzle inputs for things such as tutorials.
 func _process_input_replay() -> void:
 	if CurrentLevel.settings.input_replay.is_action_pressed(action):
@@ -110,3 +125,10 @@ func _process_input_replay() -> void:
 				# player was holding both buttons, but let go of the cancel_button
 				_just_pressed = true
 				_pressed = true
+
+
+## When the level changes, we resets the input action state to unpressed.
+##
+## This ensures tutorial replays don't break if the player keeps a button held during the level transition.
+func _on_PuzzleState_after_level_changed() -> void:
+	reset_input()


### PR DESCRIPTION
If the player held an input before a level transition, the tutorial replays would break. It would ignore all player input, but this ignored the "releasing the input" input so the entire replay would play as though the key were held.

All keys are now released at the start of a level transition.