### PR TITLE
'Cake tutorial' no longer requires squishes/spins.

### DIFF
--- a/project/assets/main/puzzle/levels/tutorial/cakes-2.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-2.json
@@ -16,8 +16,9 @@
     "tutorial"
   ],
   "piece_types": [
-    "start_piece_l",
-    "start_piece_o"
+    "ordered_start",
+    "start_piece_o",
+    "start_piece_l"
   ],
   "rank": [
     "duration 150",

--- a/project/assets/main/puzzle/levels/tutorial/cakes-3.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-3.json
@@ -16,6 +16,7 @@
     "tutorial"
   ],
   "piece_types": [
+    "ordered_start",
     "start_piece_o",
     "start_piece_t",
     "start_piece_t"

--- a/project/assets/main/puzzle/levels/tutorial/cakes-4.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-4.json
@@ -16,10 +16,11 @@
     "tutorial"
   ],
   "piece_types": [
-    "start_piece_j",
+    "ordered_start",
+    "start_piece_t",
     "start_piece_l",
     "start_piece_l",
-    "start_piece_t"
+    "start_piece_j"
   ],
   "rank": [
     "duration 150",

--- a/project/assets/main/puzzle/levels/tutorial/cakes-6.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-6.json
@@ -16,10 +16,11 @@
     "tutorial"
   ],
   "piece_types": [
-    "start_piece_l",
-    "start_piece_p",
+    "ordered_start",
+    "start_piece_v",
     "start_piece_q",
-    "start_piece_v"
+    "start_piece_l",
+    "start_piece_p"
   ],
   "rank": [
     "duration 150",

--- a/project/assets/main/puzzle/levels/tutorial/cakes-7.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-7.json
@@ -16,11 +16,12 @@
     "tutorial"
   ],
   "piece_types": [
-    "start_piece_p",
-    "start_piece_p",
-    "start_piece_t",
+    "ordered_start",
     "start_piece_u",
-    "start_piece_v"
+    "start_piece_p",
+    "start_piece_p",
+    "start_piece_v",
+    "start_piece_t"
   ],
   "rank": [
     "duration 150",

--- a/project/assets/main/puzzle/levels/tutorial/cakes-8.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-8.json
@@ -16,12 +16,13 @@
     "tutorial"
   ],
   "piece_types": [
-    "start_piece_j",
-    "start_piece_j",
+    "ordered_start",
     "start_piece_o",
+    "start_piece_v",
     "start_piece_q",
+    "start_piece_j",
     "start_piece_u",
-    "start_piece_v"
+    "start_piece_j"
   ],
   "rank": [
     "duration 150",


### PR DESCRIPTION
I personally thought it was cute how the cake tutorial shuffled the pieces every time, and how it was always possible to complete regardless of the piece order. However based on player feedback, this tutorial was too difficult and the shuffling confused some people, or they were frustrated that they had to use techniques such as spin moves or squish moves to complete it.