### PR TITLE
Better hints, diagrams for cake tutorial.

### DIFF
--- a/project/assets/main/locale/en.po
+++ b/project/assets/main/locale/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/Poobslag/turbofat/\n"
-"POT-Creation-Date: 2024-11-06 12:28-0500\n"
+"POT-Creation-Date: 2024-11-07 10:23-0500\n"
 "PO-Revision-Date: 2023-03-13 12:16-0400\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -14276,6 +14276,13 @@ msgstr ""
 
 #: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
 msgid ""
+"The white piece goes in the middle, and the brown piece goes on top.\n"
+"\n"
+"Like a sandwich!"
+msgstr ""
+
+#: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+msgid ""
 "Give it another try.\n"
 "\n"
 "See if you can make a rectangle."
@@ -14286,6 +14293,13 @@ msgid ""
 "Let's start by making gelatin.\n"
 "\n"
 "Can you make a rectangle with these pieces?"
+msgstr ""
+
+#: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+msgid ""
+"Now I feel bad for tricking you!\n"
+"\n"
+"...You only need those two T-Blocks for this one."
 msgstr ""
 
 #: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
@@ -14332,6 +14346,10 @@ msgid ""
 msgstr ""
 
 #: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+msgid "Start with the white piece, and stack the big brown piece on top of it."
+msgstr ""
+
+#: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
 msgid ""
 "How about some cheesecake?\n"
 "\n"
@@ -14339,10 +14357,21 @@ msgid ""
 msgstr ""
 
 #: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+msgid "Start with the U-Block, and tuck the pink piece inside of it."
+msgstr ""
+
+#: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
 msgid ""
 "Let's try some strawberry cake.\n"
 "\n"
 "Can you make a cake box with these pieces?"
+msgstr ""
+
+#: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+msgid ""
+"The O-Block goes with the two pink pieces!\n"
+"\n"
+"Maybe that will help."
 msgstr ""
 
 #: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd

--- a/project/assets/main/locale/es.po
+++ b/project/assets/main/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/Poobslag/turbofat/\n"
-"POT-Creation-Date: 2024-11-06 12:28-0500\n"
+"POT-Creation-Date: 2024-11-07 10:23-0500\n"
 "PO-Revision-Date: 2024-10-13 19:30-0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15983,6 +15983,17 @@ msgstr ""
 "¡Te podría mostrar, pero quiero que lo intentes!"
 
 #: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+#, needs-review
+msgid ""
+"The white piece goes in the middle, and the brown piece goes on top.\n"
+"\n"
+"Like a sandwich!"
+msgstr ""
+"La pieza blanca va en el medio, y la pieza marrón va arriba.\n"
+"\n"
+"¡Como un sándwich!"
+
+#: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
 msgid ""
 "Give it another try.\n"
 "\n"
@@ -16001,6 +16012,17 @@ msgstr ""
 "Comencemos haciendo gelatina.\n"
 "\n"
 "¿Puedes hacer un rectángulo con estas piezas?"
+
+#: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+#, needs-review
+msgid ""
+"Now I feel bad for tricking you!\n"
+"\n"
+"...You only need those two T-Blocks for this one."
+msgstr ""
+"¡Ahora me siento mal por engañarte!\n"
+"\n"
+"...Solo necesitas esos dos bloques en T para este."
 
 #: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
 msgid ""
@@ -16062,6 +16084,12 @@ msgid ""
 msgstr "Veamos si puedes descubrir las últimas cuatro recetas sin mi ayuda."
 
 #: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+#, needs-review
+msgid "Start with the white piece, and stack the big brown piece on top of it."
+msgstr ""
+"Comienza con la pieza blanca, y apila la pieza marrón grande encima."
+
+#: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
 msgid ""
 "How about some cheesecake?\n"
 "\n"
@@ -16072,6 +16100,12 @@ msgstr ""
 "Esta vez vas a necesitar un rectángulo más grande."
 
 #: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+#, needs-review
+msgid "Start with the U-Block, and tuck the pink piece inside of it."
+msgstr ""
+"Empieza con el bloque en U, y coloca la pieza rosada dentro."
+
+#: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
 msgid ""
 "Let's try some strawberry cake.\n"
 "\n"
@@ -16080,6 +16114,17 @@ msgstr ""
 "Intentemos algo de torta de frutilla\n"
 "\n"
 "¿Puedes hacer una caja de torta con estas piezas?"
+
+#: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+#, needs-review
+msgid ""
+"The O-Block goes with the two pink pieces!\n"
+"\n"
+"Maybe that will help."
+msgstr ""
+"¡El bloque en O va con las dos piezas rosadas!\n"
+"\n"
+"Tal vez eso ayude."
 
 #: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
 msgid ""

--- a/project/assets/main/locale/messages.pot
+++ b/project/assets/main/locale/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Turbo Fat 0.9000\n"
 "Report-Msgid-Bugs-To: https://github.com/Poobslag/turbofat/\n"
-"POT-Creation-Date: 2024-11-06 12:28-0500\n"
+"POT-Creation-Date: 2024-11-07 10:23-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14279,6 +14279,13 @@ msgstr ""
 
 #: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
 msgid ""
+"The white piece goes in the middle, and the brown piece goes on top.\n"
+"\n"
+"Like a sandwich!"
+msgstr ""
+
+#: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+msgid ""
 "Give it another try.\n"
 "\n"
 "See if you can make a rectangle."
@@ -14289,6 +14296,13 @@ msgid ""
 "Let's start by making gelatin.\n"
 "\n"
 "Can you make a rectangle with these pieces?"
+msgstr ""
+
+#: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+msgid ""
+"Now I feel bad for tricking you!\n"
+"\n"
+"...You only need those two T-Blocks for this one."
 msgstr ""
 
 #: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
@@ -14334,6 +14348,10 @@ msgid "Let's see if you can figure out these last four recipes without my help."
 msgstr ""
 
 #: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+msgid "Start with the white piece, and stack the big brown piece on top of it."
+msgstr ""
+
+#: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
 msgid ""
 "How about some cheesecake?\n"
 "\n"
@@ -14341,10 +14359,21 @@ msgid ""
 msgstr ""
 
 #: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+msgid "Start with the U-Block, and tuck the pink piece inside of it."
+msgstr ""
+
+#: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
 msgid ""
 "Let's try some strawberry cake.\n"
 "\n"
 "Can you make a cake box with these pieces?"
+msgstr ""
+
+#: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+msgid ""
+"The O-Block goes with the two pink pieces!\n"
+"\n"
+"Maybe that will help."
 msgstr ""
 
 #: project/src/main/puzzle/tutorial/tutorial-cakes-module.gd

--- a/project/project.godot
+++ b/project/project.godot
@@ -1595,6 +1595,11 @@ _global_script_classes=[ {
 "path": "res://src/main/puzzle/tutorial/tutorial-diagram.gd"
 }, {
 "base": "Control",
+"class": "TutorialHint",
+"language": "GDScript",
+"path": "res://src/main/puzzle/tutorial-hint.gd"
+}, {
+"base": "Control",
 "class": "TutorialHud",
 "language": "GDScript",
 "path": "res://src/main/puzzle/tutorial/tutorial-hud.gd"
@@ -1957,6 +1962,7 @@ _global_script_class_icons={
 "TouchSettings": "",
 "Tracery": "",
 "TutorialDiagram": "",
+"TutorialHint": "",
 "TutorialHud": "",
 "TutorialMessages": "",
 "TutorialModule": "",

--- a/project/src/main/puzzle/Playfield.tscn
+++ b/project/src/main/puzzle/Playfield.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=47 format=2]
+[gd_scene load_steps=48 format=2]
 
 [ext_resource path="res://src/main/puzzle/playfield.gd" type="Script" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleTileMap.tscn" type="PackedScene" id=2]
@@ -21,6 +21,7 @@
 [ext_resource path="res://src/main/puzzle/GoopViewports.tscn" type="PackedScene" id=19]
 [ext_resource path="res://src/main/puzzle/flat-mix.shader" type="Shader" id=20]
 [ext_resource path="res://src/main/puzzle/TutorialKeybindsLabel.tscn" type="PackedScene" id=21]
+[ext_resource path="res://src/main/puzzle/tutorial-hint.gd" type="Script" id=22]
 [ext_resource path="res://src/main/puzzle/LeafPoof.tscn" type="PackedScene" id=23]
 [ext_resource path="res://src/main/puzzle/line-inserter.gd" type="Script" id=25]
 [ext_resource path="res://src/main/puzzle/Pickup.tscn" type="PackedScene" id=26]
@@ -227,6 +228,13 @@ script = ExtResource( 5 )
 LeafPoofScene = ExtResource( 23 )
 puzzle_tile_map_path = NodePath("../TileMap")
 
+[node name="TutorialHint" type="Control" parent="."]
+modulate = Color( 1, 1, 1, 0.392157 )
+margin_right = 324.0
+margin_bottom = 544.0
+rect_clip_content = true
+script = ExtResource( 22 )
+
 [node name="ShadowTexture" type="TextureRect" parent="."]
 modulate = Color( 1, 1, 1, 0.313726 )
 anchor_right = 1.0
@@ -242,6 +250,7 @@ texture = SubResource( 14 )
 flip_v = true
 
 [node name="TutorialKeybindsLabel" parent="." instance=ExtResource( 21 )]
+modulate = Color( 1, 1, 1, 0.392157 )
 
 [node name="ComboTracker" type="Node" parent="."]
 script = ExtResource( 61 )

--- a/project/src/main/puzzle/playfield.gd
+++ b/project/src/main/puzzle/playfield.gd
@@ -57,6 +57,7 @@ onready var line_clearer: LineClearer = $LineClearer
 onready var _bg_glob_viewports: GoopViewports = $BgGlobViewports
 onready var _box_builder: BoxBuilder = $BoxBuilder
 onready var _combo_tracker: ComboTracker = $ComboTracker
+onready var _tutorial_hint: TutorialHint = $TutorialHint
 
 func _ready() -> void:
 	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
@@ -79,6 +80,17 @@ func _physics_process(delta: float) -> void:
 			line_clearer.set_physics_process(true)
 	elif _remaining_misc_delay_frames > 0:
 		_remaining_misc_delay_frames -= 1
+
+
+## Adds a new hint diagram to the playfield.
+##
+## These hints are currently always TileMaps, but the framework potentially allows for TextureRects or other hint
+## diagrams as well.
+##
+## Parameters:
+## 	'hint_scene': The hint diagram scene to instantiate and add behind the playfield.
+func add_hint(hint_scene: PackedScene) -> void:
+	_tutorial_hint.add_hint(hint_scene)
 
 
 func is_clearing_lines() -> bool:

--- a/project/src/main/puzzle/tutorial-hint.gd
+++ b/project/src/main/puzzle/tutorial-hint.gd
@@ -1,0 +1,33 @@
+class_name TutorialHint
+extends Control
+## Shows hint diagrams during tutorials.
+##
+## These translucent hint diagrams go behind the playfield, showing the player where to drop their pieces.
+
+func _ready() -> void:
+	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
+	CurrentLevel.connect("settings_changed", self, "_on_Level_settings_changed")
+
+
+## Adds a new hint diagram to the playfield.
+##
+## These hints are currently always TileMaps, but the framework potentially allows for TextureRects or other hint
+## diagrams as well.
+##
+## Parameters:
+## 	'hint_scene': The hint diagram scene to instantiate and add behind the playfield.
+func add_hint(hint_scene: PackedScene) -> void:
+	add_child(hint_scene.instance())
+
+
+func _prepare_level_blocks() -> void:
+	for child in get_children():
+		child.queue_free()
+
+
+func _on_Level_settings_changed() -> void:
+	_prepare_level_blocks()
+
+
+func _on_PuzzleState_game_prepared() -> void:
+	_prepare_level_blocks()

--- a/project/src/main/puzzle/tutorial/HintTileMapJjoQuv.tscn
+++ b/project/src/main/puzzle/tutorial/HintTileMapJjoQuv.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=7 format=2]
+
+[ext_resource path="res://src/main/puzzle/tutorial/hint-tile-map.gd" type="Script" id=1]
+[ext_resource path="res://src/main/puzzle/piece/PuzzleCornerMap.tscn" type="PackedScene" id=2]
+[ext_resource path="res://src/main/puzzle/puzzle-tile-set-diagram.tres" type="TileSet" id=3]
+[ext_resource path="res://src/main/puzzle/flat-mix.shader" type="Shader" id=4]
+
+[sub_resource type="ShaderMaterial" id=15]
+resource_local_to_scene = true
+shader = ExtResource( 4 )
+shader_param/mix_color = Color( 1, 1, 1, 0 )
+
+[sub_resource type="ShaderMaterial" id=16]
+resource_local_to_scene = true
+shader = ExtResource( 4 )
+shader_param/mix_color = Color( 1, 1, 1, 0 )
+
+[node name="HintTileMapJjoQuv" type="TileMap"]
+material = SubResource( 15 )
+position = Vector2( 0, -96 )
+scale = Vector2( 0.5, 0.5 )
+tile_set = ExtResource( 3 )
+cell_size = Vector2( 72, 64 )
+format = 1
+tile_data = PoolIntArray( 983040, 0, 131082, 983041, 0, 131084, 983042, 0, 131078, 1048576, 0, 131073, 1048577, 0, 65538, 1048578, 0, 131073, 1048582, 0, 131080, 1048583, 0, 131084, 1048584, 0, 131078, 1114112, 0, 2, 1114113, 0, 65547, 1114114, 0, 65542, 1114118, 0, 65546, 1114119, 0, 65540, 1114120, 0, 131073, 1179648, 0, 3, 1179649, 0, 65545, 1179650, 0, 65541, 1179654, 0, 65539, 1179655, 0, 10, 1179656, 0, 6, 1245184, 0, 9, 1245185, 0, 12, 1245186, 0, 4, 1245190, 0, 65537, 1245191, 0, 9, 1245192, 0, 5 )
+script = ExtResource( 1 )
+
+[node name="CornerMap" parent="." instance=ExtResource( 2 )]
+material = SubResource( 16 )
+tile_set = ExtResource( 3 )

--- a/project/src/main/puzzle/tutorial/HintTileMapJlo.tscn
+++ b/project/src/main/puzzle/tutorial/HintTileMapJlo.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=7 format=2]
+
+[ext_resource path="res://src/main/puzzle/piece/PuzzleCornerMap.tscn" type="PackedScene" id=1]
+[ext_resource path="res://src/main/puzzle/puzzle-tile-set-diagram.tres" type="TileSet" id=2]
+[ext_resource path="res://src/main/puzzle/flat-mix.shader" type="Shader" id=3]
+[ext_resource path="res://src/main/puzzle/tutorial/hint-tile-map.gd" type="Script" id=4]
+
+[sub_resource type="ShaderMaterial" id=6]
+resource_local_to_scene = true
+shader = ExtResource( 3 )
+shader_param/mix_color = Color( 1, 1, 1, 0 )
+
+[sub_resource type="ShaderMaterial" id=15]
+resource_local_to_scene = true
+shader = ExtResource( 3 )
+shader_param/mix_color = Color( 1, 1, 1, 0 )
+
+[node name="HintTileMapJlo" type="TileMap"]
+material = SubResource( 6 )
+position = Vector2( 0, -96 )
+scale = Vector2( 0.5, 0.5 )
+tile_set = ExtResource( 2 )
+cell_size = Vector2( 72, 64 )
+format = 1
+tile_data = PoolIntArray( 1048576, 0, 131082, 1048577, 0, 131084, 1048578, 0, 131076, 1114112, 0, 131073, 1114113, 0, 65546, 1114114, 0, 65542, 1179648, 0, 2, 1179649, 0, 65545, 1179650, 0, 65541, 1245184, 0, 9, 1245185, 0, 12, 1245186, 0, 4 )
+script = ExtResource( 4 )
+
+[node name="CornerMap" parent="." instance=ExtResource( 1 )]
+material = SubResource( 15 )
+tile_set = ExtResource( 2 )

--- a/project/src/main/puzzle/tutorial/HintTileMapJttLlo.tscn
+++ b/project/src/main/puzzle/tutorial/HintTileMapJttLlo.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=7 format=2]
+
+[ext_resource path="res://src/main/puzzle/piece/PuzzleCornerMap.tscn" type="PackedScene" id=1]
+[ext_resource path="res://src/main/puzzle/puzzle-tile-set-diagram.tres" type="TileSet" id=2]
+[ext_resource path="res://src/main/puzzle/flat-mix.shader" type="Shader" id=3]
+[ext_resource path="res://src/main/puzzle/tutorial/hint-tile-map.gd" type="Script" id=4]
+
+[sub_resource type="ShaderMaterial" id=15]
+resource_local_to_scene = true
+shader = ExtResource( 3 )
+shader_param/mix_color = Color( 1, 1, 1, 0 )
+
+[sub_resource type="ShaderMaterial" id=16]
+resource_local_to_scene = true
+shader = ExtResource( 3 )
+shader_param/mix_color = Color( 1, 1, 1, 0 )
+
+[node name="HintTileMapJttLlo" type="TileMap"]
+material = SubResource( 15 )
+position = Vector2( 0, -96 )
+scale = Vector2( 0.5, 0.5 )
+tile_set = ExtResource( 2 )
+cell_size = Vector2( 72, 64 )
+format = 1
+tile_data = PoolIntArray( 1048582, 0, 131082, 1048583, 0, 131076, 1048584, 0, 65538, 1114114, 0, 65538, 1114115, 0, 131082, 1114116, 0, 131084, 1114117, 0, 131076, 1114118, 0, 131075, 1114119, 0, 65544, 1114120, 0, 65543, 1179650, 0, 65539, 1179651, 0, 131073, 1179652, 0, 10, 1179653, 0, 6, 1179654, 0, 131073, 1179655, 0, 2, 1179656, 0, 65537, 1245186, 0, 65545, 1245187, 0, 65540, 1245188, 0, 9, 1245189, 0, 5, 1245190, 0, 8, 1245191, 0, 13, 1245192, 0, 4 )
+script = ExtResource( 4 )
+
+[node name="CornerMap" parent="." instance=ExtResource( 1 )]
+material = SubResource( 16 )
+tile_set = ExtResource( 2 )

--- a/project/src/main/puzzle/tutorial/HintTileMapLtt.tscn
+++ b/project/src/main/puzzle/tutorial/HintTileMapLtt.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=7 format=2]
+
+[ext_resource path="res://src/main/puzzle/tutorial/hint-tile-map.gd" type="Script" id=1]
+[ext_resource path="res://src/main/puzzle/piece/PuzzleCornerMap.tscn" type="PackedScene" id=2]
+[ext_resource path="res://src/main/puzzle/puzzle-tile-set-diagram.tres" type="TileSet" id=3]
+[ext_resource path="res://src/main/puzzle/flat-mix.shader" type="Shader" id=4]
+
+[sub_resource type="ShaderMaterial" id=15]
+resource_local_to_scene = true
+shader = ExtResource( 4 )
+shader_param/mix_color = Color( 1, 1, 1, 0 )
+
+[sub_resource type="ShaderMaterial" id=16]
+resource_local_to_scene = true
+shader = ExtResource( 4 )
+shader_param/mix_color = Color( 1, 1, 1, 0 )
+
+[node name="HintTileMapLtt" type="TileMap"]
+material = SubResource( 15 )
+position = Vector2( 0, -96 )
+scale = Vector2( 0.5, 0.5 )
+tile_set = ExtResource( 3 )
+cell_size = Vector2( 72, 64 )
+format = 1
+tile_data = PoolIntArray( 917504, 0, 131080, 917505, 0, 131086, 917506, 0, 131076, 983040, 0, 2, 983041, 0, 131073, 983042, 0, 65538, 1048576, 0, 3, 1048577, 0, 65544, 1048578, 0, 65543, 1114112, 0, 9, 1114113, 0, 4, 1114114, 0, 65537 )
+script = ExtResource( 1 )
+
+[node name="CornerMap" parent="." instance=ExtResource( 2 )]
+material = SubResource( 16 )
+tile_set = ExtResource( 3 )

--- a/project/src/main/puzzle/tutorial/HintTileMapPqv.tscn
+++ b/project/src/main/puzzle/tutorial/HintTileMapPqv.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=7 format=2]
+
+[ext_resource path="res://src/main/puzzle/tutorial/hint-tile-map.gd" type="Script" id=1]
+[ext_resource path="res://src/main/puzzle/piece/PuzzleCornerMap.tscn" type="PackedScene" id=2]
+[ext_resource path="res://src/main/puzzle/puzzle-tile-set-diagram.tres" type="TileSet" id=3]
+[ext_resource path="res://src/main/puzzle/flat-mix.shader" type="Shader" id=4]
+
+[sub_resource type="ShaderMaterial" id=15]
+resource_local_to_scene = true
+shader = ExtResource( 4 )
+shader_param/mix_color = Color( 1, 1, 1, 0 )
+
+[sub_resource type="ShaderMaterial" id=16]
+resource_local_to_scene = true
+shader = ExtResource( 4 )
+shader_param/mix_color = Color( 1, 1, 1, 0 )
+
+[node name="HintTileMapPqv" type="TileMap"]
+material = SubResource( 15 )
+position = Vector2( 0, -96 )
+scale = Vector2( 0.5, 0.5 )
+tile_set = ExtResource( 3 )
+cell_size = Vector2( 72, 64 )
+format = 1
+tile_data = PoolIntArray( 983043, 0, 131080, 983044, 0, 131086, 983045, 0, 131078, 1048579, 0, 65538, 1048580, 0, 131081, 1048581, 0, 131077, 1114115, 0, 65547, 1114116, 0, 65542, 1114117, 0, 2, 1179651, 0, 65545, 1179652, 0, 65541, 1179653, 0, 3, 1245187, 0, 8, 1245188, 0, 12, 1245189, 0, 5 )
+script = ExtResource( 1 )
+
+[node name="CornerMap" parent="." instance=ExtResource( 2 )]
+material = SubResource( 16 )
+tile_set = ExtResource( 3 )

--- a/project/src/main/puzzle/tutorial/HintTileMapPuv.tscn
+++ b/project/src/main/puzzle/tutorial/HintTileMapPuv.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=7 format=2]
+
+[ext_resource path="res://src/main/puzzle/tutorial/hint-tile-map.gd" type="Script" id=1]
+[ext_resource path="res://src/main/puzzle/piece/PuzzleCornerMap.tscn" type="PackedScene" id=2]
+[ext_resource path="res://src/main/puzzle/puzzle-tile-set-diagram.tres" type="TileSet" id=3]
+[ext_resource path="res://src/main/puzzle/flat-mix.shader" type="Shader" id=4]
+
+[sub_resource type="ShaderMaterial" id=15]
+resource_local_to_scene = true
+shader = ExtResource( 4 )
+shader_param/mix_color = Color( 1, 1, 1, 0 )
+
+[sub_resource type="ShaderMaterial" id=16]
+resource_local_to_scene = true
+shader = ExtResource( 4 )
+shader_param/mix_color = Color( 1, 1, 1, 0 )
+
+[node name="HintTileMapPuv" type="TileMap"]
+material = SubResource( 15 )
+position = Vector2( 0, -96 )
+scale = Vector2( 0.5, 0.5 )
+tile_set = ExtResource( 3 )
+cell_size = Vector2( 72, 64 )
+format = 1
+tile_data = PoolIntArray( 983043, 0, 131082, 983044, 0, 131084, 983045, 0, 131076, 1048579, 0, 131075, 1048580, 0, 65546, 1048581, 0, 65542, 1114115, 0, 131073, 1114116, 0, 65547, 1114117, 0, 65541, 1179651, 0, 2, 1179652, 0, 65537, 1179653, 0, 2, 1245187, 0, 9, 1245188, 0, 12, 1245189, 0, 5 )
+script = ExtResource( 1 )
+
+[node name="CornerMap" parent="." instance=ExtResource( 2 )]
+material = SubResource( 16 )
+tile_set = ExtResource( 3 )

--- a/project/src/main/puzzle/tutorial/TutorialCakesModule.tscn
+++ b/project/src/main/puzzle/tutorial/TutorialCakesModule.tscn
@@ -1,7 +1,13 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://src/main/puzzle/tutorial/tutorial-cakes-module.gd" type="Script" id=1]
 [ext_resource path="res://src/main/puzzle/tutorial/SkillTallyItem.tscn" type="PackedScene" id=2]
+[ext_resource path="res://src/main/puzzle/tutorial/HintTileMapLtt.tscn" type="PackedScene" id=3]
+[ext_resource path="res://src/main/puzzle/tutorial/HintTileMapPuv.tscn" type="PackedScene" id=4]
+[ext_resource path="res://src/main/puzzle/tutorial/HintTileMapPqv.tscn" type="PackedScene" id=5]
+[ext_resource path="res://src/main/puzzle/tutorial/HintTileMapJlo.tscn" type="PackedScene" id=6]
+[ext_resource path="res://src/main/puzzle/tutorial/HintTileMapJjoQuv.tscn" type="PackedScene" id=7]
+[ext_resource path="res://src/main/puzzle/tutorial/HintTileMapJttLlo.tscn" type="PackedScene" id=8]
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 0.11, 0.89, 0.11, 0.33 )
@@ -29,6 +35,12 @@ corner_radius_bottom_left = 8
 
 [node name="TutorialCakesModule" type="Node"]
 script = ExtResource( 1 )
+HintTileMapJjoQuvScene = ExtResource( 7 )
+HintTileMapJloScene = ExtResource( 6 )
+HintTileMapJttLloScene = ExtResource( 8 )
+HintTileMapLttScene = ExtResource( 3 )
+HintTileMapPqvScene = ExtResource( 5 )
+HintTileMapPuvScene = ExtResource( 4 )
 
 [node name="SkillTallyItems" type="Node" parent="."]
 

--- a/project/src/main/puzzle/tutorial/hint-tile-map.gd
+++ b/project/src/main/puzzle/tutorial/hint-tile-map.gd
@@ -1,0 +1,7 @@
+extends TileMap
+## A hint diagram which is shown during tutorials.
+##
+## This translucent hint diagram goes behind the playfield, showing the player where to drop their pieces.
+
+func _ready() -> void:
+	$CornerMap.dirty = true

--- a/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-cakes-module.gd
@@ -6,6 +6,14 @@ extends TutorialModule
 const CAKES_DIAGRAM_0 := preload("res://assets/main/puzzle/tutorial/cakes-diagram-0.png")
 const CAKES_DIAGRAM_1 := preload("res://assets/main/puzzle/tutorial/cakes-diagram-1.png")
 
+## Hint diagrams which show the player where to drop their pieces.
+export (PackedScene) var HintTileMapJjoQuvScene: PackedScene
+export (PackedScene) var HintTileMapJloScene: PackedScene
+export (PackedScene) var HintTileMapJttLloScene: PackedScene
+export (PackedScene) var HintTileMapLttScene: PackedScene
+export (PackedScene) var HintTileMapPqvScene: PackedScene
+export (PackedScene) var HintTileMapPuvScene: PackedScene
+
 ## player statistics for the current tutorial section
 var _cakes_built := 0
 var _failure_count := 0
@@ -47,20 +55,37 @@ func prepare_tutorial_level() -> void:
 			_advance_level()
 		"tutorial/cakes_2":
 			_prepare_cake_tally_item(1)
-			if _failure_count >= 1:
+			if _failure_count >= 4:
+				hud.puzzle.get_playfield().add_hint(HintTileMapJloScene)
+				hud.set_message(tr("The white piece goes in the middle, and the brown piece goes on top."
+						+ "\n\nLike a sandwich!"))
+			elif _failure_count >= 2:
+				hud.set_message(tr("The white piece goes in the middle, and the brown piece goes on top."
+						+ "\n\nLike a sandwich!"))
+			elif _failure_count >= 1:
 				hud.set_message(tr("Give it another try.\n\nSee if you can make a rectangle."))
 			else:
 				hud.set_message(tr("Let's start by making gelatin.\n\nCan you make a rectangle with these pieces?"))
 		"tutorial/cakes_3":
 			_prepare_cake_tally_item(1)
-			if _failure_count >= 1:
+			if _failure_count >= 4:
+				hud.puzzle.get_playfield().add_hint(HintTileMapLttScene)
+				hud.set_message(tr("Now I feel bad for tricking you!"
+						+ "\n\n...You only need those two T-Blocks for this one."))
+			elif _failure_count >= 2:
+				hud.set_message(tr("Now I feel bad for tricking you!"
+						+ "\n\n...You only need those two T-Blocks for this one."))
+			elif _failure_count >= 1:
 				hud.set_message(tr("Give it another try.\n\nSee if you can make a rectangle."))
 			else:
 				hud.set_message(tr("Next let's try double-decker brownies."
 						+ "\n\nCan you make another cake box with this?"))
 		"tutorial/cakes_4":
 			_prepare_cake_tally_item(2)
-			if _failure_count >= 3:
+			if _failure_count >= 4:
+				hud.puzzle.get_playfield().add_hint(HintTileMapJttLloScene)
+				hud.set_message(tr("I'll give you a small hint:\n\nBoth chocolate pieces go into the left box."))
+			elif _failure_count >= 2:
 				hud.set_message(tr("I'll give you a small hint:\n\nBoth chocolate pieces go into the left box."))
 			elif _failure_count >= 1:
 				hud.set_message(tr("Give it another try.\n\nSee if you can make two rectangles."))
@@ -76,19 +101,34 @@ func prepare_tutorial_level() -> void:
 			_advance_level()
 		"tutorial/cakes_6":
 			_prepare_cake_tally_item(1)
-			if _failure_count >= 1:
+			if _failure_count >= 4:
+				hud.puzzle.get_playfield().add_hint(HintTileMapPqvScene)
+				hud.set_message(tr("Start with the white piece, and stack the big brown piece on top of it."))
+			elif _failure_count >= 2:
+				hud.set_message(tr("Start with the white piece, and stack the big brown piece on top of it."))
+			elif _failure_count >= 1:
 				hud.set_message(tr("Give it another try.\n\nSee if you can make a rectangle."))
 			else:
 				hud.set_message(tr("How about some cheesecake?\n\nYou'll need a bigger rectangle this time."))
 		"tutorial/cakes_7":
 			_prepare_cake_tally_item(1)
-			if _failure_count >= 1:
+			if _failure_count >= 4:
+				hud.puzzle.get_playfield().add_hint(HintTileMapPuvScene)
+				hud.set_message(tr("Start with the U-Block, and tuck the pink piece inside of it."))
+			elif _failure_count >= 2:
+				hud.set_message(tr("Start with the U-Block, and tuck the pink piece inside of it."))
+			elif _failure_count >= 1:
 				hud.set_message(tr("Give it another try.\n\nSee if you can make a rectangle."))
 			else:
 				hud.set_message(tr("Let's try some strawberry cake.\n\nCan you make a cake box with these pieces?"))
 		"tutorial/cakes_8":
 			_prepare_cake_tally_item(2)
-			if _failure_count >= 1:
+			if _failure_count >= 4:
+				hud.puzzle.get_playfield().add_hint(HintTileMapJjoQuvScene)
+				hud.set_message(tr("The O-Block goes with the two pink pieces!\n\nMaybe that will help."))
+			elif _failure_count >= 2:
+				hud.set_message(tr("The O-Block goes with the two pink pieces!\n\nMaybe that will help."))
+			elif _failure_count >= 1:
 				hud.set_message(tr("Give it another try.\n\nSee if you can make two rectangles."))
 			else:
 				hud.set_message(tr("Okay, final two recipes!\n\n...Can you make two cakes at once?"))


### PR DESCRIPTION
The cake tutorial requires assembling 3-6 pieces into rectangles, and it is sort of like putting together a jigsaw puzzles. For players who can't solve this puzzle, the tutorial is impossible.

The tutorial has been improved in two ways:

1. Better, earlier text hints telling the player where to put each piece
2. Visual diagrams showing the player where to put each piece

We give the player a small hint after they mess up twice. We give the player the solution after they mess up four times. Hopefully this prevents players from getting stuck on the tutorial, even if they can't figure out the answer by themselves.