### PR TITLE
Soft Drop Lock Cancel tweaks: default off, description field.

### DIFF
--- a/project/assets/main/locale/en.po
+++ b/project/assets/main/locale/en.po
@@ -17104,7 +17104,11 @@ msgstr "Ghost Piece"
 msgid "Soft Drop Lock Cancel"
 msgstr "Soft Drop Lock Cancel"
 
-#: project/src/main/ui/settings/SettingsMenu.tscn:417
+#: project/src/main/ui/settings/SettingsMenu.tscn:420
+msgid "Pieces that are Hard Dropped can be unlocked by pressing Soft Drop."
+msgstr ""
+
+#: project/src/main/ui/settings/SettingsMenu.tscn:439
 msgid "Cheats"
 msgstr "Cheats"
 

--- a/project/assets/main/locale/es.po
+++ b/project/assets/main/locale/es.po
@@ -17888,7 +17888,12 @@ msgstr "Pieza Fantasma"
 msgid "Soft Drop Lock Cancel"
 msgstr "Cancelar Asegurado con Caída Lenta"
 
-#: project/src/main/ui/settings/SettingsMenu.tscn:417
+#: project/src/main/ui/settings/SettingsMenu.tscn:420
+#, fuzzy
+msgid "Pieces that are Hard Dropped can be unlocked by pressing Soft Drop."
+msgstr "Las piezas que se Caen Rápido pueden desbloquearse presionando Caída Lenta."
+
+#: project/src/main/ui/settings/SettingsMenu.tscn:439
 msgid "Cheats"
 msgstr "Trucos"
 

--- a/project/assets/main/locale/messages.pot
+++ b/project/assets/main/locale/messages.pot
@@ -15899,7 +15899,11 @@ msgstr ""
 msgid "Soft Drop Lock Cancel"
 msgstr ""
 
-#: project/src/main/ui/settings/SettingsMenu.tscn:417
+#: project/src/main/ui/settings/SettingsMenu.tscn:420
+msgid "Pieces that are Hard Dropped can be unlocked by pressing Soft Drop."
+msgstr ""
+
+#: project/src/main/ui/settings/SettingsMenu.tscn:439
 msgid "Cheats"
 msgstr ""
 

--- a/project/src/main/settings/gameplay-settings.gd
+++ b/project/src/main/settings/gameplay-settings.gd
@@ -44,7 +44,7 @@ var hold_piece := false setget set_hold_piece
 var line_piece := false setget set_line_piece
 
 ## 'true' if pressing soft drop should perform a lock cancel
-var soft_drop_lock_cancel := true setget set_soft_drop_lock_cancel
+var soft_drop_lock_cancel := false setget set_soft_drop_lock_cancel
 
 ## Current gameplay speed. The player can reduce this to make the game easier. They can also increase it to make
 ## the game harder, or to cheat on levels which otherwise require slow and thoughtful play.
@@ -104,7 +104,7 @@ func from_json_dict(json: Dictionary) -> void:
 	set_ghost_piece(json.get("ghost_piece", true))
 	set_hold_piece(json.get("hold_piece", false))
 	set_line_piece(json.get("line_piece", false))
-	set_soft_drop_lock_cancel(json.get("soft_drop_lock_cancel", true))
+	set_soft_drop_lock_cancel(json.get("soft_drop_lock_cancel", false))
 	set_speed(Utils.enum_from_snake_case(Speed, json.get("speed", "")))
 
 

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -337,7 +337,7 @@ follow_focus = true
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Window/UiArea/TabContainer/Gameplay"]
 margin_right = 736.0
-margin_bottom = 268.0
+margin_bottom = 279.0
 size_flags_horizontal = 3
 
 [node name="GhostPiece" type="HBoxContainer" parent="Window/UiArea/TabContainer/Gameplay/VBoxContainer"]
@@ -372,7 +372,7 @@ size_flags_stretch_ratio = 0.94
 [node name="LockCancel" type="HBoxContainer" parent="Window/UiArea/TabContainer/Gameplay/VBoxContainer"]
 margin_top = 38.0
 margin_right = 736.0
-margin_bottom = 70.0
+margin_bottom = 81.0
 rect_min_size = Vector2( 400, 26 )
 size_flags_horizontal = 3
 custom_constants/separation = 20
@@ -380,7 +380,7 @@ script = ExtResource( 28 )
 
 [node name="Label" type="Label" parent="Window/UiArea/TabContainer/Gameplay/VBoxContainer/LockCancel"]
 margin_right = 287.0
-margin_bottom = 32.0
+margin_bottom = 43.0
 rect_min_size = Vector2( 120, 28 )
 size_flags_horizontal = 3
 size_flags_vertical = 5
@@ -390,27 +390,49 @@ align = 2
 valign = 1
 autowrap = true
 
-[node name="CheckBox" parent="Window/UiArea/TabContainer/Gameplay/VBoxContainer/LockCancel" instance=ExtResource( 44 )]
+[node name="HBoxContainer" type="HBoxContainer" parent="Window/UiArea/TabContainer/Gameplay/VBoxContainer/LockCancel"]
 margin_left = 307.0
 margin_right = 736.0
-margin_bottom = 32.0
+margin_bottom = 43.0
 rect_min_size = Vector2( 160, 26 )
+focus_mode = 2
+mouse_filter = 0
 size_flags_horizontal = 3
 size_flags_vertical = 4
 size_flags_stretch_ratio = 0.94
+__meta__ = {
+"_editor_description_": ""
+}
+
+[node name="CheckBox" parent="Window/UiArea/TabContainer/Gameplay/VBoxContainer/LockCancel/HBoxContainer" instance=ExtResource( 44 )]
+margin_right = 38.0
+margin_bottom = 43.0
+
+[node name="Description" type="Label" parent="Window/UiArea/TabContainer/Gameplay/VBoxContainer/LockCancel/HBoxContainer"]
+modulate = Color( 1, 1, 1, 0.501961 )
+margin_left = 44.0
+margin_right = 429.0
+margin_bottom = 43.0
+rect_min_size = Vector2( 120, 0 )
+size_flags_horizontal = 3
+size_flags_vertical = 5
+size_flags_stretch_ratio = 0.63
+text = "Pieces that are Hard Dropped can be unlocked by pressing Soft Drop."
+valign = 1
+autowrap = true
 
 [node name="Spacer1" type="Control" parent="Window/UiArea/TabContainer/Gameplay/VBoxContainer"]
-margin_top = 76.0
+margin_top = 87.0
 margin_right = 736.0
-margin_bottom = 96.0
+margin_bottom = 107.0
 rect_min_size = Vector2( 0, 20 )
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.1
 
 [node name="Cheats" type="Label" parent="Window/UiArea/TabContainer/Gameplay/VBoxContainer"]
-margin_top = 102.0
+margin_top = 113.0
 margin_right = 736.0
-margin_bottom = 122.0
+margin_bottom = 133.0
 rect_min_size = Vector2( 120, 0 )
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.5
@@ -418,9 +440,9 @@ text = "Cheats"
 align = 1
 
 [node name="Speed" type="HBoxContainer" parent="Window/UiArea/TabContainer/Gameplay/VBoxContainer"]
-margin_top = 128.0
+margin_top = 139.0
 margin_right = 736.0
-margin_bottom = 157.0
+margin_bottom = 168.0
 rect_min_size = Vector2( 400, 26 )
 size_flags_horizontal = 3
 custom_constants/separation = 20
@@ -448,9 +470,9 @@ size_flags_vertical = 4
 size_flags_stretch_ratio = 1.1
 
 [node name="LinePiece" type="HBoxContainer" parent="Window/UiArea/TabContainer/Gameplay/VBoxContainer"]
-margin_top = 163.0
+margin_top = 174.0
 margin_right = 736.0
-margin_bottom = 195.0
+margin_bottom = 206.0
 rect_min_size = Vector2( 400, 26 )
 size_flags_horizontal = 3
 custom_constants/separation = 20
@@ -478,9 +500,9 @@ size_flags_vertical = 4
 size_flags_stretch_ratio = 0.94
 
 [node name="HoldPiece" type="HBoxContainer" parent="Window/UiArea/TabContainer/Gameplay/VBoxContainer"]
-margin_top = 201.0
+margin_top = 212.0
 margin_right = 736.0
-margin_bottom = 233.0
+margin_bottom = 244.0
 rect_min_size = Vector2( 400, 26 )
 size_flags_horizontal = 3
 custom_constants/separation = 20
@@ -509,9 +531,9 @@ size_flags_stretch_ratio = 0.94
 
 [node name="ResetToDefault" parent="Window/UiArea/TabContainer/Gameplay/VBoxContainer" instance=ExtResource( 43 )]
 margin_left = 298.0
-margin_top = 239.0
+margin_top = 250.0
 margin_right = 437.0
-margin_bottom = 268.0
+margin_bottom = 279.0
 size_flags_horizontal = 4
 text = "Reset to Default"
 script = ExtResource( 42 )
@@ -571,13 +593,13 @@ size_flags_vertical = 3
 follow_focus = true
 
 [node name="CenterContainer" type="CenterContainer" parent="Window/UiArea/TabContainer/Controls/PresetScrollContainer"]
-margin_right = 712.0
+margin_right = 736.0
 margin_bottom = 300.0
 size_flags_horizontal = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Window/UiArea/TabContainer/Controls/PresetScrollContainer/CenterContainer"]
-margin_left = 106.0
-margin_right = 606.0
+margin_left = 118.0
+margin_right = 618.0
 margin_bottom = 300.0
 rect_min_size = Vector2( 500, 0 )
 size_flags_horizontal = 0
@@ -1379,7 +1401,7 @@ icon_color = Color( 1, 0.866667, 0.6, 1 )
 [connection signal="item_selected" from="Window/UiArea/TabContainer/SoundAndGraphics/VBoxContainer/CreatureDetail/OptionButton" to="Window/UiArea/TabContainer/SoundAndGraphics/VBoxContainer/CreatureDetail" method="_on_OptionButton_item_selected"]
 [connection signal="item_selected" from="Window/UiArea/TabContainer/SoundAndGraphics/VBoxContainer/FeedingAnimation/OptionButton" to="Window/UiArea/TabContainer/SoundAndGraphics/VBoxContainer/FeedingAnimation" method="_on_OptionButton_item_selected"]
 [connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/VBoxContainer/GhostPiece/CheckBox" to="Window/UiArea/TabContainer/Gameplay/VBoxContainer/GhostPiece" method="_on_CheckBox_toggled"]
-[connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/VBoxContainer/LockCancel/CheckBox" to="Window/UiArea/TabContainer/Gameplay/VBoxContainer/LockCancel" method="_on_CheckBox_toggled"]
+[connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/VBoxContainer/LockCancel/HBoxContainer/CheckBox" to="Window/UiArea/TabContainer/Gameplay/VBoxContainer/LockCancel" method="_on_CheckBox_toggled"]
 [connection signal="item_selected" from="Window/UiArea/TabContainer/Gameplay/VBoxContainer/Speed/OptionButton" to="Window/UiArea/TabContainer/Gameplay/VBoxContainer/Speed" method="_on_OptionButton_item_selected"]
 [connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/VBoxContainer/LinePiece/CheckBox" to="Window/UiArea/TabContainer/Gameplay/VBoxContainer/LinePiece" method="_on_CheckBox_toggled"]
 [connection signal="toggled" from="Window/UiArea/TabContainer/Gameplay/VBoxContainer/HoldPiece/CheckBox" to="Window/UiArea/TabContainer/Gameplay/VBoxContainer/HoldPiece" method="_on_CheckBox_toggled"]

--- a/project/src/main/ui/settings/settings-lock-cancel.gd
+++ b/project/src/main/ui/settings/settings-lock-cancel.gd
@@ -1,7 +1,8 @@
 extends Control
 ## UI control for toggling the soft drop lock cancel.
 
-onready var _check_box := $CheckBox
+onready var _check_box := $HBoxContainer/CheckBox
+onready var _description := $HBoxContainer/Description
 
 func _ready() -> void:
 	SystemData.gameplay_settings.connect("soft_drop_lock_cancel_changed", self,
@@ -11,6 +12,8 @@ func _ready() -> void:
 
 func _refresh() -> void:
 	_check_box.pressed = SystemData.gameplay_settings.soft_drop_lock_cancel
+	_description.modulate = Color(1.0, 1.0, 1.0, 0.5) if SystemData.gameplay_settings.soft_drop_lock_cancel \
+			else Color.transparent
 
 
 func _on_CheckBox_toggled(_button_pressed: bool) -> void:


### PR DESCRIPTION
Disabled Soft Drop Lock Cancel by default. Two high-level Tetris players complained about the setting, and I think it's something Turbo Fat experts can seek out and enable if they like it. It's better for the default settings to cater to new players.

Added a description field for the Soft Drop Lock Cancel property.