### PR TITLE
Fixed infinite stall exploit

### DIFF
--- a/project/src/main/puzzle/piece/piece-manager.gd
+++ b/project/src/main/puzzle/piece/piece-manager.gd
@@ -230,7 +230,8 @@ func apply_lock() -> void:
 		piece.lock += 1
 		piece.gravity = 0
 	else:
-		piece.lock = 0
+		if piece.lock > 0:
+			piece.perform_lock_reset()
 
 
 func is_playfield_clearing_lines() -> bool:


### PR DESCRIPTION
Players could stall infinitely if they moved the piece back and forth without rotating it, as piece movement did not consume a lock reset.

Piece movement now consumes a lock reset.