### PR TITLE
Clearing a boss level now resets the career day.

### DIFF
--- a/project/src/main/career/career-calendar.gd
+++ b/project/src/main/career/career-calendar.gd
@@ -41,6 +41,11 @@ func advance_clock(new_distance_earned: int, success: bool, lost: bool) -> void:
 		if success:
 			# if they pass a boss level, update best_distance_travelled to mark the region as cleared
 			career_data.best_distance_travelled = max(career_data.best_distance_travelled, region.end + 1)
+			
+			# Advance the calendar. We don't want to advance players to a new area, just to reset them to the start
+			# after 1 or 2 levels.
+			PlayerData.career.show_progress = Careers.ShowProgress.STATIC
+			advance_calendar()
 		else:
 			# if they fail a boss level, they lose 1-2 days worth of progress
 			career_data.distance_earned = -int(max(region.length * rand_range(0.125, 0.25), 2))


### PR DESCRIPTION
When new players play the game, they will get past the first boss level or maybe even the first two, but they will inevitably end up in a region with only 1 or 2 levels remaining, get part way to the boss level, and be told "Let's stop and try again"

The intent of Career mode is more or less a six-level time limit to reach a goal. It has a side effect of portioning out the gameplay into bite-size sections, but that's not strictly the intent, and I definitely don't want to frustrate the player by forcing them to restart when they haven't even had a chance to progress yet