### PR TITLE
Easier difficulties have easier success criteria.

### DIFF
--- a/project/src/main/puzzle/level/gameplay-difficulty-adjustments.gd
+++ b/project/src/main/puzzle/level/gameplay-difficulty-adjustments.gd
@@ -442,7 +442,7 @@ const PIECE_SPEED_MAPPING_BY_GAMEPLAY_SPEED := {
 }
 
 
-## Adjusts the finish milestone based on the current gameplay settings.
+## Adjusts the finish and success milestones based on the current gameplay settings.
 ##
 ## When the player plays at slow speeds, we make milestones easier to reach.
 static func adjust_milestones(settings: LevelSettings) -> void:
@@ -486,6 +486,13 @@ static func adjust_score_finish(settings: LevelSettings) -> void:
 	var score_milestone_factor: float = \
 			SCORE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(PlayerData.difficulty.speed, 1.0)
 	settings.finish_condition.value = int(ceil(settings.finish_condition.value * score_milestone_factor))
+	
+	if settings.success_condition.type == Milestone.TIME_UNDER:
+		# Scale the success condition to the new finish condition, and to make it easier
+		var time_under_milestone_factor: float = \
+				TIME_UNDER_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(PlayerData.difficulty.speed, 1.0)
+		settings.success_condition.value = int(ceil(settings.success_condition.value \
+				* score_milestone_factor * time_under_milestone_factor))
 
 
 ## Adjusts a line milestone value based on the player's gameplay speed settings.
@@ -497,6 +504,13 @@ static func adjust_line_finish(settings: LevelSettings) -> void:
 	var line_milestone_factor: float = \
 			LINE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(PlayerData.difficulty.speed, 1.0)
 	settings.finish_condition.value = int(ceil(settings.finish_condition.value * line_milestone_factor))
+	
+	if settings.success_condition.type == Milestone.SCORE:
+		# Scale the success condition to the new finish condition, and to make it easier
+		var score_milestone_factor: float = \
+				SCORE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(PlayerData.difficulty.speed, 1.0)
+		settings.success_condition.value = int(ceil(settings.success_condition.value \
+				* line_milestone_factor * score_milestone_factor))
 
 
 ## Adjusts a piece milestone value based on the player's gameplay speed settings.
@@ -508,6 +522,13 @@ static func adjust_piece_finish(settings: LevelSettings) -> void:
 	var piece_milestone_factor: float = \
 			LINE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(PlayerData.difficulty.speed, 1.0)
 	settings.finish_condition.value = int(ceil(settings.finish_condition.value * piece_milestone_factor))
+	
+	if settings.success_condition.type == Milestone.SCORE:
+		# Scale the success condition to the new finish condition, and to make it easier
+		var score_milestone_factor: float = \
+				SCORE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(PlayerData.difficulty.speed, 1.0)
+		settings.success_condition.value = int(ceil(settings.success_condition.value \
+				* piece_milestone_factor * score_milestone_factor))
 
 
 ## Adjusts a duration milestone value based on the player's gameplay speed settings.
@@ -519,6 +540,13 @@ static func adjust_time_over_finish(settings: LevelSettings) -> void:
 	var time_over_milestone_factor: float = \
 			TIME_OVER_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(PlayerData.difficulty.speed, 1.0)
 	settings.finish_condition.value = int(ceil(settings.finish_condition.value * time_over_milestone_factor))
+	
+	if settings.success_condition.type == Milestone.SCORE:
+		# Scale the success condition to the new finish condition, and to make it easier
+		var score_milestone_factor: float = \
+				SCORE_MILESTONE_FACTOR_BY_GAMEPLAY_SPEED.get(PlayerData.difficulty.speed, 1.0)
+		settings.success_condition.value = int(ceil(settings.success_condition.value \
+				 * time_over_milestone_factor * score_milestone_factor))
 
 
 static func _is_piece_speed_cheat_enabled(settings: LevelSettings) -> bool:

--- a/project/src/test/puzzle/level/test-gameplay-difficulty-adjustments.gd
+++ b/project/src/test/puzzle/level/test-gameplay-difficulty-adjustments.gd
@@ -2,6 +2,7 @@ extends GutTest
 
 var settings: LevelSettings
 var default_finish_condition: Milestone = Milestone.new()
+var default_success_condition: Milestone = Milestone.new()
 
 func before_each() -> void:
 	settings = LevelSettings.new()
@@ -14,121 +15,200 @@ func after_all() -> void:
 
 func adjust_milestones() -> void:
 	settings.finish_condition.set_milestone(default_finish_condition.type, default_finish_condition.value)
+	settings.success_condition.set_milestone(default_success_condition.type, default_success_condition.value)
 	GameplayDifficultyAdjustments.adjust_milestones(settings)
 
 
 func test_adjust_line_milestone() -> void:
 	default_finish_condition.set_milestone(Milestone.LINES, 50)
+	default_success_condition.set_milestone(Milestone.SCORE, 250)
 	PlayerData.difficulty.speed = DifficultyData.Speed.DEFAULT
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 50)
+	assert_eq(settings.success_condition.value, 250)
 	
 	# slowing down gameplay speed decreases lines required
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOW
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 43)
+	assert_eq(settings.success_condition.value, 149)
 	
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWER
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 35)
+	assert_eq(settings.success_condition.value, 70)
 	
 	# lines required won't decrease below a certain threshold (1 line)
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWESTEST
 	default_finish_condition.set_milestone(Milestone.LINES, 3)
+	default_success_condition.set_milestone(Milestone.SCORE, 10)
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 1)
+	assert_eq(settings.success_condition.value, 1)
 	
 	# increasing gameplay speed does not affect milestones
 	PlayerData.difficulty.speed = DifficultyData.Speed.FASTER
 	default_finish_condition.set_milestone(Milestone.LINES, 50)
+	default_success_condition.set_milestone(Milestone.SCORE, 250)
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 50)
+	assert_eq(settings.success_condition.value, 250)
 
 
 func test_adjust_piece_milestone() -> void:
 	PlayerData.difficulty.speed = DifficultyData.Speed.DEFAULT
 	default_finish_condition.set_milestone(Milestone.PIECES, 50)
+	default_success_condition.set_milestone(Milestone.SCORE, 250)
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 50)
+	assert_eq(settings.success_condition.value, 250)
 	
 	# slowing down gameplay speed decreases pieces required
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOW
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 43)
+	assert_eq(settings.success_condition.value, 149)
 	
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWER
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 35)
+	assert_eq(settings.success_condition.value, 70)
 	
 	# pieces required won't decrease below a certain threshold (1 piece)
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWESTEST
 	default_finish_condition.set_milestone(Milestone.PIECES, 3)
+	default_success_condition.set_milestone(Milestone.SCORE, 15)
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 1)
+	assert_eq(settings.success_condition.value, 1)
 	
 	# increasing gameplay speed does not affect milestones
 	PlayerData.difficulty.speed = DifficultyData.Speed.FASTER
 	default_finish_condition.set_milestone(Milestone.PIECES, 50)
+	default_success_condition.set_milestone(Milestone.SCORE, 250)
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 50)
+	assert_eq(settings.success_condition.value, 250)
 
 
 func test_adjust_score_milestone() -> void:
 	PlayerData.difficulty.speed = DifficultyData.Speed.DEFAULT
 	default_finish_condition.set_milestone(Milestone.SCORE, 500)
+	default_success_condition.set_milestone(Milestone.TIME_UNDER, 180)
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 500)
+	assert_eq(settings.success_condition.value, 180)
 	
 	# slowing down gameplay speed decreases score required
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOW
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 350)
+	assert_eq(settings.success_condition.value, 177)
 	
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWER
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 200)
+	assert_eq(settings.success_condition.value, 180)
 	
 	# score required won't decrease below a certain threshold (¥1)
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWESTEST
 	default_finish_condition.set_milestone(Milestone.SCORE, 3)
+	default_success_condition.set_milestone(Milestone.TIME_UNDER, 1)
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 1)
+	assert_eq(settings.success_condition.value, 1)
 	
 	# increasing gameplay speed does not affect milestones
 	PlayerData.difficulty.speed = DifficultyData.Speed.FASTER
 	default_finish_condition.set_milestone(Milestone.SCORE, 500)
+	default_success_condition.set_milestone(Milestone.TIME_UNDER, 180)
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 500)
+	assert_eq(settings.success_condition.value, 180)
+
+
+func test_zen_boss_milestones() -> void:
+	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWESTEST
+	# lemon
+	default_finish_condition.set_milestone(Milestone.SCORE, 300)
+	default_success_condition.set_milestone(Milestone.TIME_UNDER, 300)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 30)
+	assert_eq(settings.success_condition.value, 300)
+	
+	# welcome
+	default_finish_condition.set_milestone(Milestone.TIME_OVER, 180)
+	default_success_condition.set_milestone(Milestone.SCORE, 400)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 72)
+	assert_eq(settings.success_condition.value, 16)
+	
+	# poki
+	default_finish_condition.set_milestone(Milestone.SCORE, 600)
+	default_success_condition.set_milestone(Milestone.TIME_UNDER, 360)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 60)
+	assert_eq(settings.success_condition.value, 360)
+	
+	# poki
+	default_finish_condition.set_milestone(Milestone.TIME_OVER, 210)
+	default_success_condition.set_milestone(Milestone.SCORE, 650)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 84)
+	assert_eq(settings.success_condition.value, 26)
+	
+	# marsh
+	default_finish_condition.set_milestone(Milestone.PIECES, 150)
+	default_success_condition.set_milestone(Milestone.SCORE, 1000)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 30)
+	assert_eq(settings.success_condition.value, 20)
+	
+	# lava
+	default_finish_condition.set_milestone(Milestone.LINES, 120)
+	default_success_condition.set_milestone(Milestone.SCORE, 2000)
+	adjust_milestones()
+	assert_eq(settings.finish_condition.value, 24)
+	assert_eq(settings.success_condition.value, 40)
 
 
 func test_adjust_time_over_milestone() -> void:
 	# 'slow' and 'default' gameplay speeds do not affect level duration
 	PlayerData.difficulty.speed = DifficultyData.Speed.DEFAULT
 	default_finish_condition.set_milestone(Milestone.TIME_OVER, 180)
+	default_success_condition.set_milestone(Milestone.SCORE, 500)
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 180)
+	assert_eq(settings.success_condition.value, 500)
 	
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOW
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 180)
+	assert_eq(settings.success_condition.value, 350)
 	
 	# decreasing gameplay speed beyond 'slow' decreases level duration
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWER
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 162)
+	assert_eq(settings.success_condition.value, 180)
 	
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWEST
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 126)
+	assert_eq(settings.success_condition.value, 70)
 	
 	# level duration won't decrease below a certain threshold (0:01)
 	PlayerData.difficulty.speed = DifficultyData.Speed.SLOWESTEST
 	default_finish_condition.set_milestone(Milestone.TIME_OVER, 3)
+	default_success_condition.set_milestone(Milestone.SCORE, 10)
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 2)
+	assert_eq(settings.success_condition.value, 1)
 	
 	# increasing gameplay speed does not affect milestones
 	PlayerData.difficulty.speed = DifficultyData.Speed.FASTER
 	default_finish_condition.set_milestone(Milestone.TIME_OVER, 180)
+	default_success_condition.set_milestone(Milestone.SCORE, 500)
 	adjust_milestones()
 	assert_eq(settings.finish_condition.value, 180)
+	assert_eq(settings.success_condition.value, 500)


### PR DESCRIPTION
Before, instead of easier boss levels requiring something like "Get $300 in 3 minutes", they were adjusted to something like "Get $300 in 1 minute" which is much, much harder. Shortening normal levels made them easier, but shortening boss level made it much harder to meet the requirements.

Now, we scale the success criteria accordingly to "Get $100 in 1 minute", but also make an additional adjustment because novices won't be able to score as many points per minute as experts. So the final result is something silly like "Get $10 in 1 minute". If players think it is too easy, there are harder difficulties. The goal of Zen mode is to open up the game to all players.