### PR TITLE
XBOX glyphs were sometimes missing for custom controls.

### DIFF
--- a/project/src/main/settings/keybind-settings.gd
+++ b/project/src/main/settings/keybind-settings.gd
@@ -316,4 +316,4 @@ func valid_custom_ui_keybinds() -> bool:
 ## Returns:
 ## 	An xbox input image texture showing a button or dpad input.
 static func xbox_image_for_input_event(input_event_json: Dictionary) -> Texture:
-	return XBOX_IMAGES_BY_BUTTON.get(input_event_json.get("button_index"))
+	return XBOX_IMAGES_BY_BUTTON.get(int(input_event_json.get("button_index", -1)))


### PR DESCRIPTION
Our code looks up xbox glyphs based on button index, but Godot stores json button indexes as floats, not ints. So these glyphs were often coming back as null.

We now cast the button indexes to an int.