### PR TITLE
Improve career mode's puzzle quit behavior.

### DIFF
--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -226,15 +226,28 @@ func _start_puzzle() -> void:
 	PuzzleState.prepare_and_start_game()
 
 
-func _quit_puzzle() -> void:
-	if PlayerData.career.is_career_mode():
+## Quits/skips the current puzzle and changes scenes, navigating back one level in the breadcrumb trail.
+##
+## Parameters:
+## 	'force_quit': In Career mode, this is 'true' if the player should be redirecting out of career mode entirely,
+## 		or 'false' if the player should be redirected back to career mode.
+func _quit_puzzle(force_quit: bool = false) -> void:
+	if PlayerData.career.is_career_mode() and force_quit and CurrentLevel.attempt_count == 0:
+		# The player can quit a puzzle in career mode if they haven't attempted it
+		pass
+	elif PlayerData.career.is_career_mode():
 		PlayerData.career.process_puzzle_result()
 	
 	CurrentLevel.reset()
 	PlayerData.customer_queue.reset()
 	
-	if PlayerData.career.is_career_mode():
-		# career mode; defer to CareerData to decide the next scene.
+	if PlayerData.career.is_career_mode() and force_quit:
+		# quitting career mode; dump them back to the main menu
+		PlayerData.cutscene_queue.reset()
+		Breadcrumb.initialize_trail()
+		SceneTransition.push_trail(Global.SCENE_MAIN_MENU)
+	elif PlayerData.career.is_career_mode() and not force_quit:
+		# continuing career mode; defer to CareerData to decide the next scene.
 		PlayerData.career.push_career_trail()
 	else:
 		# not career mode; play a cutscene or return to the previous scene
@@ -376,7 +389,7 @@ func _on_SettingsMenu_quit_pressed() -> void:
 	if _settings_menu.quit_type == SettingsMenu.GIVE_UP:
 		PuzzleState.make_player_lose()
 	else:
-		_quit_puzzle()
+		_quit_puzzle(true)
 
 
 func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDetector) -> void:


### PR DESCRIPTION
Before, going into the settings menu and choosing "Quit" from a Career Mode puzzle would abort the puzzle, incurring a penalty and leaving the player in career mode.

Now, going into the settings menu and choosing "Quit" will exit Career mode. The player may still incur a penalty if they've already played and lost the level, but they can quit and play the same level again later or even pick a different level.