### PR TITLE
Bug: Some level results were being saved twice

### DIFF
--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -164,10 +164,15 @@ func _restart() -> void:
 		# use up all of the players lives; especially for career mode, we don't want to reward players who
 		# give up
 		PuzzleState.level_performance.top_out_count = CurrentLevel.settings.lose_condition.top_out
+	
 	if PlayerData.career.is_career_mode() and CurrentLevel.attempt_count == 0:
+		# End the game, triggering the chef's reaction and negative sound effects. Also saves the level result.
 		PuzzleState.end_game()
-	var rank_result := RankCalculator.new().calculate_rank()
-	_save_level_result(rank_result)
+	else:
+		# Just save the level result, don't trigger the chef's reaction and negative sound effects.
+		var rank_result := RankCalculator.new().calculate_rank()
+		_save_level_result(rank_result)
+	
 	_start_puzzle()
 	get_tree().set_input_as_handled()
 	PuzzleState.retrying = false


### PR DESCRIPTION
In Career Mode, restarting a level would record the loss to your level history twice. One save was caused by PuzzleState's end game triggers, and one save was directly embedded in the 'restart' logic.

I've added a conditional so that the 'restart' logic does not record the loss during the first level in Career mode. It is a little kludgy but I can't think of a better fix at the moment.