### PR TITLE
Quit -> Back, Main Menu

### DIFF
--- a/project/src/demo/editor/creature-old/CreatureEditorOld.tscn
+++ b/project/src/demo/editor/creature-old/CreatureEditorOld.tscn
@@ -115,7 +115,7 @@ margin_right = 1019.0
 margin_bottom = 595.0
 theme = ExtResource( 14 )
 shortcut_in_tooltip = false
-text = "Quit"
+text = "Back"
 
 [node name="Reroll" type="VBoxContainer" parent="Ui"]
 margin_left = 220.0

--- a/project/src/demo/editor/puzzle/LevelEditor.tscn
+++ b/project/src/demo/editor/puzzle/LevelEditor.tscn
@@ -157,7 +157,7 @@ margin_right = 180.0
 margin_bottom = 590.0
 theme = ExtResource( 11 )
 shortcut_in_tooltip = false
-text = "Quit"
+text = "Back"
 
 [node name="Ui" type="CanvasLayer" parent="."]
 

--- a/project/src/main/editor/creature/CreatureEditor.tscn
+++ b/project/src/main/editor/creature/CreatureEditor.tscn
@@ -478,7 +478,7 @@ size_flags_vertical = 4
 texture_normal = ExtResource( 17 )
 texture_pressed = ExtResource( 15 )
 texture_hover = ExtResource( 17 )
-text = "Quit"
+text = "Back"
 color = 1
 shape = 5
 

--- a/project/src/main/ui/CreatureStressTest.tscn
+++ b/project/src/main/ui/CreatureStressTest.tscn
@@ -74,7 +74,7 @@ margin_top = 359.0
 margin_right = 150.0
 margin_bottom = 395.0
 theme = ExtResource( 5 )
-text = "Quit"
+text = "Back"
 
 [node name="FpsLabel" parent="Ui" instance=ExtResource( 3 )]
 margin_top = -30.0

--- a/project/src/main/ui/menu/MainMenu.tscn
+++ b/project/src/main/ui/menu/MainMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=49 format=2]
+[gd_scene load_steps=57 format=2]
 
 [ext_resource path="res://src/main/ui/menu/main-menu.gd" type="Script" id=1]
 [ext_resource path="res://assets/main/ui/candy-button/h3-p.png" type="Texture" id=2]
@@ -32,6 +32,8 @@
 [ext_resource path="res://assets/main/ui/icon-training.png" type="Texture" id=30]
 [ext_resource path="res://assets/main/ui/icon-tutorials.png" type="Texture" id=31]
 [ext_resource path="res://assets/main/ui/icon-career.png" type="Texture" id=32]
+[ext_resource path="res://src/main/ui/candy-button/gradient-yellow-normal.tres" type="Gradient" id=33]
+[ext_resource path="res://src/main/ui/candy-button/gradient-red-normal.tres" type="Gradient" id=34]
 [ext_resource path="res://src/main/ui/menu/MenuAccentH2.tscn" type="PackedScene" id=36]
 [ext_resource path="res://src/main/ui/menu/MenuAccentTitle.tscn" type="PackedScene" id=38]
 [ext_resource path="res://src/main/ui/candy-button/CandyButtonH4.tscn" type="PackedScene" id=40]
@@ -84,6 +86,36 @@ resource_local_to_scene = true
 shader = ExtResource( 11 )
 shader_param/mix_amount = 1.0
 shader_param/gradient = SubResource( 6 )
+
+[sub_resource type="GradientTexture2D" id=14]
+resource_local_to_scene = true
+gradient = ExtResource( 29 )
+
+[sub_resource type="ShaderMaterial" id=15]
+resource_local_to_scene = true
+shader = ExtResource( 11 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 14 )
+
+[sub_resource type="GradientTexture2D" id=16]
+resource_local_to_scene = true
+gradient = ExtResource( 33 )
+
+[sub_resource type="ShaderMaterial" id=17]
+resource_local_to_scene = true
+shader = ExtResource( 11 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 16 )
+
+[sub_resource type="GradientTexture2D" id=18]
+resource_local_to_scene = true
+gradient = ExtResource( 34 )
+
+[sub_resource type="ShaderMaterial" id=19]
+resource_local_to_scene = true
+shader = ExtResource( 11 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 18 )
 
 [sub_resource type="GradientTexture2D" id=12]
 resource_local_to_scene = true
@@ -248,6 +280,25 @@ shape = 4
 alignment = 1
 quit_on_cancel = false
 
+[node name="Settings" parent="DropPanel/System" index="0"]
+material = SubResource( 15 )
+margin_left = 402.0
+margin_right = 522.0
+
+[node name="Credits" parent="DropPanel/System" index="1"]
+material = SubResource( 17 )
+margin_left = 402.0
+margin_right = 522.0
+
+[node name="Quit" parent="DropPanel/System" index="2"]
+material = SubResource( 19 )
+margin_left = 402.0
+margin_right = 522.0
+text = "Quit"
+
+[node name="Spacer" parent="DropPanel/System" index="3"]
+margin_right = 924.0
+
 [node name="Debug" type="VBoxContainer" parent="DropPanel"]
 anchor_left = 1.0
 anchor_top = 1.0
@@ -275,6 +326,7 @@ shape = 6
 [node name="VersionLabel" parent="." instance=ExtResource( 7 )]
 
 [node name="SettingsMenu" parent="." instance=ExtResource( 8 )]
+quit_type = 4
 
 [node name="MusicPopup" parent="." instance=ExtResource( 10 )]
 
@@ -286,3 +338,5 @@ shape = 6
 [connection signal="settings_pressed" from="DropPanel/System" to="SettingsMenu" method="_on_Settings_pressed"]
 [connection signal="pressed" from="DropPanel/Debug/StressTest" to="DropPanel/Debug" method="_on_StressTest_pressed"]
 [connection signal="quit_pressed" from="SettingsMenu" to="DropPanel/System" method="_on_Quit_pressed"]
+
+[editable path="DropPanel/System"]

--- a/project/src/main/ui/menu/SplashScreen.tscn
+++ b/project/src/main/ui/menu/SplashScreen.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=2]
+[gd_scene load_steps=27 format=2]
 
 [ext_resource path="res://src/main/ui/menu/splash-screen.gd" type="Script" id=1]
 [ext_resource path="res://src/main/ui/VersionLabel.tscn" type="PackedScene" id=2]
@@ -14,6 +14,9 @@
 [ext_resource path="res://src/main/ui/candy-button/gradient-green-normal.tres" type="Gradient" id=12]
 [ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=13]
 [ext_resource path="res://src/main/ui/candy-button/CandyButtonH3.tscn" type="PackedScene" id=14]
+[ext_resource path="res://src/main/ui/candy-button/gradient-yellow-normal.tres" type="Gradient" id=15]
+[ext_resource path="res://src/main/ui/candy-button/gradient-violet-normal.tres" type="Gradient" id=16]
+[ext_resource path="res://src/main/ui/candy-button/gradient-red-normal.tres" type="Gradient" id=17]
 
 [sub_resource type="DynamicFont" id=1]
 size = 72
@@ -31,6 +34,36 @@ resource_local_to_scene = true
 shader = ExtResource( 13 )
 shader_param/mix_amount = 1.0
 shader_param/gradient = SubResource( 2 )
+
+[sub_resource type="GradientTexture2D" id=4]
+resource_local_to_scene = true
+gradient = ExtResource( 16 )
+
+[sub_resource type="ShaderMaterial" id=5]
+resource_local_to_scene = true
+shader = ExtResource( 13 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 4 )
+
+[sub_resource type="GradientTexture2D" id=6]
+resource_local_to_scene = true
+gradient = ExtResource( 15 )
+
+[sub_resource type="ShaderMaterial" id=7]
+resource_local_to_scene = true
+shader = ExtResource( 13 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 6 )
+
+[sub_resource type="GradientTexture2D" id=8]
+resource_local_to_scene = true
+gradient = ExtResource( 17 )
+
+[sub_resource type="ShaderMaterial" id=9]
+resource_local_to_scene = true
+shader = ExtResource( 13 )
+shader_param/mix_amount = 1.0
+shader_param/gradient = SubResource( 8 )
 
 [node name="SplashScreen" type="Control"]
 anchor_right = 1.0
@@ -86,9 +119,29 @@ shape = 8
 alignment = 1
 quit_on_cancel = false
 
+[node name="Settings" parent="DropPanel/System" index="0"]
+material = SubResource( 5 )
+margin_left = 402.0
+margin_right = 522.0
+
+[node name="Credits" parent="DropPanel/System" index="1"]
+material = SubResource( 7 )
+margin_left = 402.0
+margin_right = 522.0
+
+[node name="Quit" parent="DropPanel/System" index="2"]
+material = SubResource( 9 )
+margin_left = 402.0
+margin_right = 522.0
+text = "Quit"
+
+[node name="Spacer" parent="DropPanel/System" index="3"]
+margin_right = 924.0
+
 [node name="VersionLabel" parent="." instance=ExtResource( 2 )]
 
 [node name="SettingsMenu" parent="." instance=ExtResource( 6 )]
+quit_type = 4
 
 [node name="BadSaveDataControl" parent="." instance=ExtResource( 8 )]
 
@@ -96,3 +149,5 @@ quit_on_cancel = false
 [connection signal="quit_pressed" from="DropPanel/System" to="." method="_on_System_quit_pressed"]
 [connection signal="settings_pressed" from="DropPanel/System" to="SettingsMenu" method="_on_Settings_pressed"]
 [connection signal="quit_pressed" from="SettingsMenu" to="DropPanel/System" method="_on_Quit_pressed"]
+
+[editable path="DropPanel/System"]

--- a/project/src/main/ui/menu/SystemButtons.tscn
+++ b/project/src/main/ui/menu/SystemButtons.tscn
@@ -103,7 +103,7 @@ shortcut = ExtResource( 3 )
 texture_normal = ExtResource( 13 )
 texture_pressed = ExtResource( 14 )
 texture_hover = ExtResource( 13 )
-text = "Quit"
+text = "Back"
 color = 1
 shape = 5
 

--- a/project/src/main/ui/menu/TrainingMenu.tscn
+++ b/project/src/main/ui/menu/TrainingMenu.tscn
@@ -299,7 +299,7 @@ size_flags_vertical = 4
 texture_normal = ExtResource( 30 )
 texture_pressed = ExtResource( 29 )
 texture_hover = ExtResource( 30 )
-text = "Quit"
+text = "Back"
 color = 1
 shape = 5
 

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -158,7 +158,7 @@ size_flags_vertical = 3
 follow_focus = true
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Window/UiArea/TabContainer/SoundAndGraphics"]
-margin_right = 712.0
+margin_right = 736.0
 margin_bottom = 306.0
 size_flags_horizontal = 3
 
@@ -1264,7 +1264,7 @@ rect_min_size = Vector2( 80, 30 )
 size_flags_horizontal = 4
 size_flags_vertical = 4
 shortcut_in_tooltip = false
-text = "Quit"
+text = "Back"
 
 [node name="Holder2" type="Control" parent="Window/UiArea/Bottom/HBoxContainer/VBoxContainer1"]
 margin_top = 50.0
@@ -1285,7 +1285,7 @@ rect_min_size = Vector2( 80, 30 )
 size_flags_horizontal = 4
 size_flags_vertical = 4
 shortcut_in_tooltip = false
-text = "Quit"
+text = "Back"
 
 [node name="VBoxContainer2" type="VBoxContainer" parent="Window/UiArea/Bottom/HBoxContainer"]
 margin_left = 250.0

--- a/project/src/main/ui/settings/settings-menu-bottom.gd
+++ b/project/src/main/ui/settings/settings-menu-bottom.gd
@@ -39,12 +39,14 @@ func _refresh_quit_type() -> void:
 	var quit_text := ""
 	var other_quit_text := ""
 	match quit_type:
-		SettingsMenu.QuitType.QUIT: quit_text = tr("Quit")
-		SettingsMenu.QuitType.SAVE_AND_QUIT: quit_text = tr("Save + Quit")
+		SettingsMenu.QuitType.QUIT: quit_text = tr("Main Menu")
+		SettingsMenu.QuitType.SAVE_AND_QUIT: quit_text = tr("Main Menu")
 		SettingsMenu.QuitType.GIVE_UP: quit_text = tr("Give Up")
 		SettingsMenu.QuitType.SAVE_AND_QUIT_OR_GIVE_UP:
-			quit_text = tr("Save + Quit")
+			quit_text = tr("Main Menu")
 			other_quit_text = tr("Give Up")
+		SettingsMenu.QuitType.QUIT_TO_DESKTOP:
+			quit_text = tr("Quit")
 	
 	_quit_button.text = quit_text
 	_other_quit_button.text = other_quit_text

--- a/project/src/main/ui/settings/settings-menu.gd
+++ b/project/src/main/ui/settings/settings-menu.gd
@@ -10,7 +10,7 @@ signal quit_pressed
 signal other_quit_pressed
 
 enum QuitType {
-	QUIT, SAVE_AND_QUIT, GIVE_UP, SAVE_AND_QUIT_OR_GIVE_UP
+	QUIT, SAVE_AND_QUIT, GIVE_UP, SAVE_AND_QUIT_OR_GIVE_UP, QUIT_TO_DESKTOP
 }
 
 const QUIT := QuitType.QUIT


### PR DESCRIPTION
Changed 'quit' to 'back' and 'main menu' appropriately, for places where the button does not quit the game.

Hopefully this makes it less ambiguous what the button does.