### PR TITLE
Removed percent chance from 'sidger'

### DIFF
--- a/project/assets/main/puzzle/career-regions.json
+++ b/project/assets/main/puzzle/career-regions.json
@@ -111,7 +111,7 @@
       "cutscene_path": "chat/career/lemon_2",
       "population": {
         "chefs": [
-          "(quirky) sidger 25%"
+          "(quirky) sidger"
         ],
         "customers": [
           "goldfince 4%",


### PR DESCRIPTION
Sidger imposes special rules on their levels, so they shouldn't appear randomly