### PR TITLE
Streamline achievement checks.

### DIFF
--- a/project/src/main/steam/carrot-count-achievement.gd
+++ b/project/src/main/steam/carrot-count-achievement.gd
@@ -24,4 +24,6 @@ func _carrots() -> Carrots:
 
 
 func _on_Carrots_carrot_added() -> void:
+	if SteamUtils.is_achievement_achieved(achievement_id):
+		return
 	refresh_achievement()

--- a/project/src/main/steam/chapter-rank-s-achievement.gd
+++ b/project/src/main/steam/chapter-rank-s-achievement.gd
@@ -42,6 +42,8 @@ func _s_rank_percent() -> float:
 
 ## When a level is played, if it corresponds to our region we refresh our achievement status.
 func _on_PuzzleState_after_game_ended() -> void:
+	if SteamUtils.is_achievement_achieved(achievement_id):
+		return
 	var level_region_id := CareerLevelLibrary.region_id_for_level_id(CurrentLevel.level_id)
 	if level_region_id == region_id:
 		refresh_achievement()

--- a/project/src/main/steam/chapter-story-finished-achievement.gd
+++ b/project/src/main/steam/chapter-story-finished-achievement.gd
@@ -34,6 +34,8 @@ func _cutscene_completion_percent() -> float:
 
 ## When a cutscene is played, if it corresponds to our region we refresh our achievement status.
 func _on_CurrentCutscene_cutscene_played(chat_key: String) -> void:
+	if SteamUtils.is_achievement_achieved(achievement_id):
+		return
 	var cutscene_region: CareerRegion = CareerLevelLibrary.region_for_chat_key(chat_key)
 	if cutscene_region and cutscene_region.id == region_id:
 		refresh_achievement()

--- a/project/src/main/steam/combo-achievement.gd
+++ b/project/src/main/steam/combo-achievement.gd
@@ -19,5 +19,7 @@ func refresh_achievement() -> void:
 
 
 func _on_PuzzleState_combo_changed(value: int) -> void:
+	if SteamUtils.is_achievement_achieved(achievement_id):
+		return
 	_max_combo = max(_max_combo, value)
 	refresh_achievement()

--- a/project/src/main/steam/create-creature-achievement.gd
+++ b/project/src/main/steam/create-creature-achievement.gd
@@ -16,4 +16,5 @@ func refresh_achievement() -> void:
 
 
 func _on_PlayerSave_before_save() -> void:
-	refresh_achievement()
+	if not SteamUtils.is_achievement_achieved(achievement_id):
+		refresh_achievement()

--- a/project/src/main/steam/customer-score-achievement.gd
+++ b/project/src/main/steam/customer-score-achievement.gd
@@ -19,5 +19,7 @@ func refresh_achievement() -> void:
 
 
 func _on_PuzzleState_score_changed() -> void:
+	if SteamUtils.is_achievement_achieved(achievement_id):
+		return
 	_max_score = max(PuzzleState.get_customer_score(), _max_score)
 	refresh_achievement()

--- a/project/src/main/steam/first-customer-score-achievement.gd
+++ b/project/src/main/steam/first-customer-score-achievement.gd
@@ -18,4 +18,5 @@ func refresh_achievement() -> void:
 
 
 func _on_PuzzleState_score_changed() -> void:
-	refresh_achievement()
+	if not SteamUtils.is_achievement_achieved(achievement_id):
+		refresh_achievement()

--- a/project/src/main/steam/leftovers-score-achievement.gd
+++ b/project/src/main/steam/leftovers-score-achievement.gd
@@ -19,5 +19,6 @@ func refresh_achievement() -> void:
 
 
 func _on_PuzzleState_game_ended() -> void:
-	_max_score = max(_max_score, PuzzleState.level_performance.leftover_score)
-	refresh_achievement()
+	if not SteamUtils.is_achievement_achieved(achievement_id):
+		_max_score = max(_max_score, PuzzleState.level_performance.leftover_score)
+		refresh_achievement()

--- a/project/src/main/steam/level-pickup-achievement.gd
+++ b/project/src/main/steam/level-pickup-achievement.gd
@@ -18,4 +18,5 @@ func refresh_achievement() -> void:
 
 
 func _on_PuzzleState_score_changed() -> void:
-	refresh_achievement()
+	if not SteamUtils.is_achievement_achieved(achievement_id):
+		refresh_achievement()

--- a/project/src/main/steam/rank-m-achievement.gd
+++ b/project/src/main/steam/rank-m-achievement.gd
@@ -21,6 +21,8 @@ func _on_PuzzleState_game_ended() -> void:
 	if CurrentLevel.is_tutorial() or CurrentLevel.settings.other.after_tutorial:
 		# don't activate the achievement for tutorials
 		return
+	if SteamUtils.is_achievement_achieved(achievement_id):
+		return
 	
 	var rank_result := RankCalculator.new().calculate_rank()
 	var current_level_rank := rank_result.rank

--- a/project/src/main/steam/steam-achievement.gd
+++ b/project/src/main/steam/steam-achievement.gd
@@ -44,11 +44,13 @@ func clear_achievement() -> void:
 ##
 ## This allows the player to unlock achievements when launching the game or changing save slots.
 func _on_PlayerSave_after_load() -> void:
-	refresh_achievement()
+	if not SteamUtils.is_achievement_achieved(achievement_id):
+		refresh_achievement()
 
 
 ## We check the achievement condition each time the player saves save data.
 ##
 ## This allows the player to unlock achievements after playing a level or watching a cutscene.
 func _on_PlayerSave_save_scheduled() -> void:
-	refresh_achievement()
+	if not SteamUtils.is_achievement_achieved(achievement_id):
+		refresh_achievement()


### PR DESCRIPTION
Achievement conditions do not need to be checked if the achievement has already been achieved. We used to avoid calls to
Steam.is_achievement_achieved because API calls were expensive, resulting in internet calls and sometimes crashing the game. However these calls are now cheap and go to our facade, so it's better to avoid checking the achievement conditions for completed achievements. These achievement checks in some cases are a little expensive, such as for the 'Create Creature Achievement'.