### PR TITLE
Add a 'controller disconnected' message during puzzles

### DIFF
--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=118 format=2]
+[gd_scene load_steps=119 format=2]
 
 [ext_resource path="res://src/main/ui/theme/h3.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/tutorial/TutorialHud.tscn" type="PackedScene" id=2]
@@ -93,6 +93,7 @@
 [ext_resource path="res://src/main/puzzle/night/NightStarSeed.tscn" type="PackedScene" id=91]
 [ext_resource path="res://src/main/puzzle/MoneyBurst.tscn" type="PackedScene" id=92]
 [ext_resource path="res://src/main/ui/diagonal-particles.gd" type="Script" id=93]
+[ext_resource path="res://src/main/puzzle/unplugged-controller-detector.gd" type="Script" id=94]
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 1, 1, 1, 0.333333 )
@@ -772,6 +773,9 @@ margin_bottom = 270.0
 [node name="HudFlash" parent="Hud" instance=ExtResource( 75 )]
 
 [node name="SettingsMenu" parent="." instance=ExtResource( 26 )]
+
+[node name="UnpluggedControllerDetector" type="Node" parent="SettingsMenu"]
+script = ExtResource( 94 )
 
 [node name="TopOutTracker" type="Node" parent="."]
 script = ExtResource( 30 )

--- a/project/src/main/puzzle/unplugged-controller-detector.gd
+++ b/project/src/main/puzzle/unplugged-controller-detector.gd
@@ -1,0 +1,23 @@
+extends Node
+## Pops up a "controller disconnected" message in the settings menu when the player's controller disconnects.
+
+onready var _settings_menu: SettingsMenu = get_parent()
+
+func _ready() -> void:
+	Input.connect("joy_connection_changed", self, "_on_joy_connection_changed")
+
+
+## If the player's controller disconnects during gameplay, we pop up the settings menu with a message.
+##
+## When the player's controller reconnects, we hide the message.
+func _on_joy_connection_changed(_device_id: int, connected: bool) -> void:
+	if connected == false \
+			and InputManager.input_mode == InputManager.InputMode.JOYPAD \
+			and PuzzleState.game_active:
+		# show the 'controller disconnected' message
+		_settings_menu.show()
+		_settings_menu.controller_unplugged_message.show()
+	
+	if connected == true:
+		# hide the 'controller disconnected' message
+		_settings_menu.controller_unplugged_message.hide()

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=49 format=2]
+[gd_scene load_steps=50 format=2]
 
 [ext_resource path="res://src/main/ui/squeak/br/squeak-theme-h5.tres" type="Theme" id=1]
 [ext_resource path="res://src/main/ui/squeak/br/squeak-theme-h4.tres" type="Theme" id=2]
@@ -45,6 +45,7 @@
 [ext_resource path="res://src/main/ui/squeak/br/SqueakButton.tscn" type="PackedScene" id=43]
 [ext_resource path="res://src/main/ui/squeak/br/SqueakCheckBox.tscn" type="PackedScene" id=44]
 [ext_resource path="res://src/main/ui/WarningDialog.tscn" type="PackedScene" id=45]
+[ext_resource path="res://src/main/ui/settings/controller-unplugged-message.gd" type="Script" id=46]
 
 [sub_resource type="StyleBoxFlat" id=4]
 content_margin_left = 8.0
@@ -93,8 +94,30 @@ color = Color( 0, 0, 0, 0.752941 )
 visible = false
 emit_actions = false
 
-[node name="Window" type="Panel" parent="."]
+[node name="ControllerUnpluggedMessage" type="Panel" parent="."]
 visible = false
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -200.0
+margin_top = 238.0
+margin_right = 200.0
+margin_bottom = 263.0
+mouse_filter = 2
+size_flags_vertical = 4
+theme = ExtResource( 2 )
+script = ExtResource( 46 )
+
+[node name="Label" type="Label" parent="ControllerUnpluggedMessage"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+text = "Controller disconnected."
+align = 1
+valign = 1
+autowrap = true
+
+[node name="Window" type="Panel" parent="."]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -134,7 +157,7 @@ size_flags_vertical = 3
 follow_focus = true
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Window/UiArea/TabContainer/SoundAndGraphics"]
-margin_right = 736.0
+margin_right = 712.0
 margin_bottom = 306.0
 size_flags_horizontal = 3
 
@@ -1392,6 +1415,7 @@ Slot A (34.2 hours)"
 icon_color = Color( 1, 0.866667, 0.6, 1 )
 
 [connection signal="hide" from="." to="Window/UiArea/Bottom" method="_on_SettingsMenu_hide"]
+[connection signal="show" from="." to="ControllerUnpluggedMessage" method="_on_SettingsMenu_show"]
 [connection signal="show" from="." to="Window/UiArea/Bottom" method="_on_SettingsMenu_show"]
 [connection signal="pressed" from="Window/UiArea/TabContainer/SoundAndGraphics/VBoxContainer/Fullscreen/CheckBox" to="Window/UiArea/TabContainer/SoundAndGraphics/VBoxContainer/Fullscreen" method="_on_CheckBox_pressed"]
 [connection signal="pressed" from="Window/UiArea/TabContainer/SoundAndGraphics/VBoxContainer/UseVsync/CheckBox" to="Window/UiArea/TabContainer/SoundAndGraphics/VBoxContainer/UseVsync" method="_on_CheckBox_pressed"]

--- a/project/src/main/ui/settings/controller-unplugged-message.gd
+++ b/project/src/main/ui/settings/controller-unplugged-message.gd
@@ -1,0 +1,13 @@
+extends Panel
+## Shows a "controller disconnected" message in the settings menu.
+##
+## When the player's controller disconnects during a puzzle, we pop up the settings menu and display a message.
+
+func _ready() -> void:
+	# hide by default; must be explicitly shown after the settings menu
+	hide()
+
+
+func _on_SettingsMenu_show() -> void:
+	# hide by default; must be explicitly shown after the settings menu
+	hide()

--- a/project/src/main/ui/settings/settings-menu.gd
+++ b/project/src/main/ui/settings/settings-menu.gd
@@ -25,6 +25,8 @@ export (QuitType) var quit_type: int setget set_quit_type
 var _post_save_method: String
 var _post_save_args_array: Array
 
+onready var controller_unplugged_message := $ControllerUnpluggedMessage
+
 onready var _controls_control := $Window/UiArea/TabContainer/Controls
 onready var _save_slot_control := $Window/UiArea/TabContainer/Misc/VBoxContainer/SaveSlot
 onready var _touch_control := $Window/UiArea/TabContainer/Touch
@@ -62,6 +64,11 @@ func show() -> void:
 	_window.show()
 	Pauser.toggle_pause("settings-menu", true)
 	emit_signal("show")
+
+
+## Returns 'true' if the settings menu is currently being shown to the player.
+func is_shown() -> bool:
+	return _window.visible
 
 
 ## Hides the menu and unpauses the scene tree.


### PR DESCRIPTION
If the player's controller disconnects during gameplay, we pop up the settings menu with a message.

We don't pop up the settings menu in the creature editor, during cutscenes, or in other parts of the game.