### PR TITLE
Add and configure ViewportPurgers to prevent crashes

### DIFF
--- a/project/src/main/puzzle/Playfield.tscn
+++ b/project/src/main/puzzle/Playfield.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=48 format=2]
+[gd_scene load_steps=49 format=2]
 
 [ext_resource path="res://src/main/puzzle/playfield.gd" type="Script" id=1]
 [ext_resource path="res://src/main/puzzle/PuzzleTileMap.tscn" type="PackedScene" id=2]
@@ -23,6 +23,7 @@
 [ext_resource path="res://src/main/puzzle/TutorialKeybindsLabel.tscn" type="PackedScene" id=21]
 [ext_resource path="res://src/main/puzzle/tutorial-hint.gd" type="Script" id=22]
 [ext_resource path="res://src/main/puzzle/LeafPoof.tscn" type="PackedScene" id=23]
+[ext_resource path="res://src/main/utils/ViewportPurger.tscn" type="PackedScene" id=24]
 [ext_resource path="res://src/main/puzzle/line-inserter.gd" type="Script" id=25]
 [ext_resource path="res://src/main/puzzle/Pickup.tscn" type="PackedScene" id=26]
 [ext_resource path="res://src/main/puzzle/pickups.gd" type="Script" id=27]
@@ -372,6 +373,9 @@ bus = "Sound Bus"
 [node name="LineFillSfxResetTimer" type="Timer" parent="LineFiller"]
 wait_time = 0.3
 one_shot = true
+
+[node name="ViewportPurger" parent="." instance=ExtResource( 24 )]
+viewport_paths = [ "BgSprite:material:shader_param:goop_texture", "BgSprite:material:shader_param:rainbow_texture", "ShadowTexture:texture", "GhostPieceTexture:texture" ]
 
 [connection signal="all_lines_cleared" from="." to="LineClearSfx" method="_on_Playfield_all_lines_cleared"]
 [connection signal="before_line_cleared" from="." to="TileMapClip/PlayfieldFx" method="_on_Playfield_before_line_cleared"]

--- a/project/src/main/puzzle/Puzzle.tscn
+++ b/project/src/main/puzzle/Puzzle.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=119 format=2]
+[gd_scene load_steps=120 format=2]
 
 [ext_resource path="res://src/main/ui/theme/h3.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/puzzle/tutorial/TutorialHud.tscn" type="PackedScene" id=2]
@@ -30,6 +30,7 @@
 [ext_resource path="res://assets/main/puzzle/level-change.wav" type="AudioStream" id=28]
 [ext_resource path="res://assets/main/puzzle/tutorial/tutorial-section-fail.wav" type="AudioStream" id=29]
 [ext_resource path="res://src/main/puzzle/top-out-tracker.gd" type="Script" id=30]
+[ext_resource path="res://src/main/utils/ViewportPurger.tscn" type="PackedScene" id=31]
 [ext_resource path="res://src/main/puzzle/bursts.gd" type="Script" id=32]
 [ext_resource path="res://src/main/puzzle/step-meter.gd" type="Script" id=33]
 [ext_resource path="res://src/main/ui/theme/h2.theme" type="Theme" id=34]
@@ -894,6 +895,9 @@ script = ExtResource( 19 )
 
 [node name="NightModeToggler" type="Node" parent="."]
 script = ExtResource( 89 )
+
+[node name="ViewportPurger" parent="." instance=ExtResource( 31 )]
+viewport_paths = [ "Fg/GoopGlobs/TextureRect:texture", "Fg/GoopGlobs/RainbowTextureRect:texture", "Fg/FoodItems/TextureRect:texture", "Fg/HoldPieceDisplays/Holder/Walls:material:shader_param:goop_texture", "Fg/HoldPieceDisplays/Holder/Walls:material:shader_param:rainbow_texture" ]
 
 [connection signal="after_lines_deleted" from="Fg/Playfield" to="Fg/PieceManager" method="_on_Playfield_after_lines_deleted"]
 [connection signal="after_lines_filled" from="Fg/Playfield" to="Fg/PieceManager" method="_on_Playfield_after_lines_filled"]

--- a/project/src/main/puzzle/night/NightPlayfield.tscn
+++ b/project/src/main/puzzle/night/NightPlayfield.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=40 format=2]
+[gd_scene load_steps=41 format=2]
 
 [ext_resource path="res://src/main/puzzle/night/NightPuzzleTileMap.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/puzzle/GoopViewports.tscn" type="PackedScene" id=2]
@@ -22,6 +22,7 @@
 [ext_resource path="res://src/main/puzzle/night/night-sky-glow.gd" type="Script" id=20]
 [ext_resource path="res://src/main/puzzle/night/night-onion.gd" type="Script" id=21]
 [ext_resource path="res://assets/main/puzzle/night/night-sky-particle-sheet.png" type="Texture" id=22]
+[ext_resource path="res://src/main/utils/ViewportPurger.tscn" type="PackedScene" id=23]
 
 [sub_resource type="CanvasItemMaterial" id=24]
 particles_animation = true
@@ -306,6 +307,9 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 texture = SubResource( 14 )
 flip_v = true
+
+[node name="ViewportPurger" parent="." instance=ExtResource( 23 )]
+viewport_paths = [ "ShadowTexture:texture", "GhostPieceTexture:texture" ]
 
 [connection signal="visibility_changed" from="TileMapClip/NightSky" to="TileMapClip/NightSky" method="_on_visibility_changed"]
 [connection signal="timeout" from="TileMapClip/NightSky/AnimateTimer" to="TileMapClip/NightSky" method="_on_AnimateTimer_timeout"]

--- a/project/src/main/world/creature/ViewportCreatureOutline.tscn
+++ b/project/src/main/world/creature/ViewportCreatureOutline.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
+[ext_resource path="res://src/main/utils/ViewportPurger.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/world/creature/CreatureVisuals.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/utils/outline.shader" type="Shader" id=23]
 [ext_resource path="res://src/main/world/creature/viewport-creature-outline.gd" type="Script" id=24]
@@ -36,3 +37,6 @@ margin_bottom = 834.0
 rect_scale = Vector2( 0.4, 0.4 )
 mouse_filter = 2
 flip_v = true
+
+[node name="ViewportPurger" parent="." instance=ExtResource( 1 )]
+viewport_paths = [ "TextureRect:texture" ]


### PR DESCRIPTION
NightPlayfield, Playfield, Puzzle and ViewportCreatureOutline now use ViewportPurger to unassign their ViewportTextures. This prevents occasional crashes when exiting a puzzle.