### PR TITLE
Replaced 'adjusted_value()' with up-front adjustments

### DIFF
--- a/project/src/main/data/player-save.gd
+++ b/project/src/main/data/player-save.gd
@@ -196,6 +196,7 @@ func _calculate_rank_for_level_history() -> void:
 	for level_id in PlayerData.level_history.level_names():
 		var level_settings := LevelSettings.new()
 		level_settings.load_from_resource(level_id)
+		GameplayDifficultyAdjustments.adjust_milestones(level_settings)
 		CurrentLevel.start_level(level_settings, true)
 		for level_history_item in PlayerData.level_history.rank_results[level_id]:
 			rank_calculator.calculate_rank(level_history_item)

--- a/project/src/main/puzzle/level/current-level.gd
+++ b/project/src/main/puzzle/level/current-level.gd
@@ -81,6 +81,7 @@ func set_launched_level(new_level_id: String) -> void:
 	if new_level_id:
 		var level_settings := LevelSettings.new()
 		level_settings.load_from_resource(level_id)
+		GameplayDifficultyAdjustments.adjust_milestones(level_settings)
 		if level_settings.other.tutorial:
 			customers = [CreatureLibrary.SENSEI_ID]
 
@@ -117,6 +118,7 @@ func switch_level(new_settings: LevelSettings, suppress_change_signal: bool = fa
 func push_level_trail() -> void:
 	var level_settings := LevelSettings.new()
 	level_settings.load_from_resource(level_id)
+	GameplayDifficultyAdjustments.adjust_milestones(level_settings)
 	if piece_speed:
 		LevelSpeedAdjuster.new(level_settings).adjust(piece_speed)
 	if hardcore:

--- a/project/src/main/puzzle/level/milestone.gd
+++ b/project/src/main/puzzle/level/milestone.gd
@@ -66,25 +66,3 @@ func is_default() -> bool:
 	result = result && (value == 0)
 	result = result && (get_meta_list().empty())
 	return result
-
-
-## Returns the milestone value adjusted by the current gameplay settings.
-##
-## When the player plays at slow speeds, we make milestones easier to reach.
-func adjusted_value() -> int:
-	if not CurrentLevel.is_piece_speed_cheat_enabled():
-		# Don't adjust milestones for tutorials. Some tutorials require the player to place 3 pieces, shortening it to
-		# 2 pieces would ruin the tutorial
-		return value
-	
-	var adjusted_value := value
-	match type:
-		LINES:
-			adjusted_value = GameplayDifficultyAdjustments.adjust_line_milestone(adjusted_value)
-		PIECES:
-			adjusted_value = GameplayDifficultyAdjustments.adjust_piece_milestone(adjusted_value)
-		SCORE:
-			adjusted_value = GameplayDifficultyAdjustments.adjust_score_milestone(adjusted_value)
-		TIME_OVER:
-			adjusted_value = GameplayDifficultyAdjustments.adjust_time_over_milestone(adjusted_value)
-	return adjusted_value

--- a/project/src/main/puzzle/milestone-hud.gd
+++ b/project/src/main/puzzle/milestone-hud.gd
@@ -45,20 +45,20 @@ func _process(_delta: float) -> void:
 
 ## Updates the milestone progress bar's value and boundaries.
 func update_milebar_values() -> void:
-	_progress_bar.min_value = MilestoneManager.prev_milestone().adjusted_value()
+	_progress_bar.min_value = MilestoneManager.prev_milestone().value
 	var next_milestone := MilestoneManager.next_milestone()
-	if next_milestone.adjusted_value() == _progress_bar.min_value:
+	if next_milestone.value == _progress_bar.min_value:
 		# avoid 'cannot get ratio' errors in sandbox mode
 		_progress_bar.max_value = _progress_bar.min_value + 1.0
 	else:
-		_progress_bar.max_value = next_milestone.adjusted_value()
+		_progress_bar.max_value = next_milestone.value
 	_progress_bar.value = MilestoneManager.progress_value(next_milestone)
 
 
 ## Updates the milestone progress bar text.
 func update_milebar_text() -> void:
 	var milestone := CurrentLevel.settings.finish_condition
-	var remaining: int = max(0, ceil(milestone.adjusted_value() - MilestoneManager.progress_value(milestone)))
+	var remaining: int = max(0, ceil(milestone.value - MilestoneManager.progress_value(milestone)))
 	match milestone.type:
 		Milestone.NONE:
 			_value.text = "-"

--- a/project/src/main/puzzle/milestone-manager.gd
+++ b/project/src/main/puzzle/milestone-manager.gd
@@ -26,15 +26,15 @@ func is_met(milestone: Milestone) -> bool:
 		Milestone.NONE:
 			result = false
 		Milestone.TIME_UNDER:
-			result = progress <= milestone.adjusted_value()
+			result = progress <= milestone.value
 		_:
-			result = progress >= milestone.adjusted_value()
+			result = progress >= milestone.value
 	return result
 
 
 ## Returns the player's current progress toward the specified milestone as a percentage.
 func progress_percent(milestone: Milestone) -> float:
-	return progress_value(milestone) / milestone.adjusted_value()
+	return progress_value(milestone) / milestone.value
 
 
 ## Returns the player's current progress toward the specified milestone as a number ranged [0, inf].

--- a/project/src/main/puzzle/piece-sfx.gd
+++ b/project/src/main/puzzle/piece-sfx.gd
@@ -48,7 +48,7 @@ func _on_PieceManager_initial_das_moved_right(_piece: ActivePiece) -> void:
 	_play_move_sfx()
 
 
-func _on_PieceManager_landed(_piece: ActivePiece) -> void:
+func _on_PieceManager_landed(_piece: ActivePiece):
 	$LandSound.play()
 
 

--- a/project/src/main/puzzle/piece/piece-speeds.gd
+++ b/project/src/main/puzzle/piece/piece-speeds.gd
@@ -108,8 +108,7 @@ func _add_speed(speed: PieceSpeed) -> void:
 
 func _update_current_speed() -> void:
 	var piece_speed_string: String = MilestoneManager.prev_milestone().get_meta("speed")
-	if CurrentLevel.is_piece_speed_cheat_enabled():
-		piece_speed_string = GameplayDifficultyAdjustments.adjust_piece_speed(piece_speed_string)
+	piece_speed_string = GameplayDifficultyAdjustments.adjust_piece_speed(CurrentLevel.settings, piece_speed_string)
 	PieceSpeeds.current_speed = PieceSpeeds.speed(piece_speed_string)
 
 

--- a/project/src/main/puzzle/puzzle-state.gd
+++ b/project/src/main/puzzle/puzzle-state.gd
@@ -284,6 +284,7 @@ func prepare_level_change(level_id: String) -> void:
 func change_level(level_id: String) -> void:
 	var settings := LevelSettings.new()
 	settings.load_from_resource(level_id)
+	GameplayDifficultyAdjustments.adjust_milestones(settings)
 	CurrentLevel.switch_level(settings)
 	# initialize input_frame to allow for recording/replaying inputs
 	input_frame = 0
@@ -481,6 +482,7 @@ func _prepare_game() -> void:
 		# Load a different level to start (used for tutorials)
 		var new_settings := LevelSettings.new()
 		new_settings.load_from_resource(CurrentLevel.settings.other.start_level)
+		new_settings.adjust_milestones()
 		CurrentLevel.start_level(new_settings)
 	
 	reset()

--- a/project/src/main/puzzle/puzzle.gd
+++ b/project/src/main/puzzle/puzzle.gd
@@ -335,16 +335,22 @@ func _initialize_night_mode() -> void:
 
 ## Add the necessary lines/pieces/score to complete the necessary milestone
 func _complete_milestone(milestone: Milestone) -> void:
+	var adjusted_milestone_value: int = milestone.value
+	if milestone == CurrentLevel.settings.finish_condition:
+		adjusted_milestone_value = CurrentLevel.settings.finish_condition.value
+	elif milestone == CurrentLevel.settings.success_condition:
+		adjusted_milestone_value = CurrentLevel.settings.success_condition.value
+	
 	match milestone.type:
 		Milestone.CUSTOMERS:
-			while PuzzleState.customer_scores.size() <= milestone.adjusted_value():
+			while PuzzleState.customer_scores.size() <= adjusted_milestone_value:
 				PuzzleState.customer_scores.insert(0, 100)
 		Milestone.LINES:
-			PuzzleState.level_performance.lines = milestone.adjusted_value()
+			PuzzleState.level_performance.lines = adjusted_milestone_value
 		Milestone.PIECES:
-			PuzzleState.level_performance.pieces = milestone.adjusted_value()
+			PuzzleState.level_performance.pieces = adjusted_milestone_value
 		Milestone.SCORE:
-			var score := milestone.adjusted_value()
+			var score := adjusted_milestone_value
 			
 			# update all score fields; otherwise the results hud might be have strangely
 			PuzzleState.level_performance.score = score
@@ -359,10 +365,10 @@ func _complete_milestone(milestone: Milestone) -> void:
 			
 			PuzzleState.level_performance.seconds += 9999
 		Milestone.TIME_OVER:
-			PuzzleState.level_performance.seconds = milestone.adjusted_value()
+			PuzzleState.level_performance.seconds = adjusted_milestone_value
 		Milestone.TIME_UNDER:
 			# set the time slightly under the required time, so the player has a moment to place the piece
-			PuzzleState.level_performance.seconds = max(milestone.adjusted_value() - 10.0, 1.0)
+			PuzzleState.level_performance.seconds = max(adjusted_milestone_value - 10.0, 1.0)
 
 
 func _on_Hud_start_button_pressed() -> void:

--- a/project/src/main/ui/level-select/level-button-scroller.gd
+++ b/project/src/main/ui/level-select/level-button-scroller.gd
@@ -151,6 +151,7 @@ func _refresh_level_settings() -> void:
 	for level_id in _level_ids:
 		var level_settings := LevelSettings.new()
 		level_settings.load_from_resource(level_id)
+		GameplayDifficultyAdjustments.adjust_milestones(level_settings)
 		_level_settings_by_id[level_id] = level_settings
 
 	# Sort the levels

--- a/project/src/main/ui/menu/paged-level-buttons.gd
+++ b/project/src/main/ui/menu/paged-level-buttons.gd
@@ -167,6 +167,7 @@ func _refresh_level_settings() -> void:
 	for level_id in level_ids:
 		var level_settings := LevelSettings.new()
 		level_settings.load_from_resource(level_id)
+		GameplayDifficultyAdjustments.adjust_milestones(level_settings)
 		_level_settings_by_id[level_id] = level_settings
 	
 	# Sort the levels

--- a/project/src/main/ui/menu/region-info-panel.gd
+++ b/project/src/main/ui/menu/region-info-panel.gd
@@ -129,6 +129,7 @@ func _update_rank_region_text(region: OtherRegion) -> void:
 		if best_result:
 			var level_settings := LevelSettings.new()
 			level_settings.load_from_resource(next_level_id)
+			GameplayDifficultyAdjustments.adjust_milestones(level_settings)
 			if best_result.compare == "-seconds":
 				# If the player has finished in 4 minutes but needs 2 minutes, they are 25% complete
 				promotion_percent = level_settings.success_condition.value / float(best_result.seconds)

--- a/project/src/main/ui/menu/training-menu.gd
+++ b/project/src/main/ui/menu/training-menu.gd
@@ -92,6 +92,7 @@ func _load_recent_data() -> void:
 	# load the player's previously played level
 	_level_settings = LevelSettings.new()
 	_level_settings.load_from_resource(PlayerData.practice.level_id)
+	GameplayDifficultyAdjustments.adjust_milestones(_level_settings)
 
 
 ## Enables/disables focus for inputs as submenus are shown and hidden.

--- a/project/src/main/world/career-map.gd
+++ b/project/src/main/world/career-map.gd
@@ -106,6 +106,7 @@ func _load_level_settings() -> void:
 	for level in _pickable_career_levels:
 		var level_settings := LevelSettings.new()
 		level_settings.load_from_resource(level.level_id)
+		GameplayDifficultyAdjustments.adjust_milestones(level_settings)
 		LevelSpeedAdjuster.new(level_settings).adjust(_piece_speed)
 		_pickable_level_settings.append(level_settings)
 	

--- a/project/src/test/puzzle/level/test-gameplay-difficulty-adjustments.gd
+++ b/project/src/test/puzzle/level/test-gameplay-difficulty-adjustments.gd
@@ -1,6 +1,10 @@
 extends GutTest
 
+var settings: LevelSettings
+var default_finish_condition: Milestone = Milestone.new()
+
 func before_each() -> void:
+	settings = LevelSettings.new()
 	PlayerData.difficulty.reset()
 
 
@@ -8,85 +12,123 @@ func after_all() -> void:
 	PlayerData.difficulty.reset()
 
 
+func adjust_milestones() -> void:
+	settings.finish_condition.set_milestone(default_finish_condition.type, default_finish_condition.value)
+	GameplayDifficultyAdjustments.adjust_milestones(settings)
+
+
 func test_adjust_line_milestone() -> void:
+	default_finish_condition.set_milestone(Milestone.LINES, 50)
 	PlayerData.difficulty.speed = DifficultyData.Speed.DEFAULT
-	assert_eq(GameplayDifficultyAdjustments.adjust_line_milestone(50), 50)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 50)
 	
 	# slowing down gameplay speed decreases lines required
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOW
-	assert_eq(GameplayDifficultyAdjustments.adjust_line_milestone(50), 43)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 43)
 	
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWER
-	assert_eq(GameplayDifficultyAdjustments.adjust_line_milestone(50), 35)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 35)
 	
 	# lines required won't decrease below a certain threshold (1 line)
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWESTEST
-	assert_eq(GameplayDifficultyAdjustments.adjust_line_milestone(3), 1)
+	default_finish_condition.set_milestone(Milestone.LINES, 3)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 1)
 	
 	# increasing gameplay speed does not affect milestones
 	PlayerData.difficulty.speed = DifficultyData.Speed.FASTER
-	assert_eq(GameplayDifficultyAdjustments.adjust_line_milestone(50), 50)
+	default_finish_condition.set_milestone(Milestone.LINES, 50)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 50)
 
 
 func test_adjust_piece_milestone() -> void:
 	PlayerData.difficulty.speed = DifficultyData.Speed.DEFAULT
-	assert_eq(GameplayDifficultyAdjustments.adjust_piece_milestone(50), 50)
+	default_finish_condition.set_milestone(Milestone.PIECES, 50)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 50)
 	
 	# slowing down gameplay speed decreases pieces required
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOW
-	assert_eq(GameplayDifficultyAdjustments.adjust_piece_milestone(50), 43)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 43)
 	
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWER
-	assert_eq(GameplayDifficultyAdjustments.adjust_piece_milestone(50), 35)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 35)
 	
 	# pieces required won't decrease below a certain threshold (1 piece)
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWESTEST
-	assert_eq(GameplayDifficultyAdjustments.adjust_piece_milestone(3), 1)
+	default_finish_condition.set_milestone(Milestone.PIECES, 3)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 1)
 	
 	# increasing gameplay speed does not affect milestones
 	PlayerData.difficulty.speed = DifficultyData.Speed.FASTER
-	assert_eq(GameplayDifficultyAdjustments.adjust_piece_milestone(50), 50)
+	default_finish_condition.set_milestone(Milestone.PIECES, 50)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 50)
 
 
 func test_adjust_score_milestone() -> void:
 	PlayerData.difficulty.speed = DifficultyData.Speed.DEFAULT
-	assert_eq(GameplayDifficultyAdjustments.adjust_score_milestone(500), 500)
+	default_finish_condition.set_milestone(Milestone.SCORE, 500)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 500)
 	
 	# slowing down gameplay speed decreases score required
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOW
-	assert_eq(GameplayDifficultyAdjustments.adjust_score_milestone(500), 350)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 350)
 	
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWER
-	assert_eq(GameplayDifficultyAdjustments.adjust_score_milestone(500), 200)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 200)
 	
 	# score required won't decrease below a certain threshold (¥1)
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWESTEST
-	assert_eq(GameplayDifficultyAdjustments.adjust_score_milestone(3), 1)
+	default_finish_condition.set_milestone(Milestone.SCORE, 3)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 1)
 	
 	# increasing gameplay speed does not affect milestones
 	PlayerData.difficulty.speed = DifficultyData.Speed.FASTER
-	assert_eq(GameplayDifficultyAdjustments.adjust_score_milestone(500), 500)
+	default_finish_condition.set_milestone(Milestone.SCORE, 500)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 500)
 
 
 func test_adjust_time_over_milestone() -> void:
 	# 'slow' and 'default' gameplay speeds do not affect level duration
 	PlayerData.difficulty.speed = DifficultyData.Speed.DEFAULT
-	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(180), 180)
+	default_finish_condition.set_milestone(Milestone.TIME_OVER, 180)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 180)
 	
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOW
-	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(180), 180)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 180)
 	
 	# decreasing gameplay speed beyond 'slow' decreases level duration
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWER
-	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(180), 162)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 162)
 	
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWEST
-	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(180), 126)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 126)
 	
 	# level duration won't decrease below a certain threshold (0:01)
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWESTEST
-	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(3), 2)
+	default_finish_condition.set_milestone(Milestone.TIME_OVER, 3)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 2)
 	
 	# increasing gameplay speed does not affect milestones
 	PlayerData.difficulty.speed = DifficultyData.Speed.FASTER
-	assert_eq(GameplayDifficultyAdjustments.adjust_time_over_milestone(180), 180)
+	default_finish_condition.set_milestone(Milestone.TIME_OVER, 180)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 180)


### PR DESCRIPTION
To apply difficulty tweaks, places used to call
'finish_criteria.adjusted_value()'. This could cause bugs, as some places might call adjusted_value() while others referenced the 'value' field directly.

We now adjust the level's finish criteria up-front. This also opens the possibility of more nuanced adjustments down the road, if we decide for example "Levels with a line goal should require 30% fewer points, but levels with a time goal should require 50% fewer points." We can now easily make these kinds of milestones codependent.