### PR TITLE
Difficulty menu is forced on the player once.

### DIFF
--- a/project/assets/main/locale/en.po
+++ b/project/assets/main/locale/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/Poobslag/turbofat/\n"
-"POT-Creation-Date: 2024-11-19 09:21-0500\n"
+"POT-Creation-Date: 2024-11-19 09:48-0500\n"
 "PO-Revision-Date: 2023-03-13 12:16-0400\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15413,6 +15413,10 @@ msgstr ""
 
 #: project/src/main/ui/difficulty/DifficultyMenu.tscn
 msgid "Line Pieces"
+msgstr ""
+
+#: project/src/main/ui/difficulty/DifficultyMenu.tscn
+msgid "Customize your difficulty"
 msgstr ""
 
 #: project/src/main/ui/difficulty/difficulty-button.gd

--- a/project/assets/main/locale/es.po
+++ b/project/assets/main/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/Poobslag/turbofat/\n"
-"POT-Creation-Date: 2024-11-19 09:21-0500\n"
+"POT-Creation-Date: 2024-11-19 09:48-0500\n"
 "PO-Revision-Date: 2024-10-13 19:30-0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17486,6 +17486,11 @@ msgstr "Sostener Pieza"
 #, needs-review
 msgid "Line Pieces"
 msgstr "Piezas Largas"
+
+#: project/src/main/ui/difficulty/DifficultyMenu.tscn
+#, needs-review
+msgid "Customize your difficulty"
+msgstr "Personaliza tu dificultad"
 
 #: project/src/main/ui/difficulty/difficulty-button.gd
 #, needs-review

--- a/project/assets/main/locale/messages.pot
+++ b/project/assets/main/locale/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Turbo Fat 0.9000\n"
 "Report-Msgid-Bugs-To: https://github.com/Poobslag/turbofat/\n"
-"POT-Creation-Date: 2024-11-19 09:21-0500\n"
+"POT-Creation-Date: 2024-11-19 09:48-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15414,6 +15414,10 @@ msgstr ""
 
 #: project/src/main/ui/difficulty/DifficultyMenu.tscn
 msgid "Line Pieces"
+msgstr ""
+
+#: project/src/main/ui/difficulty/DifficultyMenu.tscn
+msgid "Customize your difficulty"
 msgstr ""
 
 #: project/src/main/ui/difficulty/difficulty-button.gd

--- a/project/src/main/puzzle/puzzle-messages.gd
+++ b/project/src/main/puzzle/puzzle-messages.gd
@@ -171,6 +171,9 @@ func _on_PuzzleState_after_game_ended() -> void:
 			# don't redirect them back to the splash screen, send them to the main menu
 			if Breadcrumb.trail.size() >= 2 and Breadcrumb.trail[1] == Global.SCENE_SPLASH:
 				Breadcrumb.trail.insert(1, Global.SCENE_MAIN_MENU)
+			if SystemData.misc_settings.show_difficulty_menu:
+				# show the player the difficulty menu if they haven't seen it
+				Breadcrumb.trail.insert(1, Global.SCENE_DIFFICULTY_MENU)
 	
 	if PlayerData.career.is_career_mode():
 		_back_button.text = tr("Continue")

--- a/project/src/main/settings/misc-settings.gd
+++ b/project/src/main/settings/misc-settings.gd
@@ -28,6 +28,9 @@ var save_slot: int = SaveSlot.SLOT_A setget set_save_slot
 ## 'true' if the player should be shown the intro screen when starting Adventure mode
 var show_adventure_mode_intro: bool = true
 
+## 'true' if the player should be shown the difficulty menu
+var show_difficulty_menu: bool = true
+
 ## 'true' if the player should be shown the confirmation when restarting/giving up in Adventure mode
 var show_give_up_confirmation: bool = true
 
@@ -71,6 +74,7 @@ func to_json_dict() -> Dictionary:
 		"locale": locale,
 		"save_slot": save_slot,
 		"show_adventure_mode_intro": show_adventure_mode_intro,
+		"show_difficulty_menu": show_difficulty_menu,
 		"show_give_up_confirmation": show_give_up_confirmation,
 	}
 
@@ -78,6 +82,7 @@ func to_json_dict() -> Dictionary:
 func from_json_dict(json: Dictionary) -> void:
 	set_save_slot(int(json.get("save_slot", SaveSlot.SLOT_A)))
 	show_adventure_mode_intro = bool(json.get("show_adventure_mode_intro", true))
+	show_difficulty_menu = bool(json.get("show_difficulty_menu", true))
 	show_give_up_confirmation = bool(json.get("show_give_up_confirmation", true))
 	
 	var new_locale: String

--- a/project/src/main/ui/difficulty/DifficultyMenu.tscn
+++ b/project/src/main/ui/difficulty/DifficultyMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=2]
+[gd_scene load_steps=26 format=2]
 
 [ext_resource path="res://src/main/ui/candy-button/gradient-map.shader" type="Shader" id=1]
 [ext_resource path="res://assets/main/ui/candy-button/h3-v.png" type="Texture" id=2]
@@ -14,6 +14,7 @@
 [ext_resource path="res://src/main/ui/menu/MenuAccentH3.tscn" type="PackedScene" id=12]
 [ext_resource path="res://src/main/ui/difficulty/DifficultyButton.tscn" type="PackedScene" id=13]
 [ext_resource path="res://src/main/ui/difficulty/difficulty-menu-description.gd" type="Script" id=14]
+[ext_resource path="res://assets/main/ui/menu/menu-accent-h2-xl1.png" type="Texture" id=15]
 [ext_resource path="res://src/main/ui/candy-button/CandyButtonH3.tscn" type="PackedScene" id=16]
 [ext_resource path="res://src/main/ui/menu/drop-panel.tres" type="StyleBox" id=21]
 [ext_resource path="res://src/main/ui/theme/h3-font-outline.tres" type="DynamicFont" id=22]
@@ -278,6 +279,22 @@ texture_hover = ExtResource( 2 )
 text = "Ok"
 color = 5
 shape = 8
+
+[node name="TipLabel" type="Label" parent="."]
+visible = false
+anchor_right = 1.0
+margin_top = 34.0
+margin_bottom = 64.0
+custom_fonts/font = ExtResource( 22 )
+text = "Customize your difficulty"
+align = 1
+
+[node name="MenuAccentH3" parent="TipLabel" instance=ExtResource( 12 )]
+margin_left = -187.5
+margin_top = -37.5
+margin_right = 187.5
+margin_bottom = 37.5
+texture = ExtResource( 15 )
 
 [connection signal="toggled" from="DropPanel/VBoxContainer/Helpers/HBoxContainer/HoldPiecePanel/CheckBox" to="DropPanel/VBoxContainer/Helpers/HBoxContainer/HoldPiecePanel" method="_on_CheckBox_toggled"]
 [connection signal="toggled" from="DropPanel/VBoxContainer/Helpers/HBoxContainer/LinePiecePanel/CheckBox" to="DropPanel/VBoxContainer/Helpers/HBoxContainer/LinePiecePanel" method="_on_CheckBox_toggled"]

--- a/project/src/main/ui/difficulty/difficulty-menu.gd
+++ b/project/src/main/ui/difficulty/difficulty-menu.gd
@@ -7,11 +7,19 @@ onready var _normal_difficulty_button := $DropPanel/VBoxContainer/Difficulty/But
 onready var _hold_piece_checkbox := $DropPanel/VBoxContainer/Helpers/HBoxContainer/HoldPiecePanel/CheckBox
 onready var _line_piece_checkbox := $DropPanel/VBoxContainer/Helpers/HBoxContainer/LinePiecePanel/CheckBox
 
+## Conditionally shows a 'Customize your difficulty!' message if the menu is forced upon the player
+onready var _tip_label := $TipLabel
+
 func _ready() -> void:
 	SystemData.gameplay_settings.connect("speed_changed", self, "_on_GameplaySettings_speed_changed")
 	
 	_focus_difficulty_button()
 	_assign_focus_neighbours()
+
+	if SystemData.misc_settings.show_difficulty_menu:
+		_tip_label.visible = true
+		SystemData.misc_settings.show_difficulty_menu = false
+		SystemData.has_unsaved_changes = true
 
 
 ## Returns:

--- a/project/src/main/ui/menu/splash-screen.gd
+++ b/project/src/main/ui/menu/splash-screen.gd
@@ -23,7 +23,14 @@ func _on_Play_pressed() -> void:
 	if not PlayerData.level_history.is_level_finished(OtherLevelLibrary.BEGINNER_TUTORIAL):
 		_launch_tutorial()
 	else:
-		SceneTransition.push_trail(Global.SCENE_MAIN_MENU, {SceneTransition.FLAG_TYPE: SceneTransition.TYPE_NONE})
+		if SystemData.misc_settings.show_difficulty_menu:
+			# show the player the difficulty menu if they haven't seen it
+			Breadcrumb.trail.push_front(Global.SCENE_MAIN_MENU)
+			SceneTransition.push_trail(Global.SCENE_DIFFICULTY_MENU,
+					{SceneTransition.FLAG_TYPE: SceneTransition.TYPE_NONE})
+		else:
+			SceneTransition.push_trail(Global.SCENE_MAIN_MENU,
+					{SceneTransition.FLAG_TYPE: SceneTransition.TYPE_NONE})
 
 
 func _on_System_quit_pressed() -> void:

--- a/project/src/main/ui/settings/reenable-tips.gd
+++ b/project/src/main/ui/settings/reenable-tips.gd
@@ -11,6 +11,10 @@ func _ready() -> void:
 
 
 func _on_Button_pressed() -> void:
+	if SystemData.misc_settings.show_difficulty_menu == false:
+		SystemData.misc_settings.show_difficulty_menu = true
+		SystemData.has_unsaved_changes = true
+		
 	if SystemData.misc_settings.show_give_up_confirmation == false:
 		SystemData.misc_settings.show_give_up_confirmation = true
 		SystemData.has_unsaved_changes = true


### PR DESCRIPTION
After completing the tutorial, the player is forcibly shown the difficulty menu. This ensures all players have the option to select an easier difficulty, even if they don't notice the main menu button. This also ensures that if they later encounter trouble, they'll hopefully remember 'Oh, I chose my difficulty earlier, I should lower it.'

If the player clicks 'Re-enable tips', the player is also shown the tutorial after the splash screen.