### PR TITLE
Calculate rank data at runtime, instead of storing it

### DIFF
--- a/project/src/main/puzzle/rank-result.gd
+++ b/project/src/main/puzzle/rank-result.gd
@@ -49,7 +49,6 @@ func to_json_dict() -> Dictionary:
 		"lines": lines,
 		"lost": lost,
 		"score": score,
-		"rank": rank,
 		"seconds": seconds,
 		"success": success,
 		"timestamp": timestamp,
@@ -64,7 +63,6 @@ func from_json_dict(json: Dictionary) -> void:
 	leftover_score = int(json.get("leftover_score", 0))
 	lines = int(json.get("lines", 0))
 	lost = bool(json.get("lost", true))
-	rank = float(json.get("rank", Ranks.WORST_RANK))
 	score = int(json.get("score", 0))
 	seconds = float(json.get("seconds", 999999.0))
 	success = bool(json.get("success", false))


### PR DESCRIPTION
Rank data is calculated at runtime instead of being stored. Storing rank data had one major design problem, which is that if we want to make a level easier, the store rank data will still give the player a worse grade

We also purge all non-existent levels.

Calculating all rank data takes about 400 ms on my computer, and it's only done at startup.

If we decide the 400 ms delay on startup is undesirable, we could adopt a 'best of both worlds' approach where rank data is stored, but conditionally refreshed (perhaps the player's save data can have a 'level_version', which causes us to recalculate all ranks when it's out of date, or something like that.)