### PR TITLE
Downgrade from GLES3 to GLES2.

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -2259,6 +2259,7 @@ translation_remaps={
 
 [rendering]
 
+quality/driver/driver_name="GLES2"
 quality/intended_usage/framebuffer_allocation=0
 quality/intended_usage/framebuffer_allocation.mobile=0
 threads/thread_model=2


### PR DESCRIPTION
GLES3 causes console errors when the GodotSteam overlay is enabled, on AMD Radeon RX 7600, when verbose logging is on.

This isn't a big deal as it's only one graphics card (my graphics card) but we're not using any GLES3 features anyways.