### PR TITLE
Added timestamp to steam logs.

### DIFF
--- a/project/src/main/steam/steam-utils.gd
+++ b/project/src/main/steam/steam-utils.gd
@@ -126,7 +126,7 @@ func _log(message: String) -> void:
 	if not verbose:
 		return
 	
-	print("[STEAM] %s" % [message])
+	print("[STEAM] %s %s" % [Time.get_ticks_msec(), message])
 
 
 ## Schedules the changed stats and achievements data to be sent to the server a few milliseconds in the future.


### PR DESCRIPTION
We're trying to diagnose achievement bugs which only affect some users. On the basis that it might be a timing or race condition issue, I've added a timestamp to the steam logs.