### PR TITLE
Added null checks for CurrentLevel.puzzle.

### DIFF
--- a/project/src/main/steam/carrot-count-achievement.gd
+++ b/project/src/main/steam/carrot-count-achievement.gd
@@ -5,7 +5,8 @@ extends UniqueLevelAchievement
 export (int) var target_carrot_count: int
 
 func prepare_level_listeners() -> void:
-	_carrots().connect("carrot_added", self, "_on_Carrots_carrot_added")
+	if CurrentLevel.puzzle:
+		_carrots().connect("carrot_added", self, "_on_Carrots_carrot_added")
 
 
 func remove_level_listeners() -> void:
@@ -20,7 +21,7 @@ func refresh_achievement() -> void:
 
 
 func _carrots() -> Carrots:
-	return CurrentLevel.puzzle.get_carrots()
+	return CurrentLevel.puzzle.get_carrots() if CurrentLevel.puzzle else null
 
 
 func _on_Carrots_carrot_added() -> void:

--- a/project/src/main/steam/shark-smush-achievement.gd
+++ b/project/src/main/steam/shark-smush-achievement.gd
@@ -9,7 +9,7 @@ func connect_signals() -> void:
 
 
 func _sharks() -> Sharks:
-	return CurrentLevel.puzzle.get_sharks()
+	return CurrentLevel.puzzle.get_sharks() if CurrentLevel.puzzle else null
 
 
 func _on_PuzzleState_game_prepared() -> void:


### PR DESCRIPTION
If certain signals were fired while no puzzle was active, a null pointer exception could cause a crash. I never saw this myself, as it would require something nonsensical like "a shark is smushed on the main menu screen," but it could potentially explain some of the crashes we're seeing on steam versions of the game.