### PR TITLE
Eaten pieces emit piece_written signals

### DIFF
--- a/project/src/main/puzzle/critter/critter-manager.gd
+++ b/project/src/main/puzzle/critter/critter-manager.gd
@@ -156,7 +156,9 @@ func check_for_empty_piece() -> void:
 		_playfield.add_misc_delay_frames(PieceSpeeds.current_speed.lock_delay)
 		
 		# fire 'piece_written' triggers to ensure critters get advanced
+		PuzzleState.before_piece_written()
 		CurrentLevel.settings.triggers.run_triggers(LevelTrigger.PIECE_WRITTEN)
+		PuzzleState.after_piece_written()
 		_piece_manager.set_state(_piece_manager.states.wait_for_playfield)
 
 


### PR DESCRIPTION
Before, eaten pieces emitted PIECE_WRITTEN trigger but not the corresponding signals. Most notably, these signals advance the ComboTracker so it meant sharks eating your piece let you place too many pieces.