### PR TITLE
Bug: Odd result fullscreening maximized window

### DIFF
--- a/project/src/main/data/system-data.gd
+++ b/project/src/main/data/system-data.gd
@@ -21,6 +21,7 @@ var has_unsaved_changes := false
 ## We store the non-fullscreened window size so we can restore it when the player disables fullscreen mode.
 var _prev_window_size: Vector2 = Global.window_size
 var _prev_window_position: Vector2 = OS.window_position
+var _prev_window_maximized: bool = OS.window_maximized
 
 ## When the graphics settings change, we update them after a few milliseconds delay.
 ##
@@ -76,10 +77,11 @@ func _refresh_graphics_settings() -> void:
 	var old_maximized := OS.window_maximized and OS.window_borderless
 	var new_maximized := graphics_settings.fullscreen
 	
-	if not old_maximized and new_maximized:
-		# becoming maximized; store the old window size and position
+	if not old_maximized:
+		# store the old window size and position
 		_prev_window_size = OS.window_size
 		_prev_window_position = OS.window_position
+		_prev_window_maximized = OS.window_maximized
 	
 	if old_maximized != new_maximized:
 		OS.window_borderless = graphics_settings.fullscreen
@@ -87,6 +89,7 @@ func _refresh_graphics_settings() -> void:
 	
 	if old_maximized and not new_maximized:
 		# becoming windowed; restore the old window size and position
+		OS.window_maximized = _prev_window_maximized
 		OS.window_size = _prev_window_size
 		OS.window_position = _prev_window_position
 


### PR DESCRIPTION
If the player maximized the window and then toggled fullscreen on and
off, the window would be restored to a size which took up the full
screen, but was not technically 'maximized'. Now, it restores to a
maximized window.