### PR TITLE
Adjusted grading criteria for training/rank levels

### DIFF
--- a/project/assets/main/puzzle/levels/practice/marathon-expert.json
+++ b/project/assets/main/puzzle/levels/practice/marathon-expert.json
@@ -48,8 +48,8 @@
     "top_out 1"
   ],
   "rank": [
-    "duration 560",
-    "rank_criteria top=10000"
+    "duration 875",
+    "rank_criteria top=6400"
   ],
   "success_condition": {
     "type": "lines",

--- a/project/assets/main/puzzle/levels/practice/marathon-hard.json
+++ b/project/assets/main/puzzle/levels/practice/marathon-hard.json
@@ -63,7 +63,7 @@
   ],
   "rank": [
     "duration 710",
-    "rank_criteria top=6900"
+    "rank_criteria top=6200"
   ],
   "success_condition": {
     "type": "lines",

--- a/project/assets/main/puzzle/levels/practice/marathon-master.json
+++ b/project/assets/main/puzzle/levels/practice/marathon-master.json
@@ -44,8 +44,8 @@
     "top_out 1"
   ],
   "rank": [
-    "duration 355",
-    "rank_criteria top=16500"
+    "duration 550",
+    "rank_criteria top=10000"
   ],
   "success_condition": {
     "type": "lines",

--- a/project/assets/main/puzzle/levels/practice/marathon-normal.json
+++ b/project/assets/main/puzzle/levels/practice/marathon-normal.json
@@ -62,7 +62,7 @@
   ],
   "rank": [
     "duration 750",
-    "rank_criteria top=3600"
+    "rank_criteria top=3200"
   ],
   "success_condition": {
     "type": "lines",

--- a/project/assets/main/puzzle/levels/practice/sprint-expert.json
+++ b/project/assets/main/puzzle/levels/practice/sprint-expert.json
@@ -12,6 +12,6 @@
   ],
   "rank": [
     "duration 180",
-    "rank_criteria top=6750"
+    "rank_criteria top=4300"
   ]
 }

--- a/project/assets/main/puzzle/levels/practice/sprint-normal.json
+++ b/project/assets/main/puzzle/levels/practice/sprint-normal.json
@@ -11,6 +11,6 @@
   ],
   "rank": [
     "duration 150",
-    "rank_criteria top=2850"
+    "rank_criteria top=2550"
   ]
 }

--- a/project/assets/main/puzzle/levels/practice/ultra-expert.json
+++ b/project/assets/main/puzzle/levels/practice/ultra-expert.json
@@ -11,7 +11,7 @@
     "basic"
   ],
   "rank": [
-    "duration 140",
-    "rank_criteria top=90"
+    "duration 220",
+    "rank_criteria top=145"
   ]
 }

--- a/project/assets/main/puzzle/levels/practice/ultra-hard.json
+++ b/project/assets/main/puzzle/levels/practice/ultra-hard.json
@@ -12,6 +12,6 @@
   ],
   "rank": [
     "duration 460",
-    "rank_criteria top=55"
+    "rank_criteria top=65"
   ]
 }

--- a/project/assets/main/puzzle/levels/rank/10d.json
+++ b/project/assets/main/puzzle/levels/rank/10d.json
@@ -16,12 +16,12 @@
     "top_out 1"
   ],
   "rank": [
-    "duration 210",
-    "rank_criteria top=255",
+    "duration 265",
+    "rank_criteria top=400",
     "success_bonus 2"
   ],
   "success_condition": {
     "type": "time_under",
-    "value": 360
+    "value": 450
   }
 }

--- a/project/assets/main/puzzle/levels/rank/1d.json
+++ b/project/assets/main/puzzle/levels/rank/1d.json
@@ -38,7 +38,7 @@
   ],
   "rank": [
     "duration 870",
-    "rank_criteria top=6250",
+    "rank_criteria top=5000",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/1k.json
+++ b/project/assets/main/puzzle/levels/rank/1k.json
@@ -63,7 +63,7 @@
   ],
   "rank": [
     "duration 1100",
-    "rank_criteria top=5250",
+    "rank_criteria top=4200",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/2d.json
+++ b/project/assets/main/puzzle/levels/rank/2d.json
@@ -16,7 +16,7 @@
   ],
   "rank": [
     "duration 360",
-    "rank_criteria top=85",
+    "rank_criteria top=110",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/2k.json
+++ b/project/assets/main/puzzle/levels/rank/2k.json
@@ -14,7 +14,7 @@
   ],
   "rank": [
     "duration 255",
-    "rank_criteria top=37",
+    "rank_criteria top=46",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/3d.json
+++ b/project/assets/main/puzzle/levels/rank/3d.json
@@ -78,7 +78,7 @@
   ],
   "rank": [
     "duration 295",
-    "rank_criteria top=3600",
+    "rank_criteria top=2850",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/3k.json
+++ b/project/assets/main/puzzle/levels/rank/3k.json
@@ -17,7 +17,7 @@
   ],
   "rank": [
     "duration 540",
-    "rank_criteria top=9450",
+    "rank_criteria top=7550",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/4d.json
+++ b/project/assets/main/puzzle/levels/rank/4d.json
@@ -16,7 +16,7 @@
   ],
   "rank": [
     "duration 300",
-    "rank_criteria top=6200",
+    "rank_criteria top=4950",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/4k.json
+++ b/project/assets/main/puzzle/levels/rank/4k.json
@@ -14,7 +14,7 @@
   ],
   "rank": [
     "duration 150",
-    "rank_criteria top=2800",
+    "rank_criteria top=2200",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/5d.json
+++ b/project/assets/main/puzzle/levels/rank/5d.json
@@ -43,7 +43,7 @@
   ],
   "rank": [
     "duration 485",
-    "rank_criteria top=6900",
+    "rank_criteria top=5500",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/5k.json
+++ b/project/assets/main/puzzle/levels/rank/5k.json
@@ -14,7 +14,7 @@
   ],
   "rank": [
     "duration 750",
-    "rank_criteria top=3600",
+    "rank_criteria top=2850",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/6d.json
+++ b/project/assets/main/puzzle/levels/rank/6d.json
@@ -17,7 +17,7 @@
   ],
   "rank": [
     "duration 185",
-    "rank_criteria top=100",
+    "rank_criteria top=80",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/6k.json
+++ b/project/assets/main/puzzle/levels/rank/6k.json
@@ -14,7 +14,7 @@
   ],
   "rank": [
     "duration 180",
-    "rank_criteria top=3350",
+    "rank_criteria top=2650",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/7d.json
+++ b/project/assets/main/puzzle/levels/rank/7d.json
@@ -84,7 +84,7 @@
   ],
   "rank": [
     "duration 460",
-    "rank_criteria top=13500",
+    "rank_criteria top=10500",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/8d.json
+++ b/project/assets/main/puzzle/levels/rank/8d.json
@@ -16,8 +16,8 @@
     "top_out 1"
   ],
   "rank": [
-    "duration 240",
-    "rank_criteria top=8900",
+    "duration 300",
+    "rank_criteria top=5650",
     "success_bonus 2"
   ],
   "success_condition": {

--- a/project/assets/main/puzzle/levels/rank/9d.json
+++ b/project/assets/main/puzzle/levels/rank/9d.json
@@ -16,12 +16,12 @@
     "top_out 1"
   ],
   "rank": [
-    "duration 195",
-    "rank_criteria top=6900",
+    "duration 240",
+    "rank_criteria top=4400",
     "success_bonus 2"
   ],
   "success_condition": {
     "type": "score",
-    "value": 5000
+    "value": 4000
   }
 }

--- a/project/assets/main/puzzle/levels/rank/m.json
+++ b/project/assets/main/puzzle/levels/rank/m.json
@@ -55,11 +55,11 @@
   ],
   "rank": [
     "duration 410",
-    "rank_criteria top=20000",
+    "rank_criteria top=12500",
     "success_bonus 2"
   ],
   "success_condition": {
     "type": "score",
-    "value": 10000
+    "value": 8000
   }
 }


### PR DESCRIPTION
The training/rank level grading criteria were still based on a mathematical model and not player data. I decreased the criteria for slower levels ('AF' and slower) by about 20%. I sharply decreased the criteria for faster levels ('FA' and faster) by about 40%.

Slightly reduced the clear requirements for 9-dan and Master Rank courses. Nobody in the Turbo Fat community has ever cleared anything past 8-dan, and even with the decreased 9-dan scoring requirements I think it will remain an insurmountable challenge. My best score for 9-dan is $1,879 and 179 lines.