### PR TITLE
Scene change tweaks: after_scene_changed, fade_in

### DIFF
--- a/project/src/main/steam/shark-smush-achievement.gd
+++ b/project/src/main/steam/shark-smush-achievement.gd
@@ -5,13 +5,17 @@ func connect_signals() -> void:
 	.connect_signals()
 	disconnect_save_signal()
 	disconnect_load_signal()
-	Breadcrumb.connect("after_scene_changed", self, "_on_Breadcrumb_after_scene_changed")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
 
 
-func _on_Breadcrumb_after_scene_changed() -> void:
-	if get_tree().current_scene is Puzzle:
-		var puzzle: Puzzle = get_tree().current_scene
-		puzzle.get_sharks().connect("shark_squished", self, "_on_Sharks_shark_squished")
+func _sharks() -> Sharks:
+	return get_tree().current_scene.get_sharks()
+
+
+func _on_PuzzleState_game_prepared() -> void:
+	if get_tree().current_scene is Puzzle \
+			and not _sharks().is_connected("shark_squished", self, "_on_Sharks_shark_squished"):
+		_sharks().connect("shark_squished", self, "_on_Sharks_shark_squished")
 
 
 func _on_Sharks_shark_squished(_shark: Shark) -> void:

--- a/project/src/main/steam/unique-level-achievement.gd
+++ b/project/src/main/steam/unique-level-achievement.gd
@@ -13,11 +13,15 @@ extends SteamAchievement
 ## The level ID whose achievement condition should be checked.
 export (String) var level_id: String
 
+## 'true' if the prepare_level_listeners() method has already been called
+var _prepared_level_listeners := false
+
 func connect_signals() -> void:
 	.connect_signals()
 	disconnect_save_signal()
 	disconnect_load_signal()
-	Breadcrumb.connect("after_scene_changed", self, "_on_Breadcrumb_after_scene_changed")
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
+	Breadcrumb.connect("before_scene_changed", self, "_on_Breadcrumb_before_scene_changed")
 
 
 ## Overridden by child classes to connect listeners to the Puzzle or PuzzleState.
@@ -25,6 +29,14 @@ func prepare_level_listeners() -> void:
 	pass
 
 
-func _on_Breadcrumb_after_scene_changed() -> void:
-	if get_tree().current_scene is Puzzle and CurrentLevel.level_id == level_id:
+func _on_PuzzleState_game_prepared() -> void:
+	if get_tree().current_scene is Puzzle \
+			and CurrentLevel.level_id == level_id \
+			and not _prepared_level_listeners:
 		prepare_level_listeners()
+		_prepared_level_listeners = true
+
+
+func _on_Breadcrumb_before_scene_changed() -> void:
+	if _prepared_level_listeners:
+		_prepared_level_listeners = false

--- a/project/src/main/ui/scene-transition.gd
+++ b/project/src/main/ui/scene-transition.gd
@@ -145,4 +145,4 @@ func _on_AnimationPlayer_animation_finished_change_scene(
 	
 	if breadcrumb_method:
 		breadcrumb_method.call_funcv(breadcrumb_arg_array)
-	fade_in(flags)
+	call_deferred("fade_in", flags)

--- a/project/src/main/utils/breadcrumb.gd
+++ b/project/src/main/utils/breadcrumb.gd
@@ -13,9 +13,6 @@ signal trail_popped(prev_path)
 ## Emitted before this class changes the running scene.
 signal before_scene_changed
 
-## Emitted after this class changes the running scene.
-signal after_scene_changed
-
 var trail := []
 
 ## Initializes the trail to be empty except for the current scene.
@@ -74,8 +71,3 @@ func change_scene() -> void:
 		ResourceCache.minimal_resources = false
 		scene_path = "res://src/main/ui/menu/LoadingScreen.tscn"
 	get_tree().change_scene_to(ResourceCache.get_resource(scene_path))
-
-	# The scene change is deferred, which means that event listeners won't be able to access it immediately after the
-	# change_scene_to call. We defer the signal until the next idle_frame.
-	yield(get_tree(), "idle_frame")
-	emit_signal("after_scene_changed")


### PR DESCRIPTION
Made some changes to the scene change logic to try and avoid crashes. These crashes are unpredictable and difficult to pin down, so we're trying many different things.

Replaced 'after_scene_change' listeners with 'game_prepared' listeners. One possible vector for crashes is these 'after_scene_changed' listeners firing at unusual times, possibly before the new scene is loaded.

Defer SceneTransition 'fade_in' effect until next available idle frame. One possible vector for crashes is firing these 'fade_in_started' signals being fired at an unusual time, possibly before the old scene is unloaded.