### PR TITLE
Disabled threaded loading to prevent crashes/errors.

### DIFF
--- a/project/src/main/puzzle/critter/shark-tile-map-pool.gd
+++ b/project/src/main/puzzle/critter/shark-tile-map-pool.gd
@@ -68,9 +68,4 @@ func _on_Level_settings_changed() -> void:
 		# there is no 'add sharks' effect, don't fill the pool
 		return
 	
-	if OS.has_feature("web"):
-		# Godot issue #12699; threads not supported for HTML5
-		_fill_pool()
-	else:
-		_load_thread = Thread.new()
-		_load_thread.start(self, "_fill_pool")
+	_fill_pool()


### PR DESCRIPTION
One user reported the game crashing with a 10+ GB godot.log file, containing millions of lines of this:

ERROR: Disconnecting nonexistent signal 'changed', slot: 142430:_recreate_quadrants.
   at: Object::_disconnect (core\object.cpp:1548) - Condition "!s->slot_map.has(target)" is true.

This appears to stem from Godot #34752
(https://github.com/godotengine/godot/issues/34752) which causes crashes when connecting to objects from multiple threads. We only employ threads in two places: when initially caching resources, and when initializing tilemaps for Sharks.

I've disabled threaded loading to prevent this issue.

Threaded loading makes the game about 40% faster to initialize (3.358s versus 5.121s) so if these issues are resolved in the future, it might be nice to re-enable it.