### PR TITLE
'Replay to continue adventure', star count

### DIFF
--- a/project/assets/main/locale/en.po
+++ b/project/assets/main/locale/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-10-11 09:11-0400\n"
+"POT-Creation-Date: 2024-10-11 09:12-0400\n"
 "PO-Revision-Date: 2023-03-13 12:16-0400\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16646,6 +16646,11 @@ msgstr "10 dan"
 
 #: project/src/main/ui/menu/region-info-panel.gd
 #, python-format
+msgid "Completion: %.1f%%"
+msgstr ""
+
+#: project/src/main/ui/menu/region-info-panel.gd
+#, python-format
 msgid "Overall grade: %s"
 msgstr "Overall grade: %s"
 
@@ -16655,14 +16660,12 @@ msgid "Promotion to %s: %.1f%%"
 msgstr "Promotion to %s: %.1f%%"
 
 #: project/src/main/ui/menu/region-info-panel.gd
-#, python-format
-msgid "Total stars: %s"
-msgstr "Total stars: %s"
+msgid "Let's start a new adventure!"
+msgstr ""
 
 #: project/src/main/ui/menu/region-info-panel.gd
-#, python-format
-msgid "Completion: %.1f%%"
-msgstr "Completion: %.1f%%"
+msgid "Play this chapter to continue your adventure!"
+msgstr ""
 
 #: project/src/main/ui/menu/region-info-panel.gd
 msgid "Replay this chapter to continue your adventure!"

--- a/project/assets/main/locale/es.po
+++ b/project/assets/main/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-10-11 09:11-0400\n"
+"POT-Creation-Date: 2024-10-11 09:12-0400\n"
 "PO-Revision-Date: 2024-10-07 03:44-0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17430,6 +17430,11 @@ msgstr "10 dan"
 
 #: project/src/main/ui/menu/region-info-panel.gd
 #, python-format
+msgid "Completion: %.1f%%"
+msgstr "Completado: %.1f%%"
+
+#: project/src/main/ui/menu/region-info-panel.gd
+#, python-format
 msgid "Overall grade: %s"
 msgstr "Grado General: %s"
 
@@ -17439,14 +17444,14 @@ msgid "Promotion to %s: %.1f%%"
 msgstr "Promoción a %s: %.1f%%"
 
 #: project/src/main/ui/menu/region-info-panel.gd
-#, python-format
-msgid "Total stars: %s"
-msgstr "Estrellas Totales: %s"
+#, fuzzy
+msgid "Let's start a new adventure!"
+msgstr "¡Empecemos una nueva aventura!"
 
 #: project/src/main/ui/menu/region-info-panel.gd
-#, python-format
-msgid "Completion: %.1f%%"
-msgstr "Completado: %.1f%%"
+#, fuzzy
+msgid "Play this chapter to continue your adventure!"
+msgstr "¡Juega este capítulo para continuar tu aventura!"
 
 #: project/src/main/ui/menu/region-info-panel.gd
 msgid "Replay this chapter to continue your adventure!"

--- a/project/assets/main/locale/messages.pot
+++ b/project/assets/main/locale/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-10-11 09:11-0400\n"
+"POT-Creation-Date: 2024-10-11 09:12-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15441,6 +15441,11 @@ msgstr ""
 
 #: project/src/main/ui/menu/region-info-panel.gd
 #, python-format
+msgid "Completion: %.1f%%"
+msgstr ""
+
+#: project/src/main/ui/menu/region-info-panel.gd
+#, python-format
 msgid "Overall grade: %s"
 msgstr ""
 
@@ -15450,13 +15455,11 @@ msgid "Promotion to %s: %.1f%%"
 msgstr ""
 
 #: project/src/main/ui/menu/region-info-panel.gd
-#, python-format
-msgid "Total stars: %s"
+msgid "Let's start a new adventure!"
 msgstr ""
 
 #: project/src/main/ui/menu/region-info-panel.gd
-#, python-format
-msgid "Completion: %.1f%%"
+msgid "Play this chapter to continue your adventure!"
 msgstr ""
 
 #: project/src/main/ui/menu/region-info-panel.gd

--- a/project/src/main/ui/menu/region-info-panel.gd
+++ b/project/src/main/ui/menu/region-info-panel.gd
@@ -61,6 +61,9 @@ func _update_region_text(region_obj: Object) -> void:
 func _update_career_region_text(region: CareerRegion) -> void:
 	var new_text := ""
 	var region_completion := PlayerData.career.region_completion(region)
+	# include completion details -- how the player can get 100%
+	new_text += tr("Completion: %.1f%%") % [100.0 * region_completion.completion_percent()]
+	new_text += "\n"
 	if region_completion.completion_percent() == 1.0:
 		# include grade details -- how the player can get a better grade
 		var ranks := []
@@ -73,18 +76,6 @@ func _update_career_region_text(region: CareerRegion) -> void:
 		for rank in ranks:
 			worst_rank = max(worst_rank, rank)
 		
-		# count the total number of 'stars' for all of the levels
-		var star_count := 0
-		for rank in ranks:
-			match Ranks.grade(rank):
-				"S-": star_count += 1
-				"S": star_count += 2
-				"S+": star_count += 3
-				"SS": star_count += 4
-				"SS+": star_count += 5
-				"SSS": star_count += 6
-				"M": star_count += 7
-		
 		# calculate the percent of levels where the player's rank is already high enough to rank up
 		var worst_rank_count := 0
 		for rank in ranks:
@@ -93,18 +84,23 @@ func _update_career_region_text(region: CareerRegion) -> void:
 		var next_rank_pct := float(ranks.size() - worst_rank_count) / ranks.size()
 		
 		new_text += tr("Overall grade: %s") % [Ranks.grade(worst_rank)]
+		new_text += "\n"
 		if Ranks.grade(worst_rank) != Ranks.BEST_GRADE:
-			new_text += "\n" + tr("Promotion to %s: %.1f%%") % [
+			new_text += tr("Promotion to %s: %.1f%%") % [
 					Ranks.next_grade(Ranks.grade(worst_rank)), 100 * next_rank_pct]
-		if star_count > 0:
-			new_text += "\n" + tr("Total stars: %s") % [star_count]
 	else:
-		# include completion details -- how the player can get 100%
-		new_text += tr("Completion: %.1f%%") % [100.0 * region_completion.completion_percent()]
-		if region_completion.cutscene_completion_percent() < 1.0:
-			new_text += "\n\n" + tr("Replay this chapter to continue your adventure!")
+		if not PlayerData.career.is_region_started(region) and region.start == 0:
+			new_text += "\n"
+			new_text += tr("Let's start a new adventure!")
+		elif not PlayerData.career.is_region_started(region):
+			new_text += "\n"
+			new_text += tr("Play this chapter to continue your adventure!")
+		elif region_completion.cutscene_completion_percent() < 1.0:
+			new_text += "\n"
+			new_text += tr("Replay this chapter to continue your adventure!")
 		else:
-			new_text += "\n\n" + tr("Clear every level to get to 100%!")
+			new_text += "\n"
+			new_text += tr("Clear every level to get to 100%!")
 	
 	set_text(new_text)
 
@@ -169,18 +165,6 @@ func _update_other_region_text(region: OtherRegion) -> void:
 		for rank in ranks:
 			worst_rank = max(worst_rank, rank)
 		
-		# count the total number of 'stars' for all of the levels
-		var star_count := 0
-		for rank in ranks:
-			match Ranks.grade(rank):
-				"S-": star_count += 1
-				"S": star_count += 2
-				"S+": star_count += 3
-				"SS": star_count += 4
-				"SS+": star_count += 5
-				"SSS": star_count += 6
-				"M": star_count += 7
-		
 		# calculate the percent of levels where the player's rank is already high enough to rank up
 		var worst_rank_count := 0
 		for rank in ranks:
@@ -190,10 +174,8 @@ func _update_other_region_text(region: OtherRegion) -> void:
 		
 		new_text += tr("Overall grade: %s") % [Ranks.grade(worst_rank)]
 		if Ranks.grade(worst_rank) != Ranks.BEST_GRADE:
-			new_text += "\n" + tr("Promotion to %s: %.1f%%") % [
+			new_text += "\n\n" + tr("Promotion to %s: %.1f%%") % [
 					Ranks.next_grade(Ranks.grade(worst_rank)), 100 * next_rank_pct]
-		if star_count > 0:
-			new_text += "\n" + tr("Total stars: %s") % [star_count]
 	else:
 		# include completion details -- how the player can get to 100%
 		new_text += tr("Completion: %.1f%%") % [100.0 * completion_percent]


### PR DESCRIPTION
Replaced the 'Replay this chapter to continue your adventure' message in Career mode with new messages, 'Start this chapter...' and 'Play this chapter...' which make more sense for players who haven't beaten the game.

Removed 'star count' message from chapter descriptions. I was originally thinking I'd have 'stars' instead of letter grades, so players wouldn't be discouraged by seeing they got a 'B-' or something like that. But I've decided letter grades are OK, the grade scale is just shifted so everybody gets an A or better.