### PR TITLE
Fixed gut tests for rank change

### DIFF
--- a/project/src/main/data/player-save.gd
+++ b/project/src/main/data/player-save.gd
@@ -33,6 +33,9 @@ var data_filename := "user://saveslot0.json" setget set_data_filename
 ## Filename for loading data older than July 2021. Can be changed for tests
 var legacy_filename := "user://turbofat0.save" setget set_legacy_filename
 
+## 'true' if rank data should be populated, and invalid levels purged from the player's save. Can be changed for tests
+var populate_rank_data := true
+
 ## Provides backwards compatibility with older save formats
 var _upgrader := PlayerSaveUpgrader.new().new_save_item_upgrader()
 
@@ -154,13 +157,23 @@ func load_player_data_from_file(filename: String) -> bool:
 		save_item.from_json_dict(json_save_item_obj)
 		_load_line(save_item.type, save_item.key, save_item.value)
 
-	# remove invalid levels
+	if populate_rank_data:
+		_purge_invalid_levels_from_level_history()
+		_calculate_rank_for_level_history()
+
+	# emit a signal indicating the level history was loaded
+	PlayerData.emit_signal("level_history_changed")
+	return true
+
+
+func _purge_invalid_levels_from_level_history() -> void:
 	for level_id in PlayerData.level_history.level_names():
 		if not FileUtils.file_exists(LevelSettings.path_from_level_key(level_id)):
 			push_warning("Invalid level: %s" % [level_id])
 			PlayerData.level_history.delete_results(level_id)
 
-	# calculate rank data
+
+func _calculate_rank_for_level_history() -> void:
 	var rank_calculator := RankCalculator.new()
 	for level_id in PlayerData.level_history.level_names():
 		var level_settings := LevelSettings.new()
@@ -169,10 +182,6 @@ func load_player_data_from_file(filename: String) -> bool:
 		for level_history_item in PlayerData.level_history.rank_results[level_id]:
 			rank_calculator.calculate_rank(level_history_item)
 	CurrentLevel.reset()
-
-	# emit a signal indicating the level history was loaded
-	PlayerData.emit_signal("level_history_changed")
-	return true
 
 
 ## Loads a list of SaveItems from the specified save file.

--- a/project/src/test/data/test-player-save-upgrader.gd
+++ b/project/src/test/data/test-player-save-upgrader.gd
@@ -135,9 +135,10 @@ func test_375c() -> void:
 	# added missing 'finished_level' entries -- successful levels weren't recorded as finished
 	assert_eq(PlayerData.level_history.finished_levels.keys(), ["practice/marathon_normal"])
 	
-	# update sandbox data to 'm' rank
+	# this test originally validated that sandbox was upgraded to 'm' rank. ranks are now calculated on startup, but
+	# we don't calculate them for tests because it's too slow, so the result is 'no rank'
 	var best_result := PlayerData.level_history.best_result("practice/sandbox_normal")
-	assert_eq(best_result.rank, 0.0)
+	assert_eq(best_result.rank, 999.0)
 
 
 ## With the removal of free roam mode, we also remove all of the old level history items.
@@ -277,4 +278,6 @@ func test_55aa_level_history_simplified() -> void:
 	assert_eq(rank_results.has("career/curly_queue"), true)
 	assert_eq(rank_results["career/curly_queue"].size(), 1)
 	var rank_result: RankResult = rank_results["career/curly_queue"][0]
-	assert_eq(rank_result.rank, 4.27)
+	
+	# ranks are now calculated on startup, but we don't calculate them for tests because it's too slow
+	assert_eq(rank_result.rank, 999.0)

--- a/project/src/test/pre-run-hook.gd
+++ b/project/src/test/pre-run-hook.gd
@@ -13,3 +13,8 @@ func run() -> void:
 	SystemSave.legacy_filename = "user://%s" % TEMP_LEGACY_FILENAME
 	PlayerSave.data_filename = "user://%s" % TEMP_FILENAME
 	SystemSave.ignore_save_slot_filename = true
+	
+	# disable population of rank data; it takes about 300 ms which is too long for unit tests. it also invalidates old
+	# tests which wanted to verify that level history is carried forward, as most of those older levels don't exist
+	# anymore and are purged from our history
+	PlayerSave.populate_rank_data = false


### PR DESCRIPTION
Now that ranks are populated on startup, it takes about 300 ms to load a save. This is fine for the player starting the game, but it's too slow for unit tests since they need to load 20-30 saves to test backwards compatibility. I've added a 'pre-run hook' which disables this functionality. It invalidates 2 tests.