### PR TITLE
Fixed SettingsMenu focus neighbours.

### DIFF
--- a/project/src/demo/ui/settings/SettingsMenuDemo.tscn
+++ b/project/src/demo/ui/settings/SettingsMenuDemo.tscn
@@ -1,10 +1,19 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://src/main/ui/settings/SettingsMenu.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/demo/ui/settings/settings-menu-demo.gd" type="Script" id=2]
+[ext_resource path="res://src/main/ui/theme/h3.theme" type="Theme" id=3]
 
 [node name="SettingsMenuDemo" type="Node"]
 script = ExtResource( 2 )
+
+[node name="Label" type="Label" parent="."]
+anchor_right = 1.0
+margin_top = 23.0
+margin_bottom = 53.0
+theme = ExtResource( 3 )
+text = "asdf"
+align = 1
 
 [node name="SettingsMenu" parent="." instance=ExtResource( 1 )]
 quit_type = 3

--- a/project/src/demo/ui/settings/settings-menu-demo.gd
+++ b/project/src/demo/ui/settings/settings-menu-demo.gd
@@ -2,6 +2,32 @@ extends Node
 ## Shows the settings menu.
 ##
 ## The settings menu is invisible by default, so a demo is necessary to view it.
+##
+## Keys:
+## 	'1-5': Update quit type: QUIT, SAVE_AND_QUIT, GIVE_UP, SAVE_AND_QUIT_OR_GIVE_UP, QUIT_TO_DESKTOP
+
+onready var _label := $Label
+onready var _settings_menu := $SettingsMenu
 
 func _ready() -> void:
-	$SettingsMenu.show()
+	pause_mode = PAUSE_MODE_PROCESS
+	_settings_menu.show()
+
+
+func _input(event: InputEvent) -> void:
+	match Utils.key_scancode(event):
+		KEY_1:
+			_settings_menu.quit_type = SettingsMenu.QuitType.QUIT
+			_label.text = "QuitType.QUIT"
+		KEY_2:
+			_settings_menu.quit_type = SettingsMenu.QuitType.SAVE_AND_QUIT
+			_label.text = "QuitType.SAVE_AND_QUIT"
+		KEY_3:
+			_settings_menu.quit_type = SettingsMenu.QuitType.GIVE_UP
+			_label.text = "QuitType.GIVE_UP"
+		KEY_4:
+			_settings_menu.quit_type = SettingsMenu.QuitType.SAVE_AND_QUIT_OR_GIVE_UP
+			_label.text = "QuitType.SAVE_AND_QUIT_OR_GIVE_UP"
+		KEY_5:
+			_settings_menu.quit_type = SettingsMenu.QuitType.QUIT_TO_DESKTOP
+			_label.text = "QuitType.QUIT_TO_DESKTOP"

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -158,7 +158,7 @@ size_flags_vertical = 3
 follow_focus = true
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Window/UiArea/TabContainer/SoundAndGraphics"]
-margin_right = 712.0
+margin_right = 736.0
 margin_bottom = 306.0
 size_flags_horizontal = 3
 
@@ -582,6 +582,7 @@ margin_left = 198.0
 margin_right = 298.0
 margin_bottom = 29.0
 rect_min_size = Vector2( 100, 0 )
+focus_neighbour_top = NodePath("../../..")
 toggle_mode = true
 pressed = true
 group = SubResource( 3 )
@@ -592,6 +593,7 @@ margin_left = 318.0
 margin_right = 418.0
 margin_bottom = 29.0
 rect_min_size = Vector2( 100, 0 )
+focus_neighbour_top = NodePath("../../..")
 toggle_mode = true
 group = SubResource( 3 )
 text = "WASD"
@@ -601,6 +603,7 @@ margin_left = 438.0
 margin_right = 538.0
 margin_bottom = 29.0
 rect_min_size = Vector2( 100, 0 )
+focus_neighbour_top = NodePath("../../..")
 toggle_mode = true
 group = SubResource( 3 )
 text = "Custom"
@@ -1234,6 +1237,7 @@ margin_right = 752.0
 margin_bottom = 434.0
 rect_min_size = Vector2( 0, 100 )
 script = ExtResource( 29 )
+tab_input_enabler_path = NodePath("../TabContainer/TabInputEnabler")
 
 [node name="HBoxContainer" type="HBoxContainer" parent="Window/UiArea/Bottom"]
 anchor_right = 1.0
@@ -1431,6 +1435,7 @@ icon_color = Color( 1, 0.866667, 0.6, 1 )
 [connection signal="pressed" from="Window/UiArea/TabContainer/Misc/VBoxContainer/SaveSlot/HBoxContainer/Delete" to="Window/UiArea/TabContainer/Misc/VBoxContainer/SaveSlot" method="_on_Delete_pressed"]
 [connection signal="pressed" from="Window/UiArea/TabContainer/Misc/VBoxContainer/OpenUserFolder/Button" to="Window/UiArea/TabContainer/Misc/VBoxContainer/OpenUserFolder" method="_on_Button_pressed"]
 [connection signal="pressed" from="Window/UiArea/TabContainer/Misc/VBoxContainer/CopySaveData/HBoxContainer/Button" to="Window/UiArea/TabContainer/Misc/VBoxContainer/CopySaveData" method="_on_Button_pressed"]
+[connection signal="focus_neighbours_refreshed" from="Window/UiArea/TabContainer/TabInputEnabler" to="Window/UiArea/TabContainer/Controls" method="_on_TabInputEnabler_focus_neighbours_refreshed"]
 [connection signal="ok_pressed" from="Window/UiArea/Bottom" to="." method="_on_Bottom_ok_pressed"]
 [connection signal="other_quit_pressed" from="Window/UiArea/Bottom" to="." method="_on_Bottom_other_quit_pressed"]
 [connection signal="quit_pressed" from="Window/UiArea/Bottom" to="." method="_on_Bottom_quit_pressed"]

--- a/project/src/main/ui/settings/keybind/settings-keybinds-control.gd
+++ b/project/src/main/ui/settings/keybind/settings-keybinds-control.gd
@@ -1,6 +1,9 @@
 extends VBoxContainer
 ## UI control which lets the player view and update the game's keybinds.
 
+onready var _tab_container: TabContainer = get_parent()
+
+
 func _ready() -> void:
 	$Presets/Guideline.connect("pressed", self, "_on_Guideline_pressed")
 	$Presets/Wasd.connect("pressed", self, "_on_Wasd_pressed")
@@ -139,7 +142,6 @@ func _assign_guideline_joypad_values() -> void:
 	_preset_control("SwapHoldPiece").keybind_values = \
 			[KeybindSettings.XBOX_IMAGE_LB, KeybindSettings.XBOX_IMAGE_RB]
 	_preset_control("SwapHoldPiece").visible = SystemData.gameplay_settings.hold_piece
-	
 
 
 ## Updates all controls within the 'Presets' scroll container with values for joypad presets.
@@ -165,22 +167,36 @@ func _assign_wasd_joypad_values() -> void:
 	_preset_control("SwapHoldPiece").visible = SystemData.gameplay_settings.hold_piece
 
 
+## Assigns the TabContainer's bottom focus neighbor to the pressed preset button.
+func _refresh_focus_neighbours() -> void:
+	var pressed_preset_button: Button
+	for preset_button in [$Presets/Guideline, $Presets/Wasd, $Presets/Custom]:
+		if preset_button.pressed:
+			pressed_preset_button = preset_button
+			break
+	if pressed_preset_button:
+		_tab_container.focus_neighbour_bottom = _tab_container.get_path_to(pressed_preset_button)
+
+
 func _on_Guideline_pressed() -> void:
 	SystemData.keybind_settings.preset = KeybindSettings.GUIDELINE
 	SystemData.has_unsaved_changes = true
 	_refresh_keybind_labels()
+	_refresh_focus_neighbours()
 
 
 func _on_Wasd_pressed() -> void:
 	SystemData.keybind_settings.preset = KeybindSettings.WASD
 	SystemData.has_unsaved_changes = true
 	_refresh_keybind_labels()
+	_refresh_focus_neighbours()
 
 
 func _on_Custom_pressed() -> void:
 	SystemData.keybind_settings.preset = KeybindSettings.CUSTOM
 	SystemData.has_unsaved_changes = true
 	_refresh_keybind_labels()
+	_refresh_focus_neighbours()
 
 
 ## When the player toggles the hold piece setting, we hide/show the swap hold piece keybind config.
@@ -197,3 +213,9 @@ func _on_ResetToDefault_pressed() -> void:
 
 func _on_InputManager_input_mode_changed() -> void:
 	_refresh_keybind_labels()
+
+
+func _on_TabInputEnabler_focus_neighbours_refreshed(current_tab: int) -> void:
+	var this_tab: int = _tab_container.get_children().find(self)
+	if current_tab == this_tab:
+		_refresh_focus_neighbours()

--- a/project/src/main/ui/settings/settings-menu-bottom.gd
+++ b/project/src/main/ui/settings/settings-menu-bottom.gd
@@ -5,6 +5,8 @@ signal ok_pressed
 signal quit_pressed
 signal other_quit_pressed
 
+export (NodePath) var tab_input_enabler_path: NodePath
+
 ## Text on the menu's quit button
 var quit_type: int setget set_quit_type
 
@@ -21,6 +23,7 @@ onready var _ok_button := $HBoxContainer/VBoxContainer2/Holder/Ok
 onready var _ok_shortcut_helper := $HBoxContainer/VBoxContainer2/Holder/Ok/ShortcutHelper
 onready var _quit_button := $HBoxContainer/VBoxContainer1/Holder2/Quit2
 onready var _other_quit_button := $HBoxContainer/VBoxContainer1/Holder1/Quit1
+onready var _tab_input_enabler := get_node(tab_input_enabler_path)
 
 func _ready() -> void:
 	var custom_keybind_buttons := get_tree().get_nodes_in_group("custom_keybind_buttons")
@@ -63,6 +66,9 @@ func _refresh_quit_type() -> void:
 		$HBoxContainer/VBoxContainer1/Holder1.visible = false
 		$HBoxContainer/VBoxContainer2/Spacer.visible = false
 		$HBoxContainer/VBoxContainer3/Spacer.visible = false
+	
+	# refresh focus neighbors for the TabContainer and newly visible buttons
+	_tab_input_enabler.refresh_focus_neighbours_for_current_tab()
 
 
 ## Blocks input from the OK button if the player is rebinding their keys, or if a modal dialog is visible.


### PR DESCRIPTION
The SettingsMenu has up to two quit buttons. Before, only the top 'quit' button had its focus neighbours set. Now, the focus neighbours are set for the topmost node which is visible in the tree, and the focus neighbours are unset for the other node.

The 'Customize Controls' tab has three topmost buttons. Before, focus neighbors were only configured for an arbitrary one of the three. Now, focus neighbors are configured for all three. Navigating down from the TabContainer selects the currently pressed button.