### PR TITLE
Bug: 'Controller Disconnected' message remained visible

### DIFF
--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -1415,6 +1415,7 @@ custom_text = "Are you sure?
 Slot A (34.2 hours)"
 icon_color = Color( 1, 0.866667, 0.6, 1 )
 
+[connection signal="hide" from="." to="ControllerUnpluggedMessage" method="_on_SettingsMenu_hide"]
 [connection signal="hide" from="." to="Window/UiArea/Bottom" method="_on_SettingsMenu_hide"]
 [connection signal="show" from="." to="ControllerUnpluggedMessage" method="_on_SettingsMenu_show"]
 [connection signal="show" from="." to="Window/UiArea/Bottom" method="_on_SettingsMenu_show"]

--- a/project/src/main/ui/settings/controller-unplugged-message.gd
+++ b/project/src/main/ui/settings/controller-unplugged-message.gd
@@ -11,3 +11,7 @@ func _ready() -> void:
 func _on_SettingsMenu_show() -> void:
 	# hide by default; must be explicitly shown after the settings menu
 	hide()
+
+
+func _on_SettingsMenu_hide() -> void:
+	hide()


### PR DESCRIPTION
If the player disconnected their controller during a puzzle, then exited the settings menu, the message remained visible.

The message now becomes invisible when the settings menu is closed.