### PR TITLE
Clip results hud receipt vertically.

### DIFF
--- a/project/src/main/puzzle/result/ResultsHud.tscn
+++ b/project/src/main/puzzle/result/ResultsHud.tscn
@@ -569,15 +569,21 @@ anchor_bottom = 1.0
 mouse_filter = 2
 script = ExtResource( 8 )
 
-[node name="ReceiptPaper" type="TextureRect" parent="."]
-margin_left = 765.0
+[node name="Clipper" type="Control" parent="."]
+margin_left = 580.0
+margin_right = 1180.0
+margin_bottom = 684.0
+rect_clip_content = true
+
+[node name="ReceiptPaper" type="TextureRect" parent="Clipper"]
+margin_left = 185.0
 margin_top = 4.0
-margin_right = 1023.0
+margin_right = 443.0
 margin_bottom = 716.0
 texture = ExtResource( 26 )
 expand = true
 
-[node name="Header" type="TextureRect" parent="ReceiptPaper"]
+[node name="Header" type="TextureRect" parent="Clipper/ReceiptPaper"]
 margin_left = 16.5
 margin_top = 20.0
 margin_right = 241.5
@@ -587,7 +593,7 @@ texture = ExtResource( 19 )
 expand = true
 script = ExtResource( 13 )
 
-[node name="Label" type="Label" parent="ReceiptPaper/Header"]
+[node name="Label" type="Label" parent="Clipper/ReceiptPaper/Header"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 custom_colors/font_color = Color( 0.85098, 0.85098, 0.85098, 1 )
@@ -597,16 +603,16 @@ Complete!"
 align = 1
 valign = 1
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="ReceiptPaper/Header"]
+[node name="AnimationPlayer" type="AnimationPlayer" parent="Clipper/ReceiptPaper/Header"]
 anims/RESET = SubResource( 3 )
 anims/play = SubResource( 4 )
 
-[node name="HeaderSfx" type="AudioStreamPlayer" parent="ReceiptPaper/Header"]
+[node name="HeaderSfx" type="AudioStreamPlayer" parent="Clipper/ReceiptPaper/Header"]
 stream = ExtResource( 6 )
 volume_db = -2.0
 bus = "Sound Bus"
 
-[node name="Table" type="TextureRect" parent="ReceiptPaper"]
+[node name="Table" type="TextureRect" parent="Clipper/ReceiptPaper"]
 margin_left = 13.0
 margin_top = 110.0
 margin_right = 245.0
@@ -615,7 +621,7 @@ texture = ExtResource( 15 )
 expand = true
 script = ExtResource( 10 )
 
-[node name="BoxesLabel" type="Label" parent="ReceiptPaper/Table"]
+[node name="BoxesLabel" type="Label" parent="Clipper/ReceiptPaper/Table"]
 margin_left = 3.0
 margin_top = 2.0
 margin_right = 78.0
@@ -627,7 +633,7 @@ text = "Boxes
 align = 1
 valign = 1
 
-[node name="CombosLabel" type="Label" parent="ReceiptPaper/Table"]
+[node name="CombosLabel" type="Label" parent="Clipper/ReceiptPaper/Table"]
 margin_left = 78.0
 margin_top = 2.0
 margin_right = 153.0
@@ -639,7 +645,7 @@ text = "Combos
 align = 1
 valign = 1
 
-[node name="ExtraLabel" type="Label" parent="ReceiptPaper/Table"]
+[node name="ExtraLabel" type="Label" parent="Clipper/ReceiptPaper/Table"]
 margin_left = 154.0
 margin_top = 2.0
 margin_right = 229.0
@@ -651,10 +657,10 @@ text = "Extra
 align = 1
 valign = 1
 
-[node name="LabelRefreshTimer" type="Timer" parent="ReceiptPaper/Table"]
+[node name="LabelRefreshTimer" type="Timer" parent="Clipper/ReceiptPaper/Table"]
 wait_time = 0.05
 
-[node name="BarGraph" type="Control" parent="ReceiptPaper"]
+[node name="BarGraph" type="Control" parent="Clipper/ReceiptPaper"]
 margin_left = 13.0
 margin_top = 160.0
 margin_right = 245.0
@@ -663,32 +669,32 @@ rect_clip_content = true
 script = ExtResource( 9 )
 receipt_table_path = NodePath("../Table")
 
-[node name="Contents" type="Control" parent="ReceiptPaper/BarGraph"]
+[node name="Contents" type="Control" parent="Clipper/ReceiptPaper/BarGraph"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 
-[node name="BoxBar" parent="ReceiptPaper/BarGraph/Contents" instance=ExtResource( 1 )]
+[node name="BoxBar" parent="Clipper/ReceiptPaper/BarGraph/Contents" instance=ExtResource( 1 )]
 material = SubResource( 21 )
 margin_top = 371.0
 margin_right = 85.0
 margin_bottom = 448.0
 custom_styles/panel = SubResource( 11 )
 
-[node name="ComboBar" parent="ReceiptPaper/BarGraph/Contents" instance=ExtResource( 1 )]
+[node name="ComboBar" parent="Clipper/ReceiptPaper/BarGraph/Contents" instance=ExtResource( 1 )]
 material = SubResource( 20 )
 margin_top = 219.0
 margin_right = 85.0
 margin_bottom = 372.0
 custom_styles/panel = SubResource( 12 )
 
-[node name="OtherBar" parent="ReceiptPaper/BarGraph/Contents" instance=ExtResource( 1 )]
+[node name="OtherBar" parent="Clipper/ReceiptPaper/BarGraph/Contents" instance=ExtResource( 1 )]
 material = SubResource( 7 )
 margin_top = 183.0
 margin_right = 85.0
 margin_bottom = 220.0
 custom_styles/panel = SubResource( 13 )
 
-[node name="TotalLabel" type="Label" parent="ReceiptPaper/BarGraph/Contents"]
+[node name="TotalLabel" type="Label" parent="Clipper/ReceiptPaper/BarGraph/Contents"]
 margin_top = 163.0
 margin_right = 85.0
 margin_bottom = 183.0
@@ -698,69 +704,69 @@ text = "¥387"
 align = 1
 valign = 1
 
-[node name="SuccessGoal" parent="ReceiptPaper/BarGraph/Contents" instance=ExtResource( 2 )]
+[node name="SuccessGoal" parent="Clipper/ReceiptPaper/BarGraph/Contents" instance=ExtResource( 2 )]
 margin_left = 0.0
 margin_top = 198.0
 margin_right = 200.0
 margin_bottom = 218.0
 
-[node name="SssGoal" parent="ReceiptPaper/BarGraph/Contents" instance=ExtResource( 2 )]
+[node name="SssGoal" parent="Clipper/ReceiptPaper/BarGraph/Contents" instance=ExtResource( 2 )]
 margin_left = 0.0
 margin_top = 198.0
 margin_right = 200.0
 margin_bottom = 218.0
 
-[node name="SsGoal" parent="ReceiptPaper/BarGraph/Contents" instance=ExtResource( 2 )]
+[node name="SsGoal" parent="Clipper/ReceiptPaper/BarGraph/Contents" instance=ExtResource( 2 )]
 margin_left = 0.0
 margin_top = 271.0
 margin_right = 200.0
 margin_bottom = 291.0
 text = "¥20,000: SS"
 
-[node name="SGoal" parent="ReceiptPaper/BarGraph/Contents" instance=ExtResource( 2 )]
+[node name="SGoal" parent="Clipper/ReceiptPaper/BarGraph/Contents" instance=ExtResource( 2 )]
 margin_left = 0.0
 margin_top = 331.0
 margin_right = 200.0
 margin_bottom = 351.0
 text = "¥15,000: S"
 
-[node name="AGoal" parent="ReceiptPaper/BarGraph/Contents" instance=ExtResource( 2 )]
+[node name="AGoal" parent="Clipper/ReceiptPaper/BarGraph/Contents" instance=ExtResource( 2 )]
 margin_left = 0.0
 margin_top = 380.0
 margin_right = 200.0
 margin_bottom = 400.0
 text = "¥10,000: A"
 
-[node name="BGoal" parent="ReceiptPaper/BarGraph/Contents" instance=ExtResource( 2 )]
+[node name="BGoal" parent="Clipper/ReceiptPaper/BarGraph/Contents" instance=ExtResource( 2 )]
 margin_left = 0.0
 margin_top = 423.0
 margin_right = 200.0
 margin_bottom = 443.0
 text = "¥5,000: B"
 
-[node name="Sfx" type="Node" parent="ReceiptPaper/BarGraph"]
+[node name="Sfx" type="Node" parent="Clipper/ReceiptPaper/BarGraph"]
 script = ExtResource( 12 )
 
-[node name="Pop" type="AudioStreamPlayer" parent="ReceiptPaper/BarGraph/Sfx"]
+[node name="Pop" type="AudioStreamPlayer" parent="Clipper/ReceiptPaper/BarGraph/Sfx"]
 stream = ExtResource( 22 )
 volume_db = -12.0
 bus = "Sound Bus"
 
-[node name="Stamp" type="Control" parent="ReceiptPaper"]
+[node name="Stamp" type="Control" parent="Clipper/ReceiptPaper"]
 margin_left = 73.0001
 margin_top = -135.0
 margin_right = 113.0
 margin_bottom = -95.0
 script = ExtResource( 11 )
 
-[node name="InkClip" type="Control" parent="ReceiptPaper/Stamp"]
+[node name="InkClip" type="Control" parent="Clipper/ReceiptPaper/Stamp"]
 margin_left = -64.0001
 margin_top = 229.0
 margin_right = 177.0
 margin_bottom = 529.0
 rect_clip_content = true
 
-[node name="Ink" type="Sprite" parent="ReceiptPaper/Stamp/InkClip"]
+[node name="Ink" type="Sprite" parent="Clipper/ReceiptPaper/Stamp/InkClip"]
 visible = false
 modulate = Color( 1, 1, 1, 0.784314 )
 position = Vector2( 162, 142 )
@@ -770,7 +776,7 @@ hframes = 5
 vframes = 4
 frame = 7
 
-[node name="Hand" type="Sprite" parent="ReceiptPaper/Stamp"]
+[node name="Hand" type="Sprite" parent="Clipper/ReceiptPaper/Stamp"]
 visible = false
 material = SubResource( 16 )
 position = Vector2( 98, 370 )
@@ -780,21 +786,21 @@ z_index = 1
 texture = ExtResource( 20 )
 offset = Vector2( 225, 800 )
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="ReceiptPaper/Stamp"]
+[node name="AnimationPlayer" type="AnimationPlayer" parent="Clipper/ReceiptPaper/Stamp"]
 anims/RESET = SubResource( 14 )
 anims/play = SubResource( 15 )
 
-[node name="StampSfx" type="AudioStreamPlayer" parent="ReceiptPaper/Stamp"]
+[node name="StampSfx" type="AudioStreamPlayer" parent="Clipper/ReceiptPaper/Stamp"]
 stream = ExtResource( 6 )
 volume_db = -2.0
 bus = "Sound Bus"
 
-[node name="Medal" type="Control" parent="ReceiptPaper"]
+[node name="Medal" type="Control" parent="Clipper/ReceiptPaper"]
 margin_right = 40.0
 margin_bottom = 40.0
 script = ExtResource( 14 )
 
-[node name="Medal" type="Sprite" parent="ReceiptPaper/Medal"]
+[node name="Medal" type="Sprite" parent="Clipper/ReceiptPaper/Medal"]
 visible = false
 position = Vector2( 204, 283 )
 scale = Vector2( 0.5, 0.5 )
@@ -803,7 +809,7 @@ hframes = 3
 vframes = 2
 frame = 2
 
-[node name="Hand" type="Sprite" parent="ReceiptPaper/Medal"]
+[node name="Hand" type="Sprite" parent="Clipper/ReceiptPaper/Medal"]
 visible = false
 material = SubResource( 17 )
 position = Vector2( 300, 507 )
@@ -812,21 +818,21 @@ z_index = 1
 texture = ExtResource( 17 )
 offset = Vector2( 350, 850 )
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="ReceiptPaper/Medal"]
+[node name="AnimationPlayer" type="AnimationPlayer" parent="Clipper/ReceiptPaper/Medal"]
 anims/RESET = SubResource( 19 )
 anims/play = SubResource( 18 )
 
-[node name="BangSfx" type="AudioStreamPlayer" parent="ReceiptPaper/Medal"]
+[node name="BangSfx" type="AudioStreamPlayer" parent="Clipper/ReceiptPaper/Medal"]
 stream = ExtResource( 24 )
 volume_db = 2.0
 bus = "Sound Bus"
 
-[node name="ShimmerSfx" type="AudioStreamPlayer" parent="ReceiptPaper/Medal"]
+[node name="ShimmerSfx" type="AudioStreamPlayer" parent="Clipper/ReceiptPaper/Medal"]
 stream = ExtResource( 23 )
 volume_db = -12.0
 bus = "Sound Bus"
 
-[node name="Shadow" type="Polygon2D" parent="ReceiptPaper" groups=["night_mode_dark"]]
+[node name="Shadow" type="Polygon2D" parent="Clipper/ReceiptPaper" groups=["night_mode_dark"]]
 show_behind_parent = true
 position = Vector2( 73.0001, -135 )
 scale = Vector2( 0.444724, 0.444458 )
@@ -847,4 +853,4 @@ volume_db = -8.0
 pitch_scale = 1.1
 bus = "Sound Bus"
 
-[connection signal="timeout" from="ReceiptPaper/Table/LabelRefreshTimer" to="ReceiptPaper/Table" method="_on_LabelRefreshTimer_timeout"]
+[connection signal="timeout" from="Clipper/ReceiptPaper/Table/LabelRefreshTimer" to="Clipper/ReceiptPaper/Table" method="_on_LabelRefreshTimer_timeout"]

--- a/project/src/main/puzzle/result/results-hud.gd
+++ b/project/src/main/puzzle/result/results-hud.gd
@@ -9,20 +9,20 @@ signal receipt_shown
 signal stamped
 
 ## Receipt paper position when it is hidden
-const POSITION_HIDDEN := Vector2(765, 800)
+const POSITION_HIDDEN := Vector2(185, 800)
 
 ## Receipt paper position when it is shown
-const POSITION_SHOWN := Vector2(765, 4)
+const POSITION_SHOWN := Vector2(185, 4)
 
 onready var _sfx_receipt_show := $Sfx/ReceiptShow
 onready var _sfx_receipt_hide := $Sfx/ReceiptHide
 
-onready var _receipt_paper := $ReceiptPaper
-onready var _header := $ReceiptPaper/Header
-onready var _table := $ReceiptPaper/Table
-onready var _bar_graph := $ReceiptPaper/BarGraph
-onready var _stamp := $ReceiptPaper/Stamp
-onready var _medal := $ReceiptPaper/Medal
+onready var _receipt_paper := $Clipper/ReceiptPaper
+onready var _header := $Clipper/ReceiptPaper/Header
+onready var _table := $Clipper/ReceiptPaper/Table
+onready var _bar_graph := $Clipper/ReceiptPaper/BarGraph
+onready var _stamp := $Clipper/ReceiptPaper/Stamp
+onready var _medal := $Clipper/ReceiptPaper/Medal
 
 ## Directs the long animation of showing the receipt, building up a bar graph, and showing the player's grade.
 onready var _tween: SceneTreeTween


### PR DESCRIPTION
The results hud receipt is now clipped. Its boundaries extend 84 pixels below the bottom of the screen. This distance means it will remain unclipped for users playing the game at a 4:3 aspect ratio, but also means it won't extend so far as to look too weird on a vertical monitor.