### PR TITLE
Added 'restart' button to puzzle menu.

### DIFF
--- a/project/assets/main/locale/en.po
+++ b/project/assets/main/locale/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/Poobslag/turbofat/\n"
-"POT-Creation-Date: 2024-11-04 11:13-0500\n"
+"POT-Creation-Date: 2024-11-04 12:39-0500\n"
 "PO-Revision-Date: 2023-03-13 12:16-0400\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15760,6 +15760,10 @@ msgstr ""
 
 #: project/src/main/ui/settings/settings-menu-bottom.gd
 msgid "Main Menu"
+msgstr ""
+
+#: project/src/main/ui/settings/settings-menu-bottom.gd
+msgid "Restart"
 msgstr ""
 
 #: project/src/main/ui/settings/settings-tab-container.gd

--- a/project/assets/main/locale/es.po
+++ b/project/assets/main/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/Poobslag/turbofat/\n"
-"POT-Creation-Date: 2024-11-04 11:13-0500\n"
+"POT-Creation-Date: 2024-11-04 12:39-0500\n"
 "PO-Revision-Date: 2024-10-13 19:30-0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17756,6 +17756,11 @@ msgstr "Rapidisisísimo"
 #: project/src/main/ui/settings/settings-menu-bottom.gd
 msgid "Main Menu"
 msgstr "Menú Principal"
+
+#: project/src/main/ui/settings/settings-menu-bottom.gd
+#, needs-review
+msgid "Restart"
+msgstr "Reiniciar"
 
 #: project/src/main/ui/settings/settings-tab-container.gd
 msgid "Sound + Graphics"

--- a/project/assets/main/locale/messages.pot
+++ b/project/assets/main/locale/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Turbo Fat 0.9000\n"
 "Report-Msgid-Bugs-To: https://github.com/Poobslag/turbofat/\n"
-"POT-Creation-Date: 2024-11-04 11:13-0500\n"
+"POT-Creation-Date: 2024-11-04 12:39-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15760,6 +15760,10 @@ msgstr ""
 
 #: project/src/main/ui/settings/settings-menu-bottom.gd
 msgid "Main Menu"
+msgstr ""
+
+#: project/src/main/ui/settings/settings-menu-bottom.gd
+msgid "Restart"
 msgstr ""
 
 #: project/src/main/ui/settings/settings-tab-container.gd

--- a/project/src/demo/ui/settings/settings-menu-demo.gd
+++ b/project/src/demo/ui/settings/settings-menu-demo.gd
@@ -4,7 +4,8 @@ extends Node
 ## The settings menu is invisible by default, so a demo is necessary to view it.
 ##
 ## Keys:
-## 	'1-5': Update quit type: QUIT, SAVE_AND_QUIT, GIVE_UP, SAVE_AND_QUIT_OR_GIVE_UP, QUIT_TO_DESKTOP
+## 	'1-6': Update quit type: QUIT, SAVE_AND_QUIT, GIVE_UP, SAVE_AND_QUIT_OR_GIVE_UP, RESTART_OR_GIVE_UP,
+## 		QUIT_TO_DESKTOP
 
 onready var _label := $Label
 onready var _settings_menu := $SettingsMenu
@@ -29,5 +30,8 @@ func _input(event: InputEvent) -> void:
 			_settings_menu.quit_type = SettingsMenu.QuitType.SAVE_AND_QUIT_OR_GIVE_UP
 			_label.text = "QuitType.SAVE_AND_QUIT_OR_GIVE_UP"
 		KEY_5:
+			_settings_menu.quit_type = SettingsMenu.QuitType.RESTART_OR_GIVE_UP
+			_label.text = "QuitType.RESTART_OR_GIVE_UP"
+		KEY_6:
 			_settings_menu.quit_type = SettingsMenu.QuitType.QUIT_TO_DESKTOP
 			_label.text = "QuitType.QUIT_TO_DESKTOP"

--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -913,6 +913,7 @@ script = ExtResource( 89 )
 [connection signal="start_button_pressed" from="Hud/Center/PuzzleMessages" to="." method="_on_Hud_start_button_pressed"]
 [connection signal="give_up_confirmed" from="SettingsMenu" to="." method="_on_SettingsMenu_give_up_confirmed"]
 [connection signal="hide" from="SettingsMenu" to="Hud/TouchButtons" method="_on_Menu_hide"]
+[connection signal="other_quit_pressed" from="SettingsMenu" to="." method="_on_SettingsMenu_other_quit_pressed"]
 [connection signal="quit_pressed" from="SettingsMenu" to="." method="_on_SettingsMenu_quit_pressed"]
 [connection signal="show" from="SettingsMenu" to="Hud/TouchButtons" method="_on_Menu_show"]
 [connection signal="cheat_detected" from="CheatCodeDetector" to="." method="_on_CheatCodeDetector_cheat_detected"]

--- a/project/src/main/ui/menu/MainMenu.tscn
+++ b/project/src/main/ui/menu/MainMenu.tscn
@@ -322,7 +322,7 @@ shape = 6
 [node name="VersionLabel" parent="." instance=ExtResource( 7 )]
 
 [node name="SettingsMenu" parent="." instance=ExtResource( 8 )]
-quit_type = 4
+quit_type = 5
 
 [connection signal="pressed" from="DropPanel/Adventure/Play" to="DropPanel/Adventure" method="_on_Career_pressed"]
 [connection signal="pressed" from="DropPanel/Adventure/Avatar" to="DropPanel/Adventure" method="_on_Avatar_pressed"]

--- a/project/src/main/ui/menu/SplashScreen.tscn
+++ b/project/src/main/ui/menu/SplashScreen.tscn
@@ -138,7 +138,7 @@ margin_right = 924.0
 [node name="VersionLabel" parent="." instance=ExtResource( 2 )]
 
 [node name="SettingsMenu" parent="." instance=ExtResource( 6 )]
-quit_type = 4
+quit_type = 5
 
 [node name="BadSaveDataControl" parent="." instance=ExtResource( 8 )]
 

--- a/project/src/main/ui/settings/settings-menu-bottom.gd
+++ b/project/src/main/ui/settings/settings-menu-bottom.gd
@@ -48,6 +48,9 @@ func _refresh_quit_type() -> void:
 		SettingsMenu.QuitType.SAVE_AND_QUIT_OR_GIVE_UP:
 			quit_text = tr("Main Menu")
 			other_quit_text = tr("Give Up")
+		SettingsMenu.QuitType.RESTART_OR_GIVE_UP:
+			quit_text = tr("Restart")
+			other_quit_text = tr("Give Up")
 		SettingsMenu.QuitType.QUIT_TO_DESKTOP:
 			quit_text = tr("Quit")
 	

--- a/project/src/main/ui/settings/settings-menu.gd
+++ b/project/src/main/ui/settings/settings-menu.gd
@@ -11,13 +11,15 @@ signal quit_pressed
 signal other_quit_pressed
 
 enum QuitType {
-	QUIT, SAVE_AND_QUIT, GIVE_UP, SAVE_AND_QUIT_OR_GIVE_UP, QUIT_TO_DESKTOP
+	QUIT, SAVE_AND_QUIT, GIVE_UP, SAVE_AND_QUIT_OR_GIVE_UP, RESTART_OR_GIVE_UP, QUIT_TO_DESKTOP
 }
 
 const QUIT := QuitType.QUIT
 const SAVE_AND_QUIT := QuitType.SAVE_AND_QUIT
 const GIVE_UP := QuitType.GIVE_UP
 const SAVE_AND_QUIT_OR_GIVE_UP := QuitType.SAVE_AND_QUIT_OR_GIVE_UP
+const RESTART_OR_GIVE_UP := QuitType.RESTART_OR_GIVE_UP
+const QUIT_TO_DESKTOP := QuitType.QUIT_TO_DESKTOP
 
 ## Text on the menu's quit button
 export (QuitType) var quit_type: int setget set_quit_type
@@ -134,7 +136,7 @@ func _on_Bottom_ok_pressed() -> void:
 
 
 func _on_Bottom_quit_pressed() -> void:
-	if quit_type in [GIVE_UP] \
+	if quit_type in [GIVE_UP, RESTART_OR_GIVE_UP] \
 			and PlayerData.career.is_career_mode() and CurrentLevel.attempt_count == 0 \
 			and SystemData.misc_settings.show_give_up_confirmation:
 		show_give_up_confirmation()
@@ -146,7 +148,11 @@ func _on_Bottom_quit_pressed() -> void:
 
 
 func _on_Bottom_other_quit_pressed() -> void:
-	if quit_type == SAVE_AND_QUIT_OR_GIVE_UP:
+	if quit_type == RESTART_OR_GIVE_UP \
+			and PlayerData.career.is_career_mode() and CurrentLevel.attempt_count == 0 \
+			and SystemData.misc_settings.show_give_up_confirmation:
+		show_give_up_confirmation()
+	elif quit_type == SAVE_AND_QUIT_OR_GIVE_UP:
 		_confirm_and_save("emit_signal", ["other_quit_pressed"])
 	else:
 		hide()


### PR DESCRIPTION
This 'restart' option only appears while a puzzle is active. It does all the same things as restarting with the 'R' key: prompting the player in adventure mode and recording the level's score.

Closes #2859.