### PR TITLE
Bug: Creature editor shows black pixels when selecting feature

### DIFF
--- a/project/src/main/editor/creature/creature-editor-library.gd
+++ b/project/src/main/editor/creature/creature-editor-library.gd
@@ -97,6 +97,12 @@ const COLOR_PRESETS_BY_COLOR_PROPERTY := {
 		],
 }
 
+## Unique creature ID for the player's offscreen doppelganger in the creature editor.
+##
+## Changing a creature's appearance forces all their textures and shaders to regenerate, making them look strange for
+## a moment. We apply these changes to a doppelganger and then swap them in after the changes are applied.
+const PLAYER_SWAP_ID := "#player_swap#"
+
 ## List of Category instances with information about the creature editor categories.
 var categories: Array = []
 

--- a/project/src/main/editor/creature/creature-editor-nametag.gd
+++ b/project/src/main/editor/creature/creature-editor-nametag.gd
@@ -6,8 +6,9 @@ export (NodePath) var overworld_environment_path: NodePath
 onready var _overworld_environment: OverworldEnvironment = get_node(overworld_environment_path)
 
 func _ready() -> void:
-	_player().connect("creature_name_changed", self, "_on_Creature_creature_name_changed")
-	_player().connect("dna_loaded", self, "_on_Creature_dna_loaded")
+	for creature in [_player(), _player_swap()]:
+		creature.connect("creature_name_changed", self, "_on_Creature_creature_name_changed", [creature])
+		creature.connect("dna_loaded", self, "_on_Creature_dna_loaded", [creature])
 	_refresh()
 
 
@@ -20,9 +21,17 @@ func _player() -> Creature:
 	return _overworld_environment.player
 
 
-func _on_Creature_creature_name_changed() -> void:
+func _player_swap() -> Creature:
+	return _overworld_environment.get_creature_by_id(CreatureEditorLibrary.PLAYER_SWAP_ID)
+
+
+func _on_Creature_creature_name_changed(creature: Creature) -> void:
+	if creature != _player():
+		return
 	_refresh()
 
 
-func _on_Creature_dna_loaded() -> void:
+func _on_Creature_dna_loaded(creature: Creature) -> void:
+	if creature != _player():
+		return
 	_refresh()

--- a/project/src/main/world/creature/creature.gd
+++ b/project/src/main/world/creature/creature.gd
@@ -91,6 +91,14 @@ var creature_visuals: CreatureVisuals
 ## Virtual property; value is only exposed through getters/setters
 var fatness: float setget set_fatness, get_fatness
 
+## If 'true', the 'refresh_creature_id' method will have no effect, and changing the creature's id will not update
+## their appearance.
+var suppress_refresh_creature_id: bool = false
+
+## If 'true', the 'refresh_dna' method will have no effect, and changing the creature's dna will not update their
+## appearance.
+var suppress_refresh_dna: bool = false
+
 ## Virtual property; value is only exposed through getters/setters
 var visual_fatness: float setget set_visual_fatness, get_visual_fatness
 
@@ -396,6 +404,8 @@ func get_creature_def() -> CreatureDef:
 func refresh_dna() -> void:
 	if not is_inside_tree():
 		return
+	if suppress_refresh_dna:
+		return
 
 	if dna:
 		dna = DnaUtils.fill_dna(dna)
@@ -513,6 +523,8 @@ func _launch_fade_tween(new_alpha: float, duration: float) -> void:
 
 func _refresh_creature_id() -> void:
 	if not is_inside_tree():
+		return
+	if suppress_refresh_creature_id:
 		return
 	
 	var new_creature_def: CreatureDef = PlayerData.creature_library.get_creature_def(creature_id)

--- a/project/src/main/world/environment/CreatureEditorEnvironment.tscn
+++ b/project/src/main/world/environment/CreatureEditorEnvironment.tscn
@@ -55,3 +55,9 @@ cell_shadow_mapping = {
 position = Vector2( -2, 32 )
 creature_id = "#player#"
 orientation = 1
+
+[node name="PlayerSwap" parent="Obstacles" instance=ExtResource( 28 )]
+visible = false
+position = Vector2( 88000, 32 )
+creature_id = "#player_swap#"
+orientation = 1


### PR DESCRIPTION
When changing the creature's appearance in the creature editor, parts of the creature blink black as the creature is redrawn.

To avoid this, I've introduced an offscreen creature where we apply the changes, and then we swap them in once their apperance is updated.

Closes #2531.