### PR TITLE
Bug: Music stops on retry

### DIFF
--- a/project/src/main/puzzle/puzzle-music-manager.gd
+++ b/project/src/main/puzzle/puzzle-music-manager.gd
@@ -21,4 +21,5 @@ func _on_PuzzleState_game_prepared() -> void:
 
 
 func _on_PuzzleState_game_ended() -> void:
-	MusicPlayer.play_menu_track()
+	if not PuzzleState.retrying:
+		MusicPlayer.play_menu_track()

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -107,6 +107,10 @@ var speed_index: int setget set_speed_index
 ## for tutorials to prevent the sensei from leaving.
 var no_more_customers: bool
 
+## Temporarily set to 'true' when the player retries a puzzle. This lets the music listener know not to stop the
+## music, even though a puzzle is ending.
+var retrying: bool
+
 ## 'True' if the player is going through the non-terminal top out process where lines are deleted and re-filled
 var topping_out: bool setget set_topping_out
 

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -68,6 +68,7 @@ func _input(event: InputEvent) -> void:
 			# still at the start of a puzzle; don't retry
 			pass
 		else:
+			PuzzleState.retrying = true
 			if not CurrentLevel.settings.lose_condition.finish_on_lose:
 				# set the game inactive before ending combo/topping out, to avoid triggering gameplay and visual
 				# effects
@@ -84,6 +85,7 @@ func _input(event: InputEvent) -> void:
 			_save_level_result(rank_result)
 			_start_puzzle()
 			get_tree().set_input_as_handled()
+			PuzzleState.retrying = false
 
 
 func get_playfield() -> Playfield:


### PR DESCRIPTION
Fixed a bug where the puzzle music stopped in career mode if the player restarted the puzzle.