### PR TITLE
Added 'vertical_line_pieces' setting.

### DIFF
--- a/project/src/demo/toolkit/fix-levels-button.gd
+++ b/project/src/demo/toolkit/fix-levels-button.gd
@@ -30,6 +30,7 @@ func run() -> void:
 	_report_invalid_career_music()
 	_report_unused_career_levels()
 	_report_level_icons()
+	_report_vertical_line_piece_levels()
 	_alphabetize_career_levels()
 	if _problem_count == 0:
 		_output.add_line("No level files have problems.")
@@ -189,6 +190,35 @@ func _report_level_icons() -> void:
 	
 	if bad_icons:
 		_report_problem("Levels with bad icons: %s" % [PoolStringArray(bad_icons).join(", ")])
+
+
+## Report levels where line pieces will cause a top out.
+##
+## Levels like 'Carrot Alley' were frustrating for players using the line piece cheat, so we made those levels
+## automatically rotate line pieces. Any level which blocks line pieces should rotate them automatically.
+func _report_vertical_line_piece_levels() -> void:
+	var level_ids := []
+	level_ids.append_array(CareerLevelLibrary.all_level_ids())
+	level_ids.append_array(OtherLevelLibrary.all_level_ids())
+	
+	# Cells at the top center of the playfield. Technically only four of these will cause a top out, but we check for
+	# all five.
+	var top_cells := [
+		Vector2(2, 3), Vector2(3, 3), Vector2(4, 3), Vector2(5, 3), Vector2(6, 3),
+	]
+	
+	var bad_line_piece_level_ids := []
+	for level_id in level_ids:
+		var level_settings := LevelSettings.new()
+		level_settings.load_from_resource(level_id)
+		var occupied_top_cells := Utils.intersection(
+				level_settings.tiles.blocks_start().block_tiles.keys(), top_cells)
+		if occupied_top_cells and not level_settings.other.vertical_line_pieces:
+			bad_line_piece_level_ids.append(level_id)
+	
+	if bad_line_piece_level_ids:
+		_report_problem("Levels which need 'vertical_line_pieces' setting: %s"
+				% [PoolStringArray(bad_line_piece_level_ids).join(", ")])
 
 
 ## Alphabetizes the levels in 'career-regions.json'

--- a/project/src/main/puzzle/level/other-rules.gd
+++ b/project/src/main/puzzle/level/other-rules.gd
@@ -40,6 +40,9 @@ var tile_set: int = PuzzleTileMap.TileSetType.DEFAULT
 ## 'true' for tutorial levels which are led by Turbo
 var tutorial := false
 
+## 'true' if line pieces should be vertical, for levels where horizontal line pieces will cause a top out
+var vertical_line_pieces := false
+
 var _rule_parser: RuleParser
 
 func _init() -> void:
@@ -57,6 +60,7 @@ func _init() -> void:
 	_rule_parser.add_string("start_level")
 	_rule_parser.add_enum("tile_set", PuzzleTileMap.TileSetType)
 	_rule_parser.add_bool("tutorial")
+	_rule_parser.add_bool("vertical_line_pieces")
 
 
 func from_json_array(json: Array) -> void:

--- a/project/src/main/puzzle/piece/piece-queue.gd
+++ b/project/src/main/puzzle/piece/piece-queue.gd
@@ -220,9 +220,11 @@ func _maybe_insert_cheat_pieces(min_line_piece_index: int) -> void:
 func _new_next_piece(type: PieceType) -> NextPiece:
 	var next_piece := NextPiece.new()
 	next_piece.type = type
+	if CurrentLevel.settings.other.vertical_line_pieces and next_piece.type == PieceTypes.piece_i:
+		next_piece.orientation = 1
 	if pieces:
 		# if the last piece in the queue has been rotated, we match its orientation.
-		next_piece.orientation = pieces.back().orientation
+		next_piece.orientation = (next_piece.orientation + pieces.back().orientation) % type.pos_arr.size()
 	return next_piece
 
 


### PR DESCRIPTION
Some levels like 'Carrot Alley' top the player out if they are using the line piece cheat. This new setting causes specific levels to automatically rotate line pieces to prevent a top out.