### PR TITLE
Explicitly type 'percent' achievements as floats

### DIFF
--- a/project/src/main/steam/chapter-rank-s-achievement.gd
+++ b/project/src/main/steam/chapter-rank-s-achievement.gd
@@ -16,7 +16,7 @@ func connect_signals() -> void:
 
 ## Refreshes the achievement based on whether the chapter has been unlocked.
 func refresh_achievement() -> void:
-	var s_rank_percent := _s_rank_percent()
+	var s_rank_percent: float = _s_rank_percent()
 	
 	if s_rank_percent >= 0.0 and s_rank_percent <= 1.0:
 		SteamUtils.set_stat_float(stat_id, 100 * s_rank_percent)

--- a/project/src/main/steam/chapter-story-finished-achievement.gd
+++ b/project/src/main/steam/chapter-story-finished-achievement.gd
@@ -16,7 +16,7 @@ func connect_signals() -> void:
 
 ## Refreshes the achievement and stat based on how many cutscenes the player has viewed in a chapter.
 func refresh_achievement() -> void:
-	var cutscene_completion_percent := _cutscene_completion_percent()
+	var cutscene_completion_percent: float = _cutscene_completion_percent()
 	
 	if cutscene_completion_percent >= 0.0 and cutscene_completion_percent <= 1.0:
 		SteamUtils.set_stat_float(stat_id, 100 * cutscene_completion_percent)


### PR DESCRIPTION
I'm still unable to duplicate #2720 locally, but we've seen similar bugs affect other Godot projects when Godot randomly swaps certain values between being ints and floats. While I can't understand how that bug could cause this behavior for this section of code, particularly with the values we're seeing logged, it still feels like a meaningful precaution.