### PR TITLE
Controller game prompts; 'enter/click' -> 'press'

### DIFF
--- a/project/assets/main/locale/en.po
+++ b/project/assets/main/locale/en.po
@@ -15012,10 +15012,10 @@ msgstr "DPAD"
 
 #: project/src/main/puzzle/tutorial-keybinds-label.gd:23
 msgid ""
-"What have you done!? Click 'Settings' to reconfigure your controls, you "
+"What have you done!? Go into 'Settings' and reconfigure your controls, you "
 "silly goose!"
 msgstr ""
-"What have you done!? Click 'Settings' to reconfigure your controls, you "
+"What have you done!? Go into 'Settings' and reconfigure your controls, you "
 "silly goose!"
 
 #: project/src/main/puzzle/level/level-settings.gd:147
@@ -17292,8 +17292,8 @@ msgid "Voice Volume"
 msgstr ""
 
 #: project/src/main/ui/settings/keybind/custom-keybind-button.gd:54
-msgid "<Enter Key>"
-msgstr "<Enter Key>"
+msgid "<Enter...>"
+msgstr "<Enter...>"
 
 #: project/src/main/ui/settings/keybind/settings-keybinds-control.gd:45
 msgid "Left, Right, Kp 4, Kp 6"

--- a/project/assets/main/locale/es.po
+++ b/project/assets/main/locale/es.po
@@ -15735,11 +15735,12 @@ msgid "DPAD"
 msgstr "DPAD"
 
 #: project/src/main/puzzle/tutorial-keybinds-label.gd:23
+#, fuzzy
 msgid ""
-"What have you done!? Click 'Settings' to reconfigure your controls, you "
+"What have you done!? Go into 'Settings' and reconfigure your controls, you "
 "silly goose!"
 msgstr ""
-"¿¡Qué has hecho!? Haz clic en 'Configuración' para reconfigurar tus "
+"¿¡Qué has hecho!? Ve a 'Configuración' y reconfigura tus "
 "controles, ¡tonto!"
 
 #: project/src/main/puzzle/level/level-settings.gd:147
@@ -18067,8 +18068,9 @@ msgid "Voice Volume"
 msgstr "Volumen de Voces"
 
 #: project/src/main/ui/settings/keybind/custom-keybind-button.gd:54
-msgid "<Enter Key>"
-msgstr "<Tecla>"
+#, fuzzy
+msgid "<Enter...>"
+msgstr "<Pulsa...>"
 
 #: project/src/main/ui/settings/keybind/settings-keybinds-control.gd:45
 msgid "Left, Right, Kp 4, Kp 6"

--- a/project/assets/main/locale/messages.pot
+++ b/project/assets/main/locale/messages.pot
@@ -14126,7 +14126,7 @@ msgstr ""
 
 #: project/src/main/puzzle/tutorial-keybinds-label.gd:23
 msgid ""
-"What have you done!? Click 'Settings' to reconfigure your controls, you "
+"What have you done!? Go into 'Settings' and reconfigure your controls, you "
 "silly goose!"
 msgstr ""
 
@@ -16087,7 +16087,7 @@ msgid "Voice Volume"
 msgstr ""
 
 #: project/src/main/ui/settings/keybind/custom-keybind-button.gd:54
-msgid "<Enter Key>"
+msgid "<Enter...>"
 msgstr ""
 
 #: project/src/main/ui/settings/keybind/settings-keybinds-control.gd:45

--- a/project/src/main/puzzle/tutorial-keybinds-label.gd
+++ b/project/src/main/puzzle/tutorial-keybinds-label.gd
@@ -20,7 +20,7 @@ func _refresh_message() -> void:
 	
 	if not text:
 		# If the player unbinds all of their keys, they can't play.
-		text = tr("What have you done!? Click 'Settings' to reconfigure your controls, you silly goose!")
+		text = tr("What have you done!? Go into 'Settings' and reconfigure your controls, you silly goose!")
 	
 	rect_size = Vector2(238, 0)
 

--- a/project/src/main/ui/settings/keybind/custom-keybind-button.gd
+++ b/project/src/main/ui/settings/keybind/custom-keybind-button.gd
@@ -51,7 +51,7 @@ func _start_awaiting() -> void:
 	
 	pressed = true
 	awaiting = true
-	text = tr("<Enter Key>")
+	text = tr("<Enter...>")
 	emit_signal("awaiting_changed", awaiting)
 
 


### PR DESCRIPTION
Changed the custom controller prompt from 'enter key' to 'press...' Enter key is nonsensical for players using a controller.

Changed the tutorial prompt for players who unbind their controls from 'Click...' to 'Go into...'. Click is specifically for mouse and keyboard players, it doesn't make sense for a controller