### PR TITLE
Save scores immediately instead of scheduling a save

### DIFF
--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -323,7 +323,7 @@ func _save_level_result(rank_result: RankResult) -> void:
 	if PlayerData.career.is_career_mode() and CurrentLevel.attempt_count == 0:
 		_update_career_data(rank_result)
 	
-	PlayerSave.schedule_save()
+	PlayerSave.save_player_data()
 
 
 ## For nighttime levels, this initializes night mode immediately to avoid an unpleasant blink effect.


### PR DESCRIPTION
Previously, saving was scheduled to avoid 50-100 ms of lag, but this led to a frustrating issue where high scores were lost if players quit before the save occurred. Now, scores are saved immediately.

We plan to mitigate lag with threading in a future update.