### PR TITLE
Improved hint messages: cheats, soft drop lock cancel

### DIFF
--- a/project/assets/main/locale/en.po
+++ b/project/assets/main/locale/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-10-11 09:12-0400\n"
+"POT-Creation-Date: 2024-10-11 09:43-0400\n"
 "PO-Revision-Date: 2023-03-13 12:16-0400\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -13933,6 +13933,17 @@ msgid "Sudden death levels are risky but reward you with an extra life."
 msgstr ""
 
 #: project/src/main/career/career-hint.gd
+msgid ""
+"Need a hand? Go into Settings to lower the difficulty or enable the hold "
+"piece!"
+msgstr ""
+
+#: project/src/main/career/career-hint.gd
+msgid ""
+"Looking for line pieces? They're over in Settings... if you really need them!"
+msgstr ""
+
+#: project/src/main/career/career-hint.gd
 msgid "The boss level is near! Can you reach it in time?"
 msgstr ""
 
@@ -14004,7 +14015,8 @@ msgid "Hold up as the next piece appears to hard-drop it instantly!"
 msgstr ""
 
 #: project/src/main/career/career-hint.gd
-msgid "Tap down after a hard drop to unlock the piece and move it again!"
+msgid ""
+"Enable 'Soft Drop Lock Cancel' in Settings for some advanced piece finesse!"
 msgstr ""
 
 #: project/src/main/career/ui/CareerRegionSelectMenu.tscn

--- a/project/assets/main/locale/es.po
+++ b/project/assets/main/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-10-11 09:12-0400\n"
+"POT-Creation-Date: 2024-10-11 09:43-0400\n"
 "PO-Revision-Date: 2024-10-07 03:44-0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -14620,6 +14620,23 @@ msgstr ""
 "vida extra."
 
 #: project/src/main/career/career-hint.gd
+#, fuzzy
+msgid ""
+"Need a hand? Go into Settings to lower the difficulty or enable the hold "
+"piece!"
+msgstr ""
+"¿Necesitas ayuda? Ve a Configuración para bajar la dificultad o habilitar el "
+"sostener pieza!"
+
+#: project/src/main/career/career-hint.gd
+#, fuzzy
+msgid ""
+"Looking for line pieces? They're over in Settings... if you really need them!"
+msgstr ""
+"¿Buscas piezas largas? Están en Configuración... si realmente las necesitas."
+
+
+#: project/src/main/career/career-hint.gd
 msgid "The boss level is near! Can you reach it in time?"
 msgstr "¡El nivel del jefe está cerca! ¿Puedes llegar a tiempo?"
 
@@ -14708,10 +14725,12 @@ msgstr ""
 "dejarla caer al instante!"
 
 #: project/src/main/career/career-hint.gd
-msgid "Tap down after a hard drop to unlock the piece and move it again!"
+#, fuzzy
+msgid ""
+"Enable 'Soft Drop Lock Cancel' in Settings for some advanced piece finesse!"
 msgstr ""
-"¡Presiona abajo después de una caída rápida para poder seguir moviendo la "
-"pieza!"
+"Habilita 'Cancelar Asegurado con Caída Lenta' en Configuración para mayor "
+"finesse con las piezas avanzadas!"
 
 #: project/src/main/career/ui/CareerRegionSelectMenu.tscn
 msgid "Chapter Select"

--- a/project/assets/main/locale/messages.pot
+++ b/project/assets/main/locale/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-10-11 09:12-0400\n"
+"POT-Creation-Date: 2024-10-11 09:46-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13054,6 +13054,18 @@ msgid "Sudden death levels are risky but reward you with an extra life."
 msgstr ""
 
 #: project/src/main/career/career-hint.gd
+msgid ""
+"Need a hand? Go into Settings to lower the difficulty or enable the hold "
+"piece!"
+msgstr ""
+
+#: project/src/main/career/career-hint.gd
+msgid ""
+"Looking for line pieces? They're over in Settings... if you really need "
+"them!"
+msgstr ""
+
+#: project/src/main/career/career-hint.gd
 msgid "The boss level is near! Can you reach it in time?"
 msgstr ""
 
@@ -13124,7 +13136,9 @@ msgid "Hold up as the next piece appears to hard-drop it instantly!"
 msgstr ""
 
 #: project/src/main/career/career-hint.gd
-msgid "Tap down after a hard drop to unlock the piece and move it again!"
+msgid ""
+"Enable 'Soft Drop Lock Cancel' in Settings for some advanced piece "
+"finesse!"
 msgstr ""
 
 #: project/src/main/career/ui/CareerRegionSelectMenu.tscn

--- a/project/src/main/career/career-hint.gd
+++ b/project/src/main/career/career-hint.gd
@@ -24,11 +24,13 @@ func _ready() -> void:
 func _hints() -> Array:
 	var result := []
 	
-	# Essential hints to help the player understand career mode
+	# Essential hints to help the player understand career mode or get accustomed to the game
 	result.append(tr("Earning more money in a level moves you further on the map."))
 	result.append(tr("Adventure mode ends after six levels. Make every level count!"))
 	result.append(tr("Adventure mode ends if you lose all your lives. Try not to top out!"))
 	result.append(tr("Sudden death levels are risky but reward you with an extra life."))
+	result.append(tr("Need a hand? Go into Settings to lower the difficulty or enable the hold piece!"))
+	result.append(tr("Looking for line pieces? They're over in Settings... if you really need them!"))
 	var region := PlayerData.career.current_region()
 	if region.boss_level and not PlayerData.career.is_region_finished(region) \
 			and not PlayerData.career.is_boss_level():
@@ -56,7 +58,7 @@ func _hints() -> Array:
 		result.append(tr("Hold both rotate keys as the next piece appears to flip it instantly!"))
 		result.append(tr("Press both rotate keys to flip a piece!"))
 		result.append(tr("Hold up as the next piece appears to hard-drop it instantly!"))
-		result.append(tr("Tap down after a hard drop to unlock the piece and move it again!"))
+		result.append(tr("Enable 'Soft Drop Lock Cancel' in Settings for some advanced piece finesse!"))
 	
 	return result
 


### PR DESCRIPTION
Added hint messages for turning on cheats. Some players are going to be discouraged at the game's difficulty, so it would be nice to occasionally remind them about the cheats they can turn on.

Changed 'soft drop lock cancel' hint to tell players where to enable this functionality. It's off by default, they'll have to turn it on.