### PR TITLE
Bug: Settings menu always resulted in save confirmation

### DIFF
--- a/project/src/main/data/system-data.gd
+++ b/project/src/main/data/system-data.gd
@@ -15,6 +15,9 @@ var misc_settings := MiscSettings.new()
 ## We accelerate scene transitions and animations during development.
 var fast_mode := OS.is_debug_build()
 
+## If 'true', the player has pending configuration changes which need to be saved
+var has_unsaved_changes := false
+
 ## We store the non-fullscreened window size so we can restore it when the player disables fullscreen mode.
 var _prev_window_size: Vector2 = Global.window_size
 var _prev_window_position: Vector2 = OS.window_position
@@ -37,6 +40,7 @@ func _ready() -> void:
 func _input(_event: InputEvent) -> void:
 	if Input.is_action_just_pressed("fullscreen"):
 		SystemData.graphics_settings.fullscreen = !SystemData.graphics_settings.fullscreen
+		SystemData.has_unsaved_changes = true
 		SystemSave.save_system_data()
 		get_tree().set_input_as_handled()
 
@@ -61,6 +65,7 @@ func reset() -> void:
 	touch_settings.reset()
 	keybind_settings.reset()
 	misc_settings.reset()
+	has_unsaved_changes = false
 
 
 ## Apply the vsync/maximized settings.

--- a/project/src/main/data/system-save.gd
+++ b/project/src/main/data/system-save.gd
@@ -76,6 +76,8 @@ func save_system_data() -> void:
 		# Preserve turbofat0.save.bak, but delete the hourly/daily/weekly backups
 		for save_slot_filename in OLD_SAVES_TO_DELETE:
 			Directory.new().remove(save_slot_filename)
+	
+	SystemData.has_unsaved_changes = false
 	emit_signal("after_save")
 
 

--- a/project/src/main/settings/misc-settings.gd
+++ b/project/src/main/settings/misc-settings.gd
@@ -50,6 +50,7 @@ func advance_locale() -> void:
 	var new_locale_index := (locales.find(old_locale) + 1) % locales.size()
 	var new_locale: String = locales[new_locale_index]
 	SystemData.misc_settings.set_locale(new_locale)
+	SystemData.has_unsaved_changes = true
 
 
 func set_save_slot(new_save_slot: int) -> void:

--- a/project/src/main/ui/settings/keybind/custom-keybind-button.gd
+++ b/project/src/main/ui/settings/keybind/custom-keybind-button.gd
@@ -21,6 +21,7 @@ func _input(event: InputEvent) -> void:
 		if input_json:
 			accept_event()
 			SystemData.keybind_settings.set_custom_keybind(action_name, action_index, input_json)
+			SystemData.has_unsaved_changes = true
 			end_awaiting()
 
 

--- a/project/src/main/ui/settings/keybind/custom-keybind-row.gd
+++ b/project/src/main/ui/settings/keybind/custom-keybind-row.gd
@@ -30,6 +30,7 @@ func _refresh_description_label() -> void:
 
 
 func _on_Delete_pressed() -> void:
+	SystemData.has_unsaved_changes = true
 	if action_name in KeybindSettings.MENU_ACTION_NAMES:
 		SystemData.keybind_settings.restore_default_keybinds(action_name)
 	else:

--- a/project/src/main/ui/settings/keybind/settings-keybinds-control.gd
+++ b/project/src/main/ui/settings/keybind/settings-keybinds-control.gd
@@ -69,16 +69,19 @@ func _refresh_keybind_labels() -> void:
 
 func _on_Guideline_pressed() -> void:
 	SystemData.keybind_settings.preset = KeybindSettings.GUIDELINE
+	SystemData.has_unsaved_changes = true
 	_refresh_keybind_labels()
 
 
 func _on_Wasd_pressed() -> void:
 	SystemData.keybind_settings.preset = KeybindSettings.WASD
+	SystemData.has_unsaved_changes = true
 	_refresh_keybind_labels()
 
 
 func _on_Custom_pressed() -> void:
 	SystemData.keybind_settings.preset = KeybindSettings.CUSTOM
+	SystemData.has_unsaved_changes = true
 	_refresh_keybind_labels()
 
 

--- a/project/src/main/ui/settings/reset-gameplay-button.gd
+++ b/project/src/main/ui/settings/reset-gameplay-button.gd
@@ -5,3 +5,4 @@ extends Button
 
 func _pressed() -> void:
 	SystemData.gameplay_settings.reset()
+	SystemData.has_unsaved_changes = true

--- a/project/src/main/ui/settings/settings-creature-detail.gd
+++ b/project/src/main/ui/settings/settings-creature-detail.gd
@@ -13,6 +13,7 @@ func _ready() -> void:
 
 func _on_OptionButton_item_selected(_index: int) -> void:
 	SystemData.graphics_settings.creature_detail = _index
+	SystemData.has_unsaved_changes = true
 
 
 ## When the player changes the detail levels, we add an asterisk.

--- a/project/src/main/ui/settings/settings-feeding-animation.gd
+++ b/project/src/main/ui/settings/settings-feeding-animation.gd
@@ -11,3 +11,4 @@ func _ready() -> void:
 
 func _on_OptionButton_item_selected(_index: int) -> void:
 	SystemData.graphics_settings.feeding_animation = _index
+	SystemData.has_unsaved_changes = true

--- a/project/src/main/ui/settings/settings-fullscreen.gd
+++ b/project/src/main/ui/settings/settings-fullscreen.gd
@@ -21,6 +21,7 @@ func _refresh_checkbox() -> void:
 
 func _on_CheckBox_pressed() -> void:
 	SystemData.graphics_settings.fullscreen = _check_box.pressed
+	SystemData.has_unsaved_changes = true
 
 
 func _on_GraphicsSettings_fullscreen_changed(_value: bool) -> void:

--- a/project/src/main/ui/settings/settings-gameplay-speed.gd
+++ b/project/src/main/ui/settings/settings-gameplay-speed.gd
@@ -28,6 +28,7 @@ func _refresh() -> void:
 func _on_OptionButton_item_selected(index: int) -> void:
 	var item_id := _option_button.get_item_id(index)
 	SystemData.gameplay_settings.speed = item_id
+	SystemData.has_unsaved_changes = true
 
 
 func _on_GameplaySettings_speed_changed(_value: int) -> void:

--- a/project/src/main/ui/settings/settings-ghost-piece.gd
+++ b/project/src/main/ui/settings/settings-ghost-piece.gd
@@ -13,7 +13,11 @@ func _refresh() -> void:
 
 
 func _on_CheckBox_toggled(_button_pressed: bool) -> void:
+	if SystemData.gameplay_settings.ghost_piece == _check_box.pressed:
+		return
+	
 	SystemData.gameplay_settings.ghost_piece = _check_box.pressed
+	SystemData.has_unsaved_changes = true
 
 
 func _on_GameplaySettings_ghost_piece_changed(_value: bool) -> void:

--- a/project/src/main/ui/settings/settings-hold-piece.gd
+++ b/project/src/main/ui/settings/settings-hold-piece.gd
@@ -14,6 +14,7 @@ func _refresh() -> void:
 
 func _on_CheckBox_toggled(_button_pressed: bool) -> void:
 	SystemData.gameplay_settings.hold_piece = _check_box.pressed
+	SystemData.has_unsaved_changes = true
 
 
 func _on_GameplaySettings_hold_piece_changed(_value: bool) -> void:

--- a/project/src/main/ui/settings/settings-language.gd
+++ b/project/src/main/ui/settings/settings-language.gd
@@ -52,3 +52,4 @@ func _current_loaded_locale() -> String:
 func _on_OptionButton_item_selected(_index: int) -> void:
 	# update the locale to the selected locale
 	SystemData.misc_settings.set_locale(TranslationServer.get_loaded_locales()[_index])
+	SystemData.has_unsaved_changes = true

--- a/project/src/main/ui/settings/settings-line-piece.gd
+++ b/project/src/main/ui/settings/settings-line-piece.gd
@@ -13,6 +13,7 @@ func _refresh() -> void:
 
 
 func _on_CheckBox_toggled(_button_pressed: bool) -> void:
+	SystemData.has_unsaved_changes = true
 	SystemData.gameplay_settings.line_piece = _check_box.pressed
 
 

--- a/project/src/main/ui/settings/settings-lock-cancel.gd
+++ b/project/src/main/ui/settings/settings-lock-cancel.gd
@@ -14,7 +14,11 @@ func _refresh() -> void:
 
 
 func _on_CheckBox_toggled(_button_pressed: bool) -> void:
+	if SystemData.gameplay_settings.soft_drop_lock_cancel == _check_box.pressed:
+		return
+	
 	SystemData.gameplay_settings.soft_drop_lock_cancel = _check_box.pressed
+	SystemData.has_unsaved_changes = true
 
 
 func _on_GameplaySettings_soft_drop_lock_cancel_changed(_value: bool) -> void:

--- a/project/src/main/ui/settings/settings-menu.gd
+++ b/project/src/main/ui/settings/settings-menu.gd
@@ -93,7 +93,8 @@ func _confirm_and_save(new_post_save_method: String, new_post_save_args_array: A
 	if _save_slot_control.get_selected_save_slot() != SystemData.misc_settings.save_slot:
 		_dialogs.confirm_new_save_slot()
 	else:
-		SystemSave.save_system_data()
+		if SystemData.has_unsaved_changes:
+			SystemSave.save_system_data()
 		hide()
 		if _post_save_method:
 			callv(_post_save_method, _post_save_args_array)
@@ -144,7 +145,8 @@ func _on_Settings_pressed() -> void:
 
 func _on_Dialogs_change_save_cancelled() -> void:
 	_save_slot_control.revert_save_slot()
-	SystemSave.save_system_data()
+	if SystemData.has_unsaved_changes:
+		SystemSave.save_system_data()
 	hide()
 	if _post_save_method:
 		callv(_post_save_method, _post_save_args_array)
@@ -153,6 +155,7 @@ func _on_Dialogs_change_save_cancelled() -> void:
 func _on_Dialogs_change_save_confirmed() -> void:
 	# update and save the player's save slot choice in SystemData
 	SystemData.misc_settings.save_slot = _save_slot_control.get_selected_save_slot()
+	SystemData.has_unsaved_changes = true
 	SystemSave.save_system_data()
 	
 	# load the save slot contents and return the player to the splash screen

--- a/project/src/main/ui/settings/settings-touch-fat-finger.gd
+++ b/project/src/main/ui/settings/settings-touch-fat-finger.gd
@@ -18,3 +18,4 @@ func _ready() -> void:
 
 func _on_OptionButton_item_selected(id: int) -> void:
 	SystemData.touch_settings.fat_finger = VALUES[id]
+	SystemData.has_unsaved_changes = true

--- a/project/src/main/ui/settings/settings-touch-scheme.gd
+++ b/project/src/main/ui/settings/settings-touch-scheme.gd
@@ -17,3 +17,4 @@ func _ready() -> void:
 
 func _on_OptionButton_item_selected(id: int) -> void:
 	SystemData.touch_settings.scheme = id
+	SystemData.has_unsaved_changes = true

--- a/project/src/main/ui/settings/settings-touch-size.gd
+++ b/project/src/main/ui/settings/settings-touch-size.gd
@@ -13,4 +13,6 @@ func _ready() -> void:
 func _on_HSlider_value_changed(index: float) -> void:
 	var value: float = VALUES[int(index)]
 	$Control/Text.text = "%04.2fx" % value
-	SystemData.touch_settings.size = value
+	if SystemData.touch_settings.size != value:
+		SystemData.touch_settings.size = value
+		SystemData.has_unsaved_changes = true

--- a/project/src/main/ui/settings/settings-use-vsync.gd
+++ b/project/src/main/ui/settings/settings-use-vsync.gd
@@ -8,4 +8,8 @@ func _ready() -> void:
 
 
 func _on_CheckBox_pressed() -> void:
+	if SystemData.graphics_settings.use_vsync == _check_box.pressed:
+		return
+	
 	SystemData.graphics_settings.use_vsync = _check_box.pressed
+	SystemData.has_unsaved_changes = true

--- a/project/src/main/ui/settings/volume-setting-control.gd
+++ b/project/src/main/ui/settings/volume-setting-control.gd
@@ -61,6 +61,7 @@ func _refresh_setting_label() -> void:
 func _on_HSlider_value_changed(value: float) -> void:
 	_refresh_percent_label()
 	SystemData.volume_settings.set_bus_volume_linear(volume_type, value)
+	SystemData.has_unsaved_changes = true
 	_sample_timer.start()
 
 


### PR DESCRIPTION
The settings menu always saved the player's data and displayed the little spinning disk, even if the player just opened the settings menu to end a puzzle or quit career mode.

The settings menu now only saves the player's data if the player makes changes to their settings.