### PR TITLE
Hide quit button on mobile/web targets

### DIFF
--- a/project/src/main/ui/menu/main-menu.gd
+++ b/project/src/main/ui/menu/main-menu.gd
@@ -7,13 +7,17 @@ extends Control
 func _ready() -> void:
 	MusicPlayer.play_menu_track()
 	
+	if OS.has_feature("web") or OS.has_feature("mobile"):
+		# don't quit from the web. it just blacks out the window, which isn't useful or user friendly
+		$DropPanel/System/Quit.visible = false
+	
 	$DropPanel/Adventure/Play.grab_focus()
 
 
 func _on_System_quit_pressed() -> void:
 	if not is_inside_tree():
 		return
-	if OS.has_feature("web"):
+	if OS.has_feature("web") or OS.has_feature("mobile"):
 		# don't quit from the web; just go back to splash screen
 		return
 	

--- a/project/src/main/ui/menu/splash-screen.gd
+++ b/project/src/main/ui/menu/splash-screen.gd
@@ -8,7 +8,7 @@ func _ready() -> void:
 	if PlayerSave.corrupt_filenames:
 		$BadSaveDataControl.popup()
 	
-	if OS.has_feature("web"):
+	if OS.has_feature("web") or OS.has_feature("mobile"):
 		# don't quit from the web. it just blacks out the window, which isn't useful or user friendly
 		$DropPanel/System/Quit.hide()
 


### PR DESCRIPTION
"Quitting" an android game results in a strange behavior where the game stays open in the background, and clicking it relaunches it. It's not helpful.

"Quitting" a web game makes the game go black. It's also not helpful.