### PR TITLE
Bug: Cutscene settings button could not be clicked.

### DIFF
--- a/project/src/main/chat/ui/click-translator.gd
+++ b/project/src/main/chat/ui/click-translator.gd
@@ -73,7 +73,10 @@ func _enable_translation() -> void:
 
 ## Emits press/release events based on a mouse click.
 func _handle_mouse_button(event: InputEventMouseButton) -> void:
-	if event.pressed and _click_index == -1 and not _showing_choices:
+	if event.pressed \
+			and _click_index == -1 \
+			and not _showing_choices \
+			and not _is_event_within_cutscene_button(event):
 		# emit a press event
 		_click_index = event.button_index
 		if is_inside_tree():
@@ -86,6 +89,19 @@ func _handle_mouse_button(event: InputEventMouseButton) -> void:
 		if is_inside_tree():
 			get_tree().set_input_as_handled()
 		_emit_ui_accept_event(false, false)
+
+
+## Returns 'true' if the press/release event is within a button, such as the settings button.
+##
+## When watching a cutscene, most mouse clicks advance the cutscene, but the player also needs to be able to press
+## certain buttons.
+func _is_event_within_cutscene_button(event: InputEventMouseButton) -> bool:
+	var result := false
+	for button in get_tree().get_nodes_in_group("cutscene_buttons"):
+		if button.visible and button.get_global_rect().has_point(event.global_position):
+			result = true
+			break
+	return result
 
 
 func _on_ChatUi_popped_in() -> void:

--- a/project/src/main/world/CutsceneUi.tscn
+++ b/project/src/main/world/CutsceneUi.tscn
@@ -92,7 +92,7 @@ mouse_filter = 2
 custom_constants/separation = 10
 alignment = 2
 
-[node name="SettingsButton" parent="Buttons/Northeast" instance=ExtResource( 6 )]
+[node name="SettingsButton" parent="Buttons/Northeast" groups=["cutscene_buttons"] instance=ExtResource( 6 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_left = 402.0


### PR DESCRIPTION
The cutscene settings button could not be clicked, except for when a dialog choice was being presented. This was broken by c0a8e988b which allowed clicking to advance cutscenes. The logic also consumed mouse events directed towards buttons in the scene.

The chat ui logic now ignores mouse click events near any buttons in the 'cutscene_buttons' group, which currently only includes the settings button.