### PR TITLE
Change Settings '...on next scene' warning boundaries

### DIFF
--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -158,7 +158,7 @@ size_flags_vertical = 3
 follow_focus = true
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Window/UiArea/TabContainer/SoundAndGraphics"]
-margin_right = 736.0
+margin_right = 712.0
 margin_bottom = 306.0
 size_flags_horizontal = 3
 
@@ -1343,14 +1343,9 @@ margin_bottom = 100.0
 size_flags_vertical = 3
 
 [node name="SettingsWarning" type="Label" parent="Window/UiArea/Bottom/HBoxContainer/VBoxContainer3/Holder"]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -90.0
-margin_top = -19.5
-margin_right = 90.0
-margin_bottom = 19.5
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_right = -10.0
 theme = ExtResource( 20 )
 text = "* Your settings will take effect in the next scene."
 align = 2


### PR DESCRIPTION
These warning boundaries were too narrow, causing text to get cut off in Spanish.