### PR TITLE
set_stat_float sanity checks, error logging

### DIFF
--- a/project/src/main/steam/chapter-rank-s-achievement.gd
+++ b/project/src/main/steam/chapter-rank-s-achievement.gd
@@ -18,7 +18,11 @@ func connect_signals() -> void:
 func refresh_achievement() -> void:
 	var s_rank_percent := _s_rank_percent()
 	
-	SteamUtils.set_stat_float(stat_id, 100 * s_rank_percent)
+	if s_rank_percent >= 0 and s_rank_percent <= 100:
+		SteamUtils.set_stat_float(stat_id, 100 * s_rank_percent)
+	else:
+		push_error("Invalid s_rank_percent for region %s: %s" % [region_id, s_rank_percent])
+	
 	if s_rank_percent == 1.0:
 		SteamUtils.set_achievement(achievement_id)
 
@@ -33,7 +37,7 @@ func _s_rank_percent() -> float:
 		if Ranks.rank_meets_grade(rank, "S-"):
 			s_rank_count += 1
 	
-	return s_rank_count / float(region.levels.size())
+	return s_rank_count / float(max(1, region.levels.size()))
 
 
 ## When a level is played, if it corresponds to our region we refresh our achievement status.

--- a/project/src/main/steam/chapter-story-finished-achievement.gd
+++ b/project/src/main/steam/chapter-story-finished-achievement.gd
@@ -16,10 +16,20 @@ func connect_signals() -> void:
 
 ## Refreshes the achievement and stat based on how many cutscenes the player has viewed in a chapter.
 func refresh_achievement() -> void:
-	var region_completion := PlayerData.career.region_completion(CareerLevelLibrary.region_for_id(region_id))
-	SteamUtils.set_stat_float(stat_id, 100 * region_completion.cutscene_completion_percent())
-	if region_completion.cutscene_completion_percent() == 1.0:
+	var cutscene_completion_percent := _cutscene_completion_percent()
+	
+	if cutscene_completion_percent >= 0.0 and cutscene_completion_percent <= 1.0:
+		SteamUtils.set_stat_float(stat_id, 100 * cutscene_completion_percent)
+	else:
+		push_error("Invalid cutscene_completion_percent for region %s: %s" % [region_id, cutscene_completion_percent])
+	
+	if cutscene_completion_percent == 1.0:
 		SteamUtils.set_achievement(achievement_id)
+
+
+func _cutscene_completion_percent() -> float:
+	var region_completion := PlayerData.career.region_completion(CareerLevelLibrary.region_for_id(region_id))
+	return region_completion.cutscene_completion_percent()
 
 
 ## When a cutscene is played, if it corresponds to our region we refresh our achievement status.


### PR DESCRIPTION
A playtester reported the 'achieve an S- rank on all levels' achievement unlocked prematurely, and looking at their logs revealed some baffing responses from Steam:

[STEAM] Setting Steam stat: CHAPTER_3_RANK_S_PERCENT -> 6.25
[STEAM] Getting Steam stat: CHAPTER_3_RANK_S_PERCENT
[STEAM] get_stat_float(CHAPTER_3_RANK_S_PERCENT) response: 728754765532960332447744
[STEAM] setStatFloat(CHAPTER_3_RANK_S_PERCENT, 6.25) response: False

While these responses wouldn't cause the achievement to unlock, it still seems like we should perform some data validation on our 'set_stat_float' calls. I'm guessing at some point a division by zero error or data issue may have resulted us setting this stat to 'INF' or something. I can't reproduce it, but we should still guard against it