### PR TITLE
Fix difficulty upgrade edge cases: slowest, fast, etc

### DIFF
--- a/project/assets/test/data/config-5a24-slowest.json
+++ b/project/assets/test/data/config-5a24-slowest.json
@@ -1,0 +1,276 @@
+[
+  {
+    "type": "version",
+    "value": "5a24"
+  },
+  {
+    "type": "gameplay_settings",
+    "value": {
+      "ghost_piece": true,
+      "hold_piece": true,
+      "line_piece": true,
+      "soft_drop_lock_cancel": true,
+      "speed": "slowest"
+    }
+  },
+  {
+    "type": "graphics_settings",
+    "value": {
+      "creature_detail": 1,
+      "feeding_animation": 1,
+      "fullscreen": false,
+      "use_vsync": true
+    }
+  },
+  {
+    "type": "volume_settings",
+    "value": {
+      "master": 0.71,
+      "music": 0,
+      "sound": 0.7,
+      "voice": 0.7
+    }
+  },
+  {
+    "type": "touch_settings",
+    "value": {
+      "fat_finger": 0,
+      "scheme": 0,
+      "size": 1
+    }
+  },
+  {
+    "type": "keybind_settings",
+    "value": {
+      "preset": 0,
+      "custom_keybinds": {
+        "move_piece_left": [
+          {
+            "type": "key",
+            "scancode": 16777231
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "move_piece_right": [
+          {
+            "type": "key",
+            "scancode": 16777233
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "soft_drop": [
+          {
+            "type": "key",
+            "scancode": 16777234
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "hard_drop": [
+          {
+            "type": "key",
+            "scancode": 32
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "retry": [
+          {
+            "type": "key",
+            "scancode": 82
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "rotate_ccw": [
+          {
+            "type": "key",
+            "scancode": 90
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "rotate_cw": [
+          {
+            "type": "key",
+            "scancode": 88
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "swap_hold_piece": [
+          {
+            "type": "key",
+            "scancode": 16777237
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_up": [
+          {
+            "type": "key",
+            "scancode": 16777232
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_down": [
+          {
+            "type": "key",
+            "scancode": 16777234
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_left": [
+          {
+            "type": "key",
+            "scancode": 16777231
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_right": [
+          {
+            "type": "key",
+            "scancode": 16777233
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_accept": [
+          {
+            "type": "key",
+            "scancode": 32
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_cancel": [
+          {
+            "type": "key",
+            "scancode": 16777217
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "ui_menu": [
+          {
+            "type": "key",
+            "scancode": 16777217
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "rewind_text": [
+          {
+            "type": "key",
+            "scancode": 16777237
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "next_tab": [
+          {
+            "type": "key",
+            "scancode": 88
+          },
+          {
+
+          },
+          {
+
+          }
+        ],
+        "prev_tab": [
+          {
+            "type": "key",
+            "scancode": 90
+          },
+          {
+
+          },
+          {
+
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "misc_settings",
+    "value": {
+      "locale": "en",
+      "save_slot": 0,
+      "show_adventure_mode_intro": true,
+      "show_difficulty_menu": false,
+      "show_give_up_confirmation": true
+    }
+  }
+]

--- a/project/src/main/data/player-save-upgrader.gd
+++ b/project/src/main/data/player-save-upgrader.gd
@@ -342,6 +342,17 @@ func _post_upgrade_59c3(new_save_items: Array) -> Array:
 		if SystemData.gameplay_settings.legacy_properties.has(property):
 			difficulty_save_item["value"][property] = SystemData.gameplay_settings.legacy_properties[property]
 	
+	# replace the 'speed' field with one of the four standard settings
+	var old_speed: String = difficulty_save_item["value"].get("speed", "")
+	var new_speed: String = old_speed
+	match old_speed:
+		"slow", "slowest":
+			new_speed = "slower"
+		"fast", "faster", "fastestest":
+			new_speed = "fastest"
+	if new_speed:
+		difficulty_save_item["value"]["speed"] = new_speed
+	
 	return new_save_items
 
 

--- a/project/src/test/data/test-system-save-upgrader.gd
+++ b/project/src/test/data/test-system-save-upgrader.gd
@@ -100,3 +100,11 @@ func test_5a24_defaults() -> void:
 	assert_eq(PlayerData.difficulty.speed, DifficultyData.Speed.DEFAULT)
 	assert_eq(PlayerData.difficulty.hold_piece, false)
 	assert_eq(PlayerData.difficulty.line_piece, false)
+
+
+func test_5a24_slowest() -> void:
+	load_system_data("config-5a24-slowest.json")
+	load_player_data("turbofat-59c3.json")
+	
+	# 'slowest' is no longer accepted through the UI; should replace with 'slower'
+	assert_eq(PlayerData.difficulty.speed, DifficultyData.Speed.SLOWER)


### PR DESCRIPTION
Difficulties such as 'fast' and 'sloweset' can not be picked in the new difficulty interface. Before, players who selected these difficulties would be able to continue using them, although the UI would make it look like they had no difficulty selected.

Now, when upgrading to the newest version, the player's difficulty is adjusted to one of the four standard difficulties. They can still hack into their save files and assign a non-standard difficulty, and the old behavior will persist. This might be construed as a feature and not a bug, it doesn't break anything and lets them try the super silly 'fastestest' difficulty if they really want.