### PR TITLE
Preempted all get_tree calls with is_inside_tree() checks

### DIFF
--- a/project/src/demo/editor/creature-old/mutate-ui.gd
+++ b/project/src/demo/editor/creature-old/mutate-ui.gd
@@ -6,6 +6,8 @@ extends Panel
 ##
 ## These alleles might change when the creature mutates, it's up to chance.
 func get_flexible_alleles() -> Array:
+	if not is_inside_tree():
+		return []
 	var alleles := []
 	for button_obj in get_tree().get_nodes_in_group("lock_allele_buttons"):
 		var button: LockAlleleButton = button_obj
@@ -18,6 +20,8 @@ func get_flexible_alleles() -> Array:
 ##
 ## These alleles always change when the creature mutates.
 func get_unlocked_alleles() -> Array:
+	if not is_inside_tree():
+		return []
 	var alleles := []
 	for button_obj in get_tree().get_nodes_in_group("lock_allele_buttons"):
 		var button: LockAlleleButton = button_obj
@@ -30,6 +34,8 @@ func get_unlocked_alleles() -> Array:
 ##
 ## These alleles never change when the creature mutates.
 func get_locked_alleles() -> Array:
+	if not is_inside_tree():
+		return []
 	var alleles := []
 	for button_obj in get_tree().get_nodes_in_group("lock_allele_buttons"):
 		var button: LockAlleleButton = button_obj

--- a/project/src/demo/editor/puzzle/playfield-editor-control.gd
+++ b/project/src/demo/editor/puzzle/playfield-editor-control.gd
@@ -55,6 +55,8 @@ func get_pickups() -> EditorPickups:
 
 
 func _connect_chunk_control_listeners() -> void:
+	if not is_inside_tree():
+		return
 	for chunk_control in get_tree().get_nodes_in_group("chunk_controls"):
 		if chunk_control.has_method("_on_RotateButton_pressed"):
 			_rotate_button.connect("pressed", chunk_control, "_on_RotateButton_pressed")

--- a/project/src/demo/toolkit/run-all-button.gd
+++ b/project/src/demo/toolkit/run-all-button.gd
@@ -2,5 +2,7 @@ extends Button
 ## Runs all release tools.
 
 func _pressed() -> void:
+	if not is_inside_tree():
+		return
 	for button in get_tree().get_nodes_in_group("release_tool_buttons"):
 		button.run()

--- a/project/src/demo/world/creature/free-roam-player.gd
+++ b/project/src/demo/world/creature/free-roam-player.gd
@@ -18,7 +18,8 @@ func _unhandled_input(event: InputEvent) -> void:
 	if Utils.ui_pressed_dir(event) or Utils.ui_released_dir(event):
 		# calculate the direction the player wants to move
 		set_non_iso_walk_direction(Utils.ui_pressed_dir())
-		get_tree().set_input_as_handled()
+		if is_inside_tree():
+			get_tree().set_input_as_handled()
 
 
 ## Stop moving when a chat choice appears.

--- a/project/src/demo/world/creature/palette-button.gd
+++ b/project/src/demo/world/creature/palette-button.gd
@@ -15,5 +15,6 @@ func set_palette(palette: Dictionary) -> void:
 
 func _gui_input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_click"):
-		get_tree().set_input_as_handled()
+		if is_inside_tree():
+			get_tree().set_input_as_handled()
 		emit_signal("pressed")

--- a/project/src/demo/world/environment/lava/lava-crowdie-demo.gd
+++ b/project/src/demo/world/environment/lava/lava-crowdie-demo.gd
@@ -52,6 +52,8 @@ func _remove_crowds(count: int) -> void:
 
 ## Toggles the crowd bouncing and cheering.
 func _toggle_bounce() -> void:
+	if not is_inside_tree():
+		return
 	var new_bouncing := true
 	if get_tree().get_nodes_in_group("lava_crowdies") \
 			and get_tree().get_nodes_in_group("lava_crowdies").front().bouncing:

--- a/project/src/main/career/ui/career-map-level-select.gd
+++ b/project/src/main/career/ui/career-map-level-select.gd
@@ -76,6 +76,9 @@ func add_level_select_button(settings: LevelSettings) -> LevelSelectButton:
 ## Restores focus to the previously selected level select button, if one was selected. Otherwise, assigns focus to the
 ## rightmost button.
 func focus_button() -> void:
+	if not is_inside_tree():
+		return
+	
 	var level_select_buttons := get_tree().get_nodes_in_group("level_select_buttons")
 	var node_to_focus: Node
 	

--- a/project/src/main/career/ui/chalkboard-map-row.gd
+++ b/project/src/main/career/ui/chalkboard-map-row.gd
@@ -31,6 +31,9 @@ var player_distance: int = 0 setget set_player_distance
 ##
 ## 	'landmark_type': Enum from Landmark.LandmarkType for the specified landmark.
 func set_landmark_type(index: int, landmark_type: int) -> void:
+	if not is_inside_tree():
+		return
+	
 	var landmarks: Array = get_tree().get_nodes_in_group("landmarks")
 	
 	if index >= landmarks.size():
@@ -49,6 +52,9 @@ func set_landmark_type(index: int, landmark_type: int) -> void:
 ## Returns:
 ## 	Enum from Landmark.LandmarkType for the specified landmark.
 func get_landmark_type(index: int) -> int:
+	if not is_inside_tree():
+		return Landmark.LandmarkType.NONE
+	
 	var landmarks: Array = get_tree().get_nodes_in_group("landmarks")
 	
 	if index >= landmarks.size():
@@ -62,6 +68,9 @@ func get_landmark_type(index: int) -> int:
 ##
 ## This distance is displayed on a label, and also used when calculating the player's distance along the path.
 func set_landmark_distance(index: int, landmark_distance: int) -> void:
+	if not is_inside_tree():
+		return
+	
 	var landmarks: Array = get_tree().get_nodes_in_group("landmarks")
 	
 	if index >= landmarks.size():
@@ -76,6 +85,9 @@ func set_landmark_distance(index: int, landmark_distance: int) -> void:
 ##
 ## This distance is displayed on a label, and also used when calculating the player's distance along the path.
 func get_landmark_distance(index: int) -> int:
+	if not is_inside_tree():
+		return 0
+	
 	var landmarks: Array = get_tree().get_nodes_in_group("landmarks")
 	
 	if index >= landmarks.size():

--- a/project/src/main/career/ui/landmark-lines.gd
+++ b/project/src/main/career/ui/landmark-lines.gd
@@ -10,6 +10,9 @@ func _ready() -> void:
 
 ## Removes and regenerates the lines connecting the landmarks.
 func _refresh_lines() -> void:
+	if not is_inside_tree():
+		return
+	
 	var landmarks := get_tree().get_nodes_in_group("landmarks")
 	
 	for child in get_children():

--- a/project/src/main/chat/ui/chat-choices.gd
+++ b/project/src/main/chat/ui/chat-choices.gd
@@ -71,7 +71,8 @@ func show_choices(choices: Array, moods: Array, new_columns: int = 0) -> void:
 		$EnableInputTimer.start()
 		
 		# wait for old chat choices to be deleted before grabbing focus
-		yield(get_tree(), "idle_frame")
+		if is_inside_tree():
+			yield(get_tree(), "idle_frame")
 		grab_focus()
 
 
@@ -79,6 +80,9 @@ func show_choices(choices: Array, moods: Array, new_columns: int = 0) -> void:
 ##
 ## This control itself doesn't have focus, so we delegate to a child control.
 func grab_focus() -> void:
+	if not is_inside_tree():
+		return
+	
 	for button in get_tree().get_nodes_in_group("chat_choices"):
 		button.grab_focus()
 		break
@@ -118,6 +122,9 @@ func _button(node: Node) -> ChatChoiceButton:
 
 ## Removes and recreates all chat choice buttons.
 func _refresh_child_buttons() -> void:
+	if not is_inside_tree():
+		return
+	
 	for child in get_tree().get_nodes_in_group("chat_choices"):
 		child.queue_free()
 	
@@ -150,7 +157,8 @@ func _refresh_child_buttons() -> void:
 			var button: ChatChoiceButton = button_object
 			button.pop_in()
 			$PopSound.play()
-			yield(get_tree().create_timer(pop_in_delay), "timeout")
+			if is_inside_tree():
+				yield(get_tree().create_timer(pop_in_delay), "timeout")
 
 
 func _on_ChatChoiceButton_focus_entered() -> void:
@@ -161,6 +169,9 @@ func _on_ChatChoiceButton_focus_entered() -> void:
 ##
 ## The chat choice buttons remain as children of this node so they can be animated away.
 func _on_ChatChoiceButton_pressed() -> void:
+	if not is_inside_tree():
+		return
+	
 	if not $EnableInputTimer.is_stopped():
 		# don't let the player mash through chat choices accidentally
 		return
@@ -189,4 +200,5 @@ func _on_ChatChoiceButton_pressed() -> void:
 	_choices = []
 	
 	emit_signal("chat_choice_chosen", choice_index)
-	get_tree().set_input_as_handled()
+	if is_inside_tree():
+		get_tree().set_input_as_handled()

--- a/project/src/main/chat/ui/chat-ui.gd
+++ b/project/src/main/chat/ui/chat-ui.gd
@@ -54,12 +54,14 @@ func _input(event: InputEvent) -> void:
 	
 	if event.is_action_pressed("rewind_text", true):
 		_handle_rewind_action(event)
-		get_tree().set_input_as_handled()
+		if is_inside_tree():
+			get_tree().set_input_as_handled()
 	if event.is_action_pressed("ui_accept", true):
 		if not _chat_choices.is_showing_choices() \
 				or _chat_choices.is_showing_choices() and event.is_echo():
 			_handle_advance_action(event)
-			get_tree().set_input_as_handled()
+			if is_inside_tree():
+				get_tree().set_input_as_handled()
 
 
 func set_overworld_environment_path(new_overworld_environment_path: NodePath) -> void:
@@ -103,7 +105,8 @@ func _handle_rewind_action(event: InputEvent) -> void:
 		rewind_action = true
 	
 	if rewind_action:
-		get_tree().set_input_as_handled()
+		if is_inside_tree():
+			get_tree().set_input_as_handled()
 		_chat_advancer.rewind()
 
 
@@ -124,7 +127,8 @@ func _handle_advance_action(event: InputEvent) -> void:
 		advance_action = true
 	
 	if advance_action:
-		get_tree().set_input_as_handled()
+		if is_inside_tree():
+			get_tree().set_input_as_handled()
 		if _chat_frame.is_chat_window_showing() and not _chat_frame.is_all_text_visible():
 			# text is still being slowly typed out, make it all visible
 			_chat_frame.make_all_text_visible()
@@ -253,7 +257,8 @@ func _on_ChatAdvancer_chat_event_shown(chat_event: ChatEvent) -> void:
 	if not chat_event.text:
 		# emitting the 'all_text_shown' signal while other nodes are still receiving the current 'chat_event_shown'
 		# signal introduces complications, so we wait until the next frame
-		yield(get_tree(), "idle_frame")
+		if is_inside_tree():
+			yield(get_tree(), "idle_frame")
 		_chat_frame.emit_signal("all_text_shown")
 		if not _chat_advancer.should_prompt():
 			_chat_advancer.advance()

--- a/project/src/main/chat/ui/click-translator.gd
+++ b/project/src/main/chat/ui/click-translator.gd
@@ -76,13 +76,15 @@ func _handle_mouse_button(event: InputEventMouseButton) -> void:
 	if event.pressed and _click_index == -1 and not _showing_choices:
 		# emit a press event
 		_click_index = event.button_index
-		get_tree().set_input_as_handled()
+		if is_inside_tree():
+			get_tree().set_input_as_handled()
 		_emit_ui_accept_event(true, false)
 
 	if not event.pressed and _click_index == event.button_index:
 		# emit a release event
 		_click_index = -1
-		get_tree().set_input_as_handled()
+		if is_inside_tree():
+			get_tree().set_input_as_handled()
 		_emit_ui_accept_event(false, false)
 
 

--- a/project/src/main/credits/credits-director.gd
+++ b/project/src/main/credits/credits-director.gd
@@ -104,6 +104,9 @@ func _ready() -> void:
 
 ## Schedules all of the credits events for the "cool credits" after the player beats the game.
 func play_cool_credits() -> void:
+	if not is_inside_tree():
+		return
+	
 	MusicPlayer.play_credits_track()
 	_music_sync_player.play("play")
 	
@@ -117,7 +120,8 @@ func play_cool_credits() -> void:
 	_schedule_part_4(credits_tween)
 	
 	# wait for CreditsScroll to initialize
-	yield(get_tree(), "idle_frame")
+	if is_inside_tree():
+		yield(get_tree(), "idle_frame")
 	
 	# assign the letters which poof into the title; these correspond to kick drums in the music
 	_credits_scroll.set_target_header_letter_for_piece(348, 0)
@@ -141,6 +145,9 @@ func play_cool_credits() -> void:
 
 ## Schedules all of the credits events for the "boring credits" before the player beats the game.
 func play_boring_credits() -> void:
+	if not is_inside_tree():
+		return
+	
 	MusicPlayer.play_menu_track()
 	var credits_tween := get_tree().create_tween()
 	

--- a/project/src/main/data/system-data.gd
+++ b/project/src/main/data/system-data.gd
@@ -42,7 +42,8 @@ func _input(_event: InputEvent) -> void:
 		SystemData.graphics_settings.fullscreen = !SystemData.graphics_settings.fullscreen
 		SystemData.has_unsaved_changes = true
 		SystemSave.save_system_data()
-		get_tree().set_input_as_handled()
+		if is_inside_tree():
+			get_tree().set_input_as_handled()
 
 
 ## Prevents the player's settings from triggering fullscreen mode or vsync.
@@ -94,6 +95,8 @@ func _refresh_graphics_settings() -> void:
 ## This delay prevents the game from rapidly toggling between fullscreen and windowed modes on startup when
 ## initializing and loading the player's settings.
 func _schedule_refresh_graphics_settings() -> void:
+	if not is_inside_tree():
+		return
 	if _refresh_graphics_settings_timer != null:
 		return
 	

--- a/project/src/main/editor/creature/color-picker-popup.gd
+++ b/project/src/main/editor/creature/color-picker-popup.gd
@@ -26,10 +26,12 @@ func _input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.is_pressed():
 		if not get_global_rect().has_point(event.position):
 			hide()
-			get_tree().set_input_as_handled()
+			if is_inside_tree():
+				get_tree().set_input_as_handled()
 	elif event.is_action_pressed("ui_cancel"):
 		hide()
-		get_tree().set_input_as_handled()
+		if is_inside_tree():
+			get_tree().set_input_as_handled()
 
 
 func set_color_presets(new_color_presets: Array) -> void:
@@ -70,5 +72,6 @@ func _on_ColorPicker_resized() -> void:
 
 func _on_visibility_changed() -> void:
 	if visible:
-		yield(get_tree(), "idle_frame")
+		if is_inside_tree():
+			yield(get_tree(), "idle_frame")
 		_color_picker.grab_focus()

--- a/project/src/main/editor/creature/creature-color-button.gd
+++ b/project/src/main/editor/creature/creature-color-button.gd
@@ -164,7 +164,8 @@ func _on_focus_exited() -> void:
 ## When the player hovers over us, we reapply a brighter color for our texture, text and icons.
 func _on_mouse_entered() -> void:
 	if not disabled:
-		yield(get_tree(), "idle_frame")
+		if is_inside_tree():
+			yield(get_tree(), "idle_frame")
 		_refresh_color()
 		_hover_sound.pitch_scale = rand_range(0.95, 1.05)
 		SfxKeeper.copy(_hover_sound).play()
@@ -173,7 +174,8 @@ func _on_mouse_entered() -> void:
 ## When the player hovers away from us, we reapply the normal color for our texture, text and icons.
 func _on_mouse_exited() -> void:
 	if not disabled:
-		yield(get_tree(), "idle_frame")
+		if is_inside_tree():
+			yield(get_tree(), "idle_frame")
 		_refresh_color()
 
 

--- a/project/src/main/editor/creature/fatness-changer.gd
+++ b/project/src/main/editor/creature/fatness-changer.gd
@@ -49,6 +49,8 @@ func _increase_fatness() -> void:
 
 
 func _find_operation_button(id: String) -> OperationButton:
+	if not is_inside_tree():
+		return null
 	var result: OperationButton
 	for operation_button in get_tree().get_nodes_in_group("operation_buttons"):
 		if operation_button.id == id:

--- a/project/src/main/puzzle/critter/shark-state-squished.gd
+++ b/project/src/main/puzzle/critter/shark-state-squished.gd
@@ -8,7 +8,8 @@ func enter(shark: Shark, prev_state_name: String) -> void:
 			shark.sfx.play_poof_sound()
 	shark.play_shark_anim("squished")
 	shark.sfx.play_squish_sound()
-	get_tree().create_timer(0.20).connect("timeout", self, "_play_voice", [shark])
+	if is_inside_tree():
+		get_tree().create_timer(0.20).connect("timeout", self, "_play_voice", [shark])
 
 
 func _play_voice(shark: Shark) -> void:

--- a/project/src/main/puzzle/critter/shark-tooth-cloud.gd
+++ b/project/src/main/puzzle/critter/shark-tooth-cloud.gd
@@ -186,6 +186,8 @@ func _borrow_tilemap() -> void:
 
 ## Returns any SharkTileMapPool in the scene tree, or 'null' if none exists.
 func _shark_tile_map_pool() -> SharkTileMapPool:
+	if not is_inside_tree():
+		return null
 	var pool: SharkTileMapPool
 	if get_tree().get_nodes_in_group("shark_tilemap_pools"):
 		pool = get_tree().get_nodes_in_group("shark_tilemap_pools")[0]

--- a/project/src/main/puzzle/critter/shark.gd
+++ b/project/src/main/puzzle/critter/shark.gd
@@ -221,6 +221,9 @@ func poof_and_free() -> void:
 
 ## Synchronizes this shark's dancing with another onscreen shark. All sharks dance in unison.
 func sync_dance() -> void:
+	if not is_inside_tree():
+		return
+	
 	# Workaround for Godot #56576 (https://github.com/godotengine/godot/issues/56576).
 	#
 	# Originally, this variable was explicitly typed as a 'Shark'. However, typing it as a 'Shark' introduces a memory

--- a/project/src/main/puzzle/food-items.gd
+++ b/project/src/main/puzzle/food-items.gd
@@ -57,6 +57,8 @@ func _physics_process(_delta: float) -> void:
 
 ## Adds a food item in the specified cell.
 func add_food_item(cell: Vector2, food_type: int, remaining_food: int = 0) -> void:
+	if not is_inside_tree():
+		return
 	# calculate and store 'food fatness' for customer; how fat the customer will be after eating each item
 	var customer := _puzzle.get_customer()
 	var old_fatness: float = _pending_food_fatness.back() if _pending_food_fatness else customer.fatness
@@ -80,7 +82,8 @@ func add_food_item(cell: Vector2, food_type: int, remaining_food: int = 0) -> vo
 	
 	# float for a moment
 	# we use a one-shot listener method instead of a yield statement to avoid 'class instance is gone' errors.
-	get_tree().create_timer(_food_float_duration).connect("timeout", self, "_on_FoodItem_float_done", [food_item])
+	if is_inside_tree():
+		get_tree().create_timer(_food_float_duration).connect("timeout", self, "_on_FoodItem_float_done", [food_item])
 
 
 ## Callback function which returns the coordinate of the customer's mouth relative to the FoodItems viewport.
@@ -149,12 +152,15 @@ func _on_FoodItem_float_done(food_item: FoodItem) -> void:
 
 
 func _on_FoodItem_ready_to_fly(food_item: FoodItem) -> void:
+	if not is_inside_tree():
+		return
 	food_item.fly_to_target(funcref(self, "get_target_pos"), \
 			[food_item.customer, food_item.customer_index], _food_flight_duration)
 	
 	# trigger the eating animation just before we arrive at the creature's mouth
 	var adjusted_flight_duration := _food_flight_duration - food_item.customer.get_eating_delay()
-	get_tree().create_timer(adjusted_flight_duration).connect("timeout", self, "_on_FoodItem_flight_done", [food_item])
+	if is_inside_tree():
+		get_tree().create_timer(adjusted_flight_duration).connect("timeout", self, "_on_FoodItem_flight_done", [food_item])
 
 
 func _on_FoodItem_flight_done(food_item: FoodItem) -> void:

--- a/project/src/main/puzzle/night/night-mode-toggler.gd
+++ b/project/src/main/puzzle/night/night-mode-toggler.gd
@@ -68,6 +68,8 @@ func is_night_mode() -> bool:
 ## 	'duration': (Optional) Transition duration in seconds. A value of 0.0 will transition instantly. If omitted, a
 ## 		default transition duration will be used.
 func _start_night_tween(duration := TWEEN_DURATION) -> void:
+	if not is_inside_tree():
+		return
 	_nodes_modulated_to_transparent.clear()
 	if duration > 0.0:
 		_tween = Utils.recreate_tween(self, _tween).set_parallel()

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -43,7 +43,8 @@ func _ready() -> void:
 	
 	if CurrentLevel.settings.other.skip_intro:
 		$PuzzleMusicManager.start_puzzle_music()
-		yield(get_tree().create_timer(0.8), "timeout")
+		if is_inside_tree():
+			yield(get_tree().create_timer(0.8), "timeout")
 		_start_puzzle()
 	else:
 		CurrentLevel.settings.triggers.run_triggers(LevelTrigger.BEFORE_START)
@@ -56,7 +57,8 @@ func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_menu") and not $Hud/Center/PuzzleMessages.is_settings_button_visible():
 		# if the player presses the 'menu' button during a puzzle, we pop open the settings panel
 		_settings_menu.show()
-		get_tree().set_input_as_handled()
+		if is_inside_tree():
+			get_tree().set_input_as_handled()
 	
 	if event.is_action_pressed("retry"):
 		if not PuzzleState.game_active and not PuzzleState.game_ended:
@@ -125,7 +127,8 @@ func start_level_countdown() -> void:
 	$Fg/PieceManager.set_physics_process(false)
 	$Hud/Center/PuzzleMessages.show_message(PuzzleMessage.NEUTRAL, tr("Ready?"))
 	$StartEndSfx.play_ready_sound()
-	yield(get_tree().create_timer(PuzzleState.READY_DURATION), "timeout")
+	if is_inside_tree():
+		yield(get_tree().create_timer(PuzzleState.READY_DURATION), "timeout")
 	$Hud/Center/PuzzleMessages.hide_message()
 	$Fg/PieceManager.set_physics_process(true)
 	$Fg/PieceManager.skip_prespawn()
@@ -158,6 +161,8 @@ func is_night_mode() -> bool:
 
 ## Restarts the puzzle, saving the level results and applying any penalties.
 func _restart() -> void:
+	if not is_inside_tree():
+		return
 	PuzzleState.retrying = true
 	if not CurrentLevel.settings.lose_condition.finish_on_lose:
 		# set the game inactive before ending combo/topping out, to avoid triggering gameplay and visual
@@ -179,7 +184,8 @@ func _restart() -> void:
 		_save_level_result(rank_result)
 	
 	_start_puzzle()
-	get_tree().set_input_as_handled()
+	if is_inside_tree():
+		get_tree().set_input_as_handled()
 	PuzzleState.retrying = false
 
 
@@ -386,7 +392,8 @@ func _on_Playfield_line_cleared(_y: int, total_lines: int, remaining_lines: int,
 	# Calculate whether or not the customer should say something positive about the combo.
 	# They say something after clearing [6, 12, 18, 24...] lines.
 	if remaining_lines == 0 and PuzzleState.combo >= 6 and total_lines > PuzzleState.combo % 6:
-		yield(get_tree().create_timer(0.5), "timeout")
+		if is_inside_tree():
+			yield(get_tree().create_timer(0.5), "timeout")
 		customer.play_combo_voice()
 
 

--- a/project/src/main/puzzle/tutorial/tutorial-hud.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-hud.gd
@@ -53,7 +53,8 @@ func replace_tutorial_module() -> void:
 		add_child(tutorial_module)
 	
 	# pause to ensure the 'ready' signal is emitted before the 'refreshed' signal
-	yield(get_tree(), "idle_frame")
+	if is_inside_tree():
+		yield(get_tree(), "idle_frame")
 	refresh()
 
 

--- a/project/src/main/ui/button-shortcut-helper.gd
+++ b/project/src/main/ui/button-shortcut-helper.gd
@@ -46,4 +46,5 @@ func _input(event: InputEvent) -> void:
 		button.toggle_mode = false
 		button.emit_signal("button_up")
 		button.emit_signal("pressed")
-	get_tree().set_input_as_handled()
+	if is_inside_tree():
+		get_tree().set_input_as_handled()

--- a/project/src/main/ui/candy-button/candy-button-c3.gd
+++ b/project/src/main/ui/candy-button/candy-button-c3.gd
@@ -232,7 +232,8 @@ func _on_mouse_entered() -> void:
 	if disabled:
 		return
 	
-	yield(get_tree(), "idle_frame")
+	if is_inside_tree():
+		yield(get_tree(), "idle_frame")
 	emit_signal("hovered_changed")
 	_hover_sound.pitch_scale = rand_range(0.95, 1.05)
 	SfxKeeper.copy(_hover_sound).play()
@@ -243,7 +244,8 @@ func _on_mouse_exited() -> void:
 	if disabled:
 		return
 	
-	yield(get_tree(), "idle_frame")
+	if is_inside_tree():
+		yield(get_tree(), "idle_frame")
 	emit_signal("hovered_changed")
 
 

--- a/project/src/main/ui/candy-button/candy-button-collapsible.gd
+++ b/project/src/main/ui/candy-button/candy-button-collapsible.gd
@@ -302,7 +302,8 @@ func _on_mouse_entered() -> void:
 	if disabled:
 		return
 	
-	yield(get_tree(), "idle_frame")
+	if is_inside_tree():
+		yield(get_tree(), "idle_frame")
 	emit_signal("hovered_changed")
 	_hover_sound.pitch_scale = rand_range(0.95, 1.05)
 	SfxKeeper.copy(_hover_sound).play()
@@ -313,7 +314,8 @@ func _on_mouse_exited() -> void:
 	if disabled:
 		return
 	
-	yield(get_tree(), "idle_frame")
+	if is_inside_tree():
+		yield(get_tree(), "idle_frame")
 	emit_signal("hovered_changed")
 
 

--- a/project/src/main/ui/candy-button/candy-button-h3.gd
+++ b/project/src/main/ui/candy-button/candy-button-h3.gd
@@ -271,7 +271,8 @@ func _on_mouse_entered() -> void:
 	if disabled:
 		return
 	
-	yield(get_tree(), "idle_frame")
+	if is_inside_tree():
+		yield(get_tree(), "idle_frame")
 	emit_signal("hovered_changed")
 	_hover_sound.pitch_scale = rand_range(0.95, 1.05)
 	SfxKeeper.copy(_hover_sound).play()
@@ -282,7 +283,8 @@ func _on_mouse_exited() -> void:
 	if disabled:
 		return
 	
-	yield(get_tree(), "idle_frame")
+	if is_inside_tree():
+		yield(get_tree(), "idle_frame")
 	emit_signal("hovered_changed")
 
 

--- a/project/src/main/ui/candy-button/candy-button-h4.gd
+++ b/project/src/main/ui/candy-button/candy-button-h4.gd
@@ -213,7 +213,8 @@ func _on_mouse_entered() -> void:
 	if disabled:
 		return
 	
-	yield(get_tree(), "idle_frame")
+	if is_inside_tree():
+		yield(get_tree(), "idle_frame")
 	emit_signal("hovered_changed")
 	_hover_sound.pitch_scale = rand_range(0.95, 1.05)
 	SfxKeeper.copy(_hover_sound).play()
@@ -224,7 +225,8 @@ func _on_mouse_exited() -> void:
 	if disabled:
 		return
 	
-	yield(get_tree(), "idle_frame")
+	if is_inside_tree():
+		yield(get_tree(), "idle_frame")
 	emit_signal("hovered_changed")
 
 

--- a/project/src/main/ui/candy-button/candy-color-picker-button.gd
+++ b/project/src/main/ui/candy-button/candy-color-picker-button.gd
@@ -36,12 +36,14 @@ func _refresh() -> void:
 
 
 func _on_mouse_entered() -> void:
-	yield(get_tree(), "idle_frame")
+	if is_inside_tree():
+		yield(get_tree(), "idle_frame")
 	_refresh()
 
 
 func _on_mouse_exited() -> void:
-	yield(get_tree(), "idle_frame")
+	if is_inside_tree():
+		yield(get_tree(), "idle_frame")
 	_refresh()
 
 

--- a/project/src/main/ui/difficulty/difficulty-menu.gd
+++ b/project/src/main/ui/difficulty/difficulty-menu.gd
@@ -25,6 +25,8 @@ func _ready() -> void:
 ## Returns:
 ## 	The button representing the difficulty stored in the player's settings.
 func _chosen_difficulty_button() -> DifficultyButton:
+	if not is_inside_tree():
+		return null
 	var chosen_difficulty_button: DifficultyButton
 	
 	# find the chosen difficulty button

--- a/project/src/main/ui/level-select/level-button-scroller.gd
+++ b/project/src/main/ui/level-select/level-button-scroller.gd
@@ -50,14 +50,16 @@ func _input(event: InputEvent) -> void:
 		if central_button_index < _level_buttons_container.get_child_count() - 1:
 			_slide_central_button(central_button_index + 1)
 			_central_button().grab_focus()
-		get_tree().set_input_as_handled()
+		if is_inside_tree():
+			get_tree().set_input_as_handled()
 
 	if _level_button_has_focus() and event.is_action_pressed("ui_left"):
 		# scroll level buttons left, if possible
 		if central_button_index > 0:
 			_slide_central_button(central_button_index - 1)
 			_central_button().grab_focus()
-		get_tree().set_input_as_handled()
+		if is_inside_tree():
+			get_tree().set_input_as_handled()
 
 
 func _process(_delta: float) -> void:

--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -11,6 +11,8 @@ func _ready() -> void:
 
 
 func _on_System_quit_pressed() -> void:
+	if not is_inside_tree():
+		return
 	if OS.has_feature("web"):
 		# don't quit from the web; just go back to splash screen
 		return

--- a/project/src/main/ui/menu/paged-level-buttons.gd
+++ b/project/src/main/ui/menu/paged-level-buttons.gd
@@ -57,12 +57,14 @@ func _input(event: InputEvent) -> void:
 	if _rightmost_level_button_has_focus() and event.is_action_pressed("ui_right"):
 		if _page < _max_selectable_page():
 			_select_next_page()
-		get_tree().set_input_as_handled()
+		if is_inside_tree():
+			get_tree().set_input_as_handled()
 
 	if _leftmost_level_button_has_focus() and event.is_action_pressed("ui_left"):
 		if _page > 0:
 			_select_previous_page()
-		get_tree().set_input_as_handled()
+		if is_inside_tree():
+			get_tree().set_input_as_handled()
 
 
 ## Returns 'true' if a button in the rightmost column has focus.
@@ -264,5 +266,6 @@ func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDete
 				break
 		_refresh()
 		if button_index_to_focus != -1:
-			yield(get_tree(), "idle_frame")
+			if is_inside_tree():
+				yield(get_tree(), "idle_frame")
 			_grid_container.get_children()[button_index_to_focus].grab_focus()

--- a/project/src/main/ui/menu/paged-region-buttons.gd
+++ b/project/src/main/ui/menu/paged-region-buttons.gd
@@ -49,12 +49,14 @@ func _input(event: InputEvent) -> void:
 	if _rightmost_region_button_has_focus() and event.is_action_pressed("ui_right"):
 		if _page < _max_selectable_page():
 			_select_next_page()
-		get_tree().set_input_as_handled()
+		if is_inside_tree():
+			get_tree().set_input_as_handled()
 
 	if _leftmost_region_button_has_focus() and event.is_action_pressed("ui_left"):
 		if _page > 0:
 			_select_previous_page()
-		get_tree().set_input_as_handled()
+		if is_inside_tree():
+			get_tree().set_input_as_handled()
 
 
 ## Focuses a specific region button, possibly changing the current page.
@@ -262,5 +264,6 @@ func _on_CheatCodeDetector_cheat_detected(cheat: String, detector: CheatCodeDete
 			button_index_to_focus = get_focus_owner().get_index()
 		_refresh()
 		if button_index_to_focus != -1:
-			yield(get_tree(), "idle_frame")
+			if is_inside_tree():
+				yield(get_tree(), "idle_frame")
 			_hbox_container.get_children()[button_index_to_focus].grab_focus()

--- a/project/src/main/ui/menu/splash-screen.gd
+++ b/project/src/main/ui/menu/splash-screen.gd
@@ -34,4 +34,6 @@ func _on_Play_pressed() -> void:
 
 
 func _on_System_quit_pressed() -> void:
+	if not is_inside_tree():
+		return
 	get_tree().quit()

--- a/project/src/main/ui/menu/training-menu.gd
+++ b/project/src/main/ui/menu/training-menu.gd
@@ -99,6 +99,8 @@ func _load_recent_data() -> void:
 ## When submenus appear over top of the main menu, we temporarily disable focus for all sliders/buttons/etc on the
 ## main menu to avoid them from grabbing keyboard focus.
 func _refresh_input_focus_mode() -> void:
+	if not is_inside_tree():
+		return
 	var submenu_visible: bool = _level_submenu.visible or _region_submenu.visible
 	for node in get_tree().get_nodes_in_group("main_practice_inputs"):
 		node.focus_mode = FOCUS_NONE if submenu_visible else FOCUS_ALL
@@ -193,14 +195,16 @@ func _on_LevelSelect_level_chosen(region: Object, settings: LevelSettings) -> vo
 	_level_description_label.text = _level_settings.description
 	_refresh_speed_selector()
 	_refresh_high_scores()
-	yield(get_tree(), "idle_frame")
+	if is_inside_tree():
+		yield(get_tree(), "idle_frame")
 	_start_button.grab_focus()
 
 
 func _on_LevelSubmenu_visibility_changed() -> void:
 	_refresh_input_focus_mode()
 	if not _level_submenu.visible:
-		yield(get_tree(), "idle_frame")
+		if is_inside_tree():
+			yield(get_tree(), "idle_frame")
 		_start_button.grab_focus()
 
 

--- a/project/src/main/ui/music-popup.gd
+++ b/project/src/main/ui/music-popup.gd
@@ -47,7 +47,8 @@ func _on_MusicPlayer_current_track_changed(value: CheckpointMusicTrack) -> void:
 
 func _on_Label_item_rect_changed() -> void:
 	# wait for a frame; it takes a frame for Label.rect_size to update
-	yield(get_tree(), "idle_frame")
+	if is_inside_tree():
+		yield(get_tree(), "idle_frame")
 	
 	# resize the music panel to accommodate the label
 	_music_panel.rect_size.x = _music_label.rect_size.x + 64

--- a/project/src/main/ui/save-indicator.gd
+++ b/project/src/main/ui/save-indicator.gd
@@ -66,7 +66,8 @@ func _schedule_looped_tween() -> void:
 ##
 ## We add a delay to ensure it's visible for a minimum amount of time.
 func _schedule_stop() -> void:
-	get_tree().create_timer(DURATION).connect("timeout", self, "stop")
+	if is_inside_tree():
+		get_tree().create_timer(DURATION).connect("timeout", self, "stop")
 
 
 func _on_PlayerSave_before_save() -> void:

--- a/project/src/main/ui/scene-transition.gd
+++ b/project/src/main/ui/scene-transition.gd
@@ -42,6 +42,8 @@ onready var _mask: Node = $MaskHolder/Mask
 ##
 ## 	'flags': Flags which affect the scene transition's duration and appearance
 func push_trail(path: String, flags: Dictionary = {}) -> void:
+	if not is_inside_tree():
+		return
 	if flags.get(FLAG_TYPE) == TransitionType.NONE \
 			or not get_tree().get_nodes_in_group("scene_transition_covers") \
 			or "::" in path:
@@ -59,6 +61,8 @@ func push_trail(path: String, flags: Dictionary = {}) -> void:
 ##
 ## 	'flags': Flags which affect the scene transition's duration and appearance
 func replace_trail(path: String, flags: Dictionary = {}) -> void:
+	if not is_inside_tree():
+		return
 	if flags.get(FLAG_TYPE) == TransitionType.NONE \
 			or not get_tree().get_nodes_in_group("scene_transition_covers") \
 			or "::" in path:
@@ -72,6 +76,8 @@ func replace_trail(path: String, flags: Dictionary = {}) -> void:
 ## Parameters:
 ## 	'flags': Flags which affect the scene transition's duration and appearance
 func change_scene(flags: Dictionary = {}) -> void:
+	if not is_inside_tree():
+		return
 	if flags.get(FLAG_TYPE) == TransitionType.NONE \
 			or not get_tree().get_nodes_in_group("scene_transition_covers"):
 		Breadcrumb.change_scene()
@@ -84,6 +90,8 @@ func change_scene(flags: Dictionary = {}) -> void:
 ## Parameters:
 ## 	'flags': Flags which affect the scene transition's duration and appearance
 func pop_trail(flags: Dictionary = {}) -> void:
+	if not is_inside_tree():
+		return
 	if flags.get(FLAG_TYPE) == TransitionType.NONE \
 			or not get_tree().get_nodes_in_group("scene_transition_covers") \
 			or (Breadcrumb.trail and "::" in Breadcrumb.trail.front()):
@@ -94,6 +102,8 @@ func pop_trail(flags: Dictionary = {}) -> void:
 
 ## Launches the 'fade in' visual transition.
 func fade_in(flags: Dictionary = {}) -> void:
+	if not is_inside_tree():
+		return
 	Global.print_verbose("Launching scene transition fade in effect")
 	# unignore input immediately; don't wait for fade in to finish
 	get_tree().get_root().set_disable_input(false)
@@ -111,6 +121,8 @@ func fade_in(flags: Dictionary = {}) -> void:
 
 ## Launches the 'fade out' visual transition.
 func fade_out(flags: Dictionary = {}, breadcrumb_method: FuncRef = null, breadcrumb_arg_array: Array = []) -> void:
+	if not is_inside_tree():
+		return
 	Global.print_verbose("Launching scene transition fade out effect")
 	# ignore input to prevent edge-cases where player does weird things during scene transitions
 	get_tree().get_root().set_disable_input(true)

--- a/project/src/main/ui/settings/keybind/custom-keybind-button.gd
+++ b/project/src/main/ui/settings/keybind/custom-keybind-button.gd
@@ -45,6 +45,8 @@ func end_awaiting() -> void:
 
 ## Takes the button into the 'awaiting state', where it waits for the player to press a key.
 func _start_awaiting() -> void:
+	if not is_inside_tree():
+		return
 	var custom_keybind_buttons := get_tree().get_nodes_in_group("custom_keybind_buttons")
 	for keybind_button in custom_keybind_buttons:
 		keybind_button.end_awaiting()

--- a/project/src/main/ui/settings/keybind/custom-keybind-row.gd
+++ b/project/src/main/ui/settings/keybind/custom-keybind-row.gd
@@ -30,6 +30,8 @@ func _refresh_description_label() -> void:
 
 
 func _on_Delete_pressed() -> void:
+	if not is_inside_tree():
+		return
 	SystemData.has_unsaved_changes = true
 	if action_name in KeybindSettings.MENU_ACTION_NAMES:
 		SystemData.keybind_settings.restore_default_keybinds(action_name)

--- a/project/src/main/ui/wallpaper/wallpaper.gd
+++ b/project/src/main/ui/wallpaper/wallpaper.gd
@@ -111,10 +111,14 @@ func _add_color_rect(rect_y: float, rect_height: float) -> ColorRect:
 ##
 ## The wallpaper is visible if the current scene is in the 'wallpaper_enabled' group.
 func _refresh_visible() -> void:
+	if not is_inside_tree():
+		return
 	visible = get_tree().current_scene.is_in_group("wallpaper_enabled")
 
 
 func _on_node_added(node: Node) -> void:
+	if not is_inside_tree():
+		return
 	if node == get_tree().current_scene:
 		_refresh_visible()
 

--- a/project/src/main/utils/breadcrumb.gd
+++ b/project/src/main/utils/breadcrumb.gd
@@ -20,6 +20,8 @@ var trail := []
 ## This is useful for demos and development where having an empty breadcrumb trail causes bugs. During regular play the
 ## breadcrumb trail should be initialized conventionally in the splash screen or menus.
 func initialize_trail() -> void:
+	if not is_inside_tree():
+		return
 	if get_tree().current_scene == null:
 		push_warning("tree.current_scene == null; could not initialize trail")
 		trail = []
@@ -65,6 +67,8 @@ func replace_trail(path: String) -> void:
 
 ## Changes the running scene to the one at the front of the breadcrumb trail.
 func change_scene() -> void:
+	if not is_inside_tree():
+		return
 	emit_signal("before_scene_changed")
 	var scene_path: String
 	if trail:
@@ -89,6 +93,8 @@ func change_scene() -> void:
 ## happens about every 300 times the player exits a puzzle. See Godot #85692
 ## (https://github.com/godotengine/godot/issues/85692).
 func _unload_current_scene_custom() -> void:
+	if not is_inside_tree():
+		return
 	var old_scene := get_tree().current_scene
 	get_tree().root.remove_child(old_scene)
 	old_scene.queue_free()

--- a/project/src/main/utils/global.gd
+++ b/project/src/main/utils/global.gd
@@ -80,11 +80,15 @@ func benchmark_end(key: String = "") -> void:
 
 
 func get_overworld_ui() -> OverworldUi:
+	if not is_inside_tree():
+		return null
 	var nodes := get_tree().get_nodes_in_group("overworld_ui")
 	return nodes[0] if nodes else null
 
 
 func get_creature_editor_library() -> CreatureEditorLibrary:
+	if not is_inside_tree():
+		return null
 	var nodes := get_tree().get_nodes_in_group("creature_editor_library")
 	return nodes[0] if nodes else null
 

--- a/project/src/main/utils/pauser.gd
+++ b/project/src/main/utils/pauser.gd
@@ -18,11 +18,15 @@ func _ready() -> void:
 
 ## Purges all pause requests and unpauses the game.
 func reset() -> void:
+	if not is_inside_tree():
+		return
 	_pausers.clear()
 	get_tree().paused = false
 
 
 func _process(_delta: float) -> void:
+	if not is_inside_tree():
+		return
 	if get_tree().paused != _paused:
 		_paused = get_tree().paused
 		emit_signal("paused_changed", _paused)
@@ -38,6 +42,8 @@ func _process(_delta: float) -> void:
 ##
 ## 	'paused': 'true' to pause, 'false' to unpause.
 func toggle_pause(request_id: String, paused: bool) -> void:
+	if not is_inside_tree():
+		return
 	if paused:
 		_pausers[request_id] = true
 	else:

--- a/project/src/main/utils/resource-cache.gd
+++ b/project/src/main/utils/resource-cache.gd
@@ -178,6 +178,8 @@ func _overworked() -> bool:
 ## Parameters:
 ## 	'_userdata': Unused; needed for threads
 func _preload_all_resources(_userdata: Object) -> void:
+	if not is_inside_tree():
+		return
 	while _remaining_resource_paths and not _exiting:
 		while _remaining_resource_paths and not _exiting \
 				and not _overworked():
@@ -185,7 +187,8 @@ func _preload_all_resources(_userdata: Object) -> void:
 		
 		# If we're ahead of schedule, we wait until the next idle frame to load more resources
 		if _overworked():
-			yield(get_tree(), "idle_frame")
+			if is_inside_tree():
+				yield(get_tree(), "idle_frame")
 
 
 ## Loads a single resource and stores the resulting resource in our cache.

--- a/project/src/main/utils/sfx-keeper.gd
+++ b/project/src/main/utils/sfx-keeper.gd
@@ -24,8 +24,9 @@ func copy(player: Node) -> Node:
 	new_player.connect("finished", self, "_cleanup_player", [new_player])
 	
 	# Clean up unplayed audio streams after a short delay
-	get_tree().create_timer(0.1).connect("timeout", self, "_cleanup_player", [new_player])
-	
+	if is_inside_tree():
+		get_tree().create_timer(0.1).connect("timeout", self, "_cleanup_player", [new_player])
+
 	return new_player
 
 

--- a/project/src/main/utils/utils.gd
+++ b/project/src/main/utils/utils.gd
@@ -166,6 +166,8 @@ static func find_focusable_nodes(parent_node: Node) -> Array:
 static func get_child_members(parent: Node, group: String) -> Array:
 	if not parent:
 		return []
+	if not parent.is_inside_tree():
+		return []
 	
 	var child_members := []
 	for member in parent.get_tree().get_nodes_in_group(group):

--- a/project/src/main/world/career-world.gd
+++ b/project/src/main/world/career-world.gd
@@ -113,6 +113,9 @@ func refresh_from_career_data(level_posses: Array) -> void:
 
 
 func get_visible_customers(level_index: int) -> Array:
+	if not is_inside_tree():
+		return []
+	
 	var result: Array
 	if PlayerData.career.level_choice_count() == 1:
 		# only one level choice; return all visible customers

--- a/project/src/main/world/cutscene-world.gd
+++ b/project/src/main/world/cutscene-world.gd
@@ -36,7 +36,8 @@ func _launch_cutscene() -> void:
 	_add_cutscene_creatures()
 	_arrange_creatures()
 	
-	yield(get_tree(), "idle_frame")
+	if is_inside_tree():
+		yield(get_tree(), "idle_frame")
 
 	Global.get_overworld_ui().start_chat(CurrentCutscene.chat_tree)
 	_camera.snap_into_position()

--- a/project/src/main/world/environment/credits/crowd-recycler.gd
+++ b/project/src/main/world/environment/credits/crowd-recycler.gd
@@ -63,6 +63,8 @@ func _on_Director_stopped() -> void:
 ## When the crowd walk director moves all crowdies, we temporarily ignore collisions. This method reenables
 ## collisions afterward.
 func _on_ReenableCollisionTimer_timeout() -> void:
+	if not is_inside_tree():
+		return
 	_just_arranged_creatures = false
 	
 	# move all overlapping crowdies

--- a/project/src/main/world/environment/credits/crowd-surf-director.gd
+++ b/project/src/main/world/environment/credits/crowd-surf-director.gd
@@ -41,6 +41,8 @@ func stop() -> void:
 
 ## Saves all creature positions to _initial_positions_by_node
 func _save_initial_positions() -> void:
+	if not is_inside_tree():
+		return
 	var repositionable_nodes := []
 	repositionable_nodes.append(_player)
 	repositionable_nodes.append(_sensei)

--- a/project/src/main/world/environment/credits/crowd-walk-director.gd
+++ b/project/src/main/world/environment/credits/crowd-walk-director.gd
@@ -38,6 +38,8 @@ func _ready() -> void:
 
 ## Saves all creature positions to _initial_positions_by_node
 func _save_initial_positions() -> void:
+	if not is_inside_tree():
+		return
 	var repositionable_nodes := []
 	repositionable_nodes.append(_player)
 	repositionable_nodes.append(_sensei)
@@ -119,6 +121,8 @@ func set_bouncing_crowd_percent(new_bouncing_crowd_percent: float) -> void:
 
 ## Makes all crowdies jump up and down with their arms raised.
 func crowd_launch() -> void:
+	if not is_inside_tree():
+		return
 	for crowd in get_tree().get_nodes_in_group("lava_crowdies"):
 		crowd.bouncing = true
 		crowd.raise_arms()
@@ -152,6 +156,8 @@ func _refresh_bouncing_crowd_percent() -> void:
 ##
 ## 	'new_bouncing': True if the crowdies should start jumping up and down, false if they should stop.
 func _toggle_bouncing(count: int, new_bouncing: bool) -> void:
+	if not is_inside_tree():
+		return
 	if count == 0:
 		return
 	

--- a/project/src/main/world/environment/overworld-environment.gd
+++ b/project/src/main/world/environment/overworld-environment.gd
@@ -32,6 +32,8 @@ func add_obstacle(node: Node2D) -> void:
 
 ## Relocate a creature to a spawn point.
 func move_creature_to_spawn(creature: Creature, spawn_id: String) -> void:
+	if not is_inside_tree():
+		return
 	var target_spawn: Spawn
 	for spawn_obj in get_tree().get_nodes_in_group("spawns"):
 		var spawn: Spawn = spawn_obj

--- a/project/src/main/world/environment/poki/poki-crowdie-spawner.gd
+++ b/project/src/main/world/environment/poki/poki-crowdie-spawner.gd
@@ -21,6 +21,8 @@ func set_shuffle(value: bool) -> void:
 ## Spawns and orients the crowdie and removes the spawner from the scene tree.
 func spawn_target() -> void:
 	.spawn_target()
+	if not is_inside_tree():
+		return
 	
 	var flip_chance := 0.5
 	

--- a/project/src/main/world/environment/stool.gd
+++ b/project/src/main/world/environment/stool.gd
@@ -60,6 +60,8 @@ func _refresh_occupied() -> void:
 ## Returns:
 ## 	The stool which is directly beneath the creature, or 'null' if no stool is found.
 static func find_stool(nearby_node2d: Node2D) -> Node2D:
+	if not nearby_node2d.is_inside_tree():
+		return null
 	var result: Node2D
 	
 	for next_stool in nearby_node2d.get_tree().get_nodes_in_group("stools"):

--- a/project/src/main/world/overworld-world.gd
+++ b/project/src/main/world/overworld-world.gd
@@ -55,6 +55,6 @@ func _refresh_environment_scene() -> void:
 		overworld_environment = empty_environment_scene.instance()
 	add_child(overworld_environment)
 	move_child(overworld_environment, 0)
-	overworld_environment.owner = get_tree().get_edited_scene_root()
+	overworld_environment.owner = get_tree().get_edited_scene_root() if is_inside_tree() else null
 	
 	emit_signal("overworld_environment_changed", overworld_environment)

--- a/project/src/main/world/puzzle-world.gd
+++ b/project/src/main/world/puzzle-world.gd
@@ -66,6 +66,9 @@ func _spawn_chef() -> void:
 ##
 ## The chef creature is spawned at the spawn with ids like 'customer_1', 'customer_2'. The numbers are not used.
 func _spawn_customers() -> void:
+	if not is_inside_tree():
+		return
+	
 	for spawn_obj in get_tree().get_nodes_in_group("spawns"):
 		if not overworld_environment.is_a_parent_of(spawn_obj):
 			continue


### PR DESCRIPTION
A user experienced a game crash after the end of day in career mode with the following message logged:

```
ERROR: Condition "!data.tree" is true. Returned: nullptr
   at: Node::get_tree (.\scene/main/node.h:333) - Condition "!data.tree" is true. Returned: nullptr
```

It's possible get_tree() could cause this error in some edge cases -- for example, if someone called 'LandmarkLines.refresh()' after it was removed from the scene tree. I've preempted all get_tree() calls with checks to ensure the node is still in the tree.

Note: I did not add checks to most calls in `_ready` or `_enter_tree` since those callbacks are only called when the node is in the tree.