### PR TITLE
Bug: Customers greeted you twice at the start of levels.

### DIFF
--- a/project/src/main/world/environment/restaurant/hello-timer.gd
+++ b/project/src/main/world/environment/restaurant/hello-timer.gd
@@ -6,7 +6,7 @@ const GREETINGS_PER_MINUTE := 3.0
 
 ## Number in the range [-1, 1] which corresponds to how many greetings we've given recently. If it's close to 1,
 ## we're very unlikely to receive a greeting. If it's close to -1, we're very likely to receive a greeting.
-var greetiness := 0.0
+var greetiness := -1.0
 
 ## Creature who is about to say hello. We use a weak reference to avoid playing sound effects for creatures who
 ## leave the scene tree.
@@ -15,7 +15,8 @@ var greetiness := 0.0
 var _hello_customer_ref: WeakRef
 
 func _process(delta: float) -> void:
-	greetiness = clamp(greetiness + delta * GREETINGS_PER_MINUTE / 60, -1.0, 1.0)
+	if PuzzleState.game_active:
+		greetiness = clamp(greetiness + delta * GREETINGS_PER_MINUTE / 60, -1.0, 1.0)
 
 
 ## Conditionally schedules a 'hello!' voice sample for when a creature enters the restaurant.


### PR DESCRIPTION
In Career mode, when the puzzle window first appears the customer said hello. But then when the player presses start, the customer said hello again.

I've tweaked the hello timer so it only runs when a puzzle is active, and so that it defaults to the minimum value. This ensures the customers say 'hello' at the start of a puzzle, and then only say hello again if the player plays the puzzle for a little while.