### PR TITLE
Notify the player when changing languages.

### DIFF
--- a/project/src/main/ui/settings/settings-warning.gd
+++ b/project/src/main/ui/settings/settings-warning.gd
@@ -5,7 +5,13 @@ func _ready() -> void:
 	visible = false
 	SystemData.graphics_settings.connect(
 			"creature_detail_changed", self, "_on_GraphicsSettings_creature_detail_changed")
+	SystemData.misc_settings.connect(
+			"locale_changed", self, "_on_MiscSettings_locale_changed")
 
 
 func _on_GraphicsSettings_creature_detail_changed(_value: int) -> void:
+	visible = true
+
+
+func _on_MiscSettings_locale_changed(_value: String) -> void:
 	visible = true


### PR DESCRIPTION
When changing languages, the UI will look a little strange, because some UI details are initialized once, and not reinitialized in response to the language changing.

Other games such as Slay The Spire tell the player 'Restart the game for display changes to take effect', but the game seems to work OK as long as the player changes scenes (starts a level, enters career mode, etc.) If we later find bugs where the player really needs to restart the game, we can change the message.