### PR TITLE
Fixed softlock when deleting/changing save

### DIFF
--- a/project/src/main/ui/settings/settings-menu.gd
+++ b/project/src/main/ui/settings/settings-menu.gd
@@ -116,6 +116,7 @@ func _refresh_quit_type() -> void:
 func _load_player_data() -> void:
 	PlayerSave.load_player_data()
 	Breadcrumb.trail = []
+	Pauser.reset()
 	SceneTransition.push_trail(Global.SCENE_SPLASH)
 
 

--- a/project/src/main/utils/pauser.gd
+++ b/project/src/main/utils/pauser.gd
@@ -16,6 +16,12 @@ func _ready() -> void:
 	pause_mode = Node.PAUSE_MODE_PROCESS
 
 
+## Purges all pause requests and unpauses the game.
+func reset() -> void:
+	_pausers.clear()
+	get_tree().paused = false
+
+
 func _process(_delta: float) -> void:
 	if get_tree().paused != _paused:
 		_paused = get_tree().paused


### PR DESCRIPTION
Deleting/changing the save left the game paused, causing the game to softlock because the SceneTransition couldn't play.

Deleting/changing the save now purges all "pausers".