### PR TITLE
Added null checks for timer signal methods

### DIFF
--- a/project/src/main/puzzle/tutorial/tutorial-module.gd
+++ b/project/src/main/puzzle/tutorial/tutorial-module.gd
@@ -105,11 +105,13 @@ func start_timer_after_all_messages_shown(wait_time: float) -> Timer:
 
 func _on_TutorialMessages_all_messages_shown_start_timer(timer: Timer) -> void:
 	hud.messages.disconnect("all_messages_shown", self, "_on_TutorialMessages_all_messages_shown_start_timer")
-	timer.start()
+	if timer:
+		timer.start()
 
 
 func _on_Timer_timeout_queue_free(timer: Timer) -> void:
-	timer.queue_free()
+	if timer:
+		timer.queue_free()
 
 
 func _on_Timer_timeout_change_level(level_id: String) -> void:

--- a/project/src/main/utils/timer-group.gd
+++ b/project/src/main/utils/timer-group.gd
@@ -56,4 +56,5 @@ func clear() -> void:
 
 ## When a timer times out, we free it.
 func _on_Timer_timeout_queue_free(timer: Timer) -> void:
-	timer.queue_free()
+	if timer:
+		timer.queue_free()


### PR DESCRIPTION
Some of these methods were called to start/free timers after a delay, but the timer could be cleared by another process. I triggered this once when testing my 'restart tutorial section' logic while some tutorial messages were playing.