### PR TITLE
dna_loaded signal now fires after all shaders are assigned.

### DIFF
--- a/project/src/main/world/creature/creature-shadow.gd
+++ b/project/src/main/world/creature/creature-shadow.gd
@@ -46,6 +46,9 @@ func _refresh_creature_path() -> void:
 	_creature.connect("dna_loaded", self, "_on_Creature_dna_loaded")
 	
 	position = _creature.position + shadow_offset
+	if not _creature.creature_visuals:
+		# wait a frame for the creature's fields to be populated
+		yield(get_tree(), "idle_frame")
 	if _creature.creature_visuals:
 		_sprite.scale = Vector2(0.17, 0.17) * shadow_scale * _creature.creature_visuals.scale.y
 		_refresh_creature_shadow_scale()

--- a/project/src/main/world/creature/dna-loader.gd
+++ b/project/src/main/world/creature/dna-loader.gd
@@ -33,6 +33,9 @@ func _process(_delta: float) -> void:
 			# nonexistent materials. We check for null to avoid a crash.
 			if _creature_visuals.has_node(node_path) and _creature_visuals.get_node(node_path).material:
 				_creature_visuals.get_node(node_path).material.set_shader_param(shader_param, shader_value)
+		
+		if not _pending_shader_keys:
+			emit_signal("dna_loaded")
 
 
 ## Unassigns the textures and animations for the creature.
@@ -153,7 +156,9 @@ func load_dna() -> void:
 	
 	# initialize creature curves, and reset the mouth/eye frame to avoid a strange transition frame
 	_creature_visuals.reset_frames()
-	emit_signal("dna_loaded")
+	
+	if not _pending_shader_keys:
+		emit_signal("dna_loaded")
 
 
 ## Removes a 'dna node', one which swaps out based on the creature's DNA.


### PR DESCRIPTION
Before, the dna_loaded signal was called immediately after the creature's fields were set, even if the shaders hadn't been updated. There was no signal to indicate "the creature is ready to display."

Rather than having two granular signals for "the creature's fields have been populated" and "their shaders have been updated", I've merged these into a single signal.