### PR TITLE
Fix 'Ambi Console' / 'Easy Console' name mixup

### DIFF
--- a/project/src/main/settings/touch-settings.gd
+++ b/project/src/main/settings/touch-settings.gd
@@ -5,18 +5,18 @@ signal settings_changed
 
 ## control schemes that decide which buttons appear where
 enum ControlScheme {
-	AMBI_CONSOLE,
-	AMBI_DESKTOP,
 	EASY_CONSOLE,
 	EASY_DESKTOP,
+	AMBI_CONSOLE,
+	AMBI_DESKTOP,
 	LOCO_CONSOLE,
 	LOCO_DESKTOP,
 }
 
-const AMBI_CONSOLE := ControlScheme.AMBI_CONSOLE
-const AMBI_DESKTOP := ControlScheme.AMBI_DESKTOP
 const EASY_CONSOLE := ControlScheme.EASY_CONSOLE
 const EASY_DESKTOP := ControlScheme.EASY_DESKTOP
+const AMBI_CONSOLE := ControlScheme.AMBI_CONSOLE
+const AMBI_DESKTOP := ControlScheme.AMBI_DESKTOP
 const LOCO_CONSOLE := ControlScheme.LOCO_CONSOLE
 const LOCO_DESKTOP := ControlScheme.LOCO_DESKTOP
 


### PR DESCRIPTION
The SettingsTouchScheme UI called 'Easy Console' the first item in the list, but the ControlScheme enum sorted them alphabetically.

I've rearranged the enum to match the display order. Easy Console should be the first one in the list, because I think it's the most intuitive.