### PR TITLE
Skipping dialog skips choices as well.

### DIFF
--- a/project/src/main/chat/ui/chat-ui.gd
+++ b/project/src/main/chat/ui/chat-ui.gd
@@ -56,7 +56,8 @@ func _input(event: InputEvent) -> void:
 		_handle_rewind_action(event)
 		get_tree().set_input_as_handled()
 	if event.is_action_pressed("ui_accept", true):
-		if not _chat_choices.is_showing_choices():
+		if not _chat_choices.is_showing_choices() \
+				or _chat_choices.is_showing_choices() and event.is_echo():
 			_handle_advance_action(event)
 			get_tree().set_input_as_handled()
 

--- a/project/src/main/chat/ui/touch-translator.gd
+++ b/project/src/main/chat/ui/touch-translator.gd
@@ -7,6 +7,9 @@ export (NodePath) var narration_frame_path: NodePath
 ## index of the current touch event, or -1 if there is none
 var _touch_index := -1
 
+## 'true' if the player is making a dialog choice
+var _showing_choices := false
+
 ## scancode which triggers a ui_accept action.
 ## echo events cannot be emitted without an InputEventKey instance which requires a scancode
 var _ui_accept_scancode: int
@@ -88,11 +91,11 @@ func _on_ChatUi_popped_in() -> void:
 
 
 func _on_ChatUi_showed_choices() -> void:
-	_disable_translation()
+	_showing_choices = true
 
 
 func _on_ChatChoices_chat_choice_chosen(_choice_index: int) -> void:
-	_enable_translation()
+	_showing_choices = false
 
 
 func _on_ChatUi_chat_finished() -> void:


### PR DESCRIPTION
I don't think people would usually skip the dialog but then care about making a specific choice. It's a little tedious having to hold a key to skip dialog, then let go and repress it during a dialogue choice, sometimes multiple times if you trigger the "don't mash through dialog choices" prevention code.

Closes #1007.