### PR TITLE
Removed ResourceCache singleton logic.

### DIFF
--- a/project/src/main/career/ui/career-win.gd
+++ b/project/src/main/career/ui/career-win.gd
@@ -8,7 +8,6 @@ onready var _button := $Bg/Chalkboard/VBoxContainer/ButtonRow/ZHolder/Button
 onready var _applause_sound := $Bg/ApplauseSound
 
 func _ready() -> void:
-	ResourceCache.substitute_singletons()
 	MusicPlayer.play_menu_track()
 	
 	_refresh_mood()
@@ -17,10 +16,6 @@ func _ready() -> void:
 	PlayerSave.schedule_save()
 	
 	_button.grab_focus()
-
-
-func _exit_tree() -> void:
-	ResourceCache.remove_singletons()
 
 
 ## Plays an applause sound if the player did well.

--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -10,14 +10,9 @@ onready var _dialogs: CreatureEditorDialogs = get_node(dialogs_path)
 onready var _creature_saver: CreatureSaver = get_node(creature_saver_path)
 
 func _ready() -> void:
-	ResourceCache.substitute_singletons()
 	MusicPlayer.play_menu_track()
 	
 	$Buttons/VBoxContainer/CategorySelector.set_selected_category_index(0)
-
-
-func _exit_tree() -> void:
-	ResourceCache.remove_singletons()
 
 
 func _quit() -> void:

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -10,7 +10,6 @@ onready var _settings_menu: SettingsMenu = $SettingsMenu
 onready var _night_mode_toggler: NightModeToggler = $NightModeToggler
 
 func _ready() -> void:
-	ResourceCache.substitute_singletons()
 	if PlayerData.career.is_career_mode() and MusicPlayer.is_playing_boss_track():
 		# don't interrupt boss music during career mode; it keeps playing from the level select to the puzzle
 		pass
@@ -48,10 +47,6 @@ func _ready() -> void:
 		_start_puzzle()
 	else:
 		CurrentLevel.settings.triggers.run_triggers(LevelTrigger.BEFORE_START)
-
-
-func _exit_tree() -> void:
-	ResourceCache.remove_singletons()
 
 
 func _input(event: InputEvent) -> void:

--- a/project/src/main/ui/menu/career-region-select-menu.gd
+++ b/project/src/main/ui/menu/career-region-select-menu.gd
@@ -6,7 +6,6 @@ export (NodePath) var region_buttons_path: NodePath
 onready var _region_buttons := get_node(region_buttons_path)
 
 func _ready() -> void:
-	ResourceCache.substitute_singletons()
 	MusicPlayer.play_menu_track()
 	
 	_region_buttons.set_regions(CareerLevelLibrary.regions)
@@ -14,10 +13,6 @@ func _ready() -> void:
 	var last_unlocked_region: CareerRegion = \
 			CareerLevelLibrary.region_for_distance(PlayerData.career.best_distance_travelled)
 	_region_buttons.focus_region(last_unlocked_region.id)
-
-
-func _exit_tree() -> void:
-	ResourceCache.remove_singletons()
 
 
 func _on_BackButton_pressed() -> void:

--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -5,14 +5,9 @@ extends Control
 ## Includes buttons for starting a new game, launching the level editor, and exiting the game.
 
 func _ready() -> void:
-	ResourceCache.substitute_singletons()
 	MusicPlayer.play_menu_track()
 	
 	$DropPanel/Adventure/Play.grab_focus()
-
-
-func _exit_tree() -> void:
-	ResourceCache.remove_singletons()
 
 
 func _on_System_quit_pressed() -> void:

--- a/project/src/main/ui/menu/splash-screen.gd
+++ b/project/src/main/ui/menu/splash-screen.gd
@@ -2,7 +2,6 @@ extends Control
 ## Splash screen which precedes the main menu.
 
 func _ready() -> void:
-	ResourceCache.substitute_singletons()
 	MusicPlayer.play_menu_track(false)
 	
 	$DropPanel/PlayHolder/Play.grab_focus()
@@ -12,10 +11,6 @@ func _ready() -> void:
 	if OS.has_feature("web"):
 		# don't quit from the web. it just blacks out the window, which isn't useful or user friendly
 		$DropPanel/System/Quit.hide()
-
-
-func _exit_tree() -> void:
-	ResourceCache.remove_singletons()
 
 
 func _launch_tutorial() -> void:

--- a/project/src/main/ui/menu/training-menu.gd
+++ b/project/src/main/ui/menu/training-menu.gd
@@ -30,7 +30,6 @@ onready var _level_submenu := $LevelSubmenu
 onready var _region_submenu := $RegionSubmenu
 
 func _ready() -> void:
-	ResourceCache.substitute_singletons()
 	MusicPlayer.play_menu_track()
 	
 	_assign_default_recent_data()
@@ -48,10 +47,6 @@ func _ready() -> void:
 	# level panels.
 	_level_submenu.disable_cheat_sfx()
 	_start_button.grab_focus()
-
-
-func _exit_tree() -> void:
-	ResourceCache.remove_singletons()
 
 
 ## Assign a region/level if this is the first time launching the practice menu

--- a/project/src/main/ui/menu/tutorial-menu.gd
+++ b/project/src/main/ui/menu/tutorial-menu.gd
@@ -4,17 +4,12 @@ extends Control
 onready var _paged_level_panel := $Panel
 
 func _ready() -> void:
-	ResourceCache.substitute_singletons()
 	MusicPlayer.play_menu_track()
 	
 	var tutorial_region := OtherLevelLibrary.region_for_id(OtherRegion.ID_TUTORIAL)
 	if tutorial_region:
 		_assign_default_recent_data(tutorial_region)
 		_populate_level_buttons(tutorial_region)
-
-
-func _exit_tree() -> void:
-	ResourceCache.remove_singletons()
 
 
 ## Assign a tutorial level if this is the first time launching the tutorial menu

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -30,8 +30,6 @@ onready var _distance_label := $Ui/Control/StatusBar/Distance
 onready var _level_select_control := $LevelSelect
 
 func _ready() -> void:
-	ResourceCache.substitute_singletons()
-	
 	if not Breadcrumb.trail:
 		# For developers accessing the CareerMap scene directly, we initialize a default Breadcrumb trail.
 		# For regular players the Breadcrumb trail will already be initialized by the menus.
@@ -57,10 +55,6 @@ func _ready() -> void:
 			# Ordinarily, we focus the level button after the progress board vanishes. But if the progress board is not
 			# being shown, we focus the button right away.
 			_after_progress_board()
-
-
-func _exit_tree() -> void:
-	ResourceCache.remove_singletons()
 
 
 func _refresh_ui() -> void:

--- a/project/src/main/world/overworld-ui.gd
+++ b/project/src/main/world/overworld-ui.gd
@@ -42,13 +42,8 @@ var _overworld_environment: OverworldEnvironment
 onready var _chat_ui := $ChatUi
 
 func _ready() -> void:
-	ResourceCache.substitute_singletons()
 	_refresh_overworld_environment_path()
 	_update_visible()
-
-
-func _exit_tree() -> void:
-	ResourceCache.remove_singletons()
 
 
 func set_overworld_environment_path(new_overworld_environment_path: NodePath) -> void:


### PR DESCRIPTION
Nodes formerly managed by ResourceCache's singleton logic are now traditional autoload singletons.

I have a hunch ResourceCache's singleton management is the source of the game's crashes during scene changes. I think our code for rescuing these singletons from Godot's node freeing logic is failing, and these nodes get cleaned up sometimes, causing errors when they're reintroduced to the scene tree.