### PR TITLE
Added BlocksDuringRules.top_out_effect. Added 'none' top out effect.

### DIFF
--- a/project/assets/test/puzzle/levels/level-59c3.json
+++ b/project/assets/test/puzzle/levels/level-59c3.json
@@ -1,0 +1,25 @@
+{
+  "version": "59c3",
+  "name": "Sandbox: Expert",
+  "description": "Practice with faster pieces! There is no way to win or lose this mode.",
+  "start_speed": "A5",
+  "blocks_during": [
+    "clear_on_top_out"
+  ],
+  "icons": [
+    "basic"
+  ],
+  "lose_condition": [
+    "finish_on_lose",
+    "top_out 999999"
+  ],
+  "rank": [
+    "duration 600",
+    "rank_criteria m=1",
+    "unranked"
+  ],
+  "success_condition": {
+    "type": "lines",
+    "value": 300
+  }
+}

--- a/project/src/main/puzzle/level/blocks-during-rules.gd
+++ b/project/src/main/puzzle/level/blocks-during-rules.gd
@@ -1,6 +1,13 @@
 class_name BlocksDuringRules
 ## Blocks/boxes/pickups which appear or disappear while the game is going on.
 
+enum TopOutEffect {
+	DEFAULT,
+	CLEAR,
+	REFRESH,
+	NONE,
+}
+
 enum FilledLineClearOrder {
 	DEFAULT,
 	HIGHEST,
@@ -31,9 +38,6 @@ enum PickupType {
 ## effect.
 var clear_filled_lines := true
 
-## if true, the entire playfield is cleared when the player tops out
-var clear_on_top_out := false
-
 ## How many pieces or trigger effects a line waits before being cleared; 0 = immediate
 ##
 ## The effect of setting this to a nonzero value is that the player fills a line, then must drop a few extra pieces
@@ -63,21 +67,20 @@ var line_clear_type: int = LineClearType.DEFAULT
 ## whether pickups move with the playfield blocks
 var pickup_type: int = PickupType.DEFAULT
 
-## if true, the entire playfield is refreshed when the player tops out
-var refresh_on_top_out := false
-
 ## whether inserted rows should start from a random row in the source tiles instead of starting from the top
 var shuffle_inserted_lines: int = ShuffleLinesType.NONE
 
 ## whether filled rows should start from a random row in the source tiles instead of starting from the top
 var shuffle_filled_lines: int = ShuffleLinesType.NONE
 
+## whether the playfield clears or resets when the player tops out
+var top_out_effect: int = TopOutEffect.DEFAULT
+
 var _rule_parser: RuleParser
 
 func _init() -> void:
 	_rule_parser = RuleParser.new(self)
 	_rule_parser.add_bool("clear_filled_lines", "no_clear_filled_lines").default(true)
-	_rule_parser.add_bool("clear_on_top_out")
 	_rule_parser.add_int("filled_line_clear_delay")
 	_rule_parser.add_int("filled_line_clear_max").default(999999)
 	_rule_parser.add_int("filled_line_clear_min")
@@ -85,11 +88,11 @@ func _init() -> void:
 	_rule_parser.add_string("fill_lines")
 	_rule_parser.add_enum("line_clear_type", LineClearType)
 	_rule_parser.add_enum("pickup_type", PickupType)
-	_rule_parser.add_bool("refresh_on_top_out")
 	_rule_parser.add_enum("shuffle_filled_lines", ShuffleLinesType) \
 			.implied(ShuffleLinesType.BAG)
 	_rule_parser.add_enum("shuffle_inserted_lines", ShuffleLinesType) \
 			.implied(ShuffleLinesType.BAG)
+	_rule_parser.add_enum("top_out_effect", TopOutEffect)
 
 
 func from_json_array(json: Array) -> void:

--- a/project/src/main/puzzle/level/level-settings-upgrader.gd
+++ b/project/src/main/puzzle/level/level-settings-upgrader.gd
@@ -21,6 +21,7 @@ var _upgrade_methods := {}
 
 func _init() -> void:
 	current_version = Levels.LEVEL_DATA_VERSION
+	_add_upgrade_method("_upgrade_59c3", "59c3", "5a6b")
 	_add_upgrade_method("_upgrade_4c5c", "4c5c", "59c3")
 	_add_upgrade_method("_upgrade_49db", "49db", "4c5c")
 	_add_upgrade_method("_upgrade_4373", "4373", "49db")
@@ -95,6 +96,23 @@ func _add_upgrade_method(method: String, old_version: String, new_version: Strin
 	upgrade_method.old_version = old_version
 	upgrade_method.new_version = new_version
 	_upgrade_methods[old_version] = upgrade_method
+
+
+func _upgrade_59c3(old_json: Dictionary, old_key: String, new_json: Dictionary) -> void:
+	match old_key:
+		"blocks_during":
+			var new_value := []
+			for old_blocks_during in old_json[old_key]:
+				match old_blocks_during:
+					"clear_on_top_out":
+						new_value.append("top_out_effect clear")
+					"refresh_on_top_out":
+						new_value.append("top_out_effect refresh")
+					_:
+						new_value.append(old_blocks_during)
+			new_json[old_key] = new_value
+		_:
+			new_json[old_key] = old_json[old_key]
 
 
 ## Simplify level rank metadata.

--- a/project/src/main/puzzle/level/levels.gd
+++ b/project/src/main/puzzle/level/levels.gd
@@ -15,4 +15,4 @@ enum Result {
 
 ## Current version for saved level data. Should be updated if and only if the level format changes.
 ## This version number follows a 'ymdh' hex date format which is documented in issue #234.
-const LEVEL_DATA_VERSION := "59c3"
+const LEVEL_DATA_VERSION := "5a6b"

--- a/project/src/main/puzzle/line-filler.gd
+++ b/project/src/main/puzzle/line-filler.gd
@@ -237,7 +237,8 @@ func _on_Level_settings_changed() -> void:
 
 
 func _on_LineClearer_after_lines_deleted(lines: Array) -> void:
-	if PuzzleState.topping_out and CurrentLevel.settings.blocks_during.refresh_on_top_out:
+	if PuzzleState.topping_out \
+			and CurrentLevel.settings.blocks_during.top_out_effect == BlocksDuringRules.TopOutEffect.REFRESH:
 		# schedule line fills after a top out
 		_schedule_playfield_refill()
 	else:

--- a/project/src/main/puzzle/pan/puzzle-frying-pans-ui.gd
+++ b/project/src/main/puzzle/pan/puzzle-frying-pans-ui.gd
@@ -28,7 +28,7 @@ func _refresh_lives() -> void:
 				# the player always starts with at least one life in career mode, even if they've topped out a lot on
 				# previous levels
 				pans_remaining = 1
-	gold = CurrentLevel.settings.blocks_during.clear_on_top_out
+	gold = CurrentLevel.settings.blocks_during.top_out_effect == BlocksDuringRules.TopOutEffect.CLEAR
 	refresh_tilemap()
 
 

--- a/project/src/main/puzzle/top-out-tracker.gd
+++ b/project/src/main/puzzle/top-out-tracker.gd
@@ -17,24 +17,29 @@ func _on_PuzzleState_topped_out() -> void:
 	
 	if not PuzzleState.level_performance.lost:
 		_playfield.break_combo()
-		if CurrentLevel.settings.blocks_during.refresh_on_top_out:
-			_playfield.schedule_line_clears(range(PuzzleTileMap.ROW_COUNT),
-					PieceSpeeds.current_speed.playfield_clear_delay(), false)
-		elif CurrentLevel.settings.blocks_during.clear_on_top_out:
-			_playfield.schedule_line_clears(range(PuzzleTileMap.ROW_COUNT),
-					PieceSpeeds.current_speed.playfield_clear_delay(), false)
-		else:
-			_playfield.schedule_line_clears(range(PuzzleTileMap.ROW_COUNT - LINES_CLEARED_ON_TOP_OUT,
-					PuzzleTileMap.ROW_COUNT), PieceSpeeds.current_speed.playfield_clear_delay(), false)
+		match CurrentLevel.settings.blocks_during.top_out_effect:
+			BlocksDuringRules.TopOutEffect.NONE:
+				pass
+			BlocksDuringRules.TopOutEffect.REFRESH:
+				_playfield.schedule_line_clears(range(PuzzleTileMap.ROW_COUNT),
+						PieceSpeeds.current_speed.playfield_clear_delay(), false)
+			BlocksDuringRules.TopOutEffect.CLEAR:
+				_playfield.schedule_line_clears(range(PuzzleTileMap.ROW_COUNT),
+						PieceSpeeds.current_speed.playfield_clear_delay(), false)
+			_:
+				_playfield.schedule_line_clears(range(PuzzleTileMap.ROW_COUNT - LINES_CLEARED_ON_TOP_OUT,
+						PuzzleTileMap.ROW_COUNT), PieceSpeeds.current_speed.playfield_clear_delay(), false)
 
 
 func _on_Playfield_after_lines_deleted(_lines: Array) -> void:
-	if PuzzleState.topping_out and not CurrentLevel.settings.blocks_during.refresh_on_top_out:
+	if PuzzleState.topping_out \
+			and CurrentLevel.settings.blocks_during.top_out_effect != BlocksDuringRules.TopOutEffect.REFRESH:
 		# The current level's top out process ends with the lines which were just deleted. Exit the top out state.
 		PuzzleState.topping_out = false
 
 
 func _on_Playfield_after_lines_filled() -> void:
-	if PuzzleState.topping_out and CurrentLevel.settings.blocks_during.refresh_on_top_out:
+	if PuzzleState.topping_out \
+			and CurrentLevel.settings.blocks_during.top_out_effect == BlocksDuringRules.TopOutEffect.REFRESH:
 		# The current level's top out process ends with the lines which were just filled. Exit the top out state.
 		PuzzleState.topping_out = false

--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -64,6 +64,8 @@ func prepare_tutorial_level() -> void:
 	# them to receive a discouraging 'you broke your combo' fanfare at the start of a section.
 	PuzzleState.set_combo(0)
 	PuzzleState.tutorial_section_finished = false
+	PuzzleState.level_performance.lost = false
+	PuzzleState.topping_out = false
 	
 	# Hide all completed skill tally items.
 	for skill_tally_item_obj in hud.skill_tally_items():

--- a/project/src/test/puzzle/level/test-blocks-during-rules.gd
+++ b/project/src/test/puzzle/level/test-blocks-during-rules.gd
@@ -18,7 +18,7 @@ func test_to_json_empty() -> void:
 
 func test_to_json_full() -> void:
 	rules.clear_filled_lines = false
-	rules.clear_on_top_out = true
+	rules.top_out_effect = BlocksDuringRules.TopOutEffect.CLEAR
 	rules.filled_line_clear_delay = 2
 	rules.filled_line_clear_max = 3
 	rules.filled_line_clear_min = 4
@@ -30,7 +30,7 @@ func test_to_json_full() -> void:
 	rules.shuffle_inserted_lines = BlocksDuringRules.ShuffleLinesType.SLICE
 	
 	assert_eq(rules.to_json_array(),
-			["no_clear_filled_lines", "clear_on_top_out", "filled_line_clear_delay 2", "filled_line_clear_max 3",
+			["no_clear_filled_lines", "top_out_effect clear", "filled_line_clear_delay 2", "filled_line_clear_max 3",
 			"filled_line_clear_min 4", "filled_line_clear_order random", "fill_lines 0", "line_clear_type float_fall",
 			"pickup_type float_regen", "shuffle_filled_lines slice", "shuffle_inserted_lines slice",
 			])
@@ -38,7 +38,7 @@ func test_to_json_full() -> void:
 
 func test_from_json_empty() -> void:
 	rules.from_json_array([])
-	assert_eq(rules.clear_on_top_out, false)
+	assert_eq(rules.top_out_effect, BlocksDuringRules.TopOutEffect.DEFAULT)
 	assert_eq(rules.filled_line_clear_delay, 0)
 	assert_eq(rules.filled_line_clear_max, 999999)
 	assert_eq(rules.filled_line_clear_min, 0)
@@ -52,11 +52,11 @@ func test_from_json_empty() -> void:
 
 func test_from_json_full() -> void:
 	rules.from_json_array(
-			["no_clear_filled_lines", "clear_on_top_out", "filled_line_clear_delay 2", "filled_line_clear_max 3",
+			["no_clear_filled_lines", "top_out_effect clear", "filled_line_clear_delay 2", "filled_line_clear_max 3",
 			"filled_line_clear_min 4", "filled_line_clear_order random", "fill_lines 0", "line_clear_type float_fall",
 			"pickup_type float_regen", "shuffle_filled_lines slice", "shuffle_inserted_lines slice",])
 	assert_eq(rules.clear_filled_lines, false)
-	assert_eq(rules.clear_on_top_out, true)
+	assert_eq(rules.top_out_effect, BlocksDuringRules.TopOutEffect.CLEAR)
 	assert_eq(rules.filled_line_clear_delay, 2)
 	assert_eq(rules.filled_line_clear_max, 3)
 	assert_eq(rules.filled_line_clear_min, 4)
@@ -69,14 +69,14 @@ func test_from_json_full() -> void:
 
 
 func test_convert_to_json_and_back() -> void:
-	rules.clear_on_top_out = true
+	rules.top_out_effect = BlocksDuringRules.TopOutEffect.CLEAR
 	rules.line_clear_type = BlocksDuringRules.LineClearType.FLOAT_FALL
 	rules.pickup_type = BlocksDuringRules.PickupType.FLOAT_REGEN
 	rules.shuffle_filled_lines = BlocksDuringRules.ShuffleLinesType.SLICE
 	rules.shuffle_inserted_lines = BlocksDuringRules.ShuffleLinesType.SLICE
 	_convert_to_json_and_back()
 	
-	assert_eq(rules.clear_on_top_out, true)
+	assert_eq(rules.top_out_effect, BlocksDuringRules.TopOutEffect.CLEAR)
 	assert_eq(rules.line_clear_type, BlocksDuringRules.LineClearType.FLOAT_FALL)
 	assert_eq(rules.pickup_type, BlocksDuringRules.PickupType.FLOAT_REGEN)
 	assert_eq(rules.shuffle_filled_lines, BlocksDuringRules.ShuffleLinesType.SLICE)

--- a/project/src/test/puzzle/level/test-level-settings.gd
+++ b/project/src/test/puzzle/level/test-level-settings.gd
@@ -93,6 +93,12 @@ func test_load_4c5c_data() -> void:
 	assert_eq(0, settings.rank.rank_criteria.thresholds_by_grade.size())
 
 
+func test_load_59c3_data() -> void:
+	load_level("level-59c3")
+	
+	assert_eq(settings.blocks_during.top_out_effect, BlocksDuringRules.TopOutEffect.CLEAR)
+
+
 func test_load_tiles() -> void:
 	load_level("level-tiles")
 	
@@ -165,7 +171,7 @@ func test_to_json_milestones_and_tiles() -> void:
 
 
 func test_to_json_rules() -> void:
-	settings.blocks_during.clear_on_top_out = true
+	settings.blocks_during.top_out_effect = BlocksDuringRules.TopOutEffect.CLEAR
 	settings.combo_break.pieces = 3
 	settings.input_replay.action_timings = {"25 +rotate_cw": true, "33 -rotate_cw": true}
 	settings.lose_condition.finish_on_lose = true
@@ -179,7 +185,7 @@ func test_to_json_rules() -> void:
 			[{"phases": ["line_cleared y=0-5"], "effect": "insert_line tiles_key=0"}])
 	_convert_to_json_and_back()
 	
-	assert_eq(settings.blocks_during.clear_on_top_out, true)
+	assert_eq(settings.blocks_during.top_out_effect, BlocksDuringRules.TopOutEffect.CLEAR)
 	assert_eq(settings.combo_break.pieces, 3)
 	assert_eq(settings.input_replay.action_timings.keys(), ["25 +rotate_cw", "33 -rotate_cw"])
 	assert_eq(settings.lose_condition.finish_on_lose, true)


### PR DESCRIPTION
Combined 'clear_on_top_out' and 'refresh_on_top_out' into a single 'top_out_effect' field. These two fields shouldn't have been separated, since otherwise it's ambiguous what should happen if both are set to true.

Added a new 'top_out_effect none'. Some tutorials don't want to alter the playfield when the player tops out, and just want to restart the tutorial section.