### PR TITLE
Bug: Restarting sometimes kept focus on current 'morphing' creature

### DIFF
--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -213,6 +213,7 @@ func _start_puzzle() -> void:
 		
 		# scroll to the starting customer
 		_restaurant_view.current_customer_index = starting_customer_index
+		_restaurant_view.purge_current_customer_index_from_queue()
 	else:
 		var current_customer_feed_count: int = _restaurant_view.get_customer().feed_count
 		

--- a/project/src/main/puzzle/restaurant-view.gd
+++ b/project/src/main/puzzle/restaurant-view.gd
@@ -74,6 +74,7 @@ func _ready() -> void:
 func reset() -> void:
 	_recent_bonuses.clear()
 	_next_customer_indexes.clear()
+	_summon_customer_timers.clear()
 
 
 func swoop_chef_bubble_onscreen() -> void:
@@ -142,6 +143,19 @@ func find_customer_index_with_id(customer_creature_id: String) -> int:
 			break
 	
 	return customer_index
+
+
+## Purges the customer index from the 'next_customer_indexes' queue.
+##
+## The 'next_customer_indexes' queue should never have the current customer index in it, or we could risk keeping the
+## camera on a customer who is being loaded, resulting in them morphing into a new creature with black blob textures
+## visible.
+##
+## This method removes the current_customer_index from the 'next_customer_indexes' queue to ensure the camera always
+## switches to a new customer, and never tries to maintain focus on the current customer.
+func purge_current_customer_index_from_queue() -> void:
+	if get_current_customer_index() in _next_customer_indexes:
+		_next_customer_indexes.remove(_next_customer_indexes.find(get_current_customer_index()))
 
 
 ## Dequeues a customer from the customer queue, summoning them to the restaurant.


### PR DESCRIPTION
When restarting a puzzle with a priority customer, the camera would often stay focused on that customer when the player broke their combo. This meant instead of swinging to a new customer and having the old customer change in the background, the camera would stay focused on the current customer and the customer would change in the foreground.

I've changed the 'puzzle preparation' code to always purge the current customer from the queue to ensure it will always focus on a new customer.

I also changed RestaurantView.reset() to kill all the summon_customer_timers. If the timers stayed running, there were some edge cases where the camera would end up on a random customer instead of the intended priority customer.