### PR TITLE
Additional 'null player checks' for 45b49cd

### DIFF
--- a/project/src/main/career/ui/career-win-world.gd
+++ b/project/src/main/career/ui/career-win-world.gd
@@ -38,14 +38,17 @@ func _refresh_mood() -> void:
 	var player := overworld_environment.player
 	var sensei := overworld_environment.sensei
 	if PlayerData.career.steps >= Careers.DAILY_STEPS_GOOD:
-		player.play_mood(Creatures.Mood.LAUGH0)
+		if player:
+			player.play_mood(Creatures.Mood.LAUGH0)
 		if sensei:
 			sensei.play_mood(Creatures.Mood.LAUGH0)
 	elif PlayerData.career.steps >= Careers.DAILY_STEPS_OK:
-		player.play_mood(Creatures.Mood.SMILE0)
+		if player:
+			player.play_mood(Creatures.Mood.SMILE0)
 		if sensei:
 			sensei.play_mood(Creatures.Mood.SMILE0)
 	else:
-		player.play_mood(Creatures.Mood.RAGE0)
+		if player:
+			player.play_mood(Creatures.Mood.RAGE0)
 		if sensei:
 			sensei.play_mood(Creatures.Mood.RAGE0)

--- a/project/src/main/editor/creature/allele-buttons.gd
+++ b/project/src/main/editor/creature/allele-buttons.gd
@@ -116,6 +116,9 @@ func _add_operation_buttons(category: int) -> void:
 
 
 func _initialize_creature_name_button(button: CreatureNameButton) -> void:
+	if not _player():
+		return
+	
 	button.creature = _player()
 	button.connect("name_changed", self, "_on_CreatureNameButton_name_changed")
 
@@ -136,6 +139,9 @@ func _initialize_operation_button(button: OperationButton, operation: Operation)
 ##
 ## These are buttons which let the player choose things like "Poofy Hair".
 func _add_allele_buttons(category: int) -> void:
+	if not _player():
+		return
+	
 	var category_button := _category_selector.get_category_button(category)
 	
 	var allele_combos := _creature_editor_library.get_allele_combos_by_category_index(category)
@@ -220,6 +226,9 @@ func _is_allele_combo_assigned(allele_combo: String) -> bool:
 ## Returns:
 ## 	'true' if the specified allele is assigned to the creature.
 func _is_allele_assigned(allele_string: String) -> bool:
+	if not _player():
+		return false
+	
 	var allele_id: String = allele_string.split("_")[0]
 	var allele_value: String = allele_string.split("_")[1]
 	return _player().dna[allele_id] == allele_value
@@ -229,6 +238,9 @@ func _is_allele_assigned(allele_string: String) -> bool:
 ##
 ## These are buttons which let the player choose things like hair color.
 func _add_color_buttons(category: int) -> void:
+	if not _player():
+		return
+	
 	var category_button := _category_selector.get_category_button(category)
 	
 	var color_properties := _creature_editor_library.get_color_properties_by_category_index(category)
@@ -318,6 +330,9 @@ func _player() -> Creature:
 
 ## When the player chooses an allele, we update the UI and update the creature's appearance.
 func _on_AlleleButton_pressed(allele_button: AlleleButton) -> void:
+	if not _player():
+		return
+	
 	# update the pressed allele buttons
 	allele_button.pressed = true
 	for other_allele_button in Utils.get_child_members(self, "allele_buttons"):
@@ -338,14 +353,19 @@ func _on_AlleleButton_pressed(allele_button: AlleleButton) -> void:
 
 ## When the player uses a CreatureColorButton, we update the creature's appearance
 func _on_CreatureColorButton_color_changed(color: Color, color_property: String) -> void:
+	if not _player():
+		return
+	
 	_player().dna[color_property] = color.to_html(false).to_lower()
 	_player().refresh_dna()
 	_player().chat_theme = CreatureLoader.chat_theme(_player().dna) # generate a new chat theme
 
 
 func _on_CreatureNameButton_name_changed(new_name: String) -> void:
-	var player := _player()
-	player.rename(new_name)
+	if not _player():
+		return
+	
+	_player().rename(new_name)
 
 
 func _on_CategorySelector_category_selected(category: int) -> void:
@@ -362,4 +382,7 @@ func _on_OperationButton_pressed(operation_button: OperationButton) -> void:
 ##
 ## Some of these presets such as for 'line_rgb' change based on the creature's body color.
 func _on_CreatureColorButton_about_to_show(color_button: CreatureColorButton, color_property: String) -> void:
+	if not _player():
+		return
+	
 	color_button.color_presets = _creature_editor_library.get_color_presets(_player().dna, color_property)

--- a/project/src/main/editor/creature/creature-editor.gd
+++ b/project/src/main/editor/creature/creature-editor.gd
@@ -49,6 +49,9 @@ func _on_AlleleButtons_operation_button_pressed(operation_id: String) -> void:
 
 
 func _on_Export_file_selected(path: String) -> void:
+	if not _overworld_environment.player:
+		return
+	
 	var exported_def := _overworld_environment.player.creature_def
 	exported_def.creature_id = NameUtils.short_name_to_id(exported_def.creature_short_name)
 	exported_def.chef_if = "true"

--- a/project/src/main/editor/creature/creature-saver.gd
+++ b/project/src/main/editor/creature/creature-saver.gd
@@ -21,6 +21,9 @@ func save_creature() -> void:
 	if not has_unsaved_changes():
 		return
 	
+	if not _overworld_environment.player:
+		return
+	
 	PlayerData.creature_library.player_def = _overworld_environment.player.get_creature_def()
 	PlayerSave.save_player_data()
 	_overworld_environment.player.play_mood(Utils.rand_value([

--- a/project/src/main/editor/creature/dialogs.gd
+++ b/project/src/main/editor/creature/dialogs.gd
@@ -53,6 +53,9 @@ func show_import_dialog() -> void:
 
 
 func show_export_dialog() -> void:
+	if not _overworld_environment.player:
+		return
+	
 	var sanitized_creature_name := StringUtils.sanitize_file_root(_overworld_environment.player.creature_short_name)
 	_export.current_file = "%s.json" % sanitized_creature_name
 	_export.popup_centered()

--- a/project/src/main/editor/creature/fatness-changer.gd
+++ b/project/src/main/editor/creature/fatness-changer.gd
@@ -25,6 +25,9 @@ func _player() -> Creature:
 
 
 func _decrease_fatness() -> void:
+	if not _player():
+		return
+	
 	if _player().min_fatness <= MIN_FATNESS:
 		return
 	
@@ -34,6 +37,9 @@ func _decrease_fatness() -> void:
 
 
 func _increase_fatness() -> void:
+	if not _player():
+		return
+	
 	if _player().min_fatness >= MAX_FATNESS:
 		return
 	

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -367,6 +367,9 @@ func _on_LevelSelectButton_level_chosen(level_index: int) -> void:
 
 
 func _on_CareerData_distance_travelled_changed() -> void:
+	if not is_inside_tree():
+		return
+	
 	_refresh_ui()
 	
 	# Restore focus to the level select buttons for controller players. This is necessary for the 'MOVEME' cheat which

--- a/project/src/main/world/career-world.gd
+++ b/project/src/main/world/career-world.gd
@@ -92,6 +92,9 @@ func initial_environment_path() -> String:
 ## Parameters:
 ## 	'level_posses': LevelPosse instances for creatures which should appear for each level.
 func refresh_from_career_data(level_posses: Array) -> void:
+	if not is_inside_tree():
+		return
+	
 	if EnvironmentScene.resource_path != _career_environment_path():
 		set_environment_scene(load(initial_environment_path()))
 		_fill_environment_scene()
@@ -148,6 +151,9 @@ func _fill_environment_scene() -> void:
 
 ## Rearranges environment objects like the player, sensei, level creatures, mile markers, and camera.
 func _move_objects_to_path() -> void:
+	if not is_inside_tree():
+		return
+	
 	var percent := _distance_percent()
 	_move_player_to_path(percent)
 	_move_sensei_to_path(percent)
@@ -159,6 +165,9 @@ func _move_objects_to_path() -> void:
 
 
 func _remove_mile_markers() -> void:
+	if not is_inside_tree():
+		return
+	
 	for mile_marker in get_tree().get_nodes_in_group("mile_markers"):
 		mile_marker.queue_free()
 
@@ -322,7 +331,8 @@ func _move_level_creature_to_path(creature_index: int, percent: float) -> void:
 	
 	# turn creature towards player
 	var player := overworld_environment.player
-	creature.orientation = Creatures.SOUTHEAST if player.position.x > creature.position.x else Creatures.SOUTHWEST
+	if player:
+		creature.orientation = Creatures.SOUTHEAST if player.position.x > creature.position.x else Creatures.SOUTHWEST
 
 
 ## Moves the player creature to a point along _player_path2d.
@@ -330,6 +340,9 @@ func _move_level_creature_to_path(creature_index: int, percent: float) -> void:
 ## Parameters:
 ## 	'percent': A number in the range [0.0, 1.0] describing how far to the right the player should be positioned.
 func _move_player_to_path(percent: float) -> void:
+	if not overworld_environment.player:
+		return
+	
 	var player := overworld_environment.player
 	var player_range := _camera_x_range()
 	if PlayerData.career.current_region().has_flag(CareerRegion.FLAG_NO_SENSEI):
@@ -348,12 +361,14 @@ func _move_player_to_path(percent: float) -> void:
 ## Parameters:
 ## 	'percent': A number in the range [0.0, 1.0] describing how far to the right the sensei should be positioned.
 func _move_sensei_to_path(percent: float) -> void:
+	if not overworld_environment.sensei:
+		return
+	
 	var sensei := overworld_environment.sensei
-	if sensei:
-		var sensei_range := _camera_x_range()
-		sensei.position.x = lerp(sensei_range.min_value, sensei_range.max_value, percent) \
-				- X_DIST_BETWEEN_PLAYER_AND_SENSEI / 2.0
-		sensei.position.y = _player_path2d_y(sensei.position.x)
+	var sensei_range := _camera_x_range()
+	sensei.position.x = lerp(sensei_range.min_value, sensei_range.max_value, percent) \
+			- X_DIST_BETWEEN_PLAYER_AND_SENSEI / 2.0
+	sensei.position.y = _player_path2d_y(sensei.position.x)
 
 
 ## Moves the camera so all creatures are visible.
@@ -474,7 +489,10 @@ func _turn_towards_level_creature() -> void:
 	var level_creature: Creature = _level_creatures[_focused_level_creature_index]
 	
 	var player := overworld_environment.player
-	player.orientation = Creatures.SOUTHEAST if level_creature.position.x > player.position.x else Creatures.SOUTHWEST
+	if player:
+		player.orientation = Creatures.SOUTHEAST if level_creature.position.x > player.position.x \
+				else Creatures.SOUTHWEST
+	
 	var sensei := overworld_environment.sensei
 	if sensei:
 		sensei.orientation = Creatures.SOUTHEAST if level_creature.position.x > sensei.position.x \

--- a/project/src/main/world/environment/overworld-environment.gd
+++ b/project/src/main/world/environment/overworld-environment.gd
@@ -75,6 +75,9 @@ func get_creature_spawners() -> Array:
 ##
 ## An id of SENSEI_ID or PLAYER_ID will return the sensei or player object.
 func get_creature_by_id(creature_id: String) -> Creature:
+	if not is_inside_tree():
+		return null
+	
 	var creature: Creature
 	
 	for creature_node in get_tree().get_nodes_in_group("creatures"):


### PR DESCRIPTION
While the root cause of 45b49cd was caused by a lingering listener connected to a node outside of the scene tree, the lines causing the crash were related to OverworldEnvironment.get_creature_by_id not handling the case where it is not in a scene tree.

I've changed OverworldEnvironment.get_creature_by_id to return null in this case, and changed many of its callers to handle this case more gracefully. This doesn't fix any crash that I know of, but it makes this code more resilient to future crashes I don't know about yet.