### PR TITLE
Output locale names in predictable order.

### DIFF
--- a/project/assets/main/locale/en.po
+++ b/project/assets/main/locale/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/Poobslag/turbofat/\n"
-"POT-Creation-Date: 2024-11-27 08:20-0500\n"
+"POT-Creation-Date: 2024-11-27 14:53-0500\n"
 "PO-Revision-Date: 2023-03-13 12:16-0400\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -12978,11 +12978,11 @@ msgid "Kp 9"
 msgstr ""
 
 #: project/assets/main/locale/localizables-extracted.py
-msgid "Spanish"
+msgid "English"
 msgstr ""
 
 #: project/assets/main/locale/localizables-extracted.py
-msgid "English"
+msgid "Spanish"
 msgstr ""
 
 #: project/src/main/career/CareerMap.tscn

--- a/project/assets/main/locale/es.po
+++ b/project/assets/main/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/Poobslag/turbofat/\n"
-"POT-Creation-Date: 2024-11-27 08:20-0500\n"
+"POT-Creation-Date: 2024-11-27 14:53-0500\n"
 "PO-Revision-Date: 2024-10-13 19:30-0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -14540,12 +14540,12 @@ msgid "Kp 9"
 msgstr "Numpad 9"
 
 #: project/assets/main/locale/localizables-extracted.py
-msgid "Spanish"
-msgstr "Español"
-
-#: project/assets/main/locale/localizables-extracted.py
 msgid "English"
 msgstr "Inglés"
+
+#: project/assets/main/locale/localizables-extracted.py
+msgid "Spanish"
+msgstr "Español"
 
 #: project/src/main/career/CareerMap.tscn
 msgid "The left level is further from the goal. Choose carefully!"

--- a/project/assets/main/locale/localizables-extracted.py
+++ b/project/assets/main/locale/localizables-extracted.py
@@ -3191,5 +3191,5 @@ tr("Kp 8")
 tr("Kp 9")
 
 # Locales
-tr("Spanish")
 tr("English")
+tr("Spanish")

--- a/project/assets/main/locale/messages.pot
+++ b/project/assets/main/locale/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Turbo Fat 0.9000\n"
 "Report-Msgid-Bugs-To: https://github.com/Poobslag/turbofat/\n"
-"POT-Creation-Date: 2024-11-27 08:20-0500\n"
+"POT-Creation-Date: 2024-11-27 14:53-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -12980,11 +12980,11 @@ msgid "Kp 9"
 msgstr ""
 
 #: project/assets/main/locale/localizables-extracted.py
-msgid "Spanish"
+msgid "English"
 msgstr ""
 
 #: project/assets/main/locale/localizables-extracted.py
-msgid "English"
+msgid "Spanish"
 msgstr ""
 
 #: project/src/main/career/CareerMap.tscn

--- a/project/src/demo/toolkit/extract-localizables-button.gd
+++ b/project/src/demo/toolkit/extract-localizables-button.gd
@@ -171,5 +171,9 @@ func _extract_localizables_from_scancodes() -> void:
 
 ## Extract localizables from TranslationServer.get_loaded_locales()
 func _extract_localizables_from_locales() -> void:
+	var locale_names := []
 	for locale in TranslationServer.get_loaded_locales():
-		_append_localizable(TranslationServer.get_locale_name(locale))
+		locale_names.append(TranslationServer.get_locale_name(locale))
+	locale_names.sort()
+	for locale_name in locale_names:
+		_append_localizable(locale_name)


### PR DESCRIPTION
Before, locale names were output in a random order resulting in unnecessary churn in our .po files.