### PR TITLE
Fixed bogus intro receit listener.

### DIFF
--- a/project/src/main/puzzle/intro/intro-receipt.gd
+++ b/project/src/main/puzzle/intro/intro-receipt.gd
@@ -8,7 +8,7 @@ var _popped_out := false
 
 func _ready() -> void:
 	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
-	PuzzleState.connect("after_game_ended", self, "_on_PuzzleState_after_game_ended")
+	PuzzleState.connect("game_started", self, "_on_PuzzleState_game_started")
 	CurrentLevel.connect("settings_changed", self, "_on_Level_settings_changed")
 	
 	_refresh()


### PR DESCRIPTION
This listener caused a warning, and the absence of a 'game started' listener could have caused the intro receipt to pop up in some edge cases, probably.