### PR TITLE
GLES2 fixes: Replace texture() with textureLod() in outline shaders

### DIFF
--- a/project/src/main/utils/icon-outline.shader
+++ b/project/src/main/utils/icon-outline.shader
@@ -29,7 +29,7 @@ void fragment() {
 	// we go around in a circle, sampling the texture in each direction.
 	// if we find an opaque section we set our alpha to 1.0 and break out of the loop
 	for (float a = 0.0; a <= TAU && final_alpha < 1.0; a += TAU / float(sample_count)) {
-		final_alpha = max(final_alpha, texture(TEXTURE, UV + vec2(sin(a) * size.x, cos(a) * size.y)).a);
+		final_alpha = max(final_alpha, textureLod(TEXTURE, UV + vec2(sin(a) * size.x, cos(a) * size.y), 0.0).a);
 	}
 	
 	vec3 final_color = mix(black.rgb, white.rgb, sprite_alpha);

--- a/project/src/main/utils/outline.shader
+++ b/project/src/main/utils/outline.shader
@@ -14,21 +14,21 @@ uniform float edge_fix_factor = 1.0;
 void fragment() {
 	vec2 size = TEXTURE_PIXEL_SIZE * width;
 	
-	vec4 sprite_color = texture(TEXTURE, UV);
+	vec4 sprite_color = textureLod(TEXTURE, UV, 0.0);
 	
 	float alpha = sprite_color.a;
 	
 	// cardinal directions
-	alpha = max(alpha, texture(TEXTURE, UV + vec2(0.0, -size.y)).a);
-	alpha = max(alpha, texture(TEXTURE, UV + vec2(size.x, 0.0)).a);
-	alpha = max(alpha, texture(TEXTURE, UV + vec2(0.0, size.y)).a);
-	alpha = max(alpha, texture(TEXTURE, UV + vec2(-size.x, 0.0)).a);
+	alpha = max(alpha, textureLod(TEXTURE, UV + vec2(0.0, -size.y), 0.0).a);
+	alpha = max(alpha, textureLod(TEXTURE, UV + vec2(size.x, 0.0), 0.0).a);
+	alpha = max(alpha, textureLod(TEXTURE, UV + vec2(0.0, size.y), 0.0).a);
+	alpha = max(alpha, textureLod(TEXTURE, UV + vec2(-size.x, 0.0), 0.0).a);
 	
 	// diagonal directions; divide by sqrt(2)
-	alpha = max(alpha, texture(TEXTURE, UV + vec2(size.x * 0.7071, -size.y * 0.7071)).a);
-	alpha = max(alpha, texture(TEXTURE, UV + vec2(size.x * 0.7071, size.y * 0.7071)).a);
-	alpha = max(alpha, texture(TEXTURE, UV + vec2(-size.x * 0.7071, size.y * 0.7071)).a);
-	alpha = max(alpha, texture(TEXTURE, UV + vec2(-size.x * 0.7071, -size.y * 0.7071)).a);
+	alpha = max(alpha, textureLod(TEXTURE, UV + vec2(size.x * 0.7071, -size.y * 0.7071), 0.0).a);
+	alpha = max(alpha, textureLod(TEXTURE, UV + vec2(size.x * 0.7071, size.y * 0.7071), 0.0).a);
+	alpha = max(alpha, textureLod(TEXTURE, UV + vec2(-size.x * 0.7071, size.y * 0.7071), 0.0).a);
+	alpha = max(alpha, textureLod(TEXTURE, UV + vec2(-size.x * 0.7071, -size.y * 0.7071), 0.0).a);
 	
 	vec3 final_color = mix(black.rgb, sprite_color.rgb / max(sprite_color.a, edge_fix_factor), sprite_color.a);
 	COLOR = vec4(final_color, alpha);

--- a/project/src/main/utils/smooth-outline.shader
+++ b/project/src/main/utils/smooth-outline.shader
@@ -20,15 +20,15 @@ uniform int sample_count = 24;
 
 void fragment() {
 	vec2 size = TEXTURE_PIXEL_SIZE * width;
-	float sprite_alpha = texture(TEXTURE, UV).a;
+	float sprite_alpha = textureLod(TEXTURE, UV, 0.0).a;
 	float final_alpha = sprite_alpha;
 
 	// we go around in a circle, sampling the texture in each direction.
 	// if we find an opaque section we set our alpha to 1.0 and break out of the loop
 	for (float a = 0.0; a <= TAU && final_alpha < 1.0; a += TAU / float(sample_count)) {
-		final_alpha = max(final_alpha, texture(TEXTURE, UV + vec2(sin(a) * size.x, cos(a) * size.y)).a);
+		final_alpha = max(final_alpha, textureLod(TEXTURE, UV + vec2(sin(a) * size.x, cos(a) * size.y), 0.0).a);
 	}
 	
-	vec3 final_color = mix(black.rgb, texture(TEXTURE, UV).rgb, sprite_alpha);
+	vec3 final_color = mix(black.rgb, textureLod(TEXTURE, UV, 0.0).rgb, sprite_alpha);
 	COLOR = vec4(final_color, final_alpha);
 }


### PR DESCRIPTION
Using texture() with ViewportTextures can result in incorrect LOD sampling on GLES2. This caused creatures to fade out or disappear when scaled. Forcing LOD 0 with textureLod() fixes it.