### PR TITLE
Bug: All save slots are loaded on scene change

### DIFF
--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -1373,6 +1373,7 @@ icon_color = Color( 1, 0.866667, 0.6, 1 )
 [connection signal="hide" from="." to="ControllerUnpluggedMessage" method="_on_SettingsMenu_hide"]
 [connection signal="hide" from="." to="Window/UiArea/Bottom" method="_on_SettingsMenu_hide"]
 [connection signal="show" from="." to="ControllerUnpluggedMessage" method="_on_SettingsMenu_show"]
+[connection signal="show" from="." to="Window/UiArea/TabContainer/Misc/VBoxContainer/SaveSlot" method="_on_SettingsMenu_show"]
 [connection signal="show" from="." to="Window/UiArea/Bottom" method="_on_SettingsMenu_show"]
 [connection signal="pressed" from="Window/UiArea/TabContainer/SoundAndGraphics/VBoxContainer/Fullscreen/CheckBox" to="Window/UiArea/TabContainer/SoundAndGraphics/VBoxContainer/Fullscreen" method="_on_CheckBox_pressed"]
 [connection signal="pressed" from="Window/UiArea/TabContainer/SoundAndGraphics/VBoxContainer/UseVsync/CheckBox" to="Window/UiArea/TabContainer/SoundAndGraphics/VBoxContainer/UseVsync" method="_on_CheckBox_pressed"]

--- a/project/src/main/ui/settings/settings-save-slot.gd
+++ b/project/src/main/ui/settings/settings-save-slot.gd
@@ -8,8 +8,6 @@ onready var _option_button := $HBoxContainer/OptionButton
 
 func _ready() -> void:
 	SystemSave.connect("save_slot_deleted", self, "_on_SystemSave_save_slot_deleted")
-	
-	_refresh_save_slots()
 
 
 func get_selected_save_slot() -> int:
@@ -33,4 +31,8 @@ func _on_Delete_pressed() -> void:
 
 
 func _on_SystemSave_save_slot_deleted() -> void:
+	_refresh_save_slots()
+
+
+func _on_SettingsMenu_show() -> void:
 	_refresh_save_slots()


### PR DESCRIPTION
The SettingsMenu's save slots dropdown was prompting SystemSave to load all four save slots every time the player changed scenes, adding a few milliseconds to the load times.

The Settingsmenu's save slots dropdown is now only populated when the SettingsMenu is shown.