### PR TITLE
Save slots now have independent difficulties.

### DIFF
--- a/project/assets/test/data/config-5a24-default.json
+++ b/project/assets/test/data/config-5a24-default.json
@@ -1,0 +1,271 @@
+[
+  {
+    "type": "version",
+    "value": "5a24"
+  },
+  {
+    "type": "gameplay_settings",
+    "value": {
+    }
+  },
+  {
+    "type": "graphics_settings",
+    "value": {
+      "creature_detail": 1,
+      "feeding_animation": 1,
+      "fullscreen": false,
+      "use_vsync": true
+    }
+  },
+  {
+    "type": "volume_settings",
+    "value": {
+      "master": 0.71,
+      "music": 0,
+      "sound": 0.7,
+      "voice": 0.7
+    }
+  },
+  {
+    "type": "touch_settings",
+    "value": {
+      "fat_finger": 0,
+      "scheme": 0,
+      "size": 1
+    }
+  },
+  {
+    "type": "keybind_settings",
+    "value": {
+      "preset": 0,
+      "custom_keybinds": {
+        "move_piece_left": [
+          {
+            "type": "key",
+            "scancode": 16777231
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "move_piece_right": [
+          {
+            "type": "key",
+            "scancode": 16777233
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "soft_drop": [
+          {
+            "type": "key",
+            "scancode": 16777234
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "hard_drop": [
+          {
+            "type": "key",
+            "scancode": 32
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "retry": [
+          {
+            "type": "key",
+            "scancode": 82
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "rotate_ccw": [
+          {
+            "type": "key",
+            "scancode": 90
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "rotate_cw": [
+          {
+            "type": "key",
+            "scancode": 88
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "swap_hold_piece": [
+          {
+            "type": "key",
+            "scancode": 16777237
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_up": [
+          {
+            "type": "key",
+            "scancode": 16777232
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_down": [
+          {
+            "type": "key",
+            "scancode": 16777234
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_left": [
+          {
+            "type": "key",
+            "scancode": 16777231
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_right": [
+          {
+            "type": "key",
+            "scancode": 16777233
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_accept": [
+          {
+            "type": "key",
+            "scancode": 32
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_cancel": [
+          {
+            "type": "key",
+            "scancode": 16777217
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_menu": [
+          {
+            "type": "key",
+            "scancode": 16777217
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "rewind_text": [
+          {
+            "type": "key",
+            "scancode": 16777237
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "next_tab": [
+          {
+            "type": "key",
+            "scancode": 88
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "prev_tab": [
+          {
+            "type": "key",
+            "scancode": 90
+          },
+          {
+
+          },
+          {
+
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "misc_settings",
+    "value": {
+      "locale": "en",
+      "save_slot": 0,
+      "show_adventure_mode_intro": true,
+      "show_difficulty_menu": false,
+      "show_give_up_confirmation": true
+    }
+  }
+]

--- a/project/assets/test/data/config-5a24.json
+++ b/project/assets/test/data/config-5a24.json
@@ -1,0 +1,276 @@
+[
+  {
+    "type": "version",
+    "value": "5a24"
+  },
+  {
+    "type": "gameplay_settings",
+    "value": {
+      "ghost_piece": true,
+      "hold_piece": true,
+      "line_piece": true,
+      "soft_drop_lock_cancel": true,
+      "speed": "slower"
+    }
+  },
+  {
+    "type": "graphics_settings",
+    "value": {
+      "creature_detail": 1,
+      "feeding_animation": 1,
+      "fullscreen": false,
+      "use_vsync": true
+    }
+  },
+  {
+    "type": "volume_settings",
+    "value": {
+      "master": 0.71,
+      "music": 0,
+      "sound": 0.7,
+      "voice": 0.7
+    }
+  },
+  {
+    "type": "touch_settings",
+    "value": {
+      "fat_finger": 0,
+      "scheme": 0,
+      "size": 1
+    }
+  },
+  {
+    "type": "keybind_settings",
+    "value": {
+      "preset": 0,
+      "custom_keybinds": {
+        "move_piece_left": [
+          {
+            "type": "key",
+            "scancode": 16777231
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "move_piece_right": [
+          {
+            "type": "key",
+            "scancode": 16777233
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "soft_drop": [
+          {
+            "type": "key",
+            "scancode": 16777234
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "hard_drop": [
+          {
+            "type": "key",
+            "scancode": 32
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "retry": [
+          {
+            "type": "key",
+            "scancode": 82
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "rotate_ccw": [
+          {
+            "type": "key",
+            "scancode": 90
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "rotate_cw": [
+          {
+            "type": "key",
+            "scancode": 88
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "swap_hold_piece": [
+          {
+            "type": "key",
+            "scancode": 16777237
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_up": [
+          {
+            "type": "key",
+            "scancode": 16777232
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_down": [
+          {
+            "type": "key",
+            "scancode": 16777234
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_left": [
+          {
+            "type": "key",
+            "scancode": 16777231
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_right": [
+          {
+            "type": "key",
+            "scancode": 16777233
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_accept": [
+          {
+            "type": "key",
+            "scancode": 32
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_cancel": [
+          {
+            "type": "key",
+            "scancode": 16777217
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_menu": [
+          {
+            "type": "key",
+            "scancode": 16777217
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "rewind_text": [
+          {
+            "type": "key",
+            "scancode": 16777237
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "next_tab": [
+          {
+            "type": "key",
+            "scancode": 88
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "prev_tab": [
+          {
+            "type": "key",
+            "scancode": 90
+          },
+          {
+
+          },
+          {
+
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "misc_settings",
+    "value": {
+      "locale": "en",
+      "save_slot": 0,
+      "show_adventure_mode_intro": true,
+      "show_difficulty_menu": false,
+      "show_give_up_confirmation": true
+    }
+  }
+]

--- a/project/assets/test/data/turbofat-59c3.json
+++ b/project/assets/test/data/turbofat-59c3.json
@@ -1,0 +1,6 @@
+[
+  {
+    "type": "version",
+    "value": "59c3"
+  }
+]

--- a/project/project.godot
+++ b/project/project.godot
@@ -470,6 +470,11 @@ _global_script_classes=[ {
 "path": "res://src/main/ui/difficulty/difficulty-button.gd"
 }, {
 "base": "Reference",
+"class": "DifficultyData",
+"language": "GDScript",
+"path": "res://src/main/data/difficulty-data.gd"
+}, {
+"base": "Reference",
 "class": "DnaAlternatives",
 "language": "GDScript",
 "path": "res://src/main/world/creature/dna-alternatives.gd"
@@ -1742,6 +1747,7 @@ _global_script_class_icons={
 "CutsceneSearchFlags": "",
 "CutsceneWorld": "",
 "DifficultyButton": "",
+"DifficultyData": "",
 "DnaAlternatives": "",
 "EditorPickups": "",
 "EditorPlayfield": "",

--- a/project/src/main/data/difficulty-data.gd
+++ b/project/src/main/data/difficulty-data.gd
@@ -1,0 +1,67 @@
+class_name DifficultyData
+## Manages settings which control the difficulty, or helpers which make the game easier.
+
+signal hold_piece_changed(value)
+signal line_piece_changed(value)
+signal speed_changed(value)
+
+enum Speed {
+	DEFAULT,
+	SLOW,
+	SLOWER,
+	SLOWEST,
+	SLOWESTEST,
+	FAST,
+	FASTER,
+	FASTEST,
+	FASTESTEST,
+}
+
+## 'true' if the player can use a 'hold piece'
+var hold_piece := false setget set_hold_piece
+
+## 'true' if line pieces should appear on all levels
+var line_piece := false setget set_line_piece
+
+## Current gameplay speed. The player can reduce this to make the game easier. They can also increase it to make
+## the game harder, or to cheat on levels which otherwise require slow and thoughtful play.
+var speed: int = Speed.DEFAULT setget set_speed
+
+func set_hold_piece(new_hold_piece: bool) -> void:
+	if hold_piece == new_hold_piece:
+		return
+	hold_piece = new_hold_piece
+	emit_signal("hold_piece_changed", new_hold_piece)
+
+
+func set_line_piece(new_line_piece: bool) -> void:
+	if line_piece == new_line_piece:
+		return
+	line_piece = new_line_piece
+	emit_signal("line_piece_changed", new_line_piece)
+
+
+func set_speed(new_speed: int) -> void:
+	if speed == new_speed:
+		return
+	speed = new_speed
+	emit_signal("speed_changed", new_speed)
+
+
+## Resets the difficulty settings to their default values.
+func reset() -> void:
+	from_json_dict({})
+
+
+func from_json_dict(json: Dictionary) -> void:
+	set_hold_piece(json.get("hold_piece", false))
+	set_line_piece(json.get("line_piece", false))
+	set_speed(Utils.enum_from_snake_case(Speed, json.get("speed", "")))
+
+
+func to_json_dict() -> Dictionary:
+	return {
+		"hold_piece": hold_piece,
+		"line_piece": line_piece,
+		"speed": Utils.enum_to_snake_case(Speed, speed),
+	}

--- a/project/src/main/data/player-data.gd
+++ b/project/src/main/data/player-data.gd
@@ -18,6 +18,7 @@ const SECONDS_PLAYED_INCREMENT := 0.619
 
 var level_history := LevelHistory.new()
 var chat_history := ChatHistory.new()
+var difficulty := DifficultyData.new()
 
 var creature_library := CreatureLibrary.new()
 var customer_queue := CustomerQueue.new()
@@ -52,6 +53,7 @@ func _ready() -> void:
 func reset() -> void:
 	level_history.reset()
 	chat_history.reset()
+	difficulty.reset()
 	creature_library.reset()
 	customer_queue.reset()
 	cutscene_queue.reset()

--- a/project/src/main/data/player-save.gd
+++ b/project/src/main/data/player-save.gd
@@ -15,7 +15,7 @@ signal after_load
 
 ## Current version for saved player data. Should be updated if and only if the player format changes.
 ## This version number follows a 'ymdh' hex date format which is documented in issue #234.
-const PLAYER_DATA_VERSION := "59c3"
+const PLAYER_DATA_VERSION := "5b9b"
 
 var rolling_backups := RollingBackups.new()
 
@@ -98,6 +98,7 @@ func save_player_data() -> void:
 	save_json.append(SaveItem.new("chat_history", PlayerData.chat_history.to_json_dict()).to_json_dict())
 	save_json.append(SaveItem.new("creature_library", PlayerData.creature_library.to_json_dict()).to_json_dict())
 	save_json.append(SaveItem.new("career", PlayerData.career.to_json_dict()).to_json_dict())
+	save_json.append(SaveItem.new("difficulty", PlayerData.difficulty.to_json_dict()).to_json_dict())
 	save_json.append(SaveItem.new("menu_region", PlayerData.menu_region.id).to_json_dict())
 	save_json.append(SaveItem.new("practice", PlayerData.practice.to_json_dict()).to_json_dict())
 	save_json.append(SaveItem.new("successful_levels",
@@ -255,6 +256,9 @@ func _load_line(type: String, key: String, json_value) -> void:
 		"creature_library":
 			var value: Dictionary = json_value
 			PlayerData.creature_library.from_json_dict(value)
+		"difficulty":
+			var value: Dictionary = json_value
+			PlayerData.difficulty.from_json_dict(value)
 		"finished_levels":
 			var value: Dictionary = json_value
 			PlayerData.level_history.finished_levels = value

--- a/project/src/main/data/system-save-upgrader.gd
+++ b/project/src/main/data/system-save-upgrader.gd
@@ -7,7 +7,8 @@ class_name SystemSaveUpgrader
 ## Creates and configures a SaveItemUpgrader capable of upgrading older system save formats.
 func new_save_item_upgrader() -> SaveItemUpgrader:
 	var upgrader := SaveItemUpgrader.new()
-	upgrader.current_version = "5a24"
+	upgrader.current_version = "5b9b"
+	upgrader.add_upgrade_method(self, "_upgrade_5a24", "5a24", "5b9b")
 	upgrader.add_upgrade_method(self, "_upgrade_37b3", "37b3", "5a24")
 	upgrader.add_upgrade_method(self, "_upgrade_27bb", "27bb", "37b3")
 	upgrader.add_upgrade_method(self, "_upgrade_2783", "2783", "27bb")
@@ -23,6 +24,20 @@ func new_save_item_upgrader() -> SaveItemUpgrader:
 	upgrader.add_upgrade_method(self, "_upgrade_2743", "163e", "2783")
 	upgrader.add_upgrade_method(self, "_upgrade_2743", "15d2", "2783")
 	return upgrader
+
+
+func _upgrade_5a24(_old_save_items: Array, save_item: SaveItem) -> SaveItem:
+	match save_item.type:
+		"gameplay_settings":
+			# ensure 'legacy_properties' property exists
+			if not "legacy_properties" in save_item:
+				save_item.value["legacy_properties"] = {}
+			
+			# move removed properties from gameplay_settings to gameplay_settings.legacy_properties
+			for property in ["hold_piece", "line_piece", "speed"]:
+				if save_item.value.has(property):
+					save_item.value["legacy_properties"][property] = save_item.value.get(property)
+	return save_item
 
 
 func _upgrade_37b3(_old_save_items: Array, save_item: SaveItem) -> SaveItem:

--- a/project/src/main/data/system-save.gd
+++ b/project/src/main/data/system-save.gd
@@ -7,7 +7,7 @@ signal before_save
 signal after_save
 signal save_slot_deleted
 
-const SYSTEM_DATA_VERSION := "5a24"
+const SYSTEM_DATA_VERSION := "5b9b"
 
 ## Save files older than July 2021 which should be deleted during an upgrade
 const OLD_SAVES_TO_DELETE := [

--- a/project/src/main/puzzle/hold-piece-displays.gd
+++ b/project/src/main/puzzle/hold-piece-displays.gd
@@ -20,7 +20,7 @@ func _ready() -> void:
 	CurrentLevel.connect("settings_changed", self, "_on_Level_settings_changed")
 	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
 	Pauser.connect("paused_changed", self, "_on_Pauser_paused_changed")
-	SystemData.gameplay_settings.connect("hold_piece_changed", self, "_on_GameplaySettings_hold_piece_changed")
+	PlayerData.difficulty.connect("hold_piece_changed", self, "_on_DifficultyData_hold_piece_changed")
 	
 	display = HoldPieceDisplayScene.instance()
 	display.initialize(_piece_queue)
@@ -46,7 +46,7 @@ func _on_Pauser_paused_changed(value: bool) -> void:
 	display.visible = not value
 
 
-func _on_GameplaySettings_hold_piece_changed(_value: bool) -> void:
+func _on_DifficultyData_hold_piece_changed(_value: bool) -> void:
 	_refresh()
 
 

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -170,7 +170,7 @@ func get_creature_ids() -> Array:
 ##
 ## Even if the player wants to cheat, we hide the hold piece window if the player is in a tutorial.
 func is_hold_piece_cheat_enabled() -> bool:
-	return SystemData.gameplay_settings.hold_piece \
+	return PlayerData.difficulty.hold_piece \
 			and not is_tutorial()
 
 
@@ -178,7 +178,7 @@ func is_hold_piece_cheat_enabled() -> bool:
 ##
 ## Even if the player wants to cheat, we preserve the game's original piece speed if the player is in a tutorial.
 func is_piece_speed_cheat_enabled() -> bool:
-	return SystemData.gameplay_settings.speed != GameplaySettings.Speed.DEFAULT \
+	return PlayerData.difficulty.speed != DifficultyData.Speed.DEFAULT \
 			and not CurrentLevel.is_tutorial()
 
 
@@ -189,7 +189,7 @@ func is_piece_speed_cheat_enabled() -> bool:
 ##
 ## Adding line pieces for tutorials can make the tutorials impossible.
 func is_line_piece_cheat_enabled() -> bool:
-	return SystemData.gameplay_settings.line_piece \
+	return PlayerData.difficulty.line_piece \
 			and not CurrentLevel.is_tutorial() \
 			and not PieceTypes.piece_i in CurrentLevel.settings.piece_types.start_types \
 			and not PieceTypes.piece_i in CurrentLevel.settings.piece_types.types

--- a/project/src/main/puzzle/level/gameplay-difficulty-adjustments.gd
+++ b/project/src/main/puzzle/level/gameplay-difficulty-adjustments.gd
@@ -6,38 +6,38 @@ class_name GameplayDifficultyAdjustments
 ## gravity levels however (50% of 20G is still 10G which is way too fast for a novice) so this script defines mappings
 ## to adjust piece speeds based on the player's gameplay speed settings.
 
-## key: (int) enum from GameplaySettings.Speed
+## key: (int) enum from DifficultyData.Speed
 ## value: (float) multiplier for score milestones. 0.5 = level is twice as short, 2.0 = level is twice as long
 const SCORE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED := {
-	GameplaySettings.Speed.SLOW: 0.70,
-	GameplaySettings.Speed.SLOWER: 0.40,
-	GameplaySettings.Speed.SLOWEST: 0.20,
-	GameplaySettings.Speed.SLOWESTEST: 0.10,
+	DifficultyData.Speed.SLOW: 0.70,
+	DifficultyData.Speed.SLOWER: 0.40,
+	DifficultyData.Speed.SLOWEST: 0.20,
+	DifficultyData.Speed.SLOWESTEST: 0.10,
 }
 
-## key: (int) enum from GameplaySettings.Speed
+## key: (int) enum from DifficultyData.Speed
 ## value: (float) multiplier for line milestones. 0.5 = level is twice as short, 2.0 = level is twice as long
 const LINE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED := {
-	GameplaySettings.Speed.SLOW: 0.85,
-	GameplaySettings.Speed.SLOWER: 0.70,
-	GameplaySettings.Speed.SLOWEST: 0.40,
-	GameplaySettings.Speed.SLOWESTEST: 0.20,
+	DifficultyData.Speed.SLOW: 0.85,
+	DifficultyData.Speed.SLOWER: 0.70,
+	DifficultyData.Speed.SLOWEST: 0.40,
+	DifficultyData.Speed.SLOWESTEST: 0.20,
 }
 
-## key: (int) enum from GameplaySettings.Speed
+## key: (int) enum from DifficultyData.Speed
 ## value: (float) multiplier for duration milestones. 0.5 = level is twice as short, 2.0 = level is twice as long
 const TIME_OVER_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED := {
-	GameplaySettings.Speed.SLOW: 1.00,
-	GameplaySettings.Speed.SLOWER: 0.90,
-	GameplaySettings.Speed.SLOWEST: 0.70,
-	GameplaySettings.Speed.SLOWESTEST: 0.40,
+	DifficultyData.Speed.SLOW: 1.00,
+	DifficultyData.Speed.SLOWER: 0.90,
+	DifficultyData.Speed.SLOWEST: 0.70,
+	DifficultyData.Speed.SLOWESTEST: 0.40,
 }
 
-## key: (int) enum from GameplaySettings.Speed
+## key: (int) enum from DifficultyData.Speed
 ## value: (Dictionary) mapping from piece speed strings to adjusted piece speed strings
 const PIECE_SPEED_MAPPING_BY_GAMEPLAY_SPEED := {
 	# pieces are literally always at the fastest 20G speed
-	GameplaySettings.Speed.FASTESTEST: {
+	DifficultyData.Speed.FASTESTEST: {
 		"T": "FFF",
 
 		"0": "FFF",
@@ -81,7 +81,7 @@ const PIECE_SPEED_MAPPING_BY_GAMEPLAY_SPEED := {
 	},
 	
 	# pieces fall much much faster (the slowest speed is F1)
-	GameplaySettings.Speed.FASTEST: {
+	DifficultyData.Speed.FASTEST: {
 		"T": "T",
 
 		"0": "F0",
@@ -125,7 +125,7 @@ const PIECE_SPEED_MAPPING_BY_GAMEPLAY_SPEED := {
 	},
 	
 	# pieces fall much faster (the slowest speed is A1)
-	GameplaySettings.Speed.FASTER: {
+	DifficultyData.Speed.FASTER: {
 		"T": "T",
 
 		"0": "A0",
@@ -169,7 +169,7 @@ const PIECE_SPEED_MAPPING_BY_GAMEPLAY_SPEED := {
 	},
 	
 	# pieces fall faster (the slowest speed is 5)
-	GameplaySettings.Speed.FAST: {
+	DifficultyData.Speed.FAST: {
 		"T": "T",
 
 		"0": "5",
@@ -212,7 +212,7 @@ const PIECE_SPEED_MAPPING_BY_GAMEPLAY_SPEED := {
 		"FFF": "FFF",
 	},
 	
-	GameplaySettings.Speed.DEFAULT: {
+	DifficultyData.Speed.DEFAULT: {
 		"T": "T",
 
 		"0": "0",
@@ -256,7 +256,7 @@ const PIECE_SPEED_MAPPING_BY_GAMEPLAY_SPEED := {
 	},
 	
 	# pieces fall slower (the fastest speed is AA)
-	GameplaySettings.Speed.SLOW: {
+	DifficultyData.Speed.SLOW: {
 		"T": "T",
 
 		"0": "0",
@@ -300,7 +300,7 @@ const PIECE_SPEED_MAPPING_BY_GAMEPLAY_SPEED := {
 	},
 	
 	# pieces fall much slower (the fastest speed is 9)
-	GameplaySettings.Speed.SLOWER: {
+	DifficultyData.Speed.SLOWER: {
 		"T": "T",
 
 		"0": "0",
@@ -344,7 +344,7 @@ const PIECE_SPEED_MAPPING_BY_GAMEPLAY_SPEED := {
 	},
 	
 	# pieces fall much much slower (the fastest speed is 7)
-	GameplaySettings.Speed.SLOWEST: {
+	DifficultyData.Speed.SLOWEST: {
 		"T": "T",
 
 		"0": "0",
@@ -388,7 +388,7 @@ const PIECE_SPEED_MAPPING_BY_GAMEPLAY_SPEED := {
 	},
 	
 	# pieces literally don't fall
-	GameplaySettings.Speed.SLOWESTEST: {
+	DifficultyData.Speed.SLOWESTEST: {
 		"T": "T",
 
 		"0": "T",
@@ -441,7 +441,7 @@ const PIECE_SPEED_MAPPING_BY_GAMEPLAY_SPEED := {
 ## 	A modified piece speed string such as '0' or 'A9'
 static func adjust_piece_speed(piece_speed_string: String) -> String:
 	var adjusted_speed_by_piece_speed: Dictionary = \
-			PIECE_SPEED_MAPPING_BY_GAMEPLAY_SPEED.get(SystemData.gameplay_settings.speed, {})
+			PIECE_SPEED_MAPPING_BY_GAMEPLAY_SPEED.get(PlayerData.difficulty.speed, {})
 	return adjusted_speed_by_piece_speed.get(piece_speed_string, piece_speed_string)
 
 
@@ -450,7 +450,7 @@ static func adjust_piece_speed(piece_speed_string: String) -> String:
 ## When the player plays at slow speeds, we make milestones easier to reach.
 static func adjust_score_milestone(score: int) -> int:
 	var score_milestone_factor: float = \
-			SCORE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(SystemData.gameplay_settings.speed, 1.0)
+			SCORE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(PlayerData.difficulty.speed, 1.0)
 	return int(ceil(score * score_milestone_factor))
 
 
@@ -459,7 +459,7 @@ static func adjust_score_milestone(score: int) -> int:
 ## When the player plays at slow speeds, we make milestones easier to reach.
 static func adjust_line_milestone(lines: int) -> int:
 	var line_milestone_factor: float = \
-			LINE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(SystemData.gameplay_settings.speed, 1.0)
+			LINE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(PlayerData.difficulty.speed, 1.0)
 	return int(ceil(lines * line_milestone_factor))
 
 
@@ -468,7 +468,7 @@ static func adjust_line_milestone(lines: int) -> int:
 ## When the player plays at slow speeds, we make milestones easier to reach.
 static func adjust_piece_milestone(pieces: int) -> int:
 	var piece_milestone_factor: float = \
-			LINE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(SystemData.gameplay_settings.speed, 1.0)
+			LINE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(PlayerData.difficulty.speed, 1.0)
 	return int(ceil(pieces * piece_milestone_factor))
 
 
@@ -477,5 +477,5 @@ static func adjust_piece_milestone(pieces: int) -> int:
 ## When the player plays at very slow speeds, we make milestones easier to reach.
 static func adjust_time_over_milestone(time_over: int) -> int:
 	var time_over_milestone_factor: float = \
-			TIME_OVER_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(SystemData.gameplay_settings.speed, 1.0)
+			TIME_OVER_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(PlayerData.difficulty.speed, 1.0)
 	return int(ceil(time_over * time_over_milestone_factor))

--- a/project/src/main/puzzle/piece/piece-dropper.gd
+++ b/project/src/main/puzzle/piece/piece-dropper.gd
@@ -8,6 +8,21 @@ signal soft_dropped(dropped_piece) # emitted when the player presses the soft dr
 signal hard_dropped(dropped_piece) # emitted when the player presses the hard drop key
 signal dropped(dropped_piece) # emitted when the piece falls as a result of a soft drop, hard drop, or gravity
 
+## Returns a number in the range [0.0, ∞) for how piece gravity should be modified for each gameplay speed setting.
+##
+## A value like 2.0 means pieces should fall faster, and a value like 0.5 means they should fall slower.
+const GRAVITY_FACTOR_BY_ENUM := {
+	DifficultyData.Speed.DEFAULT: 1.0,
+	DifficultyData.Speed.SLOW: 0.707,
+	DifficultyData.Speed.SLOWER: 0.500,
+	DifficultyData.Speed.SLOWEST: 0.333,
+	DifficultyData.Speed.SLOWESTEST: 0.0,
+	DifficultyData.Speed.FAST: 1.414,
+	DifficultyData.Speed.FASTER: 1.5,
+	DifficultyData.Speed.FASTEST: 2.0,
+	DifficultyData.Speed.FASTESTEST: 100.0,
+}
+
 export (NodePath) var input_path: NodePath
 export (NodePath) var piece_mover_path: NodePath
 
@@ -58,7 +73,7 @@ func apply_gravity(piece: ActivePiece) -> void:
 	else:
 		var current_gravity: int = PieceSpeeds.current_speed.gravity
 		if CurrentLevel.is_piece_speed_cheat_enabled():
-			current_gravity *= SystemData.gameplay_settings.get_gravity_factor()
+			current_gravity *= _get_gravity_factor()
 		
 		if input.is_soft_drop_pressed():
 			# soft drop
@@ -83,6 +98,13 @@ func apply_gravity(piece: ActivePiece) -> void:
 			emit_signal("soft_dropped", piece)
 		if pos_changed:
 			emit_signal("dropped", piece)
+
+
+## Returns a number in the range [0.0, ∞) for how piece gravity should be modified.
+##
+## A value like 2.0 means pieces should fall faster, and a value like 0.5 means they should fall slower.
+func _get_gravity_factor() -> float:
+	return GRAVITY_FACTOR_BY_ENUM.get(PlayerData.difficulty.speed, 1.0)
 
 
 ## Squish moving pauses gravity for a moment.

--- a/project/src/main/puzzle/piece/piece-queue.gd
+++ b/project/src/main/puzzle/piece/piece-queue.gd
@@ -45,7 +45,7 @@ var _cheat_bag_pieces_remaining := 0
 func _ready() -> void:
 	CurrentLevel.connect("settings_changed", self, "_on_Level_settings_changed")
 	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
-	SystemData.gameplay_settings.connect("line_piece_changed", self, "_on_GameplaySettings_line_piece_changed")
+	PlayerData.difficulty.connect("line_piece_changed", self, "_on_DifficultyData_line_piece_changed")
 	_fill()
 
 
@@ -321,7 +321,7 @@ func _on_PuzzleState_game_prepared() -> void:
 ##
 ## This has the potential for some very silly gameplay where the player repeatedly toggles the cheat on and off to get
 ## every piece in a particular order.
-func _on_GameplaySettings_line_piece_changed(_value: bool) -> void:
+func _on_DifficultyData_line_piece_changed(_value: bool) -> void:
 	if not CurrentLevel.is_line_piece_cheat_enabled():
 		return
 	

--- a/project/src/main/puzzle/piece/piece-speeds.gd
+++ b/project/src/main/puzzle/piece/piece-speeds.gd
@@ -89,7 +89,7 @@ func _ready() -> void:
 	PuzzleState.connect("speed_index_changed", self, "_on_PuzzleState_speed_index_changed")
 	PuzzleState.connect("game_prepared", self, "_on_PuzzleState_game_prepared")
 	
-	SystemData.gameplay_settings.connect("speed_changed", self, "_on_GameplaySettings_speed_changed")
+	PlayerData.difficulty.connect("speed_changed", self, "_on_DifficultyData_speed_changed")
 
 
 func speed(string: String) -> PieceSpeed:
@@ -121,5 +121,5 @@ func _on_PuzzleState_game_prepared() -> void:
 	_update_current_speed()
 
 
-func _on_GameplaySettings_speed_changed(_value: int) -> void:
+func _on_DifficultyData_speed_changed(_value: int) -> void:
 	_update_current_speed()

--- a/project/src/main/puzzle/playfield-shadow.gd
+++ b/project/src/main/puzzle/playfield-shadow.gd
@@ -7,7 +7,7 @@ onready var _normal_shadow: Polygon2D = $NormalShadow
 onready var _hold_piece_shadow: Polygon2D = $HoldPieceShadow
 
 func _ready() -> void:
-	SystemData.gameplay_settings.connect("hold_piece_changed", self, "_on_GameplaySettings_hold_piece_changed")
+	PlayerData.difficulty.connect("hold_piece_changed", self, "_on_DifficultyData_hold_piece_changed")
 	_refresh()
 
 
@@ -16,5 +16,5 @@ func _refresh() -> void:
 	_normal_shadow.visible = not _hold_piece_shadow.visible
 
 
-func _on_GameplaySettings_hold_piece_changed(_value: bool) -> void:
+func _on_DifficultyData_hold_piece_changed(_value: bool) -> void:
 	_refresh()

--- a/project/src/main/settings/gameplay-settings.gd
+++ b/project/src/main/settings/gameplay-settings.gd
@@ -2,53 +2,20 @@ class_name GameplaySettings
 ## Manages settings which control the gameplay.
 
 signal ghost_piece_changed(value)
-signal hold_piece_changed(value)
-signal line_piece_changed(value)
 signal soft_drop_lock_cancel_changed(value)
-signal speed_changed(value)
-
-enum Speed {
-	DEFAULT,
-	SLOW,
-	SLOWER,
-	SLOWEST,
-	SLOWESTEST,
-	FAST,
-	FASTER,
-	FASTEST,
-	FASTESTEST,
-}
-
-## Returns a number in the range [0.0, ∞) for how piece gravity should be modified for each gameplay speed setting.
-##
-## A value like 2.0 means pieces should fall faster, and a value like 0.5 means they should fall slower.
-const GRAVITY_FACTOR_BY_ENUM := {
-	Speed.DEFAULT: 1.0,
-	Speed.SLOW: 0.707,
-	Speed.SLOWER: 0.500,
-	Speed.SLOWEST: 0.333,
-	Speed.SLOWESTEST: 0.0,
-	Speed.FAST: 1.414,
-	Speed.FASTER: 1.5,
-	Speed.FASTEST: 2.0,
-	Speed.FASTESTEST: 100.0,
-}
 
 ## 'true' if a ghost piece should be shown during the puzzle sections.
 var ghost_piece := true setget set_ghost_piece
 
-## 'true' if the player can use a 'hold piece'
-var hold_piece := false setget set_hold_piece
-
-## 'true' if line pieces should appear on all levels
-var line_piece := false setget set_line_piece
-
 ## 'true' if pressing soft drop should perform a lock cancel
 var soft_drop_lock_cancel := false setget set_soft_drop_lock_cancel
 
-## Current gameplay speed. The player can reduce this to make the game easier. They can also increase it to make
-## the game harder, or to cheat on levels which otherwise require slow and thoughtful play.
-var speed: int = Speed.DEFAULT setget set_speed
+## Outdated properties which are preserved for backwards compatibility.
+##
+## Currently, this includes the old 'hold_piece', 'line_piece' and 'speed' settings. These have been moved into
+## PlayerData, but for our backwards-compatibility logic to run and populate PlayerData with the player's old
+## settings, they need to be available somewhere temporarily.
+var legacy_properties := {}
 
 func set_ghost_piece(new_ghost_piece: bool) -> void:
 	if ghost_piece == new_ghost_piece:
@@ -57,32 +24,11 @@ func set_ghost_piece(new_ghost_piece: bool) -> void:
 	emit_signal("ghost_piece_changed", new_ghost_piece)
 
 
-func set_hold_piece(new_hold_piece: bool) -> void:
-	if hold_piece == new_hold_piece:
-		return
-	hold_piece = new_hold_piece
-	emit_signal("hold_piece_changed", new_hold_piece)
-
-
-func set_line_piece(new_line_piece: bool) -> void:
-	if line_piece == new_line_piece:
-		return
-	line_piece = new_line_piece
-	emit_signal("line_piece_changed", new_line_piece)
-
-
 func set_soft_drop_lock_cancel(new_soft_drop_lock_cancel: bool) -> void:
 	if soft_drop_lock_cancel == new_soft_drop_lock_cancel:
 		return
 	soft_drop_lock_cancel = new_soft_drop_lock_cancel
 	emit_signal("soft_drop_lock_cancel_changed", new_soft_drop_lock_cancel)
-
-
-func set_speed(new_speed: int) -> void:
-	if speed == new_speed:
-		return
-	speed = new_speed
-	emit_signal("speed_changed", new_speed)
 
 
 ## Resets the gameplay settings to their default values.
@@ -93,23 +39,21 @@ func reset() -> void:
 func to_json_dict() -> Dictionary:
 	return {
 		"ghost_piece": ghost_piece,
-		"hold_piece": hold_piece,
-		"line_piece": line_piece,
+		
+		## We persist the 'legacy_properties' field which contains the outdated properties which are preserved for
+		## backwards compatibility.
+		##
+		## These fields are applied to the player's active save slot after it's loaded. However if we did not preserve
+		## them, they could not be applied to the player's other save slots when they're loaded in the future. This
+		## issue stems from #2910 (https://github.com/Poobslag/turbofat/issues/2910) which requires us to keep this
+		## data around because secondary save slots are not saved until the player loads them.
+		"legacy_properties": legacy_properties,
+		
 		"soft_drop_lock_cancel": soft_drop_lock_cancel,
-		"speed": Utils.enum_to_snake_case(Speed, speed),
 	}
 
 
 func from_json_dict(json: Dictionary) -> void:
 	set_ghost_piece(json.get("ghost_piece", true))
-	set_hold_piece(json.get("hold_piece", false))
-	set_line_piece(json.get("line_piece", false))
 	set_soft_drop_lock_cancel(json.get("soft_drop_lock_cancel", false))
-	set_speed(Utils.enum_from_snake_case(Speed, json.get("speed", "")))
-
-
-## Returns a number in the range [0.0, ∞) for how piece gravity should be modified.
-##
-## A value like 2.0 means pieces should fall faster, and a value like 0.5 means they should fall slower.
-func get_gravity_factor() -> float:
-	return GRAVITY_FACTOR_BY_ENUM.get(speed, 1.0)
+	legacy_properties = json.get("legacy_properties", {})

--- a/project/src/main/settings/keybind-manager.gd
+++ b/project/src/main/settings/keybind-manager.gd
@@ -5,7 +5,7 @@ signal input_map_updated
 
 func _ready() -> void:
 	SystemData.keybind_settings.connect("settings_changed", self, "_on_KeybindSettings_settings_changed")
-	SystemData.gameplay_settings.connect("hold_piece_changed", self, "_on_GameplaySettings_hold_piece_changed")
+	PlayerData.difficulty.connect("hold_piece_changed", self, "_on_DifficultyData_hold_piece_changed")
 
 
 ## Converts a json dictionary to an InputEvent instance.
@@ -103,12 +103,12 @@ func _refresh_keybinds() -> void:
 	match SystemData.keybind_settings.preset:
 		KeybindSettings.GUIDELINE:
 			var path := KeybindSettings.GUIDELINE_PATH
-			if SystemData.gameplay_settings.hold_piece:
+			if PlayerData.difficulty.hold_piece:
 				path = KeybindSettings.GUIDELINE_HOLD_PATH
 			_bind_keys_from_file(path)
 		KeybindSettings.WASD:
 			var path := KeybindSettings.WASD_PATH
-			if SystemData.gameplay_settings.hold_piece:
+			if PlayerData.difficulty.hold_piece:
 				path = KeybindSettings.WASD_HOLD_PATH
 			_bind_keys_from_file(path)
 		KeybindSettings.CUSTOM:
@@ -124,5 +124,5 @@ func _on_KeybindSettings_settings_changed() -> void:
 	_refresh_keybinds()
 
 
-func _on_GameplaySettings_hold_piece_changed(_value: bool) -> void:
+func _on_DifficultyData_hold_piece_changed(_value: bool) -> void:
 	_refresh_keybinds()

--- a/project/src/main/ui/difficulty/difficulty-button.gd
+++ b/project/src/main/ui/difficulty/difficulty-button.gd
@@ -2,50 +2,50 @@ class_name DifficultyButton
 extends Button
 ## Button on the difficulty screen which selects a difficulty.
 
-## key: (int) Enum from GameplaySettings.Speed
+## key: (int) Enum from DifficultyData.Speed
 ## value: (Array, Resource) pair of texture resources to use when the difficulty is chosen or not
 const TEXTURE_PAIRS_BY_SPEED := {
-	GameplaySettings.Speed.FASTESTEST: [preload("res://assets/main/ui/difficulty/turbo.png"),
+	DifficultyData.Speed.FASTESTEST: [preload("res://assets/main/ui/difficulty/turbo.png"),
 			preload("res://assets/main/ui/difficulty/turbo-off.png")],
-	GameplaySettings.Speed.FASTEST: [preload("res://assets/main/ui/difficulty/turbo.png"),
+	DifficultyData.Speed.FASTEST: [preload("res://assets/main/ui/difficulty/turbo.png"),
 			preload("res://assets/main/ui/difficulty/turbo-off.png")],
-	GameplaySettings.Speed.FASTER: [preload("res://assets/main/ui/difficulty/turbo.png"),
+	DifficultyData.Speed.FASTER: [preload("res://assets/main/ui/difficulty/turbo.png"),
 			preload("res://assets/main/ui/difficulty/turbo-off.png")],
-	GameplaySettings.Speed.FAST: [preload("res://assets/main/ui/difficulty/turbo.png"),
+	DifficultyData.Speed.FAST: [preload("res://assets/main/ui/difficulty/turbo.png"),
 			preload("res://assets/main/ui/difficulty/turbo-off.png")],
-	GameplaySettings.Speed.DEFAULT: [preload("res://assets/main/ui/difficulty/normal.png"),
+	DifficultyData.Speed.DEFAULT: [preload("res://assets/main/ui/difficulty/normal.png"),
 			preload("res://assets/main/ui/difficulty/normal-off.png")],
-	GameplaySettings.Speed.SLOW: [preload("res://assets/main/ui/difficulty/relaxed.png"),
+	DifficultyData.Speed.SLOW: [preload("res://assets/main/ui/difficulty/relaxed.png"),
 			preload("res://assets/main/ui/difficulty/relaxed-off.png")],
-	GameplaySettings.Speed.SLOWER: [preload("res://assets/main/ui/difficulty/relaxed.png"),
+	DifficultyData.Speed.SLOWER: [preload("res://assets/main/ui/difficulty/relaxed.png"),
 			preload("res://assets/main/ui/difficulty/relaxed-off.png")],
-	GameplaySettings.Speed.SLOWEST: [preload("res://assets/main/ui/difficulty/relaxed.png"),
+	DifficultyData.Speed.SLOWEST: [preload("res://assets/main/ui/difficulty/relaxed.png"),
 			preload("res://assets/main/ui/difficulty/relaxed-off.png")],
-	GameplaySettings.Speed.SLOWESTEST: [preload("res://assets/main/ui/difficulty/zen.png"),
+	DifficultyData.Speed.SLOWESTEST: [preload("res://assets/main/ui/difficulty/zen.png"),
 			preload("res://assets/main/ui/difficulty/zen-off.png")],
 }
 
-export (GameplaySettings.Speed) var speed: int = GameplaySettings.Speed.DEFAULT
+export (DifficultyData.Speed) var speed: int = DifficultyData.Speed.DEFAULT
 
-## key: (int) Enum from GameplaySettings.Speed
+## key: (int) Enum from DifficultyData.Speed
 ## value: (String) Difficulty name shown on the button
 var difficulty_names_by_speed := {
-	GameplaySettings.Speed.FASTESTEST: tr("Turbo Mode"),
-	GameplaySettings.Speed.FASTEST: tr("Turbo Mode"),
-	GameplaySettings.Speed.FASTER: tr("Turbo Mode"),
-	GameplaySettings.Speed.FAST: tr("Turbo Mode"),
-	GameplaySettings.Speed.DEFAULT: tr("Normal Mode"),
-	GameplaySettings.Speed.SLOW: tr("Relaxed Mode"),
-	GameplaySettings.Speed.SLOWER: tr("Relaxed Mode"),
-	GameplaySettings.Speed.SLOWEST: tr("Relaxed Mode"),
-	GameplaySettings.Speed.SLOWESTEST: tr("Zen Mode"),
+	DifficultyData.Speed.FASTESTEST: tr("Turbo Mode"),
+	DifficultyData.Speed.FASTEST: tr("Turbo Mode"),
+	DifficultyData.Speed.FASTER: tr("Turbo Mode"),
+	DifficultyData.Speed.FAST: tr("Turbo Mode"),
+	DifficultyData.Speed.DEFAULT: tr("Normal Mode"),
+	DifficultyData.Speed.SLOW: tr("Relaxed Mode"),
+	DifficultyData.Speed.SLOWER: tr("Relaxed Mode"),
+	DifficultyData.Speed.SLOWEST: tr("Relaxed Mode"),
+	DifficultyData.Speed.SLOWESTEST: tr("Zen Mode"),
 }
 
 onready var _polygon2d := $Polygon2D
 onready var _name_label := $NameLabel
 
 func _ready() -> void:
-	SystemData.gameplay_settings.connect("speed_changed", self, "_on_GameplaySettings_speed_changed")
+	PlayerData.difficulty.connect("speed_changed", self, "_on_DifficultyData_speed_changed")
 	
 	_refresh()
 
@@ -73,16 +73,16 @@ func _refresh() -> void:
 ## Returns:
 ## 	'true' if the button's difficulty matches the player's chosen difficulty.
 func is_button_difficulty_chosen() -> bool:
-	return speed == SystemData.gameplay_settings.speed
+	return speed == PlayerData.difficulty.speed
 
 
 func _pressed() -> void:
-	SystemData.gameplay_settings.speed = speed
+	PlayerData.difficulty.speed = speed
 	SystemData.has_unsaved_changes = true
 	_refresh()
 
 
-func _on_GameplaySettings_speed_changed(_value: int) -> void:
+func _on_DifficultyData_speed_changed(_value: int) -> void:
 	_refresh()
 
 

--- a/project/src/main/ui/difficulty/difficulty-hold-piece-panel.gd
+++ b/project/src/main/ui/difficulty/difficulty-hold-piece-panel.gd
@@ -4,18 +4,18 @@ extends Panel
 onready var _check_box := $CheckBox
 
 func _ready() -> void:
-	SystemData.gameplay_settings.connect("hold_piece_changed", self, "_on_GameplaySettings_hold_piece_changed")
+	PlayerData.difficulty.connect("hold_piece_changed", self, "_on_DifficultyData_hold_piece_changed")
 	_refresh()
 
 
 func _refresh() -> void:
-	_check_box.pressed = SystemData.gameplay_settings.hold_piece
+	_check_box.pressed = PlayerData.difficulty.hold_piece
 
 
 func _on_CheckBox_toggled(_button_pressed: bool) -> void:
-	SystemData.gameplay_settings.hold_piece = _check_box.pressed
+	PlayerData.difficulty.hold_piece = _check_box.pressed
 	SystemData.has_unsaved_changes = true
 
 
-func _on_GameplaySettings_hold_piece_changed(_value: bool) -> void:
+func _on_DifficultyData_hold_piece_changed(_value: bool) -> void:
 	_refresh()

--- a/project/src/main/ui/difficulty/difficulty-line-piece-panel.gd
+++ b/project/src/main/ui/difficulty/difficulty-line-piece-panel.gd
@@ -4,18 +4,18 @@ extends Panel
 onready var _check_box := $CheckBox
 
 func _ready() -> void:
-	SystemData.gameplay_settings.connect("line_piece_changed", self, "_on_GameplaySettings_line_piece_changed")
+	PlayerData.difficulty.connect("line_piece_changed", self, "_on_DifficultyData_line_piece_changed")
 	_refresh()
 
 
 func _refresh() -> void:
-	_check_box.pressed = SystemData.gameplay_settings.line_piece
+	_check_box.pressed = PlayerData.difficulty.line_piece
 
 
 func _on_CheckBox_toggled(_button_pressed: bool) -> void:
 	SystemData.has_unsaved_changes = true
-	SystemData.gameplay_settings.line_piece = _check_box.pressed
+	PlayerData.difficulty.line_piece = _check_box.pressed
 
 
-func _on_GameplaySettings_line_piece_changed(_value: bool) -> void:
+func _on_DifficultyData_line_piece_changed(_value: bool) -> void:
 	_refresh()

--- a/project/src/main/ui/difficulty/difficulty-menu-description.gd
+++ b/project/src/main/ui/difficulty/difficulty-menu-description.gd
@@ -1,25 +1,25 @@
 extends Label
 ## Shows a description of the currently active or currently selected difficulty.
 
-## key: (int) Enum from GameplaySettings.Speed
+## key: (int) Enum from DifficultyData.Speed
 ## value: (String) description
 var descriptions_by_speed := {
-	GameplaySettings.Speed.FASTESTEST: tr("Faster than intended - who needs strategy? Get down with the quickness!"),
-	GameplaySettings.Speed.FASTEST: tr("Faster than intended - who needs strategy? Get down with the quickness!"),
-	GameplaySettings.Speed.FASTER: tr("Faster than intended - who needs strategy? Get down with the quickness!"),
-	GameplaySettings.Speed.FAST: tr("Faster than intended - who needs strategy? Get down with the quickness!"),
-	GameplaySettings.Speed.DEFAULT: tr("The heart of Turbo Fat - balancing quick moves with clever strategy."),
-	GameplaySettings.Speed.SLOW: tr("Slower pieces, shorter levels - chill vibes only, please."),
-	GameplaySettings.Speed.SLOWER: tr("Slower pieces, shorter levels - chill vibes only, please."),
-	GameplaySettings.Speed.SLOWEST: tr("Slower pieces, shorter levels - chill vibes only, please."),
-	GameplaySettings.Speed.SLOWESTEST: tr("Zero gravity, super-short levels - pure tranquility at your own pace."),
+	DifficultyData.Speed.FASTESTEST: tr("Faster than intended - who needs strategy? Get down with the quickness!"),
+	DifficultyData.Speed.FASTEST: tr("Faster than intended - who needs strategy? Get down with the quickness!"),
+	DifficultyData.Speed.FASTER: tr("Faster than intended - who needs strategy? Get down with the quickness!"),
+	DifficultyData.Speed.FAST: tr("Faster than intended - who needs strategy? Get down with the quickness!"),
+	DifficultyData.Speed.DEFAULT: tr("The heart of Turbo Fat - balancing quick moves with clever strategy."),
+	DifficultyData.Speed.SLOW: tr("Slower pieces, shorter levels - chill vibes only, please."),
+	DifficultyData.Speed.SLOWER: tr("Slower pieces, shorter levels - chill vibes only, please."),
+	DifficultyData.Speed.SLOWEST: tr("Slower pieces, shorter levels - chill vibes only, please."),
+	DifficultyData.Speed.SLOWESTEST: tr("Zero gravity, super-short levels - pure tranquility at your own pace."),
 }
 
 func _ready() -> void:
 	for difficulty_button in get_tree().get_nodes_in_group("difficulty_buttons"):
 		difficulty_button.connect("focus_entered", self, "_on_DifficultyButton_focus_entered")
 		difficulty_button.connect("focus_exited", self, "_on_DifficultyButton_focus_exited")
-	SystemData.gameplay_settings.connect("speed_changed", self, "_on_GameplaySettings_speed_changed")
+	PlayerData.difficulty.connect("speed_changed", self, "_on_DifficultyData_speed_changed")
 
 
 func _refresh() -> void:
@@ -27,7 +27,7 @@ func _refresh() -> void:
 		return
 	
 	# show a description for the currently chosen difficulty
-	var speed: int = SystemData.gameplay_settings.speed
+	var speed: int = PlayerData.difficulty.speed
 	
 	# the focused difficulty overrides the currently chosen difficulty, so that the player can browse
 	if get_focus_owner() is DifficultyButton:
@@ -36,7 +36,7 @@ func _refresh() -> void:
 	text = descriptions_by_speed.get(speed)
 
 
-func _on_GameplaySettings_speed_changed(_value: int) -> void:
+func _on_DifficultyData_speed_changed(_value: int) -> void:
 	_refresh()
 
 

--- a/project/src/main/ui/difficulty/difficulty-menu.gd
+++ b/project/src/main/ui/difficulty/difficulty-menu.gd
@@ -11,7 +11,7 @@ onready var _line_piece_checkbox := $DropPanel/VBoxContainer/Helpers/HBoxContain
 onready var _tip_label := $TipLabel
 
 func _ready() -> void:
-	SystemData.gameplay_settings.connect("speed_changed", self, "_on_GameplaySettings_speed_changed")
+	PlayerData.difficulty.connect("speed_changed", self, "_on_DifficultyData_speed_changed")
 	
 	_focus_difficulty_button()
 	_assign_focus_neighbours()
@@ -60,7 +60,7 @@ func _assign_focus_neighbours() -> void:
 	_line_piece_checkbox.focus_neighbour_top = button_to_focus.get_path()
 
 
-func _on_GameplaySettings_speed_changed(_value: int) -> void:
+func _on_DifficultyData_speed_changed(_value: int) -> void:
 	_assign_focus_neighbours()
 
 

--- a/project/src/main/ui/settings/keybind/settings-keybinds-control.gd
+++ b/project/src/main/ui/settings/keybind/settings-keybinds-control.gd
@@ -9,7 +9,7 @@ func _ready() -> void:
 	$Presets/Wasd.connect("pressed", self, "_on_Wasd_pressed")
 	$Presets/Custom.connect("pressed", self, "_on_Custom_pressed")
 	_custom_control("ResetToDefault").connect("pressed", self, "_on_ResetToDefault_pressed")
-	SystemData.gameplay_settings.connect("hold_piece_changed", self, "_on_GameplaySettings_hold_piece_changed")
+	PlayerData.difficulty.connect("hold_piece_changed", self, "_on_DifficultyData_hold_piece_changed")
 	InputManager.connect("input_mode_changed", self, "_on_InputManager_input_mode_changed")
 	
 	match SystemData.keybind_settings.preset:
@@ -58,7 +58,7 @@ func _refresh_keybind_labels() -> void:
 				_assign_wasd_joypad_values()
 		KeybindSettings.CUSTOM:
 			$CustomScrollContainer.visible = true
-			_custom_control("SwapHoldPiece").visible = SystemData.gameplay_settings.hold_piece
+			_custom_control("SwapHoldPiece").visible = PlayerData.difficulty.hold_piece
 
 
 ## Assigns the standard preset keyboard values which do not change between Guideline and WASD
@@ -78,13 +78,13 @@ func _assign_guideline_keyboard_values() -> void:
 	_assign_preset_keyboard_values()
 	_preset_control("MovePiece").keybind_values = [tr("Left"), tr("Right"), tr("Kp 4"), tr("Kp 6")]
 	_preset_control("SoftDrop").keybind_values = [tr("Down"), tr("Kp 2")]
-	if SystemData.gameplay_settings.hold_piece:
+	if PlayerData.difficulty.hold_piece:
 		_preset_control("HardDrop").keybind_values = [tr("Space"), tr("Up"), tr("Kp 8")]
 	else:
 		_preset_control("HardDrop").keybind_values = [tr("Space"), tr("Up"), tr("Kp 8"), tr("Shift")]
 	_preset_control("RotatePiece").keybind_values = [tr("Z"), tr("X"), tr("Kp 7"), tr("Kp 9")]
 	_preset_control("SwapHoldPiece").keybind_values = [tr("Shift"), tr("C"), tr("Kp 0")]
-	_preset_control("SwapHoldPiece").visible = SystemData.gameplay_settings.hold_piece
+	_preset_control("SwapHoldPiece").visible = PlayerData.difficulty.hold_piece
 
 
 ## Updates all controls within the 'Presets' scroll container with values for the 'WASD' preset.
@@ -92,13 +92,13 @@ func _assign_wasd_keyboard_values() -> void:
 	_assign_preset_keyboard_values()
 	_preset_control("MovePiece").keybind_values = [tr("A"), tr("D"), tr("Kp 4"), tr("Kp 6")]
 	_preset_control("SoftDrop").keybind_values = [tr("S"), tr("Kp 8")]
-	if SystemData.gameplay_settings.hold_piece:
+	if PlayerData.difficulty.hold_piece:
 		_preset_control("HardDrop").keybind_values = [tr("W"), tr("Kp 5")]
 	else:
 		_preset_control("HardDrop").keybind_values = [tr("W"), tr("Kp 5"), tr("Kp Enter")]
 	_preset_control("RotatePiece").keybind_values = [tr("Left"), tr("Right"), tr("Kp 7"), tr("Kp 9")]
 	_preset_control("SwapHoldPiece").keybind_values = [tr("Shift"), tr("Kp Enter")]
-	_preset_control("SwapHoldPiece").visible = SystemData.gameplay_settings.hold_piece
+	_preset_control("SwapHoldPiece").visible = PlayerData.difficulty.hold_piece
 
 
 ## Assigns the standard preset joypad values which do not change between Guideline and WASD
@@ -130,7 +130,7 @@ func _assign_guideline_joypad_values() -> void:
 			[KeybindSettings.XBOX_IMAGE_DPAD_LEFT, KeybindSettings.XBOX_IMAGE_DPAD_RIGHT]
 	_preset_control("SoftDrop").keybind_values = \
 			[KeybindSettings.XBOX_IMAGE_DPAD_DOWN, KeybindSettings.XBOX_IMAGE_B]
-	if SystemData.gameplay_settings.hold_piece:
+	if PlayerData.difficulty.hold_piece:
 		_preset_control("HardDrop").keybind_values = \
 				[KeybindSettings.XBOX_IMAGE_DPAD_UP, KeybindSettings.XBOX_IMAGE_Y]
 	else:
@@ -141,7 +141,7 @@ func _assign_guideline_joypad_values() -> void:
 			[KeybindSettings.XBOX_IMAGE_X, KeybindSettings.XBOX_IMAGE_A]
 	_preset_control("SwapHoldPiece").keybind_values = \
 			[KeybindSettings.XBOX_IMAGE_LB, KeybindSettings.XBOX_IMAGE_RB]
-	_preset_control("SwapHoldPiece").visible = SystemData.gameplay_settings.hold_piece
+	_preset_control("SwapHoldPiece").visible = PlayerData.difficulty.hold_piece
 
 
 ## Updates all controls within the 'Presets' scroll container with values for joypad presets.
@@ -153,7 +153,7 @@ func _assign_wasd_joypad_values() -> void:
 			[KeybindSettings.XBOX_IMAGE_DPAD_LEFT, KeybindSettings.XBOX_IMAGE_DPAD_RIGHT]
 	_preset_control("SoftDrop").keybind_values = \
 			[KeybindSettings.XBOX_IMAGE_DPAD_DOWN, KeybindSettings.XBOX_IMAGE_X]
-	if SystemData.gameplay_settings.hold_piece:
+	if PlayerData.difficulty.hold_piece:
 		_preset_control("HardDrop").keybind_values = \
 				[KeybindSettings.XBOX_IMAGE_DPAD_UP, KeybindSettings.XBOX_IMAGE_Y]
 	else:
@@ -164,7 +164,7 @@ func _assign_wasd_joypad_values() -> void:
 			[KeybindSettings.XBOX_IMAGE_A, KeybindSettings.XBOX_IMAGE_B]
 	_preset_control("SwapHoldPiece").keybind_values = \
 			[KeybindSettings.XBOX_IMAGE_LB, KeybindSettings.XBOX_IMAGE_RB]
-	_preset_control("SwapHoldPiece").visible = SystemData.gameplay_settings.hold_piece
+	_preset_control("SwapHoldPiece").visible = PlayerData.difficulty.hold_piece
 
 
 ## Assigns the TabContainer's bottom focus neighbor to the pressed preset button.
@@ -203,7 +203,7 @@ func _on_Custom_pressed() -> void:
 ##
 ## We don't want to confuse players by letting them set a 'Swap Hold Piece' key which doesn't work because they didn't
 ## enable the cheat.
-func _on_GameplaySettings_hold_piece_changed(_value: bool) -> void:
+func _on_DifficultyData_hold_piece_changed(_value: bool) -> void:
 	_refresh_keybind_labels()
 
 

--- a/project/src/test/data/test-player-save.gd
+++ b/project/src/test/data/test-player-save.gd
@@ -21,11 +21,13 @@ func after_each() -> void:
 
 func test_save_and_load() -> void:
 	PlayerData.level_history.add_result("level_895", _rank_result)
+	PlayerData.difficulty.speed = DifficultyData.Speed.FASTEST
 	PlayerSave.save_player_data()
 	PlayerData.reset()
 	PlayerSave.load_player_data()
 	assert_true(PlayerData.level_history.has_result("level_895"))
 	assert_eq(PlayerData.level_history.results("level_895")[0].score, 7890)
+	assert_eq(PlayerData.difficulty.speed, DifficultyData.Speed.FASTEST)
 
 
 func test_one_bad_file() -> void:

--- a/project/src/test/data/test-system-save-upgrader.gd
+++ b/project/src/test/data/test-system-save-upgrader.gd
@@ -1,27 +1,41 @@
 extends GutTest
 
-const TEMP_FILENAME := "user://test-ripe-bucket.json"
+const TEMP_PLAYER_FILENAME := "user://test366.save"
+const TEMP_SYSTEM_FILENAME := "user://test-ripe-bucket.json"
 const TEMP_LEGACY_FILENAME := "user://test-oven-bucket.save"
 
 func before_each() -> void:
-	SystemSave.data_filename = TEMP_FILENAME
+	PlayerSave.data_filename = TEMP_PLAYER_FILENAME
+	SystemSave.data_filename = TEMP_SYSTEM_FILENAME
 	SystemSave.legacy_filename = TEMP_LEGACY_FILENAME
 	SystemData.reset()
+	var rolling_backups := RollingBackups.new()
+	rolling_backups.data_filename = TEMP_PLAYER_FILENAME
+	rolling_backups.delete_all_backups()
 
 
 func after_each() -> void:
 	var dir := Directory.new()
-	dir.remove(TEMP_FILENAME)
+	dir.remove(TEMP_SYSTEM_FILENAME)
 	dir.remove(TEMP_LEGACY_FILENAME)
+	var rolling_backups := RollingBackups.new()
+	rolling_backups.data_filename = TEMP_PLAYER_FILENAME
+	rolling_backups.delete_all_backups()
+
+
+func load_system_data(filename: String) -> void:
+	var dir := Directory.new()
+	dir.copy("res://assets/test/data/%s" % filename, TEMP_SYSTEM_FILENAME)
+	SystemSave.load_system_data()
 
 
 func load_player_data(filename: String) -> void:
 	var dir := Directory.new()
-	dir.copy("res://assets/test/data/%s" % filename, TEMP_FILENAME)
-	SystemSave.load_system_data()
+	dir.copy("res://assets/test/data/%s" % filename, TEMP_PLAYER_FILENAME)
+	PlayerSave.load_player_data()
 
 
-func load_legacy_player_data(filename: String) -> void:
+func load_legacy_data(filename: String) -> void:
 	var dir := Directory.new()
 	dir.copy("res://assets/test/data/%s" % filename, TEMP_LEGACY_FILENAME)
 	SystemSave.load_system_data()
@@ -29,7 +43,7 @@ func load_legacy_player_data(filename: String) -> void:
 
 func test_1b3c() -> void:
 	var original_locale := TranslationServer.get_locale()
-	load_legacy_player_data("turbofat-1b3c.json")
+	load_legacy_data("turbofat-1b3c.json")
 	
 	# 'miscellaneous settings' were renamed to 'misc settings'
 	assert_eq(TranslationServer.get_locale(), "es")
@@ -37,7 +51,8 @@ func test_1b3c() -> void:
 
 
 func test_27bb() -> void:
-	load_player_data("config-27bb.json")
+	load_system_data("config-27bb.json")
+	load_player_data("turbofat-27bb.json")
 	
 	assert_eq(SystemData.keybind_settings.custom_keybinds.has("interact"), false)
 	assert_eq(SystemData.keybind_settings.custom_keybinds.has("phone"), false)
@@ -46,13 +61,13 @@ func test_27bb() -> void:
 	assert_eq(SystemData.keybind_settings.custom_keybinds.has("walk_right"), false)
 	assert_eq(SystemData.keybind_settings.custom_keybinds.has("walk_up"), false)
 	
-	assert_eq(SystemData.gameplay_settings.speed, GameplaySettings.Speed.DEFAULT)
-	assert_eq(SystemData.gameplay_settings.hold_piece, false)
-	assert_eq(SystemData.gameplay_settings.line_piece, false)
+	assert_eq(PlayerData.difficulty.speed, DifficultyData.Speed.DEFAULT)
+	assert_eq(PlayerData.difficulty.hold_piece, false)
+	assert_eq(PlayerData.difficulty.line_piece, false)
 
 
 func test_37b3() -> void:
-	load_player_data("config-37b3.json")
+	load_system_data("config-37b3.json")
 	
 	# should fill in missing keybinds
 	assert_eq(SystemData.keybind_settings.custom_keybinds.has("next_tab"), true)
@@ -65,3 +80,23 @@ func test_37b3() -> void:
 		{},
 		{},
 	])
+
+
+func test_5a24() -> void:
+	load_system_data("config-5a24.json")
+	load_player_data("turbofat-59c3.json")
+	
+	# should load difficulty data from file
+	assert_eq(PlayerData.difficulty.speed, DifficultyData.Speed.SLOWER)
+	assert_eq(PlayerData.difficulty.hold_piece, true)
+	assert_eq(PlayerData.difficulty.line_piece, true)
+
+
+func test_5a24_defaults() -> void:
+	load_system_data("config-5a24-default.json")
+	load_player_data("turbofat-59c3.json")
+	
+	# should load difficulty data from file
+	assert_eq(PlayerData.difficulty.speed, DifficultyData.Speed.DEFAULT)
+	assert_eq(PlayerData.difficulty.hold_piece, false)
+	assert_eq(PlayerData.difficulty.line_piece, false)

--- a/project/src/test/data/test-system-save.gd
+++ b/project/src/test/data/test-system-save.gd
@@ -25,7 +25,6 @@ func test_save_and_load() -> void:
 	SystemData.volume_settings.set_bus_volume_linear(VolumeSettings.MUSIC, 0.695)
 	SystemData.volume_settings.set_bus_volume_linear(VolumeSettings.SOUND, 0.279)
 	SystemData.volume_settings.set_bus_volume_linear(VolumeSettings.VOICE, 0.405)
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.FASTEST
 	SystemSave.save_system_data()
 	SystemData.reset()
 	SystemSave.load_system_data()
@@ -33,4 +32,3 @@ func test_save_and_load() -> void:
 	assert_almost_eq(SystemData.volume_settings.get_bus_volume_linear(VolumeSettings.MUSIC), 0.695, 0.001)
 	assert_almost_eq(SystemData.volume_settings.get_bus_volume_linear(VolumeSettings.SOUND), 0.279, 0.001)
 	assert_almost_eq(SystemData.volume_settings.get_bus_volume_linear(VolumeSettings.VOICE), 0.405, 0.001)
-	assert_eq(SystemData.gameplay_settings.speed, GameplaySettings.Speed.FASTEST)

--- a/project/src/test/puzzle/level/test-gameplay-difficulty-adjustments.gd
+++ b/project/src/test/puzzle/level/test-gameplay-difficulty-adjustments.gd
@@ -1,92 +1,92 @@
 extends GutTest
 
 func before_each() -> void:
-	SystemData.gameplay_settings.reset()
+	PlayerData.difficulty.reset()
 
 
 func after_all() -> void:
-	SystemData.gameplay_settings.reset()
+	PlayerData.difficulty.reset()
 
 
 func test_adjust_line_milestone() -> void:
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.DEFAULT
+	PlayerData.difficulty.speed = DifficultyData.Speed.DEFAULT
 	assert_eq(GameplayDifficultyAdjustments.adjust_line_milestone(50), 50)
 	
 	# slowing down gameplay speed decreases lines required
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOW
+	PlayerData.difficulty.speed = DifficultyData.Speed.SLOW
 	assert_eq(GameplayDifficultyAdjustments.adjust_line_milestone(50), 43)
 	
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOWER
+	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWER
 	assert_eq(GameplayDifficultyAdjustments.adjust_line_milestone(50), 35)
 	
 	# lines required won't decrease below a certain threshold (1 line)
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOWESTEST
+	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWESTEST
 	assert_eq(GameplayDifficultyAdjustments.adjust_line_milestone(3), 1)
 	
 	# increasing gameplay speed does not affect milestones
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.FASTER
+	PlayerData.difficulty.speed = DifficultyData.Speed.FASTER
 	assert_eq(GameplayDifficultyAdjustments.adjust_line_milestone(50), 50)
 
 
 func test_adjust_piece_milestone() -> void:
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.DEFAULT
+	PlayerData.difficulty.speed = DifficultyData.Speed.DEFAULT
 	assert_eq(GameplayDifficultyAdjustments.adjust_piece_milestone(50), 50)
 	
 	# slowing down gameplay speed decreases pieces required
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOW
+	PlayerData.difficulty.speed = DifficultyData.Speed.SLOW
 	assert_eq(GameplayDifficultyAdjustments.adjust_piece_milestone(50), 43)
 	
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOWER
+	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWER
 	assert_eq(GameplayDifficultyAdjustments.adjust_piece_milestone(50), 35)
 	
 	# pieces required won't decrease below a certain threshold (1 piece)
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOWESTEST
+	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWESTEST
 	assert_eq(GameplayDifficultyAdjustments.adjust_piece_milestone(3), 1)
 	
 	# increasing gameplay speed does not affect milestones
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.FASTER
+	PlayerData.difficulty.speed = DifficultyData.Speed.FASTER
 	assert_eq(GameplayDifficultyAdjustments.adjust_piece_milestone(50), 50)
 
 
 func test_adjust_score_milestone() -> void:
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.DEFAULT
+	PlayerData.difficulty.speed = DifficultyData.Speed.DEFAULT
 	assert_eq(GameplayDifficultyAdjustments.adjust_score_milestone(500), 500)
 	
 	# slowing down gameplay speed decreases score required
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOW
+	PlayerData.difficulty.speed = DifficultyData.Speed.SLOW
 	assert_eq(GameplayDifficultyAdjustments.adjust_score_milestone(500), 350)
 	
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOWER
+	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWER
 	assert_eq(GameplayDifficultyAdjustments.adjust_score_milestone(500), 200)
 	
 	# score required won't decrease below a certain threshold (¥1)
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOWESTEST
+	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWESTEST
 	assert_eq(GameplayDifficultyAdjustments.adjust_score_milestone(3), 1)
 	
 	# increasing gameplay speed does not affect milestones
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.FASTER
+	PlayerData.difficulty.speed = DifficultyData.Speed.FASTER
 	assert_eq(GameplayDifficultyAdjustments.adjust_score_milestone(500), 500)
 
 
 func test_adjust_time_over_milestone() -> void:
 	# 'slow' and 'default' gameplay speeds do not affect level duration
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.DEFAULT
+	PlayerData.difficulty.speed = DifficultyData.Speed.DEFAULT
 	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(180), 180)
 	
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOW
+	PlayerData.difficulty.speed = DifficultyData.Speed.SLOW
 	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(180), 180)
 	
 	# decreasing gameplay speed beyond 'slow' decreases level duration
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOWER
+	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWER
 	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(180), 162)
 	
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOWEST
+	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWEST
 	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(180), 126)
 	
 	# level duration won't decrease below a certain threshold (0:01)
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.SLOWESTEST
+	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWESTEST
 	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(3), 2)
 	
 	# increasing gameplay speed does not affect milestones
-	SystemData.gameplay_settings.speed = GameplaySettings.Speed.FASTER
+	PlayerData.difficulty.speed = DifficultyData.Speed.FASTER
 	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(180), 180)


### PR DESCRIPTION
Difficulty data used to be in the system data, alongside settings like 'Ghost Piece' and 'Soft Drop Lock Cancel' and keybinds. I've moved it into the player data. I think it's common that players will want to have different save slots for different difficulties, and unusual that all save slots would need to share a difficulty