### PR TITLE
Fixed bug where mouse remained invisible in settings menu

### DIFF
--- a/project/src/main/ui/input-manager.gd
+++ b/project/src/main/ui/input-manager.gd
@@ -1,6 +1,11 @@
 extends Node
 ## Hides the mouse cursor when joypad or keyboard input is detected.
 
+func _ready() -> void:
+	# allow the mouse to show/hide when gameplay is paused
+	pause_mode = Node.PAUSE_MODE_PROCESS
+
+
 func _input(event: InputEvent) -> void:
 	if event is InputEventMouse:
 		Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)


### PR DESCRIPTION
InputManager is supposed to toggle the mouse visible/invisible, but it was disabled when the game was paused, causing the mouse to remain invisible in the settings menu