### PR TITLE
Separate 'M' and 'TOP' grades, to allow for lenient master grade

### DIFF
--- a/project/assets/test/puzzle/levels/level-5a6b.json
+++ b/project/assets/test/puzzle/levels/level-5a6b.json
@@ -1,0 +1,27 @@
+{
+  "version": "5a6b",
+  "name": "3 Kyu",
+  "description": "An escalating set of challenges. Finish with ¥999 to achieve this rank!",
+  "color": "blue",
+  "start_speed": "5",
+  "blocks_during": [
+    "top_out_effect clear"
+  ],
+  "finish_condition": {
+    "type": "time_over",
+    "value": 540
+  },
+  "icons": [
+    "basic",
+    "slow"
+  ],
+  "rank": [
+    "duration 540",
+    "rank_criteria m=7560",
+    "success_bonus 2"
+  ],
+  "success_condition": {
+    "type": "score",
+    "value": 999
+  }
+}

--- a/project/src/main/puzzle/level/levels.gd
+++ b/project/src/main/puzzle/level/levels.gd
@@ -15,4 +15,4 @@ enum Result {
 
 ## Current version for saved level data. Should be updated if and only if the level format changes.
 ## This version number follows a 'ymdh' hex date format which is documented in issue #234.
-const LEVEL_DATA_VERSION := "5a6b"
+const LEVEL_DATA_VERSION := "5c84"

--- a/project/src/main/puzzle/rank-criteria.gd
+++ b/project/src/main/puzzle/rank-criteria.gd
@@ -4,6 +4,10 @@ class_name RankCriteria
 ## Each level defines the rank criteria for the best rank, and can optionally define rank criteria for other ranks.
 ## The remaining ranks are calculated by interpolation.
 
+## The 'TOP' grade corresponds to TAS-level play. It is never awarded to the player, but it is defined in our level
+## files and other grades are extrapolated from it.
+const PERFECT_GRADE := "TOP"
+
 ## Each level defines the rank criteria for the best rank, but if no rank criteria is specified these values are used
 ## instead. These values are arbitrary and will not produce meaningful output, so we log a warning if they are used.
 const DEFAULT_BEST_SCORE := 2000
@@ -11,6 +15,7 @@ const DEFAULT_BEST_TIME := 60
 
 ## Grades with their corresponding score percent requirement. Lower values represent lower scores.
 const SCORE_PERCENT_BY_GRADE := {
+	PERFECT_GRADE: 1.000,
 	"M":   1.0,
 	"SSS": 0.854,
 	"SS+": 0.768,
@@ -33,6 +38,7 @@ const SCORE_PERCENT_BY_GRADE := {
 ##
 ## Note: Most entries are reciprocals of the entries in SCORE_PERCENT_BY_GRADE, except for WORST_GRADE.
 const TIME_PERCENT_BY_GRADE := {
+	PERFECT_GRADE:  1.000,
 	"M":    1.0,
 	"SSS":  1.171,
 	"SS+":  1.301,
@@ -117,22 +123,22 @@ func fill_missing_thresholds() -> void:
 	# assign boundaries for WORST_GRADE, BEST_GRADE
 	var new_thresholds := thresholds_by_grade.duplicate()
 	if duration_criteria:
-		if not thresholds_by_grade.has(Ranks.BEST_GRADE):
+		if not thresholds_by_grade.has(PERFECT_GRADE):
 			push_warning("Level %s does not define '%s' rank criteria; defaulting to %s" \
 					% [CurrentLevel.level_id if CurrentLevel.level_id else "(unknown)", \
-						Ranks.BEST_GRADE, DEFAULT_BEST_SCORE])
-			new_thresholds[Ranks.BEST_GRADE] = DEFAULT_BEST_TIME
+						PERFECT_GRADE, DEFAULT_BEST_SCORE])
+			new_thresholds[PERFECT_GRADE] = DEFAULT_BEST_TIME
 		if not new_thresholds.has(Ranks.WORST_GRADE):
-			new_thresholds[Ranks.WORST_GRADE] = new_thresholds[Ranks.BEST_GRADE] \
+			new_thresholds[Ranks.WORST_GRADE] = new_thresholds[PERFECT_GRADE] \
 					* TIME_PERCENT_BY_GRADE[Ranks.WORST_GRADE]
 	else:
-		if not thresholds_by_grade.has(Ranks.BEST_GRADE):
+		if not thresholds_by_grade.has(PERFECT_GRADE):
 			push_warning("Level %s does not define '%s' rank criteria; defaulting to %s" \
 					% [CurrentLevel.level_id if CurrentLevel.level_id else "(unknown)", \
-						Ranks.BEST_GRADE, DEFAULT_BEST_TIME])
-			new_thresholds[Ranks.BEST_GRADE] = DEFAULT_BEST_SCORE
+						PERFECT_GRADE, DEFAULT_BEST_TIME])
+			new_thresholds[PERFECT_GRADE] = DEFAULT_BEST_SCORE
 		if not new_thresholds.has(Ranks.WORST_GRADE):
-			new_thresholds[Ranks.WORST_GRADE] = new_thresholds[Ranks.BEST_GRADE] \
+			new_thresholds[Ranks.WORST_GRADE] = new_thresholds[PERFECT_GRADE] \
 					* SCORE_PERCENT_BY_GRADE[Ranks.WORST_GRADE]
 	
 	# fill thresholds for the remaining grades
@@ -187,11 +193,11 @@ func copy_from(rank_criteria: RankCriteria) -> void:
 ## 	'factor': A number in the range (0.0, 1.0) for the factor to apply. A value of '0.1' will make a large
 ## 		adjustment, a value of '0.9' will make a small adjustment.
 func soften(grade: String, factor: float) -> void:
-	if not thresholds_by_grade.has(Ranks.BEST_GRADE):
-		push_error("Level %s does not define '%s' rank criteria" % [CurrentLevel.level_id, Ranks.BEST_GRADE])
+	if not thresholds_by_grade.has(PERFECT_GRADE):
+		push_error("Level %s does not define '%s' rank criteria" % [CurrentLevel.level_id, PERFECT_GRADE])
 		return
 	
-	var new_threshold: int = thresholds_by_grade[Ranks.BEST_GRADE]
+	var new_threshold: int = thresholds_by_grade[PERFECT_GRADE]
 	if duration_criteria:
 		new_threshold = new_threshold * TIME_PERCENT_BY_GRADE[grade] / factor
 	else:
@@ -233,7 +239,7 @@ func _sanitize_threshold(value: int) -> int:
 static func _higher_grade_by_grades(new_thresholds: Dictionary) -> Dictionary:
 	var result := {}
 	
-	var higher_grade := Ranks.BEST_GRADE
+	var higher_grade := PERFECT_GRADE
 	var grades := SCORE_PERCENT_BY_GRADE.keys()
 	for grade in grades:
 		if new_thresholds.has(grade):

--- a/project/src/test/puzzle/level/test-level-settings.gd
+++ b/project/src/test/puzzle/level/test-level-settings.gd
@@ -99,6 +99,12 @@ func test_load_59c3_data() -> void:
 	assert_eq(settings.blocks_during.top_out_effect, BlocksDuringRules.TopOutEffect.CLEAR)
 
 
+func test_load_5a6b_data() -> void:
+	load_level("level-5a6b")
+	
+	assert_eq(settings.rank.rank_criteria.thresholds_by_grade.get("TOP"), 7560)
+
+
 func test_load_tiles() -> void:
 	load_level("level-tiles")
 	

--- a/project/src/test/puzzle/test-rank-calculator.gd
+++ b/project/src/test/puzzle/test-rank-calculator.gd
@@ -8,7 +8,7 @@ func before_each() -> void:
 
 
 func test_filled_rank_criteria_marathon() -> void:
-	CurrentLevel.settings.rank.rank_criteria.add_threshold("M", 1000)
+	CurrentLevel.settings.rank.rank_criteria.add_threshold("TOP", 1000)
 	var rank_criteria := _rank_calculator.filled_rank_criteria()
 	
 	assert_eq(rank_criteria.thresholds_by_grade.get("M"), 1000)
@@ -18,7 +18,7 @@ func test_filled_rank_criteria_marathon() -> void:
 
 
 func test_filled_rank_criteria_marathon_with_s() -> void:
-	CurrentLevel.settings.rank.rank_criteria.add_threshold("M", 1000)
+	CurrentLevel.settings.rank.rank_criteria.add_threshold("TOP", 1000)
 	CurrentLevel.settings.rank.rank_criteria.add_threshold("S-", 900)
 	var rank_criteria := _rank_calculator.filled_rank_criteria()
 	
@@ -31,7 +31,7 @@ func test_filled_rank_criteria_marathon_with_s() -> void:
 func test_filled_rank_criteria_ultra() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 2000)
 	CurrentLevel.settings.rank.rank_criteria.duration_criteria = true
-	CurrentLevel.settings.rank.rank_criteria.add_threshold("M", 110)
+	CurrentLevel.settings.rank.rank_criteria.add_threshold("TOP", 110)
 	var rank_criteria := _rank_calculator.filled_rank_criteria()
 	
 	assert_eq(rank_criteria.thresholds_by_grade.get("M"), 110)
@@ -43,7 +43,7 @@ func test_filled_rank_criteria_ultra() -> void:
 
 func test_filled_rank_criteria_ultra_with_s() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 2000)
-	CurrentLevel.settings.rank.rank_criteria.add_threshold("M", 110)
+	CurrentLevel.settings.rank.rank_criteria.add_threshold("TOP", 110)
 	CurrentLevel.settings.rank.rank_criteria.add_threshold("S-", 200)
 	var rank_criteria := _rank_calculator.filled_rank_criteria()
 	
@@ -54,7 +54,7 @@ func test_filled_rank_criteria_ultra_with_s() -> void:
 
 func test_filled_rank_criteria_sprint_short() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.TIME_OVER, 5)
-	CurrentLevel.settings.rank.rank_criteria.add_threshold("M", 50)
+	CurrentLevel.settings.rank.rank_criteria.add_threshold("TOP", 50)
 	var rank_criteria := _rank_calculator.filled_rank_criteria()
 	
 	# Score criteria can be identical; some grades are impossible. Score criteria can be low but should never be zero.
@@ -65,7 +65,7 @@ func test_filled_rank_criteria_sprint_short() -> void:
 
 func test_filled_rank_criteria_ultra_short() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 2)
-	CurrentLevel.settings.rank.rank_criteria.add_threshold("M", 4)
+	CurrentLevel.settings.rank.rank_criteria.add_threshold("TOP", 4)
 	var rank_criteria := _rank_calculator.filled_rank_criteria()
 	
 	# Score criteria can be identical, some grades are impossible.
@@ -75,7 +75,7 @@ func test_filled_rank_criteria_ultra_short() -> void:
 
 func test_calculate_rank_marathon_hard() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.LINES, 200)
-	CurrentLevel.settings.rank.rank_criteria.add_threshold("M", 6939)
+	CurrentLevel.settings.rank.rank_criteria.add_threshold("TOP", 6939)
 	PuzzleState.level_performance.score = 2200
 	var rank_result := _rank_calculator.calculate_rank()
 
@@ -84,7 +84,7 @@ func test_calculate_rank_marathon_hard() -> void:
 
 func test_calculate_rank_marathon_zero_lines() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.LINES, 10)
-	CurrentLevel.settings.rank.rank_criteria.add_threshold("M", 345)
+	CurrentLevel.settings.rank.rank_criteria.add_threshold("TOP", 345)
 	PuzzleState.level_performance.score = 0
 	var rank_result := _rank_calculator.calculate_rank()
 
@@ -93,7 +93,7 @@ func test_calculate_rank_marathon_zero_lines() -> void:
 
 func test_calculate_rank_marathon_hard_master() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.LINES, 200)
-	CurrentLevel.settings.rank.rank_criteria.add_threshold("M", 6939)
+	CurrentLevel.settings.rank.rank_criteria.add_threshold("TOP", 6939)
 	PuzzleState.level_performance.score = 7700
 	var rank_result := _rank_calculator.calculate_rank()
 
@@ -102,7 +102,7 @@ func test_calculate_rank_marathon_hard_master() -> void:
 
 func test_calculate_rank_ultra_hard() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 200)
-	CurrentLevel.settings.rank.rank_criteria.add_threshold("M", 44)
+	CurrentLevel.settings.rank.rank_criteria.add_threshold("TOP", 44)
 	PuzzleState.level_performance.seconds = 74
 	var rank_result := _rank_calculator.calculate_rank()
 
@@ -111,7 +111,7 @@ func test_calculate_rank_ultra_hard() -> void:
 
 func test_calculate_rank_ultra_hard_timeout() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 200)
-	CurrentLevel.settings.rank.rank_criteria.add_threshold("M", 44)
+	CurrentLevel.settings.rank.rank_criteria.add_threshold("TOP", 44)
 	PuzzleState.level_performance.seconds = 9999
 	var rank_result := _rank_calculator.calculate_rank()
 
@@ -120,7 +120,7 @@ func test_calculate_rank_ultra_hard_timeout() -> void:
 
 func test_calculate_rank_ultra_hard_master() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 200)
-	CurrentLevel.settings.rank.rank_criteria.add_threshold("M", 44)
+	CurrentLevel.settings.rank.rank_criteria.add_threshold("TOP", 44)
 	PuzzleState.level_performance.seconds = 34
 	var rank_result := _rank_calculator.calculate_rank()
 
@@ -129,7 +129,7 @@ func test_calculate_rank_ultra_hard_master() -> void:
 
 func test_calculate_rank_ultra_fail() -> void:
 	CurrentLevel.settings.set_finish_condition(Milestone.SCORE, 200)
-	CurrentLevel.settings.rank.rank_criteria.add_threshold("M", 44)
+	CurrentLevel.settings.rank.rank_criteria.add_threshold("TOP", 44)
 	PuzzleState.level_performance.seconds = 34
 	PuzzleState.level_performance.lost = true
 	var rank_result := _rank_calculator.calculate_rank()
@@ -139,7 +139,7 @@ func test_calculate_rank_ultra_fail() -> void:
 
 func test_unranked() -> void:
 	CurrentLevel.settings.rank.unranked = true
-	CurrentLevel.settings.rank.rank_criteria.add_threshold("M", 1)
+	CurrentLevel.settings.rank.rank_criteria.add_threshold("TOP", 1)
 	var rank_result := _rank_calculator.calculate_rank()
 	
 	# the player finishes the level; they automatically get a master rank
@@ -149,7 +149,7 @@ func test_unranked() -> void:
 func test_unranked_loss() -> void:
 	CurrentLevel.settings.rank.unranked = true
 	PuzzleState.level_performance.lost = true
-	CurrentLevel.settings.rank.rank_criteria.add_threshold("M", 1)
+	CurrentLevel.settings.rank.rank_criteria.add_threshold("TOP", 1)
 	var rank_result := _rank_calculator.calculate_rank()
 	
 	# the player lost the level; they get the worst rank

--- a/project/src/test/puzzle/test-rank-criteria.gd
+++ b/project/src/test/puzzle/test-rank-criteria.gd
@@ -8,7 +8,7 @@ func before_each() -> void:
 
 func test_soften_marathon() -> void:
 	criteria.duration_criteria = false
-	criteria.add_threshold("M", 10000)
+	criteria.add_threshold("TOP", 10000)
 	
 	assert_eq(2150, threshold_for_grade("S-"))
 	
@@ -18,7 +18,7 @@ func test_soften_marathon() -> void:
 
 func test_soften_ultra() -> void:
 	criteria.duration_criteria = true
-	criteria.add_threshold("M", 17)
+	criteria.add_threshold("TOP", 17)
 	
 	assert_eq(80, threshold_for_grade("S-"))
 	


### PR DESCRIPTION
RankCriteria now defines a distinct 'TOP' grade. Currently this is the exact same as the 'M' grade, but we can now decrease the score/time requirements for 'M' grades to make the grade more achieveable.

Since levels define their own arbitrary values for what constitutes an 'M' rank, this might be counterintuitive. Why define an arbitrary value of what a 'TOP' grade is, only to have master grades be an arbitrary fraction of it? However, keeping these separate allows us to more easily make sweeping changes such as deciding a master grades is 99% or 80% of a perfect grade. Otherwise, we'd need to make those changes in 200 different level definitions.