### PR TITLE
Analog sticks now work for UI sliders.

### DIFF
--- a/project/src/main/ui/analog-event-translator.gd
+++ b/project/src/main/ui/analog-event-translator.gd
@@ -7,8 +7,8 @@ extends Node
 ## 	1. Pressing a direction on the analog stick activates the action many times, not just once
 ## 	2. Holding the direction 100% on the analog stick stops activating the action at all
 ##
-## This autoload singleton scans the Input Map for any events mapped to the D-Pad, and activates those events when the
-## analog stick is pressed. Each event is activated only once each time the analog stick is pressed.
+## This autoload singleton scans the Input Map for any events mapped to the D-Pad, and sends out JoypadButton events
+## when the analog stick is held. A JoypadButton event is activated only once each time the analog stick is held.
 
 ## Deadzone for detecting analog stick input
 const DEADZONE := 0.5
@@ -23,13 +23,8 @@ var _down_pressed := false
 var _left_pressed := false
 var _right_pressed := false
 
-## Joypad action mappings populated by scanning the InputMap.
-##
-## Key: (String) Hyphenated joypad device and direction, such as '0-right' or '0-left'
-## Value: (Array, String) Actions activated by the specified joypad device and direction
-var _actions_by_device_and_direction := {}
-
 func _ready() -> void:
+	pause_mode = Node.PAUSE_MODE_PROCESS
 	KeybindManager.connect("input_map_updated", self, "_on_KeybindManager_input_map_updated")
 	_refresh_inputs()
 
@@ -47,63 +42,58 @@ func _process(_delta: float) -> void:
 		var left_stick_x := Input.get_joy_axis(device, JOY_AXIS_0)
 		if left_stick_x < -DEADZONE:
 			if not _left_pressed:
-				_trigger_actions(_actions_by_device_and_direction["%s-left" % [device]], true)
+				_trigger_joypad_button(device, 14, true)
 				_left_pressed = true
 		elif left_stick_x > DEADZONE:
 			if not _right_pressed:
-				_trigger_actions(_actions_by_device_and_direction["%s-right" % [device]], true)
+				_trigger_joypad_button(device, 15, true)
 				_right_pressed = true
 		else:
 			if _left_pressed:
-				_trigger_actions(_actions_by_device_and_direction["%s-left" % [device]], false)
+				_trigger_joypad_button(device, 14, false)
 				_left_pressed = false
 			if _right_pressed:
-				_trigger_actions(_actions_by_device_and_direction["%s-right" % [device]], false)
+				_trigger_joypad_button(device, 15, false)
 				_right_pressed = false
 		
 		# trigger up and down actions based on the joypad y-axis
 		var left_stick_y := Input.get_joy_axis(device, JOY_AXIS_1)
 		if left_stick_y < -DEADZONE:
 			if not _up_pressed:
-				_trigger_actions(_actions_by_device_and_direction["%s-up" % [device]], true)
+				_trigger_joypad_button(device, 12, true)
 				_up_pressed = true
 		elif left_stick_y > DEADZONE:
 			if not _down_pressed:
-				_trigger_actions(_actions_by_device_and_direction["%s-down" % [device]], true)
+				_trigger_joypad_button(device, 13, true)
 				_down_pressed = true
 		else:
 			if _up_pressed:
-				_trigger_actions(_actions_by_device_and_direction["%s-up" % [device]], false)
+				_trigger_joypad_button(device, 12, false)
 				_up_pressed = false
 			if _down_pressed:
-				_trigger_actions(_actions_by_device_and_direction["%s-down" % [device]], false)
+				_trigger_joypad_button(device, 13, false)
 				_down_pressed = false
 
 
 ## Refreshes the input mappings for all monitored devices by scanning the InputMap.
 func _refresh_inputs() -> void:
 	_monitored_devices = _get_monitored_devices()
-	
-	_actions_by_device_and_direction.clear()
-	for device in _monitored_devices:
-		_actions_by_device_and_direction["%s-up" % [device]] = _get_actions_for_device_and_button(device, 12)
-		_actions_by_device_and_direction["%s-down" % [device]] = _get_actions_for_device_and_button(device, 13)
-		_actions_by_device_and_direction["%s-left" % [device]] = _get_actions_for_device_and_button(device, 14)
-		_actions_by_device_and_direction["%s-right" % [device]] = _get_actions_for_device_and_button(device, 15)
 
 
-## Triggers the given list of actions as either pressed or released.
+## Triggers the given joypad button as either pressed or released.
 ##
 ## Parameters:
-## 	'actions': List of String actions to trigger.
+## 	'device': Joypad device to trigger
+##
+## 	'button_index': D-Pad button index to trigger such as 12 (up), 13 (down), 14 (left) or 15 (right)
 ##
 ## 	'pressed': If true, the action's state is pressed. If false, the action's state is released.
-func _trigger_actions(actions: Array, pressed: bool) -> void:
-	for action in actions:
-		var ev := InputEventAction.new()
-		ev.action = action
-		ev.pressed = pressed
-		Input.parse_input_event(ev)
+func _trigger_joypad_button(device: int, button_index: int, pressed: bool) -> void:
+	var ev := InputEventJoypadButton.new()
+	ev.device = device
+	ev.button_index = button_index
+	ev.pressed = pressed
+	Input.parse_input_event(ev)
 
 
 ## Returns a list of device indexes with D-Pad inputs mapped in the InputMap.
@@ -117,22 +107,6 @@ func _get_monitored_devices() -> Array:
 			if event is InputEventJoypadButton and event.button_index in [12, 13, 14, 15]:
 				devices_set[event.device] = true
 	return devices_set.keys()
-
-
-## Returns a list of actions mapped to the specified D-Pad input in the InputMap.
-##
-## Parameters:
-## 	'device': joypad device index
-##
-## 	'button': A D-Pad button such as 12 (up), 13 (down), 14 (left) or 15 (right)
-func _get_actions_for_device_and_button(device: int, button: int) -> Array:
-	var actions_set := {}
-	for action in InputMap.get_actions():
-		var events := InputMap.get_action_list(action)
-		for event in events:
-			if event is InputEventJoypadButton and event.device == device and event.button_index == button:
-				actions_set[action] = true
-	return actions_set.keys()
 
 
 ## When the player changes their keybinds, we refresh our joypad action mappings.


### PR DESCRIPTION
The UI sliders have some specific logic for processing JoypadButton events, but this logic was being sidestepped because our AnalogEventTranslator generated InputEventActions instead. I've rewritten the translator to use InputEventJoypadButtons instead, which also makes the code much simpler.