### PR TITLE
Fixed 'phantom asparagus' bug

### DIFF
--- a/project/src/main/data/player-save.gd
+++ b/project/src/main/data/player-save.gd
@@ -7,6 +7,8 @@ signal save_scheduled
 
 signal before_save
 
+signal before_load
+
 signal after_save
 
 signal after_load
@@ -106,6 +108,7 @@ func save_player_data() -> void:
 
 ## Populates the player's in-memory data based on their save files.
 func load_player_data() -> void:
+	emit_signal("before_load")
 	PlayerData.reset()
 	rolling_backups.load_newest_save(self, "load_player_data_from_file")
 	emit_signal("after_load")
@@ -178,7 +181,7 @@ func _calculate_rank_for_level_history() -> void:
 	for level_id in PlayerData.level_history.level_names():
 		var level_settings := LevelSettings.new()
 		level_settings.load_from_resource(level_id)
-		CurrentLevel.start_level(level_settings)
+		CurrentLevel.start_level(level_settings, true)
 		for level_history_item in PlayerData.level_history.rank_results[level_id]:
 			rank_calculator.calculate_rank(level_history_item)
 	CurrentLevel.reset()

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -83,15 +83,32 @@ func set_launched_level(new_level_id: String) -> void:
 			customers = [CreatureLibrary.SENSEI_ID]
 
 
-func start_level(new_settings: LevelSettings) -> void:
+## Updates the current level settings and resets all score data.
+##
+## Parameters:
+## 	'new_settings': Settings to apply to the current level.
+##
+## 	'suppress_change_signal': (Optional) If true, the 'settings_changed' is suppressed. This signal normally
+## 		initializes tile maps, sprites, and plays sound effects during a puzzle. If this is unnecessary, the signal
+## 		should be suppressed. Defaults to false.
+func start_level(new_settings: LevelSettings, suppress_change_signal: bool = false) -> void:
 	level_id = new_settings.id
 	PuzzleState.reset()
-	switch_level(new_settings)
+	switch_level(new_settings, suppress_change_signal)
 
 
-func switch_level(new_settings: LevelSettings) -> void:
+## Updates the current level settings.
+##
+## Parameters:
+## 	'new_settings': Settings to apply to the current level.
+##
+## 	'suppress_change_signal': (Optional) If true, the 'settings_changed' is suppressed. This signal normally
+## 		initializes tile maps, sprites, and plays sound effects during a puzzle. If this is unnecessary, the signal
+## 		should be suppressed. Defaults to false.
+func switch_level(new_settings: LevelSettings, suppress_change_signal: bool = false) -> void:
 	settings = new_settings
-	emit_signal("settings_changed")
+	if not suppress_change_signal:
+		emit_signal("settings_changed")
 
 
 ## Launches a puzzle scene with the previously specified 'launched level' settings.

--- a/project/src/main/ui/menu/training-menu.gd
+++ b/project/src/main/ui/menu/training-menu.gd
@@ -95,6 +95,7 @@ func _load_recent_data() -> void:
 		_region = OtherLevelLibrary.region_for_id(DEFAULT_REGION_ID)
 	
 	# load the player's previously played level
+	_level_settings = LevelSettings.new()
 	_level_settings.load_from_resource(PlayerData.practice.level_id)
 
 


### PR DESCRIPTION
When switching saves during a puzzle, there were a lot of unusual side-effects including asparagus sounds playing. This occurred because the new rank system recalculates all ranks on startup, which requires loading all levels into memory briefly. However, this was also triggering the Puzzle scene to do things like initialize tilemaps, load puzzle gimmicks and play sound effects.

I've changed the 'load level' logic to include an optional flag which will prevent these kinds of events from triggering, so that we can recalculate the player's rank data without asparagus sounds playing. This is also more performant; switching saves during a puzzle took 0.5-1.2 seconds, but now only takes 0.2-0.5 seconds.

Also fixed TrainingMenu's 'LevelSettings.load_from_resource' call to explicitly initialize the level settings first.