### PR TITLE
Convert Wallpaper to autoload singleton.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -1630,11 +1630,6 @@ _global_script_classes=[ {
 "path": "res://src/main/world/creature/walking-buddy.gd"
 }, {
 "base": "Control",
-"class": "Wallpaper",
-"language": "GDScript",
-"path": "res://src/main/ui/wallpaper/wallpaper.gd"
-}, {
-"base": "Control",
 "class": "WallpaperBorder",
 "language": "GDScript",
 "path": "res://src/main/ui/wallpaper/wallpaper-border.gd"
@@ -1969,7 +1964,6 @@ _global_script_class_icons={
 "Utils": "",
 "VolumeSettings": "",
 "WalkingBuddy": "",
-"Wallpaper": "",
 "WallpaperBorder": "",
 "Wobbler": ""
 }
@@ -2021,6 +2015,7 @@ SceneTransition="*res://src/main/utils/SceneTransition.tscn"
 SfxKeeper="*res://src/main/utils/sfx-keeper.gd"
 SystemData="*res://src/main/data/system-data.gd"
 SystemSave="*res://src/main/data/system-save.gd"
+Wallpaper="*res://src/main/ui/wallpaper/Wallpaper.tscn"
 
 [debug]
 

--- a/project/src/demo/career/ui/CareerWinDemo.tscn
+++ b/project/src/demo/career/ui/CareerWinDemo.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://src/main/career/ui/CareerWin.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/demo/career/ui/career-win-demo.gd" type="Script" id=2]
 
-[node name="Demo" type="Node"]
+[node name="Demo" type="Node" groups=["wallpaper_enabled"]]
 script = ExtResource( 2 )
 CareerWinScene = ExtResource( 1 )
 

--- a/project/src/demo/credits/CreditsScrollDemo.tscn
+++ b/project/src/demo/credits/CreditsScrollDemo.tscn
@@ -4,7 +4,7 @@
 [ext_resource path="res://src/demo/credits/credits-scroll-demo.gd" type="Script" id=5]
 [ext_resource path="res://src/main/ui/theme/h3.theme" type="Theme" id=10]
 
-[node name="Demo" type="Node"]
+[node name="Demo" type="Node" groups=["wallpaper_enabled"]]
 script = ExtResource( 5 )
 
 [node name="CreditsScroll" parent="." instance=ExtResource( 1 )]

--- a/project/src/main/career/CareerMap.tscn
+++ b/project/src/main/career/CareerMap.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=42 format=2]
+[gd_scene load_steps=41 format=2]
 
 [ext_resource path="res://src/main/ui/level-select/GradeLabels.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/career-map.gd" type="Script" id=2]
@@ -21,7 +21,6 @@
 [ext_resource path="res://src/main/career/career-hint.gd" type="Script" id=19]
 [ext_resource path="res://src/main/career/hint-accent.gd" type="Script" id=20]
 [ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=21]
-[ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=24]
 [ext_resource path="res://src/main/world/career-world.gd" type="Script" id=25]
 [ext_resource path="res://src/main/career/ui/career-map-level-select.gd" type="Script" id=28]
 [ext_resource path="res://src/main/ui/MoneyLabel.tscn" type="PackedScene" id=42]
@@ -252,8 +251,6 @@ action = "ui_menu"
 [node name="SettingsMenu" parent="Ui" instance=ExtResource( 14 )]
 layer = 5
 quit_type = 3
-
-[node name="MusicPopup" parent="Ui" instance=ExtResource( 24 )]
 
 [node name="CheatCodeDetector" parent="Ui" instance=ExtResource( 5 )]
 codes = [ "bossio", "cambra", "cutsio", "cyclio", "epilio", "hardio", "moveme" ]

--- a/project/src/main/career/ui/CareerRegionSelectMenu.tscn
+++ b/project/src/main/career/ui/CareerRegionSelectMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=2]
+[gd_scene load_steps=23 format=2]
 
 [ext_resource path="res://src/main/ui/theme/h2.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/ui/CheatCodeDetector.tscn" type="PackedScene" id=2]
@@ -6,7 +6,6 @@
 [ext_resource path="res://src/main/career/CareerRewinder.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=5]
 [ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=6]
-[ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=7]
 [ext_resource path="res://src/main/ui/ImageButton.tscn" type="PackedScene" id=8]
 [ext_resource path="res://src/main/ui/squeak/gy/SqueakButton.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/ui/RegionSelectButton.tscn" type="PackedScene" id=10]
@@ -43,14 +42,12 @@ action = "ui_cancel"
 [sub_resource type="ShortCut" id=2]
 shortcut = SubResource( 3 )
 
-[node name="CareerRegionSelectMenu" type="Control"]
+[node name="CareerRegionSelectMenu" type="Control" groups=["wallpaper_enabled"]]
 anchor_right = 1.0
 anchor_bottom = 1.0
 rect_min_size = Vector2( 1024, 600 )
 script = ExtResource( 15 )
 region_buttons_path = NodePath("RegionSelect/VBoxContainer/Top/RegionButtons")
-
-[node name="Wallpaper" parent="." instance=ExtResource( 7 )]
 
 [node name="Panel" type="Panel" parent="."]
 anchor_right = 1.0

--- a/project/src/main/career/ui/CareerWin.tscn
+++ b/project/src/main/career/ui/CareerWin.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=32 format=2]
+[gd_scene load_steps=31 format=2]
 
 [ext_resource path="res://src/main/career/ui/career-win.gd" type="Script" id=1]
 [ext_resource path="res://assets/main/career/ui/chalkboard-grain.png" type="Texture" id=2]
 [ext_resource path="res://src/main/career/ui/career-win-world.gd" type="Script" id=4]
-[ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=5]
 [ext_resource path="res://src/main/ui/theme/chalkboard-54.theme" type="Theme" id=6]
 [ext_resource path="res://assets/main/career/ui/chalkboard.png" type="Texture" id=7]
 [ext_resource path="res://assets/main/career/ui/chalkboard-separator-bottom.png" type="Texture" id=8]
@@ -78,13 +77,11 @@ corner_radius_top_right = 16
 corner_radius_bottom_right = 16
 corner_radius_bottom_left = 16
 
-[node name="Node" type="Node"]
+[node name="Node" type="Node" groups=["wallpaper_enabled"]]
 script = ExtResource( 1 )
 
 [node name="Bg" type="CanvasLayer" parent="."]
 layer = -1
-
-[node name="Wallpaper" parent="Bg" instance=ExtResource( 5 )]
 
 [node name="Chalkboard" type="TextureRect" parent="Bg"]
 anchor_left = 0.5

--- a/project/src/main/credits/CreditsScroll.tscn
+++ b/project/src/main/credits/CreditsScroll.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=53 format=2]
+[gd_scene load_steps=52 format=2]
 
 [ext_resource path="res://src/main/credits/CreditsHeader.tscn" type="PackedScene" id=1]
 [ext_resource path="res://assets/main/ui/menu/loading-orb-sheet.png" type="Texture" id=2]
@@ -9,7 +9,6 @@
 [ext_resource path="res://src/main/credits/credits-orb.gd" type="Script" id=7]
 [ext_resource path="res://src/main/credits/TextCreditsIndentLine.tscn" type="PackedScene" id=8]
 [ext_resource path="res://src/main/credits/credits-pieces.gd" type="Script" id=9]
-[ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=10]
 [ext_resource path="res://src/main/credits/GodotCreditsLine.tscn" type="PackedScene" id=11]
 [ext_resource path="res://src/main/credits/credits-director.gd" type="Script" id=12]
 [ext_resource path="res://src/main/credits/CreditsPiece.tscn" type="PackedScene" id=13]
@@ -537,7 +536,7 @@ tracks/11/keys = {
 "values": [ -8.0, -8.0, -23.0, -38.0, -38.0, -80.0, -8.0, -8.0, -23.0, -80.0, -8.0 ]
 }
 
-[node name="CreditsScroll" type="Control"]
+[node name="CreditsScroll" type="Control" groups=["wallpaper_enabled"]]
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource( 3 )
@@ -547,8 +546,6 @@ GodotCreditsLineScene = ExtResource( 11 )
 TextCreditsLineScene = ExtResource( 5 )
 TextCreditsIndentLineScene = ExtResource( 8 )
 TurboFatCreditsLineScene = ExtResource( 6 )
-
-[node name="Wallpaper" parent="." instance=ExtResource( 10 )]
 
 [node name="FixedContainer" type="Control" parent="."]
 anchor_left = 0.5
@@ -651,7 +648,6 @@ anchor_bottom = 1.0
 [node name="LeftTransformationTarget" type="Node2D" parent="FixedContainer/ScrollingContainer"]
 position = Vector2( -128, 345 )
 script = ExtResource( 23 )
-wallpaper_path = NodePath("../../../Wallpaper")
 
 [node name="Particles" type="Particles2D" parent="FixedContainer/ScrollingContainer/LeftTransformationTarget"]
 material = SubResource( 6 )
@@ -669,7 +665,6 @@ texture = ExtResource( 22 )
 [node name="RightTransformationTarget" type="Node2D" parent="FixedContainer/ScrollingContainer"]
 position = Vector2( 641, 345 )
 script = ExtResource( 23 )
-wallpaper_path = NodePath("../../../Wallpaper")
 
 [node name="Particles" type="Particles2D" parent="FixedContainer/ScrollingContainer/RightTransformationTarget"]
 material = SubResource( 6 )
@@ -695,7 +690,6 @@ texture = ExtResource( 2 )
 hframes = 3
 vframes = 3
 script = ExtResource( 7 )
-wallpaper_path = NodePath("../../../Wallpaper")
 
 [node name="Pieces" type="Node2D" parent="FixedContainer/OrbHolder"]
 script = ExtResource( 9 )

--- a/project/src/main/credits/credits-orb.gd
+++ b/project/src/main/credits/credits-orb.gd
@@ -12,8 +12,6 @@ const FRAME_COUNT := 8
 ## Rate at which to launch puzzle pieces. This is synchronized with the music track "Sugar Crash" for the end credits.
 const PIECES_PER_SECOND := 4.10000
 
-export (NodePath) var wallpaper_path: NodePath
-
 ## The loading orb rotates and moves. These fields are used to calculate the rotation/position.
 var _total_time := 0.0
 var _time_offset := 0.0
@@ -35,8 +33,6 @@ var _offscreen_position: Vector2
 var _offscreen_amount: float
 
 var _tween: SceneTreeTween
-
-onready var _wallpaper := get_node(wallpaper_path)
 
 func _ready() -> void:
 	# start offscreen
@@ -109,7 +105,7 @@ func show_onscreen(new_offscreen_position: Vector2) -> void:
 	_offscreen_position = new_offscreen_position
 	_tween = Utils.recreate_tween(self, _tween)
 	_tween.tween_property(self, "_offscreen_amount", 0.0, 3.0).set_trans(Tween.TRANS_QUAD).set_ease(Tween.EASE_OUT)
-	_tween.parallel().tween_property(self, "modulate", _wallpaper.light_color.lightened(0.5), 1.0)
+	_tween.parallel().tween_property(self, "modulate", Wallpaper.light_color.lightened(0.5), 1.0)
 
 
 ## Moves the orb offscreen from the specified location, making it transparent.

--- a/project/src/main/credits/transformation-target.gd
+++ b/project/src/main/credits/transformation-target.gd
@@ -1,13 +1,10 @@
 extends Node2D
 ## Location where the orb should launch its pieces when targetting pinups to transform.
 
-export (NodePath) var wallpaper_path: NodePath
-
-onready var _wallpaper := get_node(wallpaper_path)
 onready var _particles := $Particles
 
 func _ready() -> void:
-	_particles.modulate = _wallpaper.light_color.lightened(0.5)
+	_particles.modulate = Wallpaper.light_color.lightened(0.5)
 
 
 func emit_particles() -> void:

--- a/project/src/main/editor/creature/CreatureEditor.tscn
+++ b/project/src/main/editor/creature/CreatureEditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=119 format=2]
+[gd_scene load_steps=118 format=2]
 
 [ext_resource path="res://assets/main/editor/creature/icon-category-eye.png" type="Texture" id=1]
 [ext_resource path="res://assets/main/editor/creature/icon-category-nose.png" type="Texture" id=2]
@@ -60,7 +60,6 @@
 [ext_resource path="res://src/main/ui/theme/h3.theme" type="Theme" id=58]
 [ext_resource path="res://src/main/editor/creature/OperationButton.tscn" type="PackedScene" id=60]
 [ext_resource path="res://src/main/world/environment/CreatureEditorEnvironment.tscn" type="PackedScene" id=61]
-[ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=62]
 [ext_resource path="res://src/main/ui/DialogBackdrop.tscn" type="PackedScene" id=63]
 [ext_resource path="res://src/main/world/environment/restaurant/RestaurantNametagPanel.tscn" type="PackedScene" id=64]
 [ext_resource path="res://src/main/ui/candy-button/CandyButtonC3.tscn" type="PackedScene" id=65]
@@ -354,13 +353,11 @@ tracks/3/keys = {
 "values": [ true, false ]
 }
 
-[node name="CreatureEditor" type="Node"]
+[node name="CreatureEditor" type="Node" groups=["wallpaper_enabled"]]
 script = ExtResource( 56 )
 overworld_environment_path = NodePath("Preview/World/Environment")
 dialogs_path = NodePath("Buttons/Dialogs")
 creature_saver_path = NodePath("CreatureSaver")
-
-[node name="Wallpaper" parent="." instance=ExtResource( 62 )]
 
 [node name="DropPanel" type="Panel" parent="."]
 anchor_right = 1.0

--- a/project/src/main/ui/menu/LoadingScreen.tscn
+++ b/project/src/main/ui/menu/LoadingScreen.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://src/main/ui/menu/loading-screen.gd" type="Script" id=1]
-[ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/ui/menu/LoadingPiece.tscn" type="PackedScene" id=3]
 [ext_resource path="res://src/main/ui/menu/loading-orb.gd" type="Script" id=5]
 [ext_resource path="res://src/main/ui/menu/loading-pieces.gd" type="Script" id=6]
@@ -9,13 +8,11 @@
 [ext_resource path="res://assets/main/ui/menu/dotted-line.png" type="Texture" id=8]
 [ext_resource path="res://assets/main/ui/menu/loading-orb-sheet.png" type="Texture" id=9]
 
-[node name="LoadingScreen" type="Control"]
+[node name="LoadingScreen" type="Control" groups=["wallpaper_enabled"]]
 anchor_right = 1.0
 anchor_bottom = 1.0
 rect_min_size = Vector2( 1024, 600 )
 script = ExtResource( 1 )
-
-[node name="Wallpaper" parent="." instance=ExtResource( 2 )]
 
 [node name="Holder" type="Control" parent="."]
 anchor_left = 0.5

--- a/project/src/main/ui/menu/MainMenu.tscn
+++ b/project/src/main/ui/menu/MainMenu.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=57 format=2]
+[gd_scene load_steps=56 format=2]
 
 [ext_resource path="res://src/main/ui/menu/main-menu.gd" type="Script" id=1]
 [ext_resource path="res://assets/main/ui/candy-button/h3-p.png" type="Texture" id=2]
 [ext_resource path="res://assets/main/ui/font/fredoka-one-regular.ttf" type="DynamicFontData" id=3]
-[ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/main/ui/menu/SystemButtons.tscn" type="PackedScene" id=5]
 [ext_resource path="res://src/main/ui/menu/drop-panel.tres" type="StyleBox" id=6]
 [ext_resource path="res://src/main/ui/VersionLabel.tscn" type="PackedScene" id=7]
@@ -127,13 +126,11 @@ shader = ExtResource( 11 )
 shader_param/mix_amount = 1.0
 shader_param/gradient = SubResource( 12 )
 
-[node name="MainMenu" type="Control"]
+[node name="MainMenu" type="Control" groups=["wallpaper_enabled"]]
 anchor_right = 1.0
 anchor_bottom = 1.0
 rect_min_size = Vector2( 1024, 600 )
 script = ExtResource( 1 )
-
-[node name="Wallpaper" parent="." instance=ExtResource( 4 )]
 
 [node name="DropPanel" type="Panel" parent="."]
 anchor_right = 1.0

--- a/project/src/main/ui/menu/SplashScreen.tscn
+++ b/project/src/main/ui/menu/SplashScreen.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=27 format=2]
+[gd_scene load_steps=26 format=2]
 
 [ext_resource path="res://src/main/ui/menu/splash-screen.gd" type="Script" id=1]
 [ext_resource path="res://src/main/ui/VersionLabel.tscn" type="PackedScene" id=2]
@@ -10,7 +10,6 @@
 [ext_resource path="res://src/main/ui/menu/BadSaveDataControl.tscn" type="PackedScene" id=8]
 [ext_resource path="res://src/main/ui/menu/MenuAccentTitle.tscn" type="PackedScene" id=9]
 [ext_resource path="res://assets/main/ui/candy-button/h3-v-pressed.png" type="Texture" id=10]
-[ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=11]
 [ext_resource path="res://src/main/ui/candy-button/gradient-green-normal.tres" type="Gradient" id=12]
 [ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=13]
 [ext_resource path="res://src/main/ui/candy-button/CandyButtonH3.tscn" type="PackedScene" id=14]
@@ -65,13 +64,11 @@ shader = ExtResource( 13 )
 shader_param/mix_amount = 1.0
 shader_param/gradient = SubResource( 8 )
 
-[node name="SplashScreen" type="Control"]
+[node name="SplashScreen" type="Control" groups=["wallpaper_enabled"]]
 anchor_right = 1.0
 anchor_bottom = 1.0
 rect_min_size = Vector2( 1024, 600 )
 script = ExtResource( 1 )
-
-[node name="Wallpaper" parent="." instance=ExtResource( 11 )]
 
 [node name="DropPanel" type="Panel" parent="."]
 anchor_right = 1.0

--- a/project/src/main/ui/menu/TrainingMenu.tscn
+++ b/project/src/main/ui/menu/TrainingMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=48 format=2]
+[gd_scene load_steps=47 format=2]
 
 [ext_resource path="res://src/main/ui/menu/PagedRegionPanel.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/ui/ImageButton.tscn" type="PackedScene" id=2]
@@ -10,7 +10,6 @@
 [ext_resource path="res://src/main/ui/candy-button/gradient-blue-normal.tres" type="Gradient" id=8]
 [ext_resource path="res://src/main/ui/level-select/LevelButtonScroller.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/ui/menu/drop-panel.tres" type="StyleBox" id=10]
-[ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=11]
 [ext_resource path="res://src/main/ui/squeak/gy/squeak-theme-h4.tres" type="Theme" id=12]
 [ext_resource path="res://src/main/ui/HighScoreTable.tscn" type="PackedScene" id=13]
 [ext_resource path="res://src/main/ui/theme/h3-font-outline.tres" type="DynamicFont" id=14]
@@ -82,7 +81,7 @@ action = "ui_cancel"
 [sub_resource type="ShortCut" id=5]
 shortcut = SubResource( 4 )
 
-[node name="TrainingMenu" type="Control"]
+[node name="TrainingMenu" type="Control" groups=["wallpaper_enabled"]]
 anchor_right = 1.0
 anchor_bottom = 1.0
 rect_min_size = Vector2( 1024, 600 )
@@ -92,8 +91,6 @@ level_button_scroller_path = NodePath("MainMenu/DropPanel/VBoxContainer/Level/Le
 level_description_label_path = NodePath("MainMenu/DropPanel/VBoxContainer/Level/Desc")
 speed_selector_path = NodePath("MainMenu/DropPanel/VBoxContainer/Speed")
 start_button_path = NodePath("MainMenu/DropPanel/VBoxContainer/System/Start")
-
-[node name="Wallpaper" parent="." instance=ExtResource( 11 )]
 
 [node name="MainMenu" type="Control" parent="."]
 anchor_right = 1.0

--- a/project/src/main/ui/menu/TutorialMenu.tscn
+++ b/project/src/main/ui/menu/TutorialMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://src/main/ui/ButtonShortcutHelper.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/ui/ImageButton.tscn" type="PackedScene" id=2]
@@ -7,7 +7,6 @@
 [ext_resource path="res://assets/main/ui/touch/close-pressed.png" type="Texture" id=5]
 [ext_resource path="res://src/main/ui/menu/tutorial-menu.gd" type="Script" id=6]
 [ext_resource path="res://src/main/ui/MusicPopup.tscn" type="PackedScene" id=7]
-[ext_resource path="res://src/main/ui/wallpaper/Wallpaper.tscn" type="PackedScene" id=16]
 
 [sub_resource type="InputEventAction" id=1]
 action = "ui_cancel"
@@ -15,13 +14,11 @@ action = "ui_cancel"
 [sub_resource type="ShortCut" id=2]
 shortcut = SubResource( 1 )
 
-[node name="TutorialMenu" type="Control"]
+[node name="TutorialMenu" type="Control" groups=["wallpaper_enabled"]]
 anchor_right = 1.0
 anchor_bottom = 1.0
 rect_min_size = Vector2( 1024, 600 )
 script = ExtResource( 6 )
-
-[node name="Wallpaper" parent="." instance=ExtResource( 16 )]
 
 [node name="Panel" parent="." instance=ExtResource( 3 )]
 

--- a/project/src/main/ui/menu/loading-screen.gd
+++ b/project/src/main/ui/menu/loading-screen.gd
@@ -1,7 +1,6 @@
 extends Control
 ## Shows a progress bar while resources are loading.
 
-onready var _wallpaper := $Wallpaper
 onready var _orb := $Holder/Orb
 onready var _progress_bar := $Holder/ProgressBar
 
@@ -11,7 +10,7 @@ onready var _fade_cover: ColorRect = $FadeCover
 func _ready() -> void:
 	ResourceCache.connect("finished_loading", self, "_on_ResourceCache_finished_loading")
 	
-	_orb.modulate = _wallpaper.light_color.lightened(0.5)
+	_orb.modulate = Wallpaper.light_color.lightened(0.5)
 	_progress_bar.modulate = _orb.modulate
 	
 	var _fade_cover_tween: SceneTreeTween = create_tween()

--- a/project/src/main/ui/wallpaper/Wallpaper.tscn
+++ b/project/src/main/ui/wallpaper/Wallpaper.tscn
@@ -4,21 +4,24 @@
 [ext_resource path="res://src/main/ui/wallpaper/StickerRow.tscn" type="PackedScene" id=2]
 [ext_resource path="res://src/main/ui/wallpaper/wallpaper.gd" type="Script" id=3]
 
-[node name="Wallpaper" type="Control" groups=["singletons"]]
-anchor_right = 1.0
-anchor_bottom = 1.0
+[node name="Wallpaper" type="CanvasLayer"]
+layer = -128
 script = ExtResource( 3 )
 WallpaperBorderScene = ExtResource( 1 )
 StickerRowScene = ExtResource( 2 )
 
-[node name="Borders" type="Control" parent="."]
+[node name="Container" type="Control" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
 
-[node name="ColorRects" type="Control" parent="."]
+[node name="Borders" type="Control" parent="Container"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 
-[node name="Stickers" type="Control" parent="."]
+[node name="ColorRects" type="Control" parent="Container"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Stickers" type="Control" parent="Container"]
 anchor_right = 1.0
 anchor_bottom = 1.0

--- a/project/src/main/ui/wallpaper/wallpaper.gd
+++ b/project/src/main/ui/wallpaper/wallpaper.gd
@@ -1,6 +1,8 @@
-class_name Wallpaper
-extends Control
+extends CanvasLayer
 ## Background wallpaper with colored areas, borders and shapes.
+##
+## To enable wallpaper for a scene, add it to the 'wallpaper_enabled' group. This will make the Wallpaper singleton
+## visible when that node is the current scene.
 
 ## optional float parameters don't have the concept of null. this default value acts as a substitute so we can tell
 ## when a float value is unspecified.
@@ -36,10 +38,10 @@ func _ready() -> void:
 		color_rect_index += 1
 	
 	# stretch top/bottom color rects so they fill the screen
-	$ColorRects.get_children().front().anchor_top = 0.0
-	$ColorRects.get_children().front().margin_top = 0.0
-	$ColorRects.get_children().back().anchor_bottom = 1.0
-	$ColorRects.get_children().back().margin_bottom = 1.0
+	$Container/ColorRects.get_children().front().anchor_top = 0.0
+	$Container/ColorRects.get_children().front().margin_top = 0.0
+	$Container/ColorRects.get_children().back().anchor_bottom = 1.0
+	$Container/ColorRects.get_children().back().margin_bottom = 1.0
 	
 	# add sticker rows
 	var sticker_row_index := 0
@@ -48,6 +50,9 @@ func _ready() -> void:
 		sticker_row.color = light_color if sticker_row_index % 2 == 0 else dark_color
 		sticker_row.velocity = Vector2(-30.0, 0) if sticker_row_index % 2 == 0 else Vector2(30, 0)
 		sticker_row_index += 1
+	
+	get_tree().connect("node_added", self, "_on_node_added")
+	_refresh_visible()
 
 
 ## Assigns the background colors based on the day of the week.
@@ -80,7 +85,7 @@ func _add_sticker_row(row_y: float, row_height: float) -> StickerRow:
 	var row: StickerRow = StickerRowScene.instance()
 	set_anchors(row, 0.0, 0.5, 1.0)
 	set_margins(row, 0.0, row_y, 0.0, row_y + row_height)
-	$Stickers.add_child(row)
+	$Container/Stickers.add_child(row)
 	return row
 
 
@@ -90,7 +95,7 @@ func _add_border(border_y: float, border_height: float) -> WallpaperBorder:
 	set_margins(border, 0.0, border_y, 0.0, border_y + border_height)
 	border.texture_scale = Vector2(200, border_height)
 	border.velocity = Vector2(40, 0)
-	$Borders.add_child(border)
+	$Container/Borders.add_child(border)
 	return border
 
 
@@ -98,8 +103,20 @@ func _add_color_rect(rect_y: float, rect_height: float) -> ColorRect:
 	var color_rect: ColorRect = ColorRect.new()
 	set_anchors(color_rect, 0.0, 0.5, 1.0)
 	set_margins(color_rect, 0.0, rect_y, 0.0, rect_y + rect_height)
-	$ColorRects.add_child(color_rect)
+	$Container/ColorRects.add_child(color_rect)
 	return color_rect
+
+
+## Toggles the wallpaper visibility.
+##
+## The wallpaper is visible if the current scene is in the 'wallpaper_enabled' group.
+func _refresh_visible() -> void:
+	visible = get_tree().current_scene.is_in_group("wallpaper_enabled")
+
+
+func _on_node_added(node: Node) -> void:
+	if node == get_tree().current_scene:
+		_refresh_visible()
 
 
 ## Sets the left/top/right/bottom margins for a node.


### PR DESCRIPTION
Scenes used to manage their own wallpaper nodes. I'm replacing this with a Wallpaper autoload singleton to remove our dependency on ResourceCache's singleton management, to hopefully prevent game crashes.

I have a hunch ResourceCache's singleton management is the source of the game's crashes during scene changes. I think our code for rescuing these singletons from Godot's node freeing logic is failing, and these nodes get cleaned up sometimes, causing errors when they're reintroduced to the scene tree.