### PR TITLE
Bug: ResultsHud was blocking mouse clicks

### DIFF
--- a/project/src/main/puzzle/result/ResultsHud.tscn
+++ b/project/src/main/puzzle/result/ResultsHud.tscn
@@ -574,6 +574,7 @@ margin_left = 580.0
 margin_right = 1180.0
 margin_bottom = 684.0
 rect_clip_content = true
+mouse_filter = 2
 
 [node name="ReceiptPaper" type="TextureRect" parent="Clipper"]
 margin_left = 185.0


### PR DESCRIPTION
ResultsHud was blocking mouse clicks, specifically for the right side of the 'Start' or 'Retry' button.

Closes #2878.