### PR TITLE
Fixed dimensions for 'puzzle tile set diagram'

### DIFF
--- a/project/src/main/puzzle/puzzle-tile-set-diagram.tres
+++ b/project/src/main/puzzle/puzzle-tile-set-diagram.tres
@@ -10,7 +10,7 @@
 0/texture = ExtResource( 3 )
 0/tex_offset = Vector2( 0, 0 )
 0/modulate = Color( 1, 1, 1, 1 )
-0/region = Rect2( 2, 2, 1212, 172 )
+0/region = Rect2( 2, 2, 1212, 472 )
 0/tile_mode = 2
 0/autotile/icon_coordinate = Vector2( 0, 0 )
 0/autotile/tile_size = Vector2( 72, 64 )


### PR DESCRIPTION
This unique tile set is used for drawing diagrams for tutorials, and never used in the game. However, its dimensions are too short making some tiles inaccessible through the UI.