### PR TITLE
Restored GodotSteam windows debug templates.

### DIFF
--- a/project/export_presets.cfg.template
+++ b/project/export_presets.cfg.template
@@ -13,7 +13,7 @@ script_encryption_key=""
 
 [preset.0.options]
 
-custom_template/debug=""
+custom_template/debug="##GODOTSTEAM_WIN_DEBUG_TEMPLATE##"
 custom_template/release="##GODOTSTEAM_WIN_TEMPLATE##"
 binary_format/64_bits=true
 binary_format/embed_pck=false
@@ -56,7 +56,7 @@ script_encryption_key=""
 
 [preset.1.options]
 
-custom_template/debug=""
+custom_template/debug="##GODOTSTEAM_LINUX_DEBUG_TEMPLATE##"
 custom_template/release="##GODOTSTEAM_LINUX_TEMPLATE##"
 binary_format/64_bits=true
 binary_format/embed_pck=false


### PR DESCRIPTION
From https://godotsteam.com/tutorials/exporting_shipping/:

> Since the pre-compiles are never debug-release versions, you must make sure
> that only the release field contains a template and that the debug field is
> empty... ...If you have the debug field filled in, especially while using the
> pre-compiled templates, the export process will fail.

In contradiction with this advice, I experimented with the debug templates to diagnose some crashes. They seemed helpful, and it does not cause the export process to fail. I'm unsure whether this documentation is out of date, or only applies to the GodotSteam plugin, but either way I'll leave the debug templates in place unless we start seeing issues.