### PR TITLE
Touch size settings: tick count, limits

### DIFF
--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -856,9 +856,7 @@ margin_bottom = 19.0
 rect_min_size = Vector2( 80, 16 )
 size_flags_horizontal = 3
 size_flags_vertical = 4
-max_value = 11.0
 value = 1.0
-tick_count = 12
 
 [node name="Text" type="Label" parent="Window/UiArea/TabContainer/Touch/VBoxContainer/Size/Control"]
 margin_left = 338.0

--- a/project/src/main/ui/settings/settings-touch-size.gd
+++ b/project/src/main/ui/settings/settings-touch-size.gd
@@ -3,11 +3,13 @@ extends Control
 
 ## step values of 1.19
 const VALUES := [
-	0.25, 0.30, 0.35, 0.42, 0.50, 0.59, 0.71, 0.84, 1.00, 1.19, 1.42, 1.69
+	0.25, 0.30, 0.35, 0.42, 0.50, 0.59, 0.71, 0.84, 1.00, 1.18, 1.40
 ]
 
 func _ready() -> void:
 	$Control/HSlider.value = Utils.find_closest(VALUES, SystemData.touch_settings.size)
+	$Control/HSlider.max_value = VALUES.size() - 1
+	$Control/HSlider.tick_count = VALUES.size()
 
 
 func _on_HSlider_value_changed(index: float) -> void:


### PR DESCRIPTION
Decreased the maximum touch size from 1.69 to 1.40. In an upcoming change which introduces the hold piece, a scale of 1.69 is too large and causes the buttons to overlap.

Settings menu no longer hard-codes the max value and tick count, these values are derived from the SettingsTouchSize.VALUES constant.