### PR TITLE
Removed FreeRoam cruft: chat listeners, resource ids

### DIFF
--- a/project/src/demo/world/FreeRoamUi.tscn
+++ b/project/src/demo/world/FreeRoamUi.tscn
@@ -25,11 +25,11 @@
 
 [sub_resource type="StyleBoxEmpty" id=5]
 
-[sub_resource type="InputEventAction" id=15]
+[sub_resource type="InputEventAction" id=10]
 action = "ui_cancel"
 
 [sub_resource type="ShortCut" id=9]
-shortcut = SubResource( 15 )
+shortcut = SubResource( 10 )
 
 [node name="FreeRoamUi" type="CanvasLayer" groups=["overworld_ui"]]
 script = ExtResource( 1 )


### PR DESCRIPTION
Removed 'hide settings button when the chat starts' logic from FreeRoamUI. There is no way to chat to people on the overworld anymore.