### PR TITLE
Player can exit cutscenes.

### DIFF
--- a/project/src/main/chat/ui/chat-choices.gd
+++ b/project/src/main/chat/ui/chat-choices.gd
@@ -72,9 +72,16 @@ func show_choices(choices: Array, moods: Array, new_columns: int = 0) -> void:
 		
 		# wait for old chat choices to be deleted before grabbing focus
 		yield(get_tree(), "idle_frame")
-		for button in get_tree().get_nodes_in_group("chat_choices"):
-			button.grab_focus()
-			break
+		grab_focus()
+
+
+## Steals the focus from another control and becomes the focused control.
+##
+## This control itself doesn't have focus, so we delegate to a child control.
+func grab_focus() -> void:
+	for button in get_tree().get_nodes_in_group("chat_choices"):
+		button.grab_focus()
+		break
 
 
 func is_showing_choices() -> bool:
@@ -124,7 +131,6 @@ func _refresh_child_buttons() -> void:
 		button.set_mood(_moods[i])
 		button.set_mood_right(i % 2 == 1)
 		button.connect("focus_entered", self, "_on_ChatChoiceButton_focus_entered")
-		button.connect("gui_input", self, "_on_ChatChoiceButton_gui_input")
 		button.connect("pressed", self, "_on_ChatChoiceButton_pressed")
 		add_child(button)
 		new_buttons.append(button)
@@ -149,11 +155,6 @@ func _refresh_child_buttons() -> void:
 
 func _on_ChatChoiceButton_focus_entered() -> void:
 	$PopSound.play()
-
-
-func _on_ChatChoiceButton_gui_input(_event: InputEvent) -> void:
-	# swallow input; player shouldn't move when answering chat prompts
-	get_tree().set_input_as_handled()
 
 
 ## Makes all the chat choice buttons disappear and emits a signal with the player's selected choice.

--- a/project/src/main/chat/ui/chat-ui.gd
+++ b/project/src/main/chat/ui/chat-ui.gd
@@ -74,6 +74,14 @@ func play_chat_tree(chat_tree: ChatTree) -> void:
 	emit_signal("popped_in")
 
 
+## Steals the focus from another control and becomes the focused control.
+##
+## This control itself doesn't have focus, so we delegate to a child control.
+func grab_focus() -> void:
+	if _chat_choices.is_showing_choices():
+		_chat_choices.grab_focus()
+
+
 func _refresh_overworld_environment_path() -> void:
 	if not is_inside_tree():
 		return

--- a/project/src/main/world/Cutscene.tscn
+++ b/project/src/main/world/Cutscene.tscn
@@ -1,13 +1,11 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://src/main/world/cutscene-world.gd" type="Script" id=1]
 [ext_resource path="res://src/main/world/environment/EmptyEnvironment.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/world/cutscene-camera.gd" type="Script" id=3]
 [ext_resource path="res://src/main/world/CutsceneUi.tscn" type="PackedScene" id=4]
-[ext_resource path="res://src/main/world/environment/overworld-environment.gd" type="Script" id=5]
 [ext_resource path="res://src/main/world/ChatLetters.tscn" type="PackedScene" id=6]
 [ext_resource path="res://src/main/world/OverworldBg.tscn" type="PackedScene" id=7]
-[ext_resource path="res://src/main/world/creature/Creature.tscn" type="PackedScene" id=8]
 
 [node name="Cutscene" type="Node"]
 
@@ -17,11 +15,7 @@
 script = ExtResource( 1 )
 overworld_bg_path = NodePath("../Bg")
 
-[node name="Environment" type="Node2D" parent="World" groups=["overworld_environments"] instance=ExtResource( 2 )]
-script = ExtResource( 5 )
-environment_shadows_path = NodePath("Ground/Shadows")
-obstacles_path = NodePath("Obstacles")
-CreatureScene = ExtResource( 8 )
+[node name="Environment" parent="World" instance=ExtResource( 2 )]
 
 [node name="ChatLetters" parent="World" instance=ExtResource( 6 )]
 

--- a/project/src/main/world/CutsceneUi.tscn
+++ b/project/src/main/world/CutsceneUi.tscn
@@ -1,12 +1,33 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=20 format=2]
 
 [ext_resource path="res://src/main/world/cutscene-ui.gd" type="Script" id=1]
+[ext_resource path="res://src/main/world/overworld-buttons.gd" type="Script" id=2]
+[ext_resource path="res://assets/main/ui/touch/menu.png" type="Texture" id=3]
+[ext_resource path="res://assets/main/ui/touch/menu-pressed.png" type="Texture" id=4]
 [ext_resource path="res://src/main/ui/theme/h4.theme" type="Theme" id=5]
+[ext_resource path="res://src/main/ui/ImageButton.tscn" type="PackedScene" id=6]
+[ext_resource path="res://src/main/ui/settings/SettingsMenu.tscn" type="PackedScene" id=7]
 [ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=13]
 [ext_resource path="res://src/main/chat/ui/ChatUi.tscn" type="PackedScene" id=15]
 [ext_resource path="res://src/main/ui/FpsLabel.tscn" type="PackedScene" id=18]
 [ext_resource path="res://src/main/ui/VersionLabel.tscn" type="PackedScene" id=19]
 [ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=20]
+
+[sub_resource type="StyleBoxEmpty" id=16]
+
+[sub_resource type="StyleBoxEmpty" id=17]
+
+[sub_resource type="StyleBoxEmpty" id=18]
+
+[sub_resource type="StyleBoxEmpty" id=19]
+
+[sub_resource type="StyleBoxEmpty" id=20]
+
+[sub_resource type="InputEventAction" id=15]
+action = "ui_cancel"
+
+[sub_resource type="ShortCut" id=21]
+shortcut = SubResource( 15 )
 
 [node name="CutsceneUi" type="CanvasLayer" groups=["overworld_ui"]]
 script = ExtResource( 1 )
@@ -52,12 +73,57 @@ margin_bottom = 280.0
 [node name="ChatUi" parent="." instance=ExtResource( 15 )]
 visible = false
 
+[node name="Buttons" type="Control" parent="."]
+modulate = Color( 1, 1, 1, 0.627451 )
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+script = ExtResource( 2 )
+
+[node name="Northeast" type="HBoxContainer" parent="Buttons"]
+anchor_left = 1.0
+anchor_right = 1.0
+margin_left = -512.0
+margin_top = 10.0
+margin_right = -10.0
+margin_bottom = 110.0
+rect_min_size = Vector2( 100, 100 )
+mouse_filter = 2
+custom_constants/separation = 10
+alignment = 2
+
+[node name="SettingsButton" parent="Buttons/Northeast" instance=ExtResource( 6 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 402.0
+margin_right = 502.0
+margin_bottom = 100.0
+focus_mode = 2
+custom_styles/hover = SubResource( 16 )
+custom_styles/pressed = SubResource( 17 )
+custom_styles/focus = SubResource( 18 )
+custom_styles/disabled = SubResource( 19 )
+custom_styles/normal = SubResource( 20 )
+shortcut = SubResource( 21 )
+icon = ExtResource( 3 )
+expand_icon = true
+normal_icon = ExtResource( 3 )
+pressed_icon = ExtResource( 4 )
+
 [node name="CheatCodeDetector" parent="." instance=ExtResource( 20 )]
 codes = [ "bigfps" ]
+
+[node name="SettingsMenu" parent="." instance=ExtResource( 7 )]
+quit_type = 1
 
 [node name="MusicPopup" parent="." instance=ExtResource( 13 )]
 
 [connection signal="chat_event_played" from="ChatUi" to="." method="_on_ChatUi_chat_event_played"]
 [connection signal="chat_finished" from="ChatUi" to="." method="_on_ChatUi_chat_finished"]
 [connection signal="showed_choices" from="ChatUi" to="." method="_on_ChatUi_showed_choices"]
+[connection signal="pressed" from="Buttons/Northeast/SettingsButton" to="SettingsMenu" method="_on_Settings_pressed"]
 [connection signal="cheat_detected" from="CheatCodeDetector" to="Labels/SoutheastLabels/FpsLabel" method="_on_CheatCodeDetector_cheat_detected"]
+[connection signal="hide" from="SettingsMenu" to="." method="_on_SettingsMenu_hide"]
+[connection signal="hide" from="SettingsMenu" to="Buttons" method="_on_Menu_hide"]
+[connection signal="quit_pressed" from="SettingsMenu" to="." method="_on_SettingsMenu_quit_pressed"]
+[connection signal="show" from="SettingsMenu" to="Buttons" method="_on_Menu_show"]

--- a/project/src/main/world/cutscene-ui.gd
+++ b/project/src/main/world/cutscene-ui.gd
@@ -28,3 +28,21 @@ func _apply_chat_event_meta(chat_event: ChatEvent, meta_item: String) -> void:
 				if creature.creature_id == chat_event.who:
 					delay = 0.0
 				walking_buddy.start_walking(delay)
+
+
+func _on_SettingsMenu_quit_pressed() -> void:
+	PlayerData.cutscene_queue.reset()
+	
+	if Breadcrumb.trail.size() >= 2 and Breadcrumb.trail[1] == Global.SCENE_CAREER_MAP:
+		# When quitting a career mode cutscene, quit career mode entirely
+		Breadcrumb.initialize_trail()
+		SceneTransition.push_trail(Global.SCENE_MAIN_MENU)
+	else:
+		SceneTransition.pop_trail()
+
+
+func _on_SettingsMenu_hide() -> void:
+	if not _chat_ui:
+		return
+	
+	_chat_ui.grab_focus()

--- a/project/src/main/world/overworld-buttons.gd
+++ b/project/src/main/world/overworld-buttons.gd
@@ -2,9 +2,6 @@ extends Control
 ## Manages the buttons for the overworld.
 
 func _ready() -> void:
-	var overworld_ui: OverworldUi = Global.get_overworld_ui()
-	overworld_ui.connect("chat_started", self, "_on_OverworldUi_chat_started")
-	overworld_ui.connect("chat_ended", self, "_on_OverworldUi_chat_ended")
 	for button in [$Northeast/SettingsButton]:
 		button.connect("resized", self, "_on_Button_resized", [button])
 	yield(get_tree(), "idle_frame")
@@ -23,14 +20,6 @@ func _on_Menu_show() -> void:
 
 
 func _on_Menu_hide() -> void:
-	show()
-
-
-func _on_OverworldUi_chat_started() -> void:
-	hide()
-
-
-func _on_OverworldUi_chat_ended() -> void:
 	show()
 
 


### PR DESCRIPTION
Added a 'quit' button to the CutsceneUI. The player can quit by pressing the button or hitting escape.

ChatChoices no longer suppresses player input; this was vestigial behavior from when the player could run around in free roam mode and talk to people.