### PR TITLE
Night mode affects 'chalk dust'

### DIFF
--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -377,7 +377,7 @@ one_shot = true
 explosiveness = 1.0
 process_material = SubResource( 41 )
 
-[node name="TextureRect" type="TextureRect" parent="Fg/Chalkboard"]
+[node name="TextureRect" type="TextureRect" parent="Fg/Chalkboard" groups=["night_mode_dark_self"]]
 modulate = Color( 1, 1, 1, 0.705882 )
 anchor_right = 1.0
 anchor_bottom = 1.0


### PR DESCRIPTION
This chalk dust texture didn't have the 'night_mode_dark_self' group assigned, so the onion didn't darken it, resulting in weird brown dust.