### PR TITLE
Reconnected 'Reset to Default' gameplay settings button

### DIFF
--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=48 format=2]
+[gd_scene load_steps=49 format=2]
 
 [ext_resource path="res://src/main/ui/squeak/br/squeak-theme-h5.tres" type="Theme" id=1]
 [ext_resource path="res://src/main/ui/squeak/br/squeak-theme-h4.tres" type="Theme" id=2]
@@ -41,6 +41,7 @@
 [ext_resource path="res://src/main/ui/FontFitButton.tscn" type="PackedScene" id=39]
 [ext_resource path="res://src/main/ui/settings/settings-fullscreen.gd" type="Script" id=40]
 [ext_resource path="res://src/main/ui/TabInputEnabler.tscn" type="PackedScene" id=41]
+[ext_resource path="res://src/main/ui/settings/reset-gameplay-button.gd" type="Script" id=42]
 [ext_resource path="res://src/main/ui/squeak/br/SqueakButton.tscn" type="PackedScene" id=43]
 [ext_resource path="res://src/main/ui/squeak/br/SqueakCheckBox.tscn" type="PackedScene" id=44]
 [ext_resource path="res://src/main/ui/WarningDialog.tscn" type="PackedScene" id=45]
@@ -513,6 +514,7 @@ margin_right = 437.0
 margin_bottom = 268.0
 size_flags_horizontal = 4
 text = "Reset to Default"
+script = ExtResource( 42 )
 
 [node name="Controls" type="VBoxContainer" parent="Window/UiArea/TabContainer"]
 visible = false


### PR DESCRIPTION
This button was unhooked in 8699bb67 when changing the settings menu's UI.