### PR TITLE
Protect against unusual 'getAchievement' responses

### DIFF
--- a/project/src/main/steam/steam-utils.gd
+++ b/project/src/main/steam/steam-utils.gd
@@ -42,7 +42,15 @@ func is_achievement_achieved(id: String) -> bool:
 	var get_achievement_response: Dictionary = Steam.getAchievement(id)
 	_log("getAchievement(%s) response: %s" % [id, get_achievement_response])
 	
-	return get_achievement_response["achieved"]
+	var result := false
+	if get_achievement_response \
+			and get_achievement_response.has("achieved") \
+			and get_achievement_response["achieved"] is bool:
+		result = get_achievement_response["achieved"]
+	else:
+		push_warning("Unexpected getAchievement response: %s" % [get_achievement_response])
+	
+	return result
 
 
 ## Unlocks an achievement.


### PR DESCRIPTION
We're seeing crashes seemingly centered around calls to `getAchievement`. It's unclear what's causing this, but one possibility is that getAchievement is not returning a Dictionary with a boolean 'achieved' key -- if any of those weren't true, this method would crash.

I've added some logging and checks to protect against unusual responses.