### PR TITLE
Added boundary check for 'hours_passed' in career mode

### DIFF
--- a/project/src/main/career/career-calendar.gd
+++ b/project/src/main/career/career-calendar.gd
@@ -34,7 +34,7 @@ func advance_clock(new_distance_earned: int, success: bool, lost: bool) -> void:
 	if lost:
 		career_data.hours_passed = Careers.HOURS_PER_CAREER_DAY
 	else:
-		career_data.hours_passed += 1
+		career_data.hours_passed = int(clamp(career_data.hours_passed + 1, 0, Careers.HOURS_PER_CAREER_DAY))
 	
 	if career_data.is_boss_level():
 		var region: CareerRegion = career_data.current_region()


### PR DESCRIPTION
Yesterday while testing some edge cases and working on some new career mode logic, I encountered a bug where hours_passed was incremented to 7. I can't find a way to duplicate this bug this morning, but it's easy to imagine calling 'advance_clock' one too many times resulting in hours_passed exceeding the maximum.