### PR TITLE
Save indicator appears sooner.

### DIFF
--- a/project/src/main/data/player-save.gd
+++ b/project/src/main/data/player-save.gd
@@ -40,7 +40,7 @@ var populate_rank_data := true
 var _upgrader := PlayerSaveUpgrader.new().new_save_item_upgrader()
 
 ## 'true' if player data will be saved during the next scene transition
-var _save_scheduled := false
+var save_scheduled := false
 
 func _ready() -> void:
 	rolling_backups.data_filename = data_filename
@@ -72,7 +72,7 @@ func set_legacy_filename(new_legacy_filename: String) -> void:
 ## Serializing the player's in-memory data into a large JSON file takes about 50 milliseconds or longer. To prevent
 ## stuttering or frame drops, we do this during scene transitions.
 func schedule_save() -> void:
-	_save_scheduled = true
+	save_scheduled = true
 	emit_signal("save_scheduled")
 
 
@@ -264,8 +264,8 @@ func _load_line(type: String, key: String, json_value) -> void:
 
 
 func _on_Breadcrumb_before_scene_changed() -> void:
-	if _save_scheduled:
+	if save_scheduled:
 		Global.print_verbose("Scene changing; saving player data")
 		save_player_data()
 		Global.print_verbose("Finished saving player data")
-		_save_scheduled = false
+		save_scheduled = false

--- a/project/src/main/ui/save-indicator.gd
+++ b/project/src/main/ui/save-indicator.gd
@@ -19,6 +19,7 @@ func _ready() -> void:
 	SystemSave.connect("after_save", self, "_on_SystemSave_after_save")
 	PlayerSave.connect("before_save", self, "_on_PlayerSave_before_save")
 	PlayerSave.connect("after_save", self, "_on_PlayerSave_after_save")
+	SceneTransition.connect("fade_out_started", self, "_on_SceneTransition_fade_out_started")
 
 
 func is_playing() -> bool:
@@ -90,3 +91,10 @@ func _on_SystemSave_after_save() -> void:
 	Global.print_verbose("Player data saved; Hiding save indicator")
 	_schedule_stop()
 	Global.print_verbose("Finished hiding save indicator")
+
+
+func _on_SceneTransition_fade_out_started(_duration: float) -> void:
+	if PlayerSave.save_scheduled:
+		Global.print_verbose("Save scheduled; Showing save indicator")
+		play()
+		Global.print_verbose("Finished showing save indicator")


### PR DESCRIPTION
We used to show the save indicator at the start of the save operation. However because our save logic is non-threaded, this meant the save indicator would not be shown until the save operation was complete.

I've added a new signal so the save indicator is shown before the scene transition if a save is scheduled.