### PR TITLE
UniqueLevelAchievements disconnect their listeners

### DIFF
--- a/project/src/main/steam/carrot-count-achievement.gd
+++ b/project/src/main/steam/carrot-count-achievement.gd
@@ -8,6 +8,12 @@ func prepare_level_listeners() -> void:
 	_carrots().connect("carrot_added", self, "_on_Carrots_carrot_added")
 
 
+func remove_level_listeners() -> void:
+	if get_tree().current_scene is Puzzle \
+			and _carrots().is_connected("carrot_added", self, "_on_Carrots_carrot_added"):
+		_carrots().disconnect("carrot_added", self, "_on_Carrots_carrot_added")
+
+
 func refresh_achievement() -> void:
 	if get_tree().current_scene is Puzzle and _carrots().get_carrot_count() >= target_carrot_count:
 		SteamUtils.set_achievement(achievement_id)

--- a/project/src/main/steam/first-customer-score-achievement.gd
+++ b/project/src/main/steam/first-customer-score-achievement.gd
@@ -7,6 +7,11 @@ func prepare_level_listeners() -> void:
 	PuzzleState.connect("score_changed", self, "_on_PuzzleState_score_changed")
 
 
+func remove_level_listeners() -> void:
+	if PuzzleState.is_connected("score_changed", self, "_on_PuzzleState_score_changed"):
+		PuzzleState.disconnect("score_changed", self, "_on_PuzzleState_score_changed")
+
+
 func refresh_achievement() -> void:
 	if PuzzleState.customer_scores[0] >= target_score:
 		SteamUtils.set_achievement(achievement_id)

--- a/project/src/main/steam/level-pickup-achievement.gd
+++ b/project/src/main/steam/level-pickup-achievement.gd
@@ -7,6 +7,11 @@ func prepare_level_listeners() -> void:
 	PuzzleState.connect("score_changed", self, "_on_PuzzleState_score_changed")
 
 
+func remove_level_listeners() -> void:
+	if PuzzleState.is_connected("score_changed", self, "_on_PuzzleState_score_changed"):
+		PuzzleState.disconnect("score_changed", self, "_on_PuzzleState_score_changed")
+
+
 func refresh_achievement() -> void:
 	if PuzzleState.level_performance.pickup_score > target_score:
 		SteamUtils.set_achievement(achievement_id)

--- a/project/src/main/steam/unique-level-achievement.gd
+++ b/project/src/main/steam/unique-level-achievement.gd
@@ -29,6 +29,11 @@ func prepare_level_listeners() -> void:
 	pass
 
 
+## Overridden by child classes to disconnect listeners from the Puzzle or PuzzleState.
+func remove_level_listeners() -> void:
+	pass
+
+
 func _on_PuzzleState_game_prepared() -> void:
 	if get_tree().current_scene is Puzzle \
 			and CurrentLevel.level_id == level_id \
@@ -39,4 +44,5 @@ func _on_PuzzleState_game_prepared() -> void:
 
 func _on_Breadcrumb_before_scene_changed() -> void:
 	if _prepared_level_listeners:
+		remove_level_listeners()
 		_prepared_level_listeners = false


### PR DESCRIPTION
UniqueLevelAchievements like 'get $250 in pickups on this level' did not disconnect their listeners. This resulted in a few undesirable effects:

1. An console error if you played an achievement level such as 'Cheerleaders' multiple times

2. The achievements could unlock for unrelated levels. For example, playing 'Cheerleaders' and then 'Serving On A Rocket' could unlock the achievement for onscreen carrots.