### PR TITLE
Minor display issues with vertical screens.

### DIFF
--- a/project/src/main/career/ui/ProgressBoard.tscn
+++ b/project/src/main/career/ui/ProgressBoard.tscn
@@ -198,7 +198,7 @@ tracks/1/keys = {
 "values": [ Color( 1, 1, 1, 1 ) ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("ChalkboardRegion:rect_position")
+tracks/2/path = NodePath("ChalkboardRegion:rect_position:x")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -207,7 +207,7 @@ tracks/2/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
 "update": 0,
-"values": [ Vector2( 171.8, 66.396 ) ]
+"values": [ 171.8 ]
 }
 tracks/3/type = "value"
 tracks/3/path = NodePath("ChalkboardRegion:modulate")
@@ -323,7 +323,7 @@ tracks/1/keys = {
 "values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("ChalkboardRegion:rect_position")
+tracks/2/path = NodePath("ChalkboardRegion:rect_position:x")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -332,7 +332,7 @@ tracks/2/keys = {
 "times": PoolRealArray( 0.0333333, 0.166667 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 0,
-"values": [ Vector2( 171.8, 66.396 ), Vector2( 521.8, 66.396 ) ]
+"values": [ 171.8, 521.8 ]
 }
 tracks/3/type = "value"
 tracks/3/path = NodePath("ChalkboardRegion:modulate")
@@ -450,7 +450,7 @@ tracks/1/keys = {
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ) ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("ChalkboardRegion:rect_position")
+tracks/2/path = NodePath("ChalkboardRegion:rect_position:x")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -459,7 +459,7 @@ tracks/2/keys = {
 "times": PoolRealArray( 0, 0.233333, 0.366667 ),
 "transitions": PoolRealArray( 1, 1, 1 ),
 "update": 0,
-"values": [ Vector2( 21.8, 66.396 ), Vector2( 21.8, 66.396 ), Vector2( 171.8, 66.396 ) ]
+"values": [ 21.8, 21.8, 171.8 ]
 }
 tracks/3/type = "value"
 tracks/3/path = NodePath("ChalkboardRegion:modulate")

--- a/project/src/main/chat/ui/ChatUi.tscn
+++ b/project/src/main/chat/ui/ChatUi.tscn
@@ -8,14 +8,8 @@
 [ext_resource path="res://src/main/chat/ui/chat-ui.gd" type="Script" id=16]
 
 [node name="ChatUi" type="Control"]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -512.0
-margin_top = -300.0
-margin_right = 512.0
-margin_bottom = 300.0
+anchor_right = 1.0
+anchor_bottom = 1.0
 rect_min_size = Vector2( 1024, 600 )
 script = ExtResource( 16 )
 

--- a/project/src/main/ui/menu/TrainingMenu.tscn
+++ b/project/src/main/ui/menu/TrainingMenu.tscn
@@ -250,7 +250,7 @@ align = 2
 margin_top = 298.0
 margin_right = 896.0
 margin_bottom = 428.0
-size_flags_vertical = 10
+size_flags_vertical = 8
 custom_constants/separation = 10
 script = ExtResource( 5 )
 


### PR DESCRIPTION
Cutscene/chat UI now extends all the way to bottom of the screen. Before, chat choices and chat messages were appearing in the middle of the screen.

Progress board is now centered, instead of appearing at the top of the career map window.

Training menu speed slider is now centered.