### PR TITLE
Bug: Glitched creature appearance past fatness=10

### DIFF
--- a/project/src/demo/world/environment/restaurant/restaurant-view-demo.gd
+++ b/project/src/demo/world/environment/restaurant/restaurant-view-demo.gd
@@ -8,6 +8,8 @@ extends Node
 ## 	[V]: Say something
 ## 	[N]: Change the nametag names
 ## 	[1-9,0]: Change the customer's size from 10% to 100%
+## 	[O]: Increase customer's size by 10%
+## 	[P]: Change the customer's size to 1000%
 ## 	Shift + [1-9,0]: Change the customer's comfort from 0.0 -> 1.0 -> -1.0
 ## 	[Q,W,E,R]: Switch to the 1st, 2nd, 3rd or 4th customer.
 ## 	Shift + [,/.]: Swoop the customer/chef to be onscreen
@@ -69,6 +71,10 @@ func _input(event: InputEvent) -> void:
 			else:
 				# shift not pressed; change customer's fatness
 				_view.get_customer().fatness = FATNESS_KEYS[Utils.key_num(event)]
+		KEY_O:
+			_view.get_customer().fatness += 1.0
+		KEY_P:
+			_view.get_customer().fatness = 100.0
 		KEY_Q: _view.set_current_customer_index(0)
 		KEY_W: _view.set_current_customer_index(1)
 		KEY_E: _view.set_current_customer_index(2)

--- a/project/src/main/world/creature/creature-visuals.gd
+++ b/project/src/main/world/creature/creature-visuals.gd
@@ -110,22 +110,25 @@ func _physics_process(_delta: float) -> void:
 
 
 func update_fattening_animation() -> void:
+	var capped_fatness := clamp(fatness, 1.0, 10.0)
 	# bouncy animation; acceleration and squash n' stretch
-	if visual_fatness == fatness and _fattening_inertia < 0.05:
+	if visual_fatness == capped_fatness and _fattening_inertia < 0.05:
 		_fattening_inertia = 0.0
 		return
 	# inertia/acceleration/fatness/etc:
 	# as we make this value bigger, the amount of time to accelerate decreases:
 	var lerp_speed: float = 0.05
 	# as we make this value bigger, the acceleration rises (more jiggle):
-	var inertia_this_frame_slope: float = (fatness - visual_fatness) / 1.0
+	var inertia_this_frame_slope: float = (capped_fatness - visual_fatness) / 1.0
 	_fattening_inertia = lerp(_fattening_inertia, inertia_this_frame_slope, lerp_speed)
 	visual_fatness += _fattening_inertia
 	# bounce to prevent visual_fatness from going too small (avoid becoming negative or thin)
 	if visual_fatness < 1.0 and _fattening_inertia < 0:
 		_fattening_inertia = -_fattening_inertia
 	# dampening (reduces jiggle)
-	visual_fatness = lerp(visual_fatness, fatness, 0.04)
+	visual_fatness = lerp(visual_fatness, capped_fatness, 0.04)
+	if abs(visual_fatness - capped_fatness) < 0.001:
+		visual_fatness = capped_fatness
 	# behavior for values outside the range [1.0, 10.0] is undefined and results in visual errors
 	visual_fatness = clamp(visual_fatness, 1.0, 10.0)
 	set_visual_fatness(visual_fatness)
@@ -138,7 +141,7 @@ func update_fattening_animation() -> void:
 		# we won't see _fattening_inertia <= 0 often as it's only a little bit of rubber-banding that get us there
 		stretch_amount = 1 + abs(_fattening_inertia)
 	var normalized_squash_stretch: Vector2 = Vector2(squash_amount, stretch_amount).normalized()
-	var squash_stretch: Vector2 = normalized_squash_stretch / 0.7107 * _base_scale\
+	var squash_stretch: Vector2 = normalized_squash_stretch / 0.7107 * _base_scale \
 			* max(stretch_amount, squash_amount)
 	self.rescale(squash_stretch.x, squash_stretch.y, false)
 


### PR DESCRIPTION
Creatures with a fatness value greater than 10.0 appeared glitchy and stretched out.