### PR TITLE
'R' restarts only one tutorial section, not the whole tutorial.

### DIFF
--- a/project/src/main/puzzle/puzzle-messages.gd
+++ b/project/src/main/puzzle/puzzle-messages.gd
@@ -123,13 +123,16 @@ func _on_PuzzleState_game_started() -> void:
 	hide_message()
 
 
-func _on_PuzzleState_before_level_changed(_new_level_id: String) -> void:
+func _on_PuzzleState_before_level_changed(new_level_id: String) -> void:
 	if CurrentLevel.settings.other.non_interactive or not CurrentLevel.settings.input_replay.empty():
 		# non interactive levels don't show a success/failure message
 		return
 	
 	if PuzzleState.level_performance.lost:
 		show_message(PuzzleMessage.BAD, tr("Regret..."))
+	elif new_level_id == CurrentLevel.settings.id:
+		# retrying a level; don't show any message
+		pass
 	else:
 		show_message(PuzzleMessage.GOOD, tr("Good!"))
 

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -154,6 +154,11 @@ func add_timer(wait_time: float) -> Timer:
 	return _timers.add_timer(wait_time)
 
 
+## Frees all timers.
+func clear_timers() -> void:
+	_timers.clear()
+
+
 ## Resets all score data, and starts a new game after a brief pause.
 func prepare_and_start_game() -> void:
 	_prepare_game()

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -67,6 +67,9 @@ func _input(event: InputEvent) -> void:
 				and SystemData.misc_settings.show_give_up_confirmation:
 			# user hasn't been prompted yet; prompt the user to retry
 			_settings_menu.show_give_up_confirmation()
+		elif (CurrentLevel.is_tutorial() or CurrentLevel.settings.other.after_tutorial):
+			# each tutorial module handles restarting in their own way
+			pass
 		else:
 			_restart()
 

--- a/project/src/main/puzzle/start-end-sfx.gd
+++ b/project/src/main/puzzle/start-end-sfx.gd
@@ -49,13 +49,16 @@ func _on_PuzzleState_game_started() -> void:
 	play_go_sound()
 
 
-func _on_PuzzleState_before_level_changed(_new_level_id: String) -> void:
+func _on_PuzzleState_before_level_changed(new_level_id: String) -> void:
 	if CurrentLevel.settings.other.non_interactive or not CurrentLevel.settings.input_replay.empty():
 		# no sound effect or fanfare for non-interactive levels
 		return
 	
 	if PuzzleState.level_performance.lost:
 		_section_fail_sound.play()
+	elif new_level_id == CurrentLevel.settings.id:
+		# retrying a level; don't play any sfx
+		pass
 	else:
 		_section_complete_sound.play()
 


### PR DESCRIPTION
Particularly during the combo and cakes, it's possible a player might reflexively hit 'R' when they misdrop a piece. Previously this restarted the entire tutorial, which is definitely not what the player would want.

They can still restart the entire tutorial if they go into the menu.