### PR TITLE
Bug: Toggling vsync sometimes unfullscreens the game

### DIFF
--- a/project/src/main/data/system-data.gd
+++ b/project/src/main/data/system-data.gd
@@ -81,8 +81,9 @@ func _refresh_graphics_settings() -> void:
 		_prev_window_size = OS.window_size
 		_prev_window_position = OS.window_position
 	
-	OS.window_borderless = graphics_settings.fullscreen
-	OS.window_maximized = graphics_settings.fullscreen
+	if old_maximized != new_maximized:
+		OS.window_borderless = graphics_settings.fullscreen
+		OS.window_maximized = graphics_settings.fullscreen
 	
 	if old_maximized and not new_maximized:
 		# becoming windowed; restore the old window size and position


### PR DESCRIPTION
Specifically, if the player clicked the maximize button on windows, and then toggled VSync on and off, it would restore the window to its previous position.