### PR TITLE
Never start Adventure mode with 'You're done!'

### DIFF
--- a/project/src/main/ui/menu/main-menu-adventure.gd
+++ b/project/src/main/ui/menu/main-menu-adventure.gd
@@ -7,6 +7,10 @@ func _on_Career_pressed() -> void:
 	PlayerData.customer_queue.reset()
 	CurrentLevel.reset()
 	
+	# If the player quit or ended the career mode day, we give them a fresh start.
+	if PlayerData.career.is_day_over():
+		PlayerData.career.advance_calendar()
+	
 	# Launch the first scene in career mode. This is probably the career map, but in some edge cases it could be a
 	# cutscene or victory screen.
 	if PlayerData.career.hours_passed > 0:


### PR DESCRIPTION
Currently, if the player gives up on Adventure Mode or runs out of lives and quits to the main menu, then the next time they start Adventure Mode it shows them "Your day is over, here's how you did" and dumps them back to the main menu.

I've changed this so that it seamlessly advances them to the next day.

Closes #2848