### PR TITLE
Bug: Tutorials showed level name of ""

### DIFF
--- a/project/assets/main/puzzle/levels/tutorial/basics-1.json
+++ b/project/assets/main/puzzle/levels/tutorial/basics-1.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Basic Techniques",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/basics-2.json
+++ b/project/assets/main/puzzle/levels/tutorial/basics-2.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Basic Techniques",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/basics-3.json
+++ b/project/assets/main/puzzle/levels/tutorial/basics-3.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Basic Techniques",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/basics-4.json
+++ b/project/assets/main/puzzle/levels/tutorial/basics-4.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Basic Techniques",
   "finish_condition": {
     "type": "score",
     "value": 100

--- a/project/assets/main/puzzle/levels/tutorial/cakes-1.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-1.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Make Cakes",
   "start_speed": "T",
   "lose_condition": [
     "top_out 999999"

--- a/project/assets/main/puzzle/levels/tutorial/cakes-2.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-2.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Make Cakes",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect none"

--- a/project/assets/main/puzzle/levels/tutorial/cakes-3.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-3.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Make Cakes",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect none"

--- a/project/assets/main/puzzle/levels/tutorial/cakes-4.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-4.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Make Cakes",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect none"

--- a/project/assets/main/puzzle/levels/tutorial/cakes-5.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-5.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Make Cakes",
   "start_speed": "T",
   "lose_condition": [
     "top_out 999999"

--- a/project/assets/main/puzzle/levels/tutorial/cakes-6.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-6.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Make Cakes",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect none"

--- a/project/assets/main/puzzle/levels/tutorial/cakes-7.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-7.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Make Cakes",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect none"

--- a/project/assets/main/puzzle/levels/tutorial/cakes-8.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-8.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Make Cakes",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect none"

--- a/project/assets/main/puzzle/levels/tutorial/cakes-9.json
+++ b/project/assets/main/puzzle/levels/tutorial/cakes-9.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Make Cakes",
   "finish_condition": {
     "type": "time_over",
     "value": 45

--- a/project/assets/main/puzzle/levels/tutorial/combo-1.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-1.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Build Combos",
   "start_speed": "T",
   "lose_condition": [
     "top_out 999999"

--- a/project/assets/main/puzzle/levels/tutorial/combo-2-example.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-2-example.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Build Combos",
   "start_speed": "T",
   "input_replay": [
     "41 +move_piece_left",

--- a/project/assets/main/puzzle/levels/tutorial/combo-2.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-2.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Build Combos",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect none"

--- a/project/assets/main/puzzle/levels/tutorial/combo-3.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-3.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Build Combos",
   "start_speed": "T",
   "input_replay": [
     "25 +rotate_cw",

--- a/project/assets/main/puzzle/levels/tutorial/combo-4.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-4.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Build Combos",
   "start_speed": "T",
   "input_replay": [
     "17 +move_piece_right",

--- a/project/assets/main/puzzle/levels/tutorial/combo-5-example.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-5-example.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Build Combos",
   "start_speed": "T",
   "input_replay": [
     "41 +move_piece_right",

--- a/project/assets/main/puzzle/levels/tutorial/combo-5.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-5.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Build Combos",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect none"

--- a/project/assets/main/puzzle/levels/tutorial/combo-6.json
+++ b/project/assets/main/puzzle/levels/tutorial/combo-6.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Build Combos",
   "finish_condition": {
     "type": "score",
     "value": 120

--- a/project/assets/main/puzzle/levels/tutorial/oh-my.json
+++ b/project/assets/main/puzzle/levels/tutorial/oh-my.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Basic Techniques",
   "start_speed": "A1",
   "finish_condition": {
     "type": "lines",

--- a/project/assets/main/puzzle/levels/tutorial/spins-0-example.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-0-example.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",

--- a/project/assets/main/puzzle/levels/tutorial/spins-1-example.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-1-example.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/spins-1-fixed-example.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-1-fixed-example.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/spins-1-fixed.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-1-fixed.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/spins-1.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-1.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/spins-2-example.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-2-example.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/spins-2.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-2.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/spins-3-example.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-3-example.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/spins-3.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-3.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/spins-4-example.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-4-example.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "finish_condition": {
     "type": "pieces",

--- a/project/assets/main/puzzle/levels/tutorial/spins-4.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-4.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/spins-5-example.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-5-example.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/spins-5.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-5.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/spins-6.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-6.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/spins-7-example.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-7-example.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/spins-7.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-7.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/spins-8.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-8.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "5",
   "finish_condition": {
     "type": "pieces",

--- a/project/assets/main/puzzle/levels/tutorial/spins-secret.json
+++ b/project/assets/main/puzzle/levels/tutorial/spins-secret.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Meet Spins",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/squish-1.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-1.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Squish and Recover",
   "start_speed": "T",
   "lose_condition": [
     "top_out 999999"

--- a/project/assets/main/puzzle/levels/tutorial/squish-2.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-2.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Squish and Recover",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/squish-3.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-3.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Squish and Recover",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/squish-4.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-4.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Squish and Recover",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect refresh"

--- a/project/assets/main/puzzle/levels/tutorial/squish-5.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-5.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Squish and Recover",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect none"

--- a/project/assets/main/puzzle/levels/tutorial/squish-6.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-6.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Squish and Recover",
   "start_speed": "T",
   "blocks_during": [
     "top_out_effect none"

--- a/project/assets/main/puzzle/levels/tutorial/squish-7.json
+++ b/project/assets/main/puzzle/levels/tutorial/squish-7.json
@@ -1,5 +1,6 @@
 {
   "version": "5c84",
+  "name": "Squish and Recover",
   "finish_condition": {
     "type": "score",
     "value": 150


### PR DESCRIPTION
Tutorials don't usually show the scoreboard, but the final section of tutorials like "Build Combos" give the player some customers, and those parts showed a level name of "" on the scoreboard.

I've added a level name for all tutorial levels.