### PR TITLE
Decreased 'avoid repeated sfx' threshold from 200 ms to 20 ms

### DIFF
--- a/project/src/main/ui/CheatCodeDetector.tscn
+++ b/project/src/main/ui/CheatCodeDetector.tscn
@@ -11,9 +11,9 @@ script = ExtResource( 3 )
 [node name="CheatDisableSound" parent="." instance=ExtResource( 4 )]
 stream = ExtResource( 1 )
 volume_db = -4.0
-threshold_msec = 200
+suppress_sfx_msec = 200
 
 [node name="CheatEnableSound" parent="." instance=ExtResource( 4 )]
 stream = ExtResource( 2 )
 volume_db = -4.0
-threshold_msec = 200
+suppress_sfx_msec = 200

--- a/project/src/main/utils/DeconflictedAudioStreamPlayer.tscn
+++ b/project/src/main/utils/DeconflictedAudioStreamPlayer.tscn
@@ -5,4 +5,3 @@
 [node name="DeconflictedAudioStreamPlayer" type="AudioStreamPlayer"]
 bus = "Sound Bus"
 script = ExtResource( 1 )
-suppress_sfx_msec = 200


### PR DESCRIPTION
The high threshold was making the hover sound effects a little strange and sparse during the menus. Circling the mouse quickly would not play very many hover sounds.

This threshold was accidentally increased in a099b976 when fixing overlapping audio for the training menu unlock cheat. This change affected the entire game, not just the cheat sound effect, and increased the threshold very high.