### PR TITLE
Added timeout for mouse hiding logic.

### DIFF
--- a/project/src/main/ui/input-manager.gd
+++ b/project/src/main/ui/input-manager.gd
@@ -13,10 +13,16 @@ const KEYBOARD_MOUSE := InputMode.KEYBOARD_MOUSE
 const JOYPAD := InputMode.JOYPAD
 const JOYPAD_DEADZONE := 0.5
 
+## Time in milliseconds before the mouse disappears in response to joypad or keyboard input
+const MOUSE_TIMEOUT := 0.5
+
 ## The input method the player is using to play the game; keyboard or joypad
 ##
 ## This is automatically updated as the player presses keys or joypad buttons.
 var input_mode: int = InputMode.KEYBOARD_MOUSE setget set_input_mode
+
+## Time in milliseconds between when the engine started and the most recent mouse input
+var last_mouse_input_time: int = 0
 
 func _ready() -> void:
 	# allow the mouse to show/hide when gameplay is paused
@@ -24,11 +30,13 @@ func _ready() -> void:
 
 
 func _input(event: InputEvent) -> void:
+	var current_time := OS.get_ticks_msec()
 	if event is InputEventMouse:
 		Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
-	elif event is InputEventKey:
+		last_mouse_input_time = current_time
+	elif event is InputEventKey and (current_time - last_mouse_input_time) > MOUSE_TIMEOUT * 1000:
 		Input.set_mouse_mode(Input.MOUSE_MODE_HIDDEN)
-	elif event is InputEventJoypadButton:
+	elif event is InputEventJoypadButton and (current_time - last_mouse_input_time) > MOUSE_TIMEOUT * 1000:
 		Input.set_mouse_mode(Input.MOUSE_MODE_HIDDEN)
 	
 	if event is InputEventKey:


### PR DESCRIPTION
One user reported that when moving the mouse, the mouse flickered constantly. This could happen if they had a joystick leaning on its side, or some other anomaly which constantly triggered InputEventKey/InputEventJoypadButton events. I've added a timeout so that the mouse will stay visible for 0.5s after the most recent mouse event, even if there is keyboard/joypad input.

Closes #2828.