### PR TITLE
Added null checks for CurrentLevel.puzzle.

### DIFF
--- a/project/src/main/puzzle/critter/onions.gd
+++ b/project/src/main/puzzle/critter/onions.gd
@@ -55,6 +55,8 @@ func advance_onion() -> void:
 func remove_onion() -> void:
 	if not _onion:
 		return
+	if not CurrentLevel.puzzle:
+		return
 	
 	_onion.poof_and_free()
 	_onion = null
@@ -75,6 +77,8 @@ func _refresh_playfield_path() -> void:
 
 ## Initializes the onion's states with the specified onion config.
 func _initialize_onion_states(config: OnionConfig) -> void:
+	if not CurrentLevel.puzzle:
+		return
 	_onion.clear_states()
 	for i in range(config.cycle_length()):
 		_onion.append_next_state(config.get_state(i))
@@ -108,6 +112,8 @@ func _update_onion_position(onion: Onion, cell: Vector2) -> void:
 
 
 func _on_Onion_float_animation_playing_changed(_value: bool) -> void:
+	if not CurrentLevel.puzzle:
+		return
 	CurrentLevel.puzzle.set_night_mode(_onion.state == OnionConfig.OnionState.NIGHT)
 
 
@@ -127,6 +133,8 @@ func _on_PuzzleState_game_ended() -> void:
 ## Some levels introduce an onion in the middle of the level, we want to remove it when the level is restarted.
 func _on_PuzzleState_game_prepared() -> void:
 	if not _onion:
+		return
+	if not CurrentLevel.puzzle:
 		return
 	
 	if starts_in_night_mode():

--- a/project/src/main/puzzle/level/level-trigger-effects.gd
+++ b/project/src/main/puzzle/level/level-trigger-effects.gd
@@ -24,6 +24,8 @@ class ClearFilledLinesEffect extends LevelTriggerEffect:
 	
 	
 	func run() -> void:
+		if not CurrentLevel.puzzle:
+			return
 		CurrentLevel.puzzle.get_playfield().line_clearer.schedule_filled_line_clears(force)
 	
 	
@@ -69,6 +71,8 @@ class AddCarrotsEffect extends LevelTriggerEffect:
 	
 	
 	func run() -> void:
+		if not CurrentLevel.puzzle:
+			return
 		CurrentLevel.puzzle.get_carrots().add_carrots(config)
 	
 	
@@ -115,6 +119,8 @@ class AddOnionEffect extends LevelTriggerEffect:
 	
 	
 	func run() -> void:
+		if not CurrentLevel.puzzle:
+			return
 		CurrentLevel.puzzle.get_onions().add_onion(config)
 	
 	
@@ -167,6 +173,8 @@ class AddMolesEffect extends LevelTriggerEffect:
 	
 	
 	func run() -> void:
+		if not CurrentLevel.puzzle:
+			return
 		CurrentLevel.puzzle.get_moles().add_moles(config)
 	
 	
@@ -230,6 +238,8 @@ class AddSharksEffect extends LevelTriggerEffect:
 	
 	
 	func run() -> void:
+		if not CurrentLevel.puzzle:
+			return
 		CurrentLevel.puzzle.get_sharks().add_sharks(config)
 	
 	
@@ -290,6 +300,8 @@ class AddSpearsEffect extends LevelTriggerEffect:
 	
 	
 	func run() -> void:
+		if not CurrentLevel.puzzle:
+			return
 		CurrentLevel.puzzle.get_spears().add_spears(config)
 	
 	
@@ -319,6 +331,8 @@ class AdvanceOnionEffect extends LevelTriggerEffect:
 	
 	
 	func run() -> void:
+		if not CurrentLevel.puzzle:
+			return
 		CurrentLevel.puzzle.get_onions().advance_onion()
 
 
@@ -330,6 +344,8 @@ class AdvanceMolesEffect extends LevelTriggerEffect:
 	
 	
 	func run() -> void:
+		if not CurrentLevel.puzzle:
+			return
 		CurrentLevel.puzzle.get_moles().advance_moles()
 
 
@@ -341,6 +357,8 @@ class AdvanceSharksEffect extends LevelTriggerEffect:
 	
 	
 	func run() -> void:
+		if not CurrentLevel.puzzle:
+			return
 		CurrentLevel.puzzle.get_sharks().advance_sharks()
 
 
@@ -352,6 +370,8 @@ class AdvanceSpearsEffect extends LevelTriggerEffect:
 	
 	
 	func run() -> void:
+		if not CurrentLevel.puzzle:
+			return
 		CurrentLevel.puzzle.get_spears().advance_spears()
 
 
@@ -377,6 +397,8 @@ class RemoveCarrotsEffect extends LevelTriggerEffect:
 	
 	
 	func run() -> void:
+		if not CurrentLevel.puzzle:
+			return
 		CurrentLevel.puzzle.get_carrots().remove_carrots(count)
 	
 	
@@ -397,6 +419,8 @@ class RemoveOnionEffect extends LevelTriggerEffect:
 	
 	
 	func run() -> void:
+		if not CurrentLevel.puzzle:
+			return
 		CurrentLevel.puzzle.get_onions().remove_onion()
 
 
@@ -422,6 +446,8 @@ class RemoveSpearsEffect extends LevelTriggerEffect:
 	
 	
 	func run() -> void:
+		if not CurrentLevel.puzzle:
+			return
 		CurrentLevel.puzzle.get_spears().pop_out_spears(count)
 
 
@@ -474,6 +500,8 @@ class RotateNextPiecesEffect extends LevelTriggerEffect:
 	
 	
 	func run() -> void:
+		if not CurrentLevel.puzzle:
+			return
 		var pieces: Array = CurrentLevel.puzzle.get_piece_queue().pieces
 		for i in range(next_piece_from_index, next_piece_to_index + 1):
 			if i >= pieces.size():
@@ -535,6 +563,8 @@ class InsertLineEffect extends LevelTriggerEffect:
 	
 	
 	func run() -> void:
+		if not CurrentLevel.puzzle:
+			return
 		for _i in range(count):
 			CurrentLevel.puzzle.get_playfield().line_inserter.insert_line(tiles_keys, y)
 	

--- a/project/src/main/utils/breadcrumb.gd
+++ b/project/src/main/utils/breadcrumb.gd
@@ -20,7 +20,11 @@ var trail := []
 ## This is useful for demos and development where having an empty breadcrumb trail causes bugs. During regular play the
 ## breadcrumb trail should be initialized conventionally in the splash screen or menus.
 func initialize_trail() -> void:
-	trail = [get_tree().current_scene.filename]
+	if get_tree().current_scene == null:
+		push_warning("tree.current_scene == null; could not initialize trail")
+		trail = []
+	else:
+		trail = [get_tree().current_scene.filename]
 
 
 ## Navigates back one level in the breadcrumb trail.


### PR DESCRIPTION
If certain signals were fired while no puzzle was active, a null pointer exception could cause a crash. I never saw this myself, as it would require something nonsensical like "a shark is smushed on the main menu screen," but it could potentially explain some of the crashes we're seeing on steam versions of the game.

Also added a null check for get_tree().current_scene. This method is only used in a demo, but we may as well check.