### PR TITLE
Bug: Don't show ending cutscenes when retrying levels

### DIFF
--- a/project/src/demo/puzzle/result/results-hud-demo.gd
+++ b/project/src/demo/puzzle/result/results-hud-demo.gd
@@ -10,6 +10,7 @@ extends Node
 ## 	[F]: Show message for a short ultra level which the player skipped with a cheat code.
 ## 	[H]: Toggle hardcore/normal.
 ## 	[J]: Toggle passed/failed.
+## 	[I]: Toggle attempt count.
 ## 	[K]: Toggle success condition, and boss level.
 ## 	[L]: Toggle whether or not the player has beaten the level already.
 ## 	[Space]: Show/hide message
@@ -29,7 +30,7 @@ func _ready() -> void:
 	Breadcrumb.trail = [Global.SCENE_CAREER_MAP]
 	CurrentLevel.attempt_count = 0
 	CurrentLevel.hardcore = true
-	CurrentLevel.best_result = Levels.Result.FINISHED
+	CurrentLevel.first_result = Levels.Result.FINISHED
 
 
 func _input(event: InputEvent) -> void:
@@ -59,6 +60,9 @@ func _input(event: InputEvent) -> void:
 			_prepare_long_ultra_scenario(0.1)
 			PuzzleState.level_performance.seconds += 9999
 			_show_results_message()
+		KEY_I:
+			CurrentLevel.attempt_count = 1 if CurrentLevel.attempt_count == 0 else 0
+			_show_results_message()
 		KEY_A:
 			_prepare_short_ultra_scenario(0.1)
 			_show_results_message()
@@ -77,7 +81,7 @@ func _input(event: InputEvent) -> void:
 			_show_results_message()
 		KEY_J:
 			PuzzleState.level_performance.lost = not PuzzleState.level_performance.lost
-			CurrentLevel.best_result = \
+			CurrentLevel.first_result = \
 					Levels.Result.LOST if PuzzleState.level_performance.lost else Levels.Result.FINISHED
 			_show_results_message()
 		KEY_K:
@@ -108,6 +112,7 @@ func _show_results_message() -> void:
 	_label.text += "\n"
 	_label.text += "boss_level: %s\n" % [CurrentLevel.boss_level]
 	_label.text += "player_success: %s\n" % [_player_success]
+	_label.text += "attempt_count: %s\n" % [CurrentLevel.attempt_count]
 	_label.text += "hardcore: %s\n" % [CurrentLevel.hardcore]
 	_label.text += "lost: %s\n" % [PuzzleState.level_performance.lost]
 	_label.text = _label.text.strip_edges()

--- a/project/src/main/career/career-flow.gd
+++ b/project/src/main/career/career-flow.gd
@@ -49,13 +49,12 @@ func process_puzzle_result() -> void:
 		career_data.advance_clock(0, false)
 		career_data.skipped_previous_level = true
 	
-	if PlayerData.cutscene_queue.has_cutscene_flag("intro_level") \
-			and not CurrentLevel.best_result in [Levels.Result.FINISHED, Levels.Result.WON]:
+	if PlayerData.cutscene_queue.has_cutscene_flag("intro_level") and PlayerData.career.lost:
 		# player lost an intro level
 		skip_remaining_cutscenes = true
 	
 	if PlayerData.cutscene_queue.has_cutscene_flag("boss_level") \
-			and not CurrentLevel.best_result == Levels.Result.WON:
+			and not CurrentLevel.first_result == Levels.Result.WON:
 		# player didn't meet the win criteria for a boss level
 		skip_remaining_cutscenes = true
 	
@@ -63,8 +62,7 @@ func process_puzzle_result() -> void:
 		# skip career cutscenes if they skip a level, or if they fail a boss level
 		PlayerData.cutscene_queue.reset()
 	
-	if PuzzleState.game_ended and CurrentLevel.hardcore \
-			and CurrentLevel.best_result in [Levels.Result.FINISHED, Levels.Result.WON]:
+	if PuzzleState.game_ended and CurrentLevel.hardcore and not PlayerData.career.lost:
 		# completing a hardcore level gives the player an extra life
 		career_data.extra_life_count += 1
 	

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -38,6 +38,7 @@ var customers: Array
 var chef_id: String
 
 ## Monitors when the player finishes a level.
+var first_result: int = Levels.Result.NONE
 var best_result: int = Levels.Result.NONE setget set_best_result
 
 ## How many times the player has tried the level in this session.
@@ -61,6 +62,7 @@ func reset() -> void:
 	piece_speed = ""
 	customers = []
 	chef_id = ""
+	first_result = Levels.Result.NONE
 	best_result = Levels.Result.NONE
 	attempt_count = 0
 	puzzle_environment_id = ""

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -291,6 +291,7 @@ func _update_career_data(rank_result: RankResult) -> void:
 	PlayerData.career.top_out_count += PuzzleState.level_performance.top_out_count
 	if rank_result.lost:
 		PlayerData.career.lost = true
+		PlayerData.cutscene_queue.reset()
 	PlayerData.career.advance_clock(distance_to_advance, rank_result.success)
 
 
@@ -302,9 +303,12 @@ func _save_level_result(rank_result: RankResult) -> void:
 	PlayerData.emit_signal("level_history_changed")
 	PlayerData.money = int(clamp(PlayerData.money + rank_result.score, 0, PlayerData.MAX_MONEY))
 	
+	if CurrentLevel.attempt_count == 0:
+		CurrentLevel.first_result = PuzzleState.end_result()
+	CurrentLevel.best_result = max(CurrentLevel.best_result, PuzzleState.end_result())
+	
 	if PlayerData.career.is_career_mode() and CurrentLevel.attempt_count == 0:
 		_update_career_data(rank_result)
-	CurrentLevel.best_result = max(CurrentLevel.best_result, PuzzleState.end_result())
 	
 	PlayerSave.schedule_save()
 

--- a/project/src/main/puzzle/result/results-hud-blueprint.gd
+++ b/project/src/main/puzzle/result/results-hud-blueprint.gd
@@ -64,7 +64,7 @@ func _init() -> void:
 
 func should_show_medal() -> bool:
 	return PlayerData.career.is_career_mode() and CurrentLevel.attempt_count == 0 and CurrentLevel.hardcore \
-			and CurrentLevel.best_result in [Levels.Result.FINISHED, Levels.Result.WON]
+			and CurrentLevel.first_result in [Levels.Result.FINISHED, Levels.Result.WON]
 
 func box_score() -> int:
 	return rank_result.box_score


### PR DESCRIPTION
In Adventure mode, retrying a level counts as a failure and shouldn't display cutscenes. However, our logic for 'do we play a cutscene' was keying off of the player's best performance, not their first performance.

While it's not necessarily a bad thing to be lenient and say, 'oh it took you a few tries, but here is a cutscene', it was inconsistent with how Adventure mode works. It meant a player could lose a boss level, retry, beat it, see a cutscene, and then get sent backwards on the map screen and told 'try again tomorrow!'

Retrying a level now prevents cutscenes from playing. The cutscene logic cares about your first performance, not your best performance