### PR TITLE
Added 'troubleshoot.bat' file, verbose logging

### DIFF
--- a/bin/troubleshoot_bat/turbofat-troubleshoot.bat.template
+++ b/bin/troubleshoot_bat/turbofat-troubleshoot.bat.template
@@ -1,0 +1,17 @@
+@echo off
+
+:: Run the game and capture the exit code
+##WIN_EXE_FILENAME## --verbose -- --tf-verbose
+set exitCode=%ERRORLEVEL%
+
+:: Check the exit code
+if %exitCode% neq 0 (
+    echo The game has crashed. Please review the output and send it to the devs.
+) else (
+    echo The game exited normally.
+)
+
+:: Keep the window open and wait for the user to close it
+:loop
+set /p exitprompt="Press X to close the window: "
+if /I "%exitprompt%" neq "X" goto loop

--- a/package.sh
+++ b/package.sh
@@ -17,6 +17,14 @@ echo "version=$version"
 
 win_export_path="project/export/windows"
 win_zip_filename="$win_export_path/turbofat-win-v$version.zip"
+win_bat_filename="$win_export_path/turbofat-win-troubleshoot-v$version.bat"
+win_bat_template="bin/troubleshoot_bat/turbofat-troubleshoot.bat.template"
+
+# Delete the existing windows bat file
+if [ -f "$win_bat_filename" ]; then
+  echo "Deleting $win_bat_filename"
+  rm "$win_bat_filename"
+fi
 
 # Delete the existing windows zip file
 if [ -f "$win_zip_filename" ]; then
@@ -24,9 +32,13 @@ if [ -f "$win_zip_filename" ]; then
   rm "$win_zip_filename"
 fi
 
+# Create the windows bat file
+cp "$win_bat_template" "$win_bat_filename"
+sed -i "s|##WIN_EXE_FILENAME##|turbofat-win-v$version.exe|g" "$win_bat_filename"
+
 # Assemble the windows zip file
 echo "Packaging $win_zip_filename"
-zip "$win_zip_filename" "$win_export_path/turbofat-win-v$version.*" -x "*.zip" -j
+zip "$win_zip_filename" "$win_export_path/turbofat-win-v$version.*" "$win_bat_filename" -x "*.zip" -j
 
 ################################################################################
 # Package the linux release

--- a/project/src/main/data/player-save.gd
+++ b/project/src/main/data/player-save.gd
@@ -265,5 +265,7 @@ func _load_line(type: String, key: String, json_value) -> void:
 
 func _on_Breadcrumb_before_scene_changed() -> void:
 	if _save_scheduled:
+		Global.print_verbose("Scene changing; saving player data")
 		save_player_data()
+		Global.print_verbose("Finished saving player data")
 		_save_scheduled = false

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -225,4 +225,6 @@ func _customers_match(customer1, customer2) -> bool:
 ## Because CurrentLevel is a singleton, node instances should be purged before changing scenes. Otherwise they'll
 ## continue consuming resources and could cause side effects.
 func _on_Breadcrumb_before_scene_changed() -> void:
+	Global.print_verbose("Scene changing; unassigning CurrentLevel.puzzle.")
 	puzzle = null
+	Global.print_verbose("Finished unassigning CurrentLevel.puzzle.")

--- a/project/src/main/ui/save-indicator.gd
+++ b/project/src/main/ui/save-indicator.gd
@@ -69,16 +69,24 @@ func _schedule_stop() -> void:
 
 
 func _on_PlayerSave_before_save() -> void:
+	Global.print_verbose("Player data saved; Showing save indicator")
 	play()
+	Global.print_verbose("Finished showing save indicator")
 
 
 func _on_PlayerSave_after_save() -> void:
+	Global.print_verbose("Player data saved; Hiding save indicator")
 	_schedule_stop()
+	Global.print_verbose("Finished hiding save indicator")
 
 
 func _on_SystemSave_before_save() -> void:
+	Global.print_verbose("System data saved; Showing save indicator")
 	play()
+	Global.print_verbose("Finished showing save indicator")
 
 
 func _on_SystemSave_after_save() -> void:
+	Global.print_verbose("Player data saved; Hiding save indicator")
 	_schedule_stop()
+	Global.print_verbose("Finished hiding save indicator")

--- a/project/src/main/ui/scene-transition.gd
+++ b/project/src/main/ui/scene-transition.gd
@@ -94,6 +94,7 @@ func pop_trail(flags: Dictionary = {}) -> void:
 
 ## Launches the 'fade in' visual transition.
 func fade_in(flags: Dictionary = {}) -> void:
+	Global.print_verbose("Launching scene transition fade in effect")
 	# unignore input immediately; don't wait for fade in to finish
 	get_tree().get_root().set_disable_input(false)
 	
@@ -105,10 +106,12 @@ func fade_in(flags: Dictionary = {}) -> void:
 	_audio_stream_player.play(rand_range(0.0, max_audio_start))
 	
 	emit_signal("fade_in_started", _fade_in_duration(flags))
+	Global.print_verbose("Finished launching scene transition fade in effect")
 
 
 ## Launches the 'fade out' visual transition.
 func fade_out(flags: Dictionary = {}, breadcrumb_method: FuncRef = null, breadcrumb_arg_array: Array = []) -> void:
+	Global.print_verbose("Launching scene transition fade out effect")
 	# ignore input to prevent edge-cases where player does weird things during scene transitions
 	get_tree().get_root().set_disable_input(true)
 	
@@ -125,6 +128,7 @@ func fade_out(flags: Dictionary = {}, breadcrumb_method: FuncRef = null, breadcr
 	_animation_player.connect("animation_finished", self, "_on_AnimationPlayer_animation_finished_change_scene", \
 			[flags, breadcrumb_method, breadcrumb_arg_array])
 	emit_signal("fade_out_started", _fade_out_duration(flags))
+	Global.print_verbose("Finished launching scene transition fade out effect")
 
 
 func _fade_out_duration(flags: Dictionary) -> float:

--- a/project/src/main/utils/breadcrumb.gd
+++ b/project/src/main/utils/breadcrumb.gd
@@ -74,4 +74,7 @@ func change_scene() -> void:
 		# exit to loading screen and load all resources
 		ResourceCache.minimal_resources = false
 		scene_path = "res://src/main/ui/menu/LoadingScreen.tscn"
-	get_tree().change_scene_to(ResourceCache.get_resource(scene_path))
+	var new_scene: Resource = ResourceCache.get_resource(scene_path)
+	Global.print_verbose("Changing scene to %s (%s) valid=%s" % [new_scene, scene_path, is_instance_valid(new_scene)])
+	var result := get_tree().change_scene_to(new_scene)
+	Global.print_verbose("tree.change_scene_to returned %s" % [result])

--- a/project/src/main/utils/global.gd
+++ b/project/src/main/utils/global.gd
@@ -41,6 +41,8 @@ const FATNESSES := [
 ## Factor to multiply by to convert non-isometric coordinates into isometric coordinates
 const ISO_FACTOR := Vector2(1.0, 0.5)
 
+var verbose_stdout_mode := false
+
 ## Game's main viewport width, as specified in the project settings
 var window_size: Vector2 = Vector2(ProjectSettings.get_setting("display/window/size/width"), \
 		ProjectSettings.get_setting("display/window/size/height"))
@@ -48,9 +50,15 @@ var window_size: Vector2 = Vector2(ProjectSettings.get_setting("display/window/s
 ## Stores all of the benchmarks which have been started
 var _benchmark_start_times := Dictionary()
 
+
 func _init() -> void:
 	# ensure music, pieces are random
 	randomize()
+
+
+func _ready() -> void:
+	if "--tf-verbose" in OS.get_cmdline_args():
+		verbose_stdout_mode = true
 
 
 ## Sets the start time for a benchmark. Calling 'benchmark_start(foo)' and 'benchmark_finish(foo)' will display a
@@ -76,6 +84,11 @@ func get_overworld_ui() -> OverworldUi:
 func get_creature_editor_library() -> CreatureEditorLibrary:
 	var nodes := get_tree().get_nodes_in_group("creature_editor_library")
 	return nodes[0] if nodes else null
+
+
+func print_verbose(s: String) -> void:
+	if verbose_stdout_mode:
+		print(s)
 
 
 ## Convert a coordinate from global coordinates to isometric (squashed) coordinates

--- a/project/src/main/utils/resource-cache.gd
+++ b/project/src/main/utils/resource-cache.gd
@@ -121,12 +121,14 @@ func _exit_tree() -> void:
 
 ## Replaces non-singletons in the scene tree with their singleton counterparts.
 func substitute_singletons() -> void:
+	Global.print_verbose("Substituting singletons")
 	for non_singleton_obj in get_tree().get_nodes_in_group("singletons"):
 		var non_singleton: Node = non_singleton_obj
 		var singleton_name := non_singleton.name
 		
 		var parent := non_singleton.get_parent()
 		if _singletons_by_name.has(singleton_name):
+			Global.print_verbose(" Reusing singleton: %s (%s, valid=%s)" % [singleton_name, _singletons_by_name[singleton_name], is_instance_valid(_singletons_by_name[singleton_name])])
 			# we have a singleton value to substitute; remove the non-singleton value
 			var wallpaper_index := parent.get_children().find(non_singleton)
 			parent.remove_child(non_singleton)
@@ -136,8 +138,10 @@ func substitute_singletons() -> void:
 			parent.add_child(_singletons_by_name[singleton_name])
 			parent.move_child(_singletons_by_name[singleton_name], wallpaper_index)
 		else:
+			Global.print_verbose(" Initializing singleton: %s (%s, valid=%s)" % [singleton_name, non_singleton, is_instance_valid(non_singleton)])
 			# we have no singleton value stored; store a new singleton value
 			_singletons_by_name[singleton_name] = non_singleton
+	Global.print_verbose("Finished substituting singletons")
 
 
 ## Removes singletons from their parent nodes to prevent them from being freed.

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -637,8 +637,10 @@ func _on_CreatureVisuals_talking_changed() -> void:
 ## When a new scene is loaded, creatures fade in. This conceals visual glitches as their body parts load.
 func _on_SceneTransition_fade_in_started(_duration: float) -> void:
 	if visible:
+		Global.print_verbose("Fading in creature %s; valid=%s" % [creature_id, is_instance_valid(self)])
 		visible = false
 		fade_in()
+		Global.print_verbose("Finished fading in creature %s" % [creature_id])
 	else:
 		# Don't fade in invisible creatures. Some creatures start invisible during cutscenes.
 		pass


### PR DESCRIPTION
Turbo Fat now includes a 'turbofat-troubleshoot.bat' file which enables Godot's '--verbose' flag as well as a Turbo-Fat-specific '--tf-verbose' flag. These enable enhanced logging for scene transitions, singletons and resource loading. The intent is to give players a tool to share detailed crash information with developers, to try and root out the cause of the game crashing after puzzles.