### PR TITLE
Removed redundant spanish translation of data objects

### DIFF
--- a/project/src/main/career/career-region.gd
+++ b/project/src/main/career/career-region.gd
@@ -97,7 +97,7 @@ var region_button_id: String
 
 func from_json_dict(json: Dictionary) -> void:
 	id = json.get("id", "")
-	name = tr(json.get("name", ""))
+	name = json.get("name", "")
 	start = int(json.get("start", 0))
 	
 	if json.has("boss_level"):
@@ -106,7 +106,7 @@ func from_json_dict(json: Dictionary) -> void:
 	cutscene_path = json.get("cutscene_path", "")
 	if json.has("population"):
 		population.from_json_dict(json.get("population"))
-	description = tr(json.get("description", ""))
+	description = json.get("description", "")
 	for flags_string in json.get("flags", []):
 		flags[flags_string] = true
 	icon_name = json.get("icon", "")

--- a/project/src/main/puzzle/level/level-settings.gd
+++ b/project/src/main/puzzle/level/level-settings.gd
@@ -144,7 +144,7 @@ func from_json_dict(new_id: String, json: Dictionary) -> void:
 	if json.has("combo_break"):
 		combo_break.from_json_array(json["combo_break"])
 	if json.has("description"):
-		description = tr(json["description"])
+		description = json["description"]
 	if json.has("difficulty"):
 		difficulty = json["difficulty"]
 	if json.has("finish_condition"):
@@ -156,7 +156,7 @@ func from_json_dict(new_id: String, json: Dictionary) -> void:
 	if json.has("lose_condition"):
 		lose_condition.from_json_array(json["lose_condition"])
 	if json.has("name"):
-		name = tr(json["name"])
+		name = json["name"]
 	if json.has("other"):
 		other.from_json_array(json["other"])
 	if json.has("piece_types"):

--- a/project/src/main/puzzle/other-region.gd
+++ b/project/src/main/puzzle/other-region.gd
@@ -38,9 +38,9 @@ var region_button_id: String
 
 func from_json_dict(json: Dictionary) -> void:
 	id = json.get("id", "")
-	name = tr(json.get("name", ""))
+	name = json.get("name", "")
 	branch_name = json.get("branch_name", name)
-	description = tr(json.get("description", ""))
+	description = json.get("description", "")
 	for flags_string in json.get("flags", []):
 		flags[flags_string] = true
 	level_ids = json.get("level_ids", "")


### PR DESCRIPTION
Our data objects such as 'CareerRegion' and 'LevelSettings' translated their name and description on initialization. This was a flawed idea for many reasons:

1. These models are only initialized on startup, which means if the objects were translated into Spanish on startup, the player would not be able to change their language as our translation framework has no way of translating from Spanish to other languages

2. These models are initialized before PlayerSave is loaded, so they were always translating into English anyways, even if the player selected a different language

Overall it seems better for the models to remain in English, and for language translation to occur on the UI side. I've verified that career regions and levels still show up in Spanish, even removing this translation layer.