### PR TITLE
Fixed freeze when interacting with console window

### DIFF
--- a/bin/troubleshoot_bat/turbofat-troubleshoot.bat.template
+++ b/bin/troubleshoot_bat/turbofat-troubleshoot.bat.template
@@ -1,17 +1,29 @@
 @echo off
+echo Launching Turbo Fat in troubleshoot mode...
 
-:: Run the game and capture the exit code
-##WIN_EXE_FILENAME## --verbose -- --tf-verbose
+set LOG_FILE=%AppData%\Godot\app_userdata\Turbo Fat\logs\godot.log
+
+:: Run the game, suppressing all output
+##WIN_EXE_FILENAME## --verbose -- --tf-verbose > nul 2>&1
 set exitCode=%ERRORLEVEL%
+
+:: Check if the log directory exists
+if not exist "%LOG_FILE%" (
+    echo Error: Log file not found at "%LOG_FILE%".
+    pause
+    exit /b 1
+)
+
+:: Show the log contents
+echo ================================================================================
+type "%LOG_FILE%"
+echo ================================================================================
 
 :: Check the exit code
 if %exitCode% neq 0 (
-    echo The game has crashed. Please review the output and send it to the devs.
+    echo The game has crashed.
 ) else (
     echo The game exited normally.
 )
-
-:: Keep the window open and wait for the user to close it
-:loop
-set /p exitprompt="Press X to close the window: "
-if /I "%exitprompt%" neq "X" goto loop
+echo There should now be a "%LOG_FILE%" file that you can send to the devs.
+pause

--- a/project/project.godot
+++ b/project/project.godot
@@ -1990,6 +1990,7 @@ _global_script_class_icons={
 
 config/name="Turbo Fat"
 run/main_scene="res://src/main/ui/menu/LoadingScreen.tscn"
+run/flush_stdout_on_print=true
 boot_splash/show_image=false
 config/icon="res://assets/main/ui/icon.png"
 config/windows_native_icon="res://assets/main/ui/icon.ico"


### PR DESCRIPTION
Enable flush_stdout_on_print setting. This allows us to view logged messages, even when the game crashes.

Disable immediate console printing while the game is running. Immediately printing messages causes unusual behavior if the player interacts with the console window. It reliably causes the game to freeze temporarily, but other users have reported the window turning transparent or crashing as well.

Messages are still logged after the game closes, by echoing the 'godot.log' file.