### PR TITLE
Bug: Creature editor color buttons didn't return focus

### DIFF
--- a/project/src/demo/editor/creature/creature-color-button-demo.gd
+++ b/project/src/demo/editor/creature/creature-color-button-demo.gd
@@ -2,21 +2,56 @@ extends Node
 ## Shows off the creature color buttons, and provides utilities for editing creature color palettes.
 ##
 ## Keys:
-## 	[Q]: Extract new palettes from old palettes.
-## 	[W]: Report duplicate colors from our new palettes.
-## 	[E]: Report creature colors not present in our new palettes.
+## 	[Q/W/E/R/T]: Assign a palette with 0/4/8/24/100 colors.
+## 	[Z]: Extract new palettes from old palettes.
+## 	[X]: Report duplicate colors from our new palettes.
+## 	[C]: Report creature colors not present in our new palettes.
 
 onready var _tab_container := $TabContainer
 onready var _text_edit := $TabContainer/ColorAnalysis/TextEdit
 
 func _input(event: InputEvent) -> void:
 	match Utils.key_scancode(event):
-		KEY_Q:
+		KEY_Z:
 			_extract_colors_from_creature_palettes()
-		KEY_W:
+		KEY_X:
 			_show_similar_colors()
-		KEY_E:
+		KEY_C:
 			_show_missing_colors()
+		KEY_Q:
+			_assign_color_presets(0)
+		KEY_W:
+			_assign_color_presets(4)
+		KEY_E:
+			_assign_color_presets(8)
+		KEY_R:
+			_assign_color_presets(24)
+		KEY_T:
+			_assign_color_presets(100)
+
+
+func _assign_color_presets(count: int) -> void:
+	var new_color_presets := color_presets(count)
+	for button in [
+		$TabContainer/CreatureColorButton/ButtonTopLeft,
+		$TabContainer/CreatureColorButton/ButtonTopRight,
+		$TabContainer/CreatureColorButton/ButtonCenter,
+		$TabContainer/CreatureColorButton/ButtonBottomLeft,
+		$TabContainer/CreatureColorButton/ButtonBottomRight,
+	]:
+		button.set_color_presets(new_color_presets)
+
+
+func color_presets(count: int) -> Array:
+	var result := []
+	if count >= 8:
+		result.append(Color.white)
+		result.append(Color.gray)
+		result.append(Color.black)
+	while result.size() < count:
+		var random_color := Color(randf(), randf(), randf())
+		result.append(random_color)
+	return result
 
 
 ## Extract palettes from the old creature editor format and prints them in the new format.

--- a/project/src/main/editor/creature/CreatureColorButton.tscn
+++ b/project/src/main/editor/creature/CreatureColorButton.tscn
@@ -73,3 +73,4 @@ script = ExtResource( 14 )
 
 [connection signal="about_to_show" from="Popup" to="." method="_on_Popup_about_to_show"]
 [connection signal="color_changed" from="Popup" to="." method="_on_Popup_color_changed"]
+[connection signal="popup_hide" from="Popup" to="." method="_on_Popup_popup_hide"]

--- a/project/src/main/editor/creature/creature-color-button.gd
+++ b/project/src/main/editor/creature/creature-color-button.gd
@@ -184,3 +184,8 @@ func _on_Popup_color_changed(color: Color) -> void:
 
 func _on_Popup_about_to_show() -> void:
 	emit_signal("about_to_show")
+
+
+func _on_Popup_popup_hide() -> void:
+	# If any CandyColorPickerButtons grab focus, focus is permanently lost unless we grab it back.
+	grab_focus()


### PR DESCRIPTION
Pressing a Creature Editor color button and then closing the popup lost focus. The focus was not returned to the color button afterward.

This bug was confusing to track down, but it only happens if the ColorPickerPopup has at least one preset, and if the resulting preset button grabs focus.

Updated CreatureColorButtonDemo to include multiple palettes.