### PR TITLE
Tutorial top out effect -> none

### DIFF
--- a/project/assets/main/puzzle/levels/tutorial/basics-0.json
+++ b/project/assets/main/puzzle/levels/tutorial/basics-0.json
@@ -3,6 +3,9 @@
   "name": "Basic Techniques",
   "description": "Learn to clear lines, to make snack boxes and to squish pieces.",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/basics-1.json
+++ b/project/assets/main/puzzle/levels/tutorial/basics-1.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/basics-2.json
+++ b/project/assets/main/puzzle/levels/tutorial/basics-2.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/basics-3.json
+++ b/project/assets/main/puzzle/levels/tutorial/basics-3.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/cakes-0.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-0.json
@@ -3,6 +3,9 @@
   "name": "Make Cakes",
   "description": "Learn all eight different cake box recipes.",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/cakes-2.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-2.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect none"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 2

--- a/project/assets/main/puzzle/levels/tutorial/cakes-3.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-3.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect none"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 3

--- a/project/assets/main/puzzle/levels/tutorial/cakes-4.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-4.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect none"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 4

--- a/project/assets/main/puzzle/levels/tutorial/cakes-6.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-6.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect none"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 4

--- a/project/assets/main/puzzle/levels/tutorial/cakes-7.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-7.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect none"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 5

--- a/project/assets/main/puzzle/levels/tutorial/cakes-8.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-8.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect none"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 6

--- a/project/assets/main/puzzle/levels/tutorial/combo-0.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-0.json
@@ -3,6 +3,9 @@
   "name": "Build Combos",
   "description": "Learn how combos work, and learn to make snack boxes and cake boxes during your combos.",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect none"
+  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/combo-2.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-2.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect none"
+  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/combo-5.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-5.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect none"
+  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/spins-0.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-0.json
@@ -3,6 +3,9 @@
   "name": "Meet Spins",
   "description": "Learn to spin and flip pieces in tight spaces.",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 1

--- a/project/assets/main/puzzle/levels/tutorial/spins-1-fixed.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-1-fixed.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 1

--- a/project/assets/main/puzzle/levels/tutorial/spins-1.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-1.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 1

--- a/project/assets/main/puzzle/levels/tutorial/spins-2.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-2.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 1

--- a/project/assets/main/puzzle/levels/tutorial/spins-3.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-3.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 1

--- a/project/assets/main/puzzle/levels/tutorial/spins-4.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-4.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 1

--- a/project/assets/main/puzzle/levels/tutorial/spins-5.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-5.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 1

--- a/project/assets/main/puzzle/levels/tutorial/spins-6.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-6.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 1

--- a/project/assets/main/puzzle/levels/tutorial/spins-7.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-7.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 1

--- a/project/assets/main/puzzle/levels/tutorial/spins-secret.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-secret.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 1

--- a/project/assets/main/puzzle/levels/tutorial/squish-0.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-0.json
@@ -3,6 +3,9 @@
   "name": "Squish and Recover",
   "description": "Learn how squish moves work and when to use them.",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/squish-2.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-2.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/squish-3.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-3.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/squish-4.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-4.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect refresh"
+  ],
   "lose_condition": [
     "top_out 999999"
   ],

--- a/project/assets/main/puzzle/levels/tutorial/squish-5.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-5.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect none"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 5

--- a/project/assets/main/puzzle/levels/tutorial/squish-6.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-6.json
@@ -1,6 +1,9 @@
 {
   "version": "5a6b",
   "start_speed": "T",
+  "blocks_during": [
+    "top_out_effect none"
+  ],
   "finish_condition": {
     "type": "pieces",
     "value": 5

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -43,6 +43,9 @@ signal before_piece_written
 ## emitted after the piece is written, and all boxes are made, and all lines are cleared
 signal after_piece_written
 
+## emitted when the current piece can't be placed in the playfield, before TopOutTracker applies other penalties
+signal before_topped_out
+
 signal score_changed
 
 ## emitted when a combo value changes, when building or ending a combo
@@ -204,6 +207,7 @@ func top_out() -> void:
 	else:
 		set_topping_out(true)
 		apply_top_out_score_penalty()
+		emit_signal("before_topped_out")
 		emit_signal("topped_out")
 		emit_signal("score_changed")
 
@@ -226,6 +230,7 @@ func make_player_lose() -> void:
 		apply_top_out_score_penalty()
 		# use up all of the players lives; especially for career mode, we don't want to reward players who give up
 		PuzzleState.level_performance.top_out_count = CurrentLevel.settings.lose_condition.top_out
+		emit_signal("before_topped_out")
 		emit_signal("topped_out")
 		emit_signal("score_changed")
 	end_game()

--- a/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
@@ -19,6 +19,7 @@ var _level_finished := false
 func _ready() -> void:
 	PuzzleState.connect("after_game_prepared", self, "_on_PuzzleState_after_game_prepared")
 	PuzzleState.connect("after_piece_written", self, "_on_PuzzleState_after_piece_written")
+	PuzzleState.connect("topped_out", self, "_on_PuzzleState_topped_out")
 	playfield.connect("box_built", self, "_on_Playfield_box_built")
 	piece_manager.connect("piece_spawned", self, "_on_PieceManager_piece_spawned")
 	
@@ -265,3 +266,11 @@ func _on_PuzzleState_game_ended() -> void:
 					% [StringUtils.english_number(self, _cakes_built).to_upper()])
 			hud.enqueue_message(tr("I'll have to think of some harder tutorials for someone like you."
 					+ "\n\nYou little troublemaker!"))
+
+
+func _on_PuzzleState_topped_out() -> void:
+	match CurrentLevel.settings.id:
+		"tutorial/cakes_2", "tutorial/cakes_3", "tutorial/cakes_4", \
+		"tutorial/cakes_6", "tutorial/cakes_7", "tutorial/cakes_8":
+			# retry the level
+			_advance_level()

--- a/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-combo-module.gd
@@ -27,9 +27,11 @@ func _ready() -> void:
 	PuzzleState.connect("after_game_prepared", self, "_on_PuzzleState_after_game_prepared")
 	PuzzleState.connect("after_piece_written", self, "_on_PuzzleState_after_piece_written")
 	PuzzleState.connect("combo_ended", self, "_on_PuzzleState_combo_ended")
+	PuzzleState.connect("topped_out", self, "_on_PuzzleState_topped_out")
 	
 	playfield.connect("line_cleared", self, "_on_Playfield_line_cleared")
 	playfield.connect("box_built", self, "_on_Playfield_box_built")
+	
 	piece_manager.connect("piece_spawned", self, "_on_PieceManager_piece_spawned")
 	hud.diagram.connect("ok_chosen", self, "_on_TutorialDiagram_ok_chosen")
 	hud.diagram.connect("help_chosen", self, "_on_TutorialDiagram_help_chosen")
@@ -227,6 +229,12 @@ func _on_Playfield_box_built(_rect: Rect2, color: int) -> void:
 	if Foods.is_cake_box(color):
 		_cakes_built += 1
 		hud.skill_tally_item("CakeBox").increment()
+
+
+func _on_PuzzleState_topped_out() -> void:
+	match CurrentLevel.settings.id:
+		"tutorial/combo_0", "tutorial/combo_2", "tutorial/combo_5":
+			_advance_level()
 
 
 func _on_PuzzleState_combo_ended() -> void:

--- a/project/src/main/puzzle/tutorial/tutorial-spins-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-spins-module.gd
@@ -40,6 +40,7 @@ var _prev_piece_pos: Vector2
 func _ready() -> void:
 	PuzzleState.connect("after_game_prepared", self, "_on_PuzzleState_after_game_prepared")
 	PuzzleState.connect("after_piece_written", self, "_on_PuzzleState_after_piece_written")
+	PuzzleState.connect("topped_out", self, "_on_PuzzleState_topped_out")
 	
 	hud.set_message(tr("Let's learn about spin moves!"
 			+ "\n\nMaybe you already figured out how they work, but I'll try to teach you something new."))
@@ -410,3 +411,11 @@ func _on_PuzzleState_after_game_prepared() -> void:
 	hud.show_skill_tally_items()
 	hud.skill_tally_item("Box").visible = false
 	prepare_tutorial_level()
+
+
+func _on_PuzzleState_topped_out() -> void:
+	match CurrentLevel.settings.id:
+		"tutorial/spins_0", "tutorial/spins_1", "tutorial/spins_1_fixed", "tutorial/spins_2", \
+		"tutorial/spins_3", "tutorial/spins_4", "tutorial/spins_5", "tutorial/spins_6", \
+		"tutorial/spins_7", "tutorial/spins_secret":
+			_advance_level()

--- a/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-squish-module.gd
@@ -25,6 +25,7 @@ var _level_attempt_count: Dictionary
 func _ready() -> void:
 	PuzzleState.connect("after_game_prepared", self, "_on_PuzzleState_after_game_prepared")
 	PuzzleState.connect("after_piece_written", self, "_on_PuzzleState_after_piece_written")
+	PuzzleState.connect("topped_out", self, "_on_PuzzleState_topped_out")
 	
 	playfield.connect("box_built", self, "_on_Playfield_box_built")
 	piece_manager.connect("squish_moved", self, "_on_PieceManager_squish_moved")
@@ -249,3 +250,9 @@ func _on_TutorialDiagram_ok_chosen() -> void:
 
 func _on_TutorialDiagram_help_chosen() -> void:
 	_show_next_diagram()
+
+
+func _on_PuzzleState_topped_out() -> void:
+	match CurrentLevel.settings.id:
+		"tutorial/squish_5", "tutorial/squish_6":
+			_advance_level()


### PR DESCRIPTION
Changed tutorials to restart the tutorial section when the player tops out. Before, some tutorials such as the combo tutorial would let the player keep playing, even if they topped out, which is nonsensical since they were meant to keep building a combo.

It did, admittedly, take great effort to top out during those tutorials, possibly even requiring a greater level of mastery than completing the tutorial appropriately. If I had more time, I'd consider adding a little easter egg for it.