### PR TITLE
Improve quit behavior during credits

### DIFF
--- a/project/assets/main/chat/career/credits/precredits-1.chat
+++ b/project/assets/main/chat/career/credits/precredits-1.chat
@@ -7,5 +7,6 @@ credits/gift_shop
 narrator, n
 
 n: And so #player# and Fat Sensei proceeded to the Zagma gift shop, where #player# purchased their very own Zagma Chef Of The Year plaque for ¥3,000.
+ (end_day)
 n: Fat Sensei refused to help pay for the plaque. "¥3,000 is a considerable investment, it's best you do it yourself."
  (next_scene chat/career/credits/precredits_2)

--- a/project/assets/main/chat/career/credits/precredits-2.chat
+++ b/project/assets/main/chat/career/credits/precredits-2.chat
@@ -15,6 +15,7 @@ unknown, ?
  (lava_crowd start_bouncing)
  (play_sfx lava_cheer)
  (s1 mood ^_^)
+ (end_day)
 b: ^o^ Chef of the year? Wow, that's amazing!
  (s1 faces right, p1 faces right)
  (b enters)

--- a/project/assets/main/chat/career/lava/boss-level-end.chat
+++ b/project/assets/main/chat/career/lava/boss-level-end.chat
@@ -12,6 +12,7 @@ sleve, s, judge_4
 
 w: ^o^ Wow! I'd say you've officially proven your skills as a world class chef. Well done!!
  (c mood ^o^, s mood ^o^, s1 mood ^o^, p1 mood ^_^)
+ (end_day)
 c: ^o^ Yes definitely! Congratulations!
 [holy_smokes] That was an ordeal
 [phew_finally] Phew, finally

--- a/project/src/main/world/overworld-ui.gd
+++ b/project/src/main/world/overworld-ui.gd
@@ -201,16 +201,26 @@ func _apply_chat_event_meta(_chat_event: ChatEvent, meta_item: String) -> void:
 			var creature: Creature = _overworld_environment.get_creature_by_id(creature_id)
 			var orientation: int = int(meta_item_split[2])
 			creature.set_orientation(orientation)
+		"end_day":
+			_advance_to_fresh_career_day()
 		"play_credits":
 			# the credits lead directly into the main menu, so we immediately end the current career day and advance
 			# the calendar.
-			PlayerData.career.hours_passed = Careers.HOURS_PER_CAREER_DAY
-			PlayerData.career.advance_calendar()
-			PlayerSave.schedule_save()
+			_advance_to_fresh_career_day()
 			
 			PlayerData.cutscene_queue.insert_credits(0)
 	
 	emit_signal("chat_event_meta_played", meta_item)
+
+
+## If the current career day has begin, immediately end it advance the calendar.
+##
+## This is used during the credits sequence to ensure the player starts fresh after viewing the credits.
+func _advance_to_fresh_career_day() -> void:
+	if PlayerData.career.is_career_mode() and PlayerData.career.hours_passed > 0:
+		PlayerData.career.hours_passed = Careers.HOURS_PER_CAREER_DAY
+		PlayerData.career.advance_calendar()
+		PlayerSave.schedule_save()
 
 
 func _on_ChatUi_chat_finished() -> void:


### PR DESCRIPTION
Before, watching the final cutscene would end the career day, but if you exited the previous cutscenes, the player would continue into Starberry Mountain.

This isn't a big deal, but it's a little inconsistent and odd. The gameplay behavior should stay the same regardless of whether the player watches the credits or the preceding cutscenes.

I also closed a small issue where watching the cutscenes in the CutsceneDemo (or perhaps some future gallery mode) would end the current career day. The career day is now only ended if the player is watching the cutscenes from career mode.