### PR TITLE
Steam achievements are checked on load again

### DIFF
--- a/project/src/main/steam/steam-achievement.gd
+++ b/project/src/main/steam/steam-achievement.gd
@@ -9,9 +9,6 @@ export (String) var achievement_id: String
 
 func _ready() -> void:
 	add_to_group("steam_achievements")
-	
-	# avoid flooding the steam API with calls on startup; otherwise the game can crash
-	yield(get_tree().create_timer(3), "timeout")
 	connect_signals()
 
 


### PR DESCRIPTION
GodotSteam's native version crashed when checking achievements, but the standalone version does not crash.

Not checking achievements on load resulted in some edge cases where story achievements (finish the story for chapter 2) could never unlock, because the player could never view another cutscene in that chapter