### PR TITLE
More lenient slider clicks on Settings, Training Menu

### DIFF
--- a/project/src/main/ui/ClickCatcher.tscn
+++ b/project/src/main/ui/ClickCatcher.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/main/ui/click-catcher.gd" type="Script" id=1]
+
+[node name="ClickCatcher" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 1
+script = ExtResource( 1 )

--- a/project/src/main/ui/click-catcher.gd
+++ b/project/src/main/ui/click-catcher.gd
@@ -1,0 +1,9 @@
+extends Control
+## Extends the parent node's input area.
+##
+## By default, small controls like sliders are difficult to interact with, particularly on mobile devices. By
+## assigning a margin to this node, it will relay mouse press events outside the parent control.
+
+func _gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton:
+		get_parent()._gui_input(event)

--- a/project/src/main/ui/menu/TrainingMenu.tscn
+++ b/project/src/main/ui/menu/TrainingMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=46 format=2]
+[gd_scene load_steps=47 format=2]
 
 [ext_resource path="res://src/main/ui/menu/PagedRegionPanel.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/main/ui/ImageButton.tscn" type="PackedScene" id=2]
@@ -10,6 +10,7 @@
 [ext_resource path="res://src/main/ui/candy-button/gradient-blue-normal.tres" type="Gradient" id=8]
 [ext_resource path="res://src/main/ui/level-select/LevelButtonScroller.tscn" type="PackedScene" id=9]
 [ext_resource path="res://src/main/ui/menu/drop-panel.tres" type="StyleBox" id=10]
+[ext_resource path="res://src/main/ui/ClickCatcher.tscn" type="PackedScene" id=11]
 [ext_resource path="res://src/main/ui/squeak/gy/squeak-theme-h4.tres" type="Theme" id=12]
 [ext_resource path="res://src/main/ui/HighScoreTable.tscn" type="PackedScene" id=13]
 [ext_resource path="res://src/main/ui/theme/h3-font-outline.tres" type="DynamicFont" id=14]
@@ -201,12 +202,19 @@ tick_count = 4
 [node name="HSliderGamepadHelper" parent="MainMenu/DropPanel/VBoxContainer/Speed/SliderPanel/Slider" instance=ExtResource( 38 )]
 sliding_speed = 6.0
 
+[node name="ClickCatcher" parent="MainMenu/DropPanel/VBoxContainer/Speed/SliderPanel/Slider" instance=ExtResource( 11 )]
+margin_left = -25.0
+margin_top = -25.0
+margin_right = 25.0
+margin_bottom = 25.0
+
 [node name="Labels" type="HBoxContainer" parent="MainMenu/DropPanel/VBoxContainer/Speed"]
 margin_left = 144.0
 margin_top = 62.0
 margin_right = 752.0
 margin_bottom = 82.0
 rect_min_size = Vector2( 608, 0 )
+mouse_filter = 2
 size_flags_horizontal = 4
 theme = ExtResource( 6 )
 

--- a/project/src/main/ui/settings/SettingsMenu.tscn
+++ b/project/src/main/ui/settings/SettingsMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=48 format=2]
+[gd_scene load_steps=49 format=2]
 
 [ext_resource path="res://src/main/ui/squeak/br/squeak-theme-h5.tres" type="Theme" id=1]
 [ext_resource path="res://src/main/ui/squeak/br/squeak-theme-h4.tres" type="Theme" id=2]
@@ -30,6 +30,7 @@
 [ext_resource path="res://src/main/ui/settings/settings-lock-cancel.gd" type="Script" id=28]
 [ext_resource path="res://src/main/ui/settings/settings-menu-bottom.gd" type="Script" id=29]
 [ext_resource path="res://src/main/ui/settings/settings-eating-sounds.gd" type="Script" id=30]
+[ext_resource path="res://src/main/ui/ClickCatcher.tscn" type="PackedScene" id=31]
 [ext_resource path="res://src/main/ui/squeak/br/SqueakButtonHelper.tscn" type="PackedScene" id=33]
 [ext_resource path="res://src/main/ui/theme/h5-font.tres" type="DynamicFont" id=35]
 [ext_resource path="res://src/main/ui/theme/h6-font.tres" type="DynamicFont" id=36]
@@ -242,6 +243,12 @@ rect_min_size = Vector2( 160, 0 )
 size_flags_horizontal = 2
 size_flags_vertical = 4
 size_flags_stretch_ratio = 1.1
+
+[node name="ClickCatcher" parent="Window/UiArea/TabContainer/SoundAndGraphics/VBoxContainer/EatingSounds/CheckBox" instance=ExtResource( 31 )]
+margin_left = -4.0
+margin_top = -4.0
+margin_right = 4.0
+margin_bottom = 4.0
 
 [node name="HSeparator" type="HSeparator" parent="Window/UiArea/TabContainer/SoundAndGraphics/VBoxContainer"]
 margin_top = 168.0
@@ -857,6 +864,12 @@ rect_min_size = Vector2( 80, 16 )
 size_flags_horizontal = 3
 size_flags_vertical = 4
 value = 1.0
+
+[node name="ClickCatcher" parent="Window/UiArea/TabContainer/Touch/VBoxContainer/Size/Control/HSlider" instance=ExtResource( 31 )]
+margin_left = -4.0
+margin_top = -4.0
+margin_right = 4.0
+margin_bottom = 4.0
 
 [node name="Text" type="Label" parent="Window/UiArea/TabContainer/Touch/VBoxContainer/Size/Control"]
 margin_left = 338.0

--- a/project/src/main/ui/settings/VolumeSetting.tscn
+++ b/project/src/main/ui/settings/VolumeSetting.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://src/main/ui/theme/h4.theme" type="Theme" id=1]
 [ext_resource path="res://src/main/ui/settings/volume-setting-control.gd" type="Script" id=2]
 [ext_resource path="res://assets/main/puzzle/squish.wav" type="AudioStream" id=3]
 [ext_resource path="res://assets/main/world/creature/combo-voice-00.wav" type="AudioStream" id=4]
 [ext_resource path="res://src/main/ui/HSliderGamepadHelper.tscn" type="PackedScene" id=5]
+[ext_resource path="res://src/main/ui/ClickCatcher.tscn" type="PackedScene" id=6]
 
 [node name="Setting" type="HBoxContainer"]
 anchor_left = 0.5
@@ -58,6 +59,12 @@ tick_count = 11
 
 [node name="HSliderGamepadHelper" parent="HBoxContainer/HSlider" instance=ExtResource( 5 )]
 sliding_speed = 0.5
+
+[node name="ClickCatcher" parent="HBoxContainer/HSlider" instance=ExtResource( 6 )]
+margin_left = -4.0
+margin_top = -4.0
+margin_right = 4.0
+margin_bottom = 4.0
 
 [node name="Percent" type="Label" parent="HBoxContainer"]
 margin_left = 123.0


### PR DESCRIPTION
By default, small controls like sliders are difficult to interact with, particularly on mobile devices. By assigning a margin to this new ClickCatcher node, it will relay mouse press events outside the parent control.

I expanded the clickable margin for the Training Menu difficulty slider, and all sliders in the Settings menu.