### PR TITLE
Adjusted Starberry Mountain rank criteria for a few trouble levels

### DIFF
--- a/project/assets/main/puzzle/levels/career/dark/a-little-extra.json
+++ b/project/assets/main/puzzle/levels/career/dark/a-little-extra.json
@@ -12,7 +12,7 @@
   ],
   "rank": [
     "duration 150",
-    "rank_criteria top=2800"
+    "rank_criteria top=2200"
   ],
   "tiles": {
     "start": [

--- a/project/assets/main/puzzle/levels/career/dark/cheddarbox-blitz.json
+++ b/project/assets/main/puzzle/levels/career/dark/cheddarbox-blitz.json
@@ -27,7 +27,7 @@
   ],
   "rank": [
     "duration 175",
-    "rank_criteria top=4300"
+    "rank_criteria top=3400"
   ],
   "score": [
     "cake_all 20",

--- a/project/assets/main/puzzle/levels/career/dark/no-smoking-section-2.json
+++ b/project/assets/main/puzzle/levels/career/dark/no-smoking-section-2.json
@@ -6,38 +6,38 @@
   "speed_ups": [
     {
       "type": "lines",
-      "value": 70,
+      "value": 50,
       "speed": "A5"
     },
     {
       "type": "lines",
-      "value": 80,
+      "value": 60,
       "speed": "A6"
     },
     {
       "type": "lines",
-      "value": 90,
+      "value": 70,
       "speed": "A7"
     },
     {
       "type": "lines",
-      "value": 100,
+      "value": 80,
       "speed": "A8"
     },
     {
       "type": "lines",
-      "value": 110,
+      "value": 90,
       "speed": "A9"
     },
     {
       "type": "lines",
-      "value": 120,
+      "value": 100,
       "speed": "AA"
     }
   ],
   "finish_condition": {
     "type": "score",
-    "value": 1800
+    "value": 1200
   },
   "icons": [
     "carrot",

--- a/project/assets/main/puzzle/levels/career/dark/strawberry-shortcut.json
+++ b/project/assets/main/puzzle/levels/career/dark/strawberry-shortcut.json
@@ -35,7 +35,7 @@
   ],
   "rank": [
     "duration 150",
-    "rank_criteria top=2700"
+    "rank_criteria top=2150"
   ],
   "tiles": {
     "0": [

--- a/project/assets/main/puzzle/levels/career/dark/sweet-dreams.json
+++ b/project/assets/main/puzzle/levels/career/dark/sweet-dreams.json
@@ -13,7 +13,7 @@
   ],
   "rank": [
     "duration 125",
-    "rank_criteria top=2750"
+    "rank_criteria top=2200"
   ],
   "triggers": [
     {

--- a/project/assets/main/puzzle/levels/career/dark/three-minute-sprint.json
+++ b/project/assets/main/puzzle/levels/career/dark/three-minute-sprint.json
@@ -12,6 +12,6 @@
   ],
   "rank": [
     "duration 180",
-    "rank_criteria top=3850"
+    "rank_criteria top=3050"
   ]
 }


### PR DESCRIPTION
After more playtesting, these levels were too difficult to reach the target scores even for expert-level players, so I've loosened their score criteria.

The level 'No Smoking Section 2' was difficult to complete even for expert-level players. I've decreased the scoring requirements, but left the grading criteria at its old values. It's still quite challenging to clear in under 2 minutes with the decreased scoring requirements. My personal best is 1:41.