### PR TITLE
Bug: Crashes editing keybinds from older save data

### DIFF
--- a/project/assets/test/data/config-37b3.json
+++ b/project/assets/test/data/config-37b3.json
@@ -1,0 +1,249 @@
+[
+  {
+    "type": "version",
+    "value": "37b3"
+  },
+  {
+    "type": "gameplay_settings",
+    "value": {
+      "ghost_piece": true,
+      "hold_piece": false,
+      "line_piece": false,
+      "soft_drop_lock_cancel": true,
+      "speed": "default"
+    }
+  },
+  {
+    "type": "graphics_settings",
+    "value": {
+      "creature_detail": 1,
+      "feeding_animation": 1,
+      "fullscreen": false,
+      "use_vsync": false
+    }
+  },
+  {
+    "type": "volume_settings",
+    "value": {
+      "master": 0.36,
+      "music": 0.34,
+      "sound": 0.7,
+      "voice": 0.7
+    }
+  },
+  {
+    "type": "touch_settings",
+    "value": {
+      "fat_finger": 0,
+      "scheme": 0,
+      "size": 1
+    }
+  },
+  {
+    "type": "keybind_settings",
+    "value": {
+      "preset": 2,
+      "custom_keybinds": {
+        "move_piece_left": [
+          {
+            "type": "key",
+            "scancode": 16777231
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "move_piece_right": [
+          {
+            "type": "key",
+            "scancode": 16777233
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "soft_drop": [
+          {
+            "type": "key",
+            "scancode": 67
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "hard_drop": [
+          {
+            "type": "key",
+            "scancode": 32
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "retry": [
+          {
+            "type": "key",
+            "scancode": 82
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "rotate_ccw": [
+          {
+            "type": "key",
+            "scancode": 91
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "rotate_cw": [
+          {
+            "type": "key",
+            "scancode": 88
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "swap_hold_piece": [
+          {
+            "type": "key",
+            "scancode": 16777237
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_up": [
+          {
+            "type": "key",
+            "scancode": 16777232
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_down": [
+          {
+            "type": "key",
+            "scancode": 16777234
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_left": [
+          {
+            "type": "key",
+            "scancode": 16777231
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_right": [
+          {
+            "type": "key",
+            "scancode": 16777233
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_accept": [
+          {
+            "type": "key",
+            "scancode": 32
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_cancel": [
+          {
+            "type": "key",
+            "scancode": 16777217
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_menu": [
+          {
+            "type": "key",
+            "scancode": 16777217
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "rewind_text": [
+          {
+            "type": "key",
+            "scancode": 16777237
+          },
+          {
+
+          },
+          {
+
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "misc_settings",
+    "value": {
+      "locale": "en_US",
+      "save_slot": 1
+    }
+  }
+]

--- a/project/src/main/data/system-save-upgrader.gd
+++ b/project/src/main/data/system-save-upgrader.gd
@@ -7,7 +7,8 @@ class_name SystemSaveUpgrader
 ## Creates and configures a SaveItemUpgrader capable of upgrading older system save formats.
 func new_save_item_upgrader() -> SaveItemUpgrader:
 	var upgrader := SaveItemUpgrader.new()
-	upgrader.current_version = "37b3"
+	upgrader.current_version = "5a24"
+	upgrader.add_upgrade_method(self, "_upgrade_37b3", "37b3", "5a24")
 	upgrader.add_upgrade_method(self, "_upgrade_27bb", "27bb", "37b3")
 	upgrader.add_upgrade_method(self, "_upgrade_2783", "2783", "27bb")
 	upgrader.add_upgrade_method(self, "_upgrade_2743", "2743", "2783")
@@ -22,6 +23,15 @@ func new_save_item_upgrader() -> SaveItemUpgrader:
 	upgrader.add_upgrade_method(self, "_upgrade_2743", "163e", "2783")
 	upgrader.add_upgrade_method(self, "_upgrade_2743", "15d2", "2783")
 	return upgrader
+
+
+func _upgrade_37b3(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
+	match save_item.type:
+		"keybind_settings":
+			if save_item.value.get("custom_keybinds") is Dictionary:
+				save_item.value["custom_keybinds"]["next_tab"] = [{"type": "key", "scancode": 88}, {}, {}]
+				save_item.value["custom_keybinds"]["prev_tab"] = [{"type": "key", "scancode": 90}, {}, {}]
+	return save_item
 
 
 func _upgrade_27bb(_old_save_items: Array, save_item: SaveItem) -> SaveItem:

--- a/project/src/main/data/system-save.gd
+++ b/project/src/main/data/system-save.gd
@@ -7,7 +7,7 @@ signal before_save
 signal after_save
 signal save_slot_deleted
 
-const SYSTEM_DATA_VERSION := "37b3"
+const SYSTEM_DATA_VERSION := "5a24"
 
 ## Save files older than July 2021 which should be deleted during an upgrade
 const OLD_SAVES_TO_DELETE := [

--- a/project/src/test/data/test-system-save-upgrader.gd
+++ b/project/src/test/data/test-system-save-upgrader.gd
@@ -49,3 +49,19 @@ func test_27bb() -> void:
 	assert_eq(SystemData.gameplay_settings.speed, GameplaySettings.Speed.DEFAULT)
 	assert_eq(SystemData.gameplay_settings.hold_piece, false)
 	assert_eq(SystemData.gameplay_settings.line_piece, false)
+
+
+func test_37b3() -> void:
+	load_player_data("config-37b3.json")
+	
+	# should fill in missing keybinds
+	assert_eq(SystemData.keybind_settings.custom_keybinds.has("next_tab"), true)
+	assert_eq(SystemData.keybind_settings.custom_keybinds.has("prev_tab"), true)
+	
+	# should preserve existing keybinds
+	assert_eq(SystemData.keybind_settings.custom_keybinds.has("rotate_ccw"), true)
+	assert_eq_deep(SystemData.keybind_settings.custom_keybinds["rotate_ccw"], [
+		{"type": "key", "scancode": 91.0},
+		{},
+		{},
+	])

--- a/project/src/test/settings/test-keybind-settings.gd
+++ b/project/src/test/settings/test-keybind-settings.gd
@@ -1,0 +1,45 @@
+extends GutTest
+
+func before_each() -> void:
+	SystemData.gameplay_settings.reset()
+
+
+func after_all() -> void:
+	SystemData.gameplay_settings.reset()
+
+
+func test_valid_custom_ui_keybinds() -> void:
+	var custom_keybinds := _custom_keybinds()
+	SystemData.keybind_settings.custom_keybinds = custom_keybinds
+	
+	assert_eq(SystemData.keybind_settings.valid_custom_ui_keybinds(), true)
+
+
+func test_valid_custom_ui_keybinds_missing_keybind_empty_1() -> void:
+	var custom_keybinds := _custom_keybinds()
+	custom_keybinds["next_tab"] = [{}, {}, {}]
+	SystemData.keybind_settings.custom_keybinds = custom_keybinds
+	
+	assert_eq(SystemData.keybind_settings.valid_custom_ui_keybinds(), false)
+
+
+func test_valid_custom_ui_keybinds_missing_keybind_null() -> void:
+	var custom_keybinds := _custom_keybinds()
+	custom_keybinds.erase("next_tab")
+	SystemData.keybind_settings.custom_keybinds = custom_keybinds
+	
+	assert_eq(SystemData.keybind_settings.valid_custom_ui_keybinds(), false)
+
+
+func test_valid_custom_ui_keybinds_duplicate_keybind() -> void:
+	var custom_keybinds := _custom_keybinds()
+	custom_keybinds["next_tab"] = [{"type": "key", "scancode": 88}, {}, {}]
+	custom_keybinds["prev_tab"] = [{"type": "key", "scancode": 88}, {}, {}]
+	SystemData.keybind_settings.custom_keybinds = custom_keybinds
+	
+	assert_eq(SystemData.keybind_settings.valid_custom_ui_keybinds(), false)
+
+
+func _custom_keybinds() -> Dictionary:
+	var custom_keybinds_text := FileUtils.get_file_as_text("res://assets/main/keybind/default-custom.json")
+	return parse_json(custom_keybinds_text)


### PR DESCRIPTION
Older versions of the save data did not include custom keybinds for 'next_tab' or 'prev_tab', causing crashes when keybinds-settings.gd tried to verify that all UI keybinds had keys assigned. I've fixed this bug in several different ways for redundancy:

1. SystemSaveUpgrader now adds the 'next_tab' and 'prev_tab' keybinds
2. On load, KeybindSettings checks whether any custom UI keybinds are absent or duplicated and if so, restores the default custom keybinds
3. KeybindSettings checks for the absence of a custom keybind to avoid an NPE
4. A Gut test verifies that older keybinds are preserved during the upgrade -- so if a new keybind is added or this logic is broken, this test will fail as the default custom keybinds are restored