### PR TITLE
Tweak time rounding: 20:33 -> 21:00

### DIFF
--- a/project/src/main/puzzle/ranks.gd
+++ b/project/src/main/puzzle/ranks.gd
@@ -63,9 +63,9 @@ static func round_time_up(value: int) -> int:
 	var magnitude: int
 	if value <= 60:
 		magnitude = 1
-	elif value <= 600:
+	elif value <= 300:
 		magnitude = 5
-	elif value <= 6000:
+	elif value <= 1200:
 		magnitude = 10
 	else:
 		magnitude = 60

--- a/project/src/test/puzzle/test-ranks.gd
+++ b/project/src/test/puzzle/test-ranks.gd
@@ -54,19 +54,20 @@ func test_round_time_up() -> void:
 	assert_eq(Ranks.round_time_up(44), 44)
 	assert_eq(Ranks.round_time_up(60), 60)
 	
-	# numbers 61-600 are rounded up to the nearest 5
+	# numbers 61-300 are rounded up to the nearest 5
 	assert_eq(Ranks.round_time_up(61), 65)
 	assert_eq(Ranks.round_time_up(239), 240)
-	assert_eq(Ranks.round_time_up(494), 495)
-	assert_eq(Ranks.round_time_up(600), 600)
+	assert_eq(Ranks.round_time_up(294), 295)
+	assert_eq(Ranks.round_time_up(300), 300)
 	
-	# numbers 600-3599 are rounded up to the nearest 10
-	assert_eq(Ranks.round_time_up(601), 610)
-	assert_eq(Ranks.round_time_up(2095), 2100)
-	assert_eq(Ranks.round_time_up(2948), 2950)
+	# numbers 300-1199 are rounded up to the nearest 10
+	assert_eq(Ranks.round_time_up(301), 310)
+	assert_eq(Ranks.round_time_up(895), 900)
+	assert_eq(Ranks.round_time_up(1191), 1200)
+	assert_eq(Ranks.round_time_up(1200), 1200)
 	
-	# numbers over 3600 are rounded up to the nearest 60
-	assert_eq(Ranks.round_time_up(5321), 5330)
+	# numbers over 1200 are rounded up to the nearest 60
+	assert_eq(Ranks.round_time_up(1201), 1260)
 	assert_eq(Ranks.round_time_up(93546), 93600)
 	assert_eq(Ranks.round_time_up(25133386), 25133400)
 


### PR DESCRIPTION
Times over 20:00 are now rounded to the nearest minute. This is not likely to ever matter, but cosmetically I think it's better to tell the player "Finish this level in 22:00" instead of "Finish this level in 22:20"