### PR TITLE
Bug: Progress board was not centered.

### DIFF
--- a/project/src/demo/career/ui/progress-board-demo.gd
+++ b/project/src/demo/career/ui/progress-board-demo.gd
@@ -17,7 +17,7 @@ extends Node
 
 onready var _progress_board := $ProgressBoard
 onready var _label := $Label
-onready var _player := $ProgressBoard/ChalkboardRegion/Player
+onready var _player := $ProgressBoard/ChalkboardRegion/Swoosher/Player
 
 func _ready() -> void:
 	PlayerData.career.hours_passed = 2

--- a/project/src/main/career/ui/ProgressBoard.tscn
+++ b/project/src/main/career/ui/ProgressBoard.tscn
@@ -262,7 +262,7 @@ tracks/1/keys = {
 "values": [ Color( 1, 1, 1, 1 ) ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("ChalkboardRegion:rect_position:x")
+tracks/2/path = NodePath("ChalkboardRegion:visible")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -271,10 +271,10 @@ tracks/2/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
 "update": 0,
-"values": [ 171.8 ]
+"values": [ true ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("ChalkboardRegion:rect_scale")
+tracks/3/path = NodePath("ChalkboardRegion:modulate")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
@@ -283,10 +283,10 @@ tracks/3/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
 "update": 0,
-"values": [ Vector2( 1, 1 ) ]
+"values": [ Color( 1, 1, 1, 1 ) ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("ChalkboardRegion:visible")
+tracks/4/path = NodePath("ChalkboardRegion/Swoosher:rect_position:x")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
@@ -295,10 +295,10 @@ tracks/4/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
 "update": 0,
-"values": [ true ]
+"values": [ 171.8 ]
 }
 tracks/5/type = "value"
-tracks/5/path = NodePath("ChalkboardRegion:modulate")
+tracks/5/path = NodePath("ChalkboardRegion/Swoosher:rect_scale")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/imported = false
@@ -307,10 +307,10 @@ tracks/5/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
 "update": 0,
-"values": [ Color( 1, 1, 1, 1 ) ]
+"values": [ Vector2( 1, 1 ) ]
 }
 tracks/6/type = "value"
-tracks/6/path = NodePath("Clock:rect_position:x")
+tracks/6/path = NodePath("Clock/Swoosher:rect_position:x")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
@@ -319,7 +319,7 @@ tracks/6/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
 "update": 0,
-"values": [ 422.0 ]
+"values": [ 0.0 ]
 }
 tracks/7/type = "value"
 tracks/7/path = NodePath("Clock:visible")
@@ -346,7 +346,7 @@ tracks/8/keys = {
 "values": [ Color( 1, 1, 1, 1 ) ]
 }
 tracks/9/type = "value"
-tracks/9/path = NodePath("ChalkboardIntro:rect_position:x")
+tracks/9/path = NodePath("ChalkboardIntro:visible")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
@@ -354,11 +354,11 @@ tracks/9/enabled = true
 tracks/9/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ 32.0 ]
+"update": 1,
+"values": [ false ]
 }
 tracks/10/type = "value"
-tracks/10/path = NodePath("ChalkboardIntro:rect_scale")
+tracks/10/path = NodePath("ChalkboardIntro:modulate")
 tracks/10/interp = 1
 tracks/10/loop_wrap = true
 tracks/10/imported = false
@@ -367,10 +367,10 @@ tracks/10/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
 "update": 0,
-"values": [ Vector2( 1, 1 ) ]
+"values": [ Color( 1, 1, 1, 1 ) ]
 }
 tracks/11/type = "value"
-tracks/11/path = NodePath("ChalkboardIntro:visible")
+tracks/11/path = NodePath("ChalkboardIntro/Swoosher:rect_position:x")
 tracks/11/interp = 1
 tracks/11/loop_wrap = true
 tracks/11/imported = false
@@ -378,11 +378,11 @@ tracks/11/enabled = true
 tracks/11/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
-"update": 1,
-"values": [ false ]
+"update": 0,
+"values": [ 32.0 ]
 }
 tracks/12/type = "value"
-tracks/12/path = NodePath("ChalkboardIntro:modulate")
+tracks/12/path = NodePath("ChalkboardIntro/Swoosher:rect_scale")
 tracks/12/interp = 1
 tracks/12/loop_wrap = true
 tracks/12/imported = false
@@ -391,10 +391,10 @@ tracks/12/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
 "update": 0,
-"values": [ Color( 1, 1, 1, 1 ) ]
+"values": [ Vector2( 1, 1 ) ]
 }
 tracks/13/type = "value"
-tracks/13/path = NodePath("ChalkboardIntro/VBoxContainer/ButtonRow/ZHolder/Button:visible")
+tracks/13/path = NodePath("ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/ButtonRow/ZHolder/Button:visible")
 tracks/13/interp = 1
 tracks/13/loop_wrap = true
 tracks/13/imported = false
@@ -417,11 +417,35 @@ tracks/14/keys = {
 "update": 0,
 "values": [ false ]
 }
+tracks/15/type = "value"
+tracks/15/path = NodePath("ChalkboardRegion/Swoosher:rect_position")
+tracks/15/interp = 1
+tracks/15/loop_wrap = true
+tracks/15/imported = false
+tracks/15/enabled = true
+tracks/15/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ Vector2( 0, 0 ) ]
+}
+tracks/16/type = "value"
+tracks/16/path = NodePath("ChalkboardIntro/Swoosher:rect_position")
+tracks/16/interp = 1
+tracks/16/loop_wrap = true
+tracks/16/imported = false
+tracks/16/enabled = true
+tracks/16/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ Vector2( 0, 0 ) ]
+}
 
 [sub_resource type="Animation" id=36]
 resource_name = "hide"
 length = 0.166667
-step = 1.0
+step = 0.0166667
 tracks/0/type = "value"
 tracks/0/path = NodePath("Backdrop:visible")
 tracks/0/interp = 1
@@ -447,55 +471,55 @@ tracks/1/keys = {
 "values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("ChalkboardRegion:rect_position:x")
+tracks/2/path = NodePath("ChalkboardRegion:visible")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
 tracks/2/enabled = true
 tracks/2/keys = {
-"times": PoolRealArray( 0.0333333, 0.166667 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ 171.8, 521.8 ]
-}
-tracks/3/type = "value"
-tracks/3/path = NodePath("ChalkboardRegion:rect_scale")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/keys = {
-"times": PoolRealArray( 0.0333333, 0.0666667, 0.166667 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
-"update": 0,
-"values": [ Vector2( 1, 1 ), Vector2( 1.02, 0.98 ), Vector2( 1.02, 0.98 ) ]
-}
-tracks/4/type = "value"
-tracks/4/path = NodePath("ChalkboardRegion:visible")
-tracks/4/interp = 1
-tracks/4/loop_wrap = true
-tracks/4/imported = false
-tracks/4/enabled = true
-tracks/4/keys = {
 "times": PoolRealArray( 0.033, 0.166667 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 1,
 "values": [ true, false ]
 }
-tracks/5/type = "value"
-tracks/5/path = NodePath("ChalkboardRegion:modulate")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/keys = {
+tracks/3/type = "value"
+tracks/3/path = NodePath("ChalkboardRegion:modulate")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/keys = {
 "times": PoolRealArray( 0.0333333, 0.166667 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 0,
 "values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
 }
+tracks/4/type = "value"
+tracks/4/path = NodePath("ChalkboardRegion/Swoosher:rect_position:x")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/keys = {
+"times": PoolRealArray( 0.0333333, 0.166667 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 0,
+"values": [ 0.0, 350.0 ]
+}
+tracks/5/type = "value"
+tracks/5/path = NodePath("ChalkboardRegion/Swoosher:rect_scale")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/keys = {
+"times": PoolRealArray( 0.0333333, 0.0666667, 0.166667 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( 1, 1 ), Vector2( 1.02, 0.98 ), Vector2( 1.02, 0.98 ) ]
+}
 tracks/6/type = "value"
-tracks/6/path = NodePath("Clock:rect_position:x")
+tracks/6/path = NodePath("Clock/Swoosher:rect_position:x")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
@@ -504,7 +528,7 @@ tracks/6/keys = {
 "times": PoolRealArray( 0.0333333, 0.166667 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 0,
-"values": [ 422.0, 822.0 ]
+"values": [ 0.0, 400.0 ]
 }
 tracks/7/type = "value"
 tracks/7/path = NodePath("Clock:visible")
@@ -586,52 +610,52 @@ tracks/2/keys = {
 "values": [ false ]
 }
 tracks/3/type = "value"
-tracks/3/path = NodePath("ChalkboardIntro:rect_position:x")
+tracks/3/path = NodePath("ChalkboardIntro:visible")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/imported = false
 tracks/3/enabled = true
 tracks/3/keys = {
-"times": PoolRealArray( 0.0333333, 0.166667 ),
-"transitions": PoolRealArray( 1, 1 ),
-"update": 0,
-"values": [ 171.8, 521.8 ]
-}
-tracks/4/type = "value"
-tracks/4/path = NodePath("ChalkboardIntro:rect_scale")
-tracks/4/interp = 1
-tracks/4/loop_wrap = true
-tracks/4/imported = false
-tracks/4/enabled = true
-tracks/4/keys = {
-"times": PoolRealArray( 0.0333333, 0.0666667, 0.166667 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
-"update": 0,
-"values": [ Vector2( 1, 1 ), Vector2( 1.02, 0.98 ), Vector2( 1.02, 0.98 ) ]
-}
-tracks/5/type = "value"
-tracks/5/path = NodePath("ChalkboardIntro:visible")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/keys = {
 "times": PoolRealArray( 0.033, 0.166667 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 1,
 "values": [ true, false ]
 }
+tracks/4/type = "value"
+tracks/4/path = NodePath("ChalkboardIntro:modulate")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/keys = {
+"times": PoolRealArray( 0.0333333, 0.166667 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 0,
+"values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
+}
+tracks/5/type = "value"
+tracks/5/path = NodePath("ChalkboardIntro/Swoosher:rect_position:x")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/keys = {
+"times": PoolRealArray( 0.0333333, 0.166667 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 0,
+"values": [ 0.0, 350.0 ]
+}
 tracks/6/type = "value"
-tracks/6/path = NodePath("ChalkboardIntro:modulate")
+tracks/6/path = NodePath("ChalkboardIntro/Swoosher:rect_scale")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
-"times": PoolRealArray( 0.0333333, 0.166667 ),
-"transitions": PoolRealArray( 1, 1 ),
+"times": PoolRealArray( 0.0333333, 0.0666667, 0.166667 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
 "update": 0,
-"values": [ Color( 1, 1, 1, 1 ), Color( 1, 1, 1, 0 ) ]
+"values": [ Vector2( 1, 1 ), Vector2( 1.02, 0.98 ), Vector2( 1.02, 0.98 ) ]
 }
 tracks/7/type = "audio"
 tracks/7/path = NodePath("ProgressBoardDisappear")
@@ -677,79 +701,79 @@ tracks/1/keys = {
 "values": [ Color( 1, 1, 1, 1 ) ]
 }
 tracks/2/type = "value"
-tracks/2/path = NodePath("ChalkboardRegion:rect_position:x")
+tracks/2/path = NodePath("ChalkboardRegion:visible")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
 tracks/2/enabled = true
 tracks/2/keys = {
-"times": PoolRealArray( 0, 0.233333, 0.366667 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
-"update": 0,
-"values": [ 21.8, 21.8, 171.8 ]
-}
-tracks/3/type = "value"
-tracks/3/path = NodePath("ChalkboardRegion:rect_scale")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/keys = {
-"times": PoolRealArray( 0, 0.233333, 0.366667, 0.416667, 0.5 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
-"update": 0,
-"values": [ Vector2( 1.05, 0.95 ), Vector2( 1.05, 0.95 ), Vector2( 1.05, 0.95 ), Vector2( 0.99, 1.01 ), Vector2( 1, 1 ) ]
-}
-tracks/4/type = "value"
-tracks/4/path = NodePath("ChalkboardRegion:visible")
-tracks/4/interp = 1
-tracks/4/loop_wrap = true
-tracks/4/imported = false
-tracks/4/enabled = true
-tracks/4/keys = {
 "times": PoolRealArray( 0, 0.231 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 1,
 "values": [ false, true ]
 }
-tracks/5/type = "value"
-tracks/5/path = NodePath("ChalkboardRegion:modulate")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/keys = {
+tracks/3/type = "value"
+tracks/3/path = NodePath("ChalkboardRegion:modulate")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/keys = {
 "times": PoolRealArray( 0, 0.233333, 0.366667 ),
 "transitions": PoolRealArray( 1, 1, 1 ),
 "update": 0,
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ) ]
 }
+tracks/4/type = "value"
+tracks/4/path = NodePath("ChalkboardRegion/Swoosher:rect_position:x")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/keys = {
+"times": PoolRealArray( 0, 0.233333, 0.366667 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ -150.0, -150.0, 0.0 ]
+}
+tracks/5/type = "value"
+tracks/5/path = NodePath("ChalkboardRegion/Swoosher:rect_scale")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/keys = {
+"times": PoolRealArray( 0, 0.233333, 0.366667, 0.416667, 0.5 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( 1.05, 0.95 ), Vector2( 1.05, 0.95 ), Vector2( 1.05, 0.95 ), Vector2( 0.99, 1.01 ), Vector2( 1, 1 ) ]
+}
 tracks/6/type = "value"
-tracks/6/path = NodePath("Clock:rect_position:x")
+tracks/6/path = NodePath("Clock:visible")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/imported = false
 tracks/6/enabled = true
 tracks/6/keys = {
-"times": PoolRealArray( 0, 0.233333, 0.366667 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
-"update": 0,
-"values": [ 322.0, 322.0, 422.0 ]
-}
-tracks/7/type = "value"
-tracks/7/path = NodePath("Clock:visible")
-tracks/7/interp = 1
-tracks/7/loop_wrap = true
-tracks/7/imported = false
-tracks/7/enabled = true
-tracks/7/keys = {
 "times": PoolRealArray( 0, 0.233333 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 1,
 "values": [ false, true ]
 }
+tracks/7/type = "value"
+tracks/7/path = NodePath("Clock:modulate")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/keys = {
+"times": PoolRealArray( 0, 0.233333, 0.366667 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ) ]
+}
 tracks/8/type = "value"
-tracks/8/path = NodePath("Clock:modulate")
+tracks/8/path = NodePath("Clock/Swoosher:rect_position:x")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
@@ -758,7 +782,7 @@ tracks/8/keys = {
 "times": PoolRealArray( 0, 0.233333, 0.366667 ),
 "transitions": PoolRealArray( 1, 1, 1 ),
 "update": 0,
-"values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ) ]
+"values": [ -100.0, -100.0, 0.0 ]
 }
 tracks/9/type = "value"
 tracks/9/path = NodePath("ChalkboardIntro:visible")
@@ -840,55 +864,55 @@ tracks/3/keys = {
 "values": [ false ]
 }
 tracks/4/type = "value"
-tracks/4/path = NodePath("ChalkboardIntro:rect_position:x")
+tracks/4/path = NodePath("ChalkboardIntro:visible")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/imported = false
 tracks/4/enabled = true
 tracks/4/keys = {
-"times": PoolRealArray( 0, 0.233333, 0.366667 ),
-"transitions": PoolRealArray( 1, 1, 1 ),
-"update": 0,
-"values": [ -118.0, -118.0, 32.0 ]
-}
-tracks/5/type = "value"
-tracks/5/path = NodePath("ChalkboardIntro:rect_scale")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/keys = {
-"times": PoolRealArray( 0, 0.233333, 0.366667, 0.416667, 0.5 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
-"update": 0,
-"values": [ Vector2( 1.05, 0.95 ), Vector2( 1.05, 0.95 ), Vector2( 1.05, 0.95 ), Vector2( 0.99, 1.01 ), Vector2( 1, 1 ) ]
-}
-tracks/6/type = "value"
-tracks/6/path = NodePath("ChalkboardIntro:visible")
-tracks/6/interp = 1
-tracks/6/loop_wrap = true
-tracks/6/imported = false
-tracks/6/enabled = true
-tracks/6/keys = {
 "times": PoolRealArray( 0, 0.231 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 1,
 "values": [ false, true ]
 }
-tracks/7/type = "value"
-tracks/7/path = NodePath("ChalkboardIntro:modulate")
-tracks/7/interp = 1
-tracks/7/loop_wrap = true
-tracks/7/imported = false
-tracks/7/enabled = true
-tracks/7/keys = {
+tracks/5/type = "value"
+tracks/5/path = NodePath("ChalkboardIntro:modulate")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/keys = {
 "times": PoolRealArray( 0, 0.233333, 0.366667 ),
 "transitions": PoolRealArray( 1, 1, 1 ),
 "update": 0,
 "values": [ Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 0 ), Color( 1, 1, 1, 1 ) ]
 }
+tracks/6/type = "value"
+tracks/6/path = NodePath("ChalkboardIntro/Swoosher:rect_position:x")
+tracks/6/interp = 1
+tracks/6/loop_wrap = true
+tracks/6/imported = false
+tracks/6/enabled = true
+tracks/6/keys = {
+"times": PoolRealArray( 0, 0.233333, 0.366667 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ -150.0, -150.0, 0.0 ]
+}
+tracks/7/type = "value"
+tracks/7/path = NodePath("ChalkboardIntro/Swoosher:rect_scale")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/keys = {
+"times": PoolRealArray( 0, 0.233333, 0.366667, 0.416667, 0.5 ),
+"transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( 1.05, 0.95 ), Vector2( 1.05, 0.95 ), Vector2( 1.05, 0.95 ), Vector2( 0.99, 1.01 ), Vector2( 1, 1 ) ]
+}
 tracks/8/type = "value"
-tracks/8/path = NodePath("ChalkboardIntro/VBoxContainer/ButtonRow/ZHolder/Button:visible")
+tracks/8/path = NodePath("ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/ButtonRow/ZHolder/Button:visible")
 tracks/8/interp = 1
 tracks/8/loop_wrap = true
 tracks/8/imported = false
@@ -900,7 +924,7 @@ tracks/8/keys = {
 "values": [ false, true ]
 }
 tracks/9/type = "method"
-tracks/9/path = NodePath("ChalkboardIntro/VBoxContainer/ButtonRow/ZHolder/Button")
+tracks/9/path = NodePath("ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/ButtonRow/ZHolder/Button")
 tracks/9/interp = 1
 tracks/9/loop_wrap = true
 tracks/9/imported = false
@@ -941,32 +965,50 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-margin_left = -340.2
+margin_left = -340.202
 margin_top = -233.604
-margin_right = 340.203
+margin_right = 340.202
 margin_bottom = 233.604
+rect_scale = Vector2( 1.05, 0.95 )
 rect_pivot_offset = Vector2( 340.2, 233.604 )
 mouse_filter = 2
 
-[node name="Chalkboard" type="TextureRect" parent="ChalkboardRegion"]
-anchor_right = 1.0
-anchor_bottom = 1.0
+[node name="Swoosher" type="Control" parent="ChalkboardRegion"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -340.202
+margin_top = -233.604
+margin_right = 340.202
+margin_bottom = 233.604
+rect_pivot_offset = Vector2( 340.201, 233.604 )
+
+[node name="Chalkboard" type="TextureRect" parent="ChalkboardRegion/Swoosher"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -340.202
+margin_top = -233.604
+margin_right = 340.202
+margin_bottom = 233.604
 texture = ExtResource( 13 )
 expand = true
 stretch_mode = 1
 
-[node name="MapHolder" type="Control" parent="ChalkboardRegion"]
+[node name="MapHolder" type="Control" parent="ChalkboardRegion/Swoosher"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource( 19 )
 
-[node name="Map" parent="ChalkboardRegion/MapHolder" instance=ExtResource( 12 )]
+[node name="Map" parent="ChalkboardRegion/Swoosher/MapHolder" instance=ExtResource( 12 )]
 margin_right = 0.0
 margin_bottom = 0.0
 
-[node name="Trail" parent="ChalkboardRegion" instance=ExtResource( 8 )]
+[node name="Trail" parent="ChalkboardRegion/Swoosher" instance=ExtResource( 8 )]
 
-[node name="Player" type="Control" parent="ChalkboardRegion"]
+[node name="Player" type="Control" parent="ChalkboardRegion/Swoosher"]
 margin_left = 93.4843
 margin_top = 161.542
 margin_right = 93.4843
@@ -974,7 +1016,7 @@ margin_bottom = 161.542
 script = ExtResource( 6 )
 trail_path = NodePath("../Trail")
 
-[node name="PlayerSprite" type="Sprite" parent="ChalkboardRegion/Player"]
+[node name="PlayerSprite" type="Sprite" parent="ChalkboardRegion/Swoosher/Player"]
 material = SubResource( 29 )
 position = Vector2( 0, -24 )
 scale = Vector2( 0.4, 0.4 )
@@ -982,13 +1024,13 @@ texture = ExtResource( 11 )
 hframes = 2
 vframes = 2
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="ChalkboardRegion/Player/PlayerSprite"]
+[node name="AnimationPlayer" type="AnimationPlayer" parent="ChalkboardRegion/Swoosher/Player/PlayerSprite"]
 autoplay = "default"
 anims/RESET = SubResource( 23 )
 anims/alone = SubResource( 24 )
 anims/default = SubResource( 25 )
 
-[node name="Label" type="Label" parent="ChalkboardRegion/Player"]
+[node name="Label" type="Label" parent="ChalkboardRegion/Swoosher/Player"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -1004,16 +1046,16 @@ text = "0"
 align = 1
 valign = 1
 
-[node name="PlayerMoveSound" type="AudioStreamPlayer" parent="ChalkboardRegion/Player"]
+[node name="PlayerMoveSound" type="AudioStreamPlayer" parent="ChalkboardRegion/Swoosher/Player"]
 stream = ExtResource( 18 )
 bus = "Sound Bus"
 
-[node name="Shadow" type="Polygon2D" parent="ChalkboardRegion"]
+[node name="Shadow" type="Polygon2D" parent="ChalkboardRegion/Swoosher"]
 color = Color( 0, 0, 0, 0.392157 )
 antialiased = true
 polygon = PoolVector2Array( 16.2, 16.604, 21.2, 16.604, 21, 446, 664.2, 445.604, 664.2, 450.604, 16, 451 )
 
-[node name="GoalLabel" type="Control" parent="ChalkboardRegion"]
+[node name="GoalLabel" type="Control" parent="ChalkboardRegion/Swoosher"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -1025,7 +1067,7 @@ margin_bottom = 54.0
 rect_pivot_offset = Vector2( 50, 20 )
 script = ExtResource( 23 )
 
-[node name="Label" type="RichTextLabel" parent="ChalkboardRegion/GoalLabel"]
+[node name="Label" type="RichTextLabel" parent="ChalkboardRegion/Swoosher/GoalLabel"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -1043,7 +1085,7 @@ bbcode_text = "[center]GOAL[/center]"
 text = "GOAL"
 scroll_active = false
 
-[node name="Particles" parent="ChalkboardRegion/GoalLabel" instance=ExtResource( 20 )]
+[node name="Particles" parent="ChalkboardRegion/Swoosher/GoalLabel" instance=ExtResource( 20 )]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -1051,15 +1093,15 @@ anchor_bottom = 0.5
 margin_top = -32.0
 margin_bottom = -32.0
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="ChalkboardRegion/GoalLabel"]
+[node name="AnimationPlayer" type="AnimationPlayer" parent="ChalkboardRegion/Swoosher/GoalLabel"]
 anims/RESET = SubResource( 45 )
 anims/play = SubResource( 44 )
 
-[node name="GoalSound" type="AudioStreamPlayer" parent="ChalkboardRegion/GoalLabel"]
+[node name="GoalSound" type="AudioStreamPlayer" parent="ChalkboardRegion/Swoosher/GoalLabel"]
 stream = ExtResource( 25 )
 bus = "Sound Bus"
 
-[node name="Title" type="Control" parent="ChalkboardRegion"]
+[node name="Title" type="Control" parent="ChalkboardRegion/Swoosher"]
 modulate = Color( 1, 0.5, 0.945313, 1 )
 anchor_right = 1.0
 margin_left = 30.0
@@ -1068,17 +1110,17 @@ margin_right = -30.0
 margin_bottom = 70.7091
 script = ExtResource( 4 )
 
-[node name="HBoxContainer" type="HBoxContainer" parent="ChalkboardRegion/Title"]
+[node name="HBoxContainer" type="HBoxContainer" parent="ChalkboardRegion/Swoosher/Title"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 
-[node name="Control1" type="Control" parent="ChalkboardRegion/Title/HBoxContainer"]
+[node name="Control1" type="Control" parent="ChalkboardRegion/Swoosher/Title/HBoxContainer"]
 margin_right = 189.0
 margin_bottom = 50.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="TextureRect" type="TextureRect" parent="ChalkboardRegion/Title/HBoxContainer/Control1"]
+[node name="TextureRect" type="TextureRect" parent="ChalkboardRegion/Swoosher/Title/HBoxContainer/Control1"]
 modulate = Color( 1, 1, 1, 0.784314 )
 anchor_left = 0.5
 anchor_top = 0.5
@@ -1091,21 +1133,21 @@ margin_bottom = 25.0
 texture = ExtResource( 2 )
 expand = true
 
-[node name="Label" type="Label" parent="ChalkboardRegion/Title/HBoxContainer"]
+[node name="Label" type="Label" parent="ChalkboardRegion/Swoosher/Title/HBoxContainer"]
 margin_left = 193.0
 margin_right = 426.0
 margin_bottom = 50.0
 theme = ExtResource( 14 )
 text = "Lemony Thickets"
 
-[node name="Control2" type="Control" parent="ChalkboardRegion/Title/HBoxContainer"]
+[node name="Control2" type="Control" parent="ChalkboardRegion/Swoosher/Title/HBoxContainer"]
 margin_left = 430.0
 margin_right = 620.0
 margin_bottom = 50.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="TextureRect" type="TextureRect" parent="ChalkboardRegion/Title/HBoxContainer/Control2"]
+[node name="TextureRect" type="TextureRect" parent="ChalkboardRegion/Swoosher/Title/HBoxContainer/Control2"]
 modulate = Color( 1, 1, 1, 0.784314 )
 anchor_left = 0.5
 anchor_top = 0.5
@@ -1120,7 +1162,7 @@ texture = ExtResource( 2 )
 expand = true
 flip_h = true
 
-[node name="Grain" type="TextureRect" parent="ChalkboardRegion"]
+[node name="Grain" type="TextureRect" parent="ChalkboardRegion/Swoosher"]
 modulate = Color( 1, 1, 1, 0.705882 )
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -1141,16 +1183,21 @@ anchor_left = 0.5
 anchor_right = 0.5
 margin_left = -90.0
 margin_top = 8.0
-margin_right = 90.0028
+margin_right = 90.0029
 margin_bottom = 58.0
 mouse_filter = 2
 script = ExtResource( 7 )
 
-[node name="VisualsHolder" type="Control" parent="Clock"]
+[node name="Swoosher" type="Control" parent="Clock"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_right = -1.52588e-05
+
+[node name="VisualsHolder" type="Control" parent="Clock/Swoosher"]
 margin_right = 50.0
 margin_bottom = 50.0
 
-[node name="Visuals" type="Node2D" parent="Clock/VisualsHolder"]
+[node name="Visuals" type="Node2D" parent="Clock/Swoosher/VisualsHolder"]
 position = Vector2( 25, 25 )
 script = ExtResource( 5 )
 radius = 22.0
@@ -1160,7 +1207,7 @@ hour_hand_length = 10.0
 filled_color = Color( 0.894118, 0.709804, 0.584314, 1 )
 line_color = Color( 0.423529, 0.262745, 0.192157, 1 )
 
-[node name="MinuteHand" type="Line2D" parent="Clock/VisualsHolder/Visuals"]
+[node name="MinuteHand" type="Line2D" parent="Clock/Swoosher/VisualsHolder/Visuals"]
 points = PoolVector2Array( 0, 0, -6.55671e-07, -15 )
 width = 3.4
 default_color = Color( 0.423529, 0.262745, 0.192157, 1 )
@@ -1168,7 +1215,7 @@ begin_cap_mode = 2
 end_cap_mode = 2
 antialiased = true
 
-[node name="HourHand" type="Line2D" parent="Clock/VisualsHolder/Visuals"]
+[node name="HourHand" type="Line2D" parent="Clock/Swoosher/VisualsHolder/Visuals"]
 points = PoolVector2Array( 0, 0, -4.37114e-07, -10 )
 width = 3.4
 default_color = Color( 0.423529, 0.262745, 0.192157, 1 )
@@ -1176,17 +1223,17 @@ begin_cap_mode = 2
 end_cap_mode = 2
 antialiased = true
 
-[node name="Label" type="Label" parent="Clock"]
+[node name="Label" type="Label" parent="Clock/Swoosher"]
 anchor_bottom = 1.0
 margin_left = 60.0
-margin_right = 109.0
+margin_right = 169.0
 size_flags_vertical = 7
 custom_fonts/font = SubResource( 42 )
 text = "10:15 am"
 valign = 1
 script = ExtResource( 1 )
 
-[node name="Particles" parent="Clock/Label" instance=ExtResource( 20 )]
+[node name="Particles" parent="Clock/Swoosher/Label" instance=ExtResource( 20 )]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -1202,8 +1249,31 @@ stream = ExtResource( 17 )
 volume_db = -4.0
 bus = "Sound Bus"
 
-[node name="ChalkboardIntro" type="TextureRect" parent="."]
+[node name="ChalkboardIntro" type="Control" parent="."]
 visible = false
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -480.0
+margin_top = -291.2
+margin_right = 480.0
+margin_bottom = 291.2
+rect_pivot_offset = Vector2( 480, 291.2 )
+mouse_filter = 1
+
+[node name="Swoosher" type="Control" parent="ChalkboardIntro"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -480.0
+margin_top = -291.2
+margin_right = 480.0
+margin_bottom = 291.2
+rect_pivot_offset = Vector2( 480, 291.2 )
+
+[node name="Chalkboard" type="TextureRect" parent="ChalkboardIntro/Swoosher"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -1216,13 +1286,13 @@ rect_pivot_offset = Vector2( 480, 291.2 )
 texture = ExtResource( 45 )
 expand = true
 
-[node name="Shadow" type="Polygon2D" parent="ChalkboardIntro"]
+[node name="Shadow" type="Polygon2D" parent="ChalkboardIntro/Swoosher/Chalkboard"]
 show_behind_parent = true
 color = Color( 0, 0, 0, 0.392157 )
 antialiased = true
 polygon = PoolVector2Array( 1, 0, 10, -10, 970, -10, 970, 572.4, 960, 581.4, 1, 581.4 )
 
-[node name="VBoxContainer" type="VBoxContainer" parent="ChalkboardIntro"]
+[node name="VBoxContainer" type="VBoxContainer" parent="ChalkboardIntro/Swoosher/Chalkboard"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 15.0
@@ -1231,29 +1301,29 @@ margin_right = -15.0
 margin_bottom = -15.0
 custom_constants/separation = 0
 
-[node name="Spacer1" type="Control" parent="ChalkboardIntro/VBoxContainer"]
+[node name="Spacer1" type="Control" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer"]
 margin_right = 930.0
 margin_bottom = 6.0
 rect_min_size = Vector2( 0, 6 )
 
-[node name="TitleRow" type="Control" parent="ChalkboardIntro/VBoxContainer"]
+[node name="TitleRow" type="Control" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer"]
 modulate = Color( 1, 0.5, 0.945313, 1 )
 margin_top = 6.0
 margin_right = 930.0
 margin_bottom = 81.0
 rect_min_size = Vector2( 0, 75 )
 
-[node name="HBoxContainer" type="HBoxContainer" parent="ChalkboardIntro/VBoxContainer/TitleRow"]
+[node name="HBoxContainer" type="HBoxContainer" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/TitleRow"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 
-[node name="Control1" type="Control" parent="ChalkboardIntro/VBoxContainer/TitleRow/HBoxContainer"]
+[node name="Control1" type="Control" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/TitleRow/HBoxContainer"]
 margin_right = 228.0
 margin_bottom = 75.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="TextureRect" type="TextureRect" parent="ChalkboardIntro/VBoxContainer/TitleRow/HBoxContainer/Control1"]
+[node name="TextureRect" type="TextureRect" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/TitleRow/HBoxContainer/Control1"]
 modulate = Color( 1, 1, 1, 0.784314 )
 anchor_left = 0.5
 anchor_top = 0.5
@@ -1266,7 +1336,7 @@ margin_bottom = 32.5
 texture = ExtResource( 29 )
 expand = true
 
-[node name="Label" type="Label" parent="ChalkboardIntro/VBoxContainer/TitleRow/HBoxContainer"]
+[node name="Label" type="Label" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/TitleRow/HBoxContainer"]
 margin_left = 232.0
 margin_top = 7.0
 margin_right = 697.0
@@ -1277,14 +1347,14 @@ running out of time or losing all your lives!"
 align = 1
 max_lines_visible = 2
 
-[node name="Control2" type="Control" parent="ChalkboardIntro/VBoxContainer/TitleRow/HBoxContainer"]
+[node name="Control2" type="Control" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/TitleRow/HBoxContainer"]
 margin_left = 701.0
 margin_right = 930.0
 margin_bottom = 75.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="TextureRect" type="TextureRect" parent="ChalkboardIntro/VBoxContainer/TitleRow/HBoxContainer/Control2"]
+[node name="TextureRect" type="TextureRect" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/TitleRow/HBoxContainer/Control2"]
 modulate = Color( 1, 1, 1, 0.784314 )
 anchor_left = 0.5
 anchor_top = 0.5
@@ -1297,14 +1367,14 @@ margin_bottom = 32.5
 texture = ExtResource( 30 )
 expand = true
 
-[node name="Separator1" type="Control" parent="ChalkboardIntro/VBoxContainer"]
+[node name="Separator1" type="Control" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer"]
 modulate = Color( 0.726563, 0.5, 1, 1 )
 margin_top = 81.0
 margin_right = 930.0
 margin_bottom = 106.0
 rect_min_size = Vector2( 0, 25 )
 
-[node name="TextureRect" type="TextureRect" parent="ChalkboardIntro/VBoxContainer/Separator1"]
+[node name="TextureRect" type="TextureRect" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/Separator1"]
 modulate = Color( 1, 1, 1, 0.784314 )
 anchor_left = 0.5
 anchor_top = 0.5
@@ -1317,14 +1387,14 @@ margin_bottom = 13.0
 texture = ExtResource( 48 )
 expand = true
 
-[node name="Instructions" type="Control" parent="ChalkboardIntro/VBoxContainer"]
+[node name="Instructions" type="Control" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer"]
 margin_top = 106.0
 margin_right = 930.0
 margin_bottom = 458.0
 rect_min_size = Vector2( 0, 90 )
 size_flags_vertical = 3
 
-[node name="IntroHeader1" type="Label" parent="ChalkboardIntro/VBoxContainer/Instructions"]
+[node name="IntroHeader1" type="Label" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/Instructions"]
 modulate = Color( 1, 0.580392, 0.501961, 0.784314 )
 margin_left = 45.0
 margin_top = -6.79999
@@ -1334,7 +1404,7 @@ theme = ExtResource( 14 )
 text = "REACH THE GOAL"
 align = 1
 
-[node name="IntroImage1" type="TextureRect" parent="ChalkboardIntro/VBoxContainer/Instructions"]
+[node name="IntroImage1" type="TextureRect" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/Instructions"]
 modulate = Color( 1, 0.956863, 0.501961, 0.784314 )
 margin_left = 31.0
 margin_top = 22.2
@@ -1343,7 +1413,7 @@ margin_bottom = 162.2
 texture = ExtResource( 32 )
 expand = true
 
-[node name="IntroText1" type="Label" parent="ChalkboardIntro/VBoxContainer/Instructions"]
+[node name="IntroText1" type="Label" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/Instructions"]
 modulate = Color( 1, 0.580392, 0.501961, 0.784314 )
 margin_left = 213.0
 margin_top = 32.2
@@ -1356,7 +1426,7 @@ you move"
 align = 1
 valign = 1
 
-[node name="IntroHeader2" type="Label" parent="ChalkboardIntro/VBoxContainer/Instructions"]
+[node name="IntroHeader2" type="Label" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/Instructions"]
 modulate = Color( 0.54902, 1, 0.501961, 0.784314 )
 margin_left = 492.0
 margin_top = 41.2
@@ -1366,7 +1436,7 @@ theme = ExtResource( 14 )
 text = "WATCH THE CLOCK"
 align = 1
 
-[node name="IntroImage2" type="TextureRect" parent="ChalkboardIntro/VBoxContainer/Instructions"]
+[node name="IntroImage2" type="TextureRect" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/Instructions"]
 modulate = Color( 1, 0.956863, 0.501961, 0.784314 )
 margin_left = 517.0
 margin_top = 96.2
@@ -1375,7 +1445,7 @@ margin_bottom = 236.2
 texture = ExtResource( 31 )
 expand = true
 
-[node name="IntroText2" type="Label" parent="ChalkboardIntro/VBoxContainer/Instructions"]
+[node name="IntroText2" type="Label" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/Instructions"]
 modulate = Color( 0.54902, 1, 0.501961, 0.784314 )
 margin_left = 652.0
 margin_top = 82.2
@@ -1388,7 +1458,7 @@ the end"
 align = 1
 valign = 1
 
-[node name="IntroHeader3" type="Label" parent="ChalkboardIntro/VBoxContainer/Instructions"]
+[node name="IntroHeader3" type="Label" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/Instructions"]
 modulate = Color( 0.501961, 0.882353, 1, 0.784314 )
 margin_left = 87.0
 margin_top = 155.2
@@ -1398,7 +1468,7 @@ theme = ExtResource( 14 )
 text = "BE CAREFUL"
 align = 1
 
-[node name="IntroImage3" type="TextureRect" parent="ChalkboardIntro/VBoxContainer/Instructions"]
+[node name="IntroImage3" type="TextureRect" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/Instructions"]
 modulate = Color( 1, 0.956863, 0.501961, 0.784314 )
 margin_left = 95.0
 margin_top = 236.2
@@ -1407,7 +1477,7 @@ margin_bottom = 376.2
 texture = ExtResource( 34 )
 expand = true
 
-[node name="IntroText3" type="Label" parent="ChalkboardIntro/VBoxContainer/Instructions"]
+[node name="IntroText3" type="Label" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/Instructions"]
 modulate = Color( 0.501961, 0.882353, 1, 0.784314 )
 margin_left = 227.0
 margin_top = 193.2
@@ -1420,7 +1490,7 @@ have to start again"
 align = 1
 valign = 1
 
-[node name="IntroText4" type="Label" parent="ChalkboardIntro/VBoxContainer/Instructions"]
+[node name="IntroText4" type="Label" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/Instructions"]
 modulate = Color( 0.72549, 0.501961, 1, 0.784314 )
 margin_left = 707.0
 margin_top = 217.2
@@ -1433,7 +1503,7 @@ in you"
 align = 1
 valign = 1
 
-[node name="IntroImage4" type="TextureRect" parent="ChalkboardIntro/VBoxContainer/Instructions"]
+[node name="IntroImage4" type="TextureRect" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/Instructions"]
 modulate = Color( 0.72549, 0.501961, 1, 0.784314 )
 margin_left = 770.0
 margin_top = 241.2
@@ -1442,14 +1512,14 @@ margin_bottom = 381.2
 texture = ExtResource( 35 )
 expand = true
 
-[node name="Separator2" type="Control" parent="ChalkboardIntro/VBoxContainer"]
+[node name="Separator2" type="Control" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer"]
 modulate = Color( 1, 0.580392, 0.501961, 1 )
 margin_top = 458.0
 margin_right = 930.0
 margin_bottom = 483.0
 rect_min_size = Vector2( 0, 25 )
 
-[node name="TextureRect" type="TextureRect" parent="ChalkboardIntro/VBoxContainer/Separator2"]
+[node name="TextureRect" type="TextureRect" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/Separator2"]
 modulate = Color( 1, 1, 1, 0.784314 )
 anchor_left = 0.5
 anchor_top = 0.5
@@ -1462,19 +1532,19 @@ margin_bottom = 9.0
 texture = ExtResource( 46 )
 expand = true
 
-[node name="ButtonRow" type="Control" parent="ChalkboardIntro/VBoxContainer"]
+[node name="ButtonRow" type="Control" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer"]
 margin_top = 483.0
 margin_right = 930.0
 margin_bottom = 546.0
 rect_min_size = Vector2( 0, 63 )
 
-[node name="ZHolder" type="Sprite" parent="ChalkboardIntro/VBoxContainer/ButtonRow"]
+[node name="ZHolder" type="Sprite" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/ButtonRow"]
 z_index = 1
 __meta__ = {
 "_editor_description_": "Control nodes cannot have a Z index. We need this button to show up over the chalkboard texture."
 }
 
-[node name="Button" type="Button" parent="ChalkboardIntro/VBoxContainer/ButtonRow/ZHolder"]
+[node name="Button" type="Button" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/ButtonRow/ZHolder"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -1492,13 +1562,13 @@ custom_styles/disabled = SubResource( 52 )
 custom_styles/normal = SubResource( 53 )
 text = "Ok"
 
-[node name="Spacer2" type="Control" parent="ChalkboardIntro/VBoxContainer"]
+[node name="Spacer2" type="Control" parent="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer"]
 margin_top = 546.0
 margin_right = 930.0
 margin_bottom = 552.0
 rect_min_size = Vector2( 0, 6 )
 
-[node name="Grain" type="TextureRect" parent="ChalkboardIntro"]
+[node name="Grain" type="TextureRect" parent="ChalkboardIntro/Swoosher/Chalkboard"]
 modulate = Color( 1, 1, 1, 0.705882 )
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -1535,11 +1605,11 @@ wait_time = 0.5
 one_shot = true
 
 [connection signal="visibility_changed" from="Backdrop" to="." method="_on_Backdrop_visibility_changed"]
-[connection signal="travelling_finished" from="ChalkboardRegion/Player" to="." method="_on_Player_travelling_finished"]
-[connection signal="travelling_finished" from="ChalkboardRegion/Player" to="ChalkboardRegion/Trail" method="_on_Player_travelling_finished"]
-[connection signal="travelling_finished" from="ChalkboardRegion/Player" to="ChalkboardRegion/GoalLabel" method="_on_Player_travelling_finished"]
-[connection signal="travelling_finished" from="ChalkboardRegion/Player" to="ChalkboardRegion/SplashMessage" method="_on_Player_travelling_finished"]
-[connection signal="pressed" from="ChalkboardIntro/VBoxContainer/ButtonRow/ZHolder/Button" to="." method="_on_OkButton_pressed"]
+[connection signal="travelling_finished" from="ChalkboardRegion/Swoosher/Player" to="." method="_on_Player_travelling_finished"]
+[connection signal="travelling_finished" from="ChalkboardRegion/Swoosher/Player" to="ChalkboardRegion/Swoosher/Trail" method="_on_Player_travelling_finished"]
+[connection signal="travelling_finished" from="ChalkboardRegion/Swoosher/Player" to="ChalkboardRegion/Swoosher/GoalLabel" method="_on_Player_travelling_finished"]
+[connection signal="travelling_finished" from="ChalkboardRegion/Swoosher/Player" to="ChalkboardRegion/SplashMessage" method="_on_Player_travelling_finished"]
+[connection signal="pressed" from="ChalkboardIntro/Swoosher/Chalkboard/VBoxContainer/ButtonRow/ZHolder/Button" to="." method="_on_OkButton_pressed"]
 [connection signal="animation_finished" from="ShowAnimationPlayer" to="." method="_on_AnimationPlayer_animation_finished"]
 [connection signal="timeout" from="HideTimer" to="." method="_on_HideTimer_timeout"]
 [connection signal="timeout" from="AnimateStartTimer" to="." method="_on_AnimateStartTimer_timeout"]

--- a/project/src/main/career/ui/progress-board-clock.gd
+++ b/project/src/main/career/ui/progress-board-clock.gd
@@ -29,10 +29,10 @@ var hours_passed := 0 setget set_hours_passed
 var _tween: SceneTreeTween
 
 ## Digital text which shows the time using text like '8:50 pm'
-onready var _label: Label = $Label
+onready var _label: Label = $Swoosher/Label
 
 ## Analog clock which shows the time using an and hour and minute hand.
-onready var _visuals: ProgressBoardClockVisuals = $VisualsHolder/Visuals
+onready var _visuals: ProgressBoardClockVisuals = $Swoosher/VisualsHolder/Visuals
 
 ## Winding sound that plays as the clock's hands spin.
 onready var _clock_advance_sound := $ClockAdvanceSound

--- a/project/src/main/career/ui/progress-board.gd
+++ b/project/src/main/career/ui/progress-board.gd
@@ -49,19 +49,19 @@ onready var _hide_timer := $HideTimer
 onready var _animate_start_timer := $AnimateStartTimer
 
 ## Spots and lines drawn to show a trail across the progress board.
-onready var _trail := $ChalkboardRegion/Trail
+onready var _trail := $ChalkboardRegion/Swoosher/Trail
 
 ## Title at the top of the progress board.
-onready var _title := $ChalkboardRegion/Title
+onready var _title := $ChalkboardRegion/Swoosher/Title
 
 ## Player's chalk graphics on the progress board.
-onready var _player := $ChalkboardRegion/Player
+onready var _player := $ChalkboardRegion/Swoosher/Player
 
 ## Goal text which shows up over the progress board destination
-onready var _goal := $ChalkboardRegion/GoalLabel
+onready var _goal := $ChalkboardRegion/Swoosher/GoalLabel
 
 ## Chalk drawing of the region.
-onready var _map_holder := $ChalkboardRegion/MapHolder
+onready var _map_holder := $ChalkboardRegion/Swoosher/MapHolder
 
 ## Animation player which makes the progress board 'pop in' and 'pop out' animations.
 onready var _show_animation_player := $ShowAnimationPlayer


### PR DESCRIPTION
The progress board animations hard-coded x-coordinates like "422" but these x-coordinates were only valid for a specific resolution. As a result, the animations would animate the progress board into an uncentered position for most resolutions.

I've introduced a new 'swoosher' node in the ProgressBoard which has an X-coordinate of 0,0, and will appear centered regardless of the resolution.

Closes #2937.