### PR TITLE
Fixed translucent level select buttons

### DIFF
--- a/project/src/main/ui/level-select/LevelSelectButtonPressed.tres
+++ b/project/src/main/ui/level-select/LevelSelectButtonPressed.tres
@@ -1,7 +1,7 @@
 [gd_resource type="StyleBoxFlat" format=2]
 
 [resource]
-bg_color = Color( 0.5, 0.883333, 1, 0.501961 )
+bg_color = Color( 0.376471, 0.631373, 0.733333, 1 )
 border_width_left = 4
 border_width_top = 4
 border_width_right = 4


### PR DESCRIPTION
LevelSelectButton was briefly translucent when pressed. This looks kind of cool but it was accidental, and I've fixed it