### PR TITLE
Added 'give up' confirmation for Adventure mode

### DIFF
--- a/project/assets/main/locale/en.po
+++ b/project/assets/main/locale/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/Poobslag/turbofat/\n"
-"POT-Creation-Date: 2024-10-18 09:44-0400\n"
+"POT-Creation-Date: 2024-11-04 11:13-0500\n"
 "PO-Revision-Date: 2023-03-13 12:16-0400\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15637,6 +15637,14 @@ msgid "Language"
 msgstr ""
 
 #: project/src/main/ui/settings/SettingsMenu.tscn
+msgid "Re-enable Tips"
+msgstr ""
+
+#: project/src/main/ui/settings/SettingsMenu.tscn
+msgid "Re-enabled!"
+msgstr ""
+
+#: project/src/main/ui/settings/SettingsMenu.tscn
 msgid "Save Slot"
 msgstr ""
 
@@ -15672,6 +15680,13 @@ msgstr ""
 
 #: project/src/main/ui/settings/SettingsMenu.tscn
 msgid "Change save slot?"
+msgstr ""
+
+#: project/src/main/ui/settings/SettingsMenu.tscn
+msgid ""
+"Restarting or giving up will end the current day.\n"
+"\n"
+"Do you really give up?"
 msgstr ""
 
 #: project/src/main/ui/settings/VolumeSetting.tscn

--- a/project/assets/main/locale/es.po
+++ b/project/assets/main/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/Poobslag/turbofat/\n"
-"POT-Creation-Date: 2024-10-18 09:44-0400\n"
+"POT-Creation-Date: 2024-11-04 11:13-0500\n"
 "PO-Revision-Date: 2024-10-13 19:30-0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17626,6 +17626,16 @@ msgid "Language"
 msgstr "Lenguaje"
 
 #: project/src/main/ui/settings/SettingsMenu.tscn
+#, needs-review
+msgid "Re-enable Tips"
+msgstr "Volver a activar consejos"
+
+#: project/src/main/ui/settings/SettingsMenu.tscn
+#, needs-review
+msgid "Re-enabled!"
+msgstr "¡Reactivados!"
+
+#: project/src/main/ui/settings/SettingsMenu.tscn
 msgid "Save Slot"
 msgstr "Espacio de Guardado"
 
@@ -17662,6 +17672,17 @@ msgstr "Confirmar"
 #: project/src/main/ui/settings/SettingsMenu.tscn
 msgid "Change save slot?"
 msgstr "¿Cambiar espacio de guardado?"
+
+#: project/src/main/ui/settings/SettingsMenu.tscn
+#, needs-review
+msgid ""
+"Restarting or giving up will end the current day.\n"
+"\n"
+"Do you really give up?"
+msgstr ""
+"Reiniciar o rendirse terminará el día actual.\n"
+"\n"
+"¿De verdad quieres rendirte?"
 
 #: project/src/main/ui/settings/VolumeSetting.tscn
 msgid "Music"

--- a/project/assets/main/locale/messages.pot
+++ b/project/assets/main/locale/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Turbo Fat 0.9000\n"
 "Report-Msgid-Bugs-To: https://github.com/Poobslag/turbofat/\n"
-"POT-Creation-Date: 2024-10-18 09:44-0400\n"
+"POT-Creation-Date: 2024-11-04 11:13-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15637,6 +15637,14 @@ msgid "Language"
 msgstr ""
 
 #: project/src/main/ui/settings/SettingsMenu.tscn
+msgid "Re-enable Tips"
+msgstr ""
+
+#: project/src/main/ui/settings/SettingsMenu.tscn
+msgid "Re-enabled!"
+msgstr ""
+
+#: project/src/main/ui/settings/SettingsMenu.tscn
 msgid "Save Slot"
 msgstr ""
 
@@ -15672,6 +15680,13 @@ msgstr ""
 
 #: project/src/main/ui/settings/SettingsMenu.tscn
 msgid "Change save slot?"
+msgstr ""
+
+#: project/src/main/ui/settings/SettingsMenu.tscn
+msgid ""
+"Restarting or giving up will end the current day.\n"
+"\n"
+"Do you really give up?"
 msgstr ""
 
 #: project/src/main/ui/settings/VolumeSetting.tscn

--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -911,6 +911,7 @@ script = ExtResource( 89 )
 [connection signal="back_button_pressed" from="Hud/Center/PuzzleMessages" to="." method="_on_Hud_back_button_pressed"]
 [connection signal="settings_button_pressed" from="Hud/Center/PuzzleMessages" to="." method="_on_Hud_settings_button_pressed"]
 [connection signal="start_button_pressed" from="Hud/Center/PuzzleMessages" to="." method="_on_Hud_start_button_pressed"]
+[connection signal="give_up_confirmed" from="SettingsMenu" to="." method="_on_SettingsMenu_give_up_confirmed"]
 [connection signal="hide" from="SettingsMenu" to="Hud/TouchButtons" method="_on_Menu_hide"]
 [connection signal="quit_pressed" from="SettingsMenu" to="." method="_on_SettingsMenu_quit_pressed"]
 [connection signal="show" from="SettingsMenu" to="Hud/TouchButtons" method="_on_Menu_show"]

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -62,6 +62,10 @@ func _input(event: InputEvent) -> void:
 		if not PuzzleState.game_active and not PuzzleState.game_ended:
 			# still at the start of a puzzle; don't retry
 			pass
+		elif PlayerData.career.is_career_mode() and CurrentLevel.attempt_count == 0 \
+				and SystemData.misc_settings.show_give_up_confirmation:
+			# user hasn't been prompted yet; prompt the user to retry
+			_settings_menu.show_give_up_confirmation()
 		else:
 			PuzzleState.retrying = true
 			if not CurrentLevel.settings.lose_condition.finish_on_lose:
@@ -410,3 +414,7 @@ func _on_Level_settings_changed() -> void:
 	CurrentLevel.settings.triggers.run_triggers(LevelTrigger.BEFORE_START)
 	if PuzzleState.game_active:
 		CurrentLevel.settings.triggers.run_triggers(LevelTrigger.START)
+
+
+func _on_SettingsMenu_give_up_confirmed() -> void:
+	PuzzleState.make_player_lose()

--- a/project/src/main/settings/misc-settings.gd
+++ b/project/src/main/settings/misc-settings.gd
@@ -25,6 +25,9 @@ const SAVE_SLOT_PREFIXES := {
 ## Current save slot for saving/loading progress
 var save_slot: int = SaveSlot.SLOT_A setget set_save_slot
 
+## 'true' if the player should be shown the confirmation when restarting/giving up in Adventure mode
+var show_give_up_confirmation: bool = true
+
 ## Current locale. This is redundant with TranslationServer.locale, but exposing a setter lets us provide a signal
 ## to notify when the locale changes.
 var locale := "en" setget set_locale
@@ -64,11 +67,13 @@ func to_json_dict() -> Dictionary:
 	return {
 		"locale": locale,
 		"save_slot": save_slot,
+		"show_give_up_confirmation": show_give_up_confirmation,
 	}
 
 
 func from_json_dict(json: Dictionary) -> void:
 	set_save_slot(int(json.get("save_slot", SaveSlot.SLOT_A)))
+	show_give_up_confirmation = bool(json.get("show_give_up_confirmation", true))
 	
 	var new_locale: String
 	if json.has("locale"):

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=50 format=2]
+[gd_scene load_steps=51 format=2]
 
 [ext_resource path="res://src/main/ui/squeak/br/squeak-theme-h5.tres" type="Theme" id=1]
 [ext_resource path="res://src/main/ui/squeak/br/squeak-theme-h4.tres" type="Theme" id=2]
@@ -46,6 +46,7 @@
 [ext_resource path="res://src/main/ui/squeak/br/SqueakCheckBox.tscn" type="PackedScene" id=44]
 [ext_resource path="res://src/main/ui/WarningDialog.tscn" type="PackedScene" id=45]
 [ext_resource path="res://src/main/ui/settings/controller-unplugged-message.gd" type="Script" id=46]
+[ext_resource path="res://src/main/ui/settings/reenable-tips.gd" type="Script" id=47]
 
 [sub_resource type="StyleBoxFlat" id=4]
 content_margin_left = 8.0
@@ -1058,7 +1059,7 @@ follow_focus = true
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Window/UiArea/TabContainer/Misc"]
 margin_right = 736.0
-margin_bottom = 166.0
+margin_bottom = 201.0
 size_flags_horizontal = 3
 
 [node name="Spacer1" type="Control" parent="Window/UiArea/TabContainer/Misc/VBoxContainer"]
@@ -1094,16 +1095,64 @@ size_flags_horizontal = 2
 size_flags_vertical = 4
 size_flags_stretch_ratio = 1.1
 
-[node name="Spacer2" type="Control" parent="Window/UiArea/TabContainer/Misc/VBoxContainer"]
+[node name="Tips" type="HBoxContainer" parent="Window/UiArea/TabContainer/Misc/VBoxContainer"]
 margin_top = 41.0
 margin_right = 736.0
-margin_bottom = 61.0
+margin_bottom = 70.0
+rect_min_size = Vector2( 400, 26 )
+size_flags_horizontal = 3
+custom_constants/separation = 20
+script = ExtResource( 47 )
+
+[node name="Spacer" type="Control" parent="Window/UiArea/TabContainer/Misc/VBoxContainer/Tips"]
+margin_right = 287.0
+margin_bottom = 29.0
+rect_min_size = Vector2( 120, 0 )
+size_flags_horizontal = 3
+size_flags_vertical = 5
+size_flags_stretch_ratio = 0.74
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Window/UiArea/TabContainer/Misc/VBoxContainer/Tips"]
+margin_left = 307.0
+margin_right = 593.0
+margin_bottom = 29.0
+size_flags_horizontal = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 1.1
+
+[node name="Button" parent="Window/UiArea/TabContainer/Misc/VBoxContainer/Tips/HBoxContainer" instance=ExtResource( 39 )]
+margin_right = 160.0
+margin_bottom = 29.0
+rect_min_size = Vector2( 160, 26 )
+size_flags_horizontal = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 1.1
+text = "Re-enable Tips"
+fonts = [ ExtResource( 35 ), ExtResource( 36 ), ExtResource( 37 ), ExtResource( 38 ) ]
+
+[node name="SqueakButtonHelper" parent="Window/UiArea/TabContainer/Misc/VBoxContainer/Tips/HBoxContainer/Button" instance=ExtResource( 33 )]
+
+[node name="Reenabled" type="Label" parent="Window/UiArea/TabContainer/Misc/VBoxContainer/Tips/HBoxContainer"]
+margin_left = 166.0
+margin_right = 286.0
+margin_bottom = 29.0
+rect_min_size = Vector2( 120, 0 )
+size_flags_vertical = 1
+size_flags_stretch_ratio = 0.74
+text = "Re-enabled!"
+valign = 1
+autowrap = true
+
+[node name="Spacer2" type="Control" parent="Window/UiArea/TabContainer/Misc/VBoxContainer"]
+margin_top = 76.0
+margin_right = 736.0
+margin_bottom = 96.0
 rect_min_size = Vector2( 0, 20 )
 
 [node name="SaveSlot" type="HBoxContainer" parent="Window/UiArea/TabContainer/Misc/VBoxContainer"]
-margin_top = 67.0
+margin_top = 102.0
 margin_right = 736.0
-margin_bottom = 96.0
+margin_bottom = 131.0
 rect_min_size = Vector2( 400, 26 )
 size_flags_horizontal = 3
 custom_constants/separation = 20
@@ -1148,9 +1197,9 @@ size_flags_vertical = 4
 text = "X"
 
 [node name="OpenUserFolder" type="HBoxContainer" parent="Window/UiArea/TabContainer/Misc/VBoxContainer"]
-margin_top = 102.0
+margin_top = 137.0
 margin_right = 736.0
-margin_bottom = 131.0
+margin_bottom = 166.0
 rect_min_size = Vector2( 400, 26 )
 size_flags_horizontal = 3
 custom_constants/separation = 20
@@ -1178,9 +1227,9 @@ fonts = [ ExtResource( 35 ), ExtResource( 36 ), ExtResource( 37 ), ExtResource( 
 [node name="SqueakButtonHelper" parent="Window/UiArea/TabContainer/Misc/VBoxContainer/OpenUserFolder/Button" instance=ExtResource( 33 )]
 
 [node name="CopySaveData" type="HBoxContainer" parent="Window/UiArea/TabContainer/Misc/VBoxContainer"]
-margin_top = 137.0
+margin_top = 172.0
 margin_right = 736.0
-margin_bottom = 166.0
+margin_bottom = 201.0
 rect_min_size = Vector2( 400, 26 )
 size_flags_horizontal = 3
 custom_constants/separation = 20
@@ -1382,6 +1431,23 @@ window_title = "Confirm"
 dialog_text = "Change save slot?"
 dialog_autowrap = true
 
+[node name="GiveUpConfirmation" type="ConfirmationDialog" parent="Dialogs"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -100.0
+margin_top = -66.0
+margin_right = 100.0
+margin_bottom = 66.0
+theme = ExtResource( 1 )
+popup_exclusive = true
+window_title = "Confirm"
+dialog_text = "Restarting or giving up will end the current day.
+
+Do you really give up?"
+dialog_autowrap = true
+
 [node name="DeleteConfirmation1" parent="Dialogs" instance=ExtResource( 45 )]
 anchor_left = 0.5
 anchor_top = 0.5
@@ -1431,6 +1497,7 @@ icon_color = Color( 1, 0.866667, 0.6, 1 )
 [connection signal="item_selected" from="Window/UiArea/TabContainer/Touch/VBoxContainer/Scheme/OptionButton" to="Window/UiArea/TabContainer/Touch/VBoxContainer/Scheme" method="_on_OptionButton_item_selected"]
 [connection signal="item_selected" from="Window/UiArea/TabContainer/Touch/VBoxContainer/FatFinger/OptionButton" to="Window/UiArea/TabContainer/Touch/VBoxContainer/FatFinger" method="_on_OptionButton_item_selected"]
 [connection signal="item_selected" from="Window/UiArea/TabContainer/Misc/VBoxContainer/Language/OptionButton" to="Window/UiArea/TabContainer/Misc/VBoxContainer/Language" method="_on_OptionButton_item_selected"]
+[connection signal="pressed" from="Window/UiArea/TabContainer/Misc/VBoxContainer/Tips/HBoxContainer/Button" to="Window/UiArea/TabContainer/Misc/VBoxContainer/Tips" method="_on_Button_pressed"]
 [connection signal="delete_pressed" from="Window/UiArea/TabContainer/Misc/VBoxContainer/SaveSlot" to="Dialogs" method="_on_SaveSlot_delete_pressed"]
 [connection signal="pressed" from="Window/UiArea/TabContainer/Misc/VBoxContainer/SaveSlot/HBoxContainer/Delete" to="Window/UiArea/TabContainer/Misc/VBoxContainer/SaveSlot" method="_on_Delete_pressed"]
 [connection signal="pressed" from="Window/UiArea/TabContainer/Misc/VBoxContainer/OpenUserFolder/Button" to="Window/UiArea/TabContainer/Misc/VBoxContainer/OpenUserFolder" method="_on_Button_pressed"]
@@ -1446,9 +1513,12 @@ icon_color = Color( 1, 0.866667, 0.6, 1 )
 [connection signal="change_save_confirmed" from="Dialogs" to="." method="_on_Dialogs_change_save_confirmed"]
 [connection signal="delete_confirmed" from="Dialogs" to="." method="_on_Dialogs_delete_confirmed"]
 [connection signal="dialog_visibility_changed" from="Dialogs" to="Window/UiArea/Bottom" method="_on_Dialogs_dialog_visibility_changed"]
+[connection signal="give_up_confirmed" from="Dialogs" to="." method="_on_Dialogs_give_up_confirmed"]
 [connection signal="visibility_changed" from="Dialogs/Backdrop" to="Dialogs" method="_on_Backdrop_visibility_changed"]
 [connection signal="about_to_show" from="Dialogs/ChangeSaveConfirmation" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
 [connection signal="popup_hide" from="Dialogs/ChangeSaveConfirmation" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
+[connection signal="about_to_show" from="Dialogs/GiveUpConfirmation" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
+[connection signal="popup_hide" from="Dialogs/GiveUpConfirmation" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
 [connection signal="about_to_show" from="Dialogs/DeleteConfirmation1" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]
 [connection signal="popup_hide" from="Dialogs/DeleteConfirmation1" to="Dialogs/Backdrop" method="_on_Dialog_popup_hide"]
 [connection signal="about_to_show" from="Dialogs/DeleteConfirmation2" to="Dialogs/Backdrop" method="_on_Dialog_about_to_show"]

--- a/project/src/main/ui/settings/reenable-tips.gd
+++ b/project/src/main/ui/settings/reenable-tips.gd
@@ -1,0 +1,19 @@
+extends HBoxContainer
+## UI component for reenabling one-time tips, such as the confirmation when restarting/giving up in Adventure mode
+
+var _reenabled_tween: SceneTreeTween
+
+onready var _reenabled_label: Label = $HBoxContainer/Reenabled
+
+func _ready() -> void:
+	# hide the 'Re-enabled!' message until we need to display it
+	_reenabled_label.modulate = Color.transparent
+
+
+func _on_Button_pressed() -> void:
+	SystemData.misc_settings.show_give_up_confirmation = true
+	
+	# display the 'Re-enabled!' message, and gradually fade it out
+	_reenabled_label.modulate = Color.white
+	_reenabled_tween = Utils.recreate_tween(self, _reenabled_tween)
+	_reenabled_tween.tween_property(_reenabled_label, "modulate", Color.transparent, 3.0)

--- a/project/src/main/ui/settings/settings-dialogs.gd
+++ b/project/src/main/ui/settings/settings-dialogs.gd
@@ -13,6 +13,10 @@ signal delete_confirmed
 ## emitted when the player is prompted to delete a save slot and answers 'no' or closes the window
 signal delete_cancelled
 
+signal give_up_confirmed
+
+signal give_up_cancelled
+
 ## emitted when a dialog becomes visible/invisible
 ##
 ## Parameters:
@@ -29,6 +33,8 @@ onready var _delete_confirmation_1 := $DeleteConfirmation1
 
 ## 'Are you sure?' confirmation dialog
 onready var _delete_confirmation_2 := $DeleteConfirmation2
+
+onready var _give_up_confirmation := $GiveUpConfirmation
 
 onready var _backdrop: ColorRect = $Backdrop
 
@@ -56,11 +62,22 @@ func _ready() -> void:
 	_delete_confirmation_2.get_cancel().connect("pressed", self, "_on_DeleteConfirmation_cancelled")
 	_delete_confirmation_2.get_close_button().connect("pressed", self, "_on_DeleteConfirmation_cancelled")
 	_assign_dialog_cancel_shortcut(_delete_confirmation_2)
+	
+	_give_up_confirmation.get_ok().text = tr("Yes")
+	_give_up_confirmation.get_cancel().text = tr("No")
+	_give_up_confirmation.connect("confirmed", self, "_on_GiveUpConfirmation_confirmed")
+	_give_up_confirmation.get_cancel().connect("pressed", self, "_on_GiveUpConfirmation_cancelled")
+	_give_up_confirmation.get_close_button().connect("pressed", self, "_on_GiveUpConfirmation_cancelled")
+	_assign_dialog_cancel_shortcut(_give_up_confirmation)
 
 
 ## Displays a dialog prompting the player if they want to change their save slot
 func confirm_new_save_slot() -> void:
 	_change_save_confirmation.popup_centered()
+
+
+func show_give_up_confirmation() -> void:
+	_give_up_confirmation.popup_centered()
 
 
 ## Expands a simple delete confirmation message into a more detailed message.
@@ -120,3 +137,11 @@ func _on_ChangeSaveConfirmation_cancelled() -> void:
 
 func _on_Backdrop_visibility_changed() -> void:
 	emit_signal("dialog_visibility_changed", _backdrop.visible)
+
+
+func _on_GiveUpConfirmation_confirmed() -> void:
+	emit_signal("give_up_confirmed")
+
+
+func _on_GiveUpConfirmation_cancelled() -> void:
+	emit_signal("give_up_cancelled")


### PR DESCRIPTION
Before, hitting 'restart' or 'give up' would surprise or frustrate players, because Adventure mode would suddenly end and they might not realize what they had done wrong.

Now, the player is prompted '...will end the adventure day, do you really give up?'. This prompt can be restored with a button in the settings menu.

Closes #2847.