### PR TITLE
Fixed 'null tween' error in 5ed690e1

### DIFF
--- a/project/src/main/world/creature/Creature.tscn
+++ b/project/src/main/world/creature/Creature.tscn
@@ -49,4 +49,5 @@ script = ExtResource( 8 )
 
 [connection signal="food_eaten" from="." to="CreatureSfx" method="_on_Creature_food_eaten"]
 [connection signal="landed" from="." to="CreatureSfx" method="_on_Creature_landed"]
+[connection signal="tree_exited" from="." to="." method="_on_tree_exited"]
 [connection signal="timeout" from="CreatureSfx/SuppressSfxTimer" to="CreatureSfx" method="_on_SuppressSfxTimer_timeout"]

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -593,6 +593,16 @@ func _run_anim_speed() -> float:
 	return result
 
 
+## When the creature is removed from the tree, we disconnect the 'fade_in_started' listener
+##
+## If we don't disconnect this listener, we receive errors during scene changes because the 'fade_in_started' listener
+## tries to create scene tree tweens when the creature is not in the scene tree. These errors are caused by
+## Breadcrumb's Godot #85692 workaround which delays the freeing of nodes in the previous scene.
+func _on_tree_exited() -> void:
+	if SceneTransition.is_connected("fade_in_started", self, "_on_SceneTransition_fade_in_started"):
+		SceneTransition.disconnect("fade_in_started", self, "_on_SceneTransition_fade_in_started")
+
+
 func _on_CreatureVisuals_fatness_changed() -> void:
 	emit_signal("fatness_changed")
 


### PR DESCRIPTION
5ed690e1 changed how nodes are cleaned up during scene changes, causing an error in Creature's fade_in_started listener, because the listener was called after the creature was removed from the tree. This specifically occurred in the 'CutsceneDemo.tscn' but it's possible it would also affect cutscenes in the game.

We now disconnect the listener when the creature is removed from the tree.

I regression tested other parts of the game, including the intro, tutorial, puzzles and credits and did not encounter any errors.