### PR TITLE
POT update script preserves 'needs-review' flags

### DIFF
--- a/pybabel-extract.sh
+++ b/pybabel-extract.sh
@@ -19,5 +19,10 @@ pybabel extract -F project/assets/main/locale/babelrc \
   --version=0.9000 \
   --copyright-holder="Poobslag"
 
+# temporarily replace 'needs-review' flags with 'fuzzy' so that msgmerge will preserve them
+sed -i 's/#, needs-review/#, fuzzy/g' project/assets/main/locale/es.po
+
 msgmerge --update --backup=none -N project/assets/main/locale/es.po project/assets/main/locale/messages.pot
+sed -i 's/#, fuzzy/#, needs-review/g' project/assets/main/locale/es.po
+
 msgmerge --update --backup=none -N project/assets/main/locale/en.po project/assets/main/locale/messages.pot


### PR DESCRIPTION
We use a custom 'needs-review' flag to track machine translations which need to be reviewed by a human. Previously, these flags were automatically removed every time the POT update script was run, and needed to be manually reapplied.