### PR TITLE
Bug: buffered player inputs impacted replays

### DIFF
--- a/project/src/main/puzzle/piece/frame-input.gd
+++ b/project/src/main/puzzle/piece/frame-input.gd
@@ -79,6 +79,10 @@ func buffer_input() -> void:
 
 ## Replays any inputs which were pressed while buffering.
 func pop_buffered_input() -> void:
+	if not CurrentLevel.settings.input_replay.empty():
+		# don't process button presses when replaying prerecorded input
+		return
+	
 	_buffer = false
 	if not _buffer_timer.is_stopped():
 		_just_pressed = true


### PR DESCRIPTION
If the player mashed the rotate keys when a replay was starting, their buffered input would be applied to the replay. For example, during the 'squish and recover' tutorial, they could mash the rotate buttons during the two replays of the tutorial, causing Fat Sensei to clear a line or to block the well entirely.

Buffered inputs no longer impact replays.