### PR TITLE
has_feature("android") -> has_feature("mobile")

### DIFF
--- a/project/src/main/editor/creature/allele-buttons.gd
+++ b/project/src/main/editor/creature/allele-buttons.gd
@@ -134,7 +134,7 @@ func _initialize_creature_name_button(button: CreatureNameButton) -> void:
 
 func _initialize_operation_button(button: OperationButton, operation: Operation) -> void:
 	button.id = operation.id
-	if operation.id in ["export", "import"] and (OS.has_feature("web") or OS.has_feature("android")):
+	if operation.id in ["export", "import"] and (OS.has_feature("web") or OS.has_feature("mobile")):
 		# export/import are not available on web
 		button.set_disabled(true)
 	if operation.id == "save" and not _creature_saver.has_unsaved_changes():

--- a/project/src/main/ui/settings/settings-open-user-folder.gd
+++ b/project/src/main/ui/settings/settings-open-user-folder.gd
@@ -7,7 +7,7 @@ extends HBoxContainer
 onready var _button := $Button
 
 func _ready() -> void:
-	if OS.has_feature("web") or OS.has_feature("android"):
+	if OS.has_feature("web") or OS.has_feature("mobile"):
 		_button.disabled = true
 
 


### PR DESCRIPTION
Android is case sensitive, so has_feature("android") always returned false causing these buttons to stay visible. Since Android doesn't provide file access in the same way PCs do, this would crash the game.

I've fixed these checks to use has_feature("mobile") so that the options stay disabled on Android.