### PR TITLE
Let player boss level, even if time is up

### DIFF
--- a/project/src/demo/career/ui/ProgressBoardDemo.tscn
+++ b/project/src/demo/career/ui/ProgressBoardDemo.tscn
@@ -1,10 +1,26 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://src/main/career/ui/ProgressBoard.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/demo/career/ui/progress-board-demo.gd" type="Script" id=2]
+[ext_resource path="res://src/main/ui/theme/h5.theme" type="Theme" id=3]
 
 [node name="Demo" type="Node"]
 script = ExtResource( 2 )
 
 [node name="ProgressBoard" parent="." instance=ExtResource( 1 )]
+layer = 0
 suppress_hide = true
+
+[node name="Label" type="Label" parent="."]
+anchor_top = 0.5
+anchor_bottom = 0.5
+margin_left = 11.0
+margin_top = -200.0
+margin_right = 161.0
+margin_bottom = 200.0
+rect_min_size = Vector2( 150, 400 )
+theme = ExtResource( 3 )
+text = "asdf"
+align = 1
+valign = 1
+autowrap = true

--- a/project/src/demo/career/ui/progress-board-demo.gd
+++ b/project/src/demo/career/ui/progress-board-demo.gd
@@ -10,17 +10,20 @@ extends Node
 ## 	[R]: Permanently show the progress board.
 ## 	[S]: Toggle whether or not the sensei accompanies the player in this chapter.
 ## 	[I]: Show the intro board.
+## 	[L]: Toggle whether or not the player topped out.
 ## 	[Z-M]: Animate the player advancing 0-25 steps.
 ## 	[Shift + Z-M]: Animate the player going backward 0-25 steps.
 ## 	[=/-]: Move the player forward/backward on the progress board.
 
 onready var _progress_board := $ProgressBoard
+onready var _label := $Label
 onready var _player := $ProgressBoard/ChalkboardRegion/Player
 
 func _ready() -> void:
 	PlayerData.career.hours_passed = 2
 	PlayerData.career.show_progress = Careers.ShowProgress.STATIC
 	_progress_board.show_progress()
+	_refresh_label()
 
 
 func _input(event: InputEvent) -> void:
@@ -43,6 +46,8 @@ func _input(event: InputEvent) -> void:
 			_progress_board.show_progress()
 		KEY_I:
 			_progress_board.show_intro()
+		KEY_L:
+			PlayerData.career.lost = not PlayerData.career.lost
 		KEY_Z:
 			_animate_progress(0 * (-1 if Input.is_key_pressed(KEY_SHIFT) else 1))
 		KEY_X:
@@ -82,6 +87,18 @@ func _input(event: InputEvent) -> void:
 			PlayerData.career.distance_travelled -= 10 if Input.is_key_pressed(KEY_SHIFT) else 1
 			PlayerData.career.distance_travelled = int(max(PlayerData.career.distance_travelled, 0))
 			_progress_board.refresh()
+	_refresh_label()
+
+
+func _refresh_label() -> void:
+	var new_text := ""
+	new_text += "lost=%s\n" % [PlayerData.career.lost]
+	new_text += "distance_earned=%s\n" % [PlayerData.career.distance_earned]
+	new_text += "distance_travelled=%s\n" % [PlayerData.career.distance_travelled]
+	new_text += "show_progress=%s\n" % \
+			[Utils.enum_to_snake_case(Careers.ShowProgress, PlayerData.career.show_progress)]
+	
+	_label.text = new_text.strip_edges()
 
 
 func _animate_progress(distance_earned: int) -> void:

--- a/project/src/main/career/career-calendar.gd
+++ b/project/src/main/career/career-calendar.gd
@@ -27,14 +27,15 @@ func advance_clock(new_distance_earned: int, success: bool, lost: bool) -> void:
 	else:
 		career_data.show_progress = Careers.ShowProgress.ANIMATED
 	
-	
 	career_data.distance_earned = new_distance_earned
+	if lost:
+		career_data.lost = true
 	career_data.skipped_previous_level = false
 	
-	if lost:
-		career_data.hours_passed = Careers.HOURS_PER_CAREER_DAY
-	else:
-		career_data.hours_passed = int(clamp(career_data.hours_passed + 1, 0, Careers.HOURS_PER_CAREER_DAY))
+	career_data.hours_passed += 1
+	
+	if career_data.lost:
+		career_data.hours_passed = int(max(career_data.hours_passed, Careers.HOURS_PER_CAREER_DAY))
 	
 	if career_data.is_boss_level():
 		var region: CareerRegion = career_data.current_region()
@@ -88,6 +89,7 @@ func advance_calendar() -> void:
 	career_data.extra_life_count = 0
 	career_data.hours_passed = 0
 	career_data.level_ids.clear()
+	career_data.lost = false
 	career_data.money = 0
 	career_data.seconds_played = 0.0
 	career_data.steps = 0

--- a/project/src/main/career/career-flow.gd
+++ b/project/src/main/career/career-flow.gd
@@ -26,7 +26,8 @@ func push_career_trail() -> void:
 		CurrentCutscene.push_cutscene_trail()
 		redirected = true
 	
-	if not redirected and career_data.is_day_over() and career_data.show_progress == Careers.ShowProgress.NONE:
+	if not redirected and not career_data.can_play_more_levels() \
+			and career_data.show_progress == Careers.ShowProgress.NONE:
 		# If the day is over, they're redirected to the career map to view the progress board. But if they don't need
 		# to view the progress board, we can redirect them directly to the career win screen.
 		SceneTransition.replace_trail(Global.SCENE_CAREER_WIN)
@@ -45,7 +46,7 @@ func process_puzzle_result() -> void:
 	if not PuzzleState.game_ended:
 		# player skipped a level
 		skip_remaining_cutscenes = true
-		career_data.advance_clock(0, false, false)
+		career_data.advance_clock(0, false)
 		career_data.skipped_previous_level = true
 	
 	if PlayerData.cutscene_queue.has_cutscene_flag("intro_level") \

--- a/project/src/main/career/ui/career-map-level-select.gd
+++ b/project/src/main/career/ui/career-map-level-select.gd
@@ -18,7 +18,7 @@ onready var _level_buttons_container := $VBoxContainer/LevelButtons/HBoxContaine
 func _ready() -> void:
 	# If the day is over, we show the career map briefly so the player can see their progress, but we hide the level
 	# select buttons.
-	if PlayerData.career.is_day_over():
+	if not PlayerData.career.can_play_more_levels():
 		_control.visible = false
 
 

--- a/project/src/main/career/ui/career-time-label.gd
+++ b/project/src/main/career/ui/career-time-label.gd
@@ -14,11 +14,13 @@ func _ready() -> void:
 ## Update the label's text and icon.
 func _refresh() -> void:
 	# update the label's text
-	_label.text = PlayerData.career.times_of_day_by_hour.get(
-			PlayerData.career.hours_passed, PlayerData.career.invalid_time_of_day)
-	
-	if not PlayerData.career.times_of_day_by_hour.has(PlayerData.career.hours_passed):
-		push_warning("_times_of_day_by_hour has no entry for %s" % [PlayerData.career.hours_passed])
+	if PlayerData.career.hours_passed > Careers.HOURS_PER_CAREER_DAY:
+		_label.text = PlayerData.career.times_of_day_by_hour.get(Careers.HOURS_PER_CAREER_DAY)
+	else:
+		_label.text = PlayerData.career.times_of_day_by_hour.get(
+				PlayerData.career.hours_passed, PlayerData.career.invalid_time_of_day)
+		if not PlayerData.career.times_of_day_by_hour.has(PlayerData.career.hours_passed):
+			push_warning("_times_of_day_by_hour has no entry for %s" % [PlayerData.career.hours_passed])
 	
 	# update the icon
 	_icon_sprite.frame = PlayerData.career.hours_passed

--- a/project/src/main/career/ui/progress-board-clock.gd
+++ b/project/src/main/career/ui/progress-board-clock.gd
@@ -82,13 +82,28 @@ func set_hours_passed(new_hours_passed: int = 0) -> void:
 	_refresh()
 
 
+## Calculates the desired minute/hour hand positions.
+##
+## Parameters:
+## 	'new_hours_passed': The number of hours passed in career mode.
+##
+## Returns:
+## 	Array with two float entries for the position of the analog clock's hour and minute hands.
+func _hand_positions(new_hours_passed: int) -> Array:
+	var hand_positions: Array
+	if new_hours_passed > Careers.HOURS_PER_CAREER_DAY:
+		hand_positions = HAND_POSITIONS_BY_HOUR.get(Careers.HOURS_PER_CAREER_DAY)
+	else:
+		hand_positions = HAND_POSITIONS_BY_HOUR.get(new_hours_passed, INVALID_HAND_POSITIONS)
+	return hand_positions
+
+
 ## Calculates the desired minute hand position.
 ##
 ## Parameters:
 ## 	'new_hours_passed': The number of hours passed in career mode.
 func _minute_hand_position(new_hours_passed: int) -> float:
-	var hand_positions: Array = HAND_POSITIONS_BY_HOUR.get(new_hours_passed, INVALID_HAND_POSITIONS)
-	return hand_positions[1]
+	return _hand_positions(new_hours_passed)[1]
 
 
 ## Calculates the desired hour hand position, advancing it based on the minute hand position.
@@ -100,8 +115,7 @@ func _minute_hand_position(new_hours_passed: int) -> float:
 ## 		two numbers on an analog clock. If false, the hour hand will ignore the minute hand, pointing directly to one
 ## 		of the twelve numbers on an analog clock.
 func _hour_hand_position(new_hours_passed: int, advance_for_minutes: bool = true) -> float:
-	var hand_positions: Array = HAND_POSITIONS_BY_HOUR.get(new_hours_passed, INVALID_HAND_POSITIONS)
-	var new_hours: float = hand_positions[0]
+	var new_hours: float = _hand_positions(new_hours_passed)[0]
 	if advance_for_minutes:
 		new_hours += _minute_hand_position(new_hours_passed) / 60.0
 	return new_hours
@@ -125,7 +139,12 @@ func _filled_percent(new_hours_passed: int) -> float:
 
 ## Calculates the text of the digital clock, like '12:30 pm'
 func _clock_text(new_hours_passed: int) -> String:
-	return PlayerData.career.times_of_day_by_hour.get(new_hours_passed, PlayerData.career.invalid_time_of_day)
+	var text: String
+	if new_hours_passed > Careers.HOURS_PER_CAREER_DAY:
+		text = PlayerData.career.times_of_day_by_hour.get(Careers.HOURS_PER_CAREER_DAY)
+	else:
+		text = PlayerData.career.times_of_day_by_hour.get(new_hours_passed, PlayerData.career.invalid_time_of_day)
+	return text
 
 
 ## Updates the clock visuals based on the number of hours passed.

--- a/project/src/main/career/ui/progress-board-goal.gd
+++ b/project/src/main/career/ui/progress-board-goal.gd
@@ -24,7 +24,7 @@ func move_to_goal_spot(goal_spot_position: Vector2) -> void:
 
 ## When the player reaches a goal level, we play a special animation.
 func _on_Player_travelling_finished() -> void:
-	if PlayerData.career.is_boss_level():
+	if PlayerData.career.is_boss_level() and PlayerData.career.can_play_more_levels():
 		_goal_sound.play()
 		_animation_player.play("play")
 		

--- a/project/src/main/career/ui/progress-board-splash-message.gd
+++ b/project/src/main/career/ui/progress-board-splash-message.gd
@@ -4,5 +4,5 @@ extends Control
 onready var _puzzle_message := $PuzzleMessage
 
 func _on_Player_travelling_finished() -> void:
-	if PlayerData.career.is_boss_level():
+	if PlayerData.career.is_boss_level() and PlayerData.career.can_play_more_levels():
 		_puzzle_message.show_message(PuzzleMessage.GOOD, tr("Goal!"))

--- a/project/src/main/career/ui/progress-board-trail.gd
+++ b/project/src/main/career/ui/progress-board-trail.gd
@@ -82,6 +82,6 @@ func _refresh_spots() -> void:
 
 ## When the player reaches the goal, the trail flashes different colors.
 func _on_Player_travelling_finished() -> void:
-	if PlayerData.career.is_boss_level():
+	if PlayerData.career.is_boss_level() and PlayerData.career.can_play_more_levels():
 		_spots.set_cycle_colors(true)
 		_lines.set_cycle_colors(true)

--- a/project/src/main/career/ui/progress-board.gd
+++ b/project/src/main/career/ui/progress-board.gd
@@ -126,7 +126,7 @@ func play() -> void:
 	
 	## After the animation, we hide the progress board after a delay.
 	if not suppress_hide:
-		if PlayerData.career.is_boss_level():
+		if PlayerData.career.is_boss_level() and PlayerData.career.can_play_more_levels():
 			_hide_timer.start(BOSS_HIDE_DELAY + duration)
 		else:
 			_hide_timer.start(ANIMATED_HIDE_DELAY + duration)
@@ -205,7 +205,7 @@ func _hours_passed_start() -> int:
 
 ## Calculates the 'hours passed' value we should finish on when advancing the clock.
 func _hours_passed_finish() -> int:
-	return PlayerData.career.hours_passed
+	return int(min(PlayerData.career.hours_passed, Careers.HOURS_PER_CAREER_DAY))
 
 
 ## When the AnimationPlayer toggles the backdrop visibility, we emit signals so other parts of the UI can refresh.
@@ -232,7 +232,7 @@ func _on_AnimationPlayer_animation_finished(anim_name: String) -> void:
 ## When the HideTimer times out, we hide the progress board.
 func _on_HideTimer_timeout() -> void:
 	_show_animation_player.play("hide")
-	if not PlayerData.career.is_day_over():
+	if PlayerData.career.can_play_more_levels():
 		PlayerData.career.show_progress = Careers.ShowProgress.NONE
 
 
@@ -242,7 +242,7 @@ func _on_AnimateStartTimer_timeout() -> void:
 
 
 func _on_Player_travelling_finished() -> void:
-	if PlayerData.career.is_boss_level() and not PlayerData.career.is_day_over():
+	if PlayerData.career.is_boss_level() and PlayerData.career.can_play_more_levels():
 		MusicPlayer.play_boss_track(false)
 
 

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -284,7 +284,9 @@ func _update_career_data(rank_result: RankResult) -> void:
 	
 	PlayerData.career.steps += distance_to_advance
 	PlayerData.career.top_out_count += PuzzleState.level_performance.top_out_count
-	PlayerData.career.advance_clock(distance_to_advance, rank_result.success, rank_result.lost)
+	if rank_result.lost:
+		PlayerData.career.lost = true
+	PlayerData.career.advance_clock(distance_to_advance, rank_result.success)
 
 
 ## Stores the rank result for later.

--- a/project/src/main/ui/menu/main-menu-adventure.gd
+++ b/project/src/main/ui/menu/main-menu-adventure.gd
@@ -8,7 +8,7 @@ func _on_Career_pressed() -> void:
 	CurrentLevel.reset()
 	
 	# If the player quit or ended the career mode day, we give them a fresh start.
-	if PlayerData.career.is_day_over():
+	if not PlayerData.career.can_play_more_levels():
 		PlayerData.career.advance_calendar()
 	
 	# Launch the first scene in career mode. This is probably the career map, but in some edge cases it could be a

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -35,7 +35,7 @@ func _ready() -> void:
 		# For regular players the Breadcrumb trail will already be initialized by the menus.
 		Breadcrumb.initialize_trail()
 	
-	if PlayerData.career.is_boss_level() and not PlayerData.career.is_day_over() \
+	if PlayerData.career.is_boss_level() and PlayerData.career.can_play_more_levels() \
 			and (PlayerData.career.show_progress != Careers.ShowProgress.ANIMATED):
 		MusicPlayer.play_boss_track()
 	else:
@@ -271,7 +271,7 @@ func _should_play_epilogue(chat_key_pair: ChatKeyPair) -> bool:
 ##
 ## If the progress board is not being shown, this happens at the start of the level.
 func _after_progress_board() -> void:
-	if PlayerData.career.is_day_over():
+	if not PlayerData.career.can_play_more_levels():
 		# After the final level, we show a 'you win' screen.
 		SceneTransition.replace_trail(Global.SCENE_CAREER_WIN)
 	else:

--- a/project/src/test/world/test-career-data.gd
+++ b/project/src/test/world/test-career-data.gd
@@ -30,7 +30,7 @@ func test_prev_money() -> void:
 
 func test_advance_clock_stops_at_boss_level_0() -> void:
 	_data.best_distance_travelled = 0
-	_data.advance_clock(50, false, false)
+	_data.advance_clock(50, false)
 	assert_eq(_data.distance_earned, 50)
 	assert_eq(_data.distance_travelled, 9)
 	assert_eq(_data.banked_steps, 41)
@@ -39,7 +39,7 @@ func test_advance_clock_stops_at_boss_level_0() -> void:
 func test_advance_clock_stops_at_boss_level_1() -> void:
 	_data.best_distance_travelled = 0
 	_data.distance_travelled = 8 # just before a boss level
-	_data.advance_clock(3, true, false)
+	_data.advance_clock(3, true)
 	assert_eq(_data.distance_earned, 3)
 	assert_eq(_data.distance_travelled, 9)
 	assert_eq(_data.banked_steps, 2)
@@ -48,7 +48,7 @@ func test_advance_clock_stops_at_boss_level_1() -> void:
 func test_advance_clock_clears_boss_level() -> void:
 	_data.best_distance_travelled = 0
 	_data.distance_travelled = 9 # boss level
-	_data.advance_clock(4, true, false)
+	_data.advance_clock(4, true)
 	assert_eq(_data.distance_earned, 0)
 	assert_eq(_data.distance_travelled, 10)
 	assert_eq(_data.best_distance_travelled, 10)
@@ -58,7 +58,7 @@ func test_advance_clock_clears_boss_level() -> void:
 func test_advance_clock_fails_boss_level() -> void:
 	_data.best_distance_travelled = 0
 	_data.distance_travelled = 9 # boss level
-	_data.advance_clock(4, false, false)
+	_data.advance_clock(4, false)
 	assert_true(_data.distance_earned < 0,
 			"distance_earned should be less than 0 but was %s" % [_data.distance_earned])
 	assert_true(_data.distance_travelled < 9,
@@ -71,7 +71,7 @@ func test_advance_clock_stops_at_unbeaten_intro_level() -> void:
 	
 	PlayerData.level_history.delete_results("intro_311")
 	
-	_data.advance_clock(50, false, false)
+	_data.advance_clock(50, false)
 	assert_eq(_data.distance_earned, 50)
 	assert_eq(_data.distance_travelled, 10)
 	assert_eq(_data.banked_steps, 40)
@@ -84,7 +84,7 @@ func test_advance_clock_stops_at_beaten_intro_level() -> void:
 	var result := RankResult.new()
 	PlayerData.level_history.add_result("intro_311", result)
 	
-	_data.advance_clock(50, false, false)
+	_data.advance_clock(50, false)
 	assert_eq(_data.distance_earned, 50)
 	assert_eq(_data.distance_travelled, 10)
 	assert_eq(_data.banked_steps, 40)
@@ -95,7 +95,7 @@ func test_advance_clock_clears_intro_level() -> void:
 	_data.best_distance_travelled = 10
 	_data.banked_steps = 5
 	
-	_data.advance_clock(1, false, false)
+	_data.advance_clock(1, false)
 	assert_eq(_data.distance_earned, 6)
 	assert_eq(_data.distance_travelled, 16)
 	assert_eq(_data.banked_steps, 0)
@@ -106,7 +106,7 @@ func test_advance_clock_fails_intro_level() -> void:
 	_data.best_distance_travelled = 10
 	_data.banked_steps = 5
 	
-	_data.advance_clock(0, false, false)
+	_data.advance_clock(0, false)
 	assert_eq(_data.distance_earned, 0)
 	assert_eq(_data.distance_travelled, 10)
 	assert_eq(_data.banked_steps, 5)
@@ -116,7 +116,7 @@ func test_advance_clock_banked_steps_for_failed_boss_level() -> void:
 	_data.best_distance_travelled = 0
 	_data.banked_steps = 5
 	_data.distance_travelled = 9 # boss level
-	_data.advance_clock(4, false, false)
+	_data.advance_clock(4, false)
 	assert_true(_data.distance_earned < 0,
 			"distance_earned should be less than 0 but was %s" % [_data.distance_earned])
 	assert_eq(_data.banked_steps, 5)
@@ -124,20 +124,21 @@ func test_advance_clock_banked_steps_for_failed_boss_level() -> void:
 
 func test_advance_clock_banked_steps_for_failed_level() -> void:
 	_data.banked_steps = 5
-	_data.advance_clock(0, false, false)
+	_data.advance_clock(0, false)
 	assert_eq(_data.distance_earned, 0)
 	assert_eq(_data.distance_travelled, 0)
 	assert_eq(_data.banked_steps, 5)
 
 
 func test_advance_clock_lost_level() -> void:
-	_data.advance_clock(0, false, true)
+	_data.lost = true
+	_data.advance_clock(0, false)
 	assert_eq(_data.hours_passed, Careers.HOURS_PER_CAREER_DAY)
 
 
 func test_advance_clock_banked_steps_for_finished_level() -> void:
 	_data.banked_steps = 5
-	_data.advance_clock(1, false, false)
+	_data.advance_clock(1, false)
 	assert_eq(_data.distance_earned, 6)
 	assert_eq(_data.distance_travelled, 6)
 	assert_eq(_data.banked_steps, 0)


### PR DESCRIPTION
Before, if you reached the boss level on your sixth level, there would be a big fanfare but you wouldn't get to play it.

Now, you are always allowed to play the boss level even if you are out of time.

I've also fixed it where the fanfare does not play if you are not able to play the boss level -- for example, if you lose all your lives, but advance two spaces and land on a boss level. Before, this would result in a big fanfare with boss music and then the day would end. Now, there is no fanfare or special music.

Closes #2873.