### PR TITLE
Replace 'creature.on_tree_exited' with 'exit_tree'

### DIFF
--- a/project/src/main/world/creature/Creature.tscn
+++ b/project/src/main/world/creature/Creature.tscn
@@ -49,5 +49,4 @@ script = ExtResource( 8 )
 
 [connection signal="food_eaten" from="." to="CreatureSfx" method="_on_Creature_food_eaten"]
 [connection signal="landed" from="." to="CreatureSfx" method="_on_Creature_landed"]
-[connection signal="tree_exited" from="." to="." method="_on_tree_exited"]
 [connection signal="timeout" from="CreatureSfx/SuppressSfxTimer" to="CreatureSfx" method="_on_SuppressSfxTimer_timeout"]

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -148,6 +148,16 @@ func _ready() -> void:
 	_refresh_elevation()
 
 
+## When the creature is removed from the tree, we disconnect the 'fade_in_started' listener
+##
+## If we don't disconnect this listener, we receive errors during scene changes because the 'fade_in_started' listener
+## tries to create scene tree tweens when the creature is not in the scene tree. These errors are caused by
+## Breadcrumb's Godot #85692 workaround which delays the freeing of nodes in the previous scene.
+func _exit_tree() -> void:
+	if SceneTransition.is_connected("fade_in_started", self, "_on_SceneTransition_fade_in_started"):
+		SceneTransition.disconnect("fade_in_started", self, "_on_SceneTransition_fade_in_started")
+
+
 func _physics_process(delta: float) -> void:
 	if Engine.editor_hint:
 		return
@@ -591,16 +601,6 @@ func _run_anim_speed() -> float:
 	else:
 		result *= 1.000
 	return result
-
-
-## When the creature is removed from the tree, we disconnect the 'fade_in_started' listener
-##
-## If we don't disconnect this listener, we receive errors during scene changes because the 'fade_in_started' listener
-## tries to create scene tree tweens when the creature is not in the scene tree. These errors are caused by
-## Breadcrumb's Godot #85692 workaround which delays the freeing of nodes in the previous scene.
-func _on_tree_exited() -> void:
-	if SceneTransition.is_connected("fade_in_started", self, "_on_SceneTransition_fade_in_started"):
-		SceneTransition.disconnect("fade_in_started", self, "_on_SceneTransition_fade_in_started")
 
 
 func _on_CreatureVisuals_fatness_changed() -> void:


### PR DESCRIPTION
Scripts don't need to listen for their own 'tree_exited' signals; they have an '_exit_tree' callback for this